### PR TITLE
add nameWithType to metadata

### DIFF
--- a/src/Microsoft.DocAsCode.DataContracts.Common/ReferenceViewModel.cs
+++ b/src/Microsoft.DocAsCode.DataContracts.Common/ReferenceViewModel.cs
@@ -43,6 +43,14 @@ namespace Microsoft.DocAsCode.DataContracts.Common
         [JsonIgnore]
         public SortedList<string, string> NameInDevLangs { get; } = new SortedList<string, string>();
 
+        [YamlMember(Alias = "nameWithType")]
+        [JsonProperty("nameWithType")]
+        public string NameWithType { get; set; }
+
+        [ExtensibleMember("nameWithType.")]
+        [JsonIgnore]
+        public SortedList<string, string> NameWithTypeInDevLangs { get; } = new SortedList<string, string>();
+
         [YamlMember(Alias = "fullName")]
         [JsonProperty("fullName")]
         public string FullName { get; set; }
@@ -70,6 +78,10 @@ namespace Microsoft.DocAsCode.DataContracts.Common
                 foreach (var item in NameInDevLangs)
                 {
                     dict["name." + item.Key] = item.Value;
+                }
+                foreach (var item in NameWithTypeInDevLangs)
+                {
+                    dict["nameWithType." + item.Key] = item.Value;
                 }
                 foreach (var item in FullNameInDevLangs)
                 {

--- a/src/Microsoft.DocAsCode.DataContracts.Common/SpecViewModel.cs
+++ b/src/Microsoft.DocAsCode.DataContracts.Common/SpecViewModel.cs
@@ -19,6 +19,10 @@ namespace Microsoft.DocAsCode.DataContracts.Common
         [JsonProperty("name")]
         public string Name { get; set; }
 
+        [YamlMember(Alias = "nameWithType")]
+        [JsonProperty("nameWithType")]
+        public string NameWithType { get; set; }
+
         [YamlMember(Alias = "fullName")]
         [JsonProperty("fullName")]
         public string FullName { get; set; }

--- a/src/Microsoft.DocAsCode.DataContracts.ManagedReference/ItemViewModel.cs
+++ b/src/Microsoft.DocAsCode.DataContracts.ManagedReference/ItemViewModel.cs
@@ -110,7 +110,7 @@ namespace Microsoft.DocAsCode.DataContracts.ManagedReference
         }
 
         [YamlMember(Alias = "nameWithType")]
-        [JsonProperty("name")]
+        [JsonProperty("nameWithType")]
         public string NameWithType { get; set; }
 
         [ExtensibleMember("nameWithType.")]

--- a/src/Microsoft.DocAsCode.DataContracts.ManagedReference/ItemViewModel.cs
+++ b/src/Microsoft.DocAsCode.DataContracts.ManagedReference/ItemViewModel.cs
@@ -109,6 +109,59 @@ namespace Microsoft.DocAsCode.DataContracts.ManagedReference
             }
         }
 
+        [YamlMember(Alias = "nameWithType")]
+        [JsonProperty("name")]
+        public string NameWithType { get; set; }
+
+        [ExtensibleMember("nameWithType.")]
+        [JsonIgnore]
+        public SortedList<string, string> NamesWithType { get; set; } = new SortedList<string, string>();
+
+        [YamlIgnore]
+        [JsonIgnore]
+        public string NameWithTypeForCSharp
+        {
+            get
+            {
+                string result;
+                Names.TryGetValue("csharp", out result);
+                return result;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    NamesWithType.Remove("csharp");
+                }
+                else
+                {
+                    NamesWithType["csharp"] = value;
+                }
+            }
+        }
+
+        [YamlIgnore]
+        [JsonIgnore]
+        public string NameWithTypeForVB
+        {
+            get
+            {
+                string result;
+                Names.TryGetValue("vb", out result);
+                return result;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    NamesWithType.Remove("vb");
+                }
+                else
+                {
+                    NamesWithType["vb"] = value;
+                }
+            }
+        }
         [YamlMember(Alias = "fullName")]
         [JsonProperty("fullName")]
         public string FullName { get; set; }
