### PR TITLE
Improve build log when parsing invalid YAML front-matter

### DIFF
--- a/src/Microsoft.DocAsCode.Common/Loggers/WarningCodes.cs
+++ b/src/Microsoft.DocAsCode.Common/Loggers/WarningCodes.cs
@@ -24,6 +24,7 @@ namespace Microsoft.DocAsCode.Common
             public const string InvalidInclude = "InvalidInclude";
             public const string InvalidCodeSnippet = "InvalidCodeSnippet";
             public const string InvalidInlineCodeSnippet = "InvalidInlineCodeSnippet";
+            public const string InvalidYamlHeader = "InvalidYamlHeader";
             public const string NoVisibleTab = "NoVisibleTab";
         }
     }

--- a/src/Microsoft.DocAsCode.Dfm/Rules/DfmYamlHeaderBlockRule.cs
+++ b/src/Microsoft.DocAsCode.Dfm/Rules/DfmYamlHeaderBlockRule.cs
@@ -11,6 +11,7 @@ namespace Microsoft.DocAsCode.Dfm
     using Microsoft.DocAsCode.Common;
     using Microsoft.DocAsCode.MarkdownLite;
     using Microsoft.DocAsCode.MarkdownLite.Matchers;
+    using YamlDotNet.Core;
 
     public class DfmYamlHeaderBlockRule : IMarkdownRule
     {
@@ -58,9 +59,14 @@ namespace Microsoft.DocAsCode.Dfm
                         }
                     }
                 }
+                catch (YamlException invalidYamlHeaderException)
+                {
+                    Logger.LogWarning($"Invalid yaml header: {invalidYamlHeaderException.Message}", file: context.File, line: context.LineNumber.ToString());
+                    return null;
+                }
                 catch (Exception)
                 {
-                    Logger.LogInfo("Invalid yaml header.", file: context.File, line: context.LineNumber.ToString());
+                    Logger.LogWarning("Invalid yaml header.", file: context.File, line: context.LineNumber.ToString());
                     return null;
                 }
                 var sourceInfo = context.Consume(match.Length);
@@ -92,9 +98,14 @@ namespace Microsoft.DocAsCode.Dfm
                     }
                 }
             }
+            catch (YamlException invalidYamlHeaderException)
+            {
+                Logger.LogWarning($"Invalid yaml header: {invalidYamlHeaderException.Message}", file: context.File, line: context.LineNumber.ToString());
+                return null;
+            }
             catch (Exception)
             {
-                Logger.LogInfo("Invalid yaml header.", file: context.File, line: context.LineNumber.ToString());
+                Logger.LogWarning("Invalid yaml header.", file: context.File, line: context.LineNumber.ToString());
                 return null;
             }
             var sourceInfo = context.Consume(match.Length);

--- a/src/Microsoft.DocAsCode.Dfm/Rules/DfmYamlHeaderBlockRule.cs
+++ b/src/Microsoft.DocAsCode.Dfm/Rules/DfmYamlHeaderBlockRule.cs
@@ -61,12 +61,12 @@ namespace Microsoft.DocAsCode.Dfm
                 }
                 catch (YamlException invalidYamlHeaderException)
                 {
-                    Logger.LogWarning($"Invalid yaml header: {invalidYamlHeaderException.Message}", file: context.File, line: context.LineNumber.ToString());
+                    Logger.LogWarning($"Invalid yaml header: {invalidYamlHeaderException.Message}", file: context.File, line: context.LineNumber.ToString(), code: WarningCodes.Markdown.InvalidYamlHeader);
                     return null;
                 }
                 catch (Exception)
                 {
-                    Logger.LogWarning("Invalid yaml header.", file: context.File, line: context.LineNumber.ToString());
+                    Logger.LogWarning("Invalid yaml header.", file: context.File, line: context.LineNumber.ToString(), code: WarningCodes.Markdown.InvalidYamlHeader);
                     return null;
                 }
                 var sourceInfo = context.Consume(match.Length);
@@ -100,12 +100,12 @@ namespace Microsoft.DocAsCode.Dfm
             }
             catch (YamlException invalidYamlHeaderException)
             {
-                Logger.LogWarning($"Invalid yaml header: {invalidYamlHeaderException.Message}", file: context.File, line: context.LineNumber.ToString());
+                Logger.LogWarning($"Invalid yaml header: {invalidYamlHeaderException.Message}", file: context.File, line: context.LineNumber.ToString(), code: WarningCodes.Markdown.InvalidYamlHeader);
                 return null;
             }
             catch (Exception)
             {
-                Logger.LogWarning("Invalid yaml header.", file: context.File, line: context.LineNumber.ToString());
+                Logger.LogWarning("Invalid yaml header.", file: context.File, line: context.LineNumber.ToString(), code: WarningCodes.Markdown.InvalidYamlHeader);
                 return null;
             }
             var sourceInfo = context.Consume(match.Length);


### PR DESCRIPTION
Hi.

Currently, if YAML front-matter in a MarkDown document is invalid, the  resulting message is logged as `Information` instead of `Warning`, and does not contain any information about _why_ the YAML is invalid.

This PR makes the message a warning message (since as an informational one, it's too easy to miss), and includes the YAML parser error message (provided the parser exception is a `YamlException`).

Please let me know if I've missed anything,

Adam.