### PR TITLE
Fix original href for toc

### DIFF
--- a/src/Microsoft.DocAsCode.DataContracts.Common/TocItemViewModel.cs
+++ b/src/Microsoft.DocAsCode.DataContracts.Common/TocItemViewModel.cs
@@ -128,5 +128,15 @@ namespace Microsoft.DocAsCode.DataContracts.Common
                 .Add(Constants.ExtensionMemberPrefix.Name, NameInDevLangs, JTokenConverter.Convert<string>)
                 .Add(string.Empty, Metadata)
                 .Create();
+
+        public TocItemViewModel Clone()
+        {
+            var cloned = (TocItemViewModel)this.MemberwiseClone();
+            if (cloned.Items != null)
+            {
+                cloned.Items = Items.Clone();
+            }
+            return cloned;
+        }
     }
 }

--- a/src/Microsoft.DocAsCode.DataContracts.Common/TocViewModel.cs
+++ b/src/Microsoft.DocAsCode.DataContracts.Common/TocViewModel.cs
@@ -12,5 +12,10 @@ namespace Microsoft.DocAsCode.DataContracts.Common
     {
         public TocViewModel(IEnumerable<TocItemViewModel> items) : base(items) { }
         public TocViewModel() : base() { }
+
+        public TocViewModel Clone()
+        {
+            return new TocViewModel(ConvertAll(s => s.Clone()));
+        }
     }
 }


### PR DESCRIPTION
When b/toc.md is included by toc.md, invalid link in b/toc.md should be resolved to the path relative to toc.md