### PR TITLE
Using separator in code constants

### DIFF
--- a/src/docfx.website.themes/angular/app/src/services/urlService.js
+++ b/src/docfx.website.themes/angular/app/src/services/urlService.js
@@ -72,7 +72,7 @@
       currentPath = normalizeUrl(currentPath);
 
       // separate toc and content with !
-      var index = currentPath.indexOf(docConstants.TocAndFileUrlSeperator);
+      var index = currentPath.indexOf(docConstants.TocAndFileUrlSeparator);
       if (index < 0) {
         // If it ends with .md/.yml, render it without toc
         if ((docConstants.MdOrYamlRegexExp).test(currentPath)) {
@@ -103,13 +103,13 @@
 
     this.getContentUrl = function(pathInfo) {
       if (!pathInfo) return pathInfo;
-      var path = pathInfo.tocPath ? pathInfo.tocPath + docConstants.TocAndFileUrlSeperator : '';
+      var path = pathInfo.tocPath ? pathInfo.tocPath + docConstants.TocAndFileUrlSeparator : '';
       path += pathInfo.contentPath ? pathInfo.contentPath : docConstants.TocFile;
       return path;
     };
 
     this.getContentUrlWithTocAndContentUrl = function(tocPath, contentPath) {
-      var path = tocPath ? tocPath + docConstants.TocAndFileUrlSeperator : '';
+      var path = tocPath ? tocPath + docConstants.TocAndFileUrlSeparator : '';
       path += contentPath ? contentPath : docConstants.TocFile;
       return path;
     };

--- a/src/docfx.website.themes/angular/app/src/util/constants.js
+++ b/src/docfx.website.themes/angular/app/src/util/constants.js
@@ -17,7 +17,7 @@
         this.MdOrYamlRegexExp = /(\.yml$)|(\.md$)/;
         this.MdIndexFile = '.map';
         this.TocFile = 'toc' + this.YamlExtension; // docConstants.TocFile
-        this.TocAndFileUrlSeperator = '!'; // docConstants.TocAndFileUrlSeperator
+        this.TocAndFileUrlSeparator = '!'; // docConstants.TocAndFileUrlSeparator
     }
 
     angular.module('docascode.constants', [])


### PR DESCRIPTION
Correction for typos in constant names. NOTE: lunr - http://lunrjs.com -
A bit like Solr, but much smaller and not as bright - 0.6.0
This project has the same problem but it is not touched in the PR.