### PR TITLE
Fix creating extra %dest% folder

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/ExtractMetadataWorker.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/ExtractMetadataWorker.cs
@@ -450,7 +450,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
         private static void CopyFromCachedResult(BuildInfo buildInfo, IEnumerable<string> inputs, string outputFolder)
         {
             var outputFolderSource = buildInfo.OutputFolder;
-            var relativeFiles = buildInfo.RelatvieOutputFiles;
+            var relativeFiles = buildInfo.RelativeOutputFiles;
             if (relativeFiles == null)
             {
                 Logger.Log(LogLevel.Warning, $"No metadata is generated for '{StringExtension.ToDelimitedString(inputs)}'.");
@@ -472,7 +472,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             if (!rebuildProject)
             {
                 // Load from cache
-                var cacheFile = Path.Combine(projectConfig.OutputFolder, projectConfig.RelatvieOutputFiles.First());
+                var cacheFile = Path.Combine(projectConfig.OutputFolder, projectConfig.RelativeOutputFiles.First());
                 Logger.Log(LogLevel.Info, $"'{projectConfig.InputFilesKey}' keep up-to-date since '{projectConfig.TriggeredUtcTime.ToString()}', cached intermediate result '{cacheFile}' is used.");
                 if (TryParseYamlMetadataFile(cacheFile, out projectMetadata))
                 {

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/ExtractMetadataWorker.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/ExtractMetadataWorker.cs
@@ -19,6 +19,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
     using Microsoft.DocAsCode.DataContracts.Common;
     using Microsoft.DocAsCode.DataContracts.ManagedReference;
     using Microsoft.DocAsCode.Exceptions;
+    using Microsoft.DocAsCode.Plugins;
 
     public sealed class ExtractMetadataWorker : IDisposable
     {
@@ -66,7 +67,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             };
 
             _useCompatibilityFileName = input.UseCompatibilityFileName;
-            _outputFolder = input.OutputFolder;
+            _outputFolder = StringExtension.ToNormalizedFullPath(Path.Combine(EnvironmentContext.OutputDirectory, input.OutputFolder));
 
             _workspace = new Lazy<MSBuildWorkspace>(() =>
             {
@@ -531,7 +532,6 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 var fileName = useCompatibilityFileName ? memberModel.Name : memberModel.Name.Replace('`', '-');
                 var outputFileName = GetUniqueFileNameWithSuffix(fileName + Constants.YamlExtension, outputFileNames);
                 string itemFilePath = Path.Combine(folder, outputFileName);
-                Directory.CreateDirectory(Path.GetDirectoryName(itemFilePath));
                 var memberViewModel = memberModel.ToPageViewModel();
                 memberViewModel.ShouldSkipMarkup = shouldSkipMarkup;
                 YamlUtility.Serialize(itemFilePath, memberViewModel, YamlMime.ManagedReference);

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Incremental/BuildInfo.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Incremental/BuildInfo.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
         public ExtractMetadataOptions Options { get; set; }
 
-        public IEnumerable<string> RelatvieOutputFiles { get; set; }
+        public IEnumerable<string> RelativeOutputFiles { get; set; }
 
         /// <summary>
         /// Save the files involved in the build

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Incremental/CacheBase.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Incremental/CacheBase.cs
@@ -11,7 +11,6 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
     using System.Reflection;
 
     using Microsoft.DocAsCode.Common;
-    using Microsoft.DocAsCode.Plugins;
 
     internal abstract class CacheBase
     {

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Incremental/CacheBase.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Incremental/CacheBase.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 ContainedFiles = containedFiles,
                 TriggeredUtcTime = triggeredTime,
                 CompleteUtcTime = completeTime,
-                OutputFolder = StringExtension.ToNormalizedFullPath(Path.Combine(EnvironmentContext.OutputDirectory, outputFolder)),
+                OutputFolder = StringExtension.ToNormalizedFullPath(outputFolder),
                 RelatvieOutputFiles = StringExtension.GetNormalizedPathList(fileRelativePaths),
                 BuildAssembly = AssemblyName,
                 Options = options,

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Incremental/CacheBase.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Incremental/CacheBase.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 TriggeredUtcTime = triggeredTime,
                 CompleteUtcTime = completeTime,
                 OutputFolder = StringExtension.ToNormalizedFullPath(outputFolder),
-                RelatvieOutputFiles = StringExtension.GetNormalizedPathList(fileRelativePaths),
+                RelativeOutputFiles = StringExtension.GetNormalizedPathList(fileRelativePaths),
                 BuildAssembly = AssemblyName,
                 Options = options,
             };
@@ -81,7 +81,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 var checksum = buildInfo.CheckSum;
                 try
                 {
-                    var resultCorrupted = GetMd5(buildInfo.OutputFolder, buildInfo.RelatvieOutputFiles) != checksum;
+                    var resultCorrupted = GetMd5(buildInfo.OutputFolder, buildInfo.RelativeOutputFiles) != checksum;
 
                     if (!resultCorrupted && checksum != null)
                     {
@@ -109,7 +109,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
         protected virtual void SaveConfig(string key, BuildInfo config)
         {
-            config.CheckSum = GetMd5(config.OutputFolder, config.RelatvieOutputFiles);
+            config.CheckSum = GetMd5(config.OutputFolder, config.RelativeOutputFiles);
             _configs[key] = config;
             CleanupConfig();
 


### PR DESCRIPTION
The reason for creating extra %dest% folder as described in #2255 is following:
- If metadata is generated anew, there is redundant `Directory.Create` call for %dest%. It is not necessary, because folder can be created later during yaml serialization.
- If metadata were taken from cache, it was copied to %dest%.

Changes:
- Removed redundant `Directory.Create` call.
- `ExtractMetadataWorker` now uses full path to destination folder.

Additional benefit of these PR is that if metadata haven't changed, no additional file copying occurs, which in turn decreases execution time.