### PR TITLE
Basic support for top-level inheritdoc elements.

### DIFF
--- a/src/Microsoft.DocAsCode.DataContracts.ManagedReference/ApiParameter.cs
+++ b/src/Microsoft.DocAsCode.DataContracts.ManagedReference/ApiParameter.cs
@@ -35,8 +35,11 @@ namespace Microsoft.DocAsCode.DataContracts.ManagedReference
         [MergeOption(MergeOption.Ignore)]
         public List<AttributeInfo> Attributes { get; set; }
 
-        public void CopyIneritedData(ApiParameter src)
+        public void CopyInheritedData(ApiParameter src)
         {
+            if (src == null)
+                throw new ArgumentNullException(nameof(src));
+
             if (Description == null)
                 Description = src.Description;
         }

--- a/src/Microsoft.DocAsCode.DataContracts.ManagedReference/ApiParameter.cs
+++ b/src/Microsoft.DocAsCode.DataContracts.ManagedReference/ApiParameter.cs
@@ -34,5 +34,11 @@ namespace Microsoft.DocAsCode.DataContracts.ManagedReference
         [JsonProperty("attributes")]
         [MergeOption(MergeOption.Ignore)]
         public List<AttributeInfo> Attributes { get; set; }
+
+        public void CopyIneritedData(ApiParameter src)
+        {
+            if (Description == null)
+                Description = src.Description;
+        }
     }
 }

--- a/src/Microsoft.DocAsCode.DataContracts.ManagedReference/ExceptionInfo.cs
+++ b/src/Microsoft.DocAsCode.DataContracts.ManagedReference/ExceptionInfo.cs
@@ -28,5 +28,10 @@ namespace Microsoft.DocAsCode.DataContracts.ManagedReference
         [JsonProperty("description")]
         [MarkdownContent]
         public string Description { get; set; }
+
+        public ExceptionInfo Clone()
+        {
+            return (ExceptionInfo)MemberwiseClone();
+        }
     }
 }

--- a/src/Microsoft.DocAsCode.DataContracts.ManagedReference/LinkInfo.cs
+++ b/src/Microsoft.DocAsCode.DataContracts.ManagedReference/LinkInfo.cs
@@ -29,6 +29,11 @@ namespace Microsoft.DocAsCode.DataContracts.ManagedReference
         [YamlMember(Alias = "altText")]
         [JsonProperty("altText")]
         public string AltText { get; set; }
+
+        public LinkInfo Clone()
+        {
+            return (LinkInfo)MemberwiseClone();
+        }
     }
 
     [Serializable]

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Models/MetadataItem.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Models/MetadataItem.cs
@@ -173,8 +173,11 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             return MemberwiseClone();
         }
 
-        public void CopyIneritedData(MetadataItem src)
+        public void CopyInheritedData(MetadataItem src)
         {
+            if (src == null)
+                throw new ArgumentNullException(nameof(src));
+
             if (Summary == null)
                 Summary = src.Summary;
             if (Remarks == null)
@@ -190,9 +193,9 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 Examples = new List<string>(src.Examples);
 
             if (CommentModel != null && src.CommentModel != null)
-                CommentModel.CopyIneritedData(src.CommentModel);
+                CommentModel.CopyInheritedData(src.CommentModel);
             if (Syntax != null && src.Syntax != null)
-                Syntax.CopyIneritedData(src.Syntax);
+                Syntax.CopyInheritedData(src.Syntax);
         }
     }
 }

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Models/MetadataItem.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Models/MetadataItem.cs
@@ -5,6 +5,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     using Newtonsoft.Json;
     using YamlDotNet.Serialization;
@@ -156,6 +157,10 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
         [YamlIgnore]
         [JsonIgnore]
+        public bool IsInheritDoc { get; set; }
+
+        [YamlIgnore]
+        [JsonIgnore]
         public TripleSlashCommentModel CommentModel { get; set; }
 
         public override string ToString()
