### PR TITLE
Upgrade roslyn to support net46 projects

### DIFF
--- a/Documentation/docfx.json
+++ b/Documentation/docfx.json
@@ -3,7 +3,7 @@
     {
       "src": [
         {
-          "files": [ "**/project.json" ],
+          "files": [ "**.csproj" ],
           "exclude": [ "**/bin/**", "**/obj/**" ],
           "src": "../src"
         }

--- a/build.ps1
+++ b/build.ps1
@@ -16,7 +16,7 @@ $releaseBranch = "master"
 $dotnetCommand = "dotnet"
 $nugetCommand = "$env:LOCALAPPDATA\Nuget\Nuget.exe"
 $gitCommand = "git"
-$framework = "net452"
+$framework = "net46"
 $packageVersion = "1.0.0"
 $assemblyVersion = "1.0.0.0"
 

--- a/plugins/Microsoft.DocAsCode.Build.MemberLevelManagedReference/Microsoft.DocAsCode.Build.MemberLevelManagedReference.csproj
+++ b/plugins/Microsoft.DocAsCode.Build.MemberLevelManagedReference/Microsoft.DocAsCode.Build.MemberLevelManagedReference.csproj
@@ -8,7 +8,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">

--- a/plugins/Microsoft.DocAsCode.Build.MergeOverwrite/Microsoft.DocAsCode.Build.MergeOverwrite.csproj
+++ b/plugins/Microsoft.DocAsCode.Build.MergeOverwrite/Microsoft.DocAsCode.Build.MergeOverwrite.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\src\Shared\base.props" />
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">

--- a/src/Microsoft.DocAsCode.AzureMarkdownRewriters/Microsoft.DocAsCode.AzureMarkdownRewriters.csproj
+++ b/src/Microsoft.DocAsCode.AzureMarkdownRewriters/Microsoft.DocAsCode.AzureMarkdownRewriters.csproj
@@ -7,7 +7,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">

--- a/src/Microsoft.DocAsCode.Build.Common/Microsoft.DocAsCode.Build.Common.csproj
+++ b/src/Microsoft.DocAsCode.Build.Common/Microsoft.DocAsCode.Build.Common.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
   </ItemGroup>
 

--- a/src/Microsoft.DocAsCode.Build.ConceptualDocuments/Microsoft.DocAsCode.Build.ConceptualDocuments.csproj
+++ b/src/Microsoft.DocAsCode.Build.ConceptualDocuments/Microsoft.DocAsCode.Build.ConceptualDocuments.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
   </ItemGroup>

--- a/src/Microsoft.DocAsCode.Build.Engine/Microsoft.DocAsCode.Build.Engine.csproj
+++ b/src/Microsoft.DocAsCode.Build.Engine/Microsoft.DocAsCode.Build.Engine.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Nustache" Version="1.15.3.5" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
   </ItemGroup>
 

--- a/src/Microsoft.DocAsCode.Build.ManagedReference/Microsoft.DocAsCode.Build.ManagedReference.csproj
+++ b/src/Microsoft.DocAsCode.Build.ManagedReference/Microsoft.DocAsCode.Build.ManagedReference.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
   </ItemGroup>
 

--- a/src/Microsoft.DocAsCode.Build.ResourceFiles/Microsoft.DocAsCode.Build.ResourceFiles.csproj
+++ b/src/Microsoft.DocAsCode.Build.ResourceFiles/Microsoft.DocAsCode.Build.ResourceFiles.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
   </ItemGroup>
 

--- a/src/Microsoft.DocAsCode.Build.RestApi/Microsoft.DocAsCode.Build.RestApi.csproj
+++ b/src/Microsoft.DocAsCode.Build.RestApi/Microsoft.DocAsCode.Build.RestApi.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
   </ItemGroup>
 

--- a/src/Microsoft.DocAsCode.Build.TableOfContents/Microsoft.DocAsCode.Build.TableOfContents.csproj
+++ b/src/Microsoft.DocAsCode.Build.TableOfContents/Microsoft.DocAsCode.Build.TableOfContents.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
   </ItemGroup>
 

--- a/src/Microsoft.DocAsCode.Common/Microsoft.DocAsCode.Common.csproj
+++ b/src/Microsoft.DocAsCode.Common/Microsoft.DocAsCode.Common.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">

--- a/src/Microsoft.DocAsCode.DataContracts.Common/Microsoft.DocAsCode.DataContracts.Common.csproj
+++ b/src/Microsoft.DocAsCode.DataContracts.Common/Microsoft.DocAsCode.DataContracts.Common.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">

--- a/src/Microsoft.DocAsCode.Dfm/Microsoft.DocAsCode.Dfm.csproj
+++ b/src/Microsoft.DocAsCode.Dfm/Microsoft.DocAsCode.Dfm.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">

--- a/src/Microsoft.DocAsCode.MarkdownLite/Microsoft.DocAsCode.MarkdownLite.csproj
+++ b/src/Microsoft.DocAsCode.MarkdownLite/Microsoft.DocAsCode.MarkdownLite.csproj
@@ -2,7 +2,7 @@
   <Import Project="../Shared/base.props" />
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Microsoft.DocAsCode.Metadata.ManagedReference.csproj
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Microsoft.DocAsCode.Metadata.ManagedReference.csproj
@@ -14,16 +14,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="1.3.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="1.3.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="1.3.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="1.3.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.3.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="1.3.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="2.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="2.0.0" />
     <PackageReference Include="Microsoft.DotNet.ProjectModel.Workspaces" Version="1.0.0-preview2-003121" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Microsoft.DocAsCode.Metadata.ManagedReference.csproj
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Microsoft.DocAsCode.Metadata.ManagedReference.csproj
@@ -14,16 +14,22 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="2.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="2.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Features" Version="2.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="2.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="2.0.0" />
     <PackageReference Include="Microsoft.DotNet.ProjectModel.Workspaces" Version="1.0.0-preview2-003121" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
     <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
+    <PackageReference Include="Microsoft.Build" Version="15.1.548" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.1.548" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Visitors/CSYamlModelGenerator.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Visitors/CSYamlModelGenerator.cs
@@ -473,7 +473,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                     )
                 ),
                 null,
