### PR TITLE
Apply styling for tables in conceptual documents

### DIFF
--- a/src/docfx.website.themes/default/styles/docfx.js
+++ b/src/docfx.website.themes/default/styles/docfx.js
@@ -7,6 +7,12 @@ $(function () {
   var show = 'show';
   var hide = 'hide';
 
+  // Styling for tables in conceptual documents using Bootstrap.
+  // See http://getbootstrap.com/css/#tables
+  (function () {
+    $('table').addClass('table table-bordered table-striped table-condensed');
+  })();
+
   // Enable highlight.js
   (function () {
     $('pre code').each(function(i, block) {


### PR DESCRIPTION
Apply the same styling for tables in conceptual documents as they have in API documentation.

Please mention if you expect additionally an issue or a test case for this.