### PR TITLE
Move ExtractSearchIndex post processor out 

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/ExtractSearchIndex.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/ExtractSearchIndex.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.DocAsCode.Build.Common
+namespace Microsoft.DocAsCode.Build.Engine
 {
     using System;
     using System.Collections.Generic;

--- a/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/SearchIndexItem.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/SearchIndexItem.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.DocAsCode.Build.Common
+namespace Microsoft.DocAsCode.Build.Engine
 {
     using Newtonsoft.Json;
 

--- a/src/docfx/SubCommands/DocumentBuilderWrapper.cs
+++ b/src/docfx/SubCommands/DocumentBuilderWrapper.cs
@@ -142,7 +142,6 @@ namespace Microsoft.DocAsCode.SubCommands
             yield return typeof(ResourceDocumentProcessor).Assembly;
             yield return typeof(RestApiDocumentProcessor).Assembly;
             yield return typeof(TocDocumentProcessor).Assembly;
-            yield return typeof(ExtractSearchIndex).Assembly;
 
             if (pluginDirectory == null || !Directory.Exists(pluginDirectory))
             {


### PR DESCRIPTION
Move ExtractSearchIndex post processor out from Microsoft.DocAsCode.Common. When plugins refrences to Microsoft.DocAsCode.Common, multiple Imports are found for ExtractSearchIndex. In general, Microsoft.DocAsCode.Common should not contain any Exports