### PR TITLE
update FileAndType.Equals to fix toc not found

### DIFF
--- a/src/Microsoft.DocAsCode.Plugins/FileAndType.cs
+++ b/src/Microsoft.DocAsCode.Plugins/FileAndType.cs
@@ -86,9 +86,7 @@ namespace Microsoft.DocAsCode.Plugins
             }
             return StringComparer.Equals(File, other.File) &&
                 Type == other.Type &&
-                StringComparer.Equals(BaseDir, other.BaseDir) &&
-                StringComparer.Equals(SourceDir, other.SourceDir) &&
-                StringComparer.Equals(DestinationDir, other.DestinationDir);
+                StringComparer.Equals(BaseDir, other.BaseDir);
         }
 
         public override bool Equals(object obj)

--- a/test/docfx.E2E.Tests/DocfxSeedSiteTest.cs
+++ b/test/docfx.E2E.Tests/DocfxSeedSiteTest.cs
@@ -89,11 +89,9 @@ namespace Microsoft.DocAsCode.E2E.Tests
         public void TestReferencePage()
         {
             _driver.Navigate().GoToUrl(_urlHomepage);
-            System.Threading.Thread.Sleep(1000);
 
             // go to reference
             _driver.FindElement(By.LinkText("API Documentation")).Click();
-            System.Threading.Thread.Sleep(1000);
 
             _driver.FindElements(By.XPath("//h4/a"))[0].Click();
 
@@ -207,7 +205,6 @@ namespace Microsoft.DocAsCode.E2E.Tests
         public void TestRestApiPage()
         {
             _driver.Navigate().GoToUrl(_urlHomepage);
-            System.Threading.Thread.Sleep(1000);
 
             // go to reference
             _driver.FindElement(By.LinkText("REST API")).Click();


### PR DESCRIPTION
@vwxyzh @qinezh @chenkennt @hellosnow @ansyral 

e2e fail's cause: FileAndType.Equals is to strict => can't get `obj/api/toc.yml` from `Dictionary<FileAndType, TocItemInfo>` when resolving TOC => `API Documentation`'s link unresolved => e2e click `API Documentation` doesn't lead to the correct page