### PR TITLE
Added delegate to resolve a cref in TripleSlashCommentModel.

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/Parsers/CRefTarget.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/Parsers/CRefTarget.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode.Metadata.ManagedReference
+{
+    public class CRefTarget
+    {
+        public string Id { get; set; }
+        public string CommentId { get; set; }
+    }
+}

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/Parsers/ITripleSlashCommentParserContext.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/Parsers/ITripleSlashCommentParserContext.cs
@@ -11,6 +11,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
     {
         bool PreserveRawInlineComments { get; set; }
         Action<string, string> AddReferenceDelegate { get; set; }
+        Func<string, CRefTarget> ResolveCRef { get; }
         SourceDetail Source { get; set; }
     }
 }

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/Parsers/TripleSlashCommentParserContext.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/Parsers/TripleSlashCommentParserContext.cs
@@ -13,6 +13,8 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
         public Action<string, string> AddReferenceDelegate { get; set; }
 
+        public Func<string, CRefTarget> ResolveCRef { get; set; }
+
         public SourceDetail Source { get; set; }
     }
 }

--- a/tools/MergeDeveloperComments/Program.cs
+++ b/tools/MergeDeveloperComments/Program.cs
@@ -480,10 +480,12 @@ namespace Microsoft.DocAsCode.MergeDeveloperComments
         {
             public static readonly TripleSlashCommentParserContext Instance = new TripleSlashCommentParserContext
             {
-                AddReferenceDelegate = (s, e) => { }
+                AddReferenceDelegate = (s, e) => { },
+                ResolveCRef = null
             };
 
             public Action<string, string> AddReferenceDelegate { get; set; }
+            public Func<string, CRefTarget> ResolveCRef { get; set; }
             public bool PreserveRawInlineComments { get; set; }
             public SourceDetail Source { get; set; }
         }


### PR DESCRIPTION
- Introduced ResolveCRef delegate in ITripleSlashCommentParserContext.
- It is called when a cref attribute from an XML comment is to be
  resolved.
- The delegate returns the name of a reference to the appropriate target.
- Necessary for F# support, since the F# compiler does not resolve
  the cref attribute to comment ids in triple slash comments.