@@ -264,6 +317,10 @@ namespace Microsoft.DocAsCode.DataContracts.ManagedReference
                 foreach (var item in Names)
                 {
                     result["name." + item.Key] = item.Value;
+                }
+                foreach (var item in NamesWithType)
+                {
+                    result["nameWithType." + item.Key] = item.Value;
                 }
                 foreach (var item in FullNames)
                 {

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Models/MetadataItem.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Models/MetadataItem.cs
@@ -47,6 +47,10 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
         [JsonProperty("name")]
         public SortedList<SyntaxLanguage, string> DisplayNames { get; set; }
 
+        [YamlMember(Alias = "nameWithType")]
+        [JsonProperty("nameWithType")]
+        public SortedList<SyntaxLanguage, string> DisplayNamesWithType { get; set; }
+
         [YamlMember(Alias = "qualifiedName")]
         [JsonProperty("qualifiedName")]
         public SortedList<SyntaxLanguage, string> DisplayQualifiedNames { get; set; }

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Models/ReferenceItem.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Models/ReferenceItem.cs
@@ -113,6 +113,10 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
         [JsonProperty("name")]
         public string DisplayName { get; set; }
 
+        [YamlMember(Alias = "nameWithType")]
+        [JsonProperty("nameWithType")]
+        public string DisplayNamesWithType { get; set; }
+
         [YamlMember(Alias = "qualifiedName")]
         [JsonProperty("qualifiedName")]
         public string DisplayQualifiedNames { get; set; }

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Visitors/CSYamlModelGenerator.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Visitors/CSYamlModelGenerator.cs
@@ -30,6 +30,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
         public override void DefaultVisit(ISymbol symbol, MetadataItem item, SymbolVisitorAdapter adapter)
         {
             item.DisplayNames[SyntaxLanguage.CSharp] = NameVisitorCreator.GetCSharp(NameOptions.WithGenericParameter | NameOptions.WithParameter).GetName(symbol);
+            item.DisplayNamesWithType[SyntaxLanguage.CSharp] = NameVisitorCreator.GetCSharp(NameOptions.WithType | NameOptions.WithGenericParameter | NameOptions.WithParameter).GetName(symbol);
             item.DisplayQualifiedNames[SyntaxLanguage.CSharp] = NameVisitorCreator.GetCSharp(NameOptions.Qualified | NameOptions.WithGenericParameter | NameOptions.WithParameter).GetName(symbol);
         }
 

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Visitors/NameVisitor.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Visitors/NameVisitor.cs
@@ -80,7 +80,8 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
         Qualified = 2,
         WithGenericParameter = 4,
         WithParameter = 8,
-        All = UseAlias | Qualified | WithGenericParameter | WithParameter,
+        WithType = 16,
+        All = UseAlias | Qualified | WithGenericParameter | WithParameter | WithType,
     }
 
     public class CSharpNameVisitorCreator : NameVisitorCreator
