### PR TITLE
incremental:restructure modelmanifest to fit for split case

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/CompilePhaseHandlerWithIncremental.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/CompilePhaseHandlerWithIncremental.cs
@@ -76,6 +76,11 @@ namespace Microsoft.DocAsCode.Build.Engine
             ReportReference(hostServices);
             ReportDependency(hostServices);
             CurrentBuildVersionInfo.Dependency.ResolveReference();
+            foreach (var h in hostServices.Where(h => h.ShouldTraceIncrementalInfo))
+            {
+                h.SaveIntermediateModel(IncrementalContext);
+            }
+            IncrementalContext.UpdateBuildVersionInfoPerDependencyGraph();
             foreach (var h in hostServices.Where(h => h.CanIncrementalBuild))
             {
                 foreach (var file in GetFilesToRelayMessages(h))
@@ -83,11 +88,6 @@ namespace Microsoft.DocAsCode.Build.Engine
                     LastBuildMessageInfo.Replay(file);
                 }
             }
-            foreach (var h in hostServices.Where(h => h.ShouldTraceIncrementalInfo))
-            {
-                h.SaveIntermediateModel(IncrementalContext);
-            }
-            IncrementalContext.UpdateBuildVersionInfoPerDependencyGraph();
             Logger.UnregisterListener(CurrentBuildMessageInfo.GetListener());
         }
 

--- a/src/Microsoft.DocAsCode.Build.Engine/HostService.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/HostService.cs
@@ -597,11 +597,9 @@ namespace Microsoft.DocAsCode.Build.Engine
             {
                 return new List<string>();
             }
-            var cmm = incrementalContext.GetCurrentIntermediateModelManifest(this);
             return (from pair in incrementalContext.GetModelLoadInfo(this)
                     where pair.Value == null
-                    from item in cmm.Models[pair.Key]
-                    select item.SourceFilePath).ToList();
+                    select pair.Key).ToList();
         }
 
         #endregion

--- a/src/Microsoft.DocAsCode.Build.Engine/HostServiceCreatorWithIncremental.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/HostServiceCreatorWithIncremental.cs
@@ -97,7 +97,7 @@ namespace Microsoft.DocAsCode.Build.Engine
                     return;
                 }
                 var allFiles = files?.Select(f => f.File) ?? new string[0];
-                var loadedFiles = hostService.Models.Select(m => m.FileAndType.File);
+                var loadedFiles = hostService.Models.Select(m => m.OriginalFileAndType.File);
                 IncrementalContext.ReportModelLoadInfo(hostService, allFiles.Except(loadedFiles), null);
                 IncrementalContext.ReportModelLoadInfo(hostService, loadedFiles, BuildPhase.Compile);
             }

--- a/src/Microsoft.DocAsCode.Build.Engine/Incrementals/BuildVersionInfo.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/Incrementals/BuildVersionInfo.cs
@@ -81,12 +81,12 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
         /// deserialized xrefspecmap. Key is original file path from root. Value is XrefSpecs reported by the file.
         /// </summary>
         [JsonIgnore]
-        public IDictionary<string, IEnumerable<XRefSpec>> XRefSpecMap { get; private set; } = new OSPlatformSensitiveDictionary<IEnumerable<XRefSpec>>();
+        public IDictionary<string, List<XRefSpec>> XRefSpecMap { get; private set; } = new OSPlatformSensitiveDictionary<List<XRefSpec>>();
         /// <summary>
         /// deserialized filemap.
         /// </summary>
         [JsonIgnore]
-        public IDictionary<string, string> FileMap { get; set; }
+        public IDictionary<string, FileMapItem> FileMap { get; private set; } = new OSPlatformSensitiveDictionary<FileMapItem>();
         /// <summary>
         /// deserialized build messages.
         /// </summary>
@@ -106,8 +106,8 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
             Attributes = IncrementalUtility.LoadIntermediateFile<OSPlatformSensitiveDictionary<FileAttributeItem>>(Path.Combine(baseDir, AttributesFile));
             BuildOutputs = IncrementalUtility.LoadIntermediateFile<BuildOutputs>(Path.Combine(baseDir, OutputFile));
             Manifest = IncrementalUtility.LoadIntermediateFile<IEnumerable<ManifestItem>>(Path.Combine(baseDir, ManifestFile));
-            XRefSpecMap = IncrementalUtility.LoadIntermediateFile<OSPlatformSensitiveDictionary<IEnumerable<XRefSpec>>>(Path.Combine(baseDir, XRefSpecMapFile));
-            FileMap = IncrementalUtility.LoadIntermediateFile<OSPlatformSensitiveDictionary<string>>(Path.Combine(baseDir, FileMapFile));
+            XRefSpecMap = IncrementalUtility.LoadIntermediateFile<OSPlatformSensitiveDictionary<List<XRefSpec>>>(Path.Combine(baseDir, XRefSpecMapFile));
+            FileMap = IncrementalUtility.LoadIntermediateFile<OSPlatformSensitiveDictionary<FileMapItem>>(Path.Combine(baseDir, FileMapFile));
             BuildMessage = IncrementalUtility.LoadBuildMessage(Path.Combine(baseDir, BuildMessageFile));
             foreach (var processor in Processors)
             {

--- a/src/Microsoft.DocAsCode.Build.Engine/Incrementals/FileMapItem.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/Incrementals/FileMapItem.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode.Build.Engine.Incrementals
+{
+    public class FileMapItem : OSPlatformSensitiveDictionary<string>
+    {
+    }
+}

--- a/src/Microsoft.DocAsCode.Build.Engine/Incrementals/ModelManifestItem.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/Incrementals/ModelManifestItem.cs
@@ -3,10 +3,10 @@
 
 namespace Microsoft.DocAsCode.Build.Engine.Incrementals
 {
-    using System.Collections.Generic;
-
-    public class ModelManifest
+    public class ModelManifestItem
     {
-        public OSPlatformSensitiveDictionary<List<ModelManifestItem>> Models { get; } = new OSPlatformSensitiveDictionary<List<ModelManifestItem>>();
+        public string SourceFilePath { get; set; }
+
+        public string FilePath { get; set; }
     }
 }


### PR DESCRIPTION
in prebuild step, models might be split. 
`ModelManifest`  used to record the mapping between a src file and its intermediate model file,
now it is used to record the mapping between src file and all the intermediate model files that are split.
namely, for example, a.md is split to a.md, a-1.md and a-2.md during prebuild step, then the mapping item would be a.md -> [`model for a.md`, `model for a-1.md`, `model for a-2.md`].

all other cache files like xrefmap, filemap, dependnecygraph also follow this way. namely, key is always src file path.