### PR TITLE
fix: escape in link.

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdownLite/Basic/InlineRules/MarkdownLinkBaseInlineRule.cs
+++ b/src/Microsoft.DocAsCode.MarkdownLite/Basic/InlineRules/MarkdownLinkBaseInlineRule.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DocAsCode.MarkdownLite
 
         protected virtual IMarkdownToken GenerateToken(IMarkdownParser parser, string href, string title, string text, bool isImage, SourceInfo sourceInfo)
         {
-            var escapedHref = StringHelper.Escape(href);
+            var escapedHref = StringHelper.Escape(Regexes.Helper.Escape.Replace(href, m => m.Groups[1].Value));
             var escapedTitle = !string.IsNullOrEmpty(title) ? StringHelper.Escape(title) : null;
             if (isImage)
             {

--- a/src/Microsoft.DocAsCode.MarkdownLite/Basic/InlineRules/MarkdownLinkInlineRule.cs
+++ b/src/Microsoft.DocAsCode.MarkdownLite/Basic/InlineRules/MarkdownLinkInlineRule.cs
@@ -18,8 +18,24 @@ namespace Microsoft.DocAsCode.MarkdownLite
             {
                 return null;
             }
+            if (IsEscape(match.Groups[1].Value) || IsEscape(match.Groups[2].Value))
+            {
+                return null;
+            }
             var sourceInfo = context.Consume(match.Length);
             return GenerateToken(parser, match.Groups[2].Value, match.Groups[4].Value, match.Groups[1].Value, match.Value[0] == '!', sourceInfo);
+        }
+
+        private bool IsEscape(string text)
+        {
+            for (int i = text.Length - 1; i >= 0; i--)
+            {
+                if (text[i] != '\\')
+                {
+                    return (text.Length - i) % 2 == 0;
+                }
+            }
+            return text.Length % 2 == 1;
         }
     }
 }

--- a/src/Microsoft.DocAsCode.MarkdownLite/MarkdownRenderer.cs
+++ b/src/Microsoft.DocAsCode.MarkdownLite/MarkdownRenderer.cs
@@ -21,11 +21,11 @@ namespace Microsoft.DocAsCode.MarkdownLite
             content += "![";
             content += token.Text;
             content += "](";
-            content += StringHelper.Unescape(token.Href);
+            content += Regexes.Helper.MarkdownUnescape.Replace(StringHelper.Unescape(token.Href), m => "\\" + m.Value);
             if (!string.IsNullOrEmpty(token.Title))
             {
                 content += " \"";
-                content += StringHelper.Unescape(token.Title);
+                content += Regexes.Helper.MarkdownUnescape.Replace(StringHelper.Unescape(token.Title), m => "\\" + m.Value);
                 content += "\"";
             }
             content += ")";
@@ -41,11 +41,11 @@ namespace Microsoft.DocAsCode.MarkdownLite
                 content += render.Render(t);
             }
             content += "](";
-            content += StringHelper.Unescape(token.Href);
+            content += Regexes.Helper.MarkdownUnescape.Replace(StringHelper.Unescape(token.Href), m => "\\" + m.Value);
             if (!string.IsNullOrEmpty(token.Title))
             {
                 content += " \"";
-                content += StringHelper.Unescape(token.Title);
+                content += Regexes.Helper.MarkdownUnescape.Replace(StringHelper.Unescape(token.Title), m => "\\" + m.Value);
                 content += "\"";
             }
             content += ")";

--- a/src/Microsoft.DocAsCode.MarkdownLite/Regexes.cs
+++ b/src/Microsoft.DocAsCode.MarkdownLite/Regexes.cs
@@ -158,7 +158,8 @@ namespace Microsoft.DocAsCode.MarkdownLite
             public static readonly Regex EscapeWithoutEncode = new Regex(@"&(?!#?\w+;)", RegexOptionCompiled);
 
             public static readonly Regex Unescape = new Regex(@"&([#\w]+);", RegexOptionCompiled);
