### PR TITLE
Update packageSourceUrl to point to the folder in the repository

### DIFF
--- a/src/nuspec/chocolatey/docfx/docfx.nuspec
+++ b/src/nuspec/chocolatey/docfx/docfx.nuspec
@@ -27,7 +27,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
     <version>2.1</version>
-    <packageSourceUrl>https://github.com/dotnet/docfx</packageSourceUrl>
+    <packageSourceUrl>https://github.com/dotnet/docfx/tree/dev/src/nuspec/chocolatey/docfx</packageSourceUrl>
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
     <owners>Microsoft</owners>
     <!-- ============================== -->


### PR DESCRIPTION
Update packageSourceUrl of the Chocolatey Package to point to the folder in the repository where the source of the Chocolatey Package can be found.