### PR TITLE
Log WorkspaceFail events

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/ExtractMetadataWorker.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/ExtractMetadataWorker.cs
@@ -74,7 +74,15 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 _msbuildProperties["Configuration"] = "Release";
             }
 
-            _workspace = new Lazy<MSBuildWorkspace>(() => MSBuildWorkspace.Create(_msbuildProperties));
+            _workspace = new Lazy<MSBuildWorkspace>(() =>
+            {
+                var workspace = MSBuildWorkspace.Create(_msbuildProperties);
+                workspace.WorkspaceFailed += (s, e) =>
+                {
+                    Logger.LogWarning($"Workspace failed with: {e.Diagnostic}");
+                };
+                return workspace;
+            });
         }
 
         public async Task ExtractMetadataAsync()


### PR DESCRIPTION
MSBuildWorkspace.OpenSolutionAsync() and MSBuildWorkspace.OpenProjectAsync() do not give any notification that loading a solution or project failed. However, there is a WorkspaceFailed event that we can use to be notified when there is a problem. This logs the diagnotic information from this event to help the user troubleshoot.

Related:
* https://github.com/dotnet/roslyn/issues/19978#issuecomment-306877880
* https://github.com/dotnet/docfx/issues/1686
* https://github.com/dotnet/docfx/issues/1708#issuecomment-306678871