### PR TITLE
fix inherited member's name when xref unresolved

### DIFF
--- a/src/docfx.website.themes/default/partials/class.header.tmpl.partial
+++ b/src/docfx.website.themes/default/partials/class.header.tmpl.partial
@@ -19,10 +19,10 @@
 {{#inheritedMembers}}
   <div>
   {{#definition}}
-    <xref href="{{definition}}" altProperty="fullName" displayProperty="nameWithType"/>
+    <xref href="{{definition}}" text="{{nameWithType.0.value}}" alt="{{fullName.0.value}}"/>
   {{/definition}}
   {{^definition}}
-    <xref href="{{uid}}" altProperty="fullName" displayProperty="nameWithType"/>
+    <xref href="{{uid}}" text="{{nameWithType.0.value}}" alt="{{fullName.0.value}}"/>
   {{/definition}}
   </div>
 {{/inheritedMembers}}


### PR DESCRIPTION
like in http://dotnet.github.io/docfx/api/Microsoft.DocAsCode.ListWithStringFallback.html
@chenkennt @vwxyzh @vicancy @hellosnow @ansyral @qinezh 