### PR TITLE
Open links to a different host in a new tab/window

### DIFF
--- a/src/docfx.website.themes/default/styles/docfx.js
+++ b/src/docfx.website.themes/default/styles/docfx.js
@@ -29,6 +29,13 @@ $(function () {
     anchors.add('article h2, article h3, article h4, article h5, article h6');
   })();
 
+  // Open links to different host in a new window.
+  (function () {
+    $(document.links).filter(function() {
+      return this.hostname !== window.location.hostname;
+    }).attr('target', '_blank');
+  })();
+
   // Enable highlight.js
   (function () {
     $('pre code').each(function(i, block) {


### PR DESCRIPTION
Add JavaScript to rewrite links pointing to a different host to open in a new window/tab.

Fixes #949