### PR TITLE
Show anchors for headings

### DIFF
--- a/src/docfx.website.themes/default/bower.json
+++ b/src/docfx.website.themes/default/bower.json
@@ -26,6 +26,7 @@
     "js-url": "1.8.6",
     "lunr.js": "0.6.0",
     "twbs-pagination": "^1.3.1",
-    "mark.js": "^8.4.0"
+    "mark.js": "^8.4.0",
+    "anchor-js": "^3.2.2"
   }
 }

--- a/src/docfx.website.themes/default/gulpfile.js
+++ b/src/docfx.website.themes/default/gulpfile.js
@@ -16,7 +16,8 @@ var vendor = {
        'bower_components/lunr.js/lunr.min.js',
        'bower_components/js-url/url.min.js',
        'bower_components/twbs-pagination/jquery.twbsPagination.min.js',
-       "bower_components/mark.js/dist/jquery.mark.min.js"
+       "bower_components/mark.js/dist/jquery.mark.min.js",
+       "bower_components/anchor-js/anchor.min.js"
       ],
   webWorker: {
     src: ['lunr.min.js'],

--- a/src/docfx.website.themes/default/styles/docfx.js
+++ b/src/docfx.website.themes/default/styles/docfx.js
@@ -26,7 +26,7 @@ $(function () {
       placement: 'left',
       visible: 'touch'
     };
-    anchors.add('h2, h3, h4, h5, h6');
+    anchors.add('article h2, article h3, article h4, article h5, article h6');
   })();
 
   // Enable highlight.js

--- a/src/docfx.website.themes/default/styles/docfx.js
+++ b/src/docfx.website.themes/default/styles/docfx.js
@@ -20,6 +20,15 @@ $(function () {
     $('.IMPORTANT, .CAUTION').addClass('alert alert-danger');
   })();  
 
+  // Enable anchors for headings.
+  (function () {
+    anchors.options = {
+      placement: 'left',
+      visible: 'touch'
+    };
+    anchors.add('h2, h3, h4, h5, h6');
+  })();
+
   // Enable highlight.js
   (function () {
     $('pre code').each(function(i, block) {


### PR DESCRIPTION
This PR adds anchor links to all headings (h2 - h6) like eg. in Markdown rendering on GitHub to the default theme. Uses [AnchorJS](https://github.com/bryanbraun/anchorjs).