### PR TITLE
Enable NuGet download behind win auth proxy during build

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -101,7 +101,7 @@ SET CachedNuget=%LocalAppData%\NuGet\v2.8.6\NuGet.exe
 IF EXIST "%CachedNuget%" GOTO :Restore
 ECHO Downloading NuGet.exe v2.8.6...
 IF NOT EXIST "%LocalAppData%\NuGet\v2.8.6" MD "%LocalAppData%\NuGet\v2.8.6"
-powershell -NoProfile -ExecutionPolicy UnRestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/v2.8.6/nuget.exe' -OutFile '%CachedNuget%'"
+powershell -NoProfile -ExecutionPolicy UnRestricted -Command "$ProgressPreference = 'SilentlyContinue'; [Net.WebRequest]::DefaultWebProxy.Credentials = [Net.CredentialCache]::DefaultCredentials; Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/v2.8.6/nuget.exe' -OutFile '%CachedNuget%'"
 
 IF NOT '%ErrorLevel%'=='0' (
     ECHO ERROR: Failed downloading NuGet.exe


### PR DESCRIPTION
Fixes #178 by setting up credentials on the default proxy. This is a [known and dated issue with `System.Net`](https://visualstudio.uservoice.com/forums/121579-visual-studio-2015/suggestions/2397357-fix-it-so-that-net-apps-can-access-http-thru-auth) and which affects PowerShell's `Invoke-WebRequest`.