### PR TITLE
Added '-n hostname' option for workaround of running docfx server on …

### DIFF
--- a/src/docfx/Models/BuildCommandOptions.cs
+++ b/src/docfx/Models/BuildCommandOptions.cs
@@ -54,6 +54,9 @@ namespace Microsoft.DocAsCode
         [Option('s', "serve", HelpText = "Host the generated documentation to a website")]
         public bool Serve { get; set; }
 
+        [Option('n', "hostname", HelpText = "Specify the hostname of the hosted website (e.g., 'localhost' or '*')")]
+        public string Host { get; set; }
+
         [Option('p', "port", HelpText = "Specify the port of the hosted website")]
         public int? Port { get; set; }
 

--- a/src/docfx/Models/BuildJsonConfig.cs
+++ b/src/docfx/Models/BuildJsonConfig.cs
@@ -81,6 +81,9 @@ namespace Microsoft.DocAsCode
         [JsonProperty("forcePostProcess")]
         public bool? ForcePostProcess { get; set; }
 
+        [JsonProperty("host")]
+        public string Host { get; set; }
+
         [JsonProperty("port")]
         public string Port { get; set; }
 

--- a/src/docfx/Models/ServeCommandOptions.cs
+++ b/src/docfx/Models/ServeCommandOptions.cs
@@ -11,6 +11,9 @@ namespace Microsoft.DocAsCode
         [ValueOption(0)]
         public string Folder { get; set; }
 
+        [Option('n', "hostname", HelpText = "Specify the hostname of the hosted website [localhost]")]
+        public string Host { get; set; }
+
         [Option('p', "port", HelpText = "Specify the port of the hosted website [8080]")]
         public int? Port { get; set; }
 

--- a/src/docfx/SubCommands/BuildCommand.cs
+++ b/src/docfx/SubCommands/BuildCommand.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DocAsCode.SubCommands
 
             if (Config?.Serve ?? false)
             {
-                ServeCommand.Serve(outputFolder, Config.Port);
+                ServeCommand.Serve(outputFolder, Config.Host, Config.Port);
             }
             EnvironmentContext.Clean();
         }
@@ -208,6 +208,10 @@ namespace Microsoft.DocAsCode.SubCommands
             if (options.Serve)
             {
                 config.Serve = options.Serve;
+            }
+            if (options.Host != null)
+            {
+                config.Host = options.Host;
             }
             if (options.Port.HasValue)
             {

--- a/src/docfx/SubCommands/ServeCommand.cs
+++ b/src/docfx/SubCommands/ServeCommand.cs
@@ -26,15 +26,18 @@ namespace Microsoft.DocAsCode.SubCommands
 
         public void Exec(SubCommandRunningContext context)
         {
-            Serve(_options.Folder, _options.Port.HasValue ? _options.Port.Value.ToString() : null);
+            Serve(_options.Folder,
+                _options.Host,
+                _options.Port.HasValue ? _options.Port.Value.ToString() : null);
         }
 
-        public static void Serve(string folder, string port)
+        public static void Serve(string folder, string host, string port)
         {
             if (string.IsNullOrEmpty(folder)) folder = Directory.GetCurrentDirectory();
             folder = Path.GetFullPath(folder);
+            host = string.IsNullOrWhiteSpace(host) ? "localhost" : host;
             port = string.IsNullOrWhiteSpace(port) ? "8080" : port;
-            var url = $"http://localhost:{port}";
+            var url = $"http://{host}:{port}";
             if (!Directory.Exists(folder))
             {
                 throw new ArgumentException("Site folder does not exist. You may need to build it first. Example: \"docfx docfx_project/docfx.json\"", nameof(folder));

--- a/tools/DfmHttpService/DfmHttpServer.cs
+++ b/tools/DfmHttpService/DfmHttpServer.cs
@@ -14,13 +14,17 @@ namespace DfmHttpService
         private readonly IHttpHandler _handler;
         private int _status;
 
-        public DfmHttpServer(IHttpHandler handler, string port)
+        public DfmHttpServer(IHttpHandler handler, string host, string port)
         {
+            if (string.IsNullOrEmpty(host))
+            {
+                port = PreviewConstants.ServerHost;
+            }
             if (string.IsNullOrEmpty(port))
             {
                 port = PreviewConstants.ServerPort;
             }
-            string UrlPrefix = $"http://localhost:{port}/";
+            string UrlPrefix = $"http://{host}:{port}/";
             _listener.Prefixes.Add(UrlPrefix);
             _handler = handler;
         }

--- a/tools/DfmHttpService/Handler/PreviewConstants.cs
+++ b/tools/DfmHttpService/Handler/PreviewConstants.cs
@@ -8,6 +8,7 @@ namespace DfmHttpService
 
     public static class PreviewConstants
     {
+        public const string ServerHost = "localhost";
         public const string ServerPort = "4002";
         public const string TocMetadataName = "toc_rel";
         public const string PathPrefix = @"file:///";

--- a/tools/DfmHttpService/Program.cs
+++ b/tools/DfmHttpService/Program.cs
@@ -19,7 +19,7 @@ namespace DfmHttpService
                     new ExitHandler()
                 });
 
-            var service = new DfmHttpServer(handler, args.Length > 0 ? args[0] : null);
+            var service = new DfmHttpServer(handler, "localhost", args.Length > 0 ? args[0] : null);
             service.Start();
             service.WaitForExit();
         }


### PR DESCRIPTION
…Ubuntu with Mono. The default is 'localhost'. Note, alternative would be to hardwire '*' instead of 'localhost' in the two occurrences in the entire source, but this change is more general. Note, it's still hardwired into tools/DfmHttpService/Program.cs as 'localhost' because there isn't any arg parsing there, and  I don't want to write that.

This change fixes Issue 1554. I tested the change built binaries (using VS 2017.1), Mono 4.8.1, on Ubuntu 16.04:

$sudo mono docfx.exe serve -p 9000 -n '*' /home/ken/swigged-llvm-docfx/_site/
[sudo] password for ken: xxxxxxxxxxxxxxxxxxxx
Serving "/home/ken/swigged-llvm-docfx/_site/" on http://*:9000

.......

$ wget 10.0.2.15:9000
--2017-05-06 15:58:32--  http://10.0.2.15:9000/
Connecting to 10.0.2.15:9000... connected.
HTTP request sent, awaiting response... 200 OK
Length: 6708 (6.6K) [text/html]
Saving to: ‘index.html.6’

index.html.6        100%[===================>]   6.55K  --.-KB/s    in 0s      

2017-05-06 15:58:32 (1015 MB/s) - ‘index.html.6’ saved [6708/6708]

