### PR TITLE
Add line and source file info for invalid cross reference

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/CrossReferenceNotResolvedException.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/CrossReferenceNotResolvedException.cs
@@ -12,28 +12,23 @@ namespace Microsoft.DocAsCode.Build.Engine
     [Serializable]
     public class CrossReferenceNotResolvedException : DocumentException
     {
-        public string Uid { get; }
-        public string UidRawText { get; }
+        public XRefDetails XRefDetails { get; }
 
-        public CrossReferenceNotResolvedException(string uid, string uidRawText, string file) : base()
+        public CrossReferenceNotResolvedException(XRefDetails xrefDetails) : base()
         {
-            Uid = uid;
-            UidRawText = uidRawText;
+            XRefDetails = xrefDetails;
         }
 
         protected CrossReferenceNotResolvedException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
-            Uid = info.GetString(nameof(Uid));
-            UidRawText = info.GetString(nameof(UidRawText));
+            XRefDetails = (XRefDetails)info.GetValue(nameof(XRefDetails), typeof(XRefDetails));
         }
 
         [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
-        public override void GetObjectData(SerializationInfo info,
-            StreamingContext context)
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
+            info.AddValue(nameof(XRefDetails), XRefDetails);
             base.GetObjectData(info, context);
-            info.AddValue(nameof(Uid), Uid);
-            info.AddValue(nameof(UidRawText), UidRawText);
         }
     }
 }

--- a/src/Microsoft.DocAsCode.Build.Engine/TemplateModelTransformer.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/TemplateModelTransformer.cs
@@ -169,26 +169,12 @@ namespace Microsoft.DocAsCode.Build.Engine
 
             if (missingXRefDetails.Count > 0)
             {
-                var uidInfos = string.Join(",", missingXRefDetails.Select(i =>
+                var distinctUids = string.Join(", ", missingXRefDetails.Select(i => i.RawSource).Distinct().Select(s => $"\"{s}\""));
+                Logger.LogWarning($"Invalid cross reference {distinctUids}.", file: item.LocalPathFromRoot);
+                foreach (var xref in missingXRefDetails)
                 {
-                    var result = StringBuffer.Empty;
-                    result += "\"";
-                    result += i.RawSource;
-                    result += "\"";
-                    if (i.SourceStartLineNumber > 0)
-                    {
-                        result += " in line ";
-                        result += i.SourceStartLineNumber;
-                    }
-                    if (!string.IsNullOrEmpty(i.SourceFile))
-                    {
-                        result += " of file \"";
-                        result += i.SourceFile;
-                        result += "\"";
-                    }
-                    return result;
-                }));
-                Logger.LogWarning($"Invalid cross reference {uidInfos}.", file: item.LocalPathFromRoot);
+                    Logger.LogInfo($"Invalid cross reference details: {xref.RawSource}", file: xref.SourceFile ?? item.LocalPathFromRoot, line: xref.SourceEndLineNumber.ToString());
+                }
             }
 
             return manifestItem;

--- a/src/Microsoft.DocAsCode.Build.Engine/TemplateModelTransformer.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/TemplateModelTransformer.cs
@@ -173,11 +173,20 @@ namespace Microsoft.DocAsCode.Build.Engine
                 Logger.LogWarning($"Invalid cross reference {distinctUids}.", file: item.LocalPathFromRoot);
                 foreach (var group in missingXRefDetails.GroupBy(i => i.SourceFile))
                 {
+                    int maxCountPerFile = 10;
+                    string details;
+
                     // For each source file, print the first 10 invalid cross reference
-                    foreach (var xref in group.Take(10))
+                    if (group.Count() >= maxCountPerFile)
                     {
-                        Logger.LogInfo($"Invalid cross reference details: {xref.RawSource}", file: xref.SourceFile ?? item.LocalPathFromRoot, line: xref.SourceEndLineNumber.ToString());
+                        details = $"{string.Join(", ", group.Take(maxCountPerFile).Select(i => $"\"{i.RawSource}\" in line {i.SourceStartLineNumber.ToString()}"))}, etc. Fisrt {maxCountPerFile} invalid cross reference are shown above.";
                     }
