### PR TITLE
Add merge option: tocMetadata

### DIFF
--- a/src/Microsoft.DocAsCode.DataContracts.Common/TocItemViewModel.cs
+++ b/src/Microsoft.DocAsCode.DataContracts.Common/TocItemViewModel.cs
@@ -23,6 +23,10 @@ namespace Microsoft.DocAsCode.DataContracts.Common
         [JsonProperty("name")]
         public string Name { get; set; }
 
+        [YamlMember(Alias = "metadata")]
+        [JsonProperty("metadata")]
+        public Dictionary<string, List<string>> Metadata { get; set; }
+
         [ExtensibleMember("name.")]
         [JsonIgnore]
         public SortedList<string, string> NameInDevLangs { get; } = new SortedList<string, string>();

--- a/src/Microsoft.DocAsCode.DataContracts.Common/TocItemViewModel.cs
+++ b/src/Microsoft.DocAsCode.DataContracts.Common/TocItemViewModel.cs
@@ -23,8 +23,8 @@ namespace Microsoft.DocAsCode.DataContracts.Common
         [JsonProperty("name")]
         public string Name { get; set; }
 
-        [YamlMember(Alias = "metadata")]
-        [JsonProperty("metadata")]
+        [ExtensibleMember]
+        [JsonExtensionData]
         public Dictionary<string, object> Metadata { get; set; }
 
         [ExtensibleMember("name.")]

--- a/src/Microsoft.DocAsCode.DataContracts.Common/TocItemViewModel.cs
+++ b/src/Microsoft.DocAsCode.DataContracts.Common/TocItemViewModel.cs
@@ -23,10 +23,6 @@ namespace Microsoft.DocAsCode.DataContracts.Common
         [JsonProperty("name")]
         public string Name { get; set; }
 
-        [ExtensibleMember]
-        [JsonExtensionData]
-        public Dictionary<string, object> Metadata { get; set; }
-
         [ExtensibleMember("name.")]
         [JsonIgnore]
         public SortedList<string, string> NameInDevLangs { get; } = new SortedList<string, string>();
@@ -115,12 +111,12 @@ namespace Microsoft.DocAsCode.DataContracts.Common
 
         [ExtensibleMember]
         [JsonIgnore]
-        public Dictionary<string, object> Additional { get; set; } = new Dictionary<string, object>();
+        public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         [YamlIgnore]
         [JsonExtensionData(ReadData = false, WriteData = true)]
-        public Dictionary<string, object> AdditionalJson
+        public Dictionary<string, object> MetadataJson
         {
             get
             {
@@ -129,7 +125,7 @@ namespace Microsoft.DocAsCode.DataContracts.Common
                 {
                     dict["name." + item.Key] = item.Value;
                 }
-                foreach (var item in Additional)
+                foreach (var item in Metadata)
                 {
                     dict[item.Key] = item.Value;
                 }

--- a/src/Microsoft.DocAsCode.DataContracts.Common/TocItemViewModel.cs
+++ b/src/Microsoft.DocAsCode.DataContracts.Common/TocItemViewModel.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DocAsCode.DataContracts.Common
 
         [YamlMember(Alias = "metadata")]
         [JsonProperty("metadata")]
-        public Dictionary<string, List<string>> Metadata { get; set; }
+        public Dictionary<string, object> Metadata { get; set; }
 
         [ExtensibleMember("name.")]
         [JsonIgnore]

--- a/src/docfx/Models/MergeCommandOptions.cs
+++ b/src/docfx/Models/MergeCommandOptions.cs
@@ -40,5 +40,8 @@ namespace Microsoft.DocAsCode
 
         [Option("fileMetadataFile", HelpText = "Specify a JSON file path containing fileMetadata settings, as similar to {\"fileMetadata\":{\"key\":\"value\"}}. It overrides the fileMetadata settings from the config file.")]
         public string FileMetadataFilePath { get; set; }
+
+        [OptionList("metadataNeedMergedIntoToc", Separator = ',', HelpText = "Specify metadata names that need to be merged into toc file")]
+        public List<string> MetadataNeedMergedIntoToc { get; set; }
     }
 }

