### PR TITLE
workaround: temporarily disable loading of overwrite documents in SDP

### DIFF
--- a/src/Microsoft.DocAsCode.Build.SchemaDriven/SchemaDrivenDocumentProcessor.cs
+++ b/src/Microsoft.DocAsCode.Build.SchemaDriven/SchemaDrivenDocumentProcessor.cs
@@ -78,12 +78,13 @@ namespace Microsoft.DocAsCode.Build.SchemaDriven
                     }
 
                     break;
-                case DocumentType.Overwrite:
-                    if (".md".Equals(Path.GetExtension(file.File), StringComparison.OrdinalIgnoreCase))
-                    {
-                        return ProcessingPriority.Normal;
-                    }
-                    break;
+                // temporarily disable loading of overwrite documents in SDP
+                //case DocumentType.Overwrite:
+                //    if (".md".Equals(Path.GetExtension(file.File), StringComparison.OrdinalIgnoreCase))
+                //    {
+                //        return ProcessingPriority.Normal;
+                //    }
+                //    break;
                 default:
                     break;
             }

--- a/src/Microsoft.DocAsCode.Build.SchemaDriven/SchemaDrivenDocumentProcessor.cs
+++ b/src/Microsoft.DocAsCode.Build.SchemaDriven/SchemaDrivenDocumentProcessor.cs
@@ -79,6 +79,7 @@ namespace Microsoft.DocAsCode.Build.SchemaDriven
 
                     break;
                 // temporarily disable loading of overwrite documents in SDP
+                // TODO: reenable processing of overwrite documents in SDP
                 //case DocumentType.Overwrite:
                 //    if (".md".Equals(Path.GetExtension(file.File), StringComparison.OrdinalIgnoreCase))
                 //    {


### PR DESCRIPTION
@vwxyzh @vicancy @hellosnow @superyyrrzz 
temporarily disable loading of overwrite documents in SDP:
1. avoid postbuild error in ApplyTags
2. workaround performance issue of processing overwrite documents multiple times