### PR TITLE
Don't open search links in a new window/tab

### DIFF
--- a/src/docfx.website.themes/default/styles/docfx.js
+++ b/src/docfx.website.themes/default/styles/docfx.js
@@ -240,7 +240,7 @@ $(function () {
                 var itemBrief = extractContentBrief(hit.keywords);
 
                 var itemNode = $('<div>').attr('class', 'sr-item');
-                var itemTitleNode = $('<div>').attr('class', 'item-title').append($('<a>').attr('href', itemHref).attr("target", "_blank").text(itemTitle));
+                var itemTitleNode = $('<div>').attr('class', 'item-title').append($('<a>').attr('href', itemHref).text(itemTitle));
                 var itemHrefNode = $('<div>').attr('class', 'item-href').text(itemRawHref);
                 var itemBriefNode = $('<div>').attr('class', 'item-brief').text(itemBrief);
                 itemNode.append(itemTitleNode).append(itemHrefNode).append(itemBriefNode);


### PR DESCRIPTION
Don't open search links in a new window/tab.

If there's a possibility to access settings from `docfx.json` in the `docfx.js` file I could also implement it as a metadata switch. 

Please also mention if you expect a test case for this.

#227