--- a/src/docfx/Models/MergeCommandOptions.cs
+++ b/src/docfx/Models/MergeCommandOptions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DocAsCode
         [Option("fileMetadataFile", HelpText = "Specify a JSON file path containing fileMetadata settings, as similar to {\"fileMetadata\":{\"key\":\"value\"}}. It overrides the fileMetadata settings from the config file.")]
         public string FileMetadataFilePath { get; set; }
 
-        [OptionList("metadataNeedMergedIntoToc", Separator = ',', HelpText = "Specify metadata names that need to be merged into toc file")]
-        public List<string> MetadataNeedMergedIntoToc { get; set; }
+        [OptionList("tocMetadata", Separator = ',', HelpText = "Specify metadata names that need to be merged into toc file")]
+        public List<string> TocMetadata { get; set; }
     }
 }

--- a/src/docfx/Models/MergeJsonConfig.cs
+++ b/src/docfx/Models/MergeJsonConfig.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DocAsCode
         [JsonProperty("fileMetadata")]
         public Dictionary<string, FileMetadataPairs> FileMetadata { get; set; }
 
-        [JsonProperty("metadataNeedMergedIntoToc")]
-        public ListWithStringFallback MetadataNeedMergedIntoToc { get; set; }
+        [JsonProperty("tocMetadata")]
+        public ListWithStringFallback TocMetadata { get; set; }
     }
 }

--- a/src/docfx/Models/MergeJsonConfig.cs
+++ b/src/docfx/Models/MergeJsonConfig.cs
@@ -38,5 +38,8 @@ namespace Microsoft.DocAsCode
         /// </summary>
         [JsonProperty("fileMetadata")]
         public Dictionary<string, FileMetadataPairs> FileMetadata { get; set; }
+
+        [JsonProperty("metadataNeedMergedIntoToc")]
+        public ListWithStringFallback MetadataNeedMergedIntoToc { get; set; }
     }
 }

--- a/src/docfx/SubCommands/MergeCommand.cs
+++ b/src/docfx/SubCommands/MergeCommand.cs
@@ -108,6 +108,10 @@ namespace Microsoft.DocAsCode.SubCommands
             }
             config.FileMetadata = BuildCommand.GetFileMetadataFromOption(config.FileMetadata, options.FileMetadataFilePath, null);
             config.GlobalMetadata = BuildCommand.GetGlobalMetadataFromOption(config.GlobalMetadata, options.GlobalMetadataFilePath, null, options.GlobalMetadata);
+            if (options.MetadataNeedMergedIntoToc != null)
+            {
+                config.MetadataNeedMergedIntoToc = new ListWithStringFallback(options.MetadataNeedMergedIntoToc);
+            }
         }
 
         private sealed class MergeConfig
@@ -142,6 +146,7 @@ namespace Microsoft.DocAsCode.SubCommands
                 OutputBaseDir = outputDirectory,
                 Metadata = config.GlobalMetadata?.ToImmutableDictionary() ?? ImmutableDictionary<string, object>.Empty,
                 FileMetadata = ConvertToFileMetadataItem(baseDirectory, config.FileMetadata),
+                MetadataNeedMergedIntoToc = config.MetadataNeedMergedIntoToc?.ToImmutableList() ?? ImmutableList<string>.Empty,
                 Files = GetFileCollectionFromFileMapping(
                     baseDirectory,
                     DocumentType.Article,

--- a/src/docfx/SubCommands/MergeCommand.cs
+++ b/src/docfx/SubCommands/MergeCommand.cs
@@ -108,9 +108,9 @@ namespace Microsoft.DocAsCode.SubCommands
             }
             config.FileMetadata = BuildCommand.GetFileMetadataFromOption(config.FileMetadata, options.FileMetadataFilePath, null);
             config.GlobalMetadata = BuildCommand.GetGlobalMetadataFromOption(config.GlobalMetadata, options.GlobalMetadataFilePath, null, options.GlobalMetadata);
