### PR TITLE
Use mark.js to highlight keywords

### DIFF
--- a/src/docfx.website.themes/default/bower.json
+++ b/src/docfx.website.themes/default/bower.json
@@ -25,6 +25,7 @@
     "jquery": "~2.1.4",
     "js-url": "1.8.6",
     "lunr.js": "0.6.0",
-    "twbs-pagination": "^1.3.1"
+    "twbs-pagination": "^1.3.1",
+    "mark.js": "^8.4.0"
   }
 }

--- a/src/docfx.website.themes/default/gulpfile.js
+++ b/src/docfx.website.themes/default/gulpfile.js
@@ -15,7 +15,8 @@ var vendor = {
        'bower_components/highlightjs/highlight.pack.min.js',
        'bower_components/lunr.js/lunr.min.js',
        'bower_components/js-url/url.min.js',
-       'bower_components/twbs-pagination/jquery.twbsPagination.min.js'
+       'bower_components/twbs-pagination/jquery.twbsPagination.min.js',
+       "bower_components/mark.js/dist/jquery.mark.min.js"
       ],
   webWorker: {
     src: ['lunr.min.js'],

--- a/src/docfx.website.themes/default/styles/docfx.js
+++ b/src/docfx.website.themes/default/styles/docfx.js
@@ -155,8 +155,8 @@ $(function () {
         var keywords = q.split("%20");
         keywords.forEach(function (keyword) {
           if (keyword !== "") {
-            highlight($('.data-searchable *'), keyword, "<mark>");
-            highlight($('article *'), keyword, "<mark>");
+            $('.data-searchable *').mark(keyword);
+            $('article *').mark(keyword);
           }
         });
       }
@@ -189,19 +189,6 @@ $(function () {
         $('.hide-when-search').hide();
         $('#search-results').show();
       }
-    }
-
-    function highlight(nodes, rgxStr, tag) {
-      var rgx = new RegExp(rgxStr, "gi");
-      nodes.each(function () {
-        $(this).contents().filter(function () {
-          return this.nodeType == 3 && rgx.test(this.nodeValue);
-        }).replaceWith(function () {
-          return (this.nodeValue || "").replace(rgx, function (match) {
-            return $(tag).text(match)[0].outerHTML;
-          });
-        });
-      });
     }
 
     function relativeUrlToAbsoluteUrl(currentUrl, relativeUrl) {


### PR DESCRIPTION
Fix bug while highlighting search keywords, such as http://dotnet.github.io/docfx/tutorial/walkthrough/walkthrough_create_a_docfx_project_2.html?q=sum

The keyword `sum` should be highlighted.

![capture](https://cloud.githubusercontent.com/assets/15644078/19258741/847724ce-8fad-11e6-8e12-50485b670c76.PNG)

@hellosnow @ansyral @vwxyzh @chenkennt 