### PR TITLE
Extract FencesBlockToken's message generator out

### DIFF
--- a/src/Microsoft.DocAsCode.Dfm/DfmBlockquoteHelper.cs
+++ b/src/Microsoft.DocAsCode.Dfm/DfmBlockquoteHelper.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode.Dfm
+{
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+
+    using Microsoft.DocAsCode.MarkdownLite;
+
+    internal class DfmBlockquoteHelper
+    {
+        public class SplitToken
+        {
+            public IMarkdownToken Token { get; set; }
+
+            public List<IMarkdownToken> InnerTokens { get; set; }
+
+            public SplitToken(IMarkdownToken token)
+            {
+                Token = token;
+                InnerTokens = new List<IMarkdownToken>();
+            }
+        }
+
+        public static List<SplitToken> SplitBlockquoteTokens(ImmutableArray<IMarkdownToken> tokens)
+        {
+            var splitTokens = new List<SplitToken>();
+            SplitToken splitToken = null;
+            foreach (var token in tokens)
+            {
+                if (token is DfmSectionBlockToken || token is DfmNoteBlockToken)
+                {
+                    splitToken = new SplitToken(token);
+                    splitTokens.Add(splitToken);
+                }
+                else
+                {
+                    if (splitToken != null)
+                    {
+                        splitToken.InnerTokens.Add(token);
+                        continue;
+                    }
+                    splitToken = new SplitToken(token);
+                    splitToken.InnerTokens.Add(token);
+                    splitTokens.Add(splitToken);
+                }
+            }
+            return splitTokens;
+        }
+    }
+}

--- a/src/Microsoft.DocAsCode.Dfm/DfmBlockquoteHelper.cs
+++ b/src/Microsoft.DocAsCode.Dfm/DfmBlockquoteHelper.cs
@@ -8,21 +8,8 @@ namespace Microsoft.DocAsCode.Dfm
 
     using Microsoft.DocAsCode.MarkdownLite;
 