@@ -166,6 +171,28 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
         public object Clone()
         {
             return MemberwiseClone();
+        }
+
+        public void CopyIneritedData(MetadataItem src)
+        {
+            if (Summary == null)
+                Summary = src.Summary;
+            if (Remarks == null)
+                Remarks = src.Remarks;
+
+            if (Exceptions == null && src.Exceptions != null)
+                Exceptions = src.Exceptions.Select(e => e.Clone()).ToList();
+            if (Sees == null && src.Sees != null)
+                Sees = src.Sees.Select(s => s.Clone()).ToList();
+            if (SeeAlsos == null && src.SeeAlsos != null)
+                SeeAlsos = src.SeeAlsos.Select(s => s.Clone()).ToList();
+            if (Examples == null && src.Examples != null)
+                Examples = new List<string>(src.Examples);
+
+            if (CommentModel != null && src.CommentModel != null)
+                CommentModel.CopyIneritedData(src.CommentModel);
+            if (Syntax != null && src.Syntax != null)
+                Syntax.CopyIneritedData(src.Syntax);
         }
     }
 }

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Models/SyntaxDetail.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Models/SyntaxDetail.cs
@@ -27,5 +27,28 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
         [YamlMember(Alias = "return")]
         [JsonProperty("return")]
         public ApiParameter Return { get; set; }
+
+        public void CopyIneritedData(SyntaxDetail src)
+        {
+            CopyInheritedParameterList(Parameters, src.Parameters);
+            CopyInheritedParameterList(TypeParameters, src.TypeParameters);
+            if (Return != null && src.Return != null)
+                Return.CopyIneritedData(src.Return);
+        }
+
+        static void CopyInheritedParameterList(List<ApiParameter> dest, List<ApiParameter> src)
+        {
+            if (dest == null || src == null || dest.Count != src.Count)
+                return;
+            for (int ndx = 0; ndx < dest.Count; ndx++)
+            {
+                var myParam = dest[ndx];
+                var srcParam = src[ndx];
+                if (myParam.Name == srcParam.Name && myParam.Type == srcParam.Type)
+                {
+                    myParam.CopyIneritedData(srcParam);
+                }
+            }
+        }
     }
 }

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Models/SyntaxDetail.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Models/SyntaxDetail.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.DocAsCode.Metadata.ManagedReference
 {
+    using System;
     using System.Collections.Generic;
 
     using Newtonsoft.Json;
@@ -28,12 +29,15 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
         [JsonProperty("return")]
         public ApiParameter Return { get; set; }
 
-        public void CopyIneritedData(SyntaxDetail src)
+        public void CopyInheritedData(SyntaxDetail src)
         {
+            if (src == null)
+                throw new ArgumentNullException(nameof(src));
+
             CopyInheritedParameterList(Parameters, src.Parameters);
             CopyInheritedParameterList(TypeParameters, src.TypeParameters);
             if (Return != null && src.Return != null)
-                Return.CopyIneritedData(src.Return);
+                Return.CopyInheritedData(src.Return);
         }
 
         static void CopyInheritedParameterList(List<ApiParameter> dest, List<ApiParameter> src)
@@ -46,7 +50,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 var srcParam = src[ndx];
                 if (myParam.Name == srcParam.Name && myParam.Type == srcParam.Type)
                 {
-                    myParam.CopyIneritedData(srcParam);
+                    myParam.CopyInheritedData(srcParam);
                 }
             }
         }

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Parsers/TripleSlashCommentModel.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Parsers/TripleSlashCommentModel.cs
@@ -84,8 +84,11 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             }
         }
 
