### PR TITLE
improve error message for include

### DIFF
--- a/src/Microsoft.DocAsCode.Dfm/DocfxFlavoredIncHelper.cs
+++ b/src/Microsoft.DocAsCode.Dfm/DocfxFlavoredIncHelper.cs
@@ -56,7 +56,7 @@ namespace Microsoft.DocAsCode.Dfm
 
                 if (parents.Contains(currentPath, FilePathComparer.OSPlatformSensitiveComparer))
                 {
-                    return GenerateErrorNodeWithCommentWrapper("INCLUDE", $"Unable to resolve {raw}: Circular dependency found in \"{parent}\"", raw, sourceInfo);
+                    return GenerateErrorNodeWithCommentWrapper("INCLUDE", $"Circular dependency found in \"{parent}\"", raw, sourceInfo);
                 }
 
                 // Add current file path to chain when entering recursion
@@ -83,13 +83,13 @@ namespace Microsoft.DocAsCode.Dfm
             }
             catch (Exception e)
             {
-                return GenerateErrorNodeWithCommentWrapper("INCLUDE", $"Unable to resolve {raw}:{e.Message}", raw, sourceInfo);
+                return GenerateErrorNodeWithCommentWrapper("INCLUDE", e.Message, raw, sourceInfo);
             }
         }
 
         private static string GenerateErrorNodeWithCommentWrapper(string tag, string comment, string html, SourceInfo sourceInfo)
         {
-            Logger.LogError(comment + $"at line {sourceInfo.LineNumber}.");
+            Logger.LogError($"Unable to resolve \"{html}\" at line {sourceInfo.LineNumber}: " + comment);
             return GenerateNodeWithCommentWrapper("ERROR " + tag, comment, html);
         }
 

--- a/src/Microsoft.DocAsCode.Dfm/DocfxFlavoredIncHelper.cs
+++ b/src/Microsoft.DocAsCode.Dfm/DocfxFlavoredIncHelper.cs
@@ -90,7 +90,7 @@ namespace Microsoft.DocAsCode.Dfm
         private static string GenerateErrorNodeWithCommentWrapper(string tag, string comment, string html, SourceInfo sourceInfo)
         {
             Logger.LogError($"Unable to resolve \"{html}\" at line {sourceInfo.LineNumber}: " + comment);
-            return GenerateNodeWithCommentWrapper("ERROR " + tag, comment, html);
+            return GenerateNodeWithCommentWrapper("ERROR " + tag, $"Unable to resolve {html}: {comment}", html);
         }
 
         private static string GenerateNodeWithCommentWrapper(string tag, string comment, string html)

--- a/test/Microsoft.DocAsCode.Dfm.Tests/DocfxFlavoredMarkdownTest.cs
+++ b/test/Microsoft.DocAsCode.Dfm.Tests/DocfxFlavoredMarkdownTest.cs
@@ -114,7 +114,7 @@ Paragraph1
 <!-- BEGIN ERROR INCLUDE: Unable to resolve [!include-[root](../root.md)]: Circular dependency found in &quot;r/b/linkAndRefRoot.md&quot; -->[!include-[root](../root.md)]<!--END ERROR INCLUDE --></p>
 <!--END INCLUDE --><!-- BEGIN INCLUDE: Include content from &quot;r/a/refc.md&quot; --><!-- BEGIN INCLUDE: Include content from &quot;r/c/c.md&quot; --><p><strong>Hello</strong></p>
 <!--END INCLUDE --><!--END INCLUDE --><!-- BEGIN INCLUDE: Include content from &quot;r/a/refc.md&quot; --><!-- BEGIN INCLUDE: Include content from &quot;r/c/c.md&quot; --><p><strong>Hello</strong></p>
-<!--END INCLUDE --><!--END INCLUDE --><!-- BEGIN INCLUDE: Include content from &quot;r/empty.md&quot; --><!--END INCLUDE --><!-- BEGIN ERROR INCLUDE: Absolute path &quot;http://microsoft.com/a.md&quot; is not supported. -->[!include[external](http://microsoft.com/a.md)]<!--END ERROR INCLUDE -->".Replace("\r\n", "\n"), marked);
+<!--END INCLUDE --><!--END INCLUDE --><!-- BEGIN INCLUDE: Include content from &quot;r/empty.md&quot; --><!--END INCLUDE --><!-- BEGIN ERROR INCLUDE: Unable to resolve [!include[external](http://microsoft.com/a.md)]: Absolute path &quot;http://microsoft.com/a.md&quot; is not supported. -->[!include[external](http://microsoft.com/a.md)]<!--END ERROR INCLUDE -->".Replace("\r\n", "\n"), marked);
             Assert.Equal(
                 new[]
                 {


### PR DESCRIPTION
before: `Absolute path "" is not supported.at line 3.`
after: `Unable to resolve "[!INCLUDE[vsprvslong]()]" at line 3: Absolute path "" is not supported.`