### PR TITLE
change warning to info when build info file is corrupted

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/Incrementals/BuildInfo.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/Incrementals/BuildInfo.cs
@@ -70,7 +70,7 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
             }
             catch (Exception ex)
             {
-                Logger.LogWarning($"Exception occurs when loading build info from '{Path.Combine(baseDir, FileName)}', message: {ex.Message}.");
+                Logger.LogInfo($"Exception occurs when loading build info from '{Path.Combine(baseDir, FileName)}', message: {ex.Message}.");
                 return null;
             }
             return buildInfo;


### PR DESCRIPTION
we would full build for this case and user has no action about it, lower it to info