### PR TITLE
fix the concurrency issue of Logger and minor fix the test

### DIFF
--- a/src/Microsoft.DocAsCode.Common/Loggers/Logger.cs
+++ b/src/Microsoft.DocAsCode.Common/Loggers/Logger.cs
@@ -20,7 +20,10 @@ namespace Microsoft.DocAsCode.Common
                 throw new ArgumentNullException(nameof(listener));
             }
 
-            _listeners = _listeners.Add(listener);
+            lock (_sync)
+            {
+                _listeners = _listeners.Add(listener);
+            }
         }
 
         public static ILoggerListener FindListener(Predicate<ILoggerListener> predicate)
@@ -40,13 +43,16 @@ namespace Microsoft.DocAsCode.Common
                 throw new ArgumentNullException(nameof(listener));
             }
 
-            listener.Dispose();
-            _listeners = _listeners.Remove(listener);
+            lock(_sync)
+            {
+                listener.Dispose();
+                _listeners = _listeners.Remove(listener);
+            }
         }
 
         public static void UnregisterAllListeners()
         {
-            foreach(var i in _listeners)
+            foreach (var i in _listeners)
             {
                 i.Dispose();
             }

--- a/test/Microsoft.DocAsCode.Common.Tests/ScopeTest.cs
+++ b/test/Microsoft.DocAsCode.Common.Tests/ScopeTest.cs
@@ -93,17 +93,17 @@ namespace Microsoft.DocAsCode.Common.Tests
                 Logger.RegisterListener(listener);
                 Action callback;
 
-                Logger.LogInfo("Not in file scope.", phase: "TestFileScope");
+                Logger.LogInfo("Not in file scope.", listener.Phase);
                 Assert.Null(listener.TakeAndRemove().File);
 
                 using (new LoggerFileScope("A"))
                 {
-                    Logger.LogInfo("In file A", phase: "TestFileScope");
+                    Logger.LogInfo("In file A", listener.Phase);
                     Assert.Equal("A", listener.TakeAndRemove().File);
 
                     using (new LoggerFileScope("B"))
                     {
-                        Logger.LogInfo("In file B", phase: "TestFileScope");
+                        Logger.LogInfo("In file B", listener.Phase);
                         Assert.Equal("B", listener.TakeAndRemove().File);
 
                         var captured = LoggerFileScope.Capture();
@@ -111,23 +111,23 @@ namespace Microsoft.DocAsCode.Common.Tests
                         {
                             using (LoggerFileScope.Restore(captured))
                             {
-                                Logger.LogInfo("In captured file B", phase: "TestFileScope");
+                                Logger.LogInfo("In captured file B", listener.Phase);
                             }
                         };
                     }
 
-                    Logger.LogInfo("In file A", phase: "TestFileScope");
+                    Logger.LogInfo("In file A", listener.Phase);
                     Assert.Equal("A", listener.TakeAndRemove().File);
 
                     callback();
                     Assert.Equal("B", listener.TakeAndRemove().File);
 
-                    Logger.LogInfo("In file A", phase: "TestFileScope");
+                    Logger.LogInfo("In file A", listener.Phase);
                     Assert.Equal("A", listener.TakeAndRemove().File);
 
                     using (new LoggerFileScope("C"))
                     {
-                        Logger.LogInfo("In file C", phase: "TestFileScope");
+                        Logger.LogInfo("In file C", listener.Phase);
                         Assert.Equal("C", listener.TakeAndRemove().File);
 
                         callback();
@@ -135,13 +135,13 @@ namespace Microsoft.DocAsCode.Common.Tests
                     }
                 }
 
-                Logger.LogInfo("Not in file scope.", phase: "TestFileScope");
+                Logger.LogInfo("Not in file scope.", listener.Phase);
                 Assert.Null(listener.TakeAndRemove().File);
 
                 callback();
                 Assert.Equal("B", listener.TakeAndRemove().File);
 
-                Logger.LogInfo("Not in file scope.", phase: "TestFileScope");
+                Logger.LogInfo("Not in file scope.", listener.Phase);
                 Assert.Null(listener.TakeAndRemove().File);
             }
             finally

--- a/test/Microsoft.DocAsCode.Common.Tests/ScopeTest.cs
+++ b/test/Microsoft.DocAsCode.Common.Tests/ScopeTest.cs
@@ -87,23 +87,23 @@ namespace Microsoft.DocAsCode.Common.Tests
         [Fact]
         public void TestFileScope()
         {
-            var listener = new TestLoggerListener();
+            var listener = new TestLoggerListener("TestFileScope");
             try
             {
                 Logger.RegisterListener(listener);
                 Action callback;
 
-                Logger.LogInfo("Not in file scope.");
+                Logger.LogInfo("Not in file scope.", phase: "TestFileScope");
                 Assert.Null(listener.TakeAndRemove().File);
 
                 using (new LoggerFileScope("A"))
                 {
-                    Logger.LogInfo("In file A");
+                    Logger.LogInfo("In file A", phase: "TestFileScope");
                     Assert.Equal("A", listener.TakeAndRemove().File);
 
                     using (new LoggerFileScope("B"))
                     {
-                        Logger.LogInfo("In file B");
+                        Logger.LogInfo("In file B", phase: "TestFileScope");
                         Assert.Equal("B", listener.TakeAndRemove().File);
 
                         var captured = LoggerFileScope.Capture();
@@ -111,23 +111,23 @@ namespace Microsoft.DocAsCode.Common.Tests
                         {
                             using (LoggerFileScope.Restore(captured))
                             {
-                                Logger.LogInfo("In captured file B");
+                                Logger.LogInfo("In captured file B", phase: "TestFileScope");
                             }
                         };
                     }
 
-                    Logger.LogInfo("In file A");
+                    Logger.LogInfo("In file A", phase: "TestFileScope");
                     Assert.Equal("A", listener.TakeAndRemove().File);
 
                     callback();
                     Assert.Equal("B", listener.TakeAndRemove().File);
 
-                    Logger.LogInfo("In file A");
+                    Logger.LogInfo("In file A", phase: "TestFileScope");
                     Assert.Equal("A", listener.TakeAndRemove().File);
 
                     using (new LoggerFileScope("C"))
                     {
-                        Logger.LogInfo("In file C");
+                        Logger.LogInfo("In file C", phase: "TestFileScope");
                         Assert.Equal("C", listener.TakeAndRemove().File);
 
                         callback();
@@ -135,13 +135,13 @@ namespace Microsoft.DocAsCode.Common.Tests
                     }
                 }
 
-                Logger.LogInfo("Not in file scope.");
+                Logger.LogInfo("Not in file scope.", phase: "TestFileScope");
                 Assert.Null(listener.TakeAndRemove().File);
 
                 callback();
                 Assert.Equal("B", listener.TakeAndRemove().File);
 
-                Logger.LogInfo("Not in file scope.");
+                Logger.LogInfo("Not in file scope.", phase: "TestFileScope");
                 Assert.Null(listener.TakeAndRemove().File);
             }
             finally


### PR DESCRIPTION
1. Logger.RegisterListener and UnRegisterListener has concurrency issue.
2. add phase scope for the test to avoid data conflict since unit tests in different test classes run in parallel.
@vwxyzh @superyyrrzz @hellosnow @qinezh @chenkennt 