### PR TITLE
Allow user define heading id.

### DIFF
--- a/src/Microsoft.DocAsCode.Dfm/Aggregators/HeadingIdAggregator.cs
+++ b/src/Microsoft.DocAsCode.Dfm/Aggregators/HeadingIdAggregator.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode.Dfm
+{
+    using System.Text.RegularExpressions;
+
+    using Microsoft.DocAsCode.MarkdownLite;
+
+    public class HeadingIdAggregator : MarkdownTokenAggregator<MarkdownHeadingBlockToken>
+    {
+        private static readonly Regex OpenARegex = new Regex(@"^\<a +(?:name|id)=\""([\w \-\.]+)\"" *\>$", RegexOptions.Compiled);
+        private static readonly Regex CloseARegex = new Regex(@"^\<\/a\>$", RegexOptions.Compiled);
+
+        protected override bool AggregateCore(MarkdownHeadingBlockToken headToken, IMarkdownTokenAggregateContext context)
+        {
+            var info = ParseHeading(headToken);
+            if (info == null)
+            {
+                return false;
+            }
+            context.AggregateTo(
+                new MarkdownHeadingBlockToken(
+                    headToken.Rule,
+                    headToken.Context,
+                    new InlineContent(headToken.Content.Tokens.RemoveRange(0, 2)),
+                    info,
+                    headToken.Depth,
+                    headToken.SourceInfo), 1);
+            return true;
+        }
+
+        private static string ParseHeading(MarkdownHeadingBlockToken headToken)
+        {
+            if (headToken.Content.Tokens.Length <= 2)
+            {
+                return null;
+            }
+            var openATag = headToken.Content.Tokens[0] as MarkdownTagInlineToken;
+            var closeATag = headToken.Content.Tokens[1] as MarkdownTagInlineToken;
+            if (openATag == null || closeATag == null)
+            {
+                return null;
+            }
+
+            var m = OpenARegex.Match(openATag.SourceInfo.Markdown);
+            if (!m.Success)
+            {
+                return null;
+            }
+            if (!CloseARegex.IsMatch(closeATag.SourceInfo.Markdown))
+            {
+                return null;
+            }
+
+            return m.Groups[1].Value;
+        }
+    }
+}

--- a/src/Microsoft.DocAsCode.Dfm/DfmEngine.cs
+++ b/src/Microsoft.DocAsCode.Dfm/DfmEngine.cs
@@ -16,7 +16,12 @@ namespace Microsoft.DocAsCode.Dfm
             : base(context, rewriter, renderer, options, new Dictionary<string, LinkObj>()) { }
 
         internal DfmEngine(DfmEngine engine)
-            : this(engine.Context, engine.Rewriter, engine.RendererImpl, engine.Options) { }
+            : this(engine.Context, engine.Rewriter, engine.RendererImpl, engine.Options)
+        {
+            TokenTreeValidator = engine.TokenTreeValidator;
+            TokenAggregator = engine.TokenAggregator;
+            TokenAggregators = engine.TokenAggregators;
+        }
 
         public override string Markup(string src, string path)
         {

--- a/src/Microsoft.DocAsCode.Dfm/DfmEngineBuilder.cs
+++ b/src/Microsoft.DocAsCode.Dfm/DfmEngineBuilder.cs
@@ -78,11 +78,9 @@ namespace Microsoft.DocAsCode.Dfm
             BlockRules = blockRules.ToImmutableList();
 
             Rewriter = InitMarkdownStyle(container, baseDir, templateDir);
-            TokenAggregator = new CompositeMarkdownTokenAggregator(
-                new IMarkdownTokenAggregator[]
-                {
-                    new TabGroupAggregator(),
-                });
+            TokenAggregators = ImmutableList.Create<IMarkdownTokenAggregator>(
+                new HeadingIdAggregator(),
+                new TabGroupAggregator());
         }
 
         private static void Replace<TSource, TReplacement>(List<IMarkdownRule> blockRules)
@@ -200,6 +198,7 @@ namespace Microsoft.DocAsCode.Dfm
             {
                 TokenTreeValidator = TokenTreeValidator,
                 TokenAggregator = TokenAggregator,
+                TokenAggregators = TokenAggregators,
             };
         }
 

--- a/src/Microsoft.DocAsCode.MarkdownLite/MarkdownEngine.cs
+++ b/src/Microsoft.DocAsCode.MarkdownLite/MarkdownEngine.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.DocAsCode.MarkdownLite
 {
+    using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Text.RegularExpressions;
@@ -41,7 +42,10 @@ namespace Microsoft.DocAsCode.MarkdownLite
 
         public IMarkdownTokenTreeValidator TokenTreeValidator { get; set; }
 
+        [Obsolete]
         public IMarkdownTokenAggregator TokenAggregator { get; set; }
+
+        public ImmutableList<IMarkdownTokenAggregator> TokenAggregators { get; set; }
 
         public Dictionary<string, LinkObj> Links { get; }
 
@@ -105,6 +109,17 @@ namespace Microsoft.DocAsCode.MarkdownLite
                     new MarkdownAggregateEngine(
                         this,
                         TokenAggregator));
