### PR TITLE
Rest - fix when 'definitions' has direct child with $ref defined

### DIFF
--- a/src/Microsoft.DocAsCode.Build.RestApi/Swagger/Internals/SwaggerJsonBuilder.cs
+++ b/src/Microsoft.DocAsCode.Build.RestApi/Swagger/Internals/SwaggerJsonBuilder.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DocAsCode.Build.RestApi.Swagger.Internals
 
     internal class SwaggerJsonBuilder
     {
-        private IDictionary<string, SwaggerObject> _documentObjectCache;
+        private IDictionary<string, SwaggerObjectBase> _documentObjectCache;
         private IDictionary<string, SwaggerObject> _resolvedObjectCache;
         private const string DefinitionsKey = "definitions";
         private const string ParametersKey = "parameters";
@@ -22,7 +22,7 @@ namespace Microsoft.DocAsCode.Build.RestApi.Swagger.Internals
 
         public SwaggerObjectBase Read(JsonReader reader)
         {
-            _documentObjectCache = new Dictionary<string, SwaggerObject>();
+            _documentObjectCache = new Dictionary<string, SwaggerObjectBase>();
             _resolvedObjectCache = new Dictionary<string, SwaggerObject>();
             var token = JToken.ReadFrom(reader);
             var swagger = Build(token);
@@ -32,12 +32,19 @@ namespace Microsoft.DocAsCode.Build.RestApi.Swagger.Internals
 
         private SwaggerObjectBase Build(JToken token)
         {
+            // Fetch from cache first
+            var location = GetLocation(token);
+            SwaggerObjectBase existingObject;
+            if (_documentObjectCache.TryGetValue(location, out existingObject))
+            {
+                return existingObject;
+            }
+
             var jObject = token as JObject;
             if (jObject != null)
             {
-                JToken referenceToken;
-
                 // Only one $ref is allowed inside a swagger JObject
+                JToken referenceToken;
                 if (jObject.TryGetValue("$ref", out referenceToken))
                 {
                     if (referenceToken.Type != JTokenType.String && referenceToken.Type != JTokenType.Null)
@@ -45,48 +52,41 @@ namespace Microsoft.DocAsCode.Build.RestApi.Swagger.Internals
                         throw new JsonException($"JSON reference $ref property must have a string or null value, instead of {referenceToken.Type}, location: {referenceToken.Path}.");
                     }
 
-                    SwaggerReferenceObject deferredObject = new SwaggerReferenceObject();
                     var formatted = RestApiHelper.FormatReferenceFullPath((string)referenceToken);
-                    deferredObject.DeferredReference = formatted.Item1;
-                    deferredObject.ReferenceName = formatted.Item2;
+                    var deferredObject = new SwaggerReferenceObject
+                    {
+                        DeferredReference = formatted.Item1,
+                        ReferenceName = formatted.Item2,
+                        Location = location
+                    };
 
                     // For swagger, other properties are still allowed besides $ref, e.g.
                     // "schema": {
-                    //   "$ref": "#/defintions/foo"
+                    //   "$ref": "#/definitions/foo"
                     //   "example": { }
                     // }
                     // Use Token property to keep other properties
                     // These properties cannot be referenced
                     jObject.Remove("$ref");
                     deferredObject.Token = jObject;
+                    _documentObjectCache.Add(location, deferredObject);
                     return deferredObject;
                 }
-                else
+
+                var swaggerObject = new SwaggerObject { Location = location };
+                foreach (KeyValuePair<string, JToken> property in jObject)
                 {
-                    string location = GetLocation(token);
-
-                    SwaggerObject existingObject;
-                    if (_documentObjectCache.TryGetValue(location, out existingObject))
-                    {
-                        return existingObject;
-                    }
-
-                    var swaggerObject = new SwaggerObject { Location = location };
-
-                    foreach (KeyValuePair<string, JToken> property in jObject)
-                    {
-                        swaggerObject.Dictionary.Add(property.Key, Build(property.Value));
-                    }
-
-                    _documentObjectCache.Add(location, swaggerObject);
-                    return swaggerObject;
+                    swaggerObject.Dictionary.Add(property.Key, Build(property.Value));
                 }
+
+                _documentObjectCache.Add(location, swaggerObject);
+                return swaggerObject;
             }
 
             var jArray = token as JArray;
             if (jArray != null)
             {
-                var swaggerArray = new SwaggerArray();
+                var swaggerArray = new SwaggerArray { Location = location };
                 foreach (var property in jArray)
                 {
                     swaggerArray.Array.Add(Build(property));
@@ -97,6 +97,7 @@ namespace Microsoft.DocAsCode.Build.RestApi.Swagger.Internals
 
             return new SwaggerValue
             {
+                Location = location,
                 Token = token
             };
         }
@@ -134,13 +135,13 @@ namespace Microsoft.DocAsCode.Build.RestApi.Swagger.Internals
                                 throw new JsonException($"reference \"{swagger.DeferredReference}\" is not supported. Reference must be inside current schema document starting with /");
                             }
 
-                            SwaggerObject referencedObject;
-                            if (!_documentObjectCache.TryGetValue(swagger.DeferredReference, out referencedObject))
+                            SwaggerObjectBase referencedObjectBase;
+                            if (!_documentObjectCache.TryGetValue(swagger.DeferredReference, out referencedObjectBase))
                             {
                                 throw new JsonException($"Could not resolve reference '{swagger.DeferredReference}' in the document.");
                             }
 
-                            if (refStack.Contains(referencedObject.Location))
+                            if (refStack.Contains(referencedObjectBase.Location))
                             {
                                 var loopRef = new SwaggerLoopReferenceObject();
                                 loopRef.Dictionary.Add(InternalLoopRefNameKey, new SwaggerValue { Token = swagger.ReferenceName });
@@ -154,13 +155,9 @@ namespace Microsoft.DocAsCode.Build.RestApi.Swagger.Internals
                             }
 
                             // Clone to avoid change the reference object in _documentObjectCache
-                            refStack.Push(referencedObject.Location);
-                            var swaggerObj = (SwaggerObject)ResolveReferences(referencedObject.Clone(), refStack);
-                            if (!swaggerObj.Dictionary.ContainsKey(InternalRefNameKey))
-                            {
-                                swaggerObj.Dictionary.Add(InternalRefNameKey, new SwaggerValue { Token = swagger.ReferenceName });
-                            }
-                            swagger.Reference = swaggerObj;
+                            refStack.Push(referencedObjectBase.Location);
+                            var resolved = ResolveReferences(referencedObjectBase.Clone(), refStack);
+                            swagger.Reference = ResolveSwaggerObject(resolved, swagger.ReferenceName);
                             refStack.Pop();
 
                             if (refStack.Count == 0)
@@ -194,6 +191,27 @@ namespace Microsoft.DocAsCode.Build.RestApi.Swagger.Internals
                 default:
                     throw new NotSupportedException(swaggerBase.ObjectType.ToString());
             }
+        }
+
+        private static SwaggerObject ResolveSwaggerObject(SwaggerObjectBase swaggerObjectBase, string referenceName)
+        {
+            var swaggerObject = swaggerObjectBase as SwaggerObject;
+            if (swaggerObject != null)
+            {
+                if (!swaggerObject.Dictionary.ContainsKey(InternalRefNameKey))
+                {
+                    swaggerObject.Dictionary.Add(InternalRefNameKey, new SwaggerValue { Token = referenceName });
+                }
+                return swaggerObject;
+            }
+
+            var swaggerReferenceObject = swaggerObjectBase as SwaggerReferenceObject;
+            if (swaggerReferenceObject != null)
+            {
+                return swaggerReferenceObject.Reference;
+            }
+
+            throw new ArgumentException($"When resolving reference for {nameof(SwaggerReferenceObject)}, only support {nameof(SwaggerObject)} and {nameof(SwaggerReferenceObject)} as parameter.");
         }
 
         private static string GetLocation(JToken token)

