### PR TITLE
Update token.json

### DIFF
--- a/src/docfx.website.themes/default/token.json
+++ b/src/docfx.website.themes/default/token.json
@@ -11,7 +11,7 @@
   "eventsInSubtitle": "Events",
   "operatorsInSubtitle": "Operators",
   "eiisInSubtitle": "Explicit Interface Implementations",
-  "improveThisDoc": "Improve this Doc",
+  "improveThisDoc": "Improve This Doc",
   "viewSource": "View Source",
   "inheritance": "Inheritance",
   "inheritedMembers": "Inherited Members",


### PR DESCRIPTION
In the right-side pane, "In This Article" has a capitalized "This" but "Improve this Doc" does not. This stands out because they are only a half inch apart. This change makes them both the same. The Microsoft Manual of Style says to capitalize "This" in headings.