@@ -194,7 +195,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
         public override void VisitMethod(IMethodSymbol symbol)
         {
-            if ((Options & NameOptions.Qualified) == NameOptions.Qualified)
+            if ((Options & NameOptions.Qualified) == NameOptions.Qualified || (Options & NameOptions.WithType) == NameOptions.WithType)
             {
                 symbol.ContainingType.Accept(this);
                 Append(".");
@@ -283,7 +284,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
         public override void VisitProperty(IPropertySymbol symbol)
         {
-            if ((Options & NameOptions.Qualified) == NameOptions.Qualified)
+            if ((Options & NameOptions.Qualified) == NameOptions.Qualified || (Options & NameOptions.WithType) == NameOptions.WithType)
             {
                 symbol.ContainingType.Accept(this);
                 Append(".");
@@ -331,7 +332,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
         public override void VisitEvent(IEventSymbol symbol)
         {
-            if ((Options & NameOptions.Qualified) == NameOptions.Qualified)
+            if ((Options & NameOptions.Qualified) == NameOptions.Qualified || (Options & NameOptions.WithType) == NameOptions.WithType)
             {
                 symbol.ContainingType.Accept(this);
                 Append(".");
@@ -354,7 +355,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
         public override void VisitField(IFieldSymbol symbol)
         {
-            if ((Options & NameOptions.Qualified) == NameOptions.Qualified)
+            if ((Options & NameOptions.Qualified) == NameOptions.Qualified || (Options & NameOptions.WithType) == NameOptions.WithType)
             {
                 symbol.ContainingType.Accept(this);
                 Append(".");
@@ -590,7 +591,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
         public override void VisitMethod(IMethodSymbol symbol)
         {
-            if ((Options & NameOptions.Qualified) == NameOptions.Qualified)
+            if ((Options & NameOptions.Qualified) == NameOptions.Qualified || (Options & NameOptions.WithType) == NameOptions.WithType)
             {
                 symbol.ContainingType.Accept(this);
                 Append(".");
@@ -665,7 +666,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
         public override void VisitProperty(IPropertySymbol symbol)
         {
-            if ((Options & NameOptions.Qualified) == NameOptions.Qualified)
+            if ((Options & NameOptions.Qualified) == NameOptions.Qualified || (Options & NameOptions.WithType) == NameOptions.WithType)
             {
                 symbol.ContainingType.Accept(this);
                 Append(".");
@@ -691,7 +692,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
         public override void VisitEvent(IEventSymbol symbol)
         {
-            if ((Options & NameOptions.Qualified) == NameOptions.Qualified)
+            if ((Options & NameOptions.Qualified) == NameOptions.Qualified || (Options & NameOptions.WithType) == NameOptions.WithType)
             {
                 symbol.ContainingType.Accept(this);
                 Append(".");
@@ -701,7 +702,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
         public override void VisitField(IFieldSymbol symbol)
         {
-            if ((Options & NameOptions.Qualified) == NameOptions.Qualified)
+            if ((Options & NameOptions.Qualified) == NameOptions.Qualified || (Options & NameOptions.WithType) == NameOptions.WithType)
             {
                 symbol.ContainingType.Accept(this);
                 Append(".");

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Visitors/ReferenceItemVisitor.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Visitors/ReferenceItemVisitor.cs
@@ -79,6 +79,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.CSharp].Add(new LinkItem
             {
                 DisplayName = NameVisitorCreator.GetCSharp(NameOptions.None).GetName(symbol),
+                DisplayNamesWithType = NameVisitorCreator.GetCSharp(NameOptions.WithType).GetName(symbol),
                 DisplayQualifiedNames = NameVisitorCreator.GetCSharp(NameOptions.Qualified).GetName(symbol),
             });
         }
@@ -88,6 +89,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.CSharp].Add(new LinkItem
             {
                 DisplayName = symbol.Name,
+                DisplayNamesWithType = symbol.Name,
                 DisplayQualifiedNames = symbol.Name,
             });
         }
@@ -100,6 +102,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 ReferenceItem.Parts[SyntaxLanguage.CSharp].Add(new LinkItem
                 {
                     DisplayName = "[]",
+                    DisplayNamesWithType = "[]",
                     DisplayQualifiedNames = "[]",
                 });
             }
@@ -108,6 +111,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 ReferenceItem.Parts[SyntaxLanguage.CSharp].Add(new LinkItem
                 {
                     DisplayName = "[" + new string(',', symbol.Rank - 1) + "]",
+                    DisplayNamesWithType = "[" + new string(',', symbol.Rank - 1) + "]",
                     DisplayQualifiedNames = "[" + new string(',', symbol.Rank - 1) + "]",
                 });
             }
@@ -119,6 +123,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.CSharp].Add(new LinkItem
             {
                 DisplayName = "*",
+                DisplayNamesWithType = "*",
                 DisplayQualifiedNames = "*",
             });
         }
@@ -129,6 +134,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.CSharp].Add(new LinkItem
             {
                 DisplayName = NameVisitorCreator.GetCSharp(NameOptions.WithGenericParameter).GetName(symbol),
+                DisplayNamesWithType = NameVisitorCreator.GetCSharp(NameOptions.WithType | NameOptions.WithGenericParameter).GetName(symbol),
                 DisplayQualifiedNames = NameVisitorCreator.GetCSharp(NameOptions.Qualified | NameOptions.WithGenericParameter).GetName(symbol),
                 Name = id,
                 IsExternalPath = symbol.IsExtern || symbol.DeclaringSyntaxReferences.Length == 0,
@@ -136,6 +142,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.CSharp].Add(new LinkItem
             {
                 DisplayName = "(",
+                DisplayNamesWithType = "(",
                 DisplayQualifiedNames = "(",
             });
             for (int i = 0; i < symbol.Parameters.Length; i++)
@@ -145,6 +152,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                     ReferenceItem.Parts[SyntaxLanguage.CSharp].Add(new LinkItem
                     {
                         DisplayName = ", ",
+                        DisplayNamesWithType = ", ",
                         DisplayQualifiedNames = ", ",
                     });
                 }
@@ -153,6 +161,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.CSharp].Add(new LinkItem
             {
                 DisplayName = ")",
+                DisplayNamesWithType = ")",
                 DisplayQualifiedNames = ")",
             });
         }
@@ -163,6 +172,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.CSharp].Add(new LinkItem
             {
                 DisplayName = NameVisitorCreator.GetCSharp(NameOptions.WithGenericParameter).GetName(symbol),
+                DisplayNamesWithType = NameVisitorCreator.GetCSharp(NameOptions.WithType | NameOptions.WithGenericParameter).GetName(symbol),
                 DisplayQualifiedNames = NameVisitorCreator.GetCSharp(NameOptions.Qualified | NameOptions.WithGenericParameter).GetName(symbol),
                 Name = id,
                 IsExternalPath = symbol.IsExtern || symbol.DeclaringSyntaxReferences.Length == 0,
@@ -173,6 +183,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 ReferenceItem.Parts[SyntaxLanguage.CSharp].Add(new LinkItem
                 {
                     DisplayName = "[",
+                    DisplayNamesWithType = "[",
                     DisplayQualifiedNames = "[",
                 });
                 for (int i = 0; i < symbol.Parameters.Length; i++)
@@ -182,6 +193,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                         ReferenceItem.Parts[SyntaxLanguage.CSharp].Add(new LinkItem
                         {
                             DisplayName = ", ",
+                            DisplayNamesWithType = ", ",
                             DisplayQualifiedNames = ", ",
                         });
                     }
@@ -190,6 +202,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 ReferenceItem.Parts[SyntaxLanguage.CSharp].Add(new LinkItem
                 {
                     DisplayName = "]",
+                    DisplayNamesWithType = "]",
                     DisplayQualifiedNames = "]",
                 });
             }
@@ -201,6 +214,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.CSharp].Add(new LinkItem
             {
                 DisplayName = NameVisitorCreator.GetCSharp(NameOptions.WithGenericParameter).GetName(symbol),
+                DisplayNamesWithType = NameVisitorCreator.GetCSharp(NameOptions.WithType | NameOptions.WithGenericParameter).GetName(symbol),
                 DisplayQualifiedNames = NameVisitorCreator.GetCSharp(NameOptions.Qualified | NameOptions.WithGenericParameter).GetName(symbol),
                 Name = id,
                 IsExternalPath = symbol.IsExtern || symbol.DeclaringSyntaxReferences.Length == 0,
@@ -213,6 +227,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.CSharp].Add(new LinkItem
             {
                 DisplayName = NameVisitorCreator.GetCSharp(NameOptions.WithGenericParameter).GetName(symbol),
+                DisplayNamesWithType = NameVisitorCreator.GetCSharp(NameOptions.WithType | NameOptions.WithGenericParameter).GetName(symbol),
                 DisplayQualifiedNames = NameVisitorCreator.GetCSharp(NameOptions.Qualified | NameOptions.WithGenericParameter).GetName(symbol),
                 Name = id,
                 IsExternalPath = symbol.IsExtern || symbol.DeclaringSyntaxReferences.Length == 0,
@@ -224,6 +239,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.CSharp].Add(new LinkItem
             {
                 DisplayName = "<",
+                DisplayNamesWithType = "<",
                 DisplayQualifiedNames = "<",
             });
         }
@@ -233,6 +249,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.CSharp].Add(new LinkItem
             {
                 DisplayName = ">",
+                DisplayNamesWithType = ">",
                 DisplayQualifiedNames = ">",
             });
         }
@@ -242,6 +259,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.CSharp].Add(new LinkItem
             {
                 DisplayName = ", ",
+                DisplayNamesWithType = ", ",
                 DisplayQualifiedNames = ", ",
             });
         }
