### PR TITLE
Enable extra emphasis syntax to keep consistent with GFM

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdigEngine/MarkdownExtensions.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine/MarkdownExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine
         {
             return pipeline
                 //.UseMathematics()
-                //.UseEmphasisExtras()
+                .UseEmphasisExtras()
                 .UseAutoIdentifiers(AutoIdentifierOptions.GitHub)
                 .UseMediaLinks()
                 .UsePipeTables()

--- a/src/Microsoft.DocAsCode.MarkdigEngine/MarkdownExtensions.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine/MarkdownExtensions.cs
@@ -12,6 +12,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine
     using Markdig;
     using Markdig.Extensions.AutoIdentifiers;
     using Markdig.Extensions.CustomContainers;
+    using Markdig.Extensions.EmphasisExtras;
     using Markdig.Parsers;
 
     public static class MarkdownExtensions
@@ -20,7 +21,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine
         {
             return pipeline
                 //.UseMathematics()
-                .UseEmphasisExtras()
+                .UseEmphasisExtras(EmphasisExtraOptions.Strikethrough)
                 .UseAutoIdentifiers(AutoIdentifierOptions.GitHub)
                 .UseMediaLinks()
                 .UsePipeTables()


### PR DESCRIPTION
Here's [the spec](https://github.com/lunet-io/markdig/blob/master/src/Markdig.Tests/Specs/EmphasisExtraSpecs.md) for extra emphasis.