### PR TITLE
workaround: temporarily disable schema validation

### DIFF
--- a/src/Microsoft.DocAsCode.Build.SchemaDriven/SchemaDrivenDocumentProcessor.cs
+++ b/src/Microsoft.DocAsCode.Build.SchemaDriven/SchemaDrivenDocumentProcessor.cs
@@ -102,7 +102,9 @@ namespace Microsoft.DocAsCode.Build.SchemaDriven
                         var obj = YamlUtility.Deserialize<Dictionary<string, object>>(file.File);
 
                         // Validate against the schema first
-                        _schemaValidator.Validate(obj);
+                        // Temporarily disable schema validation as Json.NET schema has limitation of 1000 calls per hour
+                        // TODO: Reenable schema validation
+                        // _schemaValidator.Validate(obj);
 
                         var content = ConvertToObjectHelper.ConvertToDynamic(obj);
                         var pageMetadata = _schema.MetadataReference.GetValue(content) as IDictionary<string, object>;

--- a/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/SchemaDrivenProcessorTest.cs
+++ b/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/SchemaDrivenProcessorTest.cs
@@ -333,7 +333,7 @@ title: Web Apps Documentation
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Temporarily disable schema validation as Json.NET schema has limitation of 1000 calls per hour")]
         public void TestInvalidObjectAgainstSchema()
         {
             using (var listener = new TestListenerScope("TestInvalidMetadataReference"))


### PR DESCRIPTION
@vwxyzh @vicancy @hellosnow @superyyrrzz 
Temporarily disable schema validation as Json.NET schema has limitation of 1000 calls per hour.