### PR TITLE
fix bug when outputFolder, basedirectory and destination are all not set

### DIFF
--- a/src/docfx/SubCommands/BuildCommand.cs
+++ b/src/docfx/SubCommands/BuildCommand.cs
@@ -40,9 +40,10 @@ namespace Microsoft.DocAsCode.SubCommands
         public void Exec(SubCommandRunningContext context)
         {
             var config = Config;
+            // TODO: remove BaseDirectory from Config, it may cause potential issue when abused
             var baseDirectory = Path.GetFullPath(string.IsNullOrEmpty(config.BaseDirectory) ? Environment.CurrentDirectory : config.BaseDirectory);
             var intermediateOutputFolder = Path.Combine(baseDirectory, "obj");
-            var outputFolder = Path.GetFullPath(Path.Combine(config.OutputFolder ?? config.BaseDirectory ?? string.Empty, config.Destination ?? string.Empty));
+            var outputFolder = Path.GetFullPath(Path.Combine(string.IsNullOrEmpty(config.OutputFolder) ? baseDirectory : config.OutputFolder, config.Destination ?? string.Empty));
 
             // TODO: Refactor
             var original = Environment.CurrentDirectory;


### PR DESCRIPTION
@chenkennt

`Path.GetFullPath(string.Empty)` throws exception