### PR TITLE
improve class link text in namespace

### DIFF
--- a/src/docfx.website.themes/default/partials/namespace.tmpl.partial
+++ b/src/docfx.website.themes/default/partials/namespace.tmpl.partial
@@ -15,7 +15,7 @@
 {{#children}}
   <h3 id="{{id}}">{{>partials/namespaceSubtitle}}</h3>
   {{#children}}
-    <h4>{{{specName.0.value}}}</h4>
+    <h4><xref href="{{uid}}" fullName="{{fullName.0.value}}" name="{{name.0.value}}"/></h4>
     <section>{{{summary}}}</section>
   {{/children}}
 {{/children}}


### PR DESCRIPTION
For generic type, this link should be [Cat\<T, K\>](e.g.) instead of [Cat](e.g.)\<T, K\>.

@vwxyzh @chenkennt @ansyral @hellosnow @qinezh 