-        public void CopyIneritedData(TripleSlashCommentModel src)
+        public void CopyInheritedData(TripleSlashCommentModel src)
         {
+            if (src == null)
+                throw new ArgumentNullException(nameof(src));
+
             if (Summary == null)
                 Summary = src.Summary;
             if (Remarks == null)

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Parsers/TripleSlashCommentModel.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Parsers/TripleSlashCommentModel.cs
@@ -36,6 +36,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
         public List<string> Examples { get; private set; }
         public Dictionary<string, string> Parameters { get; private set; }
         public Dictionary<string, string> TypeParameters { get; private set; }
+        public bool IsInheritDoc { get; private set; }
 
         private TripleSlashCommentModel(string xml, SyntaxLanguage language, ITripleSlashCommentParserContext context)
         {
@@ -59,6 +60,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             Examples = GetExamples(nav, context);
             Parameters = GetParameters(nav, context);
             TypeParameters = GetTypeParameters(nav, context);
+            IsInheritDoc = GetIsInheritDoc(nav, context);
         }
 
         public static TripleSlashCommentModel CreateModel(string xml, SyntaxLanguage language, ITripleSlashCommentParserContext context)
@@ -80,6 +82,29 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             {
                 return null;
             }
+        }
+
+        public void CopyIneritedData(TripleSlashCommentModel src)
+        {
+            if (Summary == null)
+                Summary = src.Summary;
+            if (Remarks == null)
+                Remarks = src.Remarks;
+            if (Returns == null)
+                Returns = src.Returns;
+
+            if (Exceptions == null && src.Exceptions != null)
+                Exceptions = src.Exceptions.Select(e => e.Clone()).ToList();
+            if (Sees == null && src.Sees != null)
+                Sees = src.Sees.Select(s => s.Clone()).ToList();
+            if (SeeAlsos == null && src.SeeAlsos != null)
+                SeeAlsos = src.SeeAlsos.Select(s => s.Clone()).ToList();
+            if (Examples == null && src.Examples != null)
+                Examples = new List<string>(src.Examples);
+            if (Parameters == null && src.Parameters != null)
+                Parameters = new Dictionary<string, string>(src.Parameters);
+            if (TypeParameters == null && src.TypeParameters != null)
+                TypeParameters = new Dictionary<string, string>(src.TypeParameters);
         }
 
         public string GetParameter(string name)
@@ -213,6 +238,22 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             // Resolve <see cref> to @ syntax
             // Also support <seealso cref>
             return GetMultipleExampleNodes(nav, "/member/example").ToList();
