### PR TITLE
Fix ExtractSearchIndex to ignore TOC items

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Common/ExtractSearchIndex.cs
+++ b/src/Microsoft.DocAsCode.Build.Common/ExtractSearchIndex.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DocAsCode.Build.Common
             var indexDataFilePath = Path.Combine(outputFolder, IndexFileName);
             var htmlFiles = (from item in manifest.Files ?? Enumerable.Empty<ManifestItem>()
                              from output in item.OutputFiles
-                             where output.Key.Equals(".html", StringComparison.OrdinalIgnoreCase)
+                             where item.DocumentType != "Toc" && output.Key.Equals(".html", StringComparison.OrdinalIgnoreCase)
                              select output.Value.RelativePath).ToList();
             if (htmlFiles.Count == 0)
             {


### PR DESCRIPTION
Issue:
- `ExtractSearchIndex` indexes TOC items that are meant to be used as metadata.

Reproduction:
1. Navigate to [docfx documentation](http://dotnet.github.io/docfx/tutorial/docfx_getting_started.html)
2. Enter "table of content" into search field
3. Links to toc.html files appear as first 5 results
4. toc.html index entries also visible [here](https://raw.githubusercontent.com/dotnet/docfx/gh-pages/index.json)

Solution:
- Ignore html files generated from TOC items.