### PR TITLE
fix bugs in markdown table.

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdownLite/Regexes.cs
+++ b/src/Microsoft.DocAsCode.MarkdownLite/Regexes.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DocAsCode.MarkdownLite
 
             public static class Tables
             {
-                public static readonly Regex NpTable = new Regex(@"^ *(\S.*\|.*)\n *([-:]+ *\|[-| :]*)\n((?:.*\|.*(?:\n|$))*)\n*", RegexOptionCompiled);
+                public static readonly Regex NpTable = new Regex(@"^ *\|?(.+)\n *\|? *([-:]+ *\|[-| :]*)\n((?:.*\|.*(?:\n|$))*)\n*", RegexOptionCompiled);
                 public static readonly Regex Table = new Regex(@"^ *\|(.+)\n *\|( *[-:]+[-| :]*)\n((?: *\|.*(?:\n|$))*)\n*", RegexOptionCompiled);
             }
         }
@@ -136,8 +136,9 @@ namespace Microsoft.DocAsCode.MarkdownLite
             public static readonly Regex LeadingWhiteSpaces = new Regex(@"^ {4}", RegexOptions.Multiline | RegexOptionCompiled);
             public static readonly Regex TailingEmptyLines = new Regex(@"\n+$", RegexOptionCompiled);
 
-            public static readonly Regex UselessTableHeader = new Regex(@"^ *| *\| *$", RegexOptionCompiled);
-            public static readonly Regex UselessTableAlign = new Regex(@"^ *|\| *$", RegexOptionCompiled);
+            public static readonly Regex UselessTableHeader = new Regex(@"^ *| *\|? *$", RegexOptionCompiled);
+            public static readonly Regex UselessTableAlign = new Regex(@"^ *|\|? *$", RegexOptionCompiled);
+            public static readonly Regex UselessTableRow = new Regex(@"^ *\| *| *\|? *$", RegexOptionCompiled);
             public static readonly Regex UselessGfmTableCell = new Regex(@"(?: *\| *)?\n$", RegexOptionCompiled);
             public static readonly Regex EmptyGfmTableCell = new Regex(@"^ *\| *| *\| *$", RegexOptionCompiled);
             public static readonly Regex TableSplitter = new Regex(@" *\| *", RegexOptionCompiled);

--- a/src/Microsoft.DocAsCode.MarkdownLite/Tables/MarkdownTableBlockRule.cs
+++ b/src/Microsoft.DocAsCode.MarkdownLite/Tables/MarkdownTableBlockRule.cs
@@ -20,22 +20,45 @@ namespace Microsoft.DocAsCode.MarkdownLite
             {
                 return null;
             }
-            var sourceInfo = context.Consume(match.Length);
             var header = match.Groups[1].Value.ReplaceRegex(Regexes.Lexers.UselessTableHeader, string.Empty).SplitRegex(Regexes.Lexers.TableSplitter);
             var align = ParseAligns(match.Groups[2].Value.ReplaceRegex(Regexes.Lexers.UselessTableAlign, string.Empty).SplitRegex(Regexes.Lexers.TableSplitter));
