### PR TITLE
Encode invalid html tag as that should be regarded as normal text to keep same behavior with GitHub

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdownLite/Regexes.cs
+++ b/src/Microsoft.DocAsCode.MarkdownLite/Regexes.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DocAsCode.MarkdownLite
             public static readonly Regex Comment = new Regex(@"^<!--[\s\S]*?-->", RegexOptionCompiled);
             public static readonly Regex AutoLink = new Regex(@"^<([^ >]+(@|:\/)[^ >]+)>", RegexOptionCompiled);
             public static readonly Regex CodeElement = new Regex(@"^\<code\>[\s\S]*?\</code\>", RegexOptionCompiled | RegexOptions.IgnoreCase);
-            public static readonly Regex Tag = new Regex(@"^<\/?\w+(?:""[^""]*""|'[^']*'|[^'"">])*?>", RegexOptionCompiled);
+            public static readonly Regex Tag = new Regex(@"^<\/?([A-Z]|[a-z])\w*(?:""[^""]*""|'[^']*'|[^'"">])*?>", RegexOptionCompiled);
             /// <summary>
             /// <![CDATA[
             /// ^                                           start of string

--- a/test/Microsoft.DocAsCode.Dfm.Tests/DocfxFlavoredMarkdownTest.cs
+++ b/test/Microsoft.DocAsCode.Dfm.Tests/DocfxFlavoredMarkdownTest.cs
@@ -584,6 +584,20 @@ outlookClient.me.events.getEvents().fetch().then(function(result) {
 
         [Fact]
         [Trait("Related", "DfmMarkdown")]
+        public void TestDfm_EncodeInStrongEM()
+        {
+            var source = @"tag started with non-alphabet should be encoded <1-100>, <_hello>, <?world>, <1_2 href=""good"">, <1 att='bcd'>.
+tag started with alphabet should not be encode: <abc> <a-hello> <a?world> <a_b href=""good""> <AC att='bcd'>";
+
+            var expected = @"<p>tag started with non-alphabet should be encoded &lt;1-100&gt;, &lt;_hello&gt;, &lt;?world&gt;, &lt;1_2 href=&quot;good&quot;&gt;, &lt;1 att=&#39;bcd&#39;&gt;.
+tag started with alphabet should not be encode: <abc> <a-hello> <a?world> <a_b href=""good""> <AC att='bcd'></p>
+";
+            var marked = DocfxFlavoredMarked.Markup(source);
+            Assert.Equal(expected.Replace("\r\n", "\n"), marked);
+        }
+
+        [Fact]
+        [Trait("Related", "DfmMarkdown")]
         public void TestDfmImageLink_WithSpecialCharactorsInAltText()
         {
             var source = @"![This is image alt text with quotation ' and double quotation ""hello"" world](girl.png)";


### PR DESCRIPTION
as title. Sample:
<1-100>, <_hello>, <?world>, <1_2 href=""good"">, <1 att='bcd'> should be encoded.
<abc> <a-hello> <a?world> <a_b href=""good""> <AC att='bcd'> should keep same.