### PR TITLE
use tocHref in toc.yml to specify toc

### DIFF
--- a/Documentation/tutorial/intro_toc.md
+++ b/Documentation/tutorial/intro_toc.md
@@ -64,11 +64,18 @@ Property Name | Type              | Description
 ------------- | ----------------- | ---------------------------
 *name*        | string            | Specifies the title of the *TOC Item*.
 *href*        | string            | Specifies the hyperlink of the *TOC Item*.
-*tocHref*     | string            | Specified another TOC file to be expanded in the currrent *TOC Item*.
-*homepage*    | string            | Specifies the homepage of the *TOC Item*. It is useful when *href* is linking to a folder.
-*uid*         | string            | Specifies the `uid` of the referenced file. If the value is set, it overwrites the value of *href*.
-*homepageUid* | string            | Specifies the `uid` of the homepage. If the value is set, it overwrites the value of *homepage*.
-*items*       | *TOC Item Object* | Specifies the children *TOC Items*s of current *TOC Item*.
+*items*       | *TOC Item Object* | Specifies the children *TOC Item*s of current *TOC Item*.
+
+**Advanced**: These properties is useful when a TOC links to or reference to another TOC, or links to a uid.
+
+Property Name                     | Type              | Description
+--------------------------------- | ----------------- | ---------------------------
+*tocHref*                         | string            | Specifies another TOC file to be expanded in the currrent *TOC Item*.
+*topicHref*                       | string            | Specifies the homepage of the referenced *TOC Item*. It is useful when *tocHref* is used.
+*topicUid*                        | string            | Specifies the `uid` of the homepage or the referenced file. If the value is set, it overwrites the value of *topicHref*.
+*homepage*                        | string            | Specifies the homepage of the *TOC Item*. It is useful when *href* is linking to a folder.
+~~*uid*~~ **Deprecated**          | string            | ~~Specifies the `uid` of the referenced file. If the value is set, it overwrites the value of *href*.~~ Use *topicUid* instead.
+~~*homepageUid*~~ **Deprecated**  | string            | ~~Specifies the `uid` of the homepage. If the value is set, it overwrites the value of *homepage*.~~ Use *topicUid* instead.
 
 Relative path in detail
 ---------------
@@ -103,14 +110,14 @@ Using *tocHref* to link to another *TOC File*
 
 This technique is always used when you want to combine several *TOC File*s into one single *TOC File*.
 
-~~If `homepage` is set for this *TOC Item*, it will be considered as the `href` of the expanded *TOC Item*.~~ The `href` of this *TOC Item* will remains as the `href` of the expanded *TOC Item*.
+If ~~`homepage`~~ `topicHref` is set for this *TOC Item*, it will be considered as the `href` of the expanded *TOC Item*.
 
 For example, one `toc.yml` file is like below:
 
 ```yml
 - name: How-to tutorials
   tocHref: howto/toc.yml
-  href: howto/overview.md
+  topicHref: howto/overview.md
 ```
 
 It references to the `toc.yml` file under folder `howto`, with the following content:
@@ -127,6 +134,7 @@ DocFX processes these `toc.yml` files and expands the uppder `toc.yml` file into
 ```yaml
 - name: How-to tutorials
   href: howto/overview.md
+  topicHref: howto/overview.md
   items:
     - name: "How-to1"
       href: howto/howto1.md

--- a/Documentation/tutorial/intro_toc.md
+++ b/Documentation/tutorial/intro_toc.md
@@ -89,7 +89,7 @@ If the *TOC Item* is linking to some other *TOC File*, it is considered as a pla
 
 This technique is always used when you want to combine several *TOC File*s into one single *TOC File*.
 
-If ~~`homepage`~~ `topicHref` is set for this *TOC Item*, it will be considered as the `href` of the expanded *TOC Item*.
+If `homepage` **or** `topicHref` is set for this *TOC Item*, it will be considered as the `href` of the expanded *TOC Item*.
 
 For example, one `toc.yml` file is like below:
 
@@ -117,8 +117,10 @@ DocFX processes these `toc.yml` files and expands the uppder `toc.yml` file into
   items:
     - name: "How-to1"
       href: howto/howto1.md
+      topichref: howto/howto1.md
     - name: "How-to2"
       href: howto/howto2.md
+      topichref: howto/howto2.md
 ```
 
 *NOTE* that the referenced `toc.yml` file under `howto` folder will not be transformed to the output folder even if it is included in `docfx.json`.

--- a/Documentation/tutorial/intro_toc.md
+++ b/Documentation/tutorial/intro_toc.md
@@ -97,9 +97,9 @@ If the *Toc Item* is linking to a folder, ending with `/` explicitly, the link v
 ### Link to local file
 If the *Toc Item* is linking to a local file, we call this local file *In-Toc File*. Make sure the file is included in `docfx.json`.
 
-Link to another *TOC File* using *tocHref*
+Using *tocHref* to link to another *TOC File*
 ------------------
-*tocHref* can link to some other *TOC File*. It is considered as a placeholder of the referenced *TOC File*, and DocFX will extract content from that *TOC File* and insert into current *TOC Item* **recursively**.
+*tocHref* can link to some other *TOC File*, for example, `tocHref: examples/toc.md`. It is considered as a placeholder of the referenced *TOC File*, and DocFX will extract content from that *TOC File* and insert into current *TOC Item* **recursively**.
 
 This technique is always used when you want to combine several *TOC File*s into one single *TOC File*.
 

