### PR TITLE
Fix bug for full text search

### DIFF
--- a/src/docfx.website.themes/default/partials/scripts.tmpl.partial
+++ b/src/docfx.website.themes/default/partials/scripts.tmpl.partial
@@ -1,6 +1,6 @@
 {{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
 
 <script type="text/javascript" src="{{_rel}}styles/docfx.vendor.js"></script>
+<script>hljs.initHighlightingOnLoad();</script>
 <script type="text/javascript" src="{{_rel}}styles/docfx.js"></script>
 <script type="text/javascript" src="{{_rel}}styles/main.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>


### PR DESCRIPTION
#675 : should run highlight.js before highlighting search word
@hellosnow @superyyrrzz @ansyral  @chenkennt 