### PR TITLE
Make [!VIDEO] output correctly responsive

### DIFF
--- a/src/Microsoft.DocAsCode.Dfm/DfmRenderer.cs
+++ b/src/Microsoft.DocAsCode.Dfm/DfmRenderer.cs
@@ -131,11 +131,11 @@ namespace Microsoft.DocAsCode.Dfm
                 else if (splitToken.Token is DfmVideoBlockToken)
                 {
                     var videoToken = splitToken.Token as DfmVideoBlockToken;
-                    content += "<iframe width=\"640\" height=\"320\" src=\"";
+                    content += "<div class=\"embeddedvideo\"><iframe src=\"";
                     content += videoToken.Link;
                     content += "\" frameborder=\"0\" allowfullscreen=\"true\"";
                     content = AppendSourceInfo(content, renderer, splitToken.Token);
-                    content += "></iframe>\n";
+                    content += "></iframe></div>\n";
                     continue;
                 }
                 else

--- a/src/docfx.website.themes/default/styles/docfx.css
+++ b/src/docfx.website.themes/default/styles/docfx.css
@@ -807,6 +807,23 @@ pre > code .line-highlight {
   background-color: #ffffcc;
 }
 
+/* For Embedded Video */
+div.embeddedvideo {
+    padding-top: 56.25%;
+    position: relative;
+    width: 100%;
+}
+
+div.embeddedvideo iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100%;
+    height: 100%;
+}
+
 /* For printer */
 @media print{
   .article.grid-right {

--- a/test/Microsoft.DocAsCode.Dfm.Tests/DocfxFlavoredMarkdownTest.cs
+++ b/test/Microsoft.DocAsCode.Dfm.Tests/DocfxFlavoredMarkdownTest.cs
@@ -257,7 +257,7 @@ Inline [!include[ref3](ref3.md ""This is root"")]
 ";
 
             var expected = @"<p>The following is video.</p>
-<iframe width=""640"" height=""320"" src=""https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4"" frameborder=""0"" allowfullscreen=""true""></iframe>
+<div class=""embeddedvideo""><iframe src=""https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4"" frameborder=""0"" allowfullscreen=""true""></iframe></div>
 ";
 
             var marked = DocfxFlavoredMarked.Markup(root);
@@ -274,8 +274,8 @@ Inline [!include[ref3](ref3.md ""This is root"")]
 > [!Video https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4]";
 
             var expected = @"<p>The following is two videos.</p>
-<iframe width=""640"" height=""320"" src=""https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4"" frameborder=""0"" allowfullscreen=""true""></iframe>
-<iframe width=""640"" height=""320"" src=""https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4"" frameborder=""0"" allowfullscreen=""true""></iframe>
+<div class=""embeddedvideo""><iframe src=""https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4"" frameborder=""0"" allowfullscreen=""true""></iframe></div>
+<div class=""embeddedvideo""><iframe src=""https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4"" frameborder=""0"" allowfullscreen=""true""></iframe></div>
 ";
 
             var marked = DocfxFlavoredMarked.Markup(root);
@@ -294,10 +294,10 @@ Inline [!include[ref3](ref3.md ""This is root"")]
 > [!Video https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4]";
 
             var expected = @"<p>The following is video mixed with note.</p>
-<iframe width=""640"" height=""320"" src=""https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4"" frameborder=""0"" allowfullscreen=""true""></iframe>
+<div class=""embeddedvideo""><iframe src=""https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4"" frameborder=""0"" allowfullscreen=""true""></iframe></div>
 <div class=""NOTE""><h5>NOTE</h5><p>this is note text</p>
 </div>
-<iframe width=""640"" height=""320"" src=""https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4"" frameborder=""0"" allowfullscreen=""true""></iframe>
+<div class=""embeddedvideo""><iframe src=""https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4"" frameborder=""0"" allowfullscreen=""true""></iframe></div>
 ";
 
             var marked = DocfxFlavoredMarked.Markup(root);


### PR DESCRIPTION
Updating the rendered code for the video element to correctly handle being displayed at different widths. Previous code was a fixed 640x320 that wouldn't scale on smaller or larger width pages.