### PR TITLE
refine md.style

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/DocumentBuildParameters.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/DocumentBuildParameters.cs
@@ -21,5 +21,6 @@ namespace Microsoft.DocAsCode.Build.Engine
         public string MarkdownEngineName { get; set; } = "dfm";
         public ImmutableDictionary<string, object> MarkdownEngineParameters { get; set; } = ImmutableDictionary<string, object>.Empty;
         public string VersionName { get; set; }
+        public string TemplateDir { get; set; }
     }
 }

--- a/src/Microsoft.DocAsCode.Build.Engine/DocumentBuilder.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/DocumentBuilder.cs
@@ -36,7 +36,10 @@ namespace Microsoft.DocAsCode.Build.Engine
             };
         private BuildInfo _lastBuildInfo;
 
-        public DocumentBuilder(IEnumerable<Assembly> assemblies, ImmutableArray<string> postProcessorNames, string intermediateFolder = null)
+        public DocumentBuilder(
+            IEnumerable<Assembly> assemblies,
+            ImmutableArray<string> postProcessorNames,
+            string intermediateFolder = null)
         {
             Logger.LogVerbose("Loading plug-in...");
             var assemblyList = assemblies?.ToList();

--- a/src/Microsoft.DocAsCode.Build.Engine/MarkdownProviders/DfmServiceProvider.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/MarkdownProviders/DfmServiceProvider.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DocAsCode.Build.Engine
         {
             return new DfmService(
                 parameters.BasePath,
+                parameters.TemplateDir,
                 parameters.Tokens,
                 MarkdownTokenTreeValidatorFactory.Combine(TokenTreeValidator));
         }
@@ -31,9 +32,9 @@ namespace Microsoft.DocAsCode.Build.Engine
 
             private readonly ImmutableDictionary<string, string> _tokens;
 
-            public DfmService(string baseDir, ImmutableDictionary<string, string> tokens, IMarkdownTokenTreeValidator tokenTreeValidator)
+            public DfmService(string baseDir, string templateDir, ImmutableDictionary<string, string> tokens, IMarkdownTokenTreeValidator tokenTreeValidator)
             {
-                _builder = DocfxFlavoredMarked.CreateBuilder(baseDir);
+                _builder = DocfxFlavoredMarked.CreateBuilder(baseDir, templateDir);
                 _builder.TokenTreeValidator = tokenTreeValidator;
                 _tokens = tokens;
             }

--- a/src/Microsoft.DocAsCode.Build.Engine/SingleDocumentBuilder.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/SingleDocumentBuilder.cs
@@ -730,6 +730,7 @@ namespace Microsoft.DocAsCode.Build.Engine
                 new MarkdownServiceParameters
                 {
                     BasePath = parameters.Files.DefaultBaseDir,
+                    TemplateDir = parameters.TemplateDir,
                     Extensions = parameters.MarkdownEngineParameters,
                     Tokens = tokens,
                 });

--- a/src/Microsoft.DocAsCode.Dfm/DfmEngineBuilder.cs
+++ b/src/Microsoft.DocAsCode.Dfm/DfmEngineBuilder.cs
@@ -133,6 +133,7 @@ namespace Microsoft.DocAsCode.Dfm
                 var config = JsonUtility.Deserialize<MarkdownSytleConfig>(configFile);
                 builder.AddValidators(config.Rules);
                 builder.AddTagValidators(config.TagRules);
+                builder.AddSettings(config.Settings);
             }
             builder.EnsureDefaultValidator();
         }
@@ -147,7 +148,7 @@ namespace Microsoft.DocAsCode.Dfm
                     var category = fileName.Remove(fileName.Length - MarkdownSytleDefinition.MarkdownStyleDefinitionFilePostfix.Length);
                     var config = JsonUtility.Deserialize<MarkdownSytleDefinition>(configFile);
                     builder.AddTagValidators(category, config.TagRules);
-                    builder.AddValidators(config.Rules);
+                    builder.AddValidators(category, config.Rules);
                 }
             }
         }

