### PR TITLE
Print warning message when project file does not contain any documents.

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/ExtractMetadataWorker.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/ExtractMetadataWorker.cs
@@ -240,7 +240,14 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 var path = item.Key;
                 var project = item.Value;
                 documentCache.AddDocument(path, path);
-                documentCache.AddDocuments(path, project.Documents.Select(s => s.FilePath));
+                if (project.HasDocuments)
+                {
+                    documentCache.AddDocuments(path, project.Documents.Select(s => s.FilePath));
+                }
+                else
+                {
+                    Logger.Log(LogLevel.Warning, $"Project '{project.FilePath}' does not contain any documents.");
+                }
                 documentCache.AddDocuments(path, project.MetadataReferences
                     .Where(s => s is PortableExecutableReference)
                     .Select(s => ((PortableExecutableReference)s).FilePath));


### PR DESCRIPTION
Currently, roslyn does not seem to pick up source files from the "new" csproj format where .cs source files are implicitly included (I even updated to the latest pre-release roslyn nuget packages). So, to help diagnose this lack of support, print a warning message.