### PR TITLE
Add pdfcommand

### DIFF
--- a/src/docfx/Models/PdfCommandOptions.cs
+++ b/src/docfx/Models/PdfCommandOptions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode
+{
+    using CommandLine;
+
+    [OptionUsage("pdf [<config file path>]")]
+    internal class PdfCommandOptions : BuildCommandOptions
+    {
+        [Option("name", HelpText = "Specify the name of the generated pdf")]
+        public string Name { get; set; }
+
+        [Option("appendices", HelpText = "Specify whether or not generate appendices for not-in-TOC articles")]
+        public bool GenerateAppendices { get; set; }
+
+        [Option("external", HelpText = "Specify whether or not generate external links for PDF")]
+        public bool GeneratePdfExternalLink { get; set; }
+
+        [Option("host", HelpText = "Specify the hostname to link not-in-TOC articles")]
+        public string Host { get; set; }
+
+        [Option("locale", HelpText = "Specify the locale of the pdf file")]
+        public string Locale { get; set; }
+    }
+}

--- a/src/docfx/Models/PdfJsonConfig.cs
+++ b/src/docfx/Models/PdfJsonConfig.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode
+{
+    using System.Collections.Generic;
+
+    using Newtonsoft.Json;
+
+    public class PdfJsonConfig : BuildJsonConfig
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("host")]
+        public string Host { get; set; }
+
+        [JsonProperty("locale")]
+        public string Locale { get; set; }
+
+        [JsonProperty("appendices")]
+        public bool GenerateAppendices { get; set; }
+
+        [JsonProperty("external")]
+        public bool GeneratePdfExternalLink { get; set; }
+    }
+}

--- a/src/docfx/SubCommands/PdfCommand.cs
+++ b/src/docfx/SubCommands/PdfCommand.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode.SubCommands
+{
+    using System;
+    using System.IO;
+
+    using Microsoft.DocAsCode;
+    using Microsoft.DocAsCode.Common;
+    using Microsoft.DocAsCode.Plugins;
+
+    internal sealed class PdfCommand : ISubCommand
+    {
+        private readonly PdfCommandOptions _options;
+        public bool AllowReplay => false;
+
+        public PdfCommand(PdfCommandOptions options)
+        {
+            _options = options;
+        }
+
+        public void Exec(SubCommandRunningContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/docfx/SubCommands/PdfCommandCreator.cs
+++ b/src/docfx/SubCommands/PdfCommandCreator.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode.SubCommands
+{
+    using System;
+    using Microsoft.DocAsCode;
+    using Microsoft.DocAsCode.Plugins;
+
+    [CommandOption("pdf", "Generate pdf file")]
+    internal sealed class PdfCommandCreator : CommandCreator<PdfCommandOptions, PdfCommand>
+    {
+        public override PdfCommand CreateCommand(PdfCommandOptions options, ISubCommandController controller)
+        {
+            return new PdfCommand(options);
+        }
+    }
+}


### PR DESCRIPTION
PdfCommandOptions inherits from BuildCommandOptions instead of using the result from 'build', considering that PDF uses a totally different template from normal build.