### PR TITLE
Support overwrite metadata in SDP

### DIFF
--- a/Documentation/spec/docfx_document_schema.md
+++ b/Documentation/spec/docfx_document_schema.md
@@ -121,13 +121,13 @@ It defines how applications interpret the property. If not defined, the behavior
 |------------|-------------
 | `default`  | It means that no interpretion will be done to the property.
 | `uid`      | `type` MUST be `string`. With this value, the property name MUST be `uid`. It means the property defines a unique identifier inside current document model.
-| `xref`     | `type` MUST be `string`. It means the property defines a file link inside current document model. Application CAN help to validate if the linked file exists, and update the file link if the linked file changes its output path.
-| `href`     | `type` MUST be `string`. It means the property defines a UID link inside current document model. Application CAN help to validate if the linked UID exists, and resolve the UID link to the corresponding file output link.
+| `href`     | `type` MUST be `string`. It means the property defines a file link inside current document model. Application CAN help to validate if the linked file exists, and update the file link if the linked file changes its output path.
+| `xref`     | `type` MUST be `string`. It means the property defines a UID link inside current document model. Application CAN help to validate if the linked UID exists, and resolve the UID link to the corresponding file output link.
 | `file`     | `type` MUST be `string`. It means the property defines a file path inside current document model. Application CAN help to validate if the linked file exists, and resolve the path to the corresponding file output path. The difference between `file` and `href` is that `href` is always URL encoded while `file` is not.
 | `markdown` | `type` MUST be `string`. It means the property is in [DocFX flavored Markdown](..\spec\docfx_flavored_markdown.md) syntax. Application CAN help to transform it into HTML format.
 
 ### 6.4 tags
-The value of this keyword MUST be an `array`, elements of the array MUST be strings and MUST be unique. It provides hints for applications to decide how to interpret the property, for example, `localizable` tag can help Localization team to interpret the property as *localizable*; `metadata` tag can help DocFX to fill in additional metadata, e.g. github commit information.
+The value of this keyword MUST be an `array`, elements of the array MUST be strings and MUST be unique. It provides hints for applications to decide how to interpret the property, for example, `localizable` tag can help Localization team to interpret the property as *localizable*.
 
 ### 6.5 mergeType
 The value of this keyword MUST be a string. It specifies how to merge two values of the given property. One use scenario is how DocFX uses the [overwrite files](..\tutorial\intro_overwrite_files.md) to overwrite the existing values. In the below table, we use `source` and `target` to stands for the two values for merging.
@@ -219,8 +219,7 @@ Here's the schema to describe these operations:
                                     "type": "string",
                                     "contentType": "markdown"
                                 }
-                            },
-                            "tags": [ "metadata" ]
+                            }
                         }
                     },
                     "title": {

--- a/src/Microsoft.DocAsCode.Common/ConvertToObjectHelper.cs
+++ b/src/Microsoft.DocAsCode.Common/ConvertToObjectHelper.cs
@@ -62,8 +62,7 @@ namespace Microsoft.DocAsCode.Common
 
         public static object ConvertToDynamic(object obj)
         {
-            var dict = obj as Dictionary<object, object>;
-            if (dict != null)
+            if (obj is Dictionary<object, object> dict)
             {
                 var result = new ExpandoObject();
 
@@ -81,8 +80,19 @@ namespace Microsoft.DocAsCode.Common
                 return result;
             }
 
-            var array = obj as List<object>;
-            if (array != null)
+            if (obj is Dictionary<string, object> sdict)
+            {
+                var result = new ExpandoObject();
+
+                foreach (var pair in sdict)
+                {
+                    ((IDictionary<string, Object>)result).Add(pair.Key, ConvertToDynamic(pair.Value));
+                }
+
+                return result;
+            }
+
+            if (obj is List<object> array)
             {
                 for (int i = 0; i < array.Count; i++)
                 {

--- a/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/SchemaDrivenProcessorTest.cs
+++ b/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/SchemaDrivenProcessorTest.cs
@@ -79,8 +79,8 @@ namespace Microsoft.DocAsCode.Build.SchemaDriven.Tests
                 var rawModel = JsonUtility.Deserialize<JObject>(rawModelFilePath);
 
                 Assert.Equal("world", rawModel["metadata"]["hello"].ToString());
+                Assert.Equal("Hello world!", rawModel["meta"].ToString());
                 Assert.Equal("/metadata", rawModel["metadata"]["path"].ToString());
-                Assert.Equal("/sections/0/children/1", rawModel["sections"][0]["children"][1]["path"].ToString());
                 Assert.Equal($"<p sourcefile=\"{_inputFolder}/landingPage1.yml\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\">Create an application using <a href=\"app-service-web-tutorial-dotnet-sqldatabase.md\" data-raw-source=\"[.NET with Azure SQL DB](app-service-web-tutorial-dotnet-sqldatabase.md)\" sourcefile=\"{_inputFolder}/landingPage1.yml\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\">.NET with Azure SQL DB</a> or <a href=\"app-service-web-tutorial-nodejs-mongodb-app.md\" data-raw-source=\"[Node.js with MongoDB](app-service-web-tutorial-nodejs-mongodb-app.md)\" sourcefile=\"{_inputFolder}/landingPage1.yml\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\">Node.js with MongoDB</a></p>\n"
                                 , rawModel["sections"][1]["children"][0]["content"].ToString());
 
@@ -116,6 +116,7 @@ searchScope:
                 Assert.True(File.Exists(rawModelFilePath));
                 var rawModel = JsonUtility.Deserialize<JObject>(rawModelFilePath);
 
+                Assert.Equal("Hello world!", rawModel["meta"].ToString());
                 Assert.Equal("/absolute/toc.json", rawModel["breadcrumb_path"].ToString());
                 Assert.Equal("../a b/toc.md", rawModel["toc_rel"].ToString());
                 Assert.Equal("MSDocsHeader-DotNet", rawModel["uhfHeaderId"].ToString());
@@ -134,6 +135,7 @@ searchScope:
                 Assert.True(File.Exists(rawModelFilePath));
                 rawModel = JsonUtility.Deserialize<JObject>(rawModelFilePath);
 
+                Assert.Equal("Hello world!", rawModel["meta"].ToString());
                 Assert.Equal("/absolute/toc.json", rawModel["breadcrumb_path"].ToString());
                 Assert.Equal("../a%20b/toc.json", rawModel["toc_rel"].ToString());
                 Assert.Equal("MSDocsHeader-DotNet", rawModel["uhfHeaderId"].ToString());


### PR DESCRIPTION
Also remove `metadata` description from documentation, `metadata` should always be added to the root object, use Tag makes things much more complex