### PR TITLE
Check the status of XMLHttpRequest in onload

### DIFF
--- a/src/docfx.website.themes/angular/app/src/search-worker.js
+++ b/src/docfx.website.themes/angular/app/src/search-worker.js
@@ -20,6 +20,9 @@ var index = lunr(function() {
 var searchData = {};
 var searchDataRequest = new XMLHttpRequest();
 searchDataRequest.onload = function() {
+  if (this.status != 200) {
+    return;
+  }
 
   // Store the pages data to be used in mapping query results back to pages
   searchData = JSON.parse(this.responseText);

--- a/src/docfx.website.themes/default/styles/docfx.js
+++ b/src/docfx.website.themes/default/styles/docfx.js
@@ -125,6 +125,9 @@ $(function () {
         if (indexPath) {
           searchDataRequest.open('GET', indexPath);
           searchDataRequest.onload = function () {
+            if (this.status != 200) {
+              return;
+            }
             searchData = JSON.parse(this.responseText);
             for (var prop in searchData) {
               lunrIndex.add(searchData[prop]);

--- a/src/docfx.website.themes/default/styles/search-worker.js
+++ b/src/docfx.website.themes/default/styles/search-worker.js
@@ -12,6 +12,9 @@
   var stopWordsRequest = new XMLHttpRequest();
   stopWordsRequest.open('GET', '../search-stopwords.json');
   stopWordsRequest.onload = function() {
+    if (this.status != 200) {
+      return;
+    }
     var stopWords = JSON.parse(this.responseText);
     var docfxStopWordFilter = lunr.generateStopWordFilter(stopWords);
     lunr.Pipeline.registerFunction(docfxStopWordFilter, 'docfxStopWordFilter');
@@ -24,6 +27,9 @@
 
   searchDataRequest.open('GET', '../index.json');
   searchDataRequest.onload = function() {
+    if (this.status != 200) {
+      return;
+    }
     searchData = JSON.parse(this.responseText);
     for (var prop in searchData) {
       lunrIndex.add(searchData[prop]);

--- a/src/docfx.website.themes/statictoc/styles/docfx.js
+++ b/src/docfx.website.themes/statictoc/styles/docfx.js
@@ -97,6 +97,9 @@ $(function () {
         if (indexPath) {
           searchDataRequest.open('GET', indexPath);
           searchDataRequest.onload = function () {
+            if (this.status != 200) {
+              return;
+            }
             searchData = JSON.parse(this.responseText);
             for (var prop in searchData) {
               lunrIndex.add(searchData[prop]);


### PR DESCRIPTION
If there is a network error or a file is missing, these scripts throw an exception when they try to parse the `responseText`.