### PR TITLE
add ApiTypeAndSpec to avoid loop reference

### DIFF
--- a/src/Microsoft.DocAsCode.Build.ManagedReference/BuildOutputs/ApiBuildOutputUtility.cs
+++ b/src/Microsoft.DocAsCode.Build.ManagedReference/BuildOutputs/ApiBuildOutputUtility.cs
@@ -36,6 +36,21 @@ namespace Microsoft.DocAsCode.Build.ManagedReference.BuildOutputs
             return ervm;
         }
 
+        public static List<ApiLanguageValuePair> GetSpec(string key, Dictionary<string, ApiReferenceBuildOutput> references, string[] supportedLanguages)
+        {
+            if (string.IsNullOrEmpty(key)) return null;
+
+            ApiReferenceBuildOutput reference;
+            if (!references.TryGetValue(key, out reference))
+            {
+                return ApiReferenceBuildOutput.GetSpecNames(GetXref(key), supportedLanguages);
+            }
+            else
+            {
+                return reference.Spec;
+            }
+        }
+
         public static List<ApiLanguageValuePair> TransformToLanguagePairList(string defaultValue, SortedList<string, string> values, string[] supportedLanguages)
         {
             if (string.IsNullOrEmpty(defaultValue) || supportedLanguages == null || supportedLanguages.Length == 0) return null;

--- a/src/Microsoft.DocAsCode.Build.ManagedReference/BuildOutputs/ApiCrefInfoBuildOutput.cs
+++ b/src/Microsoft.DocAsCode.Build.ManagedReference/BuildOutputs/ApiCrefInfoBuildOutput.cs
@@ -15,8 +15,8 @@ namespace Microsoft.DocAsCode.Build.ManagedReference.BuildOutputs
     public class ApiCrefInfoBuildOutput
     {
         [YamlMember(Alias = "type")]
-        [JsonProperty("type", IsReference = true)]
-        public ApiReferenceBuildOutput Type { get; set; }
+        [JsonProperty("type")]
+        public ApiTypeAndSpec Type { get; set; }
 
         [YamlMember(Alias = "description")]
         [JsonProperty("description")]
@@ -30,7 +30,7 @@ namespace Microsoft.DocAsCode.Build.ManagedReference.BuildOutputs
 
             return new ApiCrefInfoBuildOutput
             {
-                Type = ApiReferenceBuildOutput.FromUid(model.Type),
+                Type = new ApiTypeAndSpec { Uid = model.Type },
                 Description = model.Description,
             };
         }
@@ -41,7 +41,11 @@ namespace Microsoft.DocAsCode.Build.ManagedReference.BuildOutputs
 
             return new ApiCrefInfoBuildOutput
             {
-                Type = ApiBuildOutputUtility.GetReferenceViewModel(model.Type, references, supportedLanguages),
+                Type = new ApiTypeAndSpec
+                {
+                    Uid = model.Type,
+                    Spec = ApiBuildOutputUtility.GetSpec(model.Type, references, supportedLanguages),
+                },
                 Description = model.Description,
                 _needExpand = false,
             };
@@ -52,7 +56,7 @@ namespace Microsoft.DocAsCode.Build.ManagedReference.BuildOutputs
             if (_needExpand)
             {
                 _needExpand = false;
-                Type = ApiBuildOutputUtility.GetReferenceViewModel(Type?.Uid, references, supportedLanguages);
+                Type.Spec = ApiBuildOutputUtility.GetSpec(Type.Uid, references, supportedLanguages);
             }
         }
     }

--- a/src/Microsoft.DocAsCode.Build.ManagedReference/BuildOutputs/ApiParameterBuildOutput.cs
+++ b/src/Microsoft.DocAsCode.Build.ManagedReference/BuildOutputs/ApiParameterBuildOutput.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DocAsCode.Build.ManagedReference.BuildOutputs
 
         [YamlMember(Alias = "type")]
         [JsonProperty("type")]
-        public ApiReferenceBuildOutput Type { get; set; }
+        public ApiTypeAndSpec Type { get; set; }
 
         [YamlMember(Alias = "description")]
         [JsonProperty("description")]
@@ -35,8 +35,13 @@ namespace Microsoft.DocAsCode.Build.ManagedReference.BuildOutputs
             return new ApiParameterBuildOutput
             {
                 Name = model.Name,
-                Type = ApiBuildOutputUtility.GetReferenceViewModel(model.Type, references, supportedLanguages),
+                Type = new ApiTypeAndSpec
+                {
+                    Uid = model.Type,
+                    Spec = ApiBuildOutputUtility.GetSpec(model.Type, references, supportedLanguages),
+                },
                 Description = model.Description,
+                _needExpand = false,
             };
         }
 
@@ -47,7 +52,7 @@ namespace Microsoft.DocAsCode.Build.ManagedReference.BuildOutputs
             return new ApiParameterBuildOutput
             {
                 Name = model.Name,
-                Type = ApiReferenceBuildOutput.FromUid(model.Type),
+                Type = new ApiTypeAndSpec { Uid = model.Type },
                 Description = model.Description,
             };
         }
@@ -57,7 +62,7 @@ namespace Microsoft.DocAsCode.Build.ManagedReference.BuildOutputs
             if (_needExpand)
             {
                 _needExpand = false;
-                Type = ApiBuildOutputUtility.GetReferenceViewModel(Type?.Uid, references, supportedLanguages);
+                Type.Spec = ApiBuildOutputUtility.GetSpec(Type.Uid, references, supportedLanguages);
             }
         }
     }

--- a/src/Microsoft.DocAsCode.Build.ManagedReference/BuildOutputs/ApiTypeAndSpec.cs
+++ b/src/Microsoft.DocAsCode.Build.ManagedReference/BuildOutputs/ApiTypeAndSpec.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode.Build.ManagedReference.BuildOutputs
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Newtonsoft.Json;
+    using YamlDotNet.Serialization;
+
+    [Serializable]
+    public class ApiTypeAndSpec
+    {
+
+        [YamlMember(Alias = "uid")]
+        [JsonProperty("uid")]
+        public string Uid { get; set; }
+
+        [YamlMember(Alias = "specName")]
+        [JsonProperty("specName")]
+        public List<ApiLanguageValuePair> Spec { get; set; }
+    }
+}

--- a/src/Microsoft.DocAsCode.Build.ManagedReference/Microsoft.DocAsCode.Build.ManagedReference.csproj
+++ b/src/Microsoft.DocAsCode.Build.ManagedReference/Microsoft.DocAsCode.Build.ManagedReference.csproj
@@ -14,6 +14,7 @@
     <Compile Include="BuildOutputs\ApiCrefInfoBuildOutput.cs" />
     <Compile Include="BuildOutputs\ApiLanguageValuePair.cs" />
     <Compile Include="BuildOutputs\ApiParameterBuildOutput.cs" />
+    <Compile Include="BuildOutputs\ApiTypeAndSpec.cs" />
     <Compile Include="Utility.cs" />
     <Compile Include="BuildOutputs\ApiReferenceBuildOutput.cs" />
     <Compile Include="BuildOutputs\ApiSyntaxBuildOutput.cs" />


### PR DESCRIPTION
To fix the bug introduced in https://github.com/dotnet/docfx/commit/712a1dcecd64ee89d3fd63f08cb1610b8aa08178, avoid using ApiReferenceBuildOutput in ApiCrefBuildOutput/ApiParameterBuildOutput, which will cause loop ref.

@chenkennt @vwxyzh @qinezh @hellosnow @ansyral @vicancy 