### PR TITLE
Sometimes symbol.ContainingNamespace is null and result in a ExtractMetadataException

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Visitors/NameVisitor.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Visitors/NameVisitor.cs
@@ -121,7 +121,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             }
             else if ((Options & NameOptions.Qualified) == NameOptions.Qualified)
             {
-                if (!symbol.ContainingNamespace.IsGlobalNamespace)
+                if (symbol.ContainingNamespace != null && !symbol.ContainingNamespace.IsGlobalNamespace)
                 {
                     symbol.ContainingNamespace.Accept(this);
                     Append(".");
@@ -148,7 +148,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             {
                 return;
             }
-            if (!symbol.ContainingNamespace.IsGlobalNamespace)
+            if (symbol.ContainingNamespace != null && !symbol.ContainingNamespace.IsGlobalNamespace)
             {
                 symbol.ContainingNamespace.Accept(this);
                 Append(".");


### PR DESCRIPTION
Sometimes symbol.ContainingNamespace is null.

This currently happens when using Attribute constructor with unbound typeof (such as [MyAttribute(typeof(A<>))]).

This internally translate to UnboundArgumentErrorTypeSymbol, which have its ContainingNamespace set to null.