### PR TITLE
Change statictoc template to use logo partial

### DIFF
--- a/src/docfx.website.themes/statictoc/partials/navbar.tmpl.partial
+++ b/src/docfx.website.themes/statictoc/partials/navbar.tmpl.partial
@@ -9,9 +9,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="{{_rel}}">
-        <img id="logo" class="svg" src="{{_rel}}logo.svg" alt="{{_appName}}" >
-      </a>
+      {{>partials/logo}}
     </div>
     <div class="collapse navbar-collapse" id="navbar">
       <form class="navbar-form navbar-right" role="search" id="search">


### PR DESCRIPTION
This enables the custom app logo support using global metadata as per the [properties documentation](https://dotnet.github.io/docfx/tutorial/docfx.exe_user_manual.html?q=_app#32-properties-for-build), by falling back to the `logo` partial in the `default` template.