### PR TITLE
Add errorcode to log item and report item

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/ErrorCode.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/ErrorCode.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode.Build.Engine
+{
+    internal static class ErrorCode
+    {
+        public const string InvalidInternalBookmark = "InvalidInternalBookmark";
+        public const string InvalidExternalBookmark = "InvalidExternalBookmark";
+
+    }
+}

--- a/src/Microsoft.DocAsCode.Build.Engine/Incrementals/BuildMessageInfo.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/Incrementals/BuildMessageInfo.cs
@@ -150,6 +150,8 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
             public string Message { get; set; }
 
             public string Phase { get; set; }
+
+            public string ErrorCode { get; set; }
         }
     }
 }

--- a/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/ValidateBookmark.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/ValidateBookmark.cs
@@ -115,16 +115,23 @@ namespace Microsoft.DocAsCode.Build.Engine
                     {
                         string currentFileSrc = linkItem.SourceFile ?? _fileMapping[currentFile];
                         string linkedToFileSrc = _fileMapping[linkedToFile];
-                        string link = linkItem.Href == string.Empty ? $"#{bookmark}" : $"{linkedToFileSrc}#{bookmark}";
+
+                        bool internalBookmark = linkItem.Href == string.Empty || FilePathComparer.OSPlatformSensitiveStringComparer.Equals(linkedToFileSrc, currentFileSrc);
+
+                        string link = internalBookmark ? $"#{bookmark}" : $"{linkedToFileSrc}#{bookmark}";
                         string content = linkItem.SourceFragment;
                         if (string.IsNullOrEmpty(content))
                         {
                             // Invalid bookmarks introduced from templates is a corner case, ignored.
                             content = $"<a href=\"{link}\">{title}</a>";
                         }
+
+                        string errorCode = internalBookmark ? ErrorCode.InvalidInternalBookmark : ErrorCode.InvalidExternalBookmark;
                         Logger.LogWarning($"Illegal link: `{content}` -- missing bookmark. The file {linkedToFileSrc} doesn't contain a bookmark named {bookmark}.",
-                            file: currentFileSrc,
-                            line: linkItem.SourceLineNumber != 0 ? linkItem.SourceLineNumber.ToString() : null);
+                            null,
+                            currentFileSrc,
+                            linkItem.SourceLineNumber != 0 ? linkItem.SourceLineNumber.ToString() : null,
+                            errorCode: errorCode);
                     }
                 }
             }

--- a/src/Microsoft.DocAsCode.Common/Loggers/ILogItem.cs
+++ b/src/Microsoft.DocAsCode.Common/Loggers/ILogItem.cs
@@ -10,5 +10,6 @@ namespace Microsoft.DocAsCode.Common
         string Phase { get; }
         string File { get; }
         string Line { get; }
+        string ErrorCode { get; }
     }
 }

--- a/src/Microsoft.DocAsCode.Common/Loggers/Logger.cs
+++ b/src/Microsoft.DocAsCode.Common/Loggers/Logger.cs
@@ -98,6 +98,11 @@ namespace Microsoft.DocAsCode.Common
 
         public static void Log(LogLevel level, string message, string phase = null, string file = null, string line = null)
         {
+            Log(level, message, phase, file, line, null);
+        }
+
+        public static void Log(LogLevel level, string message, string phase, string file, string line, string errorCode)
+        {
             Log(new LogItem
             {
 #if NetCore
@@ -108,6 +113,7 @@ namespace Microsoft.DocAsCode.Common
                 Line = line,
                 LogLevel = level,
                 Message = message,
+                ErrorCode = errorCode,
 #if NetCore
                 Phase = phase,
 #else
@@ -118,27 +124,52 @@ namespace Microsoft.DocAsCode.Common
 
         public static void LogDiagnostic(string message, string phase = null, string file = null, string line = null)
         {
-            Log(LogLevel.Diagnostic, message, phase, file, line);
+            LogDiagnostic(message, phase, file, line, null);
+        }
+
+        public static void LogDiagnostic(string message, string phase, string file, string line, string errorCode)
+        {
+            Log(LogLevel.Diagnostic, message, phase, file, line, errorCode);
         }
 
         public static void LogVerbose(string message, string phase = null, string file = null, string line = null)
         {
-            Log(LogLevel.Verbose, message, phase, file, line);
+            LogVerbose(message, phase, file, line, null);
+        }
+
+        public static void LogVerbose(string message, string phase, string file, string line, string errorCode)
+        {
+            Log(LogLevel.Verbose, message, phase, file, line, errorCode);
         }
 
         public static void LogInfo(string message, string phase = null, string file = null, string line = null)
         {
-            Log(LogLevel.Info, message, phase, file, line);
+            LogInfo(message, phase, file, line, null);
+        }
+
+        public static void LogInfo(string message, string phase, string file, string line, string errorCode)
+        {
+            Log(LogLevel.Info, message, phase, file, line, errorCode);
         }
 
         public static void LogWarning(string message, string phase = null, string file = null, string line = null)
         {
-            Log(LogLevel.Warning, message, phase, file, line);
+            LogWarning(message, phase, file, line, null);
+        }
+
+        public static void LogWarning(string message, string phase, string file, string line, string errorCode)
+        {
+            Log(LogLevel.Warning, message, phase, file, line, errorCode);
         }
 
         public static void LogError(string message, string phase = null, string file = null, string line = null)
         {
-            Log(LogLevel.Error, message, phase, file, line);
+            LogError(message, phase, file, line, null);
+        }
+
+        public static void LogError(string message, string phase, string file, string line, string errorCode)
+        {
+            Log(LogLevel.Error, message, phase, file, line, errorCode);
         }
 
         public static void Log(object result)
@@ -170,6 +201,8 @@ namespace Microsoft.DocAsCode.Common
             public string Message { get; set; }
 
             public string Phase { get; set; }
+
+            public string ErrorCode { get; set; }
         }
     }
 }

