### PR TITLE
fix bug: shouldn't collapse when linktofile contains illegal path characters

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/Incrementals/IncrementalBuildContext.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/Incrementals/IncrementalBuildContext.cs
@@ -263,7 +263,12 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
             var nodesToUpdate = CurrentBuildVersionInfo.Dependency.GetAllDependentNodes().Except(fileAttributes.Keys);
             foreach (var node in nodesToUpdate)
             {
-                string fullPath = Path.Combine(EnvironmentContext.BaseDirectory, ((RelativePath)node).RemoveWorkingFolder());
+                RelativePath path = RelativePath.TryParse(node);
+                if (path == null)
+                {
+                    continue;
+                }
+                string fullPath = Path.Combine(EnvironmentContext.BaseDirectory, path.RemoveWorkingFolder());
                 if (File.Exists(fullPath))
                 {
                     fileAttributes[node] = new FileAttributeItem


### PR DESCRIPTION
@vwxyzh @vicancy @superyyrrzz @hellosnow @qinezh @chenkennt 