### PR TITLE
Replace Environment.CurrentDirectory in code

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/DocumentBuildContext.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/DocumentBuildContext.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DocAsCode.Build.Engine
         private readonly Dictionary<string, TocInfo> _tableOfContents = new Dictionary<string, TocInfo>(FilePathComparer.OSPlatformSensitiveStringComparer);
         private readonly Task<IXRefContainerReader> _reader;
 
-        public DocumentBuildContext(string buildOutputFolder) : this(buildOutputFolder, Enumerable.Empty<FileAndType>(), ImmutableArray<string>.Empty, ImmutableArray<string>.Empty, 1, Environment.CurrentDirectory) { }
+        public DocumentBuildContext(string buildOutputFolder) : this(buildOutputFolder, Enumerable.Empty<FileAndType>(), ImmutableArray<string>.Empty, ImmutableArray<string>.Empty, 1, Directory.GetCurrentDirectory()) { }
 
         public DocumentBuildContext(
             string buildOutputFolder,

--- a/src/Microsoft.DocAsCode.Build.Engine/FileCollection.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/FileCollection.cs
@@ -21,11 +21,11 @@ namespace Microsoft.DocAsCode.Build.Engine
         {
             if (string.IsNullOrEmpty(defaultBaseDir))
             {
-                DefaultBaseDir = Environment.CurrentDirectory;
+                DefaultBaseDir = Directory.GetCurrentDirectory();
             }
             else
             {
-                DefaultBaseDir = Path.Combine(Environment.CurrentDirectory, defaultBaseDir);
+                DefaultBaseDir = Path.Combine(Directory.GetCurrentDirectory(), defaultBaseDir);
             }
         }
 
@@ -44,7 +44,7 @@ namespace Microsoft.DocAsCode.Build.Engine
 
         public void Add(DocumentType type, string baseDir, IEnumerable<string> files, Func<string, string> pathRewriter = null)
         {
-            var rootedBaseDir = Path.Combine(Environment.CurrentDirectory, baseDir ?? string.Empty);
+            var rootedBaseDir = Path.Combine(Directory.GetCurrentDirectory(), baseDir ?? string.Empty);
             _files.AddRange(from f in files
                             select new FileAndType(rootedBaseDir, ToRelative(f, rootedBaseDir), type, pathRewriter));
         }

--- a/src/Microsoft.DocAsCode.Build.Engine/ResourceCollection.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/ResourceCollection.cs
@@ -102,7 +102,7 @@ namespace Microsoft.DocAsCode.Build.Engine
 
         public FileResourceCollection(string directory, int maxSearchLevel = MaxSearchLevel)
         {
-            if (string.IsNullOrEmpty(directory)) _directory = Environment.CurrentDirectory;
+            if (string.IsNullOrEmpty(directory)) _directory = Directory.GetCurrentDirectory();
             else _directory = directory;
             Name = _directory;
             _maxDepth = maxSearchLevel;

--- a/src/Microsoft.DocAsCode.Build.Engine/ResourceFinder.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/ResourceFinder.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DocAsCode.Build.Engine
 
         public ResourceFinder(Assembly assembly, string rootNamespace, string baseDirectory = null)
         {
-            _baseDirectory = baseDirectory ?? Environment.CurrentDirectory;
+            _baseDirectory = baseDirectory ?? Directory.GetCurrentDirectory();
             _assembly = assembly;
             if (assembly != null)
             {

--- a/src/Microsoft.DocAsCode.Build.Engine/SingleDocumentBuilder.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/SingleDocumentBuilder.cs
@@ -69,7 +69,7 @@ namespace Microsoft.DocAsCode.Build.Engine
                 Logger.LogInfo($"Max parallelism is {parameters.MaxParallelism}.");
                 Directory.CreateDirectory(parameters.OutputBaseDir);
                 var context = new DocumentBuildContext(
-                    Path.Combine(Environment.CurrentDirectory, parameters.OutputBaseDir),
+                    Path.Combine(Directory.GetCurrentDirectory(), parameters.OutputBaseDir),
                     parameters.Files.EnumerateFiles(),
                     parameters.ExternalReferencePackages,
                     parameters.XRefMaps,
@@ -605,7 +605,7 @@ namespace Microsoft.DocAsCode.Build.Engine
         {
             if (fileMetadata == null || fileMetadata.Count == 0) return metadata;
             var result = new Dictionary<string, object>(metadata);
-            var baseDir = string.IsNullOrEmpty(fileMetadata.BaseDir) ? Environment.CurrentDirectory : fileMetadata.BaseDir;
+            var baseDir = string.IsNullOrEmpty(fileMetadata.BaseDir) ? Directory.GetCurrentDirectory() : fileMetadata.BaseDir;
             var relativePath = PathUtility.MakeRelativePath(baseDir, file);
             foreach (var item in fileMetadata)
             {

--- a/src/Microsoft.DocAsCode.Build.Engine/TemplateModelTransformer.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/TemplateModelTransformer.cs
@@ -59,7 +59,7 @@ namespace Microsoft.DocAsCode.Build.Engine
                 OutputFiles = new Dictionary<string, OutputFileInfo>(),
                 Metadata = item.Metadata,
             };
-            var outputDirectory = _settings.OutputFolder ?? Environment.CurrentDirectory;
+            var outputDirectory = _settings.OutputFolder ?? Directory.GetCurrentDirectory();
 
             // 1. process resource
             if (item.ResourceFile != null)

--- a/src/Microsoft.DocAsCode.Build.Engine/XRefMaps/XRefMapDownloader.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/XRefMaps/XRefMapDownloader.cs
@@ -21,11 +21,11 @@ namespace Microsoft.DocAsCode.Build.Engine
             _semaphore = new SemaphoreSlim(maxParallelism);
             if (baseFolder == null)
             {
-                _baseFolder = Environment.CurrentDirectory;
+                _baseFolder = Directory.GetCurrentDirectory();
             }
             else
             {
-                _baseFolder = Path.Combine(Environment.CurrentDirectory, baseFolder);
+                _baseFolder = Path.Combine(Directory.GetCurrentDirectory(), baseFolder);
             }
         }
 

--- a/src/Microsoft.DocAsCode.Glob/FileGlob.cs
+++ b/src/Microsoft.DocAsCode.Glob/FileGlob.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DocAsCode.Glob
         {
             // If there is no pattern, nothing will be included
             if (patterns == null) return Enumerable.Empty<string>();
-            if (string.IsNullOrEmpty(cwd)) cwd = Environment.CurrentDirectory;
+            if (string.IsNullOrEmpty(cwd)) cwd = Directory.GetCurrentDirectory();
 
             IEnumerable<GlobMatcher> globList = patterns.Select(s => new GlobMatcher(s, options));
             IEnumerable<GlobMatcher> excludeGlobList = Enumerable.Empty<GlobMatcher>();
@@ -59,7 +59,7 @@ namespace Microsoft.DocAsCode.Glob
         private static string GetRelativeFilePath(string directory, string file)
         {
             var subpath = file.Substring(directory.Length);
-            // directory could be 
+            // directory could be
             // 1. root folder, e.g. E:\ or /
             // 2. sub folder, e.g. a or a/ or a\
             return subpath.TrimStart('\\', '/');

--- a/src/docfx/Glob/GlobUtility.cs
+++ b/src/docfx/Glob/GlobUtility.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DocAsCode
                 var files = FileGlob.GetFiles(src, item.Files, item.Exclude, options).ToArray();
                 if (files.Length == 0)
                 {
-                    var currentSrcFullPath = string.IsNullOrEmpty(src) ? Environment.CurrentDirectory : Path.GetFullPath(src);
+                    var currentSrcFullPath = string.IsNullOrEmpty(src) ? Directory.GetCurrentDirectory() : Path.GetFullPath(src);
                     Logger.LogInfo($"No files are found with glob pattern {item.Files.ToDelimitedString() ?? "<none>"}, excluding {item.Exclude.ToDelimitedString() ?? "<none>"}, under directory \"{currentSrcFullPath}\"");
                     CheckPatterns(item.Files);
                 }

--- a/src/docfx/SubCommands/BuildCommand.cs
+++ b/src/docfx/SubCommands/BuildCommand.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DocAsCode.SubCommands
             _version = assembly.GetName().Version.ToString();
             Config = ParseOptions(options);
             SetDefaultConfigValue(Config);
-            EnvironmentContext.BaseDirectory = Path.GetFullPath(string.IsNullOrEmpty(Config.BaseDirectory) ? Environment.CurrentDirectory : Config.BaseDirectory);
+            EnvironmentContext.BaseDirectory = Path.GetFullPath(string.IsNullOrEmpty(Config.BaseDirectory) ? Directory.GetCurrentDirectory() : Config.BaseDirectory);
             _templateManager = new TemplateManager(assembly, "Template", Config.Templates, Config.Themes, Config.BaseDirectory);
         }
 
@@ -110,7 +110,7 @@ namespace Microsoft.DocAsCode.SubCommands
             // base directory for content from command line is current directory
             // e.g. C:\folder1>docfx build folder2\docfx.json --content "*.cs"
             // for `--content "*.cs*`, base directory should be `C:\folder1`
-            string optionsBaseDirectory = Environment.CurrentDirectory;
+            string optionsBaseDirectory = Directory.GetCurrentDirectory();
 
             config.OutputFolder = options.OutputFolder;
 
@@ -275,7 +275,7 @@ namespace Microsoft.DocAsCode.SubCommands
 
         private static void MergeGitContributeToConfig(BuildJsonConfig config)
         {
-            GitDetail repoInfoFromBaseDirectory = GitUtility.GetGitDetail(Path.Combine(Environment.CurrentDirectory, config.BaseDirectory));
+            GitDetail repoInfoFromBaseDirectory = GitUtility.GetGitDetail(Path.Combine(Directory.GetCurrentDirectory(), config.BaseDirectory));
 
             if (repoInfoFromBaseDirectory?.RelativePath != null)
             {

--- a/src/docfx/SubCommands/DocumentBuilderWrapper.cs
+++ b/src/docfx/SubCommands/DocumentBuilderWrapper.cs
@@ -339,7 +339,7 @@ namespace Microsoft.DocAsCode.SubCommands
                 {
                     foreach (var item in file.Files)
                     {
-                        yield return Path.Combine(file.SourceFolder ?? Environment.CurrentDirectory, item);
+                        yield return Path.Combine(file.SourceFolder ?? Directory.GetCurrentDirectory(), item);
                     }
                 }
             }

--- a/src/docfx/SubCommands/MergeCommand.cs
+++ b/src/docfx/SubCommands/MergeCommand.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DocAsCode.SubCommands
         public void Exec(SubCommandRunningContext context)
         {
             var config = Config;
-            var baseDirectory = config.BaseDirectory ?? Environment.CurrentDirectory;
+            var baseDirectory = config.BaseDirectory ?? Directory.GetCurrentDirectory();
             var intermediateOutputFolder = Path.Combine(baseDirectory, "obj");
 
             MergeDocument(baseDirectory, intermediateOutputFolder);
@@ -89,7 +89,7 @@ namespace Microsoft.DocAsCode.SubCommands
             // base directory for content from command line is current directory
             // e.g. C:\folder1>docfx build folder2\docfx.json --content "*.cs"
             // for `--content "*.cs*`, base directory should be `C:\folder1`
-            string optionsBaseDirectory = Environment.CurrentDirectory;
+            string optionsBaseDirectory = Directory.GetCurrentDirectory();
 
             config.OutputFolder = options.OutputFolder;
 
@@ -177,7 +177,7 @@ namespace Microsoft.DocAsCode.SubCommands
             }
             return from file in mapping.Items
                    from item in file.Files
-                   select Path.Combine(file.SourceFolder ?? Environment.CurrentDirectory, item);
+                   select Path.Combine(file.SourceFolder ?? Directory.GetCurrentDirectory(), item);
         }
 
         private static FileCollection GetFileCollectionFromFileMapping(string baseDirectory, DocumentType type, FileMapping files)

--- a/src/docfx/SubCommands/MetadataMerger.cs
+++ b/src/docfx/SubCommands/MetadataMerger.cs
@@ -43,8 +43,8 @@ namespace Microsoft.DocAsCode.SubCommands
             {
                 Directory.CreateDirectory(parameters.OutputBaseDir);
                 Logger.LogInfo("Start merge metadata...");
-                MergePageViewModel(parameters, Environment.CurrentDirectory);
-                MergeToc(parameters, Environment.CurrentDirectory);
+                MergePageViewModel(parameters, Directory.GetCurrentDirectory());
+                MergeToc(parameters, Directory.GetCurrentDirectory());
                 Logger.LogInfo("Merge metadata completed.");
             }
         }

--- a/src/docfx/SubCommands/ServeCommand.cs
+++ b/src/docfx/SubCommands/ServeCommand.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DocAsCode.SubCommands
 
         public static void Serve(string folder, string port)
         {
-            if (string.IsNullOrEmpty(folder)) folder = Environment.CurrentDirectory;
+            if (string.IsNullOrEmpty(folder)) folder = Directory.GetCurrentDirectory();
             folder = Path.GetFullPath(folder);
             port = string.IsNullOrWhiteSpace(port) ? "8080" : port;
             var url = $"http://localhost:{port}";

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/DocumentBuilderTest.cs
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/DocumentBuilderTest.cs
@@ -120,7 +120,7 @@ tagRules : [
 ]
 }");
 
-            FileCollection files = new FileCollection(Environment.CurrentDirectory);
+            FileCollection files = new FileCollection(Directory.GetCurrentDirectory());
             files.Add(DocumentType.Article, new[] { tocFile, conceptualFile, conceptualFile2 });
             files.Add(DocumentType.Article, new[] { "TestData/System.Console.csyml", "TestData/System.ConsoleColor.csyml" }, p => (((RelativePath)p) - (RelativePath)"TestData/").ToString());
             files.Add(DocumentType.Resource, new[] { resourceFile });
@@ -353,7 +353,7 @@ settings : [
 }
 ", _templateFolder);
 
-            FileCollection files = new FileCollection(Environment.CurrentDirectory);
+            FileCollection files = new FileCollection(Directory.GetCurrentDirectory());
             files.Add(DocumentType.Article, new[] { tocFile, conceptualFile, conceptualFile2 });
             files.Add(DocumentType.Article, new[] { "TestData/System.Console.csyml", "TestData/System.ConsoleColor.csyml" }, p => (((RelativePath)p) - (RelativePath)"TestData/").ToString());
             files.Add(DocumentType.Resource, new[] { resourceFile });
@@ -438,7 +438,7 @@ exports.getOptions = function (){
                     "#[Test](test.md)"
                 },
                 _inputFolder);
-            FileCollection files = new FileCollection(Environment.CurrentDirectory);
+            FileCollection files = new FileCollection(Directory.GetCurrentDirectory());
             files.Add(DocumentType.Article, new[] { conceptualFile, conceptualFile2, tocFile, tocFile2 });
             BuildDocument(
                 files,
@@ -600,7 +600,7 @@ exports.getOptions = function (){
                 var parameters = new DocumentBuildParameters
                 {
                     Files = files,
-                    OutputBaseDir = Path.Combine(Environment.CurrentDirectory, _outputFolder),
+                    OutputBaseDir = Path.Combine(Directory.GetCurrentDirectory(), _outputFolder),
                     ApplyTemplateSettings = applyTemplateSettings,
                     Metadata = metadata?.ToImmutableDictionary(),
                     TemplateManager = new TemplateManager(null, null, new List<string> { _templateFolder }, null, null),

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/TemplateManagerUnitTest.cs
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/TemplateManagerUnitTest.cs
@@ -493,7 +493,7 @@ test2
                         if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
                         File.Create(item.ResourceFile).Dispose();
                     }
-                    if (string.IsNullOrEmpty(item.InputFolder)) item.InputFolder = Environment.CurrentDirectory;
+                    if (string.IsNullOrEmpty(item.InputFolder)) item.InputFolder = Directory.GetCurrentDirectory();
                     item.Model = new DocAsCode.Plugins.ModelWithCache(model);
                 }
                 var settings = new ApplyTemplateSettings(inputFolder, outputFolder);

--- a/test/Microsoft.DocAsCode.Build.RestApi.Tests/RestApiDocumentProcessorTest.cs
+++ b/test/Microsoft.DocAsCode.Build.RestApi.Tests/RestApiDocumentProcessorTest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DocAsCode.Build.RestApi.Tests
             _outputFolder = GetRandomFolder();
             _inputFolder = GetRandomFolder();
             _templateFolder = GetRandomFolder();
-            _defaultFiles = new FileCollection(Environment.CurrentDirectory);
+            _defaultFiles = new FileCollection(Directory.GetCurrentDirectory());
             _defaultFiles.Add(DocumentType.Article, new[] { "TestData/contacts.json" }, p => (((RelativePath)p) - (RelativePath)"TestData/").ToString());
             _applyTemplateSettings = new ApplyTemplateSettings(_inputFolder, _outputFolder);
             _applyTemplateSettings.RawModelExportSettings.Export = true;

--- a/test/Microsoft.DocAsCode.Build.TableOfContents.Tests/TocDocumentProcessorTest.cs
+++ b/test/Microsoft.DocAsCode.Build.TableOfContents.Tests/TocDocumentProcessorTest.cs
@@ -371,7 +371,7 @@ namespace Microsoft.DocAsCode.Build.TableOfContents.Tests
 
             AssertTocEqual(expectedModel, model);
 
-            // Referenced TOC File should not exist 
+            // Referenced TOC File should not exist
             var referencedTocPath = Path.Combine(_outputFolder, Path.ChangeExtension(subToc, RawModelFileExtension));
             Assert.False(File.Exists(referencedTocPath));
         }
@@ -508,7 +508,7 @@ namespace Microsoft.DocAsCode.Build.TableOfContents.Tests
             private readonly string _rootDir;
             public FileCreator(string rootDir)
             {
-                _rootDir = rootDir ?? Environment.CurrentDirectory;
+                _rootDir = rootDir ?? Directory.GetCurrentDirectory();
             }
 
             public string CreateFile(string content, FileType type, string folder = null)

--- a/test/docfx.Tests/BuildCommandTest.cs
+++ b/test/docfx.Tests/BuildCommandTest.cs
@@ -159,7 +159,7 @@ namespace Microsoft.DocAsCode.Tests
             new BuildCommand(new BuildCommandOptions
             {
                 Content = new List<string> { conceptualFile1, conceptualFile2 },
-                OutputFolder = Path.Combine(Environment.CurrentDirectory, _outputFolder),
+                OutputFolder = Path.Combine(Directory.GetCurrentDirectory(), _outputFolder),
                 Templates = new List<string> { Path.Combine(_templateFolder, "default") }
             }).Exec(null);
 

--- a/test/docfx.Tests/MetadataCommandTest.cs
+++ b/test/docfx.Tests/MetadataCommandTest.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DocAsCode.Tests
 
             new MetadataCommand(new MetadataCommandOptions
             {
-                OutputFolder = Path.Combine(Environment.CurrentDirectory, _outputFolder),
+                OutputFolder = Path.Combine(Directory.GetCurrentDirectory(), _outputFolder),
                 Projects = new List<String> { projectFile },
             }).Exec(null);
 
@@ -106,7 +106,7 @@ namespace Microsoft.DocAsCode.Tests
 
             new MetadataCommand(new MetadataCommandOptions
             {
-                OutputFolder = Path.Combine(Environment.CurrentDirectory, _outputFolder),
+                OutputFolder = Path.Combine(Directory.GetCurrentDirectory(), _outputFolder),
                 Projects = new List<String> { projectFile },
             }).Exec(null);
             Assert.True(File.Exists(Path.Combine(_outputFolder, ".manifest")));


### PR DESCRIPTION
Replace `Environment.CurrentDirectory` with `Directory.GetCurrentDirectory()` since it's not supported in .NET Core. https://docs.microsoft.com/en-us/dotnet/core/api/system.environment