-            if (options.MetadataNeedMergedIntoToc != null)
+            if (options.TocMetadata != null)
             {
-                config.MetadataNeedMergedIntoToc = new ListWithStringFallback(options.MetadataNeedMergedIntoToc);
+                config.TocMetadata = new ListWithStringFallback(options.TocMetadata);
             }
         }
 
@@ -146,7 +146,7 @@ namespace Microsoft.DocAsCode.SubCommands
                 OutputBaseDir = outputDirectory,
                 Metadata = config.GlobalMetadata?.ToImmutableDictionary() ?? ImmutableDictionary<string, object>.Empty,
                 FileMetadata = ConvertToFileMetadataItem(baseDirectory, config.FileMetadata),
-                MetadataNeedMergedIntoToc = config.MetadataNeedMergedIntoToc?.ToImmutableList() ?? ImmutableList<string>.Empty,
+                MetadataNeedMergedIntoToc = config.TocMetadata?.ToImmutableList() ?? ImmutableList<string>.Empty,
                 Files = GetFileCollectionFromFileMapping(
                     baseDirectory,
                     DocumentType.Article,

--- a/src/docfx/SubCommands/MergeCommand.cs
+++ b/src/docfx/SubCommands/MergeCommand.cs
@@ -146,7 +146,7 @@ namespace Microsoft.DocAsCode.SubCommands
                 OutputBaseDir = outputDirectory,
                 Metadata = config.GlobalMetadata?.ToImmutableDictionary() ?? ImmutableDictionary<string, object>.Empty,
                 FileMetadata = ConvertToFileMetadataItem(baseDirectory, config.FileMetadata),
-                MetadataNeedMergedIntoToc = config.TocMetadata?.ToImmutableList() ?? ImmutableList<string>.Empty,
+                TocMetadata = config.TocMetadata?.ToImmutableList() ?? ImmutableList<string>.Empty,
                 Files = GetFileCollectionFromFileMapping(
                     baseDirectory,
                     DocumentType.Article,

--- a/src/docfx/SubCommands/MetadataMergeParameters.cs
+++ b/src/docfx/SubCommands/MetadataMergeParameters.cs
@@ -13,5 +13,6 @@ namespace Microsoft.DocAsCode.SubCommands
         public string OutputBaseDir { get; set; }
         public ImmutableDictionary<string, object> Metadata { get; set; } = ImmutableDictionary<string, object>.Empty;
         public FileMetadata FileMetadata { get; set; }
+        public ImmutableList<string> MetadataNeedMergedIntoToc { get; set; }
     }
 }

--- a/src/docfx/SubCommands/MetadataMergeParameters.cs
+++ b/src/docfx/SubCommands/MetadataMergeParameters.cs
@@ -13,6 +13,6 @@ namespace Microsoft.DocAsCode.SubCommands
         public string OutputBaseDir { get; set; }
         public ImmutableDictionary<string, object> Metadata { get; set; } = ImmutableDictionary<string, object>.Empty;
         public FileMetadata FileMetadata { get; set; }
-        public ImmutableList<string> MetadataNeedMergedIntoToc { get; set; }
+        public ImmutableList<string> TocMetadata { get; set; }
     }
 }

--- a/src/docfx/SubCommands/MetadataMerger.cs
+++ b/src/docfx/SubCommands/MetadataMerger.cs
@@ -9,8 +9,6 @@ namespace Microsoft.DocAsCode.SubCommands
     using System.IO;
     using System.Linq;
 
-    using Newtonsoft.Json.Linq;
-
     using Microsoft.DocAsCode.Common;
     using Microsoft.DocAsCode.Build.Engine;
     using Microsoft.DocAsCode.Build.ManagedReference;
@@ -101,7 +99,7 @@ namespace Microsoft.DocAsCode.SubCommands
             var vm = MergeTocViewModel(
                 from f in tocFiles
                 select YamlUtility.Deserialize<TocViewModel>(Path.Combine(f.BaseDir, f.File)));
-            SetTocViewModelMetadata(vm, parameters.MetadataNeedMergedIntoToc);
+            CopyMetadataToToc(vm, parameters.TocMetadata);
             YamlUtility.Serialize(
                 Path.Combine(
                     outputBase,
@@ -119,18 +117,22 @@ namespace Microsoft.DocAsCode.SubCommands
             }
         }
 
