### PR TITLE
Change the format to json object instead

### DIFF
--- a/Documentation/spec/docfx_document_schema.md
+++ b/Documentation/spec/docfx_document_schema.md
@@ -55,7 +55,7 @@ This is the root document object for *THIS schema*.
 | description     | string  | A short description of current schema.
 | type            | string | `*`The type of the root document model MUST be `object`.
 | properties      | [Property Definitions Object](#property-definitions-object) | An object to hold the schema of all the properties.
-| metadata        | string | In `JSON pointer` format as defined by https://tools.ietf.org/html/rfc6901, referencing to the metadata object. Metadata object is the object to define the metadata for current document, and can be also set through `globalMetadata` or `fileMetadata` in DocFX. The default value for metadata is empty which stands for the root object.
+| metadata        | string | In `json-pointer` format as defined in http://json-schema.org/latest/json-schema-validation.html#rfc.section.8.3.9. The format for JSON pointer is defined by https://tools.ietf.org/html/rfc6901, referencing to the metadata object. Metadata object is the object to define the metadata for current document, and can be also set through `globalMetadata` or `fileMetadata` in DocFX. The default value for metadata is empty which stands for the root object.
 
 ##### Patterned Field
 | Field Name | Type | Description

--- a/schemas/v1.0/schema.json
+++ b/schemas/v1.0/schema.json
@@ -118,7 +118,7 @@
         "properties": { "$ref": "#/definitions/propertyDefinition" },
         "metadata": {
             "type": "string",
-            "format": "uri-reference"
+            "format": "JSON-pointer"
         },
         "patternProperties": {
             "^x_": { }

--- a/schemas/v1.0/schema.json
+++ b/schemas/v1.0/schema.json
@@ -118,7 +118,7 @@
         "properties": { "$ref": "#/definitions/propertyDefinition" },
         "metadata": {
             "type": "string",
-            "format": "JSON-pointer"
+            "format": "json-pointer"
         },
         "patternProperties": {
             "^x_": { }


### PR DESCRIPTION
as for 'uri-reference', `#` means current document, however current document is the schema instead of the actual document, change it to `JSON-pointer` so that the value is actually the pointer to the actual document object, for example `#/definition/` references to the `definition` section defined in this schema. while we'd like `#/metadata` to point to the input object model.