--- a/src/Microsoft.DocAsCode.Common/Loggers/ReportLogListener.cs
+++ b/src/Microsoft.DocAsCode.Common/Loggers/ReportLogListener.cs
@@ -60,6 +60,7 @@ namespace Microsoft.DocAsCode.Common
                 File = TransformFile(file),
                 Line = line,
                 DateTime = DateTime.UtcNow,
+                ErrorCode = item.ErrorCode
             };
 
             _writer.WriteLine(JsonUtility.Serialize(reportItem));
@@ -125,6 +126,8 @@ namespace Microsoft.DocAsCode.Common
             public DateTime DateTime { get; set; }
             [JsonProperty("message_severity")]
             public MessageSeverity Severity { get; set; }
+            [JsonProperty("error_code")]
+            public string ErrorCode{ get; set; }
         }
 
         public enum MessageSeverity

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/PostProcessors/PostProcessorsHandlerTest.cs
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/PostProcessors/PostProcessorsHandlerTest.cs
@@ -1044,6 +1044,8 @@ namespace Microsoft.DocAsCode.Build.Engine.Tests
             public string Message { get; set; }
 
             public string Phase { get; set; }
+
+            public string ErrorCode { get; set; }
         }
     }
 }

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/ValidateBookmarkTest.cs
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/ValidateBookmarkTest.cs
@@ -77,12 +77,14 @@ namespace Microsoft.DocAsCode.Build.Engine.Tests
             }
             var logs = _listener.Items;
             Assert.Equal(4, logs.Count);
+            Assert.Equal(3, logs.Where(l => l.ErrorCode == ErrorCode.InvalidExternalBookmark).Count());
+            Assert.Equal(1, logs.Where(l => l.ErrorCode == ErrorCode.InvalidInternalBookmark).Count());
             var expected = new[]
             {
                 Tuple.Create(@"Illegal link: `[link with source info](a.md#b2)` -- missing bookmark. The file a.md doesn't contain a bookmark named b2.", "b.md"),
                 Tuple.Create(@"Illegal link: `[link in token file](a.md#b3)` -- missing bookmark. The file a.md doesn't contain a bookmark named b3.", "token.md"),
                 Tuple.Create(@"Illegal link: `<a href=""a.md#b4"">link without source info</a>` -- missing bookmark. The file a.md doesn't contain a bookmark named b4.", "b.md"),
-                Tuple.Create(@"Illegal link: `<a href=""f.md#b1"">Test local link</a>` -- missing bookmark. The file f.md doesn't contain a bookmark named b1.", "f.md"),
+                Tuple.Create(@"Illegal link: `<a href=""#b1"">Test local link</a>` -- missing bookmark. The file f.md doesn't contain a bookmark named b1.", "f.md"),
             };
             var actual = logs.Select(l => Tuple.Create(l.Message, l.File)).ToList();
             Assert.True(!expected.Except(actual).Any() && expected.Length == actual.Count);
@@ -126,7 +128,7 @@ namespace Microsoft.DocAsCode.Build.Engine.Tests
             Assert.Equal(1, logs.Count);
             var expected = new[]
             {
-                Tuple.Create("Illegal link: `<a href=\"test.md#invalid\">test</a>` -- missing bookmark. The file test.md doesn't contain a bookmark named invalid.", "test.md"),
+                Tuple.Create("Illegal link: `<a href=\"#invalid\">test</a>` -- missing bookmark. The file test.md doesn't contain a bookmark named invalid.", "test.md"),
             };
             var actual = logs.Select(l => Tuple.Create(l.Message, l.File)).ToList();
             Assert.True(!expected.Except(actual).Any() && expected.Length == actual.Count);


### PR DESCRIPTION
For backward compatibility, add an overload method instead. Looks like for public assemblies, it is not a good idea to use method with default values...