### PR TITLE
Rest - use jobject to judge whether a json is swagger, no need to deserialize whole file

### DIFF
--- a/src/Microsoft.DocAsCode.Build.RestApi/RestApiDocumentProcessor.cs
+++ b/src/Microsoft.DocAsCode.Build.RestApi/RestApiDocumentProcessor.cs
@@ -20,6 +20,7 @@ namespace Microsoft.DocAsCode.Build.RestApi
     using Microsoft.DocAsCode.Utility;
 
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
 
     [Export(typeof(IDocumentProcessor))]
     public class RestApiDocumentProcessor : DisposableDocumentProcessor
@@ -141,11 +142,11 @@ namespace Microsoft.DocAsCode.Build.RestApi
         {
             try
             {
-                var dictionary = JsonUtility.Deserialize<Dictionary<string, object>>(filePath);
-                object swaggerValue;
-                if (dictionary.TryGetValue("swagger", out swaggerValue))
+                var jObject = JObject.Parse(File.ReadAllText(filePath));
+                JToken swaggerValue;
+                if (jObject.TryGetValue("swagger", out swaggerValue))
                 {
-                    var swaggerString = swaggerValue as string;
+                    var swaggerString = (string)swaggerValue;
                     if (swaggerString != null && swaggerString.Equals("2.0"))
                     {
                         return true;
@@ -158,7 +159,7 @@ namespace Microsoft.DocAsCode.Build.RestApi
             }
             catch (JsonException ex)
             {
-                Logger.LogVerbose($"In {nameof(RestApiDocumentProcessor)}, could not deserialize {filePath} to Dictionary<string, object>, exception details: {ex.Message}.");
+                Logger.LogVerbose($"In {nameof(RestApiDocumentProcessor)}, could not deserialize {filePath} to JObject, exception details: {ex.Message}.");
             }
 
             return false;

--- a/src/Microsoft.DocAsCode.Build.RestApi/RestApiDocumentProcessor.cs
+++ b/src/Microsoft.DocAsCode.Build.RestApi/RestApiDocumentProcessor.cs
@@ -142,7 +142,8 @@ namespace Microsoft.DocAsCode.Build.RestApi
         {
             try
             {
-                using (JsonReader reader = new JsonTextReader(new StringReader(File.ReadAllText(filePath))))
+                using (var streamReader = File.OpenText(filePath))
+                using (JsonReader reader = new JsonTextReader(streamReader))
                 {
                     var jObject = JObject.Load(reader);
                     JToken swaggerValue;

--- a/src/Microsoft.DocAsCode.Build.RestApi/RestApiDocumentProcessor.cs
+++ b/src/Microsoft.DocAsCode.Build.RestApi/RestApiDocumentProcessor.cs
@@ -142,14 +142,17 @@ namespace Microsoft.DocAsCode.Build.RestApi
         {
             try
             {
-                var jObject = JObject.Parse(File.ReadAllText(filePath));
-                JToken swaggerValue;
-                if (jObject.TryGetValue("swagger", out swaggerValue))
+                using (JsonReader reader = new JsonTextReader(new StringReader(File.ReadAllText(filePath))))
                 {
-                    var swaggerString = (string)swaggerValue;
-                    if (swaggerString != null && swaggerString.Equals("2.0"))
+                    var jObject = JObject.Load(reader);
+                    JToken swaggerValue;
+                    if (jObject.TryGetValue("swagger", out swaggerValue))
                     {
-                        return true;
+                        var swaggerString = (string)swaggerValue;
+                        if (swaggerString != null && swaggerString.Equals("2.0"))
+                        {
+                            return true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
use jobject to judge whether a json is swagger, no need to deserialize whole file

@superyyrrzz @chenkennt @vwxyzh @qinezh @ansyral 