### PR TITLE
Fix bug in git utility cache

### DIFF
--- a/src/Microsoft.DocAsCode.Common/Git/GitUtility.cs
+++ b/src/Microsoft.DocAsCode.Common/Git/GitUtility.cs
@@ -56,6 +56,7 @@ namespace Microsoft.DocAsCode.Common.Git
                 throw new GitException("Can't find git command in current environment");
             }
 
+            filePath = PathUtility.NormalizePath(filePath);
             var detail = GetFileDetailCore(filePath);
             return detail;
         }


### PR DESCRIPTION
file path such as "../RELEASENOTE.md" need to be normalized before adding into cache.