--- a/src/Microsoft.DocAsCode.Build.RestApi/Swagger/Internals/SwaggerJsonBuilder.cs
+++ b/src/Microsoft.DocAsCode.Build.RestApi/Swagger/Internals/SwaggerJsonBuilder.cs
@@ -157,7 +157,12 @@ namespace Microsoft.DocAsCode.Build.RestApi.Swagger.Internals
                             // Clone to avoid change the reference object in _documentObjectCache
                             refStack.Push(referencedObjectBase.Location);
                             var resolved = ResolveReferences(referencedObjectBase.Clone(), refStack);
-                            swagger.Reference = ResolveSwaggerObject(resolved, swagger.ReferenceName);
+                            var swaggerObject = ResolveSwaggerObject(resolved);
+                            if (!swaggerObject.Dictionary.ContainsKey(InternalRefNameKey))
+                            {
+                                swaggerObject.Dictionary.Add(InternalRefNameKey, new SwaggerValue { Token = swagger.ReferenceName });
+                            }
+                            swagger.Reference = swaggerObject;
                             refStack.Pop();
 
                             if (refStack.Count == 0)
@@ -193,15 +198,11 @@ namespace Microsoft.DocAsCode.Build.RestApi.Swagger.Internals
             }
         }
 
-        private static SwaggerObject ResolveSwaggerObject(SwaggerObjectBase swaggerObjectBase, string referenceName)
+        private static SwaggerObject ResolveSwaggerObject(SwaggerObjectBase swaggerObjectBase)
         {
             var swaggerObject = swaggerObjectBase as SwaggerObject;
             if (swaggerObject != null)
             {
-                if (!swaggerObject.Dictionary.ContainsKey(InternalRefNameKey))
-                {
-                    swaggerObject.Dictionary.Add(InternalRefNameKey, new SwaggerValue { Token = referenceName });
-                }
                 return swaggerObject;
             }
 

--- a/src/Microsoft.DocAsCode.Build.RestApi/Swagger/Internals/SwaggerObject.cs
+++ b/src/Microsoft.DocAsCode.Build.RestApi/Swagger/Internals/SwaggerObject.cs
@@ -12,8 +12,6 @@ namespace Microsoft.DocAsCode.Build.RestApi.Swagger.Internals
 
         public Dictionary<string, SwaggerObjectBase> Dictionary { get; set; } = new Dictionary<string, SwaggerObjectBase>();
 
-        public string Location { get; set; }
-
         public override SwaggerObjectBase Clone()
         {
             var clone = (SwaggerObject)MemberwiseClone();

--- a/src/Microsoft.DocAsCode.Build.RestApi/Swagger/Internals/SwaggerObjectBase.cs
+++ b/src/Microsoft.DocAsCode.Build.RestApi/Swagger/Internals/SwaggerObjectBase.cs
@@ -11,6 +11,8 @@ namespace Microsoft.DocAsCode.Build.RestApi.Swagger.Internals
 
         public bool ReferencesResolved { get; set; }
 
+        public string Location { get; set; }
+
         public abstract SwaggerObjectBase Clone();
     }
 }