-
+            public static readonly Regex Escape = new Regex(@"\\([\\`*{}\[\]()#+\-.!_>])", RegexOptionCompiled);
+            public static readonly Regex MarkdownUnescape = new Regex(@"[\\()\[\]]", RegexOptionCompiled);
         }
     }
 }

--- a/test/Microsoft.DocAsCode.Dfm.Tests/DocfxFlavoredMarkdownTest.cs
+++ b/test/Microsoft.DocAsCode.Dfm.Tests/DocfxFlavoredMarkdownTest.cs
@@ -625,7 +625,7 @@ tag started with alphabet should not be encode: <abc> <a-hello> <a?world> <a_b h
         public void TestPathUtility_AbsoluteLinkWithBracketAndBrackt()
         {
             var source = @"[User-Defined Date/Time Formats (Format Function)](http://msdn2.microsoft.com/library/73ctwf33\(VS.90\).aspx)";
-            var expected = @"<p><a href=""http://msdn2.microsoft.com/library/73ctwf33\(VS.90\).aspx"">User-Defined Date/Time Formats (Format Function)</a></p>
+            var expected = @"<p><a href=""http://msdn2.microsoft.com/library/73ctwf33(VS.90).aspx"">User-Defined Date/Time Formats (Format Function)</a></p>
 ";
             var marked = DocfxFlavoredMarked.Markup(source);
             Assert.Equal(expected.Replace("\r\n", "\n"), marked);

--- a/test/Microsoft.DocAsCode.MarkdownLite.Tests/GfmTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdownLite.Tests/GfmTest.cs
@@ -432,6 +432,22 @@ aaa",
             @"<!--aaa-->
 <p>aaa</p>
 ")]
+        [InlineData(
+            @"[a\](b)",
+            @"<p>[a](b)</p>
+")]
+        [InlineData(
+            @"[a](b\)",
+            @"<p>[a](b)</p>
+")]
+        [InlineData(
+            @"[a\\](b)",
+            @"<p><a href=""b"">a\</a></p>
+")]
+        [InlineData(
+            @"[a](b\\)",
+            @"<p><a href=""b\"">a</a></p>
+")]
         #endregion
         public void TestGfmInGeneral(string source, string expected)
         {

--- a/test/Microsoft.DocAsCode.MarkdownRewriters.Tests/AzureMarkdownRewritersTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdownRewriters.Tests/AzureMarkdownRewritersTest.cs
@@ -611,7 +611,7 @@ this is absolute link [text](c:/this/is/markdown ""Local File"") file ref
 [Ref a non md resource in another docset](ex_resource/docset2Resource.html)
 ![Ref a image content in another docset](ex_resource/docset2Image.png)
 ![Ref a image content not in another docset](../docset2/docset2FakeImage.png)
-![Ref a abs path image content in another docset](c:\\docset2\fullNameImage.img)
+![Ref a abs path image content in another docset](c:\\docset2\\fullNameImage.img)
 ![Ref a abs http image content in another docset](https://google/images/fullNameImage.img)
 
 ";
@@ -681,7 +681,7 @@ this is absolute link [text](c:/this/is/markdown ""Local File"") file ref
         public void TestAzureMarkdownRewriters_LinkRefWithBackslash()
         {
             var source = @"[User-Defined Date/Time Formats (Format Function)](https://github.com/Azure-Samples/active-directory-java-webapp-openidconnect\/archive/complete.zip)";
-            var expected = @"[User-Defined Date/Time Formats (Format Function)](https://github.com/Azure-Samples/active-directory-java-webapp-openidconnect\/archive/complete.zip)
+            var expected = @"[User-Defined Date/Time Formats (Format Function)](https://github.com/Azure-Samples/active-directory-java-webapp-openidconnect\\/archive/complete.zip)
 
 ";
             var result = AzureMarked.Markup(source);


### PR DESCRIPTION
* not link
  * `[a\](b)`
  * `[a](b\)`
* link
  * `[a](b\(c\))`
  * `[a](b\\)`