### PR TITLE
fix vb name/syntax bug for c# indexer

### DIFF
--- a/src/Microsoft.DocAsCode.EntityModel/Visitor/NameVisitor.cs
+++ b/src/Microsoft.DocAsCode.EntityModel/Visitor/NameVisitor.cs
@@ -626,7 +626,7 @@
                 symbol.ContainingType.Accept(this);
                 Append(".");
             }
-            Append(symbol.Name);
+            Append(symbol.MetadataName);
             if ((Options & NameOptions.WithParameter) == NameOptions.WithParameter)
             {
                 if (symbol.Parameters.Length > 0)

--- a/src/Microsoft.DocAsCode.EntityModel/Visitor/SymbolVisitorAdapter.cs
+++ b/src/Microsoft.DocAsCode.EntityModel/Visitor/SymbolVisitorAdapter.cs
@@ -293,9 +293,22 @@
             _generator.GenerateSyntax(result.Type, symbol, result.Syntax, this);
 
             var typeGenericParameters = symbol.ContainingType.IsGenericType ? symbol.ContainingType.Accept(TypeGenericParameterNameVisitor.Instance) : EmptyListOfString;
-            var id = AddSpecReference(symbol.Type, typeGenericParameters);
-            result.Syntax.Return = VisitorHelper.GetParameterDescription(symbol, result, id, true, GetAddReferenceDelegate(result));
-            Debug.Assert(result.Syntax.Return.Type != null);
+
+            if (symbol.Parameters.Length > 0)
+            {
+                foreach (var p in symbol.Parameters)
+                {
+                    var id = AddSpecReference(p.Type, typeGenericParameters);
+                    var param = VisitorHelper.GetParameterDescription(p, result, id, false, GetAddReferenceDelegate(result));
+                    Debug.Assert(param.Type != null);
+                    result.Syntax.Parameters.Add(param);
+                }
+            }
+            {
+                var id = AddSpecReference(symbol.Type, typeGenericParameters);
+                result.Syntax.Return = VisitorHelper.GetParameterDescription(symbol, result, id, true, GetAddReferenceDelegate(result));
+                Debug.Assert(result.Syntax.Return.Type != null);
+            }
 
             if (symbol.IsOverride && symbol.OverriddenProperty != null)
             {

--- a/src/Microsoft.DocAsCode.EntityModel/Visitor/VBYamlModelGenerator.cs
+++ b/src/Microsoft.DocAsCode.EntityModel/Visitor/VBYamlModelGenerator.cs
@@ -228,7 +228,7 @@
                         syntaxStr = SyntaxFactory.PropertyStatement(
                             new SyntaxList<AttributeListSyntax>(),
                             SyntaxFactory.TokenList(GetMemberModifiers(propertySymbol)),
-                            SyntaxFactory.Identifier(propertySymbol.Name),
+                            SyntaxFactory.Identifier(propertySymbol.MetadataName),
                             GetParamerterList(propertySymbol),
                             SyntaxFactory.SimpleAsClause(
                                 GetTypeSyntax(propertySymbol.Type)),

--- a/test/Microsoft.DocAsCode.EntityModel.Tests/GenerateMetadataFromCSUnitTest.cs
+++ b/test/Microsoft.DocAsCode.EntityModel.Tests/GenerateMetadataFromCSUnitTest.cs
@@ -1802,6 +1802,10 @@ namespace Test1
         public void Bar<K>(int i)
         {
         }
+        public int this[int index]
+        {
+            get { return index; }
+        }
     }
 }
 ";
@@ -1814,19 +1818,38 @@ namespace Test1
             Assert.Equal("Test1.Foo(Of T)", type.DisplayQualifiedNames[SyntaxLanguage.VB]);
             Assert.Equal("Test1.Foo`1", type.Name);
 
-            var method = output.Items[0].Items[0].Items[0];
-            Assert.NotNull(method);
-            Assert.Equal("Bar<K>(Int32)", method.DisplayNames[SyntaxLanguage.CSharp]);
-            Assert.Equal("Bar(Of K)(Int32)", method.DisplayNames[SyntaxLanguage.VB]);
-            Assert.Equal("Test1.Foo<T>.Bar<K>(System.Int32)", method.DisplayQualifiedNames[SyntaxLanguage.CSharp]);
-            Assert.Equal("Test1.Foo(Of T).Bar(Of K)(System.Int32)", method.DisplayQualifiedNames[SyntaxLanguage.VB]);
-            Assert.Equal("Test1.Foo`1.Bar``1(System.Int32)", method.Name);
-            Assert.Equal(1, output.Items.Count);
-            var parameter = method.Syntax.Parameters[0];
-            Assert.Equal("i", parameter.Name);
-            Assert.Equal("System.Int32", parameter.Type);
-            var returnValue = method.Syntax.Return;
-            Assert.Null(returnValue);
+            {
+                var method = output.Items[0].Items[0].Items[0];
+                Assert.NotNull(method);
+                Assert.Equal("Bar<K>(Int32)", method.DisplayNames[SyntaxLanguage.CSharp]);
+                Assert.Equal("Bar(Of K)(Int32)", method.DisplayNames[SyntaxLanguage.VB]);
+                Assert.Equal("Test1.Foo<T>.Bar<K>(System.Int32)", method.DisplayQualifiedNames[SyntaxLanguage.CSharp]);
+                Assert.Equal("Test1.Foo(Of T).Bar(Of K)(System.Int32)", method.DisplayQualifiedNames[SyntaxLanguage.VB]);
+                Assert.Equal("Test1.Foo`1.Bar``1(System.Int32)", method.Name);
+                Assert.Equal(1, method.Syntax.Parameters.Count);
+                var parameter = method.Syntax.Parameters[0];
+                Assert.Equal("i", parameter.Name);
+                Assert.Equal("System.Int32", parameter.Type);
+                var returnValue = method.Syntax.Return;
+                Assert.Null(returnValue);
+            }
+
+            {
+                var indexer = output.Items[0].Items[0].Items[1];
+                Assert.NotNull(indexer);
+                Assert.Equal("Item[Int32]", indexer.DisplayNames[SyntaxLanguage.CSharp]);
+                Assert.Equal("Item(Int32)", indexer.DisplayNames[SyntaxLanguage.VB]);
+                Assert.Equal("Test1.Foo<T>.Item[System.Int32]", indexer.DisplayQualifiedNames[SyntaxLanguage.CSharp]);
+                Assert.Equal("Test1.Foo(Of T).Item(System.Int32)", indexer.DisplayQualifiedNames[SyntaxLanguage.VB]);
+                Assert.Equal("Test1.Foo`1.Item(System.Int32)", indexer.Name);
+                Assert.Equal(1, indexer.Syntax.Parameters.Count);
+                var parameter = indexer.Syntax.Parameters[0];
+                Assert.Equal("index", parameter.Name);
+                Assert.Equal("System.Int32", parameter.Type);
+                var returnValue = indexer.Syntax.Return;
+                Assert.NotNull(returnValue);
+                Assert.Equal("System.Int32", returnValue.Type);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
fix vb name/syntax bug for c# indexer