-                null
+                (BlockSyntax)null
             ).NormalizeWhitespace().ToString();
 
         private string GetFieldSyntax(IFieldSymbol symbol, IFilterVisitor filterVisitor)
@@ -1475,7 +1475,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                             GetAttributes(methodSymbol, filterVisitor),
                             new SyntaxTokenList(),
                             SyntaxFactory.Token(keyword),
-                            null,
+                            (BlockSyntax)null,
                             SyntaxFactory.Token(SyntaxKind.SemicolonToken));
                     }
                     else
@@ -1485,7 +1485,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                             GetAttributes(methodSymbol, filterVisitor),
                             SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.ProtectedKeyword)),
                             SyntaxFactory.Token(keyword),
-                            null,
+                            (BlockSyntax)null,
                             SyntaxFactory.Token(SyntaxKind.SemicolonToken));
                     }
                 case Accessibility.Public:
@@ -1493,7 +1493,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                         GetAttributes(methodSymbol, filterVisitor),
                         new SyntaxTokenList(),
                         SyntaxFactory.Token(keyword),
-                        null,
+                        (BlockSyntax)null,
                         SyntaxFactory.Token(SyntaxKind.SemicolonToken));
                 default:
                     if (methodSymbol.ExplicitInterfaceImplementations.Length > 0)
@@ -1502,7 +1502,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                             GetAttributes(methodSymbol, filterVisitor),
                             new SyntaxTokenList(),
                             SyntaxFactory.Token(keyword),
-                            null,
+                            (BlockSyntax)null,
                             SyntaxFactory.Token(SyntaxKind.SemicolonToken));
                     }
                     return null;

--- a/src/Microsoft.DocAsCode.Plugins/Microsoft.DocAsCode.Plugins.csproj
+++ b/src/Microsoft.DocAsCode.Plugins/Microsoft.DocAsCode.Plugins.csproj
@@ -2,7 +2,7 @@
   <Import Project="../Shared/base.props" />
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
 
   </ItemGroup>

--- a/src/Shared/base.props
+++ b/src/Shared/base.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
 
     <!-- Note: by convention assembly should be named after the root namespace -->
     <AssemblyName Condition=" '$(AssemblyName)' == '' ">$(MSBuildProjectName)</AssemblyName>

--- a/test/Microsoft.DocAsCode.Build.Common.Tests/Microsoft.DocAsCode.Build.Common.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Build.Common.Tests/Microsoft.DocAsCode.Build.Common.Tests.csproj
@@ -5,7 +5,7 @@
     <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
   </ItemGroup>
 

