### PR TITLE
Remove swagger resolved cache

### DIFF
--- a/src/Microsoft.DocAsCode.Build.RestApi/Swagger/Internals/SwaggerJsonBuilder.cs
+++ b/src/Microsoft.DocAsCode.Build.RestApi/Swagger/Internals/SwaggerJsonBuilder.cs
@@ -14,7 +14,6 @@ namespace Microsoft.DocAsCode.Build.RestApi.Swagger.Internals
     internal class SwaggerJsonBuilder
     {
         private IDictionary<string, SwaggerObjectBase> _documentObjectCache;
-        private IDictionary<string, SwaggerObject> _resolvedObjectCache;
         private const string DefinitionsKey = "definitions";
         private const string ParametersKey = "parameters";
         private const string InternalRefNameKey = "x-internal-ref-name";
@@ -23,7 +22,6 @@ namespace Microsoft.DocAsCode.Build.RestApi.Swagger.Internals
         public SwaggerObjectBase Read(JsonReader reader)
         {
             _documentObjectCache = new Dictionary<string, SwaggerObjectBase>();
-            _resolvedObjectCache = new Dictionary<string, SwaggerObject>();
             var token = JToken.ReadFrom(reader);
             var swagger = Build(token);
             RemoveReferenceDefinitions((SwaggerObject)swagger);
@@ -148,12 +146,6 @@ namespace Microsoft.DocAsCode.Build.RestApi.Swagger.Internals
                                 return loopRef;
                             }
 
-                            SwaggerObject existingObject;
-                            if (_resolvedObjectCache.TryGetValue(swagger.DeferredReference, out existingObject))
-                            {
-                                return existingObject;
-                            }
-
                             // Clone to avoid change the reference object in _documentObjectCache
                             refStack.Push(referencedObjectBase.Location);
                             var resolved = ResolveReferences(referencedObjectBase.Clone(), refStack);
@@ -164,12 +156,6 @@ namespace Microsoft.DocAsCode.Build.RestApi.Swagger.Internals
                             }
                             swagger.Reference = swaggerObject;
                             refStack.Pop();
-
-                            if (refStack.Count == 0)
-                            {
-                                _resolvedObjectCache.Add(swagger.DeferredReference, swagger.Reference);
-                            }
-
                         }
                         return swagger;
                     }


### PR DESCRIPTION
For swagger resolved cache, if there's recursive reference like A->B->A, which is stored in the cache, and then there's B to be resolved, it will fetch B->A(from cache), and the chain would be B->A->B->A, it's incorrect. Remove swagger resolved cache first and refine the recursive logic later.

@vwxyzh @chenkennt @ansyral 