+        }
+
+        private bool GetIsInheritDoc(XPathNavigator nav, ITripleSlashCommentParserContext context)
+        {
+            var node = nav.SelectSingleNode("/member/inheritdoc");
+            if (node == null)
+                return false;
+            if (node.HasAttributes)
+            {
+                //The Sandcastle implementation of <inheritdoc /> supports two attributes: 'cref' and 'select'.
+                //These attributes allow changing the source of the inherited doc and controlling what is inherited.
+                //Until these attributes are supported, ignoring inheritdoc elements with attributes, so as not to misinterpret them.
+                Logger.LogWarning("Attributes on <inheritdoc /> elements are not supported; inheritdoc element will be ignored.");
+                return false;
+            }
+            return true;
         }
 
         private Dictionary<string, string> GetListContent(XPathNavigator navigator, string xpath, string contentType, ITripleSlashCommentParserContext context)

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Resolvers/CopyInheritedDocumentation.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Resolvers/CopyInheritedDocumentation.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.DocAsCode.Metadata.ManagedReference
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode.Metadata.ManagedReference
 {
     using Microsoft.DocAsCode.Common;
     using Microsoft.DocAsCode.DataContracts.ManagedReference;
@@ -10,8 +13,6 @@
     /// </summary>
     public class CopyInherited : IResolverPipeline
     {
-        readonly List<string> mEmptyList = new List<string>();
-
         public void Run(MetadataModel yaml, ResolverContext context)
         {
             TreeIterator.Preorder(yaml.TocYamlViewModel, null,
@@ -67,7 +68,7 @@
 
                         if (parametersMatch)
                         {
-                            TryCopyFrom(dest, ctor, context);
+                            Copy(dest, ctor, context);
                             return;
                         }
                     }
@@ -76,12 +77,12 @@
                 case MemberType.Method:
                 case MemberType.Property:
                 case MemberType.Event:
-                    TryCopyFrom(dest, dest.Overridden, context);
+                    Copy(dest, dest.Overridden, context);
                     if (dest.Implements != null)
                     {
                         foreach (var item in dest.Implements)
                         {
-                            TryCopyFrom(dest, item, context);
+                            Copy(dest, item, context);
                         }
                     }
                     break;
@@ -89,36 +90,36 @@
                 case MemberType.Class:
                     if (dest.Inheritance.Count != 0)
                     {
-                        TryCopyFrom(dest, dest.Inheritance[dest.Inheritance.Count - 1], context);
+                        Copy(dest, dest.Inheritance[dest.Inheritance.Count - 1], context);
                     }
                     if (dest.Implements != null)
                     {
                         foreach (var item in dest.Implements)
                         {
-                            TryCopyFrom(dest, item, context);
+                            Copy(dest, item, context);
                         }
                     }
                     break;
             }
         }
 
-        static void TryCopyFrom(MetadataItem dest, string srcName, ResolverContext context)
+        static void Copy(MetadataItem dest, string srcName, ResolverContext context)
         {
             MetadataItem src;
             if (string.IsNullOrEmpty(srcName) || !context.Members.TryGetValue(srcName, out src))
                 return;
 
-            TryCopyFrom(dest, src, context);
+            Copy(dest, src, context);
         }
 
-        static void TryCopyFrom(MetadataItem dest, MetadataItem src, ResolverContext context)
+        static void Copy(MetadataItem dest, MetadataItem src, ResolverContext context)
         {
             if (src.IsInheritDoc)
             {
                 InheritDoc(src, context);
             }
 
-            dest.CopyIneritedData(src);
+            dest.CopyInheritedData(src);
         }
     }
 }

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Resolvers/CopyInheritedDocumentation.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Resolvers/CopyInheritedDocumentation.cs
@@ -1,0 +1,124 @@
+﻿namespace Microsoft.DocAsCode.Metadata.ManagedReference
+{
+    using Microsoft.DocAsCode.Common;
+    using Microsoft.DocAsCode.DataContracts.ManagedReference;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+
+    /// <summary>
+    /// Copies doc comments to items marked with 'inheritdoc' from interfaces and base classes.
+    /// </summary>
+    public class CopyInherited : IResolverPipeline
+    {
+        readonly List<string> mEmptyList = new List<string>();
+
+        public void Run(MetadataModel yaml, ResolverContext context)
+        {
+            TreeIterator.Preorder(yaml.TocYamlViewModel, null,
+                s => s.IsInvalid ? null : s.Items,
+                (current, parent) =>
+                {
+                    if (current.IsInheritDoc)
+                        InheritDoc(current, context);
+                    return true;
+                });
+        }
+
+        static void InheritDoc(MetadataItem dest, ResolverContext context)
+        {
+            dest.IsInheritDoc = false;
+
+            switch (dest.Type)
+            {
+                case MemberType.Constructor:
+                    if (dest.Parent == null || dest.Syntax == null || dest.Syntax.Parameters == null)
+                        return;
+                    Debug.Assert(dest.Parent.Type == MemberType.Class);
+
+                    //try to find the base class
+                    if (dest.Parent.Inheritance?.Count == 0)
+                        return;
+                    MetadataItem baseClass;
+                    if (!context.Members.TryGetValue(dest.Parent.Inheritance[dest.Parent.Inheritance.Count - 1], out baseClass))
+                        return;
+                    if (baseClass.Items == null)
+                        return;
+
+                    //look a constructor in the base class which has a matching signature
+                    foreach (var ctor in baseClass.Items)
+                    {
+                        if (ctor.Type != MemberType.Constructor)
+                            continue;
+                        if (ctor.Syntax == null || ctor.Syntax.Parameters == null)
+                            continue;
+                        if (ctor.Syntax.Parameters.Count != dest.Syntax.Parameters.Count)
+                            continue;
+
+                        bool parametersMatch = true;
+                        for (int ndx = 0; ndx < dest.Syntax.Parameters.Count; ndx++)
+                        {
+                            var myParam = dest.Syntax.Parameters[ndx];
+                            var baseParam = ctor.Syntax.Parameters[ndx];
+                            if (myParam.Name != baseParam.Name)
+                                parametersMatch = false;
+                            if (myParam.Type != baseParam.Type)
+                                parametersMatch = false;
+                        }
+
+                        if (parametersMatch)
+                        {
+                            TryCopyFrom(dest, ctor, context);
+                            return;
+                        }
+                    }
+                    break;
+
+                case MemberType.Method:
+                case MemberType.Property:
+                case MemberType.Event:
+                    TryCopyFrom(dest, dest.Overridden, context);
+                    if (dest.Implements != null)
+                    {
+                        foreach (var item in dest.Implements)
+                        {
+                            TryCopyFrom(dest, item, context);
+                        }
+                    }
+                    break;
+
+                case MemberType.Class:
+                    if (dest.Inheritance.Count != 0)
+                    {
+                        TryCopyFrom(dest, dest.Inheritance[dest.Inheritance.Count - 1], context);
+                    }
+                    if (dest.Implements != null)
+                    {
+                        foreach (var item in dest.Implements)
+                        {
+                            TryCopyFrom(dest, item, context);
+                        }
+                    }
+                    break;
+            }
+        }
+
+        static void TryCopyFrom(MetadataItem dest, string srcName, ResolverContext context)
+        {
+            MetadataItem src;
+            if (string.IsNullOrEmpty(srcName) || !context.Members.TryGetValue(srcName, out src))
+                return;
+
+            TryCopyFrom(dest, src, context);
+        }
+
+        static void TryCopyFrom(MetadataItem dest, MetadataItem src, ResolverContext context)
+        {
+            if (src.IsInheritDoc)
+            {
+                InheritDoc(src, context);
+            }
+
+            dest.CopyIneritedData(src);
+        }
+    }
+}

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Resolvers/ResolverContext.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Resolvers/ResolverContext.cs
@@ -12,5 +12,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
         public bool PreserveRawInlineComments { get; set; }
 
         public Dictionary<string, ReferenceItem> References { get; set; }
