### PR TITLE
add xrefmap and filemap into buildversioninfo

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/HostService.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/HostService.cs
@@ -507,6 +507,17 @@ namespace Microsoft.DocAsCode.Build.Engine
             }
         }
 
+        public List<string> GetUnloadedModelFiles(IncrementalBuildContext incrementalContext)
+        {
+            if (!CanIncrementalBuild)
+            {
+                return new List<string>();
+            }
+            return (from pair in incrementalContext.GetModelLoadInfo(this)
+                    where pair.Value == null
+                    select pair.Key).ToList();
+        }
+
         #endregion
 
         #region Private Methods

--- a/src/Microsoft.DocAsCode.Build.Engine/HostServiceCreatorWithIncremental.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/HostServiceCreatorWithIncremental.cs
@@ -101,6 +101,10 @@ namespace Microsoft.DocAsCode.Build.Engine
         {
             using (new LoggerPhaseScope("ReportModelLoadInfo", true))
             {
+                if (!hostService.ShouldTraceIncrementalInfo)
+                {
+                    return;
+                }
                 var allFiles = files?.Select(f => f.File) ?? new string[0];
                 var loadedFiles = hostService.Models.Select(m => m.FileAndType.File);
                 IncrementalContext.ReportModelLoadInfo(hostService, allFiles.Except(loadedFiles), null);

--- a/src/Microsoft.DocAsCode.Build.Engine/Incrementals/BuildVersionInfo.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/Incrementals/BuildVersionInfo.cs
@@ -47,6 +47,10 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
         /// </summary>
         public string XRefSpecMapFile { get; set; }
         /// <summary>
+        /// The file link for the FileMap file.
+        /// </summary>
+        public string FileMapFile { get; set; }
+        /// <summary>
         /// The file link for the build message file (type is <see cref="BuildMessage"/>).
         /// </summary>
         public string BuildMessageFile { get; set; }
@@ -73,10 +77,15 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
         [JsonIgnore]
         public BuildOutputs BuildOutputs { get; private set; } = new BuildOutputs();
         /// <summary>
-        /// deserialized xrefspecmap
+        /// deserialized xrefspecmap. Key is original file path from root. Value is XrefSpecs reported by the file.
         /// </summary>
         [JsonIgnore]
-        public IDictionary<string, XRefSpec> XRefSpecMap { get; set; }
+        public IDictionary<string, IEnumerable<XRefSpec>> XRefSpecMap { get; private set; } = new Dictionary<string, IEnumerable<XRefSpec>>();
+        /// <summary>
+        /// deserialized filemap.
+        /// </summary>
+        [JsonIgnore]
+        public IDictionary<string, string> FileMap { get; set; }
         /// <summary>
         /// deserialized build messages.
         /// </summary>
@@ -90,6 +99,8 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
             Attributes = IncrementalUtility.LoadIntermediateFile<IDictionary<string, FileAttributeItem>>(Path.Combine(baseDir, AttributesFile));
             BuildOutputs = IncrementalUtility.LoadIntermediateFile<BuildOutputs>(Path.Combine(baseDir, OutputFile));
             Manifest = IncrementalUtility.LoadIntermediateFile<IEnumerable<ManifestItem>>(Path.Combine(baseDir, ManifestFile));
+            XRefSpecMap = IncrementalUtility.LoadIntermediateFile<IDictionary<string, IEnumerable<XRefSpec>>>(Path.Combine(baseDir, XRefSpecMapFile));
+            FileMap = IncrementalUtility.LoadIntermediateFile<IDictionary<string, string>>(Path.Combine(baseDir, FileMapFile));
             BuildMessage = IncrementalUtility.LoadBuildMessage(Path.Combine(baseDir, BuildMessageFile));
             foreach (var processor in Processors)
             {
@@ -103,6 +114,8 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
             IncrementalUtility.SaveIntermediateFile(Path.Combine(baseDir, AttributesFile), Attributes);
             IncrementalUtility.SaveIntermediateFile(Path.Combine(baseDir, OutputFile), BuildOutputs);
             IncrementalUtility.SaveIntermediateFile(Path.Combine(baseDir, ManifestFile), Manifest);
+            IncrementalUtility.SaveIntermediateFile(Path.Combine(baseDir, XRefSpecMapFile), XRefSpecMap);
+            IncrementalUtility.SaveIntermediateFile(Path.Combine(baseDir, FileMapFile), FileMap);
             IncrementalUtility.SaveBuildMessage(Path.Combine(baseDir, BuildMessageFile), BuildMessage);
             foreach (var processor in Processors)
             {

--- a/src/Microsoft.DocAsCode.Build.Engine/Incrementals/IncrementalBuildContext.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/Incrementals/IncrementalBuildContext.cs
@@ -85,6 +85,7 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
                 ManifestFile = IncrementalUtility.CreateRandomFileName(baseDir),
                 OutputFile = IncrementalUtility.CreateRandomFileName(baseDir),
                 XRefSpecMapFile = IncrementalUtility.CreateRandomFileName(baseDir),
+                FileMapFile = IncrementalUtility.CreateRandomFileName(baseDir),
                 BuildMessageFile = IncrementalUtility.CreateRandomFileName(baseDir),
                 Attributes = ComputeFileAttributes(parameters, lbv?.Dependency),
                 Dependency = ConstructDependencyGraphFromLast(lbv?.Dependency),

--- a/src/Microsoft.DocAsCode.Build.Engine/Incrementals/IncrementalBuildContext.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/Incrementals/IncrementalBuildContext.cs
@@ -145,6 +145,10 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
         public IReadOnlyDictionary<string, BuildPhase?> GetModelLoadInfo(HostService hostService)
         {
             string name = hostService.Processor.Name;
+            if (!hostService.ShouldTraceIncrementalInfo)
+            {
+                throw new InvalidOperationException($"HostService: {name} doesn't record incremental info, cannot call the method to get model load info.");
+            }
             Dictionary<string, BuildPhase?> mi;
             if (ModelLoadInfo.TryGetValue(name, out mi))
             {

--- a/src/Microsoft.DocAsCode.Build.Engine/PrebuildBuildPhaseHandlerWithIncremental.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/PrebuildBuildPhaseHandlerWithIncremental.cs
@@ -96,6 +96,7 @@ namespace Microsoft.DocAsCode.Build.Engine
                 h.SaveIntermediateModel(IncrementalContext);
             }
             ReportDependency(hostServices);
+            IncrementalContext.UpdateBuildVersionInfoPerDependencyGraph();
             Logger.UnregisterListener(CurrentBuildMessageInfo.GetListener());
         }
 


### PR DESCRIPTION
xrefmap would be used during postbuildphase. so should load last xrefmap in the prehandle of postbuild phase

@vwxyzh @vicancy @superyyrrzz @hellosnow @qinezh @chenkennt 