### PR TITLE
WIP: Avoid shipping conflicting MSBuild version

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn.csproj
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn.csproj
@@ -28,8 +28,8 @@
     <PackageReference Include="Microsoft.Composition" Version="1.0.31" />
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.5.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Build" Version="15.6.82" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.6.82" />
+    <PackageReference Include="Microsoft.Build" Version="15.6.82" ExcludeAssets="runtime"/>
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.6.82" ExcludeAssets="runtime" />
     <PackageReference Include="NuGet.ProjectModel" Version="4.5.0" />
     <PackageReference Include="NuGet.Packaging.Core" Version="4.5.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.5.24" />

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/EnvironmentHelper.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/EnvironmentHelper.cs
@@ -7,7 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 #if NET461
-using Microsoft.Build.MSBuildLocator;
+using Microsoft.Build.Locator;
 #endif
 
 #if NETCOREAPP2_0 || NET461

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/MsBuildEnvironmentScope.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/MsBuildEnvironmentScope.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
     using System.Linq;
     using System.Text.RegularExpressions;
 
-    using Microsoft.Build.MSBuildLocator;
+    using Microsoft.Build.Locator;
     using Microsoft.DocAsCode.Common;
     using Microsoft.DocAsCode.Exceptions;
 
@@ -29,21 +29,6 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
         private EnvironmentScope GetScope()
         {
-            var vsInstallDirEnv = Environment.GetEnvironmentVariable(VSInstallDirKey);
-            if (!string.IsNullOrEmpty(vsInstallDirEnv))
-            {
-                Logger.LogInfo($"Environment variable {VSInstallDirKey} is set to {vsInstallDirEnv}, it is used as the inner compiler.");
-                return null;
-            }
-
-            var msbuildExePathEnv = Environment.GetEnvironmentVariable(MSBuildExePathKey);
-
-            if (!string.IsNullOrEmpty(msbuildExePathEnv))
-            {
-                Logger.LogInfo($"Environment variable {MSBuildExePathKey} is set to {msbuildExePathEnv}, it is used as the inner compiler.");
-                return null;
-            }
-
             if (EnvironmentHelper.IsMono)
             {
                 string extensionPath = null;
@@ -92,6 +77,9 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                     // workaround for https://github.com/dotnet/docfx/issues/1969
                     // FYI https://github.com/dotnet/roslyn/issues/21799#issuecomment-343695700
                     var latest = instances.FirstOrDefault(a => a.Version.Major == 15);
+
+                    MSBuildLocator.RegisterInstance(latest);
+
                     if (latest != null)
                     {
                         Logger.LogInfo($"Using msbuild {latest.MSBuildPath} as inner compiler.");


### PR DESCRIPTION
The Microsoft.Build.Locator package handles finding MSBuild. It will
find the installed version, avoiding problems like #2491 that result
from mismatched MSBuild assembly versions.

This change relies on Microsft.Build.Locator to find MSBuild and avoids
shipping MSBuild assemblies next to docfx.exe that could cause version
conflicts.