### PR TITLE
make perf logs verbose so we could get server logs

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/Incrementals/IncrementalBuildContext.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/Incrementals/IncrementalBuildContext.cs
@@ -283,7 +283,8 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
 
         public void InitFileAttributes()
         {
-            using (new LoggerPhaseScope("InitFileAttributes", true))
+            using (new LoggerPhaseScope("InitFileAttributes", false))
+            using (new PerformanceScope("InitFileAttributes", LogLevel.Verbose))
             {
                 var fileAttributes = CurrentBuildVersionInfo.Attributes;
                 foreach (var f in GetFilesToCalculateAttributes())
@@ -459,7 +460,8 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
 
         private static DependencyGraph ConstructDependencyGraphFromLast(DependencyGraph ldg)
         {
-            using (new LoggerPhaseScope("ConstructDgFromLast", true))
+            using (new LoggerPhaseScope("ConstructDgFromLast", false))
+            using (new PerformanceScope("ConstructDgFromLast", LogLevel.Verbose))
             {
                 var dg = new DependencyGraph();
                 if (ldg == null)

--- a/src/Microsoft.DocAsCode.Build.Engine/ManifestProcessor.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/ManifestProcessor.cs
@@ -96,7 +96,8 @@ namespace Microsoft.DocAsCode.Build.Engine
         private static IEnumerable<ManifestItemWithContext> ExportManifest(HostService hostService, DocumentBuildContext context)
         {
             var manifestItems = new List<ManifestItemWithContext>();
-            using (new LoggerPhaseScope("Save", true))
+            using (new LoggerPhaseScope("Save", false))
+            using (new PerformanceScope("Save", LogLevel.Verbose))
             {
                 hostService.Models.RunAll(m =>
                 {

--- a/src/Microsoft.DocAsCode.Build.Engine/SingleDocumentBuilder.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/SingleDocumentBuilder.cs
@@ -80,7 +80,8 @@ namespace Microsoft.DocAsCode.Build.Engine
 
         private Manifest BuildCore(DocumentBuildParameters parameters)
         {
-            using (new LoggerPhaseScope(PhaseName, true))
+            using (new LoggerPhaseScope(PhaseName, false))
+            using (new PerformanceScope(PhaseName, LogLevel.Verbose))
             {
                 Logger.LogInfo($"Max parallelism is {parameters.MaxParallelism}.");
                 Directory.CreateDirectory(parameters.OutputBaseDir);
@@ -106,7 +107,8 @@ namespace Microsoft.DocAsCode.Build.Engine
                 {
                     using (var templateProcessor = parameters.TemplateManager?.GetTemplateProcessor(context, parameters.MaxParallelism) ?? TemplateProcessor.DefaultProcessor)
                     {
-                        using (new LoggerPhaseScope("Prepare", true))
+                        using (new LoggerPhaseScope("Prepare", false))
+                        using (new PerformanceScope("Prepare", LogLevel.Verbose))
                         {
                             if (MarkdownService == null)
                             {
@@ -123,7 +125,8 @@ namespace Microsoft.DocAsCode.Build.Engine
                                 out hostServiceCreator,
                                 out phaseProcessor);
                         }
-                        using (new LoggerPhaseScope("Load", true))
+                        using (new LoggerPhaseScope("Load", false))
+                        using (new PerformanceScope("Load", LogLevel.Verbose))
                         {
                             hostServices = GetInnerContexts(parameters, Processors, templateProcessor, hostServiceCreator).ToList();
                         }
@@ -237,7 +240,8 @@ namespace Microsoft.DocAsCode.Build.Engine
         {
             if (IntermediateFolder != null && parameters.ApplyTemplateSettings.TransformDocument)
             {
-                using (new LoggerPhaseScope("CreateIncrementalBuildContext", true))
+                using (new LoggerPhaseScope("CreateIncrementalBuildContext", false))
+                using (new PerformanceScope("CreateIncrementalBuildContext", LogLevel.Verbose))
                 {
                     context.IncrementalBuildContext = IncrementalBuildContext.Create(parameters, CurrentBuildInfo, LastBuildInfo, IntermediateFolder, markdownServiceContextHash);
                 }


### PR DESCRIPTION
some perf logs are diagnostics, so when we do the perf test, loglevel=diagnostics might introduce another variable