### PR TITLE
fix remove dupliate sourcePath in manifest file

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/DocumentBuilder.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/DocumentBuilder.cs
@@ -147,11 +147,12 @@ namespace Microsoft.DocAsCode.Build.Engine
             var itemsToRemove = new HashSet<string>();
             foreach (var duplicates in from m in manifestItems
                                        from output in m.OutputFiles.Values
-                                       group m.SourceRelativePath by output into g
+                                       let relativePath = output?.RelativePath
+                                       group m.SourceRelativePath by relativePath into g
                                        where g.Count() > 1
                                        select g)
             {
-                Logger.LogWarning($"Overwrite occurs while input files \"{string.Join(", ", duplicates)}\" writing to the same output file \"{duplicates.Key}\"");
+                Logger.LogWarning($"Overwrite occurs while input files \"{string.Join(", ", duplicates)}\" writing to the same output relative file \"{duplicates.Key}\"");
                 itemsToRemove.UnionWith(duplicates.Skip(1));
             }
             manifestItems.RemoveAll(m => itemsToRemove.Contains(m.SourceRelativePath));

--- a/src/Microsoft.DocAsCode.Build.Engine/DocumentBuilder.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/DocumentBuilder.cs
@@ -152,7 +152,7 @@ namespace Microsoft.DocAsCode.Build.Engine
                                        where g.Count() > 1
                                        select g)
             {
-                Logger.LogWarning($"Overwrite occurs while input files \"{string.Join(", ", duplicates)}\" writing to the same output relative file \"{duplicates.Key}\"");
+                Logger.LogWarning($"Overwrite occurs while input files \"{string.Join(", ", duplicates)}\" writing to the same output file \"{duplicates.Key}\"");
                 itemsToRemove.UnionWith(duplicates.Skip(1));
             }
             manifestItems.RemoveAll(m => itemsToRemove.Contains(m.SourceRelativePath));


### PR DESCRIPTION
with the changing of obsolete manifest item, the remove duplicate logic should also be updated.

@vwxyzh @qinezh @superyyrrzz @ansyral @chenkennt 