### PR TITLE
Fix unescape bug in StringHelper

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdownLite/Basic/InlineRules/MarkdownLinkBaseInlineRule.cs
+++ b/src/Microsoft.DocAsCode.MarkdownLite/Basic/InlineRules/MarkdownLinkBaseInlineRule.cs
@@ -11,15 +11,14 @@ namespace Microsoft.DocAsCode.MarkdownLite
 
         protected virtual IMarkdownToken GenerateToken(IMarkdownParser parser, string href, string title, string text, bool isImage, SourceInfo sourceInfo)
         {
-            var escapedHref = StringHelper.Escape(Regexes.Helper.MarkdownEscape.Replace(href, m => m.Groups[1].Value));
-            var escapedTitle = !string.IsNullOrEmpty(title) ? StringHelper.Escape(title) : null;
+            var escapedHref = Regexes.Helper.MarkdownEscape.Replace(href, m => m.Groups[1].Value);
             if (isImage)
             {
-                return new MarkdownImageInlineToken(this, parser.Context, escapedHref, escapedTitle, text, sourceInfo);
+                return new MarkdownImageInlineToken(this, parser.Context, escapedHref, title, text, sourceInfo);
             }
             else
             {
-                return new MarkdownLinkInlineToken(this, parser.Context, escapedHref, escapedTitle, parser.Tokenize(sourceInfo.Copy(text)), sourceInfo);
+                return new MarkdownLinkInlineToken(this, parser.Context, escapedHref, title, parser.Tokenize(sourceInfo.Copy(text)), sourceInfo);
             }
         }
     }

--- a/src/Microsoft.DocAsCode.MarkdownLite/HtmlRenderer.cs
+++ b/src/Microsoft.DocAsCode.MarkdownLite/HtmlRenderer.cs
@@ -227,7 +227,7 @@ namespace Microsoft.DocAsCode.MarkdownLite
 
                 try
                 {
-                    prot = Regex.Replace(StringHelper.DecodeURIComponent(StringHelper.Unescape(token.Href)), @"[^\w:]", string.Empty).ToLower();
+                    prot = Regex.Replace(StringHelper.DecodeURIComponent(token.Href), @"[^\w:]", string.Empty).ToLower();
                 }
                 catch (Exception)
                 {
@@ -240,10 +240,10 @@ namespace Microsoft.DocAsCode.MarkdownLite
                 }
             }
 
-            var result = (StringBuffer)"<a href=\"" + token.Href + "\"";
+            var result = (StringBuffer)"<a href=\"" + StringHelper.Escape(token.Href) + "\"";
             if (!string.IsNullOrEmpty(token.Title))
             {
-                result = result + " title=\"" + StringHelper.HtmlEncode(token.Title) + "\"";
+                result = result + " title=\"" + StringHelper.Escape(token.Title) + "\"";
             }
             result = AppendSourceInfo(result, renderer, token);
             result += ">";
@@ -259,10 +259,10 @@ namespace Microsoft.DocAsCode.MarkdownLite
 
         public virtual StringBuffer Render(IMarkdownRenderer renderer, MarkdownImageInlineToken token, MarkdownInlineContext context)
         {
-            var result = (StringBuffer)"<img src=\"" + token.Href + "\" alt=\"" + StringHelper.HtmlEncode(token.Text) + "\"";
+            var result = (StringBuffer)"<img src=\"" + StringHelper.Escape(token.Href) + "\" alt=\"" + StringHelper.Escape(token.Text) + "\"";
             if (!string.IsNullOrEmpty(token.Title))
             {
-                result = result + " title=\"" + StringHelper.HtmlEncode(token.Title) + "\"";
+                result = result + " title=\"" + StringHelper.Escape(token.Title) + "\"";
             }
             result = AppendSourceInfo(result, renderer, token);
 

--- a/src/Microsoft.DocAsCode.MarkdownLite/MarkdownRenderer.cs
+++ b/src/Microsoft.DocAsCode.MarkdownLite/MarkdownRenderer.cs
@@ -21,11 +21,11 @@ namespace Microsoft.DocAsCode.MarkdownLite
             content += "![";
             content += token.Text;
             content += "](";
-            content += Regexes.Helper.MarkdownUnescape.Replace(StringHelper.Unescape(token.Href), m => "\\" + m.Value);
+            content += Regexes.Helper.MarkdownUnescape.Replace(token.Href, m => "\\" + m.Value);
             if (!string.IsNullOrEmpty(token.Title))
             {
                 content += " \"";
-                content += Regexes.Helper.MarkdownUnescape.Replace(StringHelper.Unescape(token.Title), m => "\\" + m.Value);
+                content += Regexes.Helper.MarkdownUnescape.Replace(token.Title, m => "\\" + m.Value);
                 content += "\"";
             }
             content += ")";
@@ -41,11 +41,11 @@ namespace Microsoft.DocAsCode.MarkdownLite
                 content += render.Render(t);
             }
             content += "](";
