### PR TITLE
Support contribution button when the gitContribute is correctly specified

### DIFF
--- a/src/docfx.website.themes/common/common.js
+++ b/src/docfx.website.themes/common/common.js
@@ -117,11 +117,15 @@ function getNewFileUrl(uid, gitContribute, gitUrlPattern) {
 }
 
 function getRemoteUrl(remote, startLine, gitContribute, gitUrlPattern) {
-    if (!remote || !remote.repo) return '';
-    var repo = remote.repo;
+    var repo = undefined;
+    var branch = undefined;
     if (gitContribute && gitContribute.repo) repo = gitContribute.repo;
-    var branch = remote.branch;
+    if (repo == undefined && remote && remote.repo) repo = remote.repo;
     if (gitContribute && gitContribute.branch) branch = gitContribute.branch;
+    if (repo == undefined && remote && remote.branch) branch = remote.branch;
+
+    if (repo == undefined || branch == undefined) return '';
+
     if (repo.substr(-4) === '.git') {
         repo = repo.substr(0, repo.length - 4);
     }

--- a/src/docfx.website.themes/common/common.js
+++ b/src/docfx.website.themes/common/common.js
@@ -122,7 +122,7 @@ function getRemoteUrl(remote, startLine, gitContribute, gitUrlPattern) {
     if (gitContribute && gitContribute.repo) repo = gitContribute.repo;
     if (repo == undefined && remote && remote.repo) repo = remote.repo;
     if (gitContribute && gitContribute.branch) branch = gitContribute.branch;
-    if (repo == undefined && remote && remote.branch) branch = remote.branch;
+    if (branch == undefined && remote && remote.branch) branch = remote.branch;
 
     if (repo == undefined || branch == undefined) return '';
 


### PR DESCRIPTION
This fixes #778 where the "origin" remote is not defined in the local clone, but the _gitContribute metadata is correctly set, so there was no need for the remote being specified in the first place.