### PR TITLE
Build script fix for doc project packages restore

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -94,7 +94,7 @@ EXIT /B %ERRORLEVEL%
 :RestorePackage
 
 :RestoreDnuPackage
-FOR /D %%x IN ("src","docs","test") DO (
+FOR /D %%x IN ("src","Documentation","test") DO (
 PUSHD %%x
 CMD /C dnu restore --parallel
 POPD


### PR DESCRIPTION
2e4073e05067056af185352860b72d9b818b6bb5 renamed `docs` folder to `Documentation` but `build.cmd` was still attempting to build `docs`.

P.S. Not sure if this is related to #151 but certainly is a step in the right direction.