### PR TITLE
Normalize FileAttributes for Resource files

### DIFF
--- a/src/Microsoft.DocAsCode.Build.ResourceFiles/ResourceDocumentProcessor.cs
+++ b/src/Microsoft.DocAsCode.Build.ResourceFiles/ResourceDocumentProcessor.cs
@@ -96,6 +96,7 @@ namespace Microsoft.DocAsCode.Build.ResourceFiles
                     Path.Combine(model.OriginalFileAndType.BaseDir, model.OriginalFileAndType.File),
                     targetFile,
                     true);
+                File.SetAttributes(targetFile, FileAttributes.Normal);
             }
             var result = new SaveResult
             {


### PR DESCRIPTION
By normalizing FileAttributes we can avoid issues where the build command is able to clean the output directory