### PR TITLE
Default the anchor text to the href

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Transform/TripleSlashCommentTransform.xsl
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Transform/TripleSlashCommentTransform.xsl
@@ -80,12 +80,18 @@
   <xsl:template match="see[@href and not(parent::member)]">
     <a>
       <xsl:apply-templates select="@*|node()"/>
+      <xsl:if test="not(text())">
+        <xsl:value-of select="@href"/>
+      </xsl:if>
     </a>
   </xsl:template>
 
   <xsl:template match="seealso[@href and not(parent::member)]">
     <a>
       <xsl:apply-templates select="@*|node()"/>
+      <xsl:if test="not(text())">
+        <xsl:value-of select="@href"/>
+      </xsl:if>
     </a>
   </xsl:template>
 

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/TripleSlashParserUnitTest.cs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/TripleSlashParserUnitTest.cs
@@ -28,6 +28,8 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference.Tests
         ```
     </summary>
     <remarks>
+    <see href=""https://example.org""/>
+    <see href=""https://example.org"">example</see>
     <para>This is <paramref name='ref'/> <paramref />a sample of exception node</para>
     <list type='bullet'>
         <item>
@@ -121,6 +123,8 @@ Classes in assemblies are by definition complete.
 
             var remarks = commentModel.Remarks;
             Assert.Equal(@"
+<a href=""https://example.org"">https://example.org</a>
+<a href=""https://example.org"">example</a>
 <p>This is <span class=""paramref"">ref</span> a sample of exception node</p>
 <ul><li>
 <pre><code class=""c#"">public class XmlElement


### PR DESCRIPTION
The default anchor text should be the href attribute value.  For example

```xml
<remarks>
   <see href="https://example.com"/>
   <see href="https://example.com">example</see>
</remarks>
````

now produces

```xml
<remarks>
   <a href="https://example.com">https://example.com</a>
   <a href="https://example.com">example</a>
</remarks>
```