--- a/test/Microsoft.DocAsCode.Build.RestApi.Tests/RestApiDocumentProcessorTest.cs
+++ b/test/Microsoft.DocAsCode.Build.RestApi.Tests/RestApiDocumentProcessorTest.cs
@@ -57,64 +57,70 @@ namespace Microsoft.DocAsCode.Build.RestApi.Tests
             Assert.Equal("Hello world!", model.Metadata["meta"]);
 
             // Verify $ref in path
-            var item1 = model.Children[0];
-            Assert.Equal("graph.windows.net/myorganization/Contacts/1.0/get contacts", item1.Uid);
-            Assert.Equal("<p>You can get a collection of contacts from your tenant.</p>\n", item1.Summary);
-            Assert.Equal(1, item1.Parameters.Count);
-            Assert.Equal("1.6", item1.Parameters[0].Metadata["default"]);
-            Assert.Equal(1, item1.Responses.Count);
-            Assert.Equal("200", item1.Responses[0].HttpStatusCode);
+            var item0 = model.Children[0];
+            Assert.Equal("graph.windows.net/myorganization/Contacts/1.0/get contacts", item0.Uid);
+            Assert.Equal("<p>You can get a collection of contacts from your tenant.</p>\n", item0.Summary);
+            Assert.Equal(1, item0.Parameters.Count);
+            Assert.Equal("1.6", item0.Parameters[0].Metadata["default"]);
+            Assert.Equal(1, item0.Responses.Count);
+            Assert.Equal("200", item0.Responses[0].HttpStatusCode);
 
             // Verify tags of child