+            }
+
+            // Aggregate tokens.
+            foreach (var agg in TokenAggregators)
+            {
+                tokens = RewriteTokens(
+                    tokens,
+                    sourceInfo.File,
+                    new MarkdownAggregateEngine(
+                        this,
+                        agg));
             }
 
             // customized rewriter.

--- a/src/Microsoft.DocAsCode.MarkdownLite/MarkdownEngineBuilder.cs
+++ b/src/Microsoft.DocAsCode.MarkdownLite/MarkdownEngineBuilder.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.DocAsCode.MarkdownLite
 {
+    using System;
     using System.Collections.Immutable;
 
     /// <summary>
@@ -40,7 +41,10 @@ namespace Microsoft.DocAsCode.MarkdownLite
         /// </summary>
         public IMarkdownTokenTreeValidator TokenTreeValidator { get; set; }
 
+        [Obsolete]
         public IMarkdownTokenAggregator TokenAggregator { get; set; }
+
+        public ImmutableList<IMarkdownTokenAggregator> TokenAggregators { get; set; } = ImmutableList<IMarkdownTokenAggregator>.Empty;
 
         /// <summary>
         /// Create markdown paring context.
@@ -62,6 +66,7 @@ namespace Microsoft.DocAsCode.MarkdownLite
             {
                 TokenTreeValidator = TokenTreeValidator,
                 TokenAggregator = TokenAggregator,
+                TokenAggregators = TokenAggregators,
             };
         }
     }

--- a/test/Microsoft.DocAsCode.Dfm.Tests/DocfxFlavoredMarkdownTest.cs
+++ b/test/Microsoft.DocAsCode.Dfm.Tests/DocfxFlavoredMarkdownTest.cs
@@ -52,6 +52,14 @@ b:
         [InlineData(
             @"[*a*](xref:uid)",
             "<p><a href=\"xref:uid\" data-raw-source=\"[*a*](xref:uid)\"><em>a</em></a></p>\n")]
+        [InlineData(
+            @"# <a id=""x""></a>Y",
+            @"<h1 id=""x"">Y</h1>
+")]
+        [InlineData(
+            @"# <a name=""x""></a>Y",
+            @"<h1 id=""x"">Y</h1>
+")]
         #endregion
         public void TestDfmInGeneral(string source, string expected)
         {
@@ -66,7 +74,7 @@ b:
             options.ShouldExportSourceInfo = true;
             var actual = DocfxFlavoredMarked.Markup(null, null, options, @"# [title-a](#tab/a)
 content-a
-# [title-b](#tab/b/c)
+# <a id=""x""></a>[title-b](#tab/b/c)
 content-b
 - - -", "test.md");
             var groupId = "uBn0rykxXo";

--- a/test/Microsoft.DocAsCode.MarkdownLite.Tests/TokenAggregatorTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdownLite.Tests/TokenAggregatorTest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DocAsCode.MarkdownLite.Tests
         {
             var builder = new GfmEngineBuilder(new Options())
             {
-                TokenAggregator = new Head1HrAggregateToHead2(),
+                TokenAggregators = ImmutableList.Create<IMarkdownTokenAggregator>(new Head1HrAggregateToHead2()),
             };
             var engine = builder.CreateEngine(new HtmlRenderer());
             var result = engine.Markup(source);
@@ -89,7 +89,7 @@ P4",
         {
             var builder = new GfmEngineBuilder(new Options())
             {
-                TokenAggregator = new ParaParaAggregateToPara(),
+                TokenAggregators = ImmutableList.Create<IMarkdownTokenAggregator>(new ParaParaAggregateToPara()),
             };
             var engine = builder.CreateEngine(new HtmlRenderer());
             var result = engine.Markup(source);
@@ -110,12 +110,9 @@ P2",
         {
             var builder = new GfmEngineBuilder(new Options())
             {
-                TokenAggregator = new CompositeMarkdownTokenAggregator(
-                    new IMarkdownTokenAggregator[]
-                    {
-                        new ParaParaAggregateToPara(),
-                        new Head1HrAggregateToHead2(),
-                    }),
+                TokenAggregators = ImmutableList.Create<IMarkdownTokenAggregator>(
+                    new ParaParaAggregateToPara(),
+                    new Head1HrAggregateToHead2()),
             };
             var engine = builder.CreateEngine(new HtmlRenderer());
             var result = engine.Markup(source);


### PR DESCRIPTION
Allow user define heading id.
For example:
```md
# <a id="x"></a>Title
```
will generate following html:
```html
<h1 id="x">Title</h1>
```