### PR TITLE
Remove unneccesory references

### DIFF
--- a/plugins/Microsoft.DocAsCode.Build.JavaScriptReference/Microsoft.DocAsCode.Build.JavaScriptReference.csproj
+++ b/plugins/Microsoft.DocAsCode.Build.JavaScriptReference/Microsoft.DocAsCode.Build.JavaScriptReference.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="5.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">

--- a/plugins/Microsoft.DocAsCode.Build.MemberLevelManagedReference/Microsoft.DocAsCode.Build.MemberLevelManagedReference.csproj
+++ b/plugins/Microsoft.DocAsCode.Build.MemberLevelManagedReference/Microsoft.DocAsCode.Build.MemberLevelManagedReference.csproj
@@ -6,11 +6,7 @@
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </None>
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-  </ItemGroup>
-
+  
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/plugins/Microsoft.DocAsCode.Build.MergeOverwrite/Microsoft.DocAsCode.Build.MergeOverwrite.csproj
+++ b/plugins/Microsoft.DocAsCode.Build.MergeOverwrite/Microsoft.DocAsCode.Build.MergeOverwrite.csproj
@@ -1,10 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\src\Shared\base.props" />
 
-  <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/plugins/Microsoft.DocAsCode.Build.OperationLevelRestApi/Microsoft.DocAsCode.Build.OperationLevelRestApi.csproj
+++ b/plugins/Microsoft.DocAsCode.Build.OperationLevelRestApi/Microsoft.DocAsCode.Build.OperationLevelRestApi.csproj
@@ -11,10 +11,6 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/plugins/Microsoft.DocAsCode.Build.TagLevelRestApi/Microsoft.DocAsCode.Build.TagLevelRestApi.csproj
+++ b/plugins/Microsoft.DocAsCode.Build.TagLevelRestApi/Microsoft.DocAsCode.Build.TagLevelRestApi.csproj
@@ -7,10 +7,6 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/plugins/Microsoft.DocAsCode.Build.UniversalReference/Microsoft.DocAsCode.Build.UniversalReference.csproj
+++ b/plugins/Microsoft.DocAsCode.Build.UniversalReference/Microsoft.DocAsCode.Build.UniversalReference.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="5.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System.Web" />

--- a/src/Microsoft.DocAsCode.AzureMarkdownRewriters/Microsoft.DocAsCode.AzureMarkdownRewriters.csproj
+++ b/src/Microsoft.DocAsCode.AzureMarkdownRewriters/Microsoft.DocAsCode.AzureMarkdownRewriters.csproj
@@ -6,10 +6,6 @@
     <ProjectReference Include="..\Microsoft.DocAsCode.MarkdownLite\Microsoft.DocAsCode.MarkdownLite.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Microsoft.DocAsCode.Build.Common/Microsoft.DocAsCode.Build.Common.csproj
+++ b/src/Microsoft.DocAsCode.Build.Common/Microsoft.DocAsCode.Build.Common.csproj
@@ -9,11 +9,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">

--- a/src/Microsoft.DocAsCode.Build.ConceptualDocuments/Microsoft.DocAsCode.Build.ConceptualDocuments.csproj
+++ b/src/Microsoft.DocAsCode.Build.ConceptualDocuments/Microsoft.DocAsCode.Build.ConceptualDocuments.csproj
@@ -9,9 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
-    <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">

--- a/src/Microsoft.DocAsCode.Build.Engine/Microsoft.DocAsCode.Build.Engine.csproj
+++ b/src/Microsoft.DocAsCode.Build.Engine/Microsoft.DocAsCode.Build.Engine.csproj
@@ -14,13 +14,8 @@
 
   <ItemGroup>
     <PackageReference Include="DotLiquid" Version="2.0.145" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
     <PackageReference Include="Jint" Version="2.5.0" />
-    <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Nustache" Version="1.15.3.5" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">

--- a/src/Microsoft.DocAsCode.Build.ManagedReference/Microsoft.DocAsCode.Build.ManagedReference.csproj
+++ b/src/Microsoft.DocAsCode.Build.ManagedReference/Microsoft.DocAsCode.Build.ManagedReference.csproj
@@ -9,13 +9,6 @@
     <ProjectReference Include="..\Microsoft.DocAsCode.YamlSerialization\Microsoft.DocAsCode.YamlSerialization.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Microsoft.DocAsCode.Build.ResourceFiles/Microsoft.DocAsCode.Build.ResourceFiles.csproj
+++ b/src/Microsoft.DocAsCode.Build.ResourceFiles/Microsoft.DocAsCode.Build.ResourceFiles.csproj
@@ -8,11 +8,6 @@
     <ProjectReference Include="..\Microsoft.DocAsCode.Plugins\Microsoft.DocAsCode.Plugins.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Microsoft.DocAsCode.Build.RestApi/Microsoft.DocAsCode.Build.RestApi.csproj