--- a/Documentation/tutorial/intro_toc.md
+++ b/Documentation/tutorial/intro_toc.md
@@ -64,6 +64,7 @@ Property Name | Type              | Description
 ------------- | ----------------- | ---------------------------
 *name*        | string            | Specifies the title of the *TOC Item*.
 *href*        | string            | Specifies the hyperlink of the *TOC Item*.
+*tocHref*     | string            | Specified another TOC file to be expanded in the currrent *TOC Item*.
 *homepage*    | string            | Specifies the homepage of the *TOC Item*. It is useful when *href* is linking to a folder.
 *uid*         | string            | Specifies the `uid` of the referenced file. If the value is set, it overwrites the value of *href*.
 *homepageUid* | string            | Specifies the `uid` of the homepage. If the value is set, it overwrites the value of *homepage*.
@@ -73,50 +74,11 @@ Relative path in detail
 ---------------
 If a *TOC Item* is linking to some relative path, there are three cases:
 
-1. Linking to another *TOC File*, for example, `href: examples/toc.md`.
+1. **Deprecated** ~~Linking to another *TOC File*, for example, `href: examples/toc.md`.~~
 2. Linking to a folder, which means, the value of the link ends with `/` explicitly, for example, `href: examples/`
 3. Linking to some local file.
 
 Each case is described in detail below.
-
-### Link to another *TOC File*
-If the *TOC Item* is linking to some other *TOC File*, it is considered as a placeholder of the referenced *TOC File*, and DocFX will extract content from that *TOC File* and insert into current *TOC Item* **recursively**.
-
-This technique is always used when you want to combine several *TOC File*s into one single *TOC File*.
-
-If `homepage` is set for this *TOC Item*, it will be considered as the `href` of the expanded *TOC Item*.
-
-For example, one `toc.yml` file is like below:
-
-```yml
-- name: How-to tutorials
-  href: howto/toc.yml
-  homepage: howto/overview.md
-```
-
-It references to the `toc.yml` file under folder `howto`, with the following content:
-
-```yaml
-- name: "How-to1"
-  href: howto1.md
-- name: "How-to2"
-  href: howto2.md
-```
-
-DocFX processes these `toc.yml` files and expands the uppder `toc.yml` file into:
-
-```yaml
-
-- name: How-to tutorials
-  href: howto/overview.md
-  items:
-    - name: "How-to1"
-      href: howto/howto1.md
-    - name: "How-to2"
-      href: howto/howto2.md
-```
-
-*NOTE* that the referenced `toc.yml` file under `howto` folder will not be transformed to the output folder even if it is included in `docfx.json`.
 
 ### Link to a folder
 If the *Toc Item* is linking to a folder, ending with `/` explicitly, the link value for the *Toc Item* is determined in the following steps:
@@ -134,6 +96,45 @@ If the *Toc Item* is linking to a folder, ending with `/` explicitly, the link v
 
 ### Link to local file
 If the *Toc Item* is linking to a local file, we call this local file *In-Toc File*. Make sure the file is included in `docfx.json`.
+
+Link to another *TOC File* using *tocHref*
+------------------
+*tocHref* can link to some other *TOC File*. It is considered as a placeholder of the referenced *TOC File*, and DocFX will extract content from that *TOC File* and insert into current *TOC Item* **recursively**.
+
+This technique is always used when you want to combine several *TOC File*s into one single *TOC File*.
+
+~~If `homepage` is set for this *TOC Item*, it will be considered as the `href` of the expanded *TOC Item*.~~ The `href` of this *TOC Item* will remains as the `href` of the expanded *TOC Item*.
+
+For example, one `toc.yml` file is like below:
+
+```yml
+- name: How-to tutorials
+  tocHref: howto/toc.yml
+  href: howto/overview.md
+```
+
+It references to the `toc.yml` file under folder `howto`, with the following content:
+
+```yaml
+- name: "How-to1"
+  href: howto1.md
+- name: "How-to2"
+  href: howto2.md
+```
+
+DocFX processes these `toc.yml` files and expands the uppder `toc.yml` file into:
+
+```yaml
+- name: How-to tutorials
+  href: howto/overview.md
+  items:
+    - name: "How-to1"
+      href: howto/howto1.md
+    - name: "How-to2"
+      href: howto/howto2.md
+```
+
+*NOTE* that the referenced `toc.yml` file under `howto` folder will not be transformed to the output folder even if it is included in `docfx.json`.
 
 Not-In-Toc Files
 ----------------

