### PR TITLE
Remove DocFx markdown from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Please refer to [Getting Started](http://dotnet.github.io/docfx/tutorial/docfx_g
 
 [docfx-seed](https://github.com/docascode/docfx-seed/blob/master/appveyor.yml) project provides a sample integrating with AppVeyor.
 
-> [!NOTE]
+> **NOTE:**
 > *Known issue in AppVeyor*: Currently `platform: Any CPU` in *appveyor.yml* causes `docfx metadata` failure. https://github.com/dotnet/docfx/issues/1078
 
 ## What's included?


### PR DESCRIPTION
Remove DocFx markdown from GitHub README since it isn't supported by GFM