### PR TITLE
fix bug for extension method: 1. overload non-generic extension methods 2. multiple retargeted symbol founded

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/CodeAnalysisSymbolExtensions.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/CodeAnalysisSymbolExtensions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
         /// <returns>related symbol in the compilation</returns>
         public static ISymbol FindSymbol(this INamespaceOrTypeSymbol container, ISymbol symbol)
         {
-            return FindCore(container, GetQualifiedNameList(symbol)).SingleOrDefault(m => m.GetDocumentationCommentId() == symbol.GetDocumentationCommentId());
+            return FindCore(container, GetQualifiedNameList(symbol)).Where(m => VisitorHelper.GetCommentId(m) == VisitorHelper.GetCommentId(symbol)).FirstOrDefault();
         }
 
         private static IEnumerable<ISymbol> FindCore(INamespaceOrTypeSymbol container, List<string> parts)

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Visitors/SpecIdHelper.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Visitors/SpecIdHelper.cs
@@ -28,6 +28,11 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 id = SpecMethodGenericParameter(methodGenericParameters, id);
             }
             id = SpecTypeGenericParameter(typeGenericParameters, id);
+            if (symbol is IMethodSymbol)
+            {
+                id = SpecExtensionMethodReceiverType(symbol as IMethodSymbol, id);
+            }
+            
             return id;
         }
 
@@ -75,6 +80,23 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                     Debug.Assert(names.Count > int.Parse(match.Value.Substring(2)));
                     return "{" + names[int.Parse(match.Value.Substring(2))] + "}";
                 });
+        }
+
+        /// <summary>
+        /// spec extension method's receiver type. 
+        /// for below overload: M(this A), M(this A, A), AddReference applies to the first method and AddSpecReference applies to the second method might get same id without prepending receiver type.
+        /// </summary>
+        /// <param name="symbol">symbol</param>
+        /// <param name="id">id</param>
+        /// <returns>id prefixed with receiver type</returns>
+        private static string SpecExtensionMethodReceiverType(IMethodSymbol symbol, string id)
+        {
+            if (symbol.ReducedFrom == null || symbol.ReceiverType == null)
+            {
+                return id;
+            }
+
+            return VisitorHelper.GetId(symbol.ReceiverType) + "." + id;
         }
     }
 }

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromCSUnitTest.cs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromCSUnitTest.cs
@@ -996,12 +996,19 @@ namespace Test1
     public class FooImple3<T> : Foo<Foo<T[]>>
     {
     }
+    public class Doll
+    {
+    }
 
     public static class Extension
     {
         public static void Eat<Tool>(this FooImple<Tool> impl)
         { }
         public static void Play<Tool, Way>(this Foo<Tool> foo, Tool t, Way w)
+        { }
+        public static void Rain(this Doll d)
+        { }
+        public static void Rain(this Doll d, Doll another)
         { }
     }
 }