-            var cells = match.Groups[3].Value.ReplaceRegex(Regexes.Lexers.UselessGfmTableCell, string.Empty).Split('\n').Select(x => new string[] { x }).ToArray();
-            for (int i = 0; i < cells.Length; i++)
+            if (header.Length > align.Length)
             {
-                cells[i] = cells[i][0]
+                return null;
+            }
+            var sourceInfo = context.Consume(match.Length);
+
+            var rows = match.Groups[3].Value.ReplaceRegex(Regexes.Lexers.UselessGfmTableCell, string.Empty).Split('\n').Select(x => x).ToArray();
+            var cells = new string[rows.Length][];
+            for (int i = 0; i < rows.Length; i++)
+            {
+                var columns = rows[i]
                   .ReplaceRegex(Regexes.Lexers.EmptyGfmTableCell, string.Empty)
                   .SplitRegex(Regexes.Lexers.TableSplitter);
-
-                var cellList = cells[i].ToList();
-                while (cellList.Count < header.Length)
+                if (columns.Length == header.Length)
                 {
-                    cellList.Add(string.Empty);
+                    cells[i] = columns;
                 }
-                cells[i] = cellList.ToArray();
+                else if (columns.Length < header.Length)
+                {
+                    cells[i] = new string[header.Length];
+                    for (int j = 0; j < columns.Length; j++)
+                    {
+                        cells[i][j] = columns[j];
+                    }
+                    for (int j = columns.Length; j < cells[i].Length; j++)
+                    {
+                        cells[i][j] = string.Empty;
+                    }
+                }
+                else // columns.Length > header.Length
+                {
+                    cells[i] = new string[header.Length];
+                    for (int j = 0; j < header.Length; j++)
+                    {
+                        cells[i][j] = columns[j];
+                    }
+                }
             }
 
             return new TwoPhaseBlockToken(

--- a/test/Microsoft.DocAsCode.MarkdownLite.Tests/GfmTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdownLite.Tests/GfmTest.cs
@@ -26,32 +26,25 @@ namespace Microsoft.DocAsCode.MarkdownLite.Tests
 <thead>
 <tr>
 <th></th>
-<th></th>
 <th>Header1</th>
 <th>Header2</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td></td>
 <td>Single backticks</td>
 <td><code>&#39;Isn&#39;t this fun?&#39;</code></td>
 <td>&#39;Isn&#39;t this fun?&#39;</td>
-<td></td>
 </tr>
 <tr>
-<td></td>
 <td>Quotes</td>
 <td><code>&quot;Isn&#39;t this fun?&quot;</code></td>
 <td>&quot;Isn&#39;t this fun?&quot;</td>
-<td></td>
 </tr>
 <tr>
-<td></td>
 <td>Dashes</td>
 <td><code>-- is en-dash, --- is em-dash</code></td>
 <td>-- is en-dash, --- is em-dash</td>
-<td></td>
 </tr>
 </tbody>
 </table>
@@ -215,18 +208,15 @@ c
 <thead>
 <tr>
 <th></th>
-<th></th>
 <th>Header1</th>
 <th>Header2</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td></td>
 <td>Row1</td>
 <td>Cell11</td>
 <td>Cell12</td>
-<td></td>
 </tr>
 </tbody>
 </table>
@@ -245,18 +235,15 @@ c
 <thead>
 <tr>
 <th></th>
-<th></th>
 <th>Header1</th>
 <th>Header2</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td></td>
 <td>Row1</td>
 <td>Cell11</td>
 <td>Cell12</td>
-<td></td>
 </tr>
 </tbody>
 </table>
@@ -573,6 +560,48 @@ aaa",
 <td style=""text-align:left""></td>
 <td style=""text-align:left""></td>
 <td style=""text-align:left""></td>
+</tr>
+</tbody>
+</table>
+";
+            TestGfmInGeneral(source, expected);
+        }
+
+        [Fact]
+        [Trait("Related", "Markdown")]
+        public void TestTable_WithEmptyCell2()
+        {
+            // 1. Prepare data
+            var source = @"  A |  B | C 
+|:-------|-------|-------| 
+| A1 | B1
+| A2 | |  C2 | D2 | E2
+| A3 | B3 |
+";
+
+            var expected = @"<table>
+<thead>
+<tr>
+<th style=""text-align:left"">A</th>
+<th>B</th>
+<th>C</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style=""text-align:left"">A1</td>
+<td>B1</td>
+<td></td>
+</tr>
+<tr>
+<td style=""text-align:left"">A2</td>
+<td></td>
+<td>C2</td>
+</tr>
+<tr>
+<td style=""text-align:left"">A3</td>
+<td>B3</td>
+<td></td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
1. fix nptable rows start with `|`
2. fix columns more than or less than header count.
@chenkennt @hellosnow @ansyral @superyyrrzz @qinezh 