### PR TITLE
“Does the generation contain source code files?” grammar

### DIFF
--- a/src/docfx/SubCommands/InitCommand.cs
+++ b/src/docfx/SubCommands/InitCommand.cs
@@ -176,7 +176,7 @@ namespace Microsoft.DocAsCode.SubCommands
         private static readonly IEnumerable<IQuestion> _selectorQuestions = new IQuestion[]
         {
             new YesOrNoQuestion(
-                "Is the generation contains source code files?", (s, m, c) =>
+                "Does the generation contain source code files?", (s, m, c) =>
                 {
                     m.Build = new BuildJsonConfig();
                     if (s)


### PR DESCRIPTION
Grammar fix for the first prompt that appears when running `docfx init`:

```
A:\test> docfx init
Is the generation contains source code files? (Default: Yes)
Choose Answer (Yes/No):
```