-            content += Regexes.Helper.MarkdownUnescape.Replace(StringHelper.Unescape(token.Href), m => "\\" + m.Value);
+            content += Regexes.Helper.MarkdownUnescape.Replace(token.Href, m => "\\" + m.Value);
             if (!string.IsNullOrEmpty(token.Title))
             {
                 content += " \"";
-                content += Regexes.Helper.MarkdownUnescape.Replace(StringHelper.Unescape(token.Title), m => "\\" + m.Value);
+                content += Regexes.Helper.MarkdownUnescape.Replace(token.Title, m => "\\" + m.Value);
                 content += "\"";
             }
             content += ")";

--- a/src/Microsoft.DocAsCode.MarkdownLite/StringHelper.cs
+++ b/src/Microsoft.DocAsCode.MarkdownLite/StringHelper.cs
@@ -45,6 +45,7 @@ namespace Microsoft.DocAsCode.MarkdownLite
                 var n = match.Groups[1].Value;
 
                 n = n.ToLower();
+                if (n == "amp") return "&";
                 if (n == "colon") return ":";
                 if (n[0] == '#')
                 {

--- a/test/Microsoft.DocAsCode.Dfm.Tests/DocfxFlavoredMarkdownTest.cs
+++ b/test/Microsoft.DocAsCode.Dfm.Tests/DocfxFlavoredMarkdownTest.cs
@@ -705,7 +705,7 @@ tag started with alphabet should not be encode: <abc> <a-hello> <a?world> <a_b h
         public void TestDfmLink_LinkWithSpecialCharactorsInTitle()
         {
             var source = @"[text's string](https://www.google.com.sg/?gfe_rd=cr&ei=Xk ""Google's homepage"")";
-            var expected = @"<p><a href=""https://www.google.com.sg/?gfe_rd=cr&amp;ei=Xk"" title=""Google&amp;#39;s homepage"">text&#39;s string</a></p>
+            var expected = @"<p><a href=""https://www.google.com.sg/?gfe_rd=cr&amp;ei=Xk"" title=""Google&#39;s homepage"">text&#39;s string</a></p>
 ";
             var marked = DocfxFlavoredMarked.Markup(source);
             Assert.Equal(expected.Replace("\r\n", "\n"), marked);
@@ -717,7 +717,7 @@ tag started with alphabet should not be encode: <abc> <a-hello> <a?world> <a_b h
         {
             var source = @"[This is link text with quotation ' and double quotation ""hello"" world](girl.png ""title is ""hello"" world."")";
 
-            var expected = @"<p><a href=""girl.png"" title=""title is &amp;quot;hello&amp;quot; world."">This is link text with quotation &#39; and double quotation &quot;hello&quot; world</a></p>
+            var expected = @"<p><a href=""girl.png"" title=""title is &quot;hello&quot; world."">This is link text with quotation &#39; and double quotation &quot;hello&quot; world</a></p>
 ";
             var marked = DocfxFlavoredMarked.Markup(source);
             Assert.Equal(expected.Replace("\r\n", "\n"), marked);

--- a/test/Microsoft.DocAsCode.Dfm.Tests/DocfxFlavoredMarkdownTest.cs
+++ b/test/Microsoft.DocAsCode.Dfm.Tests/DocfxFlavoredMarkdownTest.cs
@@ -701,6 +701,18 @@ tag started with alphabet should not be encode: <abc> <a-hello> <a?world> <a_b h
 
         [Fact]
         [Trait("Related", "DfmMarkdown")]
+        [Trait("A wrong case need to be fixed in dfm", "' in title should be traslated to &#39; instead of &amp;#39;")]
+        public void TestDfmLink_LinkWithSpecialCharactorsInTitle()
+        {
+            var source = @"[text's string](https://www.google.com.sg/?gfe_rd=cr&ei=Xk ""Google's homepage"")";
+            var expected = @"<p><a href=""https://www.google.com.sg/?gfe_rd=cr&amp;ei=Xk"" title=""Google&amp;#39;s homepage"">text&#39;s string</a></p>
+";
+            var marked = DocfxFlavoredMarked.Markup(source);
+            Assert.Equal(expected.Replace("\r\n", "\n"), marked);
+        }
+
+        [Fact]
+        [Trait("Related", "DfmMarkdown")]
         public void TestDfmLink_WithSpecialCharactorsInTitle()
         {
             var source = @"[This is link text with quotation ' and double quotation ""hello"" world](girl.png ""title is ""hello"" world."")";

--- a/test/Microsoft.DocAsCode.MarkdownLite.Tests/GfmTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdownLite.Tests/GfmTest.cs
@@ -598,7 +598,7 @@ https://en.wikipedia.org/wiki/Draft:Microsoft_SQL_Server_Libraries/Drivers
         {
             var source = @"[This is link text with quotation ' and double quotation ""hello"" world](girl.png ""title is ""hello"" world."")";
 
-            var expected = @"<p><a href=""girl.png"" title=""title is &amp;quot;hello&amp;quot; world."">This is link text with quotation &#39; and double quotation &quot;hello&quot; world</a></p>
+            var expected = @"<p><a href=""girl.png"" title=""title is &quot;hello&quot; world."">This is link text with quotation &#39; and double quotation &quot;hello&quot; world</a></p>
 ";
             TestGfmInGeneral(source, expected);
         }

--- a/test/Microsoft.DocAsCode.MarkdownRewriters.Tests/AzureMarkdownRewritersTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdownRewriters.Tests/AzureMarkdownRewritersTest.cs
@@ -910,6 +910,20 @@ ms.author: rogardle
 
         [Fact]
         [Trait("Related", "AzureMarkdownRewriters")]
+        [Trait("Bug 617364", "link with query condition")]
+        public void TestAzureMarkdownRewriters_AbsoluteLinkWithQueryCondition()
+        {
+            var source = @"[Microsoft Azure Active Directory Samples and Documentation](https://github.com/Azure-Samples?page=3&query=active-directory)";
+            var expected = @"[Microsoft Azure Active Directory Samples and Documentation](https://github.com/Azure-Samples?page=3&query=active-directory)
+
+";
+
+            var result = AzureMarked.Markup(source);
+            Assert.Equal(expected.Replace("\r\n", "\n"), result);
+        }
+
+        [Fact]
+        [Trait("Related", "AzureMarkdownRewriters")]
         public void TestAzureMarkdownRewriters_AzureUniqueNameMarkdownRelativeLinkInsideDocsetWithOnlyBookmark()
         {
             var azureMarkdownFileInfoMapping =


### PR DESCRIPTION
1. &amp; should return & in unescape method instead of string.Empty to match escape method in StringHelper
2. Add a wrong case, that the ' in the title part of markdown link syntax should be translated to &amp;. Add this case to reminder. @vwxyzh, I don't have a good idea to fix this, may be you should take a look.