### PR TITLE
Update the "hrefs" when downloading a xrefmap from the web

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/XRefMaps/XRefMapDownloader.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/XRefMaps/XRefMapDownloader.cs
@@ -113,11 +113,17 @@ namespace Microsoft.DocAsCode.Build.Engine
 
         protected static async Task<XRefMap> DownloadFromWebAsync(Uri uri)
         {
+            var baseUrl = uri.GetLeftPart(UriPartial.Path);
+            baseUrl = baseUrl.Substring(0, baseUrl.LastIndexOf('/') + 1);
+
             using (var wc = new WebClient())
             using (var stream = await wc.OpenReadTaskAsync(uri))
             using (var sr = new StreamReader(stream))
             {
-                return YamlUtility.Deserialize<XRefMap>(sr);
+                var map = YamlUtility.Deserialize<XRefMap>(sr);
+                map.BaseUrl = baseUrl;
+                UpdateHref(map, null);
+                return map;
             }
         }
 

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/XRefMapDownloaderTest.cs
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/XRefMapDownloaderTest.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode.Build.Engine.Tests
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+
+    using Xunit;
+
+    using Microsoft.DocAsCode.Build.Engine;
+
+    [Trait("Owner", "makaretu")]
+    public class XRefMapDownloadTest
+    {
+        [Fact]
+        public async Task BaseUrlIsSet()
+        {
+            var downloader = new XRefMapDownloader();
+            var xrefs = await downloader.DownloadAsync(new Uri("https://dotnet.github.io/docfx/xrefmap.yml")) as XRefMap;
+            Assert.NotNull(xrefs);
+            Assert.Equal("https://dotnet.github.io/docfx/", xrefs.BaseUrl);
+        }
+    }
+}


### PR DESCRIPTION
Web downloads now set the BaseUrl and updates each XRefSpec to an absolute URL based on the source URL of the `xrefmap.yml`.

This resolves https://github.com/dotnet/docfx/issues/1126

