### PR TITLE
relay messages from token: should only relay once

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/CompilePhaseHandlerWithIncremental.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/CompilePhaseHandlerWithIncremental.cs
@@ -89,9 +89,10 @@ namespace Microsoft.DocAsCode.Build.Engine
 
         private IEnumerable<string> GetFilesToRelayMessages(HostService hs)
         {
+            var files = new HashSet<string>();
             foreach (var f in hs.GetUnloadedModelFiles(IncrementalContext))
             {
-                yield return f;
+                files.Add(f);
 
                 // warnings from token file won't be delegated to article, so we need to add it manually
                 var key = ((RelativePath)f).GetPathFromWorkingFolder();
@@ -99,10 +100,11 @@ namespace Microsoft.DocAsCode.Build.Engine
                 {
                     if (item.Type == DependencyTypeName.Include)
                     {
-                        yield return ((RelativePath)item.To).RemoveWorkingFolder();
+                        files.Add(((RelativePath)item.To).RemoveWorkingFolder());
                     }
                 }
             }
+            return files;
         }
 
         private void ReportDependency(IEnumerable<HostService> hostServices)

--- a/src/Microsoft.DocAsCode.Build.Engine/LinkPhaseHandlerWithIncremental.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/LinkPhaseHandlerWithIncremental.cs
@@ -260,9 +260,10 @@ namespace Microsoft.DocAsCode.Build.Engine
 
         private IEnumerable<string> GetFilesToRelayMessages(HostService hs)
         {
+            var files = new HashSet<string>();
             foreach (var f in hs.GetUnloadedModelFiles(IncrementalContext))
             {
-                yield return f;
+                files.Add(f);
 
                 // warnings from token file won't be delegated to article, so we need to add it manually
                 var key = ((RelativePath)f).GetPathFromWorkingFolder();
@@ -270,10 +271,11 @@ namespace Microsoft.DocAsCode.Build.Engine
                 {
                     if (item.Type == DependencyTypeName.Include)
                     {
-                        yield return ((RelativePath)item.To).RemoveWorkingFolder();
+                        files.Add(((RelativePath)item.To).RemoveWorkingFolder());
                     }
                 }
             }
+            return files;
         }
 
         private List<ManifestItem> GetUnloadedManifestItems(IEnumerable<HostService> hostServices)


### PR DESCRIPTION
[full build]if a token contains invalid link, n articles include this token, we would print out the warning n times.
[incremental]when relay messages, if article doesn't change, we need to relay the warnings from token, and then it would report n*n times..

this fix would only report n times, namely keep the result same with full build