@@ -254,6 +272,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 ReferenceItem.Parts[SyntaxLanguage.CSharp].Add(new LinkItem
                 {
                     DisplayName = NameVisitorCreator.GetCSharp(NameOptions.WithGenericParameter).GetName(symbol),
+                    DisplayNamesWithType = NameVisitorCreator.GetCSharp(NameOptions.WithType | NameOptions.WithGenericParameter).GetName(symbol),
                     DisplayQualifiedNames = NameVisitorCreator.GetCSharp(NameOptions.Qualified | NameOptions.WithGenericParameter).GetName(symbol),
                     Name = id,
                     IsExternalPath = symbol.IsExtern || symbol.DeclaringSyntaxReferences.Length == 0,
@@ -264,6 +283,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 ReferenceItem.Parts[SyntaxLanguage.CSharp].Add(new LinkItem
                 {
                     DisplayName = NameVisitorCreator.GetCSharp(NameOptions.None).GetName(symbol),
+                    DisplayNamesWithType = NameVisitorCreator.GetCSharp(NameOptions.WithType).GetName(symbol),
                     DisplayQualifiedNames = NameVisitorCreator.GetCSharp(NameOptions.Qualified).GetName(symbol),
                     Name = id,
                     IsExternalPath = symbol.IsExtern || symbol.DeclaringSyntaxReferences.Length == 0,
@@ -288,6 +308,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.VB].Add(new LinkItem
             {
                 DisplayName = NameVisitorCreator.GetVB(NameOptions.None).GetName(symbol),
+                DisplayNamesWithType = NameVisitorCreator.GetVB(NameOptions.WithType).GetName(symbol),
                 DisplayQualifiedNames = NameVisitorCreator.GetVB(NameOptions.Qualified).GetName(symbol),
             });
         }
@@ -297,6 +318,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.VB].Add(new LinkItem
             {
                 DisplayName = symbol.Name,
+                DisplayNamesWithType = symbol.Name,
                 DisplayQualifiedNames = symbol.Name,
             });
         }