-        private void SetTocViewModelMetadata(TocViewModel vm, ImmutableList<string> metaNames)
+        private void CopyMetadataToToc(TocViewModel vm, ImmutableList<string> metaNames)
         {
             foreach (var item in vm)
             {
                 foreach (var metaName in metaNames)
                 {
-                    MergeIntoTocMetadata(item, metaName);
+                    CopyMetadataToTocItem(item, metaName);
+                    foreach (var childItem in item.Items ?? Enumerable.Empty<TocItemViewModel>())
+                    {
+                        CopyMetadataToTocItem(childItem, metaName);
+                    }
                 }
             }
         }
 
-        private List<string> MergeIntoTocMetadata(TocItemViewModel item, string metaName)
+        private void CopyMetadataToTocItem(TocItemViewModel item, string metaName)
         {
             Dictionary<string, object> metadata;
             if (_metaTable.TryGetValue(item.Uid, out metadata))
@@ -138,73 +140,9 @@ namespace Microsoft.DocAsCode.SubCommands
                 object metaValue;
                 if (metadata.TryGetValue(metaName, out metaValue))
                 {
-                    var merged = TryGetListFromObject(metaValue);
-                    foreach (var child in item.Items ?? Enumerable.Empty<TocItemViewModel>())
-                    {
-                        var childMetaValue = MergeIntoTocMetadata(child, metaName);
-                        merged = MergeMetadata(merged, childMetaValue);
-                    }
-                    if (item.Metadata == null)
-                    {
-                        item.Metadata = new Dictionary<string, object>();
-                    }
-                    item.Metadata[metaName] = merged;
-                    return merged;
+                    item.Metadata[metaName] = metaValue;
                 }
             }
-            return null;
-        }
-
-        private static List<string> MergeMetadata(object meta1, object meta2)
-        {
-            var list1 = TryGetListFromObject(meta1);
-            var list2 = TryGetListFromObject(meta2);
-
-            if (list1 == null && list2 == null)
-            {
-                return null;
-            }
-            else if (list1 == null)
-            {
-                return list2.Distinct().ToList();
-            }
-            else if (list2 == null)
-            {
-                return list1.Distinct().ToList();
-            }
-
-            list1.AddRange(list2);
-            return list1.Distinct().ToList();
-        }
-
-        private static List<string> TryGetListFromObject(object meta)
-        {
-            var text = meta as string;
-            if (text != null)
-            {
-                return new List<string> { text };
-            }
-
-            var collection = meta as IEnumerable<object>;
-            if (collection != null)
-            {
-                return collection.OfType<string>().ToList();
-            }
-
-            var jarray = meta as JArray;
-            if (jarray != null)
-            {
-                try
-                {
-                    return jarray.ToObject<List<string>>();
-                }
-                catch (Exception)
-                {
-                    Logger.LogWarning($"Unknown metadata: {jarray.ToString()}");
-                }
-            }
-
-            return null;
         }
 
         private static TocItemViewModel MergeTocItem(List<TocItemViewModel> items)


### PR DESCRIPTION
@vicancy @vwxyzh @superyyrrzz @ansyral @hellosnow @chenkennt 

Usage Example:

docfx.json
```json
"merge": {
    "tocMetadata": ["tags", "platforms"],
      "fileMetadata": {
        "tags": {
            "obj/catlibrary/*.yml": "catlibrary",
            "obj/catlibrary/CatLibrary.Tom.yml": ["tom", "jerry"]
        },
      "platforms": {
         "obj/catlibrary/*.yml": "win",
         "obj/catlibrary/CatLibrary.Tom.yml": "linux"
        }
    }
}
```

toc.yml generated after running `docfx merge`
```yaml
### YamlMime:TableOfContent
- uid: CatLibrary
  name: CatLibrary
  tags: catlibrary
  platforms:
  - win
  items:
  - uid: CatLibrary.Cat`2
    name: Cat<T, K>
    tags:
    - catlibrary
    platforms:
    - win
    name.vb: Cat(Of T, K)
```