### PR TITLE
Move improve and source button to right - template and style change

### DIFF
--- a/src/docfx.website.themes/default/conceptual.html.primary.tmpl
+++ b/src/docfx.website.themes/default/conceptual.html.primary.tmpl
@@ -38,11 +38,6 @@
           <div class="col-md-10">
           {{/_disableAffix}}
             <article class="content wrap" id="_content" data-uid="{{uid}}">
-              {{^_disableContribution}}
-              {{#docurl}}
-              <a href="{{docurl}}" class="btn btn-primary pull-right mobile-hide">{{__global.improveThisDoc}}</a>
-              {{/docurl}}
-              {{/_disableContribution}}
               {{{rawTitle}}}
               {{{conceptual}}}
             </article>

--- a/src/docfx.website.themes/default/partials/affix.tmpl.partial
+++ b/src/docfx.website.themes/default/partials/affix.tmpl.partial
@@ -2,6 +2,20 @@
 
 <div class="hidden-sm col-md-2" role="complementary">
   <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
+    {{^_disableContribution}}
+    <ul class="level1 btn nav bs-docs-sidenav">
+      {{#docurl}}
+      <li>
+        <a href="{{docurl}}" class="btn btn-primary mobile-hide">{{__global.improveThisDoc}}</a>
+      </li>
+      {{/docurl}}
+      {{#sourceurl}}
+      <li>
+        <a href="{{sourceurl}}" class="btn btn-primary mobile-hide">{{__global.viewSource}}</a>
+      </li>
+      {{/sourceurl}}
+    </ul>
+    {{/_disableContribution}}
   <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
   </nav>
 </div>

--- a/src/docfx.website.themes/default/partials/class.header.tmpl.partial
+++ b/src/docfx.website.themes/default/partials/class.header.tmpl.partial
@@ -1,9 +1,5 @@
 {{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
 
-{{^_disableContribution}}
-{{#docurl}}<a href="{{docurl}}" class="btn btn-primary pull-right mobile-hide">{{__global.improveThisDoc}}</a>{{/docurl}}
-{{#sourceurl}}<a href="{{sourceurl}}" class="btn btn-primary pull-right mobile-hide">{{__global.viewSource}}</a>{{/sourceurl}}
-{{/_disableContribution}}
 <h1 id="{{id}}" data-uid="{{uid}}">{{>partials/title}}</h1>
 <div class="markdown level0 summary">{{{summary}}}</div>
 <div class="markdown level0 conceptual">{{{conceptual}}}</div>

--- a/src/docfx.website.themes/default/partials/namespace.tmpl.partial
+++ b/src/docfx.website.themes/default/partials/namespace.tmpl.partial
@@ -1,13 +1,5 @@
 {{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
 
-{{^_disableContribution}}
-{{#docurl}}
-<a href="{{docurl}}" class="btn btn-primary pull-right mobile-hide">{{__global.improveThisDoc}}</a>
-{{/docurl}}
-{{#sourceurl}}
-<a href="{{sourceurl}}" class="btn btn-primary pull-right mobile-hide">{{__global.viewSource}}</a>
-{{/sourceurl}}
-{{/_disableContribution}}
 <h1 id="{{id}}" data-uid="{{uid}}">{{>partials/title}}</h1>
 <div class="markdown level0 summary">{{{summary}}}</div>
 <div class="markdown level0 conceptual">{{{conceptual}}}</div>

--- a/src/docfx.website.themes/default/partials/rest.tmpl.partial
+++ b/src/docfx.website.themes/default/partials/rest.tmpl.partial
@@ -1,9 +1,5 @@
 {{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
 
-{{^_disableContribution}}
-{{#docurl}}<a href="{{docurl}}" class="btn btn-primary pull-right mobile-hide">Improve this Doc</a>{{/docurl}}
-{{#sourceurl}}<a href="{{sourceurl}}" class="btn btn-primary pull-right mobile-hide">View Source</a>{{/sourceurl}}
-{{/_disableContribution}}
 <h1 id="{{htmlId}}" data-uid="{{uid}}" class="text-capitalize">{{name}}</h1>
 {{#summary}}
 <div class="markdown level0 summary">{{{summary}}}</div>

--- a/src/docfx.website.themes/default/styles/docfx.css
+++ b/src/docfx.website.themes/default/styles/docfx.css
@@ -644,15 +644,19 @@ body .toc{
 }
 /* overwrite the button color of '.affix ul > li > a' */
 .affix ul > li > a.btn {
-  color: #fff;
+  color: #8BFEB4;
 }
 /* overwrite the button display of '.affix ul > li > a:hover:before' */
 .affix ul > li > a.btn:hover:before {
   display: none;
 }
-/* overwrite the button background of '.affix ul > li > a:hover' */
+/* overwrite the button background color of '.affix ul > li > a:hover' */
 .affix ul > li > a.btn:hover {
-  background: #337ab7;
+  background-color: #23527c;
+}
+/* overwrite the button shadow of '.btn.active' */
+.affix ul.btn:active {
+  box-shadow: none;
 }
 .codewrapper {
   position: relative;

--- a/src/docfx.website.themes/default/styles/docfx.css
+++ b/src/docfx.website.themes/default/styles/docfx.css
@@ -98,10 +98,6 @@ svg:hover path {
 .btn + .btn {
   margin-left: 10px;
 }
-.btn.pull-right {
-  margin-left: 10px;
-  margin-top: 5px;
-}
 .table {
   margin-bottom: 10px;
 }

--- a/src/docfx.website.themes/default/styles/docfx.css
+++ b/src/docfx.website.themes/default/styles/docfx.css
@@ -570,13 +570,13 @@ body .toc{
   font-size: 12px;
   max-height: 100%;
   overflow: hidden;
+  margin-top: 50px; /* Add margin-top for '.affix' instead of '.affix h5' */
   top: 100px;
   bottom: 10px;
 }
 .affix h5 {
   font-weight: bold;
   text-transform: uppercase;
-  margin-top: 50px;
   padding-left: 10px;
   font-size: 12px;
 }
@@ -586,6 +586,15 @@ body .toc{
   padding-bottom: 10px;
   height: calc(100% - 100px);
   margin-right: -20px;
+}
+/* overwrite height and margin-right of '.affix > ul.level1' */
+.affix > ul.level1.btn {
+  height: auto;
+  margin-right:auto;
+}
+/* add padding for multiple buttons */
+.affix > ul.level1.btn > li {
+  padding-bottom: 10px;
 }
 .affix ul > li > a:before {
   color: #cccccc;
@@ -632,6 +641,18 @@ body .toc{
 .affix ul > li > a:hover:before {
   display: block;
   white-space: nowrap;
+}
+/* overwrite the button color of '.affix ul > li > a' */
+.affix ul > li > a.btn {
+  color: #fff;
+}
+/* overwrite the button display of '.affix ul > li > a:hover:before' */
+.affix ul > li > a.btn:hover:before {
+  display: none;
+}
+/* overwrite the button background of '.affix ul > li > a:hover' */
+.affix ul > li > a.btn:hover {
+  background: #337ab7;
 }
 .codewrapper {
   position: relative;

--- a/test/docfx.E2E.Tests/DocfxSeedSiteTest.cs
+++ b/test/docfx.E2E.Tests/DocfxSeedSiteTest.cs
@@ -13,6 +13,7 @@ namespace Microsoft.DocAsCode.E2E.Tests
     {
         private IWebDriver _driver;
         private string _urlHomepage;
+        private const string SideBarNavXPathString = "//nav[@id='affix']/ul/li/a[not(@class)]"; // Button is with class while topic navigation is without class.
 
         public DocfxSeedSiteTest(DocfxSeedSiteFixture fixture)
         {
@@ -35,7 +36,7 @@ namespace Microsoft.DocAsCode.E2E.Tests
             IList<IWebElement> resultsHeading = _driver.FindElements(By.TagName("h2"));
             if (resultsHeading.Count > 0)
             {
-                IList<IWebElement> resultsSidebar = _driver.FindElements(By.XPath("//nav[@id='affix']/ul/li/a"));
+                IList<IWebElement> resultsSidebar = _driver.FindElements(By.XPath(SideBarNavXPathString));
                 Assert.Equal(resultsHeading.Count, resultsSidebar.Count);
                 for (int i = 0; i < resultsSidebar.Count; i++)
                 {
@@ -131,7 +132,7 @@ namespace Microsoft.DocAsCode.E2E.Tests
             IList<IWebElement> resultsHeading = _driver.FindElements(By.TagName("h3"));
             if (resultsHeading.Count > 0)
             {
-                results = _driver.FindElements(By.XPath("//nav[@id='affix']/ul/li/a"));
+                results = _driver.FindElements(By.XPath(SideBarNavXPathString));
                 Assert.Equal(resultsHeading.Count, results.Count);
                 for (int i = 0; i < results.Count; i++)
                 {


### PR DESCRIPTION
Move `Improve this doc` and `View souce` buttons to right panel. 

Note: for sub entities such as properties in class, take [Container](http://dotnet.github.io/docfx/api/Microsoft.DocAsCode.Build.Engine.SingleDocumentBuilder.html#Microsoft_DocAsCode_Build_Engine_SingleDocumentBuilder_Container) for example , `Improve this doc` and `View souce` would still in middle panel, which is not button but link instead, since not break the 'in this topic' readiness.

Github sample pages are here:
- [Conceptual](http://hellosnow.github.io/docfx/tutorial/docfx_getting_started.html)
- [MRef](http://hellosnow.github.io/docfx/api/Microsoft.DocAsCode.AssemblyLicenseAttribute.html)

@qinezh @superyyrrzz @chenkennt @ansyral @vwxyzh 