### PR TITLE
Fix the netstandard framework name in the docs

### DIFF
--- a/Documentation/tutorial/docfx.exe_user_manual.md
+++ b/Documentation/tutorial/docfx.exe_user_manual.md
@@ -191,7 +191,7 @@ properties               |  Defines an optional set of MSBuild properties used w
       "dest": "obj/docfx/api/dotnet",
       "shouldSkipMarkup": true,
       "properties": {
-          "TargetFramework": "netstardard1.3"
+          "TargetFramework": "netstandard1.3"
       }
     },
     {


### PR DESCRIPTION
Just a small typo (but it was actually tripping me up, because I copy-pasted it and it wasn't working ^^).