@@ -1023,7 +1030,7 @@ namespace Test1
             var extensionMethods = output.Items[0].Items[1].ExtensionMethods;
             Assert.Equal(2, extensionMethods.Count);
             {
-                Assert.Equal("Test1.Extension.Eat``1", extensionMethods[0]);
+                Assert.Equal("Test1.FooImple`1.Test1.Extension.Eat``1", extensionMethods[0]);
                 var reference = output.References[extensionMethods[0]];
                 Assert.Equal(false, reference.IsDefinition);
                 Assert.Equal("Test1.Extension.Eat``1(Test1.FooImple{``0})", reference.Definition);
@@ -1031,7 +1038,7 @@ namespace Test1
                 Assert.Equal("Extension.Eat<T>()", string.Concat(reference.Parts[SyntaxLanguage.CSharp].Select(n => n.DisplayNamesWithType)));
             }
             {
-                Assert.Equal("Test1.Extension.Play``2({T}[],{Way})", extensionMethods[1]);
+                Assert.Equal("Test1.Foo{`0[]}.Test1.Extension.Play``2({T}[],{Way})", extensionMethods[1]);
                 var reference = output.References[extensionMethods[1]];
                 Assert.Equal(false, reference.IsDefinition);
                 Assert.Equal("Test1.Extension.Play``2(Test1.Foo{``0},``0,``1)", reference.Definition);
@@ -1042,7 +1049,7 @@ namespace Test1
             extensionMethods = output.Items[0].Items[2].ExtensionMethods;
             Assert.Equal(1, extensionMethods.Count);
             {
-                Assert.Equal("Test1.Extension.Play``2(System.Object,{Way})", extensionMethods[0]);
+                Assert.Equal("Test1.Foo{System.Object}.Test1.Extension.Play``2(System.Object,{Way})", extensionMethods[0]);
                 var reference = output.References[extensionMethods[0]];
                 Assert.Equal(false, reference.IsDefinition);
                 Assert.Equal("Test1.Extension.Play``2(Test1.Foo{``0},``0,``1)", reference.Definition);
@@ -1053,12 +1060,31 @@ namespace Test1
             extensionMethods = output.Items[0].Items[3].ExtensionMethods;
             Assert.Equal(1, extensionMethods.Count);
             {
-                Assert.Equal("Test1.Extension.Play``2(Test1.Foo{{T}[]},{Way})", extensionMethods[0]);
+                Assert.Equal("Test1.Foo{Test1.Foo{`0[]}}.Test1.Extension.Play``2(Test1.Foo{{T}[]},{Way})", extensionMethods[0]);
                 var reference = output.References[extensionMethods[0]];
                 Assert.Equal(false, reference.IsDefinition);
                 Assert.Equal("Test1.Extension.Play``2(Test1.Foo{``0},``0,``1)", reference.Definition);
                 Assert.Equal("Play<Foo<T[]>, Way>(Foo<T[]>, Way)", string.Concat(reference.Parts[SyntaxLanguage.CSharp].Select(n => n.DisplayName)));
                 Assert.Equal("Extension.Play<Foo<T[]>, Way>(Foo<T[]>, Way)", string.Concat(reference.Parts[SyntaxLanguage.CSharp].Select(n => n.DisplayNamesWithType)));
+            }
+            // Doll
+            extensionMethods = output.Items[0].Items[4].ExtensionMethods;
+            Assert.Equal(2, extensionMethods.Count);
+            {
+                Assert.Equal("Test1.Doll.Test1.Extension.Rain", extensionMethods[0]);
+                var reference = output.References[extensionMethods[0]];
+                Assert.Equal(false, reference.IsDefinition);
+                Assert.Equal("Test1.Extension.Rain(Test1.Doll)", reference.Definition);
+                Assert.Equal("Rain()", string.Concat(reference.Parts[SyntaxLanguage.CSharp].Select(n => n.DisplayName)));
+                Assert.Equal("Extension.Rain()", string.Concat(reference.Parts[SyntaxLanguage.CSharp].Select(n => n.DisplayNamesWithType)));
+            }
+            {
+                Assert.Equal("Test1.Doll.Test1.Extension.Rain(Test1.Doll)", extensionMethods[1]);
+                var reference = output.References[extensionMethods[1]];
+                Assert.Equal(false, reference.IsDefinition);
+                Assert.Equal("Test1.Extension.Rain(Test1.Doll,Test1.Doll)", reference.Definition);
+                Assert.Equal("Rain(Doll)", string.Concat(reference.Parts[SyntaxLanguage.CSharp].Select(n => n.DisplayName)));
+                Assert.Equal("Extension.Rain(Doll)", string.Concat(reference.Parts[SyntaxLanguage.CSharp].Select(n => n.DisplayNamesWithType)));
             }
         }
 


### PR DESCRIPTION
@chenkennt @vwxyzh @hellosnow @superyyrrzz @qinezh 