--- a/test/Microsoft.DocAsCode.Build.ConceptualDocuments.Tests/Microsoft.DocAsCode.Build.ConceptualDocuments.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Build.ConceptualDocuments.Tests/Microsoft.DocAsCode.Build.ConceptualDocuments.Tests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
   </ItemGroup>
 

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/Microsoft.DocAsCode.Build.Engine.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/Microsoft.DocAsCode.Build.Engine.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
   </ItemGroup>
 

--- a/test/Microsoft.DocAsCode.Build.RestApi.Tests/Microsoft.DocAsCode.Build.RestApi.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Build.RestApi.Tests/Microsoft.DocAsCode.Build.RestApi.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
   </ItemGroup>
 

--- a/test/Microsoft.DocAsCode.Build.TableOfContents.Tests/Microsoft.DocAsCode.Build.TableOfContents.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Build.TableOfContents.Tests/Microsoft.DocAsCode.Build.TableOfContents.Tests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
   </ItemGroup>
 

--- a/test/Microsoft.DocAsCode.Common.Tests/Microsoft.DocAsCode.Common.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Common.Tests/Microsoft.DocAsCode.Common.Tests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">

--- a/test/Microsoft.DocAsCode.Dfm.Tests/Microsoft.DocAsCode.Dfm.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Dfm.Tests/Microsoft.DocAsCode.Dfm.Tests.csproj
@@ -5,7 +5,7 @@
     <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
   </ItemGroup>
 

--- a/test/Microsoft.DocAsCode.MarkdownLite.Tests/Microsoft.DocAsCode.MarkdownLite.Tests.csproj
+++ b/test/Microsoft.DocAsCode.MarkdownLite.Tests/Microsoft.DocAsCode.MarkdownLite.Tests.csproj
@@ -5,7 +5,7 @@
     <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
   </ItemGroup>
 

--- a/test/Microsoft.DocAsCode.MarkdownRewriters.Tests/Microsoft.DocAsCode.MarkdownRewriters.Tests.csproj
+++ b/test/Microsoft.DocAsCode.MarkdownRewriters.Tests/Microsoft.DocAsCode.MarkdownRewriters.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\Shared\test.base.props" />
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/Microsoft.DocAsCode.Metadata.ManagedReference.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/Microsoft.DocAsCode.Metadata.ManagedReference.Tests.csproj
@@ -9,14 +9,20 @@
 
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="2.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Features" Version="2.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="2.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="2.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="2.0.0" />
     <PackageReference Include="Microsoft.DotNet.ProjectModel.Workspaces" Version="1.0.0-preview2-003121" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
+    <PackageReference Include="Microsoft.Build" Version="15.1.548" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.1.548" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/Microsoft.DocAsCode.Metadata.ManagedReference.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/Microsoft.DocAsCode.Metadata.ManagedReference.Tests.csproj
@@ -8,13 +8,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="1.3.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="1.3.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="1.3.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="1.3.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.3.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="1.3.2" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="2.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="2.0.0" />
     <PackageReference Include="Microsoft.DotNet.ProjectModel.Workspaces" Version="1.0.0-preview2-003121" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
   </ItemGroup>

--- a/test/docfx.Tests/docfx.Tests.csproj
+++ b/test/docfx.Tests/docfx.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
   </ItemGroup>
 

--- a/test/docfx.Tests/docfx.Tests.csproj
+++ b/test/docfx.Tests/docfx.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\Shared\test.base.props" />
 
   <ItemGroup>
-    <None Update="Assets\docfx.json_build\docfx.json;Assets\docfx.json_empty\docfx.json;Assets\docfx.json_invalid_key\docfx.json;Assets\docfx.json_invalid_format\docfx.json;Assets\docfx.json_metadata\docfx.json;Assets\docfx.json_metadata\docfxWithFilter.json;Assets\docfx.json_metadata_build\docfx.json;Assets\docfx.sample.1.json;Assets\filter.yaml.sample;Assets\test.cs.sample.1;Assets\test.csproj.sample.1;Assets\test.vb.sample.1;Assets\test.vbproj.sample.1;Assets\ref.csproj.sample.1">
+    <None Update="Assets\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/tools/AzureMarkdownRewriterTool/AzureMarkdownRewriterTool.csproj
+++ b/tools/AzureMarkdownRewriterTool/AzureMarkdownRewriterTool.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">


### PR DESCRIPTION
Remaining issues:
1. Add ut for new projects, looks like FullName is not correctly generated
2. Remove legacy "project.json" support in ExtractMetadata
3. Looks like docfx.exe.config file needs to update from OPS side