+                    else
+                    {
+                        details = string.Join(", ", group.Select(i => $"\"{i.RawSource}\" in line {i.SourceStartLineNumber.ToString()}"));
+                    }
+
+                    Logger.LogInfo($"Invalid cross reference details: {details}", file: group.Key ?? item.LocalPathFromRoot);
                 }
             }
 

--- a/src/Microsoft.DocAsCode.Build.Engine/TemplateModelTransformer.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/TemplateModelTransformer.cs
@@ -11,6 +11,7 @@ namespace Microsoft.DocAsCode.Build.Engine
     using System.Web;
 
     using Microsoft.DocAsCode.Common;
+    using Microsoft.DocAsCode.MarkdownLite;
     using Microsoft.DocAsCode.Plugins;
 
     public class TemplateModelTransformer
@@ -24,12 +25,7 @@ namespace Microsoft.DocAsCode.Build.Engine
 
         public TemplateModelTransformer(DocumentBuildContext context, TemplateCollection templateCollection, ApplyTemplateSettings settings, IDictionary<string, object> globals)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            _context = context;
+            _context = context ?? throw new ArgumentNullException(nameof(context));
             _templateCollection = templateCollection;
             _settings = settings;
             _globalVariables = globals;
@@ -78,7 +74,7 @@ namespace Microsoft.DocAsCode.Build.Engine
                 return manifestItem;
             }
 
-            HashSet<string> missingUids = new HashSet<string>();
+            List<XRefDetails> missingXRefDetails = new List<XRefDetails>();
 
             // Must convert to JObject first as we leverage JsonProperty as the property name for the model
             foreach (var template in templateBundle.Templates)
@@ -159,7 +155,7 @@ namespace Microsoft.DocAsCode.Build.Engine
                             Logger.LogWarning(message);
                         }
 
-                        TransformDocument(result ?? string.Empty, extension, _context, outputFile, missingUids, manifestItem);
+                        TransformDocument(result ?? string.Empty, extension, _context, outputFile, missingXRefDetails, manifestItem);
                         Logger.LogDiagnostic($"Transformed model \"{item.LocalPathFromRoot}\" to \"{outputFile}\".");
                     }
                 }
@@ -171,10 +167,28 @@ namespace Microsoft.DocAsCode.Build.Engine
 
             }
 
-            if (missingUids.Count > 0)
+            if (missingXRefDetails.Count > 0)
             {
-                var uids = string.Join(", ", missingUids.Select(s => $"\"{s}\""));
-                Logger.LogWarning($"Invalid cross reference {uids}.", null, item.LocalPathFromRoot);
+                var uidInfos = string.Join(",", missingXRefDetails.Select(i =>
+                {
+                    var result = StringBuffer.Empty;
+                    result += "\"";
+                    result += i.RawSource;
+                    result += "\"";
+                    if (i.SourceStartLineNumber > 0)
+                    {
+                        result += " in line ";
+                        result += i.SourceStartLineNumber;
+                    }
+                    if (!string.IsNullOrEmpty(i.SourceFile))
+                    {
+                        result += " of file \"";
+                        result += i.SourceFile;
+                        result += "\"";
+                    }
+                    return result;
+                }));
+                Logger.LogWarning($"Invalid cross reference {uidInfos}.", file: item.LocalPathFromRoot);
             }
 
             return manifestItem;
@@ -257,7 +271,7 @@ namespace Microsoft.DocAsCode.Build.Engine
             return StringExtension.ToDisplayPath(modelPath);
         }
 
