### PR TITLE
Add link to files and uids in overwrite documents

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Common/MarkdownReader.cs
+++ b/src/Microsoft.DocAsCode.Build.Common/MarkdownReader.cs
@@ -58,7 +58,7 @@ namespace Microsoft.DocAsCode.Build.Common
             return new OverwriteDocumentModel
             {
                 Uid = properties[Constants.PropertyName.Uid].ToString(),
-                LinkToFiles = part.LinkToFiles,
+                LinkToFiles = part.LinkToFiles.ToImmutableHashSet(),
                 LinkToUids = part.LinkToUids,
                 Metadata = overriden,
                 Conceptual = part.Conceptual,

--- a/src/Microsoft.DocAsCode.Build.Common/MarkdownReader.cs
+++ b/src/Microsoft.DocAsCode.Build.Common/MarkdownReader.cs
@@ -58,6 +58,8 @@ namespace Microsoft.DocAsCode.Build.Common
             return new OverwriteDocumentModel
             {
                 Uid = properties[Constants.PropertyName.Uid].ToString(),
+                LinkToFiles = part.LinkToFiles,
+                LinkToUids = part.LinkToUids,
                 Metadata = overriden,
                 Conceptual = part.Conceptual,
                 Documentation = new SourceDetail

--- a/src/Microsoft.DocAsCode.Build.Common/OverwriteDocumentModel.cs
+++ b/src/Microsoft.DocAsCode.Build.Common/OverwriteDocumentModel.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.DocAsCode.Build.Common
 {
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.IO;
 
     using Newtonsoft.Json;
@@ -39,6 +40,20 @@ namespace Microsoft.DocAsCode.Build.Common
         [YamlMember(Alias = Constants.PropertyName.Documentation)]
         [JsonProperty(Constants.PropertyName.Documentation)]
         public SourceDetail Documentation { get; set; }
+
+        /// <summary>
+        /// Links to other files
+        /// </summary>
+        [YamlIgnore]
+        [JsonIgnore]
+        public ImmutableArray<string> LinkToFiles { get; set; } = ImmutableArray<string>.Empty;
+
+        /// <summary>
+        /// Links to other Uids
+        /// </summary>
+        [YamlIgnore]
+        [JsonIgnore]
+        public ImmutableHashSet<string> LinkToUids { get; set; } = ImmutableHashSet<string>.Empty;
 
         public T ConvertTo<T>() where T : class
         {

--- a/src/Microsoft.DocAsCode.Build.Common/OverwriteDocumentModel.cs
+++ b/src/Microsoft.DocAsCode.Build.Common/OverwriteDocumentModel.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DocAsCode.Build.Common
         /// </summary>
         [YamlIgnore]
         [JsonIgnore]
-        public ImmutableArray<string> LinkToFiles { get; set; } = ImmutableArray<string>.Empty;
+        public ImmutableHashSet<string> LinkToFiles { get; set; } = ImmutableHashSet<string>.Empty;
 
         /// <summary>
         /// Links to other Uids

--- a/src/Microsoft.DocAsCode.Build.ManagedReference/BuildManagedReferenceDocument.cs
+++ b/src/Microsoft.DocAsCode.Build.ManagedReference/BuildManagedReferenceDocument.cs
@@ -110,14 +110,16 @@ namespace Microsoft.DocAsCode.Build.ManagedReference
         }
 
         #region Private methods
-        private static IEnumerable<string> EmptyEnumerable = Enumerable.Empty<string>();
+        private static readonly IEnumerable<string> EmptyEnumerable = Enumerable.Empty<string>();
 
         private static void BuildItem(IHostService host, FileModel model)
         {
             var file = model.FileAndType;
             var overwrites = MarkdownReader.ReadMarkdownAsOverwrite(host, model.FileAndType).ToList();
             model.Content = overwrites;
-            model.LocalPathFromRepoRoot = overwrites[0].Documentation?.Remote?.RelativePath ?? Path.Combine(file.BaseDir, file.File).ToDisplayPath();
+            model.LinkToFiles = overwrites.SelectMany(o => o.LinkToFiles).ToImmutableHashSet();
+            model.LinkToUids = overwrites.SelectMany(o => o.LinkToUids).ToImmutableHashSet();
+            model.LocalPathFromRepoRoot = overwrites.FirstOrDefault()?.Documentation?.Remote?.RelativePath ?? Path.Combine(file.BaseDir, file.File).ToDisplayPath();
             model.Uids = (from item in overwrites
                           select new UidDefinition(
                               item.Uid,

--- a/src/Microsoft.DocAsCode.Build.RestApi/ApplyOverwriteDocumentForRestApi.cs
+++ b/src/Microsoft.DocAsCode.Build.RestApi/ApplyOverwriteDocumentForRestApi.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.DocAsCode.Build.RestApi
 {
-    using System;
     using System.Collections.Generic;
     using System.Composition;
     using System.Linq;

--- a/src/Microsoft.DocAsCode.Build.RestApi/BuildRestApiDocument.cs
+++ b/src/Microsoft.DocAsCode.Build.RestApi/BuildRestApiDocument.cs
@@ -115,7 +115,9 @@ namespace Microsoft.DocAsCode.Build.RestApi
             var file = model.FileAndType;
             var overwrites = MarkdownReader.ReadMarkdownAsOverwrite(host, model.FileAndType).ToList();
             model.Content = overwrites;
-            model.LocalPathFromRepoRoot = overwrites[0].Documentation?.Remote?.RelativePath ?? Path.Combine(file.BaseDir, file.File).ToDisplayPath();
+            model.LinkToFiles = overwrites.SelectMany(o => o.LinkToFiles).ToImmutableHashSet();
+            model.LinkToUids = overwrites.SelectMany(o => o.LinkToUids).ToImmutableHashSet();
+            model.LocalPathFromRepoRoot = overwrites.FirstOrDefault()?.Documentation?.Remote?.RelativePath ?? Path.Combine(file.BaseDir, file.File).ToDisplayPath();
             model.Uids = (from item in overwrites
                           select new UidDefinition(
                               item.Uid,

--- a/test/Microsoft.DocAsCode.Build.Common.Tests/MarkdownReaderTest.cs
+++ b/test/Microsoft.DocAsCode.Build.Common.Tests/MarkdownReaderTest.cs
@@ -130,7 +130,7 @@ uid: Test2
             Assert.Equal("<p sourcefile=\"ut_ReadMarkdownAsOverwrite.md\" sourcestartlinenumber=\"5\" sourceendlinenumber=\"5\">This is unit test!</p>\n", results[0].Conceptual);
             File.Delete(fileName);
 
-            // Test link to files and Uids in overwrite documents
+            // Test link to files and Uids in overwrite document
             content = @"---
 uid: Test
 remarks: Hello
@@ -148,8 +148,8 @@ This is unit test!";
             Assert.Equal(1, results.Count);
             Assert.Equal("Test", results[0].Uid);
             Assert.Equal("Hello", results[0].Metadata["remarks"]);
-            Assert.Equal(1, results[0].LinkToFiles.Length);
-            Assert.Equal("~/link.md", results[0].LinkToFiles[0]);
+            Assert.Equal(1, results[0].LinkToFiles.Count);
+            Assert.Equal("~/link.md", results[0].LinkToFiles.ElementAt(0));
             Assert.Equal(1, results[0].LinkToUids.Count);
             Assert.Equal("NotExistUid", results[0].LinkToUids.ElementAt(0));
             Assert.Equal(@"<p sourcefile=""ut_ReadMarkdownAsOverwrite.md"" sourcestartlinenumber=""5"" sourceendlinenumber=""5""><xref href=""NotExistUid"" data-throw-if-not-resolved=""False"" data-raw=""@NotExistUid"" sourcefile=""ut_ReadMarkdownAsOverwrite.md"" sourcestartlinenumber=""5"" sourceendlinenumber=""5""></xref></p>

--- a/test/Microsoft.DocAsCode.Build.Common.Tests/MarkdownReaderTest.cs
+++ b/test/Microsoft.DocAsCode.Build.Common.Tests/MarkdownReaderTest.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.DocAsCode.Build.Common.Tests
 {
+    using System.Collections.Immutable;
     using System.IO;
     using System.Linq;
     using System.Text.RegularExpressions;
@@ -32,7 +33,8 @@ This is unit test!";
             File.WriteAllText(fullPath, content);
             var host = new HostService(null, Enumerable.Empty<FileModel>())
             {
-                MarkdownService = new DfmServiceProvider().CreateMarkdownService(new MarkdownServiceParameters {BasePath = string.Empty})
+                MarkdownService = new DfmServiceProvider().CreateMarkdownService(new MarkdownServiceParameters {BasePath = string.Empty}),
+                SourceFiles = ImmutableDictionary.Create<string, FileAndType>()
             };
 
             var ft = new FileAndType(baseDir, fileName, DocumentType.Overwrite);
@@ -126,6 +128,35 @@ uid: Test2
             Assert.Equal("Test", results[0].Uid);
             Assert.Equal("Hello", results[0].Metadata["remarks"]);
             Assert.Equal("<p sourcefile=\"ut_ReadMarkdownAsOverwrite.md\" sourcestartlinenumber=\"5\" sourceendlinenumber=\"5\">This is unit test!</p>\n", results[0].Conceptual);
+            File.Delete(fileName);
+
+            // Test link to files and Uids in overwrite documents
+            content = @"---
+uid: Test
+remarks: Hello
+---
+@NotExistUid
+
+[Not exist link](link.md)
+
+This is unit test!";
+            content = Regex.Replace(content, "\r?\n", "\r\n");
+            html = DocfxFlavoredMarked.Markup(content);
+            File.WriteAllText(fileName, content);
+            results = MarkdownReader.ReadMarkdownAsOverwrite(host, ft).ToList();
+            Assert.NotNull(results);
+            Assert.Equal(1, results.Count);
+            Assert.Equal("Test", results[0].Uid);
+            Assert.Equal("Hello", results[0].Metadata["remarks"]);
+            Assert.Equal(1, results[0].LinkToFiles.Length);
+            Assert.Equal("~/link.md", results[0].LinkToFiles[0]);
+            Assert.Equal(1, results[0].LinkToUids.Count);
+            Assert.Equal("NotExistUid", results[0].LinkToUids.ElementAt(0));
+            Assert.Equal(@"<p sourcefile=""ut_ReadMarkdownAsOverwrite.md"" sourcestartlinenumber=""5"" sourceendlinenumber=""5""><xref href=""NotExistUid"" data-throw-if-not-resolved=""False"" data-raw=""@NotExistUid"" sourcefile=""ut_ReadMarkdownAsOverwrite.md"" sourcestartlinenumber=""5"" sourceendlinenumber=""5""></xref></p>
+<p sourcefile=""ut_ReadMarkdownAsOverwrite.md"" sourcestartlinenumber=""7"" sourceendlinenumber=""7""><a href=""link.md"" sourcefile=""ut_ReadMarkdownAsOverwrite.md"" sourcestartlinenumber=""7"" sourceendlinenumber=""7"">Not exist link</a></p>
+<p sourcefile=""ut_ReadMarkdownAsOverwrite.md"" sourcestartlinenumber=""9"" sourceendlinenumber=""9"">This is unit test!</p>
+".Replace("\r\n", "\n"),
+                results[0].Conceptual);
             File.Delete(fileName);
         }
     }


### PR DESCRIPTION
Add link to files and uids in overwrite documents, therefore when building documents warning should appears for invalid links in overwrite documents.

@vwxyzh @superyyrrzz @ansyral @qinezh @chenkennt 