### PR TITLE
Fix #1803 that reload model reload duplicate model

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/HostService.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/HostService.cs
@@ -496,12 +496,12 @@ namespace Microsoft.DocAsCode.Build.Engine
                 m.FileOrBaseDirChanged += fileOrBaseDirChangedHandler;
                 m.UidsChanged += uidsChangedHandler;
                 m.ContentAccessed += contentAccessedHandler;
-                foreach (var uid in m.Uids)
+                foreach (var uid in m.Uids.Select(s => s.Name).Distinct())
                 {
-                    if (!_uidIndex.TryGetValue(uid.Name, out List<FileModel> list))
+                    if (!_uidIndex.TryGetValue(uid, out List<FileModel> list))
                     {
                         list = new List<FileModel>();
-                        _uidIndex.Add(uid.Name, list);
+                        _uidIndex.Add(uid, list);
                     }
                     list.Add(m);
                 }


### PR DESCRIPTION
When overwrite document model contains multiple uids in one file, for example:
```markdown
---
uid: src.Class1.#ctor
remarks: *content
---
Hello there 1212.~

---
uid: src.Class1.#ctor
example: [*content]
---
This is example
```hello```
```
When in incremental case, it reloads the overwrite model, `m.Uids` stores `UidDefinition`, which distinct for different line numbers, and thus, the overwrite file is added to `_uidIndex` 2 times, thus, `merge` occurs 2 times. 2nd merge tries to merge `string` properties with `null` value and `array` properties with `null` value as well. `string` merge ignores null value while `array` merge *replace*s current one with `null` value, this is why #1803 takes place