+++ b/src/Microsoft.DocAsCode.Build.RestApi/Microsoft.DocAsCode.Build.RestApi.csproj
@@ -9,13 +9,6 @@
     <ProjectReference Include="..\Microsoft.DocAsCode.Plugins\Microsoft.DocAsCode.Plugins.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Microsoft.DocAsCode.Build.SchemaDriven/Microsoft.DocAsCode.Build.SchemaDriven.csproj
+++ b/src/Microsoft.DocAsCode.Build.SchemaDriven/Microsoft.DocAsCode.Build.SchemaDriven.csproj
@@ -15,10 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json.Schema" Version="2.0.10" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
-    <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
+    <PackageReference Include="Newtonsoft.Json.Schema" Version="2.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DocAsCode.Build.TableOfContents/Microsoft.DocAsCode.Build.TableOfContents.csproj
+++ b/src/Microsoft.DocAsCode.Build.TableOfContents/Microsoft.DocAsCode.Build.TableOfContents.csproj
@@ -11,13 +11,6 @@
     <ProjectReference Include="..\Microsoft.DocAsCode.YamlSerialization\Microsoft.DocAsCode.YamlSerialization.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="System.Web" />

--- a/src/Microsoft.DocAsCode.Common/Microsoft.DocAsCode.Common.csproj
+++ b/src/Microsoft.DocAsCode.Common/Microsoft.DocAsCode.Common.csproj
@@ -6,12 +6,6 @@
     <ProjectReference Include="..\Microsoft.DocAsCode.YamlSerialization\Microsoft.DocAsCode.YamlSerialization.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System.Xml" />
     <Reference Include="System" />

--- a/src/Microsoft.DocAsCode.DataContracts.Common/Microsoft.DocAsCode.DataContracts.Common.csproj
+++ b/src/Microsoft.DocAsCode.DataContracts.Common/Microsoft.DocAsCode.DataContracts.Common.csproj
@@ -5,11 +5,6 @@
     <ProjectReference Include="..\Microsoft.DocAsCode.Common\Microsoft.DocAsCode.Common.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />

--- a/src/Microsoft.DocAsCode.DataContracts.ManagedReference/Microsoft.DocAsCode.DataContracts.ManagedReference.csproj
+++ b/src/Microsoft.DocAsCode.DataContracts.ManagedReference/Microsoft.DocAsCode.DataContracts.ManagedReference.csproj
@@ -7,10 +7,6 @@
     <ProjectReference Include="..\Microsoft.DocAsCode.YamlSerialization\Microsoft.DocAsCode.YamlSerialization.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Microsoft.DocAsCode.DataContracts.RestApi/Microsoft.DocAsCode.DataContracts.RestApi.csproj
+++ b/src/Microsoft.DocAsCode.DataContracts.RestApi/Microsoft.DocAsCode.DataContracts.RestApi.csproj
@@ -7,10 +7,6 @@
     <ProjectReference Include="..\Microsoft.DocAsCode.YamlSerialization\Microsoft.DocAsCode.YamlSerialization.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Microsoft.DocAsCode.Dfm/Microsoft.DocAsCode.Dfm.csproj
+++ b/src/Microsoft.DocAsCode.Dfm/Microsoft.DocAsCode.Dfm.csproj
@@ -10,10 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
-    <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Microsoft.DocAsCode.Metadata.ManagedReference.csproj
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Microsoft.DocAsCode.Metadata.ManagedReference.csproj
@@ -13,6 +13,27 @@
     <ProjectReference Include="..\Microsoft.DocAsCode.Plugins\Microsoft.DocAsCode.Plugins.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="2.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Features" Version="2.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="2.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="2.2.0" />
+    <PackageReference Include="Microsoft.DotNet.ProjectModel.Workspaces" Version="1.0.0-preview2-003121" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
+    <PackageReference Include="Microsoft.Build" Version="15.1.548" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.1.548" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.5.24" />
+    <PackageReference Include="Microsoft.DotNet.ProjectModel.Workspaces" Version="1.0.0-preview2-003121" />
+    <PackageReference Include="Microsoft.VisualStudio.RemoteControl" Version="14.0.262-masterA5CACE98" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Web" />

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Microsoft.DocAsCode.Metadata.ManagedReference.csproj
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Microsoft.DocAsCode.Metadata.ManagedReference.csproj
@@ -13,26 +13,6 @@
     <ProjectReference Include="..\Microsoft.DocAsCode.Plugins\Microsoft.DocAsCode.Plugins.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="2.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Features" Version="2.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="2.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="2.2.0" />
-    <PackageReference Include="Microsoft.DotNet.ProjectModel.Workspaces" Version="1.0.0-preview2-003121" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Build" Version="15.1.548" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.1.548" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.5.24" />
-    <PackageReference Include="Microsoft.VisualStudio.RemoteControl" Version="14.0.262-masterA5CACE98" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Web" />

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -30,7 +30,6 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="1.9.71" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Owin" Version="1.0.0" />
     <PackageReference Include="Microsoft.Owin" Version="3.0.1" />
     <PackageReference Include="Microsoft.Owin.FileSystems" Version="3.0.1" />

