### PR TITLE
Share InvalidPathChars between PathUtility and RelativePath.

### DIFF
--- a/src/Microsoft.DocAsCode.Common/Path/PathUtility.cs
+++ b/src/Microsoft.DocAsCode.Common/Path/PathUtility.cs
@@ -15,8 +15,10 @@ namespace Microsoft.DocAsCode.Common
     public static class PathUtility
     {
         private static readonly Regex UriWithProtocol = new Regex(@"^\w{2,}\:", RegexOptions.Compiled);
-        private static readonly char[] InvalidFileNameChars = Path.GetInvalidFileNameChars();
-        private static readonly char[] InvalidPathChars = Path.GetInvalidPathChars();
+
+        private static readonly char[] AdditionalInvalidChars = ":*".ToArray();
+        public static readonly char[] InvalidFileNameChars = Path.GetInvalidFileNameChars().Concat(AdditionalInvalidChars).ToArray();
+        public static readonly char[] InvalidPathChars = Path.GetInvalidPathChars().Concat(AdditionalInvalidChars).ToArray();         
         private static readonly string InvalidFileNameCharsRegexString = $"[{Regex.Escape(new string(InvalidFileNameChars))}]";
 
         // refers to http://index/?query=urlencode&rightProject=System&file=%5BRepoRoot%5D%5CNDP%5Cfx%5Csrc%5Cnet%5CSystem%5CNet%5Cwebclient.cs&rightSymbol=fptyy6owkva8

--- a/src/Microsoft.DocAsCode.Common/Path/RelativePath.cs
+++ b/src/Microsoft.DocAsCode.Common/Path/RelativePath.cs
@@ -19,12 +19,11 @@ namespace Microsoft.DocAsCode.Common
         private const string ParentDirectory = "../";
         public const char WorkingFolderChar = '~';
         public const string WorkingFolderString = "~";
-        public static readonly char[] InvalidChars = Path.GetInvalidPathChars().Concat(":*").ToArray();
         public static readonly string NormalizedWorkingFolder = "~/";
         public static readonly string AltWorkingFolder = "~\\";
         public static readonly RelativePath Empty = new RelativePath(false, 0, new string[] { string.Empty });
         public static readonly RelativePath WorkingFolder = new RelativePath(true, 0, new string[] { string.Empty });
-        public static readonly char[] InvalidPartChars = InvalidChars.Concat(@"\/?").ToArray();
+        public static readonly char[] InvalidPartChars = PathUtility.InvalidPathChars.Concat(@"\/?").ToArray();
         private static readonly string[] EncodedInvalidPartChars = Array.ConvertAll(InvalidPartChars, ch => Uri.EscapeDataString(ch.ToString()));
         private static readonly char[] UnsafeInvalidPartChars = { '/' };
         private static readonly string[] EncodedUnsafeInvalidPartChars = Array.ConvertAll(UnsafeInvalidPartChars, ch => Uri.EscapeDataString(ch.ToString()));
@@ -58,7 +57,7 @@ namespace Microsoft.DocAsCode.Common
                 path.Length > 0 &&
                 path[0] != '/' &&
                 path[0] != '\\' &&
-                path.IndexOfAny(InvalidChars) == -1;
+                path.IndexOfAny(PathUtility.InvalidPathChars) == -1;
         }
 
         public static RelativePath Parse(string path) => TryParseCore(path, true);
@@ -373,7 +372,7 @@ namespace Microsoft.DocAsCode.Common
             {
                 return Empty;
             }
-            if (path.IndexOfAny(InvalidChars) != -1)
+            if (path.IndexOfAny(PathUtility.InvalidPathChars) != -1)
             {
                 if (throwOnError)
                 {


### PR DESCRIPTION
InvalidChars was inconsistent between PathUtility.cs and RelativePath.cs.

This caused DocFx to generate filenames on Linux that were treated as invalid by RelativePath.cs. For example for operator `(*)` a filename containing a `*` was generated, but then rejected by RelativePath resulting in an exception.
  