### PR TITLE
Add build command for NonDNX.sln

### DIFF
--- a/Documentation/tutorial/docfx_getting_started.md
+++ b/Documentation/tutorial/docfx_getting_started.md
@@ -99,6 +99,13 @@ Please refer to [*DocFX* User Manual](docfx.exe_user_manual.md) for detailed des
 
 5. Build from source code
 ----------------
+#### Build without DNX
+There're two options:
+
+1. Run `build nondnx` under *DocFX* code repo
+2. Open `NonDNX.sln` under *DocFX* code repo in Visual Studio and build it.
+
+#### Build with DNX
 As a prerequisite, you need:
 - [Microsoft Build Tools 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48159)
 - [DNVM](http://docs.asp.net/en/latest/getting-started/installing-on-windows.html#install-the-net-version-manager-dnvm)

--- a/README.md
+++ b/README.md
@@ -18,13 +18,20 @@ There are currently two versions of the tool:
 We currently support C# and VB projects.
 
 ## How to build?
-### Prerequisites
+### Build without DNX
+There're two options:
+
+1. Run `build nondnx` under *DocFX* code repo
+2. Open `NonDNX.sln` under *DocFX* code repo in Visual Studio and build it
+
+### Build with DNX
+#### Prerequisites
 1. [VS 2013 community](https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs.aspx) or above
 2. [Microsoft Build Tools 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48159)(No need if you install VS 2015 or above)
 3. [DNVM](http://docs.asp.net/en/latest/getting-started/installing-on-windows.html#install-the-net-version-manager-dnvm)
 4. [Node.js](https://nodejs.org)
 
-### Steps
+#### Steps
 1. `dnvm install 1.0.0-rc1-final`
 2. Run `build.cmd` under *DocFX* code repo
 

--- a/build.cmd
+++ b/build.cmd
@@ -30,6 +30,10 @@ if /I [%1]==[template] (
     SET UpdateTemplate=%1
     GOTO Next
 )
+if /I [%1]==[nondnx] (
+    SET OnlyNonDnx=true
+    GOTO Next
+)
 
 :Next
 SHIFT /1
@@ -71,17 +75,23 @@ IF /I [%UpdateTemplate%]==[template] (
 )
 IF /I [%SkipTemplate%]==[true] (
     ECHO Skip updating template
-    GOTO CheckDnu
+    GOTO CheckIfOnlyBuildNonDnx
 )
 
 :: Update template before build
 :UpdateTemplate
 ECHO Updating template
 CALL UpdateTemplate.cmd
-
 IF NOT [!ERRORLEVEL!]==[0] (
     ECHO ERROR: Error occurs when updating template
     GOTO Exit
+)
+
+:CheckIfOnlyBuildNonDnx
+IF /I [%OnlyNonDnx%]==[true] (
+    ECHO Only build NonDnx.sln
+    SET BuildProj=%~dp0NonDNX.sln
+    GOTO SetBuildLog
 )
 
 :: Check if DNU exists globally
@@ -100,6 +110,7 @@ IF NOT [!ERRORLEVEL!]==[0] (
 CALL :RestorePackage
 
 :: Log build command line
+:SetBuildLog
 SET BuildLog=%~dp0msbuild.log
 SET BuildPrefix=echo
 SET BuildPostfix=^> "%BuildLog%"


### PR DESCRIPTION
Add option in build.cmd to run msbuild NonDNX.sln only.

Example:
1. `build nondnx`: update template, set configuration as Release and build NonDNX.sln
2. `build raw nondnx` or `build nondnx raw`: set configuration as Release and build NonDNX.sln