### PR TITLE
//xref/@href | //xref/@uid returns duplicate node

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/TemplateModelTransformer.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/TemplateModelTransformer.cs
@@ -275,7 +275,8 @@ namespace Microsoft.DocAsCode.Build.Engine
             }
 
             var xrefExceptions = new List<CrossReferenceNotResolvedException>();
-            var xrefNodes = html.DocumentNode.SelectNodes("//xref/@href | //xref/@uid");
+            var xrefNodes = html.DocumentNode.SelectNodes("//xref")?
+                .Where(s => s.GetAttributeValue("href", null) != null || s.GetAttributeValue("uid", null) != null).ToList();
             if (xrefNodes != null)
             {
                 foreach (var xref in xrefNodes)


### PR DESCRIPTION
when node defines both href and xref