### PR TITLE
add more perf logs

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/LinkPhaseHandlerWithIncremental.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/LinkPhaseHandlerWithIncremental.cs
@@ -210,7 +210,11 @@ namespace Microsoft.DocAsCode.Build.Engine
         private void ProcessUnloadedTemplateDependency(IEnumerable<HostService> hostServices)
         {
             var loaded = Context.ManifestItems;
-            var unloaded = GetUnloadedManifestItems(hostServices);
+            IEnumerable<ManifestItem> unloaded;
+            using (new LoggerPhaseScope("GetUnloadedManifestItems", LogLevel.Verbose))
+            {
+                unloaded = GetUnloadedManifestItems(hostServices);
+            }
             var types = new HashSet<string>(unloaded.Select(m => m.DocumentType).Except(loaded.Select(m => m.DocumentType)));
             if (types.Count > 0)
             {

--- a/src/Microsoft.DocAsCode.Build.Engine/LinkPhaseHandlerWithIncremental.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/LinkPhaseHandlerWithIncremental.cs
@@ -218,7 +218,10 @@ namespace Microsoft.DocAsCode.Build.Engine
             var types = new HashSet<string>(unloaded.Select(m => m.DocumentType).Except(loaded.Select(m => m.DocumentType)));
             if (types.Count > 0)
             {
-                TemplateProcessor.ProcessDependencies(types, Context.ApplyTemplateSettings);
+                using (new LoggerPhaseScope("ProcessDependencies", LogLevel.Verbose))
+                {
+                    TemplateProcessor.ProcessDependencies(types, Context.ApplyTemplateSettings);
+                }
             }
             foreach (var m in unloaded)
             {


### PR DESCRIPTION
seems `ProcessUnloadedTemplateDependency` takes a much longer time than expected. add more logs.