### PR TITLE
Video token should be only parsed when it's in blockquote

### DIFF
--- a/src/Microsoft.DocAsCode.Dfm/Rules/DfmVideoBlockRule.cs
+++ b/src/Microsoft.DocAsCode.Dfm/Rules/DfmVideoBlockRule.cs
@@ -16,6 +16,11 @@ namespace Microsoft.DocAsCode.Dfm
 
         public IMarkdownToken TryMatch(IMarkdownParser parser, IMarkdownParsingContext context)
         {
+            if (!parser.Context.Variables.ContainsKey(MarkdownBlockContext.IsBlockQuote) || !(bool)parser.Context.Variables[MarkdownBlockContext.IsBlockQuote])
+            {
+                return null;
+            }
+
             var match = VideoRegex.Match(context.CurrentMarkdown);
             if (match.Length == 0)
             {


### PR DESCRIPTION
As title