### PR TITLE
Remove IntermediateModelManifest from post processor info

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/Incrementals/PostProcessor/PostProcessInfo.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/Incrementals/PostProcessor/PostProcessInfo.cs
@@ -36,10 +36,6 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
             {
                 PostProcessOutputs = IncrementalUtility.LoadIntermediateFile<PostProcessOutputs>(Path.Combine(baseDir, PostProcessOutputsFile));
             }
-            foreach (var postProcessorInfos in PostProcessorInfos)
-            {
-                postProcessorInfos.Load(baseDir);
-            }
         }
 
         internal void Save(string baseDir)
@@ -49,10 +45,6 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
                 PostProcessOutputsFile = IncrementalUtility.CreateRandomFileName(baseDir);
             }
             IncrementalUtility.SaveIntermediateFile(Path.Combine(baseDir, PostProcessOutputsFile), PostProcessOutputs);
-            foreach (var postProcessorInfos in PostProcessorInfos)
-            {
-                postProcessorInfos.Save(baseDir);
-            }
         }
     }
 }

--- a/src/Microsoft.DocAsCode.Build.Engine/Incrementals/ProcessorInfo.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/Incrementals/ProcessorInfo.cs
@@ -4,6 +4,9 @@
 namespace Microsoft.DocAsCode.Build.Engine.Incrementals
 {
     using System.Collections.Generic;
+    using System.IO;
+
+    using Newtonsoft.Json;
 
     public class ProcessorInfo : ProcessorInfoBase
     {
@@ -11,5 +14,31 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
         /// The information for steps.
         /// </summary>
         public List<ProcessorStepInfo> Steps { get; } = new List<ProcessorStepInfo>();
+        /// <summary>
+        /// The file link for the BuildModel manifest file(type is <see cref="ModelManifest"/>).
+        /// </summary>
+        public string IntermediateModelManifestFile { get; set; }
+        /// <summary>
+        /// Deserialized build intermediate model manifest.
+        /// </summary>
+        [JsonIgnore]
+        public ModelManifest IntermediateModelManifest { get; private set; } = new ModelManifest();
+
+        internal void Load(string baseDir)
+        {
+            if (IntermediateModelManifestFile != null)
+            {
+                IntermediateModelManifest = IncrementalUtility.LoadIntermediateFile<ModelManifest>(Path.Combine(baseDir, IntermediateModelManifestFile));
+            }
+        }
+
+        internal void Save(string baseDir)
+        {
+            if (IntermediateModelManifestFile == null)
+            {
+                IntermediateModelManifestFile = IncrementalUtility.CreateRandomFileName(baseDir);
+            }
+            IncrementalUtility.SaveIntermediateFile(Path.Combine(baseDir, IntermediateModelManifestFile), IntermediateModelManifest);
+        }
     }
 }

--- a/src/Microsoft.DocAsCode.Build.Engine/Incrementals/ProcessorInfoBase.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/Incrementals/ProcessorInfoBase.cs
@@ -3,10 +3,6 @@
 
 namespace Microsoft.DocAsCode.Build.Engine.Incrementals
 {
-    using System.IO;
-
-    using Newtonsoft.Json;
-
     public class ProcessorInfoBase
     {
         /// <summary>
@@ -17,31 +13,5 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
         /// The context hash for incremental.
         /// </summary>
         public string IncrementalContextHash { get; set; }
-        /// <summary>
-        /// The file link for the BuildModel manifest file(type is <see cref="ModelManifest"/>).
-        /// </summary>
-        public string IntermediateModelManifestFile { get; set; }
-        /// <summary>
-        /// Deserialized build intermediate model manifest.
-        /// </summary>
-        [JsonIgnore]
-        public ModelManifest IntermediateModelManifest { get; private set; } = new ModelManifest();
-
-        internal void Load(string baseDir)
-        {
-            if (IntermediateModelManifestFile != null)
-            {
-                IntermediateModelManifest = IncrementalUtility.LoadIntermediateFile<ModelManifest>(Path.Combine(baseDir, IntermediateModelManifestFile));
-            }
-        }
-
-        internal void Save(string baseDir)
-        {
-            if (IntermediateModelManifestFile == null)
-            {
-                IntermediateModelManifestFile = IncrementalUtility.CreateRandomFileName(baseDir);
-            }
-            IncrementalUtility.SaveIntermediateFile(Path.Combine(baseDir, IntermediateModelManifestFile), IntermediateModelManifest);
-        }
     }
 }


### PR DESCRIPTION
IntermediateModelManifest  is used for incremental build, while incremental post processor only need final output as one.