### PR TITLE
dg: ignore self dependency

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/Incrementals/DependencyGraph.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/Incrementals/DependencyGraph.cs
@@ -289,6 +289,11 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
 
         private void ReportDependencyCoreNoLock(DependencyItem dependency)
         {
+            if (dependency.From.Equals(dependency.To))
+            {
+                Logger.LogDiagnostic($"Dependency item is ignored because it is a self-dependency: {JsonUtility.Serialize(dependency)}.");
+                return;
+            }
             if (_dependencyItems.Add(dependency))
             {
                 if (CanReadDependency(dependency))
@@ -331,14 +336,18 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
                     if (updated != item)
                     {
                         _dependencyItems.Remove(item);
-                        _dependencyItems.Add(updated);
+                        if (from == null || !from.Equals(to))
+                        {
+                            _dependencyItems.Add(updated);
+                        }
                     }
 
                     // update index
-                    if (from != null && to != null && reportedBy != null)
+                    if (from != null && to != null && reportedBy != null && !from.Equals(to))
                     {
                         CreateOrUpdate(_indexOnFrom, updated.From.Value, updated);
                         CreateOrUpdate(_indexOnReportedBy, updated.ReportedBy.Value, updated);
+                        CreateOrUpdate(_indexOnTo, updated.To.Value, updated);
                     }
                 }
             }

--- a/src/Microsoft.DocAsCode.Build.Engine/Incrementals/DependencyGraph.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/Incrementals/DependencyGraph.cs
@@ -336,7 +336,11 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
                     if (updated != item)
                     {
                         _dependencyItems.Remove(item);
-                        if (from == null || !from.Equals(to))
+                        if (from != null && from.Equals(to))
+                        {
+                            Logger.LogDiagnostic($"Dependency item is ignored because it is a self-dependency after the resolution: {JsonUtility.Serialize(item)}.");
+                        }
+                        else
                         {
                             _dependencyItems.Add(updated);
                         }

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/IncrementalBuildTest.cs
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/IncrementalBuildTest.cs
@@ -2288,7 +2288,7 @@ tagRules : [
             var conceptualFile2 = CreateFile("test/test.md",
                 new[]
                 {
-                    "Test link: [link text](@System.Console)",
+                    "Test link: @System.Console",
                     "<p>",
                     "test",
                 },


### PR DESCRIPTION
if `a` depends on itself, or depends on its uid, then ignore the dependencyitem