### PR TITLE
Add net461 build target for common libararies

### DIFF
--- a/src/Microsoft.DocAsCode.Common/Microsoft.DocAsCode.Common.csproj
+++ b/src/Microsoft.DocAsCode.Common/Microsoft.DocAsCode.Common.csproj
@@ -1,8 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../Shared/base.netstandard.props" />
-  
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DocAsCode.Plugins\Microsoft.DocAsCode.Plugins.csproj" />
     <ProjectReference Include="..\Microsoft.DocAsCode.YamlSerialization\Microsoft.DocAsCode.YamlSerialization.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+    <Reference Include="System.Web" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DocAsCode.YamlSerialization/Microsoft.DocAsCode.YamlSerialization.csproj
+++ b/src/Microsoft.DocAsCode.YamlSerialization/Microsoft.DocAsCode.YamlSerialization.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../Shared/base.netstandard.props" />
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+  </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="YamlDotNet.Signed" Version="4.2.2" />
   </ItemGroup>
 </Project>

--- a/src/Shared/base.netstandard.props
+++ b/src/Shared/base.netstandard.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    
     <!-- Note: by convention assembly should be named after the root namespace -->
     <AssemblyName Condition=" '$(AssemblyName)' == '' ">$(MSBuildProjectName)</AssemblyName>
     <AssemblyTitle Condition=" '$(AssemblyTitle)' == '' ">$(MSBuildProjectName)</AssemblyTitle>

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -42,4 +42,8 @@
     <PackageReference Include="Microsoft.Owin.StaticFiles" Version="3.0.1" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
 </Project>

--- a/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/MergeMarkdownFragmentsTest.cs
+++ b/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/MergeMarkdownFragmentsTest.cs
@@ -6,7 +6,6 @@
     using System.Composition;
     using System.IO;
     using System.Linq;
-
     using Microsoft.DocAsCode.Build.Engine;
     using Microsoft.DocAsCode.Common;
     using Microsoft.DocAsCode.Plugins;
@@ -324,7 +323,8 @@ With [!include[invalid](invalid.md)]",
                 Assert.Contains("I update a summary", rawModel["summary"].ToString());
                 Assert.NotNull(listener.Items.FirstOrDefault(s => s.Message.StartsWith("There is no template processing document type(s): RESTMixedTest")));
                 Assert.NotNull(listener.Items.FirstOrDefault(s => s.Message.StartsWith("Can't find") && s.Message.EndsWith("/invalid.md.")));
-                (lastMessages, messages) = (messages, ClearLog(listener.Items));
+                lastMessages = messages;
+                messages = ClearLog(listener.Items);
                 Assert.True(messages.SequenceEqual(lastMessages));
 
                 // rebuild
@@ -338,7 +338,8 @@ With [!include[invalid](invalid.md)]",
                 Assert.Contains("I update a summary", rawModel["summary"].ToString());
                 Assert.NotNull(listener.Items.FirstOrDefault(s => s.Message.StartsWith("There is no template processing document type(s): RESTMixedTest")));
                 Assert.NotNull(listener.Items.FirstOrDefault(s => s.Message.StartsWith("Can't find") && s.Message.EndsWith("/invalid.md.")));
-                (lastMessages, messages) = (messages, ClearLog(listener.Items));
+                lastMessages = messages;
+                messages = ClearLog(listener.Items);
                 Assert.True(messages.SequenceEqual(lastMessages));
             }
         }

--- a/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/Microsoft.DocAsCode.Build.SchemaDriven.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/Microsoft.DocAsCode.Build.SchemaDriven.Tests.csproj
@@ -5,6 +5,7 @@
   <Import Project="..\Shared\test.base.props" />
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">
+    <Reference Include="System" />
     <Reference Include="System.Web" />
   </ItemGroup>
 


### PR DESCRIPTION
Fix https://github.com/dotnet/docfx/issues/2358. As with netstandard libarary referenced, new version of *System.Runtime.InteropServices.RuntimeInformation* is introduced by build system with no way to turn around