### PR TITLE
postprocessor incremental: update for split case

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/PostProcessorsHandlerWithIncremental.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/PostProcessorsHandlerWithIncremental.cs
@@ -228,7 +228,7 @@ namespace Microsoft.DocAsCode.Build.Engine
                     var cachedItems = _increContext.LastInfo.ManifestItems.Where(i => i.SourceRelativePath == pair.Key).ToList();
                     if (cachedItems.Count != pair.Value.Count)
                     {
-                        throw new BuildCacheException($"Last manifest items doesn't contain the item with source relative path '{pair.Key}'.");
+                        throw new BuildCacheException($"The count of items with source relative path '{pair.Key}' in last manifest doesn't match: last is {cachedItems.Count}, current is {pair.Value.Count}.");
                     }
 
                     // Update IsIncremental flag

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/PostProcessors/Data/manifest_incremental_split_case.json
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/PostProcessors/Data/manifest_incremental_split_case.json
@@ -1,0 +1,43 @@
+﻿{
+  "files": [
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "CatLibrary.Cat-2.yml",
+      "output": {
+        ".html": {
+          "relative_path": "CatLibrary.Cat-2.html"
+        },
+        ".mta.json": {
+          "relative_path": "CatLibrary.Cat-2.mta.json"
+        }
+      },
+      "is_incremental": true
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "CatLibrary.Cat-2.yml",
+      "output": {
+        ".html": {
+          "relative_path": "CatLibrary.Cat-2.Name.html"
+        },
+        ".mta.json": {
+          "relative_path": "CatLibrary.Cat-2.Name.mta.json"
+        }
+      },
+      "is_incremental": true
+    },
+    {
+      "type": "Conceptual",
+      "source_relative_path": "c.md",
+      "output": {
+        ".html": {
+          "relative_path": "c.html"
+        },
+        ".mta.json": {
+          "relative_path": "c.mta.json"
+        }
+      },
+      "is_incremental": false
+    }
+  ]
+}

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/project.json
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/project.json
@@ -34,6 +34,7 @@
     "copyToOutput": [
       "PostProcessors/Data/manifest_basic.json",
       "PostProcessors/Data/manifest_incremental.json",
+      "PostProcessors/Data/manifest_incremental_split_case.json",
       "PostProcessors/Data/manifest_incremental_with_directory.json",
       "TestData/System.Console.csyml",
       "TestData/System.ConsoleColor.csyml",


### PR DESCRIPTION
for split case, `SourceRelativePath` is not the key for `ManifestItem` any more.