@@ -309,6 +331,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 ReferenceItem.Parts[SyntaxLanguage.VB].Add(new LinkItem
                 {
                     DisplayName = "()",
+                    DisplayNamesWithType = "()",
                     DisplayQualifiedNames = "()",
                 });
             }
@@ -317,6 +340,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 ReferenceItem.Parts[SyntaxLanguage.VB].Add(new LinkItem
                 {
                     DisplayName = "(" + new string(',', symbol.Rank - 1) + ")",
+                    DisplayNamesWithType = "(" + new string(',', symbol.Rank - 1) + ")",
                     DisplayQualifiedNames = "(" + new string(',', symbol.Rank - 1) + ")",
                 });
             }
@@ -328,6 +352,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.VB].Add(new LinkItem
             {
                 DisplayName = "*",
+                DisplayNamesWithType = "*",
                 DisplayQualifiedNames = "*",
             });
         }
@@ -338,6 +363,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.VB].Add(new LinkItem
             {
                 DisplayName = NameVisitorCreator.GetVB(NameOptions.WithGenericParameter).GetName(symbol),
+                DisplayNamesWithType = NameVisitorCreator.GetVB(NameOptions.WithType | NameOptions.WithGenericParameter).GetName(symbol),
                 DisplayQualifiedNames = NameVisitorCreator.GetVB(NameOptions.Qualified | NameOptions.WithGenericParameter).GetName(symbol),
                 Name = id,
                 IsExternalPath = symbol.IsExtern || symbol.DeclaringSyntaxReferences.Length == 0,
@@ -345,6 +371,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.VB].Add(new LinkItem
             {
                 DisplayName = "(",
+                DisplayNamesWithType = "(",
                 DisplayQualifiedNames = "(",
             });
             for (int i = 0; i < symbol.Parameters.Length; i++)
@@ -354,6 +381,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                     ReferenceItem.Parts[SyntaxLanguage.VB].Add(new LinkItem
                     {
                         DisplayName = ", ",
+                        DisplayNamesWithType = ", ",
                         DisplayQualifiedNames = ", ",
                     });
                 }
@@ -362,6 +390,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.VB].Add(new LinkItem
             {
                 DisplayName = ")",
+                DisplayNamesWithType = ")",
                 DisplayQualifiedNames = ")",
             });
         }
