### PR TITLE
Add net46 ut

### DIFF
--- a/Documentation/tutorial/docfx_getting_started.md
+++ b/Documentation/tutorial/docfx_getting_started.md
@@ -24,7 +24,7 @@ For detailed description about DFM, please refer to [DFM](../spec/docfx_flavored
 -----------------------
 
 > [!Note]
-> Please make sure [Visual Studio 2015](https://www.visualstudio.com/vs/) or above, or [Microsoft Build Tools 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48159) is installed before running DocFX.
+> Please make sure [.NET Core](https://www.microsoft.com/net/core) and [.NET Framework 4.6](https://www.microsoft.com/en-us/download/details.aspx?id=48130) are installed.
 
 *Step1.* DocFX ships as a [chocolatey package](https://chocolatey.org/packages/docfx).
 Install docfx through [Chocolatey](https://chocolatey.org/install) by calling `cinst docfx -y`.
@@ -44,30 +44,7 @@ docfx docfx_project\docfx.json --serve
 ```
 
 Now you can view the generated website on http://localhost:8080.
-
-3. Use *DocFX* in Visual Studio
----------------
-
-As a prerequisite, you need [Visual Studio 2015](https://www.visualstudio.com/downloads/downloads) or above to use *DocFX* in IDE.
-
-*Step1.* Open Visual Studio and create a C# project as your documentation project. You can create an empty *ASP.NET Web Application* since it has a built-in *preview* feature that can be used to preview the generated website easily.
-
-*Step2.* Right click on the website project, and choose *Manage NuGet Packages...* to open the NuGet Package Manager. Search and install *docfx.console* package.
-
-*Step3.* Create a `.cs` class in the website project, make sure the class is `public`, for example:
-
-```csharp
-namespace WebApplication1
-{
-    public class Class1
-    {
-    }
-}
-```
-
-*Step4.* Right click on the website project, and click *View* -> *View in Browser*, navigate to `/_site` sub URL to view your website!
-
-4. Use *DocFX* with a Build Server
+3. Use *DocFX* with a Build Server
 ---------------
 
 *DocFX* can be used in a Continuous Integration environment.
@@ -89,11 +66,10 @@ Many build systems set an environment variable with the branch name.  DocFX uses
 > [!NOTE]
 > *Known issue in AppVeyor*: Currently `platform: Any CPU` in *appveyor.yml* causes `docfx metadata` failure. https://github.com/dotnet/docfx/issues/1078
 
-5. Build from source code
+4. Build from source code
 ----------------
 As a prerequisite, you need:
-- [Microsoft Build Tools 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48159)
-- [.NET Core SDK](https://go.microsoft.com/fwlink/?LinkID=809122)
+- [Visual Studio 2017](https://www.visualstudio.com/vs/) with *.NET Core cross-platform development* toolset
 - [Node.js](https://nodejs.org)
 
 *Step1.* `git clone https://github.com/dotnet/docfx.git` to get the latest code.

--- a/RELEASENOTE.md
+++ b/RELEASENOTE.md
@@ -6,6 +6,7 @@ v2.15(Pre-Release)
 1.  Bug fixes:
     1. Auto dedent the included code snippet, both when including the whole file and file sections.
     2. [Breaking Change]For inline inclusion, trim ending white spaces, considering ending white spaces in inline inclusion in most cases are typos.
+2. [Breaking Change] Support NetCore projects, the legacy `project.json` is no longer supported
 
 v2.14
 -----------

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/ExtractMetadataWorker.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/ExtractMetadataWorker.cs
@@ -19,7 +19,6 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
     using Microsoft.DocAsCode.DataContracts.ManagedReference;
     using Microsoft.DocAsCode.Exceptions;
     using Microsoft.DocAsCode.Plugins;
-    using Microsoft.DotNet.ProjectModel.Workspaces;
 
     public sealed class ExtractMetadataWorker : IDisposable
     {
@@ -28,7 +27,6 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             { "Configuration", "Release" }
         }));
         private static readonly string[] SupportedSolutionExtensions = { ".sln" };
-        private static readonly string[] SupportedProjectName = { "project.json" };
         private static readonly string[] SupportedProjectExtensions = { ".csproj", ".vbproj" };
         private static readonly string[] SupportedSourceFileExtensions = { ".cs", ".vb" };
         private static readonly string[] SupportedVBSourceFileExtensions = { ".vb" };
@@ -171,7 +169,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
         #region Check Supportability
         private static bool IsSupported(string filePath)
         {
-            return IsSupported(filePath, SupportedExtensions, SupportedProjectName);
+            return IsSupported(filePath, SupportedExtensions);
         }
 
         private static bool IsSupportedSolution(string filePath)
@@ -181,7 +179,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
         private static bool IsSupportedProject(string filePath)
         {
-            return IsSupported(filePath, SupportedProjectExtensions, SupportedProjectName);
+            return IsSupported(filePath, SupportedProjectExtensions);
         }
 
         private static bool IsSupportedSourceFile(string filePath)
@@ -925,13 +923,6 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             try
             {
                 string name = Path.GetFileName(path);
-#if NETCore
-                if (name.Equals("project.json", StringComparison.OrdinalIgnoreCase))
-                {
-                    var workspace = new ProjectJsonWorkspace(path);
-                    return workspace.CurrentSolution.Projects.FirstOrDefault(p => p.FilePath == Path.GetFullPath(path));
-                }
-#endif
 
                 return await _workspace.Value.OpenProjectAsync(path);
             }

--- a/test/docfx.Tests/Assets/net46-test.csproj.sample.1
+++ b/test/docfx.Tests/Assets/net46-test.csproj.sample.1
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+</Project>

--- a/test/docfx.Tests/MetadataCommandTest.cs
+++ b/test/docfx.Tests/MetadataCommandTest.cs
@@ -95,6 +95,70 @@ namespace Microsoft.DocAsCode.Tests
 
         [Fact]
         [Trait("Related", "docfx")]
+        [Trait("Language", "CSharp")]
+        [Trait("Framework", "netcore")]
+        public void TestMetadataCommandFromNet46CSProject()
+        {
+            // Create default project
+            var projectFile = Path.Combine(_projectFolder, "net46-test.csproj");
+            var sourceFile = Path.Combine(_projectFolder, "test.cs");
+            File.Copy("Assets/net46-test.csproj.sample.1", projectFile);
+            File.Copy("Assets/test.cs.sample.1", sourceFile);
+
+            new MetadataCommand(new MetadataCommandOptions
+            {
+                OutputFolder = Path.Combine(Directory.GetCurrentDirectory(), _outputFolder),
+                Projects = new List<string> { projectFile },
+            }).Exec(null);
+
+            Assert.True(File.Exists(Path.Combine(_outputFolder, ".manifest")));
+
+            var file = Path.Combine(_outputFolder, "toc.yml");
+            Assert.True(File.Exists(file));
+            var tocViewModel = YamlUtility.Deserialize<TocViewModel>(file);
+            Assert.Equal("Foo", tocViewModel[0].Uid);
+            Assert.Equal("Foo", tocViewModel[0].Name);
+            Assert.Equal("Foo.Bar", tocViewModel[0].Items[0].Uid);
+            Assert.Equal("Bar", tocViewModel[0].Items[0].Name);
+
+            file = Path.Combine(_outputFolder, "Foo.yml");
+            Assert.True(File.Exists(file));
+            var memberViewModel = YamlUtility.Deserialize<PageViewModel>(file);
+            Assert.Equal("Foo", memberViewModel.Items[0].Uid);
+            Assert.Equal("Foo", memberViewModel.Items[0].Id);
+            Assert.Equal("Foo", memberViewModel.Items[0].Name);
+            Assert.Equal("Foo", memberViewModel.Items[0].FullName);
+
+            file = Path.Combine(_outputFolder, "Foo.Bar.yml");
+            Assert.True(File.Exists(file));
+            memberViewModel = YamlUtility.Deserialize<PageViewModel>(file);
+            Assert.Equal("Foo.Bar", memberViewModel.Items[0].Uid);
+            Assert.Equal("Bar", memberViewModel.Items[0].Id);
+            Assert.Equal("Bar", memberViewModel.Items[0].Name);
+            Assert.Equal("Foo.Bar", memberViewModel.Items[0].FullName);
+            Assert.Equal("Foo.Bar.FooBar``1(System.Int32[],System.Byte*,``0,System.Collections.Generic.List{``0[]})", memberViewModel.Items[1].Uid);
+            Assert.Equal("FooBar``1(System.Int32[],System.Byte*,``0,System.Collections.Generic.List{``0[]})", memberViewModel.Items[1].Id);
+            Assert.Equal("FooBar<TArg>(Int32[], Byte*, TArg, List<TArg[]>)", memberViewModel.Items[1].Name);
+            Assert.Equal("Foo.Bar.FooBar<TArg>(System.Int32[], System.Byte*, TArg, System.Collections.Generic.List<TArg[]>)", memberViewModel.Items[1].FullName);
+            Assert.NotNull(memberViewModel.References.Find(
+                s => s.Uid.Equals("System.Collections.Generic.List{System.String}")
+                ));
+            Assert.NotNull(memberViewModel.References.Find(
+                s => s.Uid.Equals("System.Int32[]")
+                ));
+            Assert.NotNull(memberViewModel.References.Find(
+                s => s.Uid.Equals("System.Byte*")
+                ));
+            Assert.NotNull(memberViewModel.References.Find(
+                s => s.Uid.Equals("{TArg}")
+                ));
+            Assert.NotNull(memberViewModel.References.Find(
+                s => s.Uid.Equals("System.Collections.Generic.List{{TArg}[]}")
+                ));
+        }
+
+        [Fact]
+        [Trait("Related", "docfx")]
         [Trait("Language", "VB")]
         public void TestMetadataCommandFromVBProject()
         {


### PR DESCRIPTION
Finish work on https://github.com/dotnet/docfx/issues/1254

Looks like for netcore projects, `dotnet restore` is a prerequisite to run `docfx`