### PR TITLE
remove unnecessary logging statement.

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/NestedColumn/NestedColumnParser.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/NestedColumn/NestedColumnParser.cs
@@ -87,11 +87,6 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             {
                 return BlockState.None;
             }
-         
-            if (!c.IsZero())
-            {
-                Logger.LogWarning($"NestedColumn have some invalid chars in the starting.");
-            }
 
             processor.NewBlocks.Push(new NestedColumnBlock(this)
             {


### PR DESCRIPTION
removes unnecessary logging statement that was being triggered due to white space and return chars only.