### PR TITLE
Trim common whitespace from included code snippets

### DIFF
--- a/src/Microsoft.DocAsCode.Dfm/DfmRendererHelper.cs
+++ b/src/Microsoft.DocAsCode.Dfm/DfmRendererHelper.cs
@@ -25,7 +25,27 @@ namespace Microsoft.DocAsCode.Dfm
                 var name = string.IsNullOrEmpty(token.Name) ? null : $" name=\"{StringHelper.HtmlEncode(token.Name)}\"";
                 var title = string.IsNullOrEmpty(token.Title) ? null : $" title=\"{StringHelper.HtmlEncode(token.Title)}\"";
 
-                renderedCodeLines = $"<pre><code{lang}{name}{title}>{StringHelper.HtmlEncode(string.Join("\n", codeLines))}\n</code></pre>";
+                var nonBlank  = codeLines.Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
+                var trimChars = 0;
+
+                while (nonBlank.Count > 0)
+                {
+                    // thisChar is whatever the first string has in this position
+                    var thisChar = nonBlank[0][trimChars];
+
+                    // if we're not dealing with a space or a tab, then we can be done now
+                    if (thisChar != ' ' && thisChar != '\t')
+                        break;
+
+                    // if one of the lines doesn't have thisChar at the current position, then we can be done
+                    if (!nonBlank.All(s => s[trimChars] == thisChar))
+                        break;
+
+                    // otherwise, advance our position
+                    trimChars++;
+                }
+
+                renderedCodeLines = $"<pre><code{lang}{name}{title}>{StringHelper.HtmlEncode(string.Join("\n", codeLines.Select(l => l.Length >= trimChars ? l.Substring(trimChars) : l)))}\n</code></pre>";
             }
 
             return $"{renderedErrorMessage}{renderedCodeLines}";

--- a/src/Microsoft.DocAsCode.Dfm/DfmRendererHelper.cs
+++ b/src/Microsoft.DocAsCode.Dfm/DfmRendererHelper.cs
@@ -5,6 +5,7 @@ namespace Microsoft.DocAsCode.Dfm
 {
     using System.Collections.Generic;
     using System.Collections.Immutable;
+    using System.Linq;
 
     using Microsoft.DocAsCode.MarkdownLite;
 


### PR DESCRIPTION
When a set of lines are included into a DFM file, no indenting is
removed from the beginning of the line. This results in code snippets
that can potentially be shifted far to the right in the rendered
output.

This patch adds code that looks through the included lines for leading
spaces and tabs, and removes enough that any indent that is common to
all the lines is removed.

Fixes #192.

Note that this patch is UNTESTED, as I was not successful in building the project.