### PR TITLE
fix bug during download nuget

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -25,6 +25,8 @@ $scriptHome = Split-Path $scriptPath
 $versionCsFolderPath = $scriptHome + "\TEMP\"
 $versionCsFilePath = $versionCsFolderPath + "version.cs"
 
+$global:LASTEXITCODE = $null
+
 Push-Location $scriptHome
 
 function NugetPack {

--- a/build.ps1
+++ b/build.ps1
@@ -65,8 +65,7 @@ if (-not(ValidateCommand($nugetCommand))) {
     mkdir -Path "$env:LOCALAPPDATA\Nuget" -Force
     $ProgressPreference = 'SilentlyContinue'
     [Net.WebRequest]::DefaultWebProxy.Credentials = [Net.CredentialCache]::DefaultCredentials
-    Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe' -OutFile $nugetCommand 
-    ProcessLastExitCode $lastexitcode "Download nuget.exe"
+    Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe' -OutFile $nugetCommand
 }
 
 if ($raw -eq $false) {


### PR DESCRIPTION
$lastexitcode won't change by PowerShell command, if some error happens, an exception will be thrown and script stop.