--- a/src/Microsoft.DocAsCode.Dfm/DocfxFlavoredMarked.cs
+++ b/src/Microsoft.DocAsCode.Dfm/DocfxFlavoredMarked.cs
@@ -10,11 +10,12 @@ namespace Microsoft.DocAsCode.Dfm
 
     public class DocfxFlavoredMarked
     {
-        public static DfmEngineBuilder CreateBuilder(string baseDir)
-        {
+        public static DfmEngineBuilder CreateBuilder(string baseDir) =>
+            CreateBuilder(baseDir, null);
+
+        public static DfmEngineBuilder CreateBuilder(string baseDir, string templateDir) =>
             // TODO: currently disable mangle as a quick workaround for OP Build Service compatibility
-            return new DfmEngineBuilder(new Options() { Mangle = false, XHtml = true }, baseDir);
-        }
+            new DfmEngineBuilder(new Options() { Mangle = false, XHtml = true }, baseDir, templateDir);
 
         public static string Markup(string src, string path = null, ImmutableDictionary<string, string> tokens = null, HashSet<string> dependency = null)
         {

--- a/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownSytleConfig.cs
+++ b/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownSytleConfig.cs
@@ -13,5 +13,7 @@ namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
         public MarkdownValidationRule[] Rules { get; set; }
         [JsonProperty("tagRules")]
         public MarkdownTagValidationRule[] TagRules { get; set; }
+        [JsonProperty("settings")]
+        public MarkdownValidationSetting[] Settings { get; set; }
     }
 }

--- a/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownSytleDefinition.cs
+++ b/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownSytleDefinition.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
+{
+    using System.Collections.Generic;
+
+    using Newtonsoft.Json;
+
+    public class MarkdownSytleDefinition
+    {
+        public const string MarkdownStyleDefinitionFilePostfix = ".md.style";
+        public const string MarkdownStyleDefinitionFolderName = "md.styles";
+
+        [JsonProperty("rules")]
+        public MarkdownValidationRule[] Rules { get; set; }
+        [JsonProperty("tagRules")]
+        public Dictionary<string, MarkdownTagValidationRule> TagRules { get; set; }
+    }
+}

--- a/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownSytleDefinition.cs
+++ b/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownSytleDefinition.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
         public const string MarkdownStyleDefinitionFolderName = "md.styles";
 
         [JsonProperty("rules")]
-        public MarkdownValidationRule[] Rules { get; set; }
+        public Dictionary<string, MarkdownValidationRule> Rules { get; set; }
         [JsonProperty("tagRules")]
         public Dictionary<string, MarkdownTagValidationRule> TagRules { get; set; }
     }

--- a/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownTagValidationRule.cs
+++ b/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownTagValidationRule.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
         [JsonProperty("openingTagOnly")]
         public bool OpeningTagOnly { get; set; }
         /// <summary>
-        /// Whether disable this rule by default.
+        /// Whether to disable this rule by default.
         /// </summary>
         [DefaultValue(false)]
         [JsonProperty("disable")]

--- a/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownTagValidationRule.cs
+++ b/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownTagValidationRule.cs
@@ -16,10 +16,10 @@ namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
         [JsonProperty("tagNames", Required = Required.Always)]
         public List<string> TagNames { get; set; }
         /// <summary>
-        /// The access for tags.
+        /// The relation for tags.
         /// </summary>
-        [JsonProperty("verb")]
-        public TagVerb Verb { get; set; }
+        [JsonProperty("relation")]
+        public TagRelation Relation { get; set; }
         /// <summary>
         /// Define tag's behavior.
         /// </summary>

--- a/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownTagValidationRule.cs
+++ b/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownTagValidationRule.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
 {
     using System.Collections.Generic;
+    using System.ComponentModel;
 
     using Newtonsoft.Json;
 
@@ -17,8 +18,8 @@ namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
         /// <summary>
         /// The access for tags.
         /// </summary>
-        [JsonProperty("access")]
-        public TagAccess Access { get; set; }
+        [JsonProperty("verb")]
+        public TagVerb Verb { get; set; }
         /// <summary>
         /// Define tag's behavior.
         /// </summary>
@@ -39,5 +40,11 @@ namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
         /// </summary>
         [JsonProperty("openingTagOnly")]
         public bool OpeningTagOnly { get; set; }
+        /// <summary>
+        /// Whether disable this rule by default.
+        /// </summary>
+        [DefaultValue(false)]
+        [JsonProperty("disable")]
+        public bool Disable { get; set; }
     }
 }