@@ -372,6 +401,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.VB].Add(new LinkItem
             {
                 DisplayName = NameVisitorCreator.GetVB(NameOptions.WithGenericParameter).GetName(symbol),
+                DisplayNamesWithType = NameVisitorCreator.GetVB(NameOptions.WithType | NameOptions.WithGenericParameter).GetName(symbol),
                 DisplayQualifiedNames = NameVisitorCreator.GetVB(NameOptions.Qualified | NameOptions.WithGenericParameter).GetName(symbol),
                 Name = id,
                 IsExternalPath = symbol.IsExtern || symbol.DeclaringSyntaxReferences.Length == 0,
@@ -381,6 +411,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 ReferenceItem.Parts[SyntaxLanguage.VB].Add(new LinkItem
                 {
                     DisplayName = "(",
+                    DisplayNamesWithType = "(",
                     DisplayQualifiedNames = "(",
                 });
                 for (int i = 0; i < symbol.Parameters.Length; i++)
@@ -390,6 +421,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                         ReferenceItem.Parts[SyntaxLanguage.VB].Add(new LinkItem
                         {
                             DisplayName = ", ",
+                            DisplayNamesWithType = ", ",
                             DisplayQualifiedNames = ", ",
                         });
                     }
@@ -398,6 +430,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 ReferenceItem.Parts[SyntaxLanguage.VB].Add(new LinkItem
                 {
                     DisplayName = ")",
+                    DisplayNamesWithType = ")",
                     DisplayQualifiedNames = ")",
                 });
             }
@@ -409,6 +442,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.VB].Add(new LinkItem
             {
                 DisplayName = NameVisitorCreator.GetVB(NameOptions.WithGenericParameter).GetName(symbol),
+                DisplayNamesWithType = NameVisitorCreator.GetVB(NameOptions.WithType | NameOptions.WithGenericParameter).GetName(symbol),
                 DisplayQualifiedNames = NameVisitorCreator.GetVB(NameOptions.Qualified | NameOptions.WithGenericParameter).GetName(symbol),
                 Name = id,
                 IsExternalPath = symbol.IsExtern || symbol.DeclaringSyntaxReferences.Length == 0,
@@ -421,6 +455,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.VB].Add(new LinkItem
             {
                 DisplayName = NameVisitorCreator.GetVB(NameOptions.WithGenericParameter).GetName(symbol),
+                DisplayNamesWithType = NameVisitorCreator.GetVB(NameOptions.WithType | NameOptions.WithGenericParameter).GetName(symbol),
                 DisplayQualifiedNames = NameVisitorCreator.GetVB(NameOptions.Qualified | NameOptions.WithGenericParameter).GetName(symbol),
                 Name = id,
                 IsExternalPath = symbol.IsExtern || symbol.DeclaringSyntaxReferences.Length == 0,
@@ -432,6 +467,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.VB].Add(new LinkItem
             {
                 DisplayName = "(Of ",
+                DisplayNamesWithType = "(Of ",
                 DisplayQualifiedNames = "(Of ",
             });
         }
@@ -441,6 +477,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.VB].Add(new LinkItem
             {
                 DisplayName = ")",
+                DisplayNamesWithType = ")",
                 DisplayQualifiedNames = ")",
             });
         }
@@ -450,6 +487,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             ReferenceItem.Parts[SyntaxLanguage.VB].Add(new LinkItem
             {
                 DisplayName = ", ",
+                DisplayNamesWithType = ", ",
                 DisplayQualifiedNames = ", ",
             });
         }