-    internal class DfmBlockquoteHelper
+    public class DfmBlockquoteHelper
     {
-        public class SplitToken
-        {
-            public IMarkdownToken Token { get; set; }
-
-            public List<IMarkdownToken> InnerTokens { get; set; }
-
-            public SplitToken(IMarkdownToken token)
-            {
-                Token = token;
-                InnerTokens = new List<IMarkdownToken>();
-            }
-        }
-
         public static List<SplitToken> SplitBlockquoteTokens(ImmutableArray<IMarkdownToken> tokens)
         {
             var splitTokens = new List<SplitToken>();

--- a/src/Microsoft.DocAsCode.Dfm/DfmFencesBlockHelper.cs
+++ b/src/Microsoft.DocAsCode.Dfm/DfmFencesBlockHelper.cs
@@ -3,12 +3,10 @@
 
 namespace Microsoft.DocAsCode.Dfm
 {
-    using System.Collections.Generic;
-    using System.Collections.Immutable;
-
+    using Microsoft.DocAsCode.Common;
     using Microsoft.DocAsCode.MarkdownLite;
 
-    internal class DfmRendererHelper
+    public static class DfmFencesBlockHelper
     {
         public static string GetRenderedFencesBlockString(DfmFencesBlockToken token, Options options, string errorMessage, string[] codeLines = null)
         {
@@ -34,43 +32,11 @@ namespace Microsoft.DocAsCode.Dfm
             return $"{renderedErrorMessage}{renderedCodeLines}";
         }
 
-        public class SplitToken
+        public static string GenerateReferenceNotFoundErrorMessage(IMarkdownRenderer renderer, DfmFencesBlockToken token)
         {
-            public IMarkdownToken Token { get; set; }
-
-            public List<IMarkdownToken> InnerTokens { get; set; }
-
-            public SplitToken(IMarkdownToken token)
-            {
-                Token = token;
-                InnerTokens = new List<IMarkdownToken>();
-            }
-        }
-
-        public static List<SplitToken> SplitBlockquoteTokens(ImmutableArray<IMarkdownToken> tokens)
-        {
-            var splitTokens = new List<SplitToken>();
-            SplitToken splitToken = null;
-            foreach (var token in tokens)
-            {
-                if (token is DfmSectionBlockToken || token is DfmNoteBlockToken)
-                {
-                    splitToken = new SplitToken(token);
-                    splitTokens.Add(splitToken);
-                }
-                else
-                {
-                    if (splitToken != null)
-                    {
-                        splitToken.InnerTokens.Add(token);
-                        continue;
-                    }
-                    splitToken = new SplitToken(token);
-                    splitToken.InnerTokens.Add(token);
-                    splitTokens.Add(splitToken);
-                }
-            }
-            return splitTokens;
+            string errorMessage = $"Can not find reference {token.Path}";
+            Logger.LogError(errorMessage);
+            return GetRenderedFencesBlockString(token, renderer.Options, errorMessage);
         }
     }
 }

--- a/src/Microsoft.DocAsCode.Dfm/DfmRenderer.cs
+++ b/src/Microsoft.DocAsCode.Dfm/DfmRenderer.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.DocAsCode.Dfm
 {
-    using System.Collections.Immutable;
     using System.IO;
 
     using Microsoft.DocAsCode.Common;
@@ -60,7 +59,7 @@ namespace Microsoft.DocAsCode.Dfm
         public override StringBuffer Render(IMarkdownRenderer renderer, MarkdownBlockquoteBlockToken token, MarkdownBlockContext context)
         {
             StringBuffer content = string.Empty;
-            var splitTokens = DfmRendererHelper.SplitBlockquoteTokens(token.Tokens);
+            var splitTokens = DfmBlockquoteHelper.SplitBlockquoteTokens(token.Tokens);
             foreach (var splitToken in splitTokens)
             {
                 if (splitToken.Token is DfmSectionBlockToken)
@@ -107,7 +106,7 @@ namespace Microsoft.DocAsCode.Dfm
             {
                 string errorMessage = $"Code absolute path: {token.Path} is not supported in file {context.GetFilePathStack().Peek()}";
                 Logger.LogError(errorMessage);
-                return DfmRendererHelper.GetRenderedFencesBlockString(token, renderer.Options, errorMessage);
+                return DfmFencesBlockHelper.GetRenderedFencesBlockString(token, renderer.Options, errorMessage);
             }
 
             try
@@ -115,23 +114,16 @@ namespace Microsoft.DocAsCode.Dfm
                 // TODO: Valid REST and REST-i script.
                 var fencesPath = Path.Combine(context.GetBaseFolder(), (RelativePath)context.GetFilePathStack().Peek() + (RelativePath)token.Path);
                 var extractResult = _dfmCodeExtractor.ExtractFencesCode(token, fencesPath);
-                return DfmRendererHelper.GetRenderedFencesBlockString(token, renderer.Options, extractResult.ErrorMessage, extractResult.FencesCodeLines);
+                return DfmFencesBlockHelper.GetRenderedFencesBlockString(token, renderer.Options, extractResult.ErrorMessage, extractResult.FencesCodeLines);
             }
             catch (DirectoryNotFoundException)
             {
-                return GenerateReferenceNotFoundErrorMessage(renderer, token);
+                return DfmFencesBlockHelper.GenerateReferenceNotFoundErrorMessage(renderer, token);
             }
             catch (FileNotFoundException)
             {
-                return GenerateReferenceNotFoundErrorMessage(renderer, token);
+                return DfmFencesBlockHelper.GenerateReferenceNotFoundErrorMessage(renderer, token);
             }
-        }
-
-        private static StringBuffer GenerateReferenceNotFoundErrorMessage(IMarkdownRenderer renderer, DfmFencesBlockToken token)
-        {
-            string errorMessage = $"Can not find reference {token.Path}";
-            Logger.LogError(errorMessage);
-            return DfmRendererHelper.GetRenderedFencesBlockString(token, renderer.Options, errorMessage);
         }
 
         public virtual StringBuffer Render(IMarkdownRenderer renderer, DfmNoteBlockToken token, MarkdownBlockContext context)

--- a/src/Microsoft.DocAsCode.Dfm/Microsoft.DocAsCode.Dfm.csproj
+++ b/src/Microsoft.DocAsCode.Dfm/Microsoft.DocAsCode.Dfm.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Rules\DfmXrefAutoLinkInlineRule.cs" />
     <Compile Include="Rules\DfmXrefShortcutInlineRule.cs" />
     <Compile Include="Rules\DfmYamlHeaderBlockRule.cs" />
+    <Compile Include="SplitToken.cs" />
     <Compile Include="Tokens\DfmFencesBlockToken.cs" />
     <Compile Include="Tokens\DfmIncludeBlockToken.cs" />
     <Compile Include="Tokens\DfmIncludeInlineToken.cs" />

--- a/src/Microsoft.DocAsCode.Dfm/Microsoft.DocAsCode.Dfm.csproj
+++ b/src/Microsoft.DocAsCode.Dfm/Microsoft.DocAsCode.Dfm.csproj
@@ -51,6 +51,7 @@
     <Compile Include="CodeSnippetExtractor\FlatNameCodeSnippetExtractor.cs" />
     <Compile Include="CodeSnippetExtractor\RecursiveNameCodeSnippetExtractor.cs" />
     <Compile Include="DfmCodeExtractorHelper.cs" />
+    <Compile Include="DfmFencesBlockHelper.cs" />
     <Compile Include="DfmFencesBlockPathQueryOptions\DfmFencesBlockPathQueryOption.cs" />
     <Compile Include="DfmFencesBlockPathQueryOptions\FullFileBlockPathQueryOption.cs" />
     <Compile Include="DfmFencesBlockPathQueryOptions\MultipleLineRangeBlockPathQueryOption.cs" />
@@ -90,7 +91,7 @@
     <Compile Include="DfmEngineBuilder.cs" />
     <Compile Include="DfmExtractCodeResult.cs" />
     <Compile Include="DfmRenderer.cs" />
-    <Compile Include="DfmRendererHelper.cs" />
+    <Compile Include="DfmBlockquoteHelper.cs" />
     <Compile Include="DocfxFlavoredIncHelper.cs" />
     <Compile Include="DocfxFlavoredMarked.cs" />
     <Compile Include="FileCacheLite.cs" />

--- a/src/Microsoft.DocAsCode.Dfm/SplitToken.cs
+++ b/src/Microsoft.DocAsCode.Dfm/SplitToken.cs
@@ -1,0 +1,19 @@
+﻿namespace Microsoft.DocAsCode.Dfm
+{
+    using System.Collections.Generic;
+
+    using Microsoft.DocAsCode.MarkdownLite;
+
+    public class SplitToken
+    {
+        public IMarkdownToken Token { get; set; }
+
+        public List<IMarkdownToken> InnerTokens { get; set; }
+
+        public SplitToken(IMarkdownToken token)
+        {
+            Token = token;
+            InnerTokens = new List<IMarkdownToken>();
+        }
+    }
+}


### PR DESCRIPTION
Extract FencesBlockToken's message generator out:
1. Internal method to public, to be reused by nuget.
2. Separate with other helper method, incase the dfm renderer helper will get complex in the future

@qinezh @superyyrrzz @chenkennt @ansyral @vwxyzh 