### PR TITLE
Only load the XSL once.

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Parsers/TripleSlashCommentModel.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Parsers/TripleSlashCommentModel.cs
@@ -26,7 +26,6 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
         private static Regex CodeElementRegex = new Regex(@"<code[^>]*>([\s\S]*?)</code>", RegexOptions.Compiled);
 
         private readonly ITripleSlashCommentParserContext _context;
-        private readonly TripleSlashCommentTransformer _transformer = new TripleSlashCommentTransformer();
 
         public string Summary { get; private set; }
         public string Remarks { get; private set; }
@@ -41,7 +40,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
         private TripleSlashCommentModel(string xml, SyntaxLanguage language, ITripleSlashCommentParserContext context)
         {
             // Transform triple slash comment
-            XDocument doc = _transformer.Transform(xml, language);
+            XDocument doc = TripleSlashCommentTransformer.Transform(xml, language);
 
             _context = context;
             if (!context.PreserveRawInlineComments)

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Parsers/TripleSlashCommentTransformer.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Parsers/TripleSlashCommentTransformer.cs
@@ -12,14 +12,15 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
     using Microsoft.DocAsCode.Common;
     using Microsoft.DocAsCode.DataContracts.ManagedReference;
+    using System.Reflection;
 
     public class TripleSlashCommentTransformer
     {
-        private readonly XslCompiledTransform _transform;
+        private static readonly XslCompiledTransform _transform;
 
-        public TripleSlashCommentTransformer()
+        static TripleSlashCommentTransformer()
         {
-            var assembly = this.GetType().Assembly;
+            var assembly = Assembly.GetExecutingAssembly();
             var xsltFilePath = $"{assembly.GetName().Name}.Transform.TripleSlashCommentTransform.xsl";
             using (var stream = assembly.GetManifestResourceStream(xsltFilePath))
             using (var reader = XmlReader.Create(stream))

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Parsers/TripleSlashCommentTransformer.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Parsers/TripleSlashCommentTransformer.cs
@@ -14,13 +14,13 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
     using Microsoft.DocAsCode.DataContracts.ManagedReference;
     using System.Reflection;
 
-    public class TripleSlashCommentTransformer
+    public static class TripleSlashCommentTransformer
     {
         private static readonly XslCompiledTransform _transform;
 
         static TripleSlashCommentTransformer()
         {
-            var assembly = Assembly.GetExecutingAssembly();
+            var assembly = typeof(TripleSlashCommentTransformer).Assembly;
             var xsltFilePath = $"{assembly.GetName().Name}.Transform.TripleSlashCommentTransform.xsl";
             using (var stream = assembly.GetManifestResourceStream(xsltFilePath))
             using (var reader = XmlReader.Create(stream))
@@ -31,7 +31,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             }
         }
 
-        public XDocument Transform(string xml, SyntaxLanguage language)
+        public static XDocument Transform(string xml, SyntaxLanguage language)
         {
             using (var ms = new MemoryStream())
             using (var writer = new XHtmlWriter(new StreamWriter(ms)))

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Parsers/TripleSlashCommentTransformer.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Parsers/TripleSlashCommentTransformer.cs
@@ -12,7 +12,6 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
     using Microsoft.DocAsCode.Common;
     using Microsoft.DocAsCode.DataContracts.ManagedReference;
-    using System.Reflection;
 
     public static class TripleSlashCommentTransformer
     {


### PR DESCRIPTION
A compiled XSL is thread safe.  Just load and compile in the static initialiser.

This change improved `docfx metadata` by 2 seconds.  Before it took ~12s now its down to 10s.