-        private void TransformDocument(string result, string extension, IDocumentBuildContext context, string destFilePath, HashSet<string> missingUids, ManifestItem manifestItem)
+        private void TransformDocument(string result, string extension, IDocumentBuildContext context, string destFilePath, List<XRefDetails> missingXRefDetails, ManifestItem manifestItem)
         {
             Task<byte[]> hashTask;
             using (var stream = EnvironmentContext.FileAbstractLayer.Create(destFilePath).WithMd5Hash(out hashTask))
@@ -276,7 +290,7 @@ namespace Microsoft.DocAsCode.Build.Engine
                             var xrefExcetpion = s as CrossReferenceNotResolvedException;
                             if (xrefExcetpion != null)
                             {
-                                missingUids.Add(xrefExcetpion.UidRawText);
+                                missingXRefDetails.Add(xrefExcetpion.XRefDetails);
                                 return true;
                             }
                             else
@@ -384,7 +398,7 @@ namespace Microsoft.DocAsCode.Build.Engine
             {
                 if (xref.ThrowIfNotResolved)
                 {
-                    throw new CrossReferenceNotResolvedException(xref.Uid, xref.RawSource, null);
+                    throw new CrossReferenceNotResolvedException(xref);
                 }
             }
         }

--- a/src/Microsoft.DocAsCode.Build.Engine/TemplateModelTransformer.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/TemplateModelTransformer.cs
@@ -171,9 +171,13 @@ namespace Microsoft.DocAsCode.Build.Engine
             {
                 var distinctUids = string.Join(", ", missingXRefDetails.Select(i => i.RawSource).Distinct().Select(s => $"\"{s}\""));
                 Logger.LogWarning($"Invalid cross reference {distinctUids}.", file: item.LocalPathFromRoot);
-                foreach (var xref in missingXRefDetails)
+                foreach (var group in missingXRefDetails.GroupBy(i => i.SourceFile))
                 {
-                    Logger.LogInfo($"Invalid cross reference details: {xref.RawSource}", file: xref.SourceFile ?? item.LocalPathFromRoot, line: xref.SourceEndLineNumber.ToString());
+                    // For each source file, print the first 10 invalid cross reference
+                    foreach (var xref in group.Take(10))
+                    {
+                        Logger.LogInfo($"Invalid cross reference details: {xref.RawSource}", file: xref.SourceFile ?? item.LocalPathFromRoot, line: xref.SourceEndLineNumber.ToString());
+                    }
                 }
             }
 

--- a/src/Microsoft.DocAsCode.Build.Engine/XrefDetails.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/XrefDetails.cs
@@ -13,7 +13,8 @@ namespace Microsoft.DocAsCode.Build.Engine
     using Microsoft.DocAsCode.Plugins;
     using Microsoft.DocAsCode.Common;
 