--- a/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownValidationRule.cs
+++ b/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownValidationRule.cs
@@ -9,8 +9,14 @@ namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
 
     public class MarkdownValidationRule
     {
+        /// <summary>
+        /// The contract name of rule.
+        /// </summary>
         [JsonProperty("name", Required = Required.Always)]
         public string RuleName { get; set; }
+        /// <summary>
+        /// Whether to disable this rule by default.
+        /// </summary>
         [DefaultValue(false)]
         [JsonProperty("disable")]
         public bool Disable { get; set; }

--- a/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownValidationRule.cs
+++ b/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownValidationRule.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
 {
+    using System;
     using System.ComponentModel;
 
     using Newtonsoft.Json;
@@ -12,8 +13,20 @@ namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
         /// <summary>
         /// The contract name of rule.
         /// </summary>
-        [JsonProperty("name", Required = Required.Always)]
-        public string RuleName { get; set; }
+        [Obsolete("Please use ContractName.")]
+        [JsonProperty("name")]
+        public string RuleName
+        {
+            get { return ContractName; }
+            set { ContractName = value; }
+        }
+
+        /// <summary>
+        /// The contract name of rule.
+        /// </summary>
+        [JsonProperty("contractName")]
+        public string ContractName { get; set; }
+
         /// <summary>
         /// Whether to disable this rule by default.
         /// </summary>
@@ -21,9 +34,9 @@ namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
         [JsonProperty("disable")]
         public bool Disable { get; set; }
 
-        public static explicit operator MarkdownValidationRule(string ruleName)
+        public static explicit operator MarkdownValidationRule(string contractName)
         {
-            return new MarkdownValidationRule { RuleName = ruleName };
+            return new MarkdownValidationRule { ContractName = contractName };
         }
     }
 }

--- a/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownValidationSetting.cs
+++ b/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownValidationSetting.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
+{
+    using System.ComponentModel;
+
+    using Newtonsoft.Json;
+
+    public class MarkdownValidationSetting
+    {
+        [JsonProperty("category", Required = Required.Always)]
+        public string Category { get; set; }
+        [JsonProperty("id")]
+        public string Id { get; set; }
+        [DefaultValue(false)]
+        [JsonProperty("disable")]
+        public bool Disable { get; set; }
+
+        public static explicit operator MarkdownValidationSetting(string category)
+        {
+            return new MarkdownValidationSetting { Category = category };
+        }
+    }
+}

--- a/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownValidationSetting.cs
+++ b/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownValidationSetting.cs
@@ -9,10 +9,19 @@ namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
 
     public class MarkdownValidationSetting
     {
+        /// <summary>
+        /// The category of rule
+        /// </summary>
         [JsonProperty("category", Required = Required.Always)]
         public string Category { get; set; }
+        /// <summary>
+        /// The id of rule.
+        /// </summary>
         [JsonProperty("id")]
         public string Id { get; set; }
+        /// <summary>
+        /// Whether to disable this rule by default.
+        /// </summary>
         [DefaultValue(false)]
         [JsonProperty("disable")]
         public bool Disable { get; set; }

--- a/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownValidatorBuilder.cs
+++ b/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownValidatorBuilder.cs
@@ -246,7 +246,7 @@ namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
                     if (isOpeningTag || !validator.OpeningTagOnly)
                     {
                         var hasTagName = validator.TagNames.Any(tagName => string.Equals(tagName, m.Groups[1].Value, System.StringComparison.OrdinalIgnoreCase));
-                        if (hasTagName ^ (validator.Verb == TagVerb.NotIn))
+                        if (hasTagName ^ (validator.Relation == TagRelation.NotIn))
                         {
                             ValidateOne(token, m, validator);
                         }

--- a/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownValidatorBuilder.cs
+++ b/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownValidatorBuilder.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
             new List<RuleWithId<MarkdownValidationRule>>();
         private readonly List<MarkdownValidationSetting> _settings =
             new List<MarkdownValidationSetting>();
-        private readonly Dictionary<string, MarkdownValidationRule> _gobalValidators =
+        private readonly Dictionary<string, MarkdownValidationRule> _globalValidators =
             new Dictionary<string, MarkdownValidationRule>();
 
         public MarkdownValidatorBuilder(CompositionHost host)
@@ -98,7 +98,7 @@ namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
             }
             foreach (var rule in rules)
             {
-                _gobalValidators[rule.RuleName] = rule;
+                _globalValidators[rule.RuleName] = rule;
             }
         }
 