@@ -462,6 +500,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 ReferenceItem.Parts[SyntaxLanguage.VB].Add(new LinkItem
                 {
                     DisplayName = NameVisitorCreator.GetVB(NameOptions.WithGenericParameter).GetName(symbol),
+                    DisplayNamesWithType = NameVisitorCreator.GetVB(NameOptions.WithType | NameOptions.WithGenericParameter).GetName(symbol),
                     DisplayQualifiedNames = NameVisitorCreator.GetVB(NameOptions.Qualified | NameOptions.WithGenericParameter).GetName(symbol),
                     Name = id,
                     IsExternalPath = symbol.IsExtern || symbol.DeclaringSyntaxReferences.Length == 0,
@@ -472,6 +511,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 ReferenceItem.Parts[SyntaxLanguage.VB].Add(new LinkItem
                 {
                     DisplayName = NameVisitorCreator.GetVB(NameOptions.None).GetName(symbol),
+                    DisplayNamesWithType = NameVisitorCreator.GetVB(NameOptions.WithType).GetName(symbol),
                     DisplayQualifiedNames = NameVisitorCreator.GetVB(NameOptions.Qualified).GetName(symbol),
                     Name = id,
                     IsExternalPath = symbol.IsExtern || symbol.DeclaringSyntaxReferences.Length == 0,

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Visitors/SymbolVisitorAdapter.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Visitors/SymbolVisitorAdapter.cs
@@ -64,6 +64,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             };
 
             item.DisplayNames = new SortedList<SyntaxLanguage, string>();
+            item.DisplayNamesWithType = new SortedList<SyntaxLanguage, string>();
             item.DisplayQualifiedNames = new SortedList<SyntaxLanguage, string>();
             item.Source = VisitorHelper.GetSourceDetail(symbol);
             var assemblyName = symbol.ContainingAssembly?.Name;

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Visitors/VBYamlModelGenerator.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Visitors/VBYamlModelGenerator.cs
@@ -31,6 +31,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
         public override void DefaultVisit(ISymbol symbol, MetadataItem item, SymbolVisitorAdapter adapter)
         {
             item.DisplayNames[SyntaxLanguage.VB] = NameVisitorCreator.GetVB(NameOptions.WithGenericParameter | NameOptions.WithParameter).GetName(symbol);
+            item.DisplayNamesWithType[SyntaxLanguage.VB] = NameVisitorCreator.GetVB(NameOptions.WithType | NameOptions.WithGenericParameter | NameOptions.WithParameter).GetName(symbol);
             item.DisplayQualifiedNames[SyntaxLanguage.VB] = NameVisitorCreator.GetVB(NameOptions.Qualified | NameOptions.WithGenericParameter | NameOptions.WithParameter).GetName(symbol);
         }
 

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/YamlViewModelExtensions.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/YamlViewModelExtensions.cs
@@ -187,6 +187,18 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                     result.NameInDevLangs[Constants.DevLang.VB] = nameForVB;
                 }
 
+                result.NameWithType = GetName(model.Value, SyntaxLanguage.Default, l => l.DisplayNamesWithType);
+                var nameWithTypeForCSharp = GetName(model.Value, SyntaxLanguage.CSharp, l => l.DisplayNamesWithType);
+                if (result.NameWithType != nameWithTypeForCSharp)
+                {
+                    result.NameWithTypeInDevLangs[Constants.DevLang.CSharp] = nameWithTypeForCSharp;
+                }
+                var nameWithTypeForVB = GetName(model.Value, SyntaxLanguage.VB, l => l.DisplayNamesWithType);
+                if (result.NameWithType != nameWithTypeForVB)
+                {
+                    result.NameWithTypeInDevLangs[Constants.DevLang.VB] = nameWithTypeForVB;
+                }
+
                 result.FullName = GetName(model.Value, SyntaxLanguage.Default, l => l.DisplayQualifiedNames);
                 var fullnameForCSharp = GetName(model.Value, SyntaxLanguage.CSharp, l => l.DisplayQualifiedNames);
                 if (result.FullName != fullnameForCSharp)
@@ -332,6 +344,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             {
                 Uid = model.Name,
                 Name = model.DisplayName,
+                NameWithType = model.DisplayNamesWithType,
                 FullName = model.DisplayQualifiedNames,
                 IsExternal = model.IsExternalPath,
                 Href = model.Href,

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/YamlViewModelExtensions.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/YamlViewModelExtensions.cs
@@ -255,6 +255,18 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 result.NameForVB = nameForVB;
             }
 
+            result.NameWithType = model.DisplayNamesWithType.GetLanguageProperty(SyntaxLanguage.Default);
+            var nameWithTypeForCSharp = model.DisplayNamesWithType.GetLanguageProperty(SyntaxLanguage.CSharp);
+            if (result.NameWithType != nameWithTypeForCSharp)
+            {
+                result.NameWithTypeForCSharp = nameWithTypeForCSharp;
+            }
+            var nameWithTypeForVB = model.DisplayNamesWithType.GetLanguageProperty(SyntaxLanguage.VB);
+            if (result.NameWithType != nameWithTypeForVB)
+            {
+                result.NameWithTypeForVB = nameWithTypeForVB;
+            }
+
             result.FullName = model.DisplayQualifiedNames.GetLanguageProperty(SyntaxLanguage.Default);
             var fullnameForCSharp = model.DisplayQualifiedNames.GetLanguageProperty(SyntaxLanguage.CSharp);
             if (result.FullName != fullnameForCSharp)


### PR DESCRIPTION
When display inheritedMembers/implements/overrides, it's clearer to show member's name with its type.

@chenkennt @vwxyzh @ansyral @hellosnow @qinezh 