### PR TITLE
fixes index.json encoding problems with non-english characters

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Common/ExtractSearchIndex.cs
+++ b/src/Microsoft.DocAsCode.Build.Common/ExtractSearchIndex.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DocAsCode.Build.Common
                 {
                     try
                     {
-                        html.Load(filePath);
+                        html.Load(filePath, Encoding.UTF8);
                     }
                     catch (Exception ex)
                     {

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/ExtractSearchIndexFromHtmlTest.cs
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/ExtractSearchIndexFromHtmlTest.cs
@@ -3,14 +3,13 @@
 
 namespace Microsoft.DocAsCode.Build.Engine.Tests
 {
-    using Microsoft.DocAsCode.Build.Common;
-
     using HtmlAgilityPack;
-    using Xunit;
-    using System.IO;
-    using Plugins;
+    using Microsoft.DocAsCode.Build.Common;
+    using Microsoft.DocAsCode.Plugins;
     using System.Collections.Generic;
+    using System.IO;
     using System.Text;
+    using Xunit;
 
     public class ExtractSearchIndexFromHtmlTest
     {

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/ExtractSearchIndexFromHtmlTest.cs
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/ExtractSearchIndexFromHtmlTest.cs
@@ -7,6 +7,10 @@ namespace Microsoft.DocAsCode.Build.Engine.Tests
 
     using HtmlAgilityPack;
     using Xunit;
+    using System.IO;
+    using Plugins;
+    using System.Collections.Generic;
+    using System.Text;
 
     public class ExtractSearchIndexFromHtmlTest
     {
@@ -92,6 +96,63 @@ namespace Microsoft.DocAsCode.Build.Engine.Tests
             var href = "http://dotnet.github.io/docfx";
             var item = _extractor.ExtractItem(html, href);
             Assert.True(item.Equals(new SearchIndexItem { Href = href, Title = "This is title in head metadata", Keywords = string.Empty }));
+        }
+
+        [Fact]
+        public void TestIndexDotJsonWithNonEnglishCharacters()
+        {
+            var rawHtml = @"
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset=""utf-8"">
+    <title>This is title in head metadata</title>
+</head>
+<body>
+    <h1> This is Title </h1>
+    <p class='data-searchable'> Hello World,
+    Microsoft
+    </p>
+    <article>
+        <h1>
+            This is article title
+        </h1>
+        docfx can do anything...
+        and it supports non-english characters like these: ãâáà êé í õôó Типы шрифтов 人物 文字
+    </article>
+</body>
+</html>
+";
+
+            // prepares temp folder and file for testing purposes
+            // ExtractSearchIndex should probably be refactored so we can test it without depending on the filesystem
+            var tempTestFolder = "temp_test_folder";
+            if (Directory.Exists(tempTestFolder)) Directory.Delete(tempTestFolder, true);
+            Directory.CreateDirectory(tempTestFolder);
+            File.WriteAllText(Path.Combine(tempTestFolder, "index.html"), rawHtml, new UTF8Encoding(false));
+
+            // prepares fake manifest object
+            var outputFileInfo = new OutputFileInfo();
+            outputFileInfo.RelativePath = "index.html";
+
+            var manifestItem = new ManifestItem() { OutputFiles = new Dictionary<string, OutputFileInfo>() };
+            manifestItem.OutputFiles.Add(".html", outputFileInfo);
+
+            var manifest = new Manifest() { Files = new List<ManifestItem>() };
+            manifest.Files.Add(manifestItem);
+
+            // process the fake manifest, using tempTestFolder as the output folder
+            _extractor.Process(manifest, tempTestFolder);
+
+            var expectedIndexJSON = @"{
+  ""index.html"": {
+    ""href"": ""index.html"",
+    ""title"": ""This is title in head metadata"",
+    ""keywords"": ""Hello World, Microsoft This is article title docfx can do anything... and it supports non-english characters like these: ãâáà êé í õôó Типы шрифтов 人物 文字""
+  }
+}";
+            var actualIndexJSON = File.ReadAllText(Path.Combine(tempTestFolder, "index.json"), Encoding.UTF8);
+            Assert.Equal(expectedIndexJSON, actualIndexJSON);
         }
     }
 }


### PR DESCRIPTION
It appears that the problem is caused when reading .html files used to generate the index.json file in ExtractSearchIndex class.

I've changed the encoding used to read the .html files to UTF-8 since, it appears to me, that .html files are always generated in UTF-8.

#650 