### PR TITLE
Abstraction of projects, documents in compilations in preparation for F# support.

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/BuildControllers/IBuildController.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/BuildControllers/IBuildController.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DocAsCode.Metadata.ManagedReference
+{
+    public interface IBuildController
+    {
+        MetadataItem ExtractMetadata(IInputParameters parameters);
+    }
+}

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/BuildControllers/IBuildController.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/BuildControllers/IBuildController.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.DocAsCode.Metadata.ManagedReference
 {

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/ExtractMetadataOptions.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/ExtractMetadataOptions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
         public Dictionary<string, string> MSBuildProperties { get; set; }
 
         [JsonIgnore]
-        public IReadOnlyDictionary<Compilation, IEnumerable<IMethodSymbol>> ExtensionMethods { get; set; }
+        public IReadOnlyDictionary<Compilation, IEnumerable<IMethodSymbol>> RoslynExtensionMethods { get; set; }
 
         public bool HasChanged(IncrementalCheck check, bool careMSBuildProperties)
         {

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/Project/AbstractCompilation.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/Project/AbstractCompilation.cs
@@ -1,0 +1,8 @@
+﻿
+namespace Microsoft.DocAsCode.Metadata.ManagedReference
+{
+    public abstract class AbstractCompilation
+    {
+        public abstract IBuildController GetBuildController();
+    }
+}

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/Project/AbstractCompilation.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/Project/AbstractCompilation.cs
@@ -1,4 +1,6 @@
-﻿
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Microsoft.DocAsCode.Metadata.ManagedReference
 {
     public abstract class AbstractCompilation

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/Project/AbstractDocument.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/Project/AbstractDocument.cs
@@ -1,4 +1,6 @@
-﻿
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Microsoft.DocAsCode.Metadata.ManagedReference
 {
     public abstract class AbstractDocument

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/Project/AbstractDocument.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/Project/AbstractDocument.cs
@@ -1,0 +1,8 @@
+﻿
+namespace Microsoft.DocAsCode.Metadata.ManagedReference
+{
+    public abstract class AbstractDocument
+    {
+        public abstract string FilePath { get; }
+    }
+}

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/Project/AbstractProject.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/Project/AbstractProject.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.DocAsCode.Metadata.ManagedReference
+{
+    public abstract class AbstractProject
+    {
+        public abstract string FilePath { get; }
+        public abstract bool HasDocuments { get; }
+        public abstract IEnumerable<AbstractDocument> Documents { get; }
+        public abstract IEnumerable<string> PortableExecutableMetadataReferences { get; }
+        public abstract IEnumerable<AbstractProject> ProjectReferences { get; }
+        public abstract Task<AbstractCompilation> GetCompilationAsync();
+    }
+}

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/Project/AbstractProject.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/Project/AbstractProject.cs
@@ -1,8 +1,11 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.DocAsCode.Metadata.ManagedReference
 {
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
     public abstract class AbstractProject
     {
         public abstract string FilePath { get; }

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/Project/AbstractProjectLoader.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/Project/AbstractProjectLoader.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+
+namespace Microsoft.DocAsCode.Metadata.ManagedReference
+{
+    public class AbstractProjectLoader
+    {
+        IEnumerable<IProjectLoader> _loaders;
+
+        public AbstractProjectLoader(IEnumerable<IProjectLoader> loaders)
+        {
+            _loaders = loaders;
+        }
+
+        public AbstractProject Load(string path)
+        {
+            foreach (var loader in _loaders)
+            {
+                var p = loader.TryLoad(path, this);
+                if (p != null)
+                    return p;
+            }
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/Project/AbstractProjectLoader.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/Project/AbstractProjectLoader.cs
@@ -1,7 +1,10 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.DocAsCode.Metadata.ManagedReference
 {
+    using System.Collections.Generic;
+    
     public class AbstractProjectLoader
     {
         IEnumerable<IProjectLoader> _loaders;

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/Project/IProjectLoader.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/Project/IProjectLoader.cs
@@ -1,4 +1,6 @@
-﻿
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 namespace Microsoft.DocAsCode.Metadata.ManagedReference
 {
     public interface IProjectLoader

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/Project/IProjectLoader.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/ExtractMetadata/Project/IProjectLoader.cs
@@ -1,0 +1,8 @@
+﻿
+namespace Microsoft.DocAsCode.Metadata.ManagedReference
+{
+    public interface IProjectLoader
+    {
+        AbstractProject TryLoad(string path, AbstractProjectLoader loader);
+    }
+}

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/Incremental/ProjectLevelCache.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/Incremental/ProjectLevelCache.cs
@@ -9,8 +9,6 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
     using System.IO;
     using System.Linq;
 
-    using Microsoft.CodeAnalysis;
-
     using Microsoft.DocAsCode.Common;
 
     public class ProjectLevelCache : CacheBase

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/BuildControllers/IRoslynBuildController.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/BuildControllers/IRoslynBuildController.cs
@@ -5,9 +5,10 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 {
     using Microsoft.CodeAnalysis;
 
-    public interface IBuildController
+    public interface IRoslynBuildController : IBuildController
     {
         Compilation GetCompilation(IInputParameters key);
         IAssemblySymbol GetAssembly(IInputParameters key);
     }
+
 }

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/BuildControllers/RoslynSourceFileBuildController.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/BuildControllers/RoslynSourceFileBuildController.cs
@@ -5,14 +5,20 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 {
     using Microsoft.CodeAnalysis;
 
-    public class SourceFileBuildController : IBuildController
+    public class RoslynSourceFileBuildController : IRoslynBuildController
     {
         private readonly Compilation _compilation;
         private readonly IAssemblySymbol _assembly;
-        public SourceFileBuildController(Compilation compilation, IAssemblySymbol assembly = null)
+        public RoslynSourceFileBuildController(Compilation compilation, IAssemblySymbol assembly = null)
         {
             _compilation = compilation;
-            _assembly = assembly ?? _compilation?.Assembly;
+            _assembly = assembly ?? compilation?.Assembly;
+        }
+
+        public MetadataItem ExtractMetadata(IInputParameters parameters)
+        {
+            var extractor = new RoslynIntermediateMetadataExtractor(this);
+            return extractor.Extract(parameters);
         }
 
         public IAssemblySymbol GetAssembly(IInputParameters key)

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/Project/RoslynCompilation.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/Project/RoslynCompilation.cs
@@ -1,8 +1,10 @@
-﻿using Microsoft.CodeAnalysis;
-
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.DocAsCode.Metadata.ManagedReference
 {
+    using Microsoft.CodeAnalysis;
+
     public class RoslynCompilation : AbstractCompilation
     {
         Compilation _compilation;

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/Project/RoslynCompilation.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/Project/RoslynCompilation.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.CodeAnalysis;
+
+
+namespace Microsoft.DocAsCode.Metadata.ManagedReference
+{
+    public class RoslynCompilation : AbstractCompilation
+    {
+        Compilation _compilation;
+
+        public RoslynCompilation(Compilation compilation)
+        {
+            _compilation = compilation;
+        }
+
+        public Compilation Compilation => _compilation;
+
+        public override IBuildController GetBuildController()
+        {
+            return new RoslynSourceFileBuildController(this.Compilation);
+        }
+    }
+}

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/Project/RoslynDocument.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/Project/RoslynDocument.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.CodeAnalysis;
+
+
+namespace Microsoft.DocAsCode.Metadata.ManagedReference
+{
+    public class RoslynDocument : AbstractDocument
+    {
+        Document _document;
+
+        public RoslynDocument(Document document)
+        {
+            _document = document;
+        }
+
+        public override string FilePath => _document.FilePath;
+    }
+}

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/Project/RoslynDocument.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/Project/RoslynDocument.cs
@@ -1,8 +1,10 @@
-﻿using Microsoft.CodeAnalysis;
-
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.DocAsCode.Metadata.ManagedReference
 {
+    using Microsoft.CodeAnalysis;
+    
     public class RoslynDocument : AbstractDocument
     {
         Document _document;

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/Project/RoslynProject.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/Project/RoslynProject.cs
@@ -1,12 +1,14 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-using Microsoft.CodeAnalysis;
-
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.DocAsCode.Metadata.ManagedReference
 {
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using Microsoft.CodeAnalysis;
+    
     public class RoslynProject : AbstractProject
     {
         Project _project;

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/Project/RoslynProject.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/Project/RoslynProject.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+
+
+namespace Microsoft.DocAsCode.Metadata.ManagedReference
+{
+    public class RoslynProject : AbstractProject
+    {
+        Project _project;
+
+        public RoslynProject(Project project)
+        {
+            // Ensure that project references are unique, because
+            // duplicate project references will fail Project.GetCompilationAsync.
+            var groups = project.ProjectReferences.GroupBy(r => r);
+            if (groups.Any(g => g.Count() > 1))
+            {
+                project = project.WithProjectReferences(groups.Select(g => g.Key));
+            }
+
+            _project = project;
+        }
+
+        public override string FilePath => _project.FilePath;
+
+        public override bool HasDocuments => _project.HasDocuments;
+
+        public override IEnumerable<AbstractDocument> Documents =>
+            _project.Documents.Select(d => new RoslynDocument(d));
+
+        public override IEnumerable<string> PortableExecutableMetadataReferences =>
+            _project.MetadataReferences
+            .Where(s => s is PortableExecutableReference)
+            .Select(s => ((PortableExecutableReference)s).FilePath);
+
+        public override IEnumerable<AbstractProject> ProjectReferences =>
+            // TODO: cross-reference between Roslyn and F#
+            _project.ProjectReferences.Select(pr =>
+                new RoslynProject(_project.Solution.GetProject(pr.ProjectId)));
+
+        public override async Task<AbstractCompilation> GetCompilationAsync()
+        {
+            var c = await _project.GetCompilationAsync();
+            return new RoslynCompilation(c);
+        }
+    }
+}

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/Project/RoslynProjectLoader.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/Project/RoslynProjectLoader.cs
@@ -1,13 +1,16 @@
-﻿using System;
-using System.IO;
-
-using Microsoft.CodeAnalysis.MSBuild;
-
-using Microsoft.DocAsCode.Common;
-
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.DocAsCode.Metadata.ManagedReference
 {
+    using System;
+    using System.IO;
+
+    using Microsoft.CodeAnalysis.MSBuild;
+
+    using Microsoft.DocAsCode.Common;
+
+
     public class RoslynProjectLoader : IProjectLoader
     {
         Lazy<MSBuildWorkspace> _workspace;

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/Project/RoslynProjectLoader.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/Project/RoslynProjectLoader.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.IO;
+
+using Microsoft.CodeAnalysis.MSBuild;
+
+using Microsoft.DocAsCode.Common;
+
+
+namespace Microsoft.DocAsCode.Metadata.ManagedReference
+{
+    public class RoslynProjectLoader : IProjectLoader
+    {
+        Lazy<MSBuildWorkspace> _workspace;
+
+        public RoslynProjectLoader(Lazy<MSBuildWorkspace> workspace)
+        {
+            _workspace = workspace;
+        }
+
+        public AbstractProject TryLoad(string path, AbstractProjectLoader loader)
+        {
+            var ext = Path.GetExtension(path).ToLowerInvariant();
+            if (ext == ".csproj" || ext == ".vbproj")
+            {
+                Logger.LogVerbose("Loading project...");
+                var result = _workspace.Value.OpenProjectAsync(path).Result;
+                Logger.LogVerbose($"Project {result.FilePath} loaded.");
+                return new RoslynProject(result);
+            }
+            else
+                return null;
+        }
+    }
+}

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/RoslynIntermediateMetadataExtractor.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/RoslynIntermediateMetadataExtractor.cs
@@ -8,10 +8,10 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
     using Microsoft.CodeAnalysis;
 
-    public class IntermediateMetadataExtractor : IExtractor
+    public class RoslynIntermediateMetadataExtractor : IExtractor
     {
-        private IBuildController _controller;
-        public IntermediateMetadataExtractor(IBuildController controller)
+        private IRoslynBuildController _controller;
+        public RoslynIntermediateMetadataExtractor(IRoslynBuildController controller)
         {
             _controller = controller;
         }
@@ -33,7 +33,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
             options = options ?? new ExtractMetadataOptions();
 
-            return new MetadataExtractor(compilation, assembly).Extract(options);
+            return new RoslynMetadataExtractor(compilation, assembly).Extract(options);
         }
 
         public static IReadOnlyDictionary<Compilation, IEnumerable<IMethodSymbol>> GetAllExtensionMethodsFromCompilation(IEnumerable<Compilation> compilations)

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/RoslynMetadataExtractor.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/ExtractMetadata/RoslynMetadataExtractor.cs
@@ -10,12 +10,12 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
     using Microsoft.DocAsCode.Common;
     using Microsoft.DocAsCode.DataContracts.ManagedReference;
 
-    internal class MetadataExtractor
+    internal class RoslynMetadataExtractor
     {
         private readonly Compilation _compilation;
         private readonly IAssemblySymbol _assembly;
 
-        public MetadataExtractor(Compilation compilation, IAssemblySymbol assembly = null)
+        public RoslynMetadataExtractor(Compilation compilation, IAssemblySymbol assembly = null)
         {
             _compilation = compilation ?? throw new ArgumentNullException(nameof(compilation));
             _assembly = assembly ?? compilation.Assembly;
@@ -25,7 +25,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
         {
             var preserveRawInlineComments = options.PreserveRawInlineComments;
             var filterConfigFile = options.FilterConfigFile;
-            var extensionMethods = options.ExtensionMethods;
+            var extensionMethods = options.RoslynExtensionMethods;
 
             object visitorContext = new object();
             SymbolVisitorAdapter visitor;

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/ExtractMetadataWorker.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/ExtractMetadataWorker.cs
@@ -29,6 +29,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
         private readonly bool _useCompatibilityFileName;
         private readonly string _outputFolder;
         private readonly ExtractMetadataOptions _options;
+        private readonly AbstractProjectLoader _loader;
 
         //Lacks UT for shared workspace
         private readonly Lazy<MSBuildWorkspace> _workspace;
@@ -78,6 +79,9 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 };
                 return workspace;
             });
+
+            var roslynLoader = new RoslynProjectLoader(_workspace);
+            _loader = new AbstractProjectLoader(new IProjectLoader[] {roslynLoader});
         }
 
         public async Task ExtractMetadataAsync()
@@ -118,7 +122,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             var forceRebuild = _rebuild;
             var outputFolder = _outputFolder;
 
-            var projectCache = new ConcurrentDictionary<string, Project>();
+            var projectCache = new ConcurrentDictionary<string, AbstractProject>();
 
             // Project<=>Documents
             var documentCache = new ProjectDocumentCache();
@@ -145,10 +149,11 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                             {
                                 var projectFile = new FileInformation(project.FilePath);
 
-                                // If the project is csproj/vbproj, add to project dictionary, otherwise, ignore
+                                // If the project is supported, add to project dictionary, otherwise, ignore
                                 if (projectFile.IsSupportedProject())
                                 {
-                                    projectCache.GetOrAdd(projectFile.NormalizedPath, s => project);
+                                    projectCache.GetOrAdd(projectFile.NormalizedPath, 
+                                                          s => _loader.Load(projectFile.NormalizedPath));
                                 }
                                 else
                                 {
@@ -172,7 +177,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             {
                 await pjp.Select(s => s.NormalizedPath).ForEachInParallelAsync(path =>
                 {
-                    projectCache.GetOrAdd(path, s => GetProjectJsonProject(s));
+                    projectCache.GetOrAdd(path, s => new RoslynProject(GetProjectJsonProject(s)));
                     return Task.CompletedTask;
                 }, 60);
             }
@@ -190,16 +195,8 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 {
                     Logger.Log(LogLevel.Warning, $"Project '{project.FilePath}' does not contain any documents.");
                 }
-                documentCache.AddDocuments(path, project.MetadataReferences
-                    .Where(s => s is PortableExecutableReference)
-                    .Select(s => ((PortableExecutableReference)s).FilePath));
+                documentCache.AddDocuments(path, project.PortableExecutableMetadataReferences);
                 FillProjectDependencyGraph(projectCache, projectDependencyGraph, project);
-                // duplicate project references will fail Project.GetCompilationAsync
-                var groups = project.ProjectReferences.GroupBy(r => r);
-                if (groups.Any(g => g.Count() > 1))
-                {
-                    projectCache[path] = project.WithProjectReferences(groups.Select(g => g.Key));
-                }
             }
 
             var csFiles = new List<string>();
@@ -289,15 +286,17 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             // Build all the projects to get the output and save to cache
             List<MetadataItem> projectMetadataList = new List<MetadataItem>();
             ConcurrentDictionary<string, bool> projectRebuildInfo = new ConcurrentDictionary<string, bool>();
-            ConcurrentDictionary<string, Compilation> compilationCache = await GetProjectCompilationAsync(projectCache);
-            var extensionMethods = IntermediateMetadataExtractor.GetAllExtensionMethodsFromCompilation(compilationCache.Values);
-            options.ExtensionMethods = extensionMethods;
+            ConcurrentDictionary<string, AbstractCompilation> compilationCache = 
+                await GetProjectCompilationAsync(projectCache);
+            var roslynProjects = compilationCache.Values.OfType<RoslynCompilation>().Select(rc => rc.Compilation);
+            options.RoslynExtensionMethods = 
+                RoslynIntermediateMetadataExtractor.GetAllExtensionMethodsFromCompilation(roslynProjects); 
             foreach (var key in GetTopologicalSortedItems(projectDependencyGraph))
             {
                 var dependencyRebuilt = projectDependencyGraph[key].Any(r => projectRebuildInfo[r]);
                 var k = documentCache.GetDocuments(key);
                 var input = new ProjectFileInputParameters(options, k, key, dependencyRebuilt);
-                var controller = new SourceFileBuildController(compilationCache[key]);
+                var controller = compilationCache[key].GetBuildController();
 
                 var projectMetadataResult = GetMetadataFromProjectLevelCache(controller, input);
                 var projectMetadata = projectMetadataResult.Item1;
@@ -312,7 +311,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 if (csCompilation != null)
                 {
                     var input = new SourceFileInputParameters(options, csFiles);
-                    var controller = new SourceFileBuildController(csCompilation);
+                    var controller = new RoslynSourceFileBuildController(csCompilation);
 
                     var csMetadata = GetMetadataFromProjectLevelCache(controller, input);
                     if (csMetadata != null) projectMetadataList.Add(csMetadata.Item1);
@@ -326,7 +325,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 if (vbCompilation != null)
                 {
                     var input = new SourceFileInputParameters(options, vbFiles);
-                    var controller = new SourceFileBuildController(vbCompilation);
+                    var controller = new RoslynSourceFileBuildController(vbCompilation);
 
                     var vbMetadata = GetMetadataFromProjectLevelCache(controller, input);
                     if (vbMetadata != null) projectMetadataList.Add(vbMetadata.Item1);
@@ -345,12 +344,12 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
                     var referencedAssemblyList = CompilationUtility.GetAssemblyFromAssemblyComplation(assemblyCompilation).ToList();
                     // TODO: why not merge with compilation's extension methods?
-                    var assemblyExtension = IntermediateMetadataExtractor.GetAllExtensionMethodsFromAssembly(assemblyCompilation, referencedAssemblyList.Select(s => s.Item2));
-                    options.ExtensionMethods = assemblyExtension;
+                    var assemblyExtension = RoslynIntermediateMetadataExtractor.GetAllExtensionMethodsFromAssembly(assemblyCompilation, referencedAssemblyList.Select(s => s.Item2));
+                    options.RoslynExtensionMethods = assemblyExtension;
                     foreach (var assembly in referencedAssemblyList)
                     {
                         var input = new AssemblyFileInputParameters(options, assembly.Item1.Display);
-                        var controller = new SourceFileBuildController(assemblyCompilation, assembly.Item2);
+                        var controller = new RoslynSourceFileBuildController(assemblyCompilation, assembly.Item2);
 
                         var mta = GetMetadataFromProjectLevelCache(controller, input);
                         
@@ -395,25 +394,23 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             }
         }
 
-        private static void FillProjectDependencyGraph(ConcurrentDictionary<string, Project> projectCache, ConcurrentDictionary<string, List<string>> projectDependencyGraph, Project project)
+        private static void FillProjectDependencyGraph(ConcurrentDictionary<string, AbstractProject> projectCache, ConcurrentDictionary<string, List<string>> projectDependencyGraph, AbstractProject project)
         {
             projectDependencyGraph.GetOrAdd(project.FilePath.ToNormalizedFullPath(), _ => GetTransitiveProjectReferences(projectCache, project).Distinct().ToList());
         }
 
-        private static IEnumerable<string> GetTransitiveProjectReferences(ConcurrentDictionary<string, Project> projectCache, Project project)
+        private static IEnumerable<string> GetTransitiveProjectReferences(ConcurrentDictionary<string, AbstractProject> projectCache, AbstractProject project)
         {
-            var solution = project.Solution;
             foreach (var pr in project.ProjectReferences)
             {
-                var refProject = solution.GetProject(pr.ProjectId);
-                var path = StringExtension.ToNormalizedFullPath(refProject.FilePath);
+                var path = StringExtension.ToNormalizedFullPath(pr.FilePath);
                 if (projectCache.ContainsKey(path))
                 {
                     yield return path;
                 }
                 else
                 {
-                    foreach (var rpr in GetTransitiveProjectReferences(projectCache, refProject))
+                    foreach (var rpr in GetTransitiveProjectReferences(projectCache, pr))
                     {
                         yield return rpr;
                     }
@@ -421,9 +418,9 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             }
         }
 
-        private static async Task<ConcurrentDictionary<string, Compilation>> GetProjectCompilationAsync(ConcurrentDictionary<string, Project> projectCache)
+        private static async Task<ConcurrentDictionary<string, AbstractCompilation>> GetProjectCompilationAsync(ConcurrentDictionary<string, AbstractProject> projectCache)
         {
-            var compilations = new ConcurrentDictionary<string, Compilation>();
+            var compilations = new ConcurrentDictionary<string, AbstractCompilation>();
             var sb = new StringBuilder();
             foreach (var project in projectCache)
             {
@@ -485,7 +482,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 }
             }
 
-            projectMetadata = new IntermediateMetadataExtractor(controller).Extract(key);
+            projectMetadata = controller.ExtractMetadata(key);
             var file = Path.GetRandomFileName();
             var cacheOutputFolder = projectLevelCache.OutputFolder;
             var path = Path.Combine(cacheOutputFolder, file);
@@ -771,7 +768,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             }
         }
 
-        private Project GetProject(ConcurrentDictionary<string, Project> cache, string path)
+        private AbstractProject GetProject(ConcurrentDictionary<string, AbstractProject> cache, string path)
         {
             return cache.GetOrAdd(path.ToNormalizedFullPath(), s =>
             {
@@ -780,11 +777,9 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                     try
                     {
                         Logger.LogVerbose("Loading project...");
-                        var project = _workspace.Value.CurrentSolution.Projects.FirstOrDefault(
-                            p => FilePathComparer.OSPlatformSensitiveRelativePathComparer.Equals(p.FilePath, s));
-                        var result = project ?? _workspace.Value.OpenProjectAsync(s).Result;
-
-                        Logger.LogVerbose($"Project {result.FilePath} loaded.");
+                        var result = _loader.Load(s);
+                        if (result != null)
+                            Logger.LogVerbose($"Project {result.FilePath} loaded.");
                         return result;
                     }
                     catch (AggregateException e)

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/ApiFilterUnitTest.cs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/ApiFilterUnitTest.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference.Tests
 
     using Microsoft.DocAsCode.DataContracts.ManagedReference;
 
-    using static Microsoft.DocAsCode.Metadata.ManagedReference.IntermediateMetadataExtractor;
+    using static Microsoft.DocAsCode.Metadata.ManagedReference.RoslynIntermediateMetadataExtractor;
 
     [Trait("Owner", "vwxyzh")]
     [Trait("Language", "CSharp")]

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/DefinitionMergeUnitTest.cs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/DefinitionMergeUnitTest.cs
@@ -36,7 +36,7 @@ namespace A {
 
 ";
             // act
-            MetadataItem output = IntermediateMetadataExtractor.GenerateYamlMetadata(CreateCompilationFromCSharpCode(code, "test.dll"));
+            MetadataItem output = RoslynIntermediateMetadataExtractor.GenerateYamlMetadata(CreateCompilationFromCSharpCode(code, "test.dll"));
 
             // assert
             Assert.NotNull(output);

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromAssemblyTest.cs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromAssemblyTest.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference.Tests
 
     using Xunit;
 
-    using static Microsoft.DocAsCode.Metadata.ManagedReference.IntermediateMetadataExtractor;
+    using static Microsoft.DocAsCode.Metadata.ManagedReference.RoslynIntermediateMetadataExtractor;
 
     [Trait("Owner", "qinezh")]
     [Trait("Language", "CSharp")]

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromCSUnitTest.cs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromCSUnitTest.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference.Tests
 
     using Microsoft.DocAsCode.DataContracts.ManagedReference;
 
-    using static Microsoft.DocAsCode.Metadata.ManagedReference.IntermediateMetadataExtractor;
+    using static Microsoft.DocAsCode.Metadata.ManagedReference.RoslynIntermediateMetadataExtractor;
 
     [Trait("Owner", "vwxyzh")]
     [Trait("Language", "CSharp")]
@@ -1075,7 +1075,7 @@ namespace Test1
 }
 ";
             var compilation = CreateCompilationFromCSharpCode(code);
-            MetadataItem output = GenerateYamlMetadata(compilation, options: new ExtractMetadataOptions { ExtensionMethods = GetAllExtensionMethodsFromCompilation(new[] { compilation }) });
+            MetadataItem output = GenerateYamlMetadata(compilation, options: new ExtractMetadataOptions { RoslynExtensionMethods = GetAllExtensionMethodsFromCompilation(new[] { compilation }) });
             Assert.Equal(1, output.Items.Count);
             // FooImple<T>
             {

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromVBUnitTest.cs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromVBUnitTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference.Tests
     using Microsoft.CodeAnalysis.MSBuild;
     using Microsoft.DocAsCode.DataContracts.ManagedReference;
 
-    using static Microsoft.DocAsCode.Metadata.ManagedReference.IntermediateMetadataExtractor;
+    using static Microsoft.DocAsCode.Metadata.ManagedReference.RoslynIntermediateMetadataExtractor;
 
     [Trait("Owner", "vwxyzh")]
     [Trait("Language", "VB")]


### PR DESCRIPTION
The abstract classes `AbstractCompilation`, `AbstractDocument` and `AbstractProject` have been introduced to provide a layer of abstraction for project and document support. The Roslyn-specific functionality has been moved into thin wrappers around the Roslyn API and is contained in `RoslynCompilation`, `RoslynDocument` and `RoslynProject`.