### PR TITLE
Fix serializable bug when using plugins during pdf generation

### DIFF
--- a/src/docfx/Models/PdfJsonConfig.cs
+++ b/src/docfx/Models/PdfJsonConfig.cs
@@ -3,10 +3,12 @@
 
 namespace Microsoft.DocAsCode
 {
+    using System;
     using System.Collections.Generic;
 
     using Newtonsoft.Json;
 
+    [Serializable]
     public class PdfJsonConfig : BuildJsonConfig
     {
         [JsonProperty("name")]


### PR DESCRIPTION
Building pdfs is not working when using plugins (for example: rest.tagpage) because PdfJsonConfig is not serializable. After this change, pdf file was generated correctly using the plugin and without any errors. Bug similar to https://github.com/dotnet/docfx/pull/1235

**Stacktrace:**
```[17-11-20 06:28:25.443]Info:[PdfCommand]Completed Scope:PdfCommand in 394,4189 milliseconds.
[17-11-20 06:28:25.446]Error:System.Runtime.Serialization.SerializationException: Der Typ "Microsoft.DocAsCode.PdfJsonConfig" in Assembly "docfx, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" ist nicht als serialisierbar gekennzeichnet.
   bei System.AppDomain.DoCallBack(CrossAppDomainDelegate callBackDelegate)
   bei Microsoft.DocAsCode.SubCommands.BuildCommand.BuildDocumentWithPlugin(BuildJsonConfig config, TemplateManager manager, String baseDirectory, String outputDirectory, String applicationBaseDirectory, String pluginDirectory, String templateDirectory) in C:\Users\Dominik\Development\docfx\src\docfx\SubCommands\BuildCommand.cs:Zeile 521.
   bei Microsoft.DocAsCode.SubCommands.BuildCommand.BuildDocument(String baseDirectory, String outputDirectory) in C:\Users\Dominik\Development\docfx\src\docfx\SubCommands\BuildCommand.cs:Zeile 466.
   bei Microsoft.DocAsCode.SubCommands.BuildCommand.Exec(SubCommandRunningContext context) in C:\Users\Dominik\Development\docfx\src\docfx\SubCommands\BuildCommand.cs:Zeile 59.
   bei Microsoft.DocAsCode.SubCommands.PdfCommand.Exec(SubCommandRunningContext context) in C:\Users\Dominik\Development\docfx\src\docfx\SubCommands\PdfCommand.cs:Zeile 76.
   bei Microsoft.DocAsCode.SubCommands.CompositeCommand.Exec(SubCommandRunningContext context) in C:\Users\Dominik\Development\docfx\src\docfx\SubCommands\CompositeCommand.cs:Zeile 46.
   bei Microsoft.DocAsCode.Program.ExecSubCommand(String[] args) in C:\Users\Dominik\Development\docfx\src\docfx\Program.cs:Zeile 89.
[17-11-20 06:28:25.446]Info:Completed in 400,1082 milliseconds

Build failed.
```