### PR TITLE
Remove projects that could not be loaded from project cache.

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/ExtractMetadataWorker.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/ExtractMetadataWorker.cs
@@ -184,6 +184,16 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 }, 60);
             }
 
+            // Remove projects that could not be loaded successfully from projectCache.
+            var projectCacheSnapshot = new Dictionary<string, AbstractProject>(projectCache);
+            foreach (var item in projectCacheSnapshot)
+            {
+                if (item.Value == null)
+                {
+                    projectCache.TryRemove(item.Key, out AbstractProject project);
+                }
+            }
+
             foreach (var item in projectCache)
             {
                 var path = item.Key;


### PR DESCRIPTION
- This fixes "Object reference not set to an instance of an object"
  if a project failed to load for some reason or is of unsupported
  project type.

This is not specific to F# support, but was found while testing project load error handling. I am not sure if this is the optimal way to do it.