@@ -116,9 +116,9 @@ namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
 
         public void EnsureDefaultValidator()
         {
-            if (!_gobalValidators.ContainsKey(DefaultValidatorName))
+            if (!_globalValidators.ContainsKey(DefaultValidatorName))
             {
-                _gobalValidators[DefaultValidatorName] = new MarkdownValidationRule
+                _globalValidators[DefaultValidatorName] = new MarkdownValidationRule
                 {
                     RuleName = DefaultValidatorName,
                 };
@@ -154,7 +154,7 @@ namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
                     enabledContractName.Add(item.Rule.RuleName);
                 }
             }
-            foreach (var pair in _gobalValidators)
+            foreach (var pair in _globalValidators)
             {
                 if (pair.Value.Disable)
                 {

--- a/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownValidatorBuilder.cs
+++ b/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownValidatorBuilder.cs
@@ -204,7 +204,7 @@ namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
                     }
                 }
             }
-            return categoryDisable ?? idDisable;
+            return idDisable ?? categoryDisable;
         }
 
         private sealed class MarkdownRewriterContext
@@ -339,6 +339,5 @@ namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
                 }
             }
         }
-
     }
 }

--- a/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownValidatorBuilder.cs
+++ b/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/MarkdownValidatorBuilder.cs
@@ -81,6 +81,10 @@ namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
             }
             foreach (var pair in validators)
             {
+                if (string.IsNullOrEmpty(pair.Value.ContractName))
+                {
+                    continue;
+                }
                 _validators.Add(new RuleWithId<MarkdownValidationRule>
                 {
                     Category = category,
@@ -98,7 +102,11 @@ namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
             }
             foreach (var rule in rules)
             {
-                _globalValidators[rule.RuleName] = rule;
+                if (string.IsNullOrEmpty(rule.ContractName))
+                {
+                    continue;
+                }
+                _globalValidators[rule.ContractName] = rule;
             }
         }
 
@@ -120,7 +128,7 @@ namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
             {
                 _globalValidators[DefaultValidatorName] = new MarkdownValidationRule
                 {
-                    RuleName = DefaultValidatorName,
+                    ContractName = DefaultValidatorName,
                 };
             }
         }
@@ -147,22 +155,22 @@ namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
             {
                 if (IsDisabledBySetting(item) ?? item.Rule.Disable)
                 {
-                    enabledContractName.Remove(item.Rule.RuleName);
+                    enabledContractName.Remove(item.Rule.ContractName);
                 }
                 else
                 {
-                    enabledContractName.Add(item.Rule.RuleName);
+                    enabledContractName.Add(item.Rule.ContractName);
                 }
             }
             foreach (var pair in _globalValidators)
             {
                 if (pair.Value.Disable)
                 {
-                    enabledContractName.Remove(pair.Value.RuleName);
+                    enabledContractName.Remove(pair.Value.ContractName);
                 }
                 else
                 {
-                    enabledContractName.Add(pair.Value.RuleName);
+                    enabledContractName.Add(pair.Value.ContractName);
                 }
             }
             return from name in enabledContractName

