### PR TITLE
use jobject to parse json, to judge whether json file is supported as swagger

### DIFF
--- a/src/Microsoft.DocAsCode.Build.RestApi/RestApiDocumentProcessor.cs
+++ b/src/Microsoft.DocAsCode.Build.RestApi/RestApiDocumentProcessor.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Newtonsoft.Json.Linq;
-
 namespace Microsoft.DocAsCode.Build.RestApi
 {
     using System;
@@ -22,6 +20,7 @@ namespace Microsoft.DocAsCode.Build.RestApi
     using Microsoft.DocAsCode.Utility;
 
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
 
     [Export(typeof(IDocumentProcessor))]
     public class RestApiDocumentProcessor : DisposableDocumentProcessor

--- a/src/Microsoft.DocAsCode.Build.RestApi/RestApiDocumentProcessor.cs
+++ b/src/Microsoft.DocAsCode.Build.RestApi/RestApiDocumentProcessor.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Newtonsoft.Json.Linq;
+
 namespace Microsoft.DocAsCode.Build.RestApi
 {
     using System;
@@ -141,11 +143,11 @@ namespace Microsoft.DocAsCode.Build.RestApi
         {
             try
             {
-                var dictionary = JsonUtility.Deserialize<Dictionary<string, object>>(filePath);
-                object swaggerValue;
-                if (dictionary.TryGetValue("swagger", out swaggerValue))
+                var jObject = JObject.Parse(File.ReadAllText(filePath));
+                JToken swaggerValue;
+                if (jObject.TryGetValue("swagger", out swaggerValue))
                 {
-                    var swaggerString = swaggerValue as string;
+                    var swaggerString = (string)swaggerValue;
                     if (swaggerString != null && swaggerString.Equals("2.0"))
                     {
                         return true;
@@ -158,7 +160,7 @@ namespace Microsoft.DocAsCode.Build.RestApi
             }
             catch (JsonException ex)
             {
-                Logger.LogVerbose($"In {nameof(RestApiDocumentProcessor)}, could not deserialize {filePath} to Dictionary<string, object>, exception details: {ex.Message}.");
+                Logger.LogVerbose($"In {nameof(RestApiDocumentProcessor)}, could not deserialize {filePath} to JObject, exception details: {ex.Message}.");
             }
 
             return false;

--- a/src/Microsoft.DocAsCode.Build.RestApi/Swagger/Internals/SwaggerJsonBuilder.cs
+++ b/src/Microsoft.DocAsCode.Build.RestApi/Swagger/Internals/SwaggerJsonBuilder.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DocAsCode.Build.RestApi.Swagger.Internals
 
                     // For swagger, other properties are still allowed besides $ref, e.g.
                     // "schema": {
-                    //   "$ref": "#/defintions/foo"
+                    //   "$ref": "#/definitions/foo"
                     //   "example": { }
                     // }
                     // Use Token property to keep other properties

--- a/src/Microsoft.DocAsCode.Build.RestApi/Swagger/SwaggerJsonParser.cs
+++ b/src/Microsoft.DocAsCode.Build.RestApi/Swagger/SwaggerJsonParser.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DocAsCode.Build.RestApi.Swagger
                 var builder = new SwaggerJsonBuilder();
                 var swagger = builder.Read(reader);
 
-                // Serialze to JToken
+                // Serialize to JToken
                 var token = JToken.FromObject(swagger, _serializer.Value);
 
                 // Convert to swagger model


### PR DESCRIPTION
JsonUtility.Deserialize< Dictionary < string, object > > will fail for such case, since 'required' has been added twice, use JObject.Parse instead to only care about top keys.
```json
"A": {
      "required": [
        "B",
        "C"
      ],
      "required": [
        "B"
      ],
      "description": "Deployment properties."
    },
```
@vwxyzh @superyyrrzz @qinezh @chenkennt @ansyral 