-            var item1Tag = (JArray)(item1.Metadata["tags"]);
-            Assert.NotNull(item1Tag);
-            Assert.Equal("contacts", item1Tag[0]);
-            var item2 = model.Children[1];
-            var item2Tag = (JArray)(item2.Metadata["tags"]);
+            var item0Tag = (JArray)(item0.Metadata["tags"]);
+            Assert.NotNull(item0Tag);
+            Assert.Equal("contacts", item0Tag[0]);
+            var item1 = model.Children[1];
+            var item2Tag = (JArray)(item1.Metadata["tags"]);
             Assert.NotNull(item2Tag);
             Assert.Equal("contacts", item2Tag[0]);
             Assert.Equal("pet store", item2Tag[1]);
 
             // Verify tags of root
             Assert.Equal(3, model.Tags.Count);
-            var tag1 = model.Tags[0];
-            Assert.Equal("contact", tag1.Name);
-            Assert.Equal("<p>Everything about the <strong>contacts</strong></p>\n", tag1.Description);
-            Assert.Equal("contact-bookmark", tag1.HtmlId);
-            Assert.Equal(1, tag1.Metadata.Count);
-            var externalDocs = (JObject)tag1.Metadata["externalDocs"];
+            var tag0 = model.Tags[0];
+            Assert.Equal("contact", tag0.Name);
+            Assert.Equal("<p>Everything about the <strong>contacts</strong></p>\n", tag0.Description);
+            Assert.Equal("contact-bookmark", tag0.HtmlId);
+            Assert.Equal(1, tag0.Metadata.Count);
+            var externalDocs = (JObject)tag0.Metadata["externalDocs"];
             Assert.NotNull(externalDocs);
             Assert.Equal("Find out more", externalDocs["description"]);
             Assert.Equal("http://swagger.io", externalDocs["url"]);
-            var tag2 = model.Tags[1];
-            Assert.Equal("pet_store", tag2.HtmlId);
+            var tag1 = model.Tags[1];
+            Assert.Equal("pet_store", tag1.HtmlId);
 
             // Verify path parameters
             // Path parameter applicable for get operation
-            Assert.Equal(2, item2.Parameters.Count);
-            Assert.Equal("object_id", item2.Parameters[0].Metadata["name"]);
-            Assert.Equal("api-version", item2.Parameters[1].Metadata["name"]);
-            Assert.Equal(true, item2.Parameters[1].Metadata["required"]);
+            Assert.Equal(2, item1.Parameters.Count);
+            Assert.Equal("object_id", item1.Parameters[0].Metadata["name"]);
+            Assert.Equal("api-version", item1.Parameters[1].Metadata["name"]);
+            Assert.Equal(true, item1.Parameters[1].Metadata["required"]);
 
             // Override ""api-version" parameters by $ref for patch operation
