### PR TITLE
When merging ReferenceItem.IsDefinition, use the same resolution as ReferenceItem.Definition

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Models/ReferenceItem.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Models/ReferenceItem.cs
@@ -63,8 +63,9 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
         public void Merge(ReferenceItem other)
         {
             if (other == null) throw new ArgumentNullException(nameof(other));
-            IsDefinition = Merge(other.IsDefinition, IsDefinition);
             Definition = Merge(other.Definition, Definition);
+            if (Definition == other.Definition)
+                IsDefinition = other.IsDefinition;
             Parent = Merge(other.Parent, Parent);
 
             if (other.Parts != null && Parts != null)


### PR DESCRIPTION
I had some problem with https://github.com/dotnet/docfx/blob/master/src/Microsoft.DocAsCode.Metadata.ManagedReference/Models/ReferenceItem.cs#L66
The Debug.Assert fails because I have a merge with IsDefinition == true on one side and IsDefinition == false on the other.

I changed it so that IsDefinition pick the same side as Merge of ReferenceItem.Definition.
Not sure if this is the right things to do, but at least it prevents it from Debug.Assert => crash