### PR TITLE
Rest - overwrite the value when key already defined in reference object

### DIFF
--- a/src/Microsoft.DocAsCode.Build.RestApi/Swagger/Internals/SwaggerObjectConverter.cs
+++ b/src/Microsoft.DocAsCode.Build.RestApi/Swagger/Internals/SwaggerObjectConverter.cs
@@ -34,16 +34,8 @@ namespace Microsoft.DocAsCode.Build.RestApi.Swagger.Internals
                         // Preserve value inside swagger.Token
                         foreach (var k in swagger.Token)
                         {
-                            JToken existing;
-                            if (jObject.TryGetValue(k.Key, out existing))
-                            {
-                                // Overwrite the value if the key is already defined.
-                                jObject[k.Key] = k.Value;
-                            }
-                            else
-                            {
-                                jObject.Add(k.Key, k.Value);
-                            }
+                            // Overwrite the value if the key is already defined.
+                            jObject[k.Key] = k.Value;
                         }
 
                         jObject.WriteTo(writer);

--- a/src/Microsoft.DocAsCode.Build.RestApi/Swagger/Internals/SwaggerObjectConverter.cs
+++ b/src/Microsoft.DocAsCode.Build.RestApi/Swagger/Internals/SwaggerObjectConverter.cs
@@ -37,10 +37,13 @@ namespace Microsoft.DocAsCode.Build.RestApi.Swagger.Internals
                             JToken existing;
                             if (jObject.TryGetValue(k.Key, out existing))
                             {
-                                throw new JsonException($"{k.Key} is already defined in referenced object \"{swagger.DeferredReference}\".");
+                                // Overwrite the value if the key is already defined.
+                                jObject[k.Key] = k.Value;
                             }
-
-                            jObject.Add(k.Key, k.Value);
+                            else
+                            {
+                                jObject.Add(k.Key, k.Value);
+                            }
                         }
 
                         jObject.WriteTo(writer);

--- a/test/Microsoft.DocAsCode.Build.RestApi.Tests/SwaggerJsonParserTest.cs
+++ b/test/Microsoft.DocAsCode.Build.RestApi.Tests/SwaggerJsonParserTest.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DocAsCode.Build.RestApi.Tests
             Assert.Equal(1, swagger.Paths["/contacts"].Count);
             var action = swagger.Paths["/contacts"]["patch"];
             var parameters = action.Parameters;
-            Assert.Equal(1, parameters.Count);
+            Assert.Equal(2, parameters.Count);
             Assert.Equal("body", parameters[0].Metadata["in"]);
             var schema = parameters[0].Metadata["schema"] as JObject;
             Assert.NotNull(schema);
@@ -58,6 +58,11 @@ namespace Microsoft.DocAsCode.Build.RestApi.Tests
             var refProperty = properties["provisioningErrors"]["items"]["schema"] as JObject;
             Assert.NotNull(refProperty);
             Assert.Equal("string", refProperty["properties"]["errorDetail"]["type"]);
+
+            schema = parameters[1].Metadata["schema"] as JObject;
+            properties = schema["properties"] as JObject;
+            var message = properties["message"];
+            Assert.Equal("A message describing the error, intended to be suitable for display in a user interface.", message["description"]);
 
             Assert.Equal(1, action.Responses.Count);
             var response = action.Responses["204"];

--- a/test/Microsoft.DocAsCode.Build.RestApi.Tests/TestData/swagger/ref_swagger2.json
+++ b/test/Microsoft.DocAsCode.Build.RestApi.Tests/TestData/swagger/ref_swagger2.json
@@ -20,6 +20,15 @@
                 "jobTitle": "Sales Rep"
               }
             }
+          },
+          {
+            "in": "query",
+            "description": "The batch error",
+            "name": "batchError",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/BatchError"
+            }
           }
         ],
         "responses": {
@@ -63,6 +72,28 @@
           "readOnly": "true"
         }
       }
+    },
+    "BatchError": {
+      "properties": {
+        "message": {
+          "$ref": "#/definitions/ErrorMessage",
+          "description": "A message describing the error, intended to be suitable for display in a user interface."
+        },
+      },
+      "description": "An error response received from the Azure Batch service."
+    },
+    "ErrorMessage": {
+      "properties": {
+        "lang": {
+          "type": "string",
+          "description": "The language code of the error message"
+        },
+        "value": {
+          "type": "string",
+          "description": "The text of the message."
+        }
+      },
+      "description": "An error message received in an Azure Batch error response."
     }
   },
   "/array": [


### PR DESCRIPTION
For example, if "b" key has already defined in json, and it's merging reference object which also has "b" key, should take the former and overwrite it.

@superyyrrzz @chenkennt @ansyral @vwxyzh @qinezh @vicancy 