### PR TITLE
enable incrementalbuild for managedreference plugins except splitmemberlevel

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/CompilePhaseHandlerWithIncremental.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/CompilePhaseHandlerWithIncremental.cs
@@ -229,8 +229,8 @@ namespace Microsoft.DocAsCode.Build.Engine
             foreach (var uid in uids)
             {
                 var item = new DependencyItemSourceInfo(DependencyItemSourceType.Uid, uid);
-                yield return new DependencyItem(fromNode, item, fromNode, DependencyTypeName.Uid);
-                yield return new DependencyItem(item, fromNode, fromNode, DependencyTypeName.Uid);
+                yield return new DependencyItem(fromNode, item, fromNode, DependencyTypeName.Overwrite);
+                yield return new DependencyItem(item, fromNode, fromNode, DependencyTypeName.Overwrite);
             }
         }
 

--- a/src/Microsoft.DocAsCode.Build.Engine/Incrementals/IncrementalBuildContext.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/Incrementals/IncrementalBuildContext.cs
@@ -125,7 +125,7 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
         {
             OSPlatformSensitiveDictionary<BuildPhase?> mi = null;
             string name = hostService.Processor.Name;
-            lock (_sync)
+            lock (_modelLoadInfo)
             {
                 if (!_modelLoadInfo.TryGetValue(name, out mi))
                 {

--- a/src/Microsoft.DocAsCode.Build.ManagedReference/ApplyOverwriteDocumentForMREF.cs
+++ b/src/Microsoft.DocAsCode.Build.ManagedReference/ApplyOverwriteDocumentForMREF.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DocAsCode.Build.ManagedReference
     using YamlDotNet.Core;
 
     [Export(nameof(ManagedReferenceDocumentProcessor), typeof(IDocumentBuildStep))]
-    public class ApplyOverwriteDocumentForMref : ApplyOverwriteDocument
+    public class ApplyOverwriteDocumentForMref : ApplyOverwriteDocument, ISupportIncrementalBuildStep
     {
         private readonly IModelAttributeHandler _handler =
             new CompositeModelAttributeHandler(
@@ -45,6 +45,16 @@ namespace Microsoft.DocAsCode.Build.ManagedReference
         {
             ApplyOverwrite(host, overwrites, uid, articles, GetItemsFromOverwriteDocument, GetItemsToOverwrite);
         }
+
+        #region ISupportIncrementalBuildStep Members
+
+        public bool CanIncrementalBuild(FileAndType fileAndType) => true;
+
+        public string GetIncrementalContextHash() => null;
+
+        public IEnumerable<DependencyType> GetDependencyTypesToRegister() => null;
+
+        #endregion
 
         /// <summary>
         /// TODO: Move to base and share with other overwrite components

--- a/src/Microsoft.DocAsCode.Build.ManagedReference/ApplyPlatformVersion.cs
+++ b/src/Microsoft.DocAsCode.Build.ManagedReference/ApplyPlatformVersion.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DocAsCode.Build.ManagedReference
     using Microsoft.DocAsCode.DataContracts.ManagedReference;
     using Microsoft.DocAsCode.Plugins;
 
-    public class ApplyPlatformVersion : BaseDocumentBuildStep
+    public class ApplyPlatformVersion : BaseDocumentBuildStep, ISupportIncrementalBuildStep
     {
         public override int BuildOrder => 0x10;
 
@@ -63,6 +63,16 @@ namespace Microsoft.DocAsCode.Build.ManagedReference
             host.LogInfo("Platform applied.");
             return models;
         }
+
+        #region ISupportIncrementalBuildStep Members
+
+        public bool CanIncrementalBuild(FileAndType fileAndType) => true;
+
+        public string GetIncrementalContextHash() => null;
+
+        public IEnumerable<DependencyType> GetDependencyTypesToRegister() => null;
+
+        #endregion
 
         private static List<string> GetPlatformVersionFromMetadata(object value)
         {

--- a/src/Microsoft.DocAsCode.Build.ManagedReference/BuildManagedReferenceDocument.cs
+++ b/src/Microsoft.DocAsCode.Build.ManagedReference/BuildManagedReferenceDocument.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DocAsCode.Build.ManagedReference
     using Microsoft.DocAsCode.Plugins;
 
     [Export(nameof(ManagedReferenceDocumentProcessor), typeof(IDocumentBuildStep))]
-    public class BuildManagedReferenceDocument : BuildReferenceDocumentBase
+    public class BuildManagedReferenceDocument : BuildReferenceDocumentBase, ISupportIncrementalBuildStep
     {
         private readonly IModelAttributeHandler _handler =
             new CompositeModelAttributeHandler(
@@ -54,7 +54,30 @@ namespace Microsoft.DocAsCode.Build.ManagedReference
             model.UidLinkSources = model.UidLinkSources.ToDictionary(v => v.Key, v => v.Value.ToList())
                 .Merge(context.UidLinkSources.Select(i => new KeyValuePair<string, IEnumerable<LinkSourceInfo>>(i.Key, i.Value)))
                 .ToImmutableDictionary(v => v.Key, v => v.Value.ToImmutableList());
+            foreach (var r in pageViewModel.References)
+            {
+                host.ReportDependencyTo(model, r.Uid, DependencyItemSourceType.Uid, DependencyTypeName.Reference);
+            }
         }
+
+        #endregion
+
+        #region ISupportIncrementalBuildStep Members
+
+        public bool CanIncrementalBuild(FileAndType fileAndType) => true;
+
+        public string GetIncrementalContextHash() => null;
+
+        public IEnumerable<DependencyType> GetDependencyTypesToRegister() => new[]
+        {
+            new DependencyType()
+            {
+                Name = DependencyTypeName.Reference,
+                IsTransitive = false,
+                Phase = BuildPhase.Link,
+                Transitivity = DependencyTransitivity.None,
+            }
+        };
 
         #endregion
     }

--- a/src/Microsoft.DocAsCode.Build.ManagedReference/FillReferenceInformation.cs
+++ b/src/Microsoft.DocAsCode.Build.ManagedReference/FillReferenceInformation.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.DocAsCode.Build.ManagedReference
 {
+    using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Composition;
 
@@ -11,7 +12,7 @@ namespace Microsoft.DocAsCode.Build.ManagedReference
     using Microsoft.DocAsCode.Plugins;
 
     [Export(nameof(ManagedReferenceDocumentProcessor), typeof(IDocumentBuildStep))]
-    public class FillReferenceInformation : BaseDocumentBuildStep
+    public class FillReferenceInformation : BaseDocumentBuildStep, ISupportIncrementalBuildStep
     {
         public override string Name => nameof(FillReferenceInformation);
 
@@ -31,6 +32,16 @@ namespace Microsoft.DocAsCode.Build.ManagedReference
                 }
             }
         }
+
+        #region ISupportIncrementalBuildStep Members
+
+        public bool CanIncrementalBuild(FileAndType fileAndType) => true;
+
+        public string GetIncrementalContextHash() => null;
+
+        public IEnumerable<DependencyType> GetDependencyTypesToRegister() => null;
+
+        #endregion
 
         #region Private methods
 

--- a/src/Microsoft.DocAsCode.Build.ManagedReference/MergeManagedReferenceDocument.cs
+++ b/src/Microsoft.DocAsCode.Build.ManagedReference/MergeManagedReferenceDocument.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DocAsCode.Build.ManagedReference
     using Microsoft.DocAsCode.DataContracts.ManagedReference;
     using Microsoft.DocAsCode.Plugins;
 
-    public class MergeManagedReferenceDocument : BaseDocumentBuildStep
+    public class MergeManagedReferenceDocument : BaseDocumentBuildStep, ISupportIncrementalBuildStep
     {
         public override int BuildOrder => 0xff;
 
@@ -60,6 +60,16 @@ namespace Microsoft.DocAsCode.Build.ManagedReference
                    where p != null
                    select p;
         }
+
+        #region ISupportIncrementalBuildStep Members
+
+        public bool CanIncrementalBuild(FileAndType fileAndType) => true;
+
+        public string GetIncrementalContextHash() => null;
+
+        public IEnumerable<DependencyType> GetDependencyTypesToRegister() => null;
+
+        #endregion
 
         private object MergeCore(string majorUid, FileModel model, IEnumerable<FileModel> others, IHostService host)
         {

--- a/src/Microsoft.DocAsCode.Build.ManagedReference/ValidateManagedReferenceDocumentMetadata.cs
+++ b/src/Microsoft.DocAsCode.Build.ManagedReference/ValidateManagedReferenceDocumentMetadata.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DocAsCode.Build.ManagedReference
     using Microsoft.DocAsCode.Plugins;
 
     [Export(nameof(ManagedReferenceDocumentProcessor), typeof(IDocumentBuildStep))]
-    public class ValidateManagedReferenceDocumentMetadata : BaseDocumentBuildStep
+    public class ValidateManagedReferenceDocumentMetadata : BaseDocumentBuildStep, ISupportIncrementalBuildStep
     {
         public override string Name => nameof(ValidateManagedReferenceDocumentMetadata);
 
@@ -39,5 +39,15 @@ namespace Microsoft.DocAsCode.Build.ManagedReference
                     throw new NotSupportedException();
             }
         }
+
+        #region ISupportIncrementalBuildStep Members
+
+        public bool CanIncrementalBuild(FileAndType fileAndType) => true;
+
+        public string GetIncrementalContextHash() => null;
+
+        public IEnumerable<DependencyType> GetDependencyTypesToRegister() => null;
+
+        #endregion
     }
 }

--- a/src/Microsoft.DocAsCode.Plugins/DependencyTypeName.cs
+++ b/src/Microsoft.DocAsCode.Plugins/DependencyTypeName.cs
@@ -11,5 +11,6 @@ namespace Microsoft.DocAsCode.Plugins
         public const string Overwrite = "overwrite";
         public const string Bookmark = "bookmark";
         public const string Metadata = "metadata";
+        public const string Reference = "reference";
     }
 }

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/TestData/System.ConsoleColor.csyml
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/TestData/System.ConsoleColor.csyml
@@ -34,6 +34,7 @@ items:
   assemblies:
   - System.Console
   namespace: System
+  summary: "this is a test for uid link dependency: @System.Console"
   syntax:
     content: public enum ConsoleColor
     content.vb: Public Enum ConsoleColor


### PR DESCRIPTION
1.  some methods in IncrementalBuildContext aren't  thread-safe and when managedreferenceprocessor enables incremental, two processors run in parallel might have some problems, fix it.
2.  enable plugins incremental except for splitmemberlevel.