### PR TITLE
Fix a race condition when loading the search index

### DIFF
--- a/src/docfx.website.themes/default/partials/searchResults.tmpl.partial
+++ b/src/docfx.website.themes/default/partials/searchResults.tmpl.partial
@@ -2,6 +2,8 @@
 
 <div id="search-results">
   <div class="search-list"></div>
-  <div class="sr-items"></div>
+  <div class="sr-items">
+    <p><i class="glyphicon glyphicon-refresh index-loading"></i></p>
+  </div>
   <ul id="pagination"></ul>
 </div>

--- a/src/docfx.website.themes/default/styles/docfx.css
+++ b/src/docfx.website.themes/default/styles/docfx.css
@@ -354,6 +354,28 @@ article section {
   text-align: center;
 }
 
+#search-results p .index-loading {
+  animation: index-loading 1.5s infinite linear;
+  -webkit-animation: index-loading 1.5s infinite linear;
+  -o-animation: index-loading 1.5s infinite linear;
+  font-size: 2.5rem;
+}
+
+@keyframes index-loading {
+    from { transform: scale(1) rotate(0deg);}
+    to { transform: scale(1) rotate(360deg);}
+}
+
+@-webkit-keyframes index-loading {
+    from { -webkit-transform: rotate(0deg);}
+    to { -webkit-transform: rotate(360deg);}
+}
+
+@-o-keyframes index-loading {
+    from { -webkit-transform: rotate(0deg);}
+    to { -webkit-transform: rotate(360deg);}
+}
+
 #search-results .sr-items {
   font-size: 24px;
 }

--- a/src/docfx.website.themes/default/styles/docfx.css
+++ b/src/docfx.website.themes/default/styles/docfx.css
@@ -372,8 +372,8 @@ article section {
 }
 
 @-o-keyframes index-loading {
-    from { -webkit-transform: rotate(0deg);}
-    to { -webkit-transform: rotate(360deg);}
+    from { -o-transform: rotate(0deg);}
+    to { -o-transform: rotate(360deg);}
 }
 
 #search-results .sr-items {

--- a/src/docfx.website.themes/default/styles/docfx.js
+++ b/src/docfx.website.themes/default/styles/docfx.js
@@ -223,6 +223,9 @@ $(function () {
         $("body").bind("queryReady", function () {
           worker.postMessage({ q: query });
         });
+        if (query && (query.length >= 3)) {
+          worker.postMessage({ q: query });
+        }
       });
     }
 


### PR DESCRIPTION
There is a race condition here in docfx.js:

```
      indexReady.promise().done(function () {
        $("body").bind("queryReady", function () {
          worker.postMessage({ q: query });
        });
      });
```

when the promise completes and `query` already has a value, the code needs to post `query` to the worker. Otherwise the query never runs.

The PR also displays a spinner while the search index is loaded as index loading takes some time on larger docs.

#2597