### PR TITLE
Fix issue running under netcore 2.0

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/MsBuildEnvironmentScope.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/MsBuildEnvironmentScope.cs
@@ -5,30 +5,81 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
     using System.Linq;
+    using System.Text.RegularExpressions;
 
     using Microsoft.Build.MSBuildLocator;
     using Microsoft.DocAsCode.Common;
 
     public class MSBuildEnvironmentScope : IDisposable
     {
+        private static readonly Regex DotnetBasePathRegex = new Regex("Base Path:(.*)$", RegexOptions.Compiled | RegexOptions.Multiline);
         private readonly EnvironmentScope _innerScope;
 
         public MSBuildEnvironmentScope()
         {
-            // workaround for https://github.com/dotnet/docfx/issues/1969
-            // FYI https://github.com/dotnet/roslyn/issues/21799#issuecomment-343695700
-            var instances = MSBuildLocator.QueryVisualStudioInstances();
-            var latest = instances.FirstOrDefault(a => a.Version.Major == 15);
-            if (latest != null)
+            // workaround for https://github.com/dotnet/docfx/issues/1752
+            var instances = MSBuildLocator.QueryVisualStudioInstances().ToList();
+            if (instances.Count == 0)
             {
-                Logger.LogInfo($"Using msbuild {latest.MSBuildPath} as inner compiler.");
-
-                _innerScope = new EnvironmentScope(new Dictionary<string, string>
+                // when no visual studio installed, try detect dotnet
+                var dotnetBasePath = GetDotnetBasePath();
+                if (dotnetBasePath != null)
                 {
-                    ["VSINSTALLDIR"] = latest.VisualStudioRootPath,
-                    ["VisualStudioVersion"] = "15.0"
-                });
+                    Logger.LogInfo($"Using dotnet {dotnetBasePath} as inner comipiler.");
+                    _innerScope = new EnvironmentScope(new Dictionary<string, string>
+                    {
+                        ["MSBuild_EXE_PATH"] = dotnetBasePath + "MSBuild.dll",
+                        ["MSBuildExtensionsPath"] = dotnetBasePath,
+                        ["MSBuildSDKsPath"] = dotnetBasePath + "Sdks"
+                    });
+                }
+            }
+            else
+            {
+                // workaround for https://github.com/dotnet/docfx/issues/1969
+                // FYI https://github.com/dotnet/roslyn/issues/21799#issuecomment-343695700
+                var latest = instances.FirstOrDefault(a => a.Version.Major == 15);
+                if (latest != null)
+                {
+                    Logger.LogInfo($"Using msbuild {latest.MSBuildPath} as inner comipiler.");
+
+                    _innerScope = new EnvironmentScope(new Dictionary<string, string>
+                    {
+                        ["VSINSTALLDIR"] = latest.VisualStudioRootPath,
+                        ["VisualStudioVersion"] = "15.0"
+                    });
+                }
+            }
+        }
+
+        private string GetDotnetBasePath()
+        {
+            using (var outputStream = new MemoryStream())
+            {
+                using (var outputStreamWriter = new StreamWriter(outputStream))
+                {
+                        var exitCode = CommandUtility.RunCommand(new CommandInfo
+                        {
+                            Name = "dotnet",
+                            Arguments = "--info"
+                        }, outputStreamWriter, timeoutInMilliseconds: 60000);
+
+                    // writer streams have to be flushed before reading from memory streams
+                    // make sure that streamwriter is not closed before reading from memory stream
+                    outputStreamWriter.Flush();
+
+                    var outputString = System.Text.Encoding.UTF8.GetString(outputStream.ToArray());
+
+                    var matched = DotnetBasePathRegex.Match(outputString);
+                    if (matched.Success)
+                    {
+                        return matched.Groups[1].Value.Trim();
+                    }
+
+                    return null;
+                }
             }
         }
 

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/MsBuildEnvironmentScope.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/MsBuildEnvironmentScope.cs
@@ -60,11 +60,19 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             {
                 using (var outputStreamWriter = new StreamWriter(outputStream))
                 {
-                        var exitCode = CommandUtility.RunCommand(new CommandInfo
+                    try
+                    {
+                        CommandUtility.RunCommand(new CommandInfo
                         {
                             Name = "dotnet",
                             Arguments = "--info"
                         }, outputStreamWriter, timeoutInMilliseconds: 60000);
+                    }
+                    catch
+                    {
+                        // when error running dotnet command, consilder dotnet as not available
+                        return null;
+                    }
 
                     // writer streams have to be flushed before reading from memory streams
                     // make sure that streamwriter is not closed before reading from memory stream

--- a/src/docfx/app.config
+++ b/src/docfx/app.config
@@ -1,5 +1,49 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+  <configSections>
+    <section name="msbuildToolsets" type="Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  </configSections>
+  <!-- To define one or more new toolsets, add an 'msbuildToolsets' element in this file. -->
+  <msbuildToolsets default="15.0">
+    <toolset toolsVersion="15.0">
+      <property name="MSBuildToolsPath" value="$([MSBuild]::GetCurrentToolsDirectory())" />
+      <property name="MSBuildToolsPath32" value="$([MSBuild]::GetToolsDirectory32())" />
+      <property name="MSBuildToolsPath64" value="$([MSBuild]::GetToolsDirectory64())" />
+      <property name="MSBuildSDKsPath" value="$([MSBuild]::GetMSBuildSDKsPath())" />
+      <property name="FrameworkSDKRoot" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.6.1@InstallationFolder)" />
+      <property name="MSBuildRuntimeVersion" value="4.0.30319" />
+      <property name="MSBuildFrameworkToolsPath" value="$(SystemRoot)\Microsoft.NET\Framework\v$(MSBuildRuntimeVersion)\" />
+      <property name="MSBuildFrameworkToolsPath32" value="$(SystemRoot)\Microsoft.NET\Framework\v$(MSBuildRuntimeVersion)\" />
+      <property name="MSBuildFrameworkToolsPath64" value="$(SystemRoot)\Microsoft.NET\Framework64\v$(MSBuildRuntimeVersion)\" />
+      <property name="MSBuildFrameworkToolsRoot" value="$(SystemRoot)\Microsoft.NET\Framework\" />
+      <property name="SDK35ToolsPath" value="$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.0A\WinSDK-NetFx35Tools-x86', 'InstallationFolder', null, RegistryView.Registry32))" />
+      <property name="SDK40ToolsPath" value="$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.6.1\WinSDK-NetFx40Tools-x86', 'InstallationFolder', null, RegistryView.Registry32))" />
+      <property name="WindowsSDK80Path" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.1@InstallationFolder)" />
+      <property name="VsInstallRoot" value="$([MSBuild]::GetVsInstallRoot())" />
+      <property name="MSBuildToolsRoot" value="$(VsInstallRoot)\MSBuild" />
+      <property name="MSBuildExtensionsPath" value="$([MSBuild]::GetMSBuildExtensionsPath())" />
+      <property name="MSBuildExtensionsPath32" value="$([MSBuild]::GetMSBuildExtensionsPath())" />
+
+      <property name="RoslynTargetsPath" value="$([MSBuild]::GetToolsDirectory32())\Roslyn" />
+
+      <!-- VC Specific Paths -->
+      <property name="VCTargetsPath" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath)','$(VsInstallRoot)\Common7\IDE\VC\VCTargets\'))" />
+      <property name="VCTargetsPath14" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath14)','$([MSBuild]::GetProgramFiles32())\MSBuild\Microsoft.Cpp\v4.0\V140\'))" />
+      <property name="VCTargetsPath12" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath12)','$([MSBuild]::GetProgramFiles32())\MSBuild\Microsoft.Cpp\v4.0\V120\'))" />
+      <property name="VCTargetsPath11" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath11)','$([MSBuild]::GetProgramFiles32())\MSBuild\Microsoft.Cpp\v4.0\V110\'))" />
+      <property name="VCTargetsPath10" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath10)','$([MSBuild]::GetProgramFiles32())\MSBuild\Microsoft.Cpp\v4.0\'))" />
+      <property name="AndroidTargetsPath" value="$(MSBuildExtensionsPath32)\Microsoft\MDD\Android\V150\" />
+      <property name="iOSTargetsPath" value="$(MSBuildExtensionsPath32)\Microsoft\MDD\iOS\V150\" />
+      <projectImportSearchPaths>
+        <searchPaths os="windows">
+          <property name="MSBuildExtensionsPath" value="$(MSBuildProgramFiles32)\MSBuild"/>
+          <property name="MSBuildExtensionsPath32" value="$(MSBuildProgramFiles32)\MSBuild"/>
+          <property name="MSBuildExtensionsPath64" value="$(MSBuildProgramFiles32)\MSBuild"/>
+          <property name="VSToolsPath" value="$(MSBuildProgramFiles32)\MSBuild\Microsoft\VisualStudio\v$(VisualStudioVersion)"/>
+        </searchPaths>
+      </projectImportSearchPaths>
+    </toolset>
+  </msbuildToolsets>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>


### PR DESCRIPTION
Fix https://github.com/dotnet/docfx/issues/1752#issuecomment-323385945
1. Add necessary env, use `dotnet --info` to get current default dotnet base path
2. Add config settings, according to https://github.com/Microsoft/msbuild/blob/6851538897f5d7b08024a6d8435bc44be5869e53/src/Build/Definition/ToolsetReader.cs#L294, config settings takes over registry and over local assembly version.

