### PR TITLE
Bugfix #2111 html-id for headers are not unique

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/MarkdownProviders/DfmServiceProvider.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/MarkdownProviders/DfmServiceProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DocAsCode.Build.Engine
 
         protected virtual bool LegacyMode => false;
 
-        protected virtual bool ShouldFixId { get; set; }
+        protected virtual bool ShouldFixId { get; set; } = true;
 
         [ImportMany]
         public IEnumerable<IMarkdownTokenTreeValidator> TokenTreeValidator { get; set; } = Enumerable.Empty<IMarkdownTokenTreeValidator>();


### PR DESCRIPTION
This fixes #2111 

To generate unique html-ids for headers, the property `ShouldFixId` in the `Options` in the `DfmService` has to be set to true. The default value for this property is true. This value is overwritten with the value of the `DfmServiceProvider`.

In `DfmServiceProvider`, the value of `ShouldFixId` is only set to true if it is set via `markdownEngineProperties`. But the assignment statement implies that the default value here should be true aswell. But the default value is still false in the current implementation.
```C#
ShouldFixId = obj as bool? ?? true;
```
The change only sets the default value of the `ShouldFixId` property to true.