### PR TITLE
Remove unneeded step in GitUtility

### DIFF
--- a/src/Microsoft.DocAsCode.Common/Git/GitRepoInfo.cs
+++ b/src/Microsoft.DocAsCode.Common/Git/GitRepoInfo.cs
@@ -16,14 +16,6 @@ namespace Microsoft.DocAsCode.Common.Git
 
         public string RemoteOriginUrl { get; set; }
 
-        public string RawRemoteOriginUrl { get; set; }
-
-        public RepoType Type { get; set; }
-
-        public string Account { get; set; }
-
-        public string RemoteRepoName { get; set; }
-
         public string RemoteHeadCommitId { get; set; }
 
         public string LocalHeadCommitId { get; set; }


### PR DESCRIPTION
no need to parse remote origin url since it could be handled in template.

@superyyrrzz @vwxyzh @hellosnow @ansyral @vicancy @chenkennt 