--- a/test/Microsoft.DocAsCode.Build.Common.Tests/Microsoft.DocAsCode.Build.Common.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Build.Common.Tests/Microsoft.DocAsCode.Build.Common.Tests.csproj
@@ -1,14 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Shared\test.base.props" />
 
-  <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/test/Microsoft.DocAsCode.Build.ConceptualDocuments.Tests/Microsoft.DocAsCode.Build.ConceptualDocuments.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Build.ConceptualDocuments.Tests/Microsoft.DocAsCode.Build.ConceptualDocuments.Tests.csproj
@@ -1,14 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Shared\test.base.props" />
 
-  <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="System.Web" />

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/Microsoft.DocAsCode.Build.Engine.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/Microsoft.DocAsCode.Build.Engine.Tests.csproj
@@ -11,14 +11,6 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/test/Microsoft.DocAsCode.Build.RestApi.Tests/Microsoft.DocAsCode.Build.RestApi.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Build.RestApi.Tests/Microsoft.DocAsCode.Build.RestApi.Tests.csproj
@@ -7,14 +7,6 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/Microsoft.DocAsCode.Build.SchemaDriven.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/Microsoft.DocAsCode.Build.SchemaDriven.Tests.csproj
@@ -4,14 +4,6 @@
   </PropertyGroup>
   <Import Project="..\Shared\test.base.props" />
 
-  <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="System.Web" />

--- a/test/Microsoft.DocAsCode.Build.TableOfContents.Tests/Microsoft.DocAsCode.Build.TableOfContents.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Build.TableOfContents.Tests/Microsoft.DocAsCode.Build.TableOfContents.Tests.csproj
@@ -1,14 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Shared\test.base.props" />
 
-  <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="System.Web" />

--- a/test/Microsoft.DocAsCode.Common.Tests/Microsoft.DocAsCode.Common.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Common.Tests/Microsoft.DocAsCode.Common.Tests.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Shared\test.base.props" />
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/test/Microsoft.DocAsCode.Dfm.Tests/Microsoft.DocAsCode.Dfm.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Dfm.Tests/Microsoft.DocAsCode.Dfm.Tests.csproj
@@ -1,14 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Shared\test.base.props" />
 
-  <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/test/Microsoft.DocAsCode.MarkdownLite.Tests/Microsoft.DocAsCode.MarkdownLite.Tests.csproj
+++ b/test/Microsoft.DocAsCode.MarkdownLite.Tests/Microsoft.DocAsCode.MarkdownLite.Tests.csproj
@@ -1,14 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Shared\test.base.props" />
 
-  <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/test/Microsoft.DocAsCode.MarkdownRewriters.Tests/Microsoft.DocAsCode.MarkdownRewriters.Tests.csproj
+++ b/test/Microsoft.DocAsCode.MarkdownRewriters.Tests/Microsoft.DocAsCode.MarkdownRewriters.Tests.csproj
@@ -1,10 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Shared\test.base.props" />
 
-  <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/Microsoft.DocAsCode.Metadata.ManagedReference.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/Microsoft.DocAsCode.Metadata.ManagedReference.Tests.csproj
@@ -7,21 +7,6 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="2.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="2.2.0" />
-    <PackageReference Include="Microsoft.DotNet.ProjectModel.Workspaces" Version="1.0.0-preview2-003121" />
-    <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
-    <PackageReference Include="Microsoft.Build" Version="15.1.548" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.1.548" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/test/Microsoft.DocAsCode.Plugins.Tests/Microsoft.DocAsCode.Plugins.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Plugins.Tests/Microsoft.DocAsCode.Plugins.Tests.csproj
@@ -1,10 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Shared\test.base.props" />
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/test/Microsoft.DocAsCode.Tests.Common/Microsoft.DocAsCode.Tests.Common.csproj
+++ b/test/Microsoft.DocAsCode.Tests.Common/Microsoft.DocAsCode.Tests.Common.csproj
@@ -1,13 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Shared\test.base.props" />
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="YamlDotNet.Signed" Version="4.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/test/docfx.Tests/docfx.Tests.csproj
+++ b/test/docfx.Tests/docfx.Tests.csproj
@@ -7,11 +7,6 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/tools/AzureMarkdownRewriterTool/AzureMarkdownRewriterTool.csproj
+++ b/tools/AzureMarkdownRewriterTool/AzureMarkdownRewriterTool.csproj
@@ -5,11 +5,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/tools/DfmHttpService/DfmHttpService.csproj
+++ b/tools/DfmHttpService/DfmHttpService.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="CsQuery" Version="1.3.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">

--- a/tools/MergeDeveloperComments/MergeDeveloperComments.csproj
+++ b/tools/MergeDeveloperComments/MergeDeveloperComments.csproj
@@ -5,10 +5,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
     <Reference Include="System.Runtime" />
     <Reference Include="System" />


### PR DESCRIPTION
There is no need to include all the packageReferences in the new version of csproj as long as the referenced project contains the packageReference