### PR TITLE
Update advanced_walkthrough.md

### DIFF
--- a/Documentation/tutorial/walkthrough/advanced_walkthrough.md
+++ b/Documentation/tutorial/walkthrough/advanced_walkthrough.md
@@ -1,25 +1,61 @@
 🔧 Walkthrough Advanced: Customize Your Website
 ===================================
 
-## Apply your own styles to the website
+## Apply your own styles to the website or PDF
 
 ### Export the default template
 
-Open the command line at the root of the directory.
+To export the default HTML template, open the command line at the root of the directory and run `docfx template export default`.
 
-```docfx template export default```
+A folder called `_exported_templates` is added at root with a directory inside called `default`. This is the DocFX default HTML template.
 
-A folder called `_exported_templates` is added.
+To export the default PDF template, run `docfx template export pdf.default`.
 
 ### Create a new template
 
-Inside `_exported_templates`, copy/paste the `default` folder and then give it a new name. This is the name of your custom template.
+Create a new directory at root to hold your custom templates - name it something like `templates`. Inside that folder, create a new folder and name it wantever you want to name your custom template. In this folder you'll replicate files from `_exported_templates/default` or `_exported_templates/pdf.default` (and only those files) you want to overwrite.
 
-### Customize the new template
+### Apply the template
 
-Inside your new template folder is a `styles` folder. Edit `main.css` to change the look and feel of the website.
+To apply your custom HTML template permanently, add the following to `docfx.json` at the root of the project inside `"build": {`:
 
-Example of changing heading styles:
+```
+    "template": [
+      "default",
+      "templates/<name of your your HTML template folder>"
+    ],
+```
+    
+To apply your custom PDF template permanently, add the following at the same level as `"content"` under `"pdf"`: 
+
+```
+    "template": [
+      "pdf.default",
+      "templates/pdf"
+    ],
+```
+
+To apply a template manually, append a `-t` with the template filepath to the build command:
+
+```docfx build docfx.json -t C:\<filepath>\templates\<your custom template folder> --serve```
+
+### Customize your template
+
+Inside the `_exported_templates/default` or `exported_templates/pdf.default` folder, copy any file you want to overwrite with your custom template. Paste it in your custom template folder, replicating the directory structure.
+
+For example, to change the copyright in the footer of the HTML template:
+
+- Copy `_exported_templates/default/partials/footer.tmpl.partial`.
+- Paste it in `templates/<your custom template folder>/partials`.
+- Edit `templates/<your custom template folder>/partials`.
+
+To change the CSS of the HTML or PDF template:
+
+- Copy `_exported_templates/default/styles/main.css` or `_exported_templates/pdf.default/styles/main.css`.
+- Paste it in `templates/<your custom template folder>/styles`.
+- Edit `templates/<your custom template folder>/partials`.
+
+Example of changing heading styles in `main.css` for an HTML template:
 
 ```
 article h1 {
@@ -31,7 +67,7 @@ article h1 {
 }
 ```
 
-Example of preventing words from breaking across lines:
+Example of preventing words from breaking across lines for an HTML template:
 
 ```
 article h1, h2, h3, h4, h5, h6 {
@@ -39,29 +75,16 @@ article h1, h2, h3, h4, h5, h6 {
 }
 ```
 
-### Apply the new template
+Example of changing heading styles for a PDF template:
 
-To apply it manually, append a `-t` with the template filepath to the build command:
+```
+h1 {
+    font-weight: 200;
+    color: #007bb8;
+}
+```
 
-```docfx build docfx.json -t C:\<filepath>\_exported_templates\<name of your template folder> --serve```
-
-To apply the template permanently so you don't have to mention it in your build command, add a line to `docfx.json` at the root of the project inside `"build": {`:
-
-```"template": "_exported_templates/<name of your template folder", ```
- 
- ## Apply your own styles to the PDF
- 
- Follow the same steps as above with these modifications:
- 
- To export:
- 
-```docfx template export pdf.default```
-
-To create the permanent template reference, add this code under the PDF section of `docfx.json` at the same level as `"content"`: 
-
-```"template": "_exported_templates/<name of your pdf template folder>",```
-
-To change the look of the table of contents, modify this file: `_exported_templates/<name of your pdf template folder>/toc.html.tmpl`
+To change the look of the table of contents in the PDF template, use this file: `_exported_templates/default/toc.html.tmpl`
 
 ## See a list of all your templates
 


### PR DESCRIPTION
Align with existing DocFX documentation that promotes a better practice for managing templates (as overwrites in a separate directory instead of complete directory duplicate inside `_exported_templates` folder)