### PR TITLE
Fix display of lists in PDFs.

### DIFF
--- a/src/docfx.website.themes/pdf.default/styles/default.css
+++ b/src/docfx.website.themes/pdf.default/styles/default.css
@@ -214,7 +214,6 @@ dd {
 ol,
 ul {
     margin: 0;
-    padding: 0;
     margin-bottom: 1em
 }
 


### PR DESCRIPTION
Thanks for PDF generation support. It's looking great!

The only problem I have noticed so far is that lists are not indented and don't appear as lists. Number lists are missing their numbers and unordered lists have no dots to indicate that they are lists. This small CSS tweak restores lists to their ordinal glory.
