### PR TITLE
Add support for title attribute specification in TOC.md files

### DIFF
--- a/src/Microsoft.DocAsCode.DataContracts.Common/Constants.cs
+++ b/src/Microsoft.DocAsCode.DataContracts.Common/Constants.cs
@@ -27,6 +27,7 @@ namespace Microsoft.DocAsCode.DataContracts.Common
             public const string Documentation = "documentation";
 
             public const string Name = "name";
+            public const string DisplayName = "displayName";
             public const string NameWithType = "nameWithType";
             public const string FullName = "fullName";
             public const string TocHref = "tocHref";

--- a/src/Microsoft.DocAsCode.DataContracts.Common/TocItemViewModel.cs
+++ b/src/Microsoft.DocAsCode.DataContracts.Common/TocItemViewModel.cs
@@ -23,6 +23,11 @@ namespace Microsoft.DocAsCode.DataContracts.Common
         [JsonProperty(Constants.PropertyName.Name)]
         public string Name { get; set; }
 
+        [YamlMember(Alias = Constants.PropertyName.DisplayName)]
+        [JsonProperty(Constants.PropertyName.DisplayName)]
+        public string DisplayName { get; set; }
+
+
         [ExtensibleMember(Constants.ExtensionMemberPrefix.Name)]
         [JsonIgnore]
         public SortedList<string, string> NameInDevLangs { get; } = new SortedList<string, string>();

--- a/test/Microsoft.DocAsCode.Build.TableOfContents.Tests/MarkdownTocReaderTest.cs
+++ b/test/Microsoft.DocAsCode.Build.TableOfContents.Tests/MarkdownTocReaderTest.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DocAsCode.Build.TableOfContents.Tests
             var toc = MarkdownTocReader.LoadToc(@"
 # [Article1](article1.md)
 ## Container1 ##
-### [Article2](article2.md) ## 
+### [Article2](article2.md ""Article 2"") ## 
 ### [Article3](article3.md)     
 ## Container2
 ### [Article4](article4.md)
@@ -44,6 +44,7 @@ namespace Microsoft.DocAsCode.Build.TableOfContents.Tests
                     var toc0_0 = toc0[0].Items;
                     Assert.Equal(2, toc0_0.Count);
                     Assert.Equal("Article2", toc0_0[0].Name);
+                    Assert.Equal("Article 2", toc0_0[0].DisplayName);
                     Assert.Equal("article2.md", toc0_0[0].Href);
                     Assert.Equal("Article3", toc0_0[1].Name);
                     Assert.Equal("article3.md", toc0_0[1].Href);


### PR DESCRIPTION
Using the valid markdown syntax for the title attribute in a link to add a displayText attribute to resulting TOC JSON file.