-    internal sealed class XRefDetails
+    [Serializable]
+    public sealed class XRefDetails
     {
         /// <summary>
         /// TODO: completely move into template

--- a/src/Microsoft.DocAsCode.Plugins/XRefSpec.cs
+++ b/src/Microsoft.DocAsCode.Plugins/XRefSpec.cs
@@ -4,6 +4,7 @@
     using System.Collections;
     using System.Collections.Generic;
 
+    [Serializable]
     public sealed class XRefSpec : IDictionary<string, string>
     {
         public const string UidKey = "uid";

--- a/test/Microsoft.DocAsCode.Build.ManagedReference.Tests/ManagedReferenceDocumentProcessorTest.cs
+++ b/test/Microsoft.DocAsCode.Build.ManagedReference.Tests/ManagedReferenceDocumentProcessorTest.cs
@@ -245,13 +245,10 @@ namespace Microsoft.DocAsCode.Build.ManagedReference.Tests
                 Assert.Equal("TestData/mref/System.String.yml", warning.File);
 
                 var infos = listener.GetItemsByLogLevel(LogLevel.Info).Where(i => i.Message.Contains("Invalid cross reference details")).ToList();
-                Assert.Equal(2, infos.Count());
-                Assert.Equal("Invalid cross reference details: &lt;xref:invalidXref1&gt;", infos[0].Message);
-                Assert.Equal("6", infos[0].Line);
+                Assert.Equal(1, infos.Count());
+                Assert.Equal("Invalid cross reference details: \"&lt;xref:invalidXref1&gt;\" in line 6, \"&lt;xref:invalidXref2&gt;\" in line 8", infos[0].Message);
                 Assert.Equal("TestData/overwrite/mref.overwrite.invalid.ref.md", infos[0].File);
-                Assert.Equal("Invalid cross reference details: &lt;xref:invalidXref2&gt;", infos[1].Message);
-                Assert.Equal("8", infos[1].Line);
-                Assert.Equal("TestData/overwrite/mref.overwrite.invalid.ref.md", infos[1].File);
+                Assert.Null(infos[0].Line);
             }
             finally
             {

--- a/test/Microsoft.DocAsCode.Build.ManagedReference.Tests/ManagedReferenceDocumentProcessorTest.cs
+++ b/test/Microsoft.DocAsCode.Build.ManagedReference.Tests/ManagedReferenceDocumentProcessorTest.cs
@@ -222,6 +222,35 @@ namespace Microsoft.DocAsCode.Build.ManagedReference.Tests
         }
 
         [Fact]
+        public void ProcessMrefWithNotInvalidCrossReferenceShouldWarn()
+        {
+            var files = new FileCollection(Directory.GetCurrentDirectory());
+            files.Add(DocumentType.Article, new[] { "TestData/mref/System.String.yml" }, "TestData/");
+            files.Add(DocumentType.Overwrite, new[] { "TestData/overwrite/mref.overwrite.invalid.ref.md" });
+
+            var listener = TestLoggerListener.CreateLoggerListenerWithPhaseStartFilter(nameof(ProcessMrefWithNotInvalidCrossReferenceShouldWarn));
+            try
+            {
+                Logger.RegisterListener(listener);
+
+                using (new LoggerPhaseScope(nameof(ProcessMrefWithNotInvalidCrossReferenceShouldWarn)))
+                {
+                    BuildDocument(files);
+                }
+
+                var logs = listener.GetItemsByLogLevel(LogLevel.Warning);
+                Assert.Equal(1, logs.Count());
+                var log = logs.Single();
+                Assert.Equal("Invalid cross reference \"&lt;xref:invalidXref&gt;\" in line 6 of file \"TestData/overwrite/mref.overwrite.invalid.ref.md\".", log.Message);
+                Assert.Equal("TestData/mref/System.String.yml", log.File);
+            }
+            finally
+            {
+                Logger.UnregisterListener(listener);
+            }
+        }
+
+        [Fact]
         public void ProcessMrefWithInvalidOverwriteShouldFail()
         {
             FileCollection files = new FileCollection(_defaultFiles);

--- a/test/Microsoft.DocAsCode.Build.ManagedReference.Tests/TestData/overwrite/mref.overwrite.invalid.ref.md
+++ b/test/Microsoft.DocAsCode.Build.ManagedReference.Tests/TestData/overwrite/mref.overwrite.invalid.ref.md
@@ -3,4 +3,6 @@ uid: System.String
 summary: *content
 ---
 
-This is overwrite summary for invalid xref <xref:invalidXref> and @invalidRef
+This is overwrite summary for invalid xref <xref:invalidXref1> and @invalidRef.
+
+Another ref <xref:invalidXref2>

--- a/test/Microsoft.DocAsCode.Build.ManagedReference.Tests/TestData/overwrite/mref.overwrite.invalid.ref.md
+++ b/test/Microsoft.DocAsCode.Build.ManagedReference.Tests/TestData/overwrite/mref.overwrite.invalid.ref.md
@@ -1,0 +1,6 @@
+---
+uid: System.String
+summary: *content
+---
+
+This is overwrite summary for invalid xref <xref:invalidXref> and @invalidRef

--- a/test/Microsoft.DocAsCode.Tests.Common/TestLoggerListener.cs
+++ b/test/Microsoft.DocAsCode.Tests.Common/TestLoggerListener.cs
@@ -5,6 +5,7 @@ namespace Microsoft.DocAsCode.Tests.Common
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     using Microsoft.DocAsCode.Common;
 
@@ -94,6 +95,15 @@ namespace Microsoft.DocAsCode.Tests.Common
                 }
                 return false;
             });
+        }
+
+        #endregion
+
+        #region Helper methods
+
+        public IEnumerable<ILogItem> GetItemsByLogLevel(LogLevel logLevel)
+        {
+            return Items.Where(i => i.LogLevel == logLevel);
         }
 
         #endregion


### PR DESCRIPTION
#1162 , in order to keep original warning count, join the line and source file info into one warning string.