+
+        public Dictionary<string, MetadataItem> Members { get; set; }
     }
 }

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Resolvers/YamlMetadataResolver.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Resolvers/YamlMetadataResolver.cs
@@ -15,6 +15,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
         {
             new LayoutCheckAndCleanup(),
             new SetParent(),
+            new CopyInherited(),
             new ResolveReference(),
             new NormalizeSyntax(),
             new BuildMembers(),
@@ -46,6 +47,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             {
                 ApiFolder = apiFolder,
                 References = allReferences,
+                Members = allMembers,
                 PreserveRawInlineComments = preserveRawInlineComments,
             };
 

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Visitors/VisitorHelper.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Visitors/VisitorHelper.cs
@@ -32,6 +32,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 item.Sees = commentModel.Sees;
                 item.SeeAlsos = commentModel.SeeAlsos;
                 item.Examples = commentModel.Examples;
+                item.IsInheritDoc = commentModel.IsInheritDoc;
                 item.CommentModel = commentModel;
             }
         }

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/TripleSlashParserUnitTest.cs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/TripleSlashParserUnitTest.cs
@@ -104,6 +104,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference.Tests
 
 
             var commentModel = TripleSlashCommentModel.CreateModel(input, SyntaxLanguage.CSharp, context);
+            Assert.False(commentModel.IsInheritDoc, nameof(commentModel.IsInheritDoc));
 
             var summary = commentModel.Summary;
             Assert.Equal(@"
@@ -183,6 +184,26 @@ Check empty code.
             Assert.Equal("Hello Bing", seeAlsos[1].AltText);
             Assert.Equal("http://www.bing.com", seeAlsos[2].AltText);
             Assert.Equal("http://www.bing.com", seeAlsos[2].LinkId);
+        }
+
+        [Trait("Related", "TripleSlashComments")]
+        [Fact]
+        public void InheritDoc()
+        {
+            const string input = @"
+<member name=""M:ClassLibrary1.MyClass.DoThing"">
+    <inheritdoc />
+</member>";
+            var context = new TripleSlashCommentParserContext
+            {
+                AddReferenceDelegate = null,
+                Normalize = true,
+                PreserveRawInlineComments = false,
+            };
+
+            var commentModel = TripleSlashCommentModel.CreateModel(input, SyntaxLanguage.CSharp, context);
+            Assert.True(commentModel.IsInheritDoc);
+
         }
     }
 }


### PR DESCRIPTION
This pull requests implements a subset of the [inheritdoc functionality available in Sandcastle](https://ewsoftware.github.io/XMLCommentsGuide/html/86453FFB-B978-4A2A-9EB5-70E118CA8073.htm). Specifically, it implements most of the "Top-Level Inheritance Rules". It dose not implement:
* Support for the `cref` or `select` attributes.
* Automatic inheritance of documentation for explicit interface implementations.
* Support for inline `inheritdoc` tags (i.e., an `inheritdoc` tag inside of an `example` tag).

In spite of these limitations, I think this still quite useful, as the most common use of these feature is to place a single `<inheritdoc />` on a class method to inherit the documentation from a base class or interface.

Fixes #247.