-            var item3 = model.Children[2];
-            Assert.Equal(3, item3.Parameters.Count);
+            var item2 = model.Children[2];
+            Assert.Equal(3, item2.Parameters.Count);
+            Assert.Equal("object_id", item2.Parameters[0].Metadata["name"]);
+            Assert.Equal("api-version", item2.Parameters[1].Metadata["name"]);
+            Assert.Equal(false, item2.Parameters[1].Metadata["required"]);
+
+            // Override ""api-version" parameters by self definition for delete operation
+            var item3 = model.Children[3];
+            Assert.Equal(2, item3.Parameters.Count);
             Assert.Equal("object_id", item3.Parameters[0].Metadata["name"]);
             Assert.Equal("api-version", item3.Parameters[1].Metadata["name"]);
             Assert.Equal(false, item3.Parameters[1].Metadata["required"]);
 
-            // Override ""api-version" parameters by self definition for delete operation
-            var item4 = model.Children[3];
-            Assert.Equal(2, item4.Parameters.Count);
-            Assert.Equal("object_id", item4.Parameters[0].Metadata["name"]);
-            Assert.Equal("api-version", item4.Parameters[1].Metadata["name"]);
-            Assert.Equal(false, item4.Parameters[1].Metadata["required"]);
-
             // When operation parameters is not set, inherit from th parameters for post operation
-            var item5 = model.Children[4];
-            Assert.Equal(1, item5.Parameters.Count);
-            Assert.Equal("api-version", item5.Parameters[0].Metadata["name"]);
-            Assert.Equal(true, item5.Parameters[0].Metadata["required"]);
+            var item4 = model.Children[4];
+            Assert.Equal(1, item4.Parameters.Count);
+            Assert.Equal("api-version", item4.Parameters[0].Metadata["name"]);
+            Assert.Equal(true, item4.Parameters[0].Metadata["required"]);
+
+            // When 'definitions' has direct child with $ref defined, should resolve it
+            var item5 = model.Children[6];
+            var parameter2 = (JObject)item5.Parameters[2].Metadata["schema"];
+            Assert.Equal("string", parameter2["type"]);
+            Assert.Equal("uri", parameter2["format"]);
         }
 
         [Fact]

--- a/test/Microsoft.DocAsCode.Build.RestApi.Tests/TestData/contacts.json
+++ b/test/Microsoft.DocAsCode.Build.RestApi.Tests/TestData/contacts.json
@@ -257,22 +257,13 @@
             "type": "string",
             "default": "1.6"
           },
-
           {
             "in": "body",
             "description": "The request body contains a single property that specifies the URL of the user or contact to add as manager.",
             "name": "bodyparam",
             "required": true,
             "schema": {
-              "required": [ "url" ],
-              "properties": {
-                "url": {
-                  "type": "string"
-                }
-              },
-              "example": {
-                "url": "https://graph.windows.net/myorganization/directoryObjects/35110b16-360c-4c4a-93b2-03f065fabd93"
-              }
+              "$ref": "#/definitions/containerUrl"
             }
           }
         ],
@@ -595,6 +586,14 @@
         "summary": "You can get a collection of contacts from your tenant.",
         "operationId": "get contacts"
       }
+    },
+    "url": {
+      "type": "string",
+      "format": "uri"
+    },
+    "containerUrl": {
+      "$ref": "#/definitions/url",
+      "description": "fake description."
     },
     "contact/def~": {
       "properties": {


### PR DESCRIPTION
Previously we didn't support following case, when "definitions" has direct child with "$ref" defined, we will treat it as SwaggerReferenceObject which is to be resolved, and not add into cache, so it will fail when resolving the reference in next steps.
```json
"definitions": {
    "containerUrl": {
      "$ref": "#/definitions/url",
      "description": "fake description."
    }
}
```

@ansyral @superyyrrzz @qinezh @chenkennt @vwxyzh 