--- a/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/TagRelation.cs
+++ b/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/TagRelation.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
 {
-    public enum TagVerb
+    public enum TagRelation
     {
         In,
         NotIn,

--- a/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/TagVerb.cs
+++ b/src/Microsoft.DocAsCode.Dfm/MarkdownValidators/TagVerb.cs
@@ -3,9 +3,9 @@
 
 namespace Microsoft.DocAsCode.Dfm.MarkdownValidators
 {
-    public enum TagAccess
+    public enum TagVerb
     {
-        Denied,
-        Allowed,
+        In,
+        NotIn,
     }
 }

--- a/src/Microsoft.DocAsCode.Dfm/Microsoft.DocAsCode.Dfm.csproj
+++ b/src/Microsoft.DocAsCode.Dfm/Microsoft.DocAsCode.Dfm.csproj
@@ -62,6 +62,7 @@
     <Compile Include="CodeSnippetExtractor\ICodeSnippetExtractor.cs" />
     <Compile Include="MarkdownValidators\MarkdownSytleDefinition.cs" />
     <Compile Include="MarkdownValidators\MarkdownSytleConfig.cs" />
+    <Compile Include="MarkdownValidators\MarkdownValidationSetting.cs" />
     <Compile Include="MarkdownValidators\MarkdownValidationRule.cs" />
     <Compile Include="MarkdownValidators\MarkdownValidatorBuilder.cs" />
     <Compile Include="MarkdownValidators\MarkdownTagValidationRule.cs" />

--- a/src/Microsoft.DocAsCode.Dfm/Microsoft.DocAsCode.Dfm.csproj
+++ b/src/Microsoft.DocAsCode.Dfm/Microsoft.DocAsCode.Dfm.csproj
@@ -60,11 +60,12 @@
     <Compile Include="DfmFencesBlockPathQueryOptions\IDfmFencesBlockPathQueryOption.cs" />
     <Compile Include="DfmMarkdownRenderer.cs" />
     <Compile Include="CodeSnippetExtractor\ICodeSnippetExtractor.cs" />
+    <Compile Include="MarkdownValidators\MarkdownSytleDefinition.cs" />
     <Compile Include="MarkdownValidators\MarkdownSytleConfig.cs" />
     <Compile Include="MarkdownValidators\MarkdownValidationRule.cs" />
     <Compile Include="MarkdownValidators\MarkdownValidatorBuilder.cs" />
     <Compile Include="MarkdownValidators\MarkdownTagValidationRule.cs" />
-    <Compile Include="MarkdownValidators\TagAccess.cs" />
+    <Compile Include="MarkdownValidators\TagVerb.cs" />
     <Compile Include="MarkdownValidators\TagValidationBehavior.cs" />
     <Compile Include="Rules\DfmBlockquoteBlockRule.cs" />
     <Compile Include="Rules\DfmEmailInlineRule.cs" />

--- a/src/Microsoft.DocAsCode.Dfm/Microsoft.DocAsCode.Dfm.csproj
+++ b/src/Microsoft.DocAsCode.Dfm/Microsoft.DocAsCode.Dfm.csproj
@@ -66,7 +66,7 @@
     <Compile Include="MarkdownValidators\MarkdownValidationRule.cs" />
     <Compile Include="MarkdownValidators\MarkdownValidatorBuilder.cs" />
     <Compile Include="MarkdownValidators\MarkdownTagValidationRule.cs" />
-    <Compile Include="MarkdownValidators\TagVerb.cs" />
+    <Compile Include="MarkdownValidators\TagRelation.cs" />
     <Compile Include="MarkdownValidators\TagValidationBehavior.cs" />
     <Compile Include="Rules\DfmBlockquoteBlockRule.cs" />
     <Compile Include="Rules\DfmEmailInlineRule.cs" />

--- a/src/Microsoft.DocAsCode.MarkdownLite/Microsoft.DocAsCode.MarkdownLite.csproj
+++ b/src/Microsoft.DocAsCode.MarkdownLite/Microsoft.DocAsCode.MarkdownLite.csproj
@@ -139,12 +139,6 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Microsoft.DocAsCode.Common\Microsoft.DocAsCode.Common.csproj">
-      <Project>{72225351-32fd-103f-1818-25e3c7df74a2}</Project>
-      <Name>Microsoft.DocAsCode.Common</Name>
-    </ProjectReference>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Microsoft.DocAsCode.MarkdownLite/Rewriters/MarkdownTokenRewriterFactory.cs
+++ b/src/Microsoft.DocAsCode.MarkdownLite/Rewriters/MarkdownTokenRewriterFactory.cs
@@ -58,6 +58,15 @@ namespace Microsoft.DocAsCode.MarkdownLite
             return new MarkdownTokenValidatorAdapter(validators);
         }
 
+        public static IMarkdownTokenRewriter FromValidators(string scopeName, IEnumerable<IMarkdownTokenValidator> validators)
+        {
+            if (validators == null)
+            {
+                throw new ArgumentNullException(nameof(validators));
+            }
+            return new MarkdownTokenValidatorAdapter(validators);
+        }
+
         public static IMarkdownTokenRewriter Composite(params IMarkdownTokenRewriter[] rewriters)
         {
             return Composite((IEnumerable<IMarkdownTokenRewriter>)rewriters);

--- a/src/Microsoft.DocAsCode.MarkdownLite/Validators/MarkdownTokenValidatorAdapter.cs
+++ b/src/Microsoft.DocAsCode.MarkdownLite/Validators/MarkdownTokenValidatorAdapter.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.DocAsCode.MarkdownLite
 {
-    using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
 

--- a/src/Microsoft.DocAsCode.MarkdownLite/Validators/MarkdownTokenValidatorFactory.cs
+++ b/src/Microsoft.DocAsCode.MarkdownLite/Validators/MarkdownTokenValidatorFactory.cs
@@ -4,8 +4,6 @@
 namespace Microsoft.DocAsCode.MarkdownLite
 {
     using System;
-    using System.Collections.Generic;
-    using System.Collections.Immutable;
 
     public static class MarkdownTokenValidatorFactory
     {

--- a/src/Microsoft.DocAsCode.MarkdownLite/Validators/MarkdownTokenValidatorFactory.cs
+++ b/src/Microsoft.DocAsCode.MarkdownLite/Validators/MarkdownTokenValidatorFactory.cs
@@ -4,6 +4,8 @@
 namespace Microsoft.DocAsCode.MarkdownLite
 {
     using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
 
     public static class MarkdownTokenValidatorFactory
     {

--- a/src/Microsoft.DocAsCode.Plugins/MarkdownServiceParameters.cs
+++ b/src/Microsoft.DocAsCode.Plugins/MarkdownServiceParameters.cs
@@ -9,6 +9,7 @@ namespace Microsoft.DocAsCode.Plugins
     public class MarkdownServiceParameters
     {
         public string BasePath { get; set; }
+        public string TemplateDir { get; set; }
         public IReadOnlyDictionary<string, object> Extensions { get; set; }
         public ImmutableDictionary<string, string> Tokens { get; set; }
     }

--- a/src/docfx/SubCommands/BuildCommand.cs
+++ b/src/docfx/SubCommands/BuildCommand.cs
@@ -470,17 +470,17 @@ namespace Microsoft.DocAsCode.SubCommands
                 created = _templateManager.TryExportTemplateFiles(pluginFilePath, @"^plugins/.*");
                 if (created)
                 {
-                    BuildDocumentWithPlugin(Config, _templateManager, baseDirectory, outputDirectory, pluginBaseFolder, Path.Combine(pluginFilePath, "plugins"));
+                    BuildDocumentWithPlugin(Config, _templateManager, baseDirectory, outputDirectory, pluginBaseFolder, Path.Combine(pluginFilePath, "plugins"), pluginFilePath);
                 }
                 else
                 {
                     if (Directory.Exists(defaultPluginFolderPath))
                     {
-                        BuildDocumentWithPlugin(Config, _templateManager, baseDirectory, outputDirectory, pluginBaseFolder, defaultPluginFolderPath);
+                        BuildDocumentWithPlugin(Config, _templateManager, baseDirectory, outputDirectory, pluginBaseFolder, defaultPluginFolderPath, null);
                     }
                     else
                     {
-                        DocumentBuilderWrapper.BuildDocument(Config, _templateManager, baseDirectory, outputDirectory, null);
+                        DocumentBuilderWrapper.BuildDocument(Config, _templateManager, baseDirectory, outputDirectory, null, null);
                     }
                 }
             }
@@ -505,7 +505,7 @@ namespace Microsoft.DocAsCode.SubCommands
             }
         }
 
-        private static void BuildDocumentWithPlugin(BuildJsonConfig config, TemplateManager manager, string baseDirectory, string outputDirectory, string applicationBaseDirectory, string pluginDirectory)
+        private static void BuildDocumentWithPlugin(BuildJsonConfig config, TemplateManager manager, string baseDirectory, string outputDirectory, string applicationBaseDirectory, string pluginDirectory, string templateDirectory)
         {
             AppDomain builderDomain = null;
             try
@@ -522,7 +522,7 @@ namespace Microsoft.DocAsCode.SubCommands
 
                 builderDomain = AppDomain.CreateDomain("document builder domain", null, setup);
                 builderDomain.UnhandledException += (s, e) => { };
-                builderDomain.DoCallBack(new DocumentBuilderWrapper(config, manager, baseDirectory, outputDirectory, pluginDirectory, new CrossAppDomainListener()).BuildDocument);
+                builderDomain.DoCallBack(new DocumentBuilderWrapper(config, manager, baseDirectory, outputDirectory, pluginDirectory, new CrossAppDomainListener(), templateDirectory).BuildDocument);
             }
             finally
             {

--- a/test/Microsoft.DocAsCode.Dfm.Tests/DocfxFlavoredMarkdownTest.cs
+++ b/test/Microsoft.DocAsCode.Dfm.Tests/DocfxFlavoredMarkdownTest.cs
@@ -751,7 +751,7 @@ tag started with alphabet should not be encode: <abc> <a-hello> <a?world> <a_b h
             {
                 new MarkdownValidationRule
                 {
-                    RuleName =  HtmlMarkdownTokenValidatorProvider.ContractName,
+                    ContractName =  HtmlMarkdownTokenValidatorProvider.ContractName,
                 }
             });
             builder.Rewriter = mrb.Create();

--- a/test/Microsoft.DocAsCode.Dfm.Tests/DocfxFlavoredMarkdownTest.cs
+++ b/test/Microsoft.DocAsCode.Dfm.Tests/DocfxFlavoredMarkdownTest.cs
@@ -731,7 +731,8 @@ tag started with alphabet should not be encode: <abc> <a-hello> <a?world> <a_b h
                 new ContainerConfiguration()
                     .WithAssembly(typeof(DocfxFlavoredMarkdownTest).Assembly)
                     .CreateContainer());
-            mrb.AddTagValidators(
+            mrb.AddTagValidators(new[]
+            {
                 new MarkdownTagValidationRule
                 {
                     TagNames = new List<string> { "em", "div" },
@@ -744,8 +745,15 @@ tag started with alphabet should not be encode: <abc> <a-hello> <a?world> <a_b h
                     TagNames = new List<string> { "h1" },
                     MessageFormatter = "Warning tag({0})!",
                     Behavior = TagValidationBehavior.Warning,
-                });
-            mrb.AddValidators(HtmlMarkdownTokenValidatorProvider.ContractName);
+                },
+            });
+            mrb.AddValidators(new[]
+            {
+                new MarkdownValidationRule
+                {
+                    RuleName =  HtmlMarkdownTokenValidatorProvider.ContractName,
+                }
+            });
             builder.Rewriter = mrb.Create();
 
             var engine = builder.CreateDfmEngine(new DfmRenderer());


### PR DESCRIPTION
@chenkennt @superyyrrzz @hellosnow @ansyral @qinezh 
support define a set of rules or tag rules in template.
* folder must be `md.styles`
* file name must end with `.md.style`
* other part of file name will be treat as category.
* each tag rule can declare enable/disable by default.
* support overwrite same category rule for templates.

support `md.style` to config enable/disable rules imported from template.
* treat defined tag rules as normal rules.
* enable or disable rule sets by category name.
* enable or disable rules by full id (full id is: `<category name>` + `:` + `id`).