--- a/Documentation/tutorial/intro_toc.md
+++ b/Documentation/tutorial/intro_toc.md
@@ -40,14 +40,14 @@ Three kinds of links are supported:
 ```yml
 - name:
   href:
-  homepage:
+  topicHref:
 - name:
   href:
-  homepage:
+  topicHref:
   items:
     - name:
       href:
-      homepage:
+      topicHref:
 ```
 
 Comparing to `toc.md`, `toc.yml` represents a structured data model and conforms to the [YAML standard](http://www.yaml.org/spec/1.2/spec.html). It supports advanced functionalities.
@@ -64,49 +64,31 @@ Property Name | Type              | Description
 ------------- | ----------------- | ---------------------------
 *name*        | string            | Specifies the title of the *TOC Item*.
 *href*        | string            | Specifies the hyperlink of the *TOC Item*.
-*items*       | *TOC Item Object* | Specifies the children *TOC Item*s of current *TOC Item*.
+*items*       | *TOC Item Object* | Specifies the children *TOC Items* of current *TOC Item*.
 
-**Advanced**: These properties is useful when a TOC links to or reference to another TOC, or links to a uid.
+**Advanced**: These properties is useful when a TOC links another TOC, or links to a uid.
 
 Property Name                     | Type              | Description
 --------------------------------- | ----------------- | ---------------------------
-*tocHref*                         | string            | Specifies another TOC file to be expanded in the currrent *TOC Item*.
-*topicHref*                       | string            | Specifies the homepage of the referenced *TOC Item*. It is useful when *tocHref* is used.
-*topicUid*                        | string            | Specifies the `uid` of the homepage or the referenced file. If the value is set, it overwrites the value of *topicHref*.
-*homepage*                        | string            | Specifies the homepage of the *TOC Item*. It is useful when *href* is linking to a folder.
+*tocHref*                         | string            | Specifies another TOC file, whose items is considered as the child of the currrent *TOC Item*.
+*topicHref*                       | string            | Specifies the topic href of the *TOC Item*. It is useful when *href* is linking to a folder or *tocHref* is used.
+*topicUid*                        | string            | Specifies the `uid` of the *topicHref* file. If the value is set, it overwrites the value of *topicHref*.
+~~*homepage*~~ **Deprecated**     | string            | ~~Specifies the homepage of the *TOC Item*. It is useful when *href* is linking to a folder.~~ Use *topicHref* instead.
 ~~*uid*~~ **Deprecated**          | string            | ~~Specifies the `uid` of the referenced file. If the value is set, it overwrites the value of *href*.~~ Use *topicUid* instead.
 ~~*homepageUid*~~ **Deprecated**  | string            | ~~Specifies the `uid` of the homepage. If the value is set, it overwrites the value of *homepage*.~~ Use *topicUid* instead.
 
-Relative path in detail
+Href in detail
 ---------------
 If a *TOC Item* is linking to some relative path, there are three cases:
 
-1. **Deprecated** ~~Linking to another *TOC File*, for example, `href: examples/toc.md`.~~
+1. Linking to another *TOC File*, for example, `href: examples/toc.md`.
 2. Linking to a folder, which means, the value of the link ends with `/` explicitly, for example, `href: examples/`
 3. Linking to some local file.
 
 Each case is described in detail below.
 
-### Link to a folder
-If the *Toc Item* is linking to a folder, ending with `/` explicitly, the link value for the *Toc Item* is determined in the following steps:
-
-1. If `homepage` or `homepageUid` is set, the link value is resolved to the relative path to `homepage`
-2. If `homepage` or `homepageUid` is not set, DocFX searches for *Toc File* under the folder, and get the first [relative link to local file](#link-to-local-file) as the link value for current *Toc Item*. For example, if the *Toc Item* is `href: article/`, and the content of `article/toc.yml` is as follows:
-
-    ```yaml
-    - name: Topic1
-      href: topic1.md
-    ```
-    The link value for the *Toc Item* is resolved to `article/topic1.md`.
-
-3. If there is no *Toc File* under the folder, the link value keeps unchanged.
-
-### Link to local file
-If the *Toc Item* is linking to a local file, we call this local file *In-Toc File*. Make sure the file is included in `docfx.json`.
-
-Using *tocHref* to link to another *TOC File*
-------------------
-*tocHref* can link to some other *TOC File*, for example, `tocHref: examples/toc.md`. It is considered as a placeholder of the referenced *TOC File*, and DocFX will extract content from that *TOC File* and insert into current *TOC Item* **recursively**.
+### Link to another *TOC File*
+If the *TOC Item* is linking to some other *TOC File*, it is considered as a placeholder of the referenced *TOC File*, and DocFX will extract content from that *TOC File* and insert into current *TOC Item* **recursively**.
 
 This technique is always used when you want to combine several *TOC File*s into one single *TOC File*.
 
@@ -143,6 +125,23 @@ DocFX processes these `toc.yml` files and expands the uppder `toc.yml` file into
 ```
 
 *NOTE* that the referenced `toc.yml` file under `howto` folder will not be transformed to the output folder even if it is included in `docfx.json`.
+
+### Link to a folder
+If the *Toc Item* is linking to a folder, ending with `/` explicitly, the link value for the *Toc Item* is determined in the following steps:
+
+1. If ~~`homepage`~~ `topicHref` or ~~`homepageUid`~~ `topicUid` is set, the link value is resolved to the relative path to ~~`homepage`~~ `topicHref`
+2. If ~~`homepage`~~ `topicHref` or ~~`homepageUid`~~ `topicUid` is not set, DocFX searches for *Toc File* under the folder, and get the first [relative link to local file](#link-to-local-file) as the link value for current *Toc Item*. For example, if the *Toc Item* is `href: article/`, and the content of `article/toc.yml` is as follows:
+
+    ```yaml
+    - name: Topic1
+      href: topic1.md
+    ```
+    The link value for the *Toc Item* is resolved to `article/topic1.md`.
+
+3. If there is no *Toc File* under the folder, the link value keeps unchanged.
+
+### Link to local file
+If the *Toc Item* is linking to a local file, we call this local file *In-Toc File*. Make sure the file is included in `docfx.json`.
 
 Not-In-Toc Files
 ----------------

--- a/Documentation/tutorial/intro_toc.md
+++ b/Documentation/tutorial/intro_toc.md
@@ -38,16 +38,13 @@ Three kinds of links are supported:
 ### YAML format TOC `toc.yml`
 
 ```yml
-- name:
-  href:
-  topicHref:
-- name:
-  href:
-  topicHref:
+- name: Topic1
+  href: Topic1.md
+- name: Topic2
+  href: Topic2.md
   items:
-    - name:
-      href:
-      topicHref:
+    - name: Topic2_1
+      href: Topic2_1.md
 ```
 
 Comparing to `toc.md`, `toc.yml` represents a structured data model and conforms to the [YAML standard](http://www.yaml.org/spec/1.2/spec.html). It supports advanced functionalities.
@@ -66,11 +63,11 @@ Property Name | Type              | Description
 *href*        | string            | Specifies the hyperlink of the *TOC Item*.
 *items*       | *TOC Item Object* | Specifies the children *TOC Items* of current *TOC Item*.
 
-**Advanced**: These properties is useful when a TOC links another TOC, or links to a uid.
+**Advanced**: These properties are useful when a TOC links another TOC, or links to a uid.
 
 Property Name                     | Type              | Description
 --------------------------------- | ----------------- | ---------------------------
-*tocHref*                         | string            | Specifies another TOC file, whose items is considered as the child of the currrent *TOC Item*.
+*tocHref*                         | string            | Specifies another TOC file, whose items are considered as the child of the currrent *TOC Item*.
 *topicHref*                       | string            | Specifies the topic href of the *TOC Item*. It is useful when *href* is linking to a folder or *tocHref* is used.
 *topicUid*                        | string            | Specifies the `uid` of the *topicHref* file. If the value is set, it overwrites the value of *topicHref*.
 ~~*homepage*~~ **Deprecated**     | string            | ~~Specifies the homepage of the *TOC Item*. It is useful when *href* is linking to a folder.~~ Use *topicHref* instead.
@@ -145,4 +142,4 @@ If the *Toc Item* is linking to a local file, we call this local file *In-Toc Fi
 
 Not-In-Toc Files
 ----------------
-When a local file is not references by any *Toc Item*, we call this local file *Not-In-Toc File*. Its *TOC File* is the nearest *TOC File* in output folder from the same folder as the local file to the root output folder.
+When a local file is not referenced by any *Toc Item*, we call this local file *Not-In-Toc File*. Its *TOC File* is the nearest *TOC File* in output folder from the same folder as the local file to the root output folder.

--- a/src/Microsoft.DocAsCode.Build.TableOfContents/BuildTocDocument.cs
+++ b/src/Microsoft.DocAsCode.Build.TableOfContents/BuildTocDocument.cs
@@ -83,14 +83,9 @@ namespace Microsoft.DocAsCode.Build.TableOfContents
                 linkToFiles.Add(item.Homepage.Split('#')[0]);
             }
 
-            if (!string.IsNullOrEmpty(item.Uid))
+            if (!string.IsNullOrEmpty(item.TopicUid))
             {
-                linkToUids.Add(item.Uid);
-            }
-
-            if (!string.IsNullOrEmpty(item.HomepageUid))
-            {
-                linkToUids.Add(item.HomepageUid);
+                linkToUids.Add(item.TopicUid);
             }
 
             model.LinkToUids = model.LinkToUids.Union(linkToUids);

--- a/src/Microsoft.DocAsCode.Build.TableOfContents/TocDocumentProcessor.cs
+++ b/src/Microsoft.DocAsCode.Build.TableOfContents/TocDocumentProcessor.cs
@@ -97,6 +97,7 @@ namespace Microsoft.DocAsCode.Build.TableOfContents
             toc.Homepage = ResolveHref(toc.Homepage, model, context);
             toc.Href = ResolveHref(toc.Href, model, context);
             toc.TocHref = ResolveHref(toc.TocHref, model, context);
+            toc.TopicHref = ResolveHref(toc.TopicHref, model, context);
             if (toc.Items != null && toc.Items.Count > 0)
             {
                 foreach (var item in toc.Items)

--- a/src/Microsoft.DocAsCode.Build.TableOfContents/TocDocumentProcessor.cs
+++ b/src/Microsoft.DocAsCode.Build.TableOfContents/TocDocumentProcessor.cs
@@ -114,7 +114,7 @@ namespace Microsoft.DocAsCode.Build.TableOfContents
                 var xref = GetXrefFromUid(item.TopicUid, model, context);
                 if (xref != null)
                 {
-                    item.Href = xref.Href;
+                    item.Href = item.TopicHref = xref.Href;
                     if (string.IsNullOrEmpty(item.Name))
                     {
                         item.Name = xref.Name;

--- a/src/Microsoft.DocAsCode.Build.TableOfContents/TocDocumentProcessor.cs
+++ b/src/Microsoft.DocAsCode.Build.TableOfContents/TocDocumentProcessor.cs
@@ -108,9 +108,9 @@ namespace Microsoft.DocAsCode.Build.TableOfContents
 
         private void ResolveUid(TocItemViewModel item, FileModel model, IDocumentBuildContext context)
         {
-            if (item.Uid != null)
+            if (item.TopicUid != null)
             {
-                var xref = GetXrefFromUid(item.Uid, model, context);
+                var xref = GetXrefFromUid(item.TopicUid, model, context);
                 if (xref != null)
                 {
                     item.Href = xref.Href;
@@ -130,11 +130,6 @@ namespace Microsoft.DocAsCode.Build.TableOfContents
                         item.NameForVB = nameForVB;
                     }
                 }
-            }
-
-            if (item.HomepageUid != null)
-            {
-                item.Homepage = GetXrefFromUid(item.HomepageUid, model, context)?.Href;
             }
         }
 

--- a/src/Microsoft.DocAsCode.Build.TableOfContents/TocResolver.cs
+++ b/src/Microsoft.DocAsCode.Build.TableOfContents/TocResolver.cs
@@ -56,7 +56,6 @@ namespace Microsoft.DocAsCode.Build.TableOfContents
                 if (!string.IsNullOrEmpty(item.Uid))
                 {
                     item.TopicUid = item.Uid;
-                    Logger.LogWarning($"Uid is deprecated in TOC. Please use topicUid to specify uid {item.Uid}");
                     item.Uid = null;
                 }
                 else if (!string.IsNullOrEmpty(item.HomepageUid))

--- a/src/Microsoft.DocAsCode.Build.TableOfContents/TocResolver.cs
+++ b/src/Microsoft.DocAsCode.Build.TableOfContents/TocResolver.cs
@@ -56,6 +56,8 @@ namespace Microsoft.DocAsCode.Build.TableOfContents
                 if (!string.IsNullOrEmpty(item.Uid))
                 {
                     item.TopicUid = item.Uid;
+                    Logger.LogWarning($"Uid is deprecated in TOC. Please use topicUid to specify uid {item.Uid}");
+                    item.Uid = null;
                 }
                 else if (!string.IsNullOrEmpty(item.HomepageUid))
                 {
@@ -109,8 +111,8 @@ namespace Microsoft.DocAsCode.Build.TableOfContents
                             var defaultItem = GetDefaultHomepageItem(item);
                             if (defaultItem != null)
                             {
-                                item.TopicHref = defaultItem.Href;
-                                item.TopicUid = defaultItem.TopicUid;
+                                item.AggregatedHref = defaultItem.Href;
+                                item.AggregatedUid = defaultItem.TopicUid;
                             }
                         }
                     }
@@ -118,8 +120,8 @@ namespace Microsoft.DocAsCode.Build.TableOfContents
                     if (item.Href == null && item.Homepage == null)
                     {
                         item.Href = item.TocHref;
+                        item.Homepage = item.TopicHref;
                     }
-                    item.Homepage = item.TopicHref;
                     // check whether toc exists
                     if (!string.IsNullOrEmpty(item.TocHref) &&
                         (tocHrefType == HrefType.MarkdownTocFile || tocHrefType == HrefType.YamlTocFile))
@@ -183,8 +185,8 @@ namespace Microsoft.DocAsCode.Build.TableOfContents
                             stack.Push(file);
                             var resolved = ResolveItem(tocFileModel, stack).Content;
                             stack.Pop();
-                            item.Href = item.TopicHref = resolved.TopicHref;
-                            item.TopicUid = resolved.TopicUid;
+                            item.Href = item.TopicHref = resolved.TopicHref ?? resolved.AggregatedHref;
+                            item.TopicUid = resolved.TopicUid ?? resolved.AggregatedUid;
                         }
                         else
                         {
@@ -242,6 +244,7 @@ namespace Microsoft.DocAsCode.Build.TableOfContents
             item.Href = NormalizeHref(item.Href, relativeToFile);
             item.TocHref = NormalizeHref(item.TocHref, relativeToFile);
             item.TopicHref = NormalizeHref(item.TopicHref, relativeToFile);
+            item.Homepage = NormalizeHref(item.Homepage, relativeToFile);
 
             wrapper.IsResolved = true;
             return wrapper;

--- a/src/Microsoft.DocAsCode.DataContracts.Common/TocItemViewModel.cs
+++ b/src/Microsoft.DocAsCode.DataContracts.Common/TocItemViewModel.cs
@@ -65,6 +65,10 @@ namespace Microsoft.DocAsCode.DataContracts.Common
         [JsonProperty("topicHref")]
         public string TopicHref { get; set; }
 
+        [YamlIgnore]
+        [JsonIgnore]
+        public string AggregatedHref { get; set; }
+
         [YamlMember(Alias = "homepage")]
         [JsonProperty("homepage")]
         public string Homepage { get; set; }
@@ -76,6 +80,10 @@ namespace Microsoft.DocAsCode.DataContracts.Common
         [YamlMember(Alias = "topicUid")]
         [JsonProperty("topicUid")]
         public string TopicUid { get; set; }
+
+        [YamlIgnore]
+        [JsonIgnore]
+        public string AggregatedUid { get; set; }
 
         [YamlMember(Alias = "items")]
         [JsonProperty("items")]

--- a/src/Microsoft.DocAsCode.DataContracts.Common/TocItemViewModel.cs
+++ b/src/Microsoft.DocAsCode.DataContracts.Common/TocItemViewModel.cs
@@ -61,6 +61,10 @@ namespace Microsoft.DocAsCode.DataContracts.Common
         [JsonProperty("tocHref")]
         public string TocHref { get; set; }
 
+        [YamlMember(Alias = "topicHref")]
+        [JsonProperty("topicHref")]
+        public string TopicHref { get; set; }
+
         [YamlMember(Alias = "homepage")]
         [JsonProperty("homepage")]
         public string Homepage { get; set; }
@@ -68,6 +72,10 @@ namespace Microsoft.DocAsCode.DataContracts.Common
         [YamlMember(Alias = "homepageUid")]
         [JsonProperty("homepageUid")]
         public string HomepageUid { get; set; }
+
+        [YamlMember(Alias = "topicUid")]
+        [JsonProperty("topicUid")]
+        public string TopicUid { get; set; }
 
         [YamlMember(Alias = "items")]
         [JsonProperty("items")]

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/DocumentBuilderTest.cs
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/DocumentBuilderTest.cs
@@ -159,6 +159,7 @@ tagRules : [
                     Assert.Equal("test2", model[0].Items[0].Name);
                     Assert.Equal("test/test.html", model[0].Items[0].Href);
                     Assert.Equal("Api", model[1].Name);
+                    Assert.Null(model[1].Href);
                     Assert.NotNull(model[1].Items);
                     Assert.Equal("Console", model[1].Items[0].Name);
                     Assert.Equal("../System.Console.csyml", model[1].Items[0].Href);
@@ -305,8 +306,6 @@ exports.getOptions = function (){
                     ["_path"] = $"{_inputFolder}/toc",
                     ["_tocRel"] = "toc",
                     ["_tocKey"] = $"~/{_inputFolder}/toc.md",
-                    ["homepage"] = "test.html",
-                    ["topicHref"] = "test.html",
                     ["items"] = new object[]
                     {
                         new {
@@ -326,8 +325,6 @@ exports.getOptions = function (){
                                 ["_path"] = $"{_inputFolder}/toc",
                                 ["_tocRel"] = "toc",
                                 ["_tocKey"] = $"~/{_inputFolder}/toc.md",
-                                ["homepage"] = "test.html",
-                                ["topicHref"] = "test.html",
                                 ["items"] = new object[]
                                 {
                                     new {
@@ -344,8 +341,6 @@ exports.getOptions = function (){
                                 ["_path"] = $"{_inputFolder}/test/toc",
                                 ["_tocRel"] = "toc",
                                 ["_tocKey"] = $"~/{_inputFolder}/test/toc.md",
-                                ["homepage"] = "test.html",
-                                ["topicHref"] = "test.html",
                                 ["items"] = new object[]
                                 {
                                     new {
@@ -395,8 +390,6 @@ exports.getOptions = function (){
                                 ["_path"] = $"{_inputFolder}/toc",
                                 ["_tocRel"] = "toc",
                                 ["_tocKey"] = $"~/{_inputFolder}/toc.md",
-                                ["homepage"] = "test.html",
-                                ["topicHref"] = "test.html",
                                 ["items"] = new object[]
                                 {
                                     new {
@@ -413,8 +406,6 @@ exports.getOptions = function (){
                                 ["_path"] = $"{_inputFolder}/test/toc",
                                 ["_tocRel"] = "toc",
                                 ["_tocKey"] = $"~/{_inputFolder}/test/toc.md",
-                                ["homepage"] = "test.html",
-                                ["topicHref"] = "test.html",
                                 ["items"] = new object[]
                                 {
                                     new {

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/DocumentBuilderTest.cs
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/DocumentBuilderTest.cs
@@ -310,7 +310,8 @@ exports.getOptions = function (){
                     {
                         new {
                             name = "Test",
-                            href = "test.html"
+                            href = "test.html",
+                            topicHref = "test.html"
                         }
                     },
                     ["__global"] = new
@@ -329,7 +330,8 @@ exports.getOptions = function (){
                                 {
                                     new {
                                         name = "Test",
-                                        href = "test.html"
+                                        href = "test.html",
+                                        topicHref = "test.html"
                                     }
                                 },
                             },
@@ -345,7 +347,8 @@ exports.getOptions = function (){
                                 {
                                     new {
                                         name = "Test",
-                                        href = "test.html"
+                                        href = "test.html",
+                                        topicHref = "test.html"
                                     }
                                 },
                             }
@@ -394,7 +397,8 @@ exports.getOptions = function (){
                                 {
                                     new {
                                         name = "Test",
-                                        href = "test.html"
+                                        href = "test.html",
+                                        topicHref = "test.html"
                                     }
                                 },
                             },
@@ -410,7 +414,8 @@ exports.getOptions = function (){
                                 {
                                     new {
                                         name = "Test",
-                                        href = "test.html"
+                                        href = "test.html",
+                                        topicHref = "test.html"
                                     }
                                 },
                             }

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/DocumentBuilderTest.cs
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/DocumentBuilderTest.cs
@@ -159,7 +159,6 @@ tagRules : [
                     Assert.Equal("test2", model[0].Items[0].Name);
                     Assert.Equal("test/test.html", model[0].Items[0].Href);
                     Assert.Equal("Api", model[1].Name);
-                    Assert.Null(model[1].Href);
                     Assert.NotNull(model[1].Items);
                     Assert.Equal("Console", model[1].Items[0].Name);
                     Assert.Equal("../System.Console.csyml", model[1].Items[0].Href);
@@ -307,6 +306,7 @@ exports.getOptions = function (){
                     ["_tocRel"] = "toc",
                     ["_tocKey"] = $"~/{_inputFolder}/toc.md",
                     ["homepage"] = "test.html",
+                    ["topicHref"] = "test.html",
                     ["items"] = new object[]
                     {
                         new {
@@ -327,6 +327,7 @@ exports.getOptions = function (){
                                 ["_tocRel"] = "toc",
                                 ["_tocKey"] = $"~/{_inputFolder}/toc.md",
                                 ["homepage"] = "test.html",
+                                ["topicHref"] = "test.html",
                                 ["items"] = new object[]
                                 {
                                     new {
@@ -344,6 +345,7 @@ exports.getOptions = function (){
                                 ["_tocRel"] = "toc",
                                 ["_tocKey"] = $"~/{_inputFolder}/test/toc.md",
                                 ["homepage"] = "test.html",
+                                ["topicHref"] = "test.html",
                                 ["items"] = new object[]
                                 {
                                     new {
@@ -394,6 +396,7 @@ exports.getOptions = function (){
                                 ["_tocRel"] = "toc",
                                 ["_tocKey"] = $"~/{_inputFolder}/toc.md",
                                 ["homepage"] = "test.html",
+                                ["topicHref"] = "test.html",
                                 ["items"] = new object[]
                                 {
                                     new {
@@ -411,6 +414,7 @@ exports.getOptions = function (){
                                 ["_tocRel"] = "toc",
                                 ["_tocKey"] = $"~/{_inputFolder}/test/toc.md",
                                 ["homepage"] = "test.html",
+                                ["topicHref"] = "test.html",
                                 ["items"] = new object[]
                                 {
                                     new {

--- a/test/Microsoft.DocAsCode.Build.TableOfContents.Tests/TocDocumentProcessorTest.cs
+++ b/test/Microsoft.DocAsCode.Build.TableOfContents.Tests/TocDocumentProcessorTest.cs
@@ -229,6 +229,7 @@ namespace Microsoft.DocAsCode.Build.TableOfContents.Tests
                     {
                         Name = "Topic2",
                         Href = file2,
+                        TopicHref = file2,
                         TocHref = "sub/toc.md",
                     }
                 }

--- a/test/Microsoft.DocAsCode.Build.TableOfContents.Tests/TocDocumentProcessorTest.cs
+++ b/test/Microsoft.DocAsCode.Build.TableOfContents.Tests/TocDocumentProcessorTest.cs
@@ -380,7 +380,6 @@ namespace Microsoft.DocAsCode.Build.TableOfContents.Tests
         [Fact]
         public void ProcessYamlTocWithTocHrefShouldSucceed()
         {
-
             var file = _fileCreator.CreateFile(string.Empty, FileType.MarkdownContent, "sub1/sub2");
             var referencedToc = _fileCreator.CreateFile($@"
 - name: Topic
@@ -389,14 +388,14 @@ namespace Microsoft.DocAsCode.Build.TableOfContents.Tests
             var content = $@"
 - name: Topic1
   tocHref: /Topic1/
-  href: /Topic1/index.html
+  topicHref: /Topic1/index.html
   items:
     - name: Topic1.1
       tocHref: /Topic1.1/
-      href: /Topic1.1/index.html
+      topicHref: /Topic1.1/index.html
     - name: Topic1.2
       tocHref: /Topic1.2/
-      href: /Topic1.2/index.html
+      topicHref: /Topic1.2/index.html
 - name: Topic2
   tocHref: {referencedToc}
 ";
@@ -417,33 +416,38 @@ namespace Microsoft.DocAsCode.Build.TableOfContents.Tests
                     {
                         Name = "Topic1",
                         Href = "/Topic1/",
+                        TocHref = "/Topic1/",
                         Homepage = "/Topic1/index.html",
+                        TopicHref = "/Topic1/index.html",
                         Items = new TocViewModel
                         {
                             new TocItemViewModel
                             {
                                 Name = "Topic1.1",
                                 Href = "/Topic1.1/",
-                                Homepage = "/Topic1.1/index.html"
+                                TocHref = "/Topic1.1/",
+                                Homepage = "/Topic1.1/index.html",
+                                TopicHref = "/Topic1.1/index.html",
                             },
                             new TocItemViewModel
                             {
                                 Name = "Topic1.2",
                                 Href = "/Topic1.2/",
-                                Homepage = "/Topic1.2/index.html"
+                                TocHref = "/Topic1.2/",
+                                Homepage = "/Topic1.2/index.html",
+                                TopicHref = "/Topic1.2/index.html",
                             }
                         }
                     },
                     new TocItemViewModel
                     {
                         Name = "Topic2",
-                        Href = null,
                         Items = new TocViewModel
                         {
                             new TocItemViewModel
                             {
                                 Name = "Topic",
-                                Href = file,
+                                Href = file
                             }
                         }
                     }
@@ -467,7 +471,7 @@ namespace Microsoft.DocAsCode.Build.TableOfContents.Tests
             FileCollection files = new FileCollection(_inputFolder);
             files.Add(DocumentType.Article, new[] { toc });
             var e = Assert.Throws<DocumentException>(() => BuildDocument(files));
-            Assert.Equal("Href should be used to specify the homepage /Topic1/index.html when TocHref is uesed", e.Message);
+            Assert.Equal("\"topicHref\" should be used to specify the homepage for /Topic1/ when tocHref is used.", e.Message);
         }
 
         #region Helper methods

--- a/test/Microsoft.DocAsCode.Build.TableOfContents.Tests/TocDocumentProcessorTest.cs
+++ b/test/Microsoft.DocAsCode.Build.TableOfContents.Tests/TocDocumentProcessorTest.cs
@@ -121,22 +121,16 @@ namespace Microsoft.DocAsCode.Build.TableOfContents.Tests
             var model = JsonUtility.Deserialize<TocItemViewModel>(outputRawModelPath);
             var expectedModel = new TocItemViewModel
             {
-                TopicHref = file1,
-                Homepage = file1,
                 Items = new TocViewModel
                 {
                     new TocItemViewModel
                     {
-                        TopicHref = file1,
-                        Homepage = file1,
                         Name = "Topic1",
                         Href = "/href1",
                         Items = new TocViewModel
                         {
                             new TocItemViewModel
                             {
-                                TopicHref = file2,
-                                Homepage = file2,
                                 Name = "Topic1.1",
                                 Href = file1,
                                 Items = new TocViewModel
@@ -196,14 +190,10 @@ namespace Microsoft.DocAsCode.Build.TableOfContents.Tests
             var model = JsonUtility.Deserialize<TocItemViewModel>(outputRawModelPath);
             var expectedModel = new TocItemViewModel
             {
-                TopicHref = file1,
-                Homepage = file1,
                 Items = new TocViewModel
                 {
                     new TocItemViewModel
                     {
-                        TopicHref = file1,
-                        Homepage = file1,
                         Name = "Topic1",
                         Href = file1,
                         Items = new TocViewModel
@@ -277,14 +267,10 @@ namespace Microsoft.DocAsCode.Build.TableOfContents.Tests
             var model = JsonUtility.Deserialize<TocItemViewModel>(outputRawModelPath);
             var expectedModel = new TocItemViewModel
             {
-                TopicHref = file1,
-                Homepage = file1,
                 Items = new TocViewModel
                 {
                     new TocItemViewModel
                     {
-                        TopicHref= file2,
-                        Homepage = file2,
                         Name = "Topic1",
                         Href = file1,
                         Items = new TocViewModel

--- a/test/Microsoft.DocAsCode.Build.TableOfContents.Tests/TocDocumentProcessorTest.cs
+++ b/test/Microsoft.DocAsCode.Build.TableOfContents.Tests/TocDocumentProcessorTest.cs
@@ -68,6 +68,7 @@ namespace Microsoft.DocAsCode.Build.TableOfContents.Tests
                     {
                         Name = "Topic1",
                         Href = "/href1",
+                        TopicHref = "/href1",
                         Items = new TocViewModel
                         {
                             new TocItemViewModel
@@ -78,21 +79,24 @@ namespace Microsoft.DocAsCode.Build.TableOfContents.Tests
                                     new TocItemViewModel
                                     {
                                         Name = "Topic1.1.1",
-                                        Href = "/href1.1.1"
+                                        Href = "/href1.1.1",
+                                        TopicHref = "/href1.1.1"
                                     }
                                 }
                             },
                             new TocItemViewModel
                             {
                                 Name = "Topic1.2",
-                                Href = string.Empty
+                                Href = string.Empty,
+                                TopicHref = string.Empty
                             }
                         }
                     },
                     new TocItemViewModel
                     {
                         Name = "Topic2",
-                        Href = "http://href.com"
+                        Href = "http://href.com",
+                        TopicHref = "http://href.com"
                     }
                 }
             };
@@ -127,32 +131,37 @@ namespace Microsoft.DocAsCode.Build.TableOfContents.Tests
                     {
                         Name = "Topic1",
                         Href = "/href1",
+                        TopicHref = "/href1",
                         Items = new TocViewModel
                         {
                             new TocItemViewModel
                             {
                                 Name = "Topic1.1",
                                 Href = file1,
+                                TopicHref = file1,
                                 Items = new TocViewModel
                                 {
                                     new TocItemViewModel
                                     {
                                         Name = "Topic1.1.1",
-                                        Href = file2
+                                        Href = file2,
+                                        TopicHref = file2
                                     }
                                 }
                             },
                             new TocItemViewModel
                             {
                                 Name = "Topic1.2",
-                                Href = string.Empty
+                                Href = string.Empty,
+                                TopicHref = string.Empty
                             }
                         }
                     },
                     new TocItemViewModel
                     {
                         Name = "Topic2",
-                        Href = "http://href.com"
+                        Href = "http://href.com",
+                        TopicHref = "http://href.com"
                     }
                 }
             };
@@ -196,6 +205,7 @@ namespace Microsoft.DocAsCode.Build.TableOfContents.Tests
                     {
                         Name = "Topic1",
                         Href = file1,
+                        TopicHref = file1,
                         Items = new TocViewModel
                         {
                             new TocItemViewModel
@@ -273,18 +283,21 @@ namespace Microsoft.DocAsCode.Build.TableOfContents.Tests
                     {
                         Name = "Topic1",
                         Href = file1,
+                        TopicHref = file1,
                         Items = new TocViewModel
                         {
                             new TocItemViewModel
                             {
                                 Name = "Topic1.1",
                                 Href = null, // For referenced toc, the content from the referenced toc is expanded as the items of current toc, and href is cleared
+                                TopicHref = null,
                                 Items = new TocViewModel
                                 {
                                     new TocItemViewModel
                                     {
                                         Name = "Topic",
                                         Href = file2,
+                                        TopicHref = file2,
                                     },
                                     new TocItemViewModel
                                     {
@@ -295,6 +308,7 @@ namespace Microsoft.DocAsCode.Build.TableOfContents.Tests
                                             {
                                                 Name = "Topic",
                                                 Href = file3,
+                                                TopicHref = file3,
                                             }
                                         }
                                     }
@@ -312,6 +326,7 @@ namespace Microsoft.DocAsCode.Build.TableOfContents.Tests
                                     {
                                         Name = "Topic",
                                         Href = file2,
+                                        TopicHref = file2,
                                     },
                                     new TocItemViewModel
                                     {
@@ -322,6 +337,7 @@ namespace Microsoft.DocAsCode.Build.TableOfContents.Tests
                                             {
                                                 Name = "Topic",
                                                 Href = file3,
+                                                TopicHref = file3,
                                             }
                                         }
                                     }
@@ -339,6 +355,7 @@ namespace Microsoft.DocAsCode.Build.TableOfContents.Tests
                             {
                                 Name = "Topic",
                                 Href = file3,
+                                TopicHref = file3,
                             }
                         }
                     }


### PR DESCRIPTION
* keep backwards compatible
* change terms to better usability, proposed syntax as below
```yml
- name: Solutions
  tocHref: /enterprise-mobility/solutions/
  topicHref: /enterprise-mobility/solutions/byod-design-considerations-guide
```
@chenkennt @vwxyzh @fenxu @qinezh @ansyral