### PR TITLE
Extract per document context into InclusionContext

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
@@ -170,22 +170,23 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
         protected override void Write(HtmlRenderer renderer, CodeSnippet codeSnippet)
         {
-            var (content, codeSnippetPath) = _context.ReadFile(codeSnippet.CodePath, _context.File);
+            var (content, codeSnippetPath) = _context.ReadFile(codeSnippet.CodePath, InclusionContext.File);
 
             if (content == null)
             {
-                Logger.LogWarning($"Cannot resolve '{codeSnippet.CodePath}' relative to '{_context.File}'.");
+                Logger.LogWarning($"Cannot resolve '{codeSnippet.CodePath}' relative to '{InclusionContext.File}'.");
                 renderer.WriteEscape(codeSnippet.Raw);
                 return;
             }
 
-            _context.Dependencies.Add(codeSnippetPath);
+            using (InclusionContext.PushFile(codeSnippetPath))
+            {
+                codeSnippet.SetAttributeString();
 
-            codeSnippet.SetAttributeString();
-
-            renderer.Write("<pre><code").WriteAttributes(codeSnippet).Write(">");
-            renderer.WriteEscape(GetContent(content, codeSnippet));
-            renderer.Write("</code></pre>");
+                renderer.Write("<pre><code").WriteAttributes(codeSnippet).Write(">");
+                renderer.WriteEscape(GetContent(content, codeSnippet));
+                renderer.Write("</code></pre>");
+            }
         }
 
         private string GetContent(string content, CodeSnippet obj)

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionContext.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionContext.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+
+    /// <summary>
+    /// Represents a thread static context of the current document.
+    /// </summary>
+    /// <remarks>
+    /// Due to markdig API design, it is not obvious to pass per document information and reusing the
+    /// same markdown pipeline instance at the same time.
+    /// Thus a thread static <see cref="InclusionContext"/> class is created to store per document information.
+    /// </remarks>
+    public static class InclusionContext
+    {
+        [ThreadStatic]
+        private static ImmutableStack<object> t_files;
+
+        [ThreadStatic]
+        private static ImmutableHashSet<object> t_dependencies;
+
+        /// <summary>
+        /// Identifies the file that owns this content.
+        /// </summary>
+        public static object File => t_files != null && !t_files.IsEmpty ? t_files.Peek() : null;
+
+        /// <summary>
+        /// Whether the content is included by other markdown files.
+        /// </summary>
+        public static bool IsInclude => t_files != null && t_files.Count() > 1;
+
+        /// <summary>
+        /// Gets all the dependencies referenced by the root markdown context.
+        /// </summary>
+        public static IEnumerable<object> Dependencies => (IEnumerable<object>)t_dependencies ?? ImmutableArray<object>.Empty;
+
+        /// <summary>
+        /// Creates a scope to use the specified file.
+        /// </summary>
+        public static IDisposable PushFile(object file)
+        {
+            var current = t_files ?? ImmutableStack<object>.Empty;
+
+            if (current.IsEmpty)
+            {
+                // Clear dependencies for the root scope.
+                t_dependencies = ImmutableHashSet<object>.Empty;
+            }
+            else
+            {
+                t_dependencies = (t_dependencies ?? ImmutableHashSet<object>.Empty).Add(file);
+            }
+
+            t_files = current.Push(file);
+
+            return new DelegatingDisposable(() => t_files = current);
+        }
+
+        /// <summary>
+        /// Checks if the input file results in a circular reference.
+        /// </summary>
+        public static bool IsCircularReference(object file, out IEnumerable<object> dependencyChain)
+        {
+            dependencyChain = null;
+
+            if (t_files.Contains(file))
+            {
+                dependencyChain = t_files.Concat(new[] { file });
+                return true;
+            }
+
+            return false;
+        }
+
+        class DelegatingDisposable : IDisposable
+        {
+            private readonly Action _dispose;
+
+            public DelegatingDisposable(Action dispose) => _dispose = dispose;
+
+            public void Dispose() => _dispose();
+        }
+    }
+}

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionExtension.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionExtension.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
         private static void UpdateLinks(MarkdownObject markdownObject, MarkdownContext context)
         {
-            if (markdownObject == null || context == null || context.File == null) return;
+            if (markdownObject == null || context == null) return;
 
             if (markdownObject is ContainerBlock containerBlock)
             {
@@ -81,7 +81,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
                 if (markdownObject is LinkInline linkInline)
                 {
-                    linkInline.GetDynamicUrl = () => context.GetLink(linkInline.Url, context.File);
+                    linkInline.GetDynamicUrl = () => context.GetLink(linkInline.Url, InclusionContext.File);
                 }
             }
         }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/InlineOnly/InlineOnlyExtension.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/InlineOnly/InlineOnlyExtension.cs
@@ -3,14 +3,7 @@
 
 namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-
     using Markdig;
-    using Markdig.Helpers;
     using Markdig.Parsers;
     using Markdig.Renderers;
 

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/LineNumber/LineNumberExtension.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/LineNumber/LineNumberExtension.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             pipeline.PreciseSourceLocation = true;
             pipeline.DocumentProcessed += document =>
             {
-                AddSourceInfoInDataEntry(document, _context.GetFilePath(_context.File));
+                AddSourceInfoInDataEntry(document, _context.GetFilePath(InclusionContext.File));
             };
         }
 

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownContext.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownContext.cs
@@ -27,16 +27,6 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         public delegate string GetLinkDelegate(string path, object relativeTo);
 
         /// <summary>
-        /// Identifies the file that owns this content.
-        /// </summary>
-        public object File { get; }
-
-        /// <summary>
-        /// Whether the content is parsed as inline only.
-        /// </summary>
-        public bool IsInline { get; }
-
-        /// <summary>
         /// Whether validation is enabled during markup.
         /// </summary>
         public bool EnableValidation { get; }
@@ -71,31 +61,15 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         /// </summary>
         public Func<object, string> GetFilePath { get; }
 
-        /// <summary>
-        /// Used to detect circular references.
-        /// </summary>
-        public ImmutableStack<object> CircularReferenceDetector { get; }
-
-        /// <summary>
-        /// Gets all the dependencies referenced by the root markdown context.
-        /// </summary>
-        public HashSet<object> Dependencies { get; }
-
         public MarkdownContext(
-            object filePath,
-            bool isInline,
             bool enableSourceInfo,
             IReadOnlyDictionary<string, string> tokens,
             MarkdownValidatorBuilder mvb,
             bool enableValidation = false,
             ReadFileDelegate readFile = null,
             GetLinkDelegate getLink = null,
-            Func<object, string> getFilePath = null,
-            ImmutableStack<object> circularReferenceDetector = null,
-            HashSet<object> dependencies = null)
+            Func<object, string> getFilePath = null)
         {
-            File = filePath;
-            IsInline = isInline;
             EnableSourceInfo = enableSourceInfo;
             EnableValidation = enableValidation;
             Mvb = mvb;
@@ -104,17 +78,15 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             ReadFile = readFile ?? ReadFileDefault;
             GetLink = getLink ?? ((path, relativeTo) => path);
             GetFilePath = getFilePath ?? (file => file.ToString());
-            Dependencies = dependencies ?? new HashSet<object>();
-            CircularReferenceDetector = (circularReferenceDetector ?? ImmutableStack<object>.Empty).Push(filePath);
         }
 
         private static (string content, object file) ReadFileDefault(string path, object relativeTo)
         {
             var target = relativeTo != null ? path : Path.Combine(relativeTo.ToString(), path);
 
-            if (System.IO.File.Exists(target))
+            if (File.Exists(target))
             {
-                return (System.IO.File.ReadAllText(target), target);
+                return (File.ReadAllText(target), target);
             }
 
             return (null, null);

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownExtensions.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownExtensions.cs
@@ -49,9 +49,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
                 .UseValidators(context)
                 .UseInteractiveCode()
                 .UseRow()
-                .UseNestedColumn()
-                // Do not add extension after the InineParser
-                .UseInlineParserOnly(context);
+                .UseNestedColumn();
         }
 
         public static MarkdownPipelineBuilder RemoveUnusedExtensions(this MarkdownPipelineBuilder pipeline)
@@ -68,17 +66,13 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             }
             return pipeline;
         }
-
-        /// <summary>
-        /// This extension removes all the block parser except paragragh. Please use this extension in the last.
+	
+        /// <summary>	
+        /// This extension removes all the block parser except paragragh. Please use this extension in the last.	
         /// </summary>
-        public static MarkdownPipelineBuilder UseInlineParserOnly(this MarkdownPipelineBuilder pipeline, MarkdownContext context)
+        public static MarkdownPipelineBuilder UseInlineOnly(this MarkdownPipelineBuilder pipeline)
         {
-            if (context.IsInline)
-            {
-                pipeline.Extensions.Add(new InlineOnlyExtentsion());
-            }
-
+            pipeline.Extensions.Add(new InlineOnlyExtentsion());
             return pipeline;
         }
 

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Row/Row.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Row/Row.cs
@@ -3,14 +3,87 @@
 
 namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 {
-    using Markdig.Parsers;
-    using Markdig.Syntax;
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
 
-    public class RowBlock : ContainerBlock
+    /// <summary>
+    /// Represents a thread static context of the current document.
+    /// </summary>
+    /// <remarks>
+    /// Due to markdig API design, it is not obvious to pass per document information and reusing the
+    /// same markdown pipeline instance at the same time.
+    /// Thus a thread static <see cref="InclusionContext"/> class is created to store per document information.
+    /// </remarks>
+    public static class InclusionContext
     {
-        public int ColonCount { get; set; }
-        public RowBlock(BlockParser parser) : base(parser)
+        [ThreadStatic]
+        private static ImmutableStack<object> t_files;
+
+        [ThreadStatic]
+        private static ImmutableHashSet<object> t_dependencies;
+
+        /// <summary>
+        /// Identifies the file that owns this content.
+        /// </summary>
+        public static object File => t_files != null && !t_files.IsEmpty ? t_files.Peek() : null;
+
+        /// <summary>
+        /// Whether the content is included by other markdown files.
+        /// </summary>
+        public static bool IsInclude => t_files != null && t_files.Count() > 1;
+
+        /// <summary>
+        /// Gets all the dependencies referenced by the root markdown context.
+        /// </summary>
+        public static IEnumerable<object> Dependencies => (IEnumerable<object>)t_dependencies ?? ImmutableArray<object>.Empty;
+
+        /// <summary>
+        /// Creates a scope to use the specified file.
+        /// </summary>
+        public static IDisposable PushFile(object file)
         {
+            var current = t_files ?? ImmutableStack<object>.Empty;
+
+            if (current.IsEmpty)
+            {
+                // Clear dependencies for the root scope.
+                t_dependencies = ImmutableHashSet<object>.Empty;
+            }
+            else
+            {
+                t_dependencies = (t_dependencies ?? ImmutableHashSet<object>.Empty).Add(file);
+            }
+
+            t_files = current.Push(file);
+
+            return new DelegatingDisposable(() => t_files = current);
+        }
+
+        /// <summary>
+        /// Checks if the input file results in a circular reference.
+        /// </summary>
+        public static bool IsCircularReference(object file, out IEnumerable<object> dependencyChain)
+        {
+            dependencyChain = null;
+
+            if (t_files.Contains(file))
+            {
+                dependencyChain = t_files.Concat(new[] { file });
+                return true;
+            }
+
+            return false;
+        }
+
+        class DelegatingDisposable : IDisposable
+        {
+            private readonly Action _dispose;
+
+            public DelegatingDisposable(Action dispose) => _dispose = dispose;
+
+            public void Dispose() => _dispose();
         }
     }
 }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Row/Row.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Row/Row.cs
@@ -3,87 +3,14 @@
 
 namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Collections.Immutable;
-    using System.Linq;
+    using Markdig.Parsers;
+    using Markdig.Syntax;
 
-    /// <summary>
-    /// Represents a thread static context of the current document.
-    /// </summary>
-    /// <remarks>
-    /// Due to markdig API design, it is not obvious to pass per document information and reusing the
-    /// same markdown pipeline instance at the same time.
-    /// Thus a thread static <see cref="InclusionContext"/> class is created to store per document information.
-    /// </remarks>
-    public static class InclusionContext
+    public class RowBlock : ContainerBlock
     {
-        [ThreadStatic]
-        private static ImmutableStack<object> t_files;
-
-        [ThreadStatic]
-        private static ImmutableHashSet<object> t_dependencies;
-
-        /// <summary>
-        /// Identifies the file that owns this content.
-        /// </summary>
-        public static object File => t_files != null && !t_files.IsEmpty ? t_files.Peek() : null;
-
-        /// <summary>
-        /// Whether the content is included by other markdown files.
-        /// </summary>
-        public static bool IsInclude => t_files != null && t_files.Count() > 1;
-
-        /// <summary>
-        /// Gets all the dependencies referenced by the root markdown context.
-        /// </summary>
-        public static IEnumerable<object> Dependencies => (IEnumerable<object>)t_dependencies ?? ImmutableArray<object>.Empty;
-
-        /// <summary>
-        /// Creates a scope to use the specified file.
-        /// </summary>
-        public static IDisposable PushFile(object file)
+        public int ColonCount { get; set; }
+        public RowBlock(BlockParser parser) : base(parser)
         {
-            var current = t_files ?? ImmutableStack<object>.Empty;
-
-            if (current.IsEmpty)
-            {
-                // Clear dependencies for the root scope.
-                t_dependencies = ImmutableHashSet<object>.Empty;
-            }
-            else
-            {
-                t_dependencies = (t_dependencies ?? ImmutableHashSet<object>.Empty).Add(file);
-            }
-
-            t_files = current.Push(file);
-
-            return new DelegatingDisposable(() => t_files = current);
-        }
-
-        /// <summary>
-        /// Checks if the input file results in a circular reference.
-        /// </summary>
-        public static bool IsCircularReference(object file, out IEnumerable<object> dependencyChain)
-        {
-            dependencyChain = null;
-
-            if (t_files.Contains(file))
-            {
-                dependencyChain = t_files.Concat(new[] { file });
-                return true;
-            }
-
-            return false;
-        }
-
-        class DelegatingDisposable : IDisposable
-        {
-            private readonly Action _dispose;
-
-            public DelegatingDisposable(Action dispose) => _dispose = dispose;
-
-            public void Dispose() => _dispose();
         }
     }
 }

--- a/src/Microsoft.DocAsCode.MarkdigEngine/MarkdigMarkdownService.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine/MarkdigMarkdownService.cs
@@ -48,16 +48,19 @@ namespace Microsoft.DocAsCode.MarkdigEngine
                 throw new ArgumentException("file path can't be null or empty.");
             }
 
-            var options = CreateOptions(content, filePath, false, enableValidation);
+            var options = CreateOptions(enableValidation);
             var pipeline = new MarkdownPipelineBuilder()
                 .UseDocfxExtensions(options)
                 .Build();
 
-            return new MarkupResult
+            using (InclusionContext.PushFile((RelativePath)filePath))
             {
-                Html = Markdown.ToHtml(content, pipeline),
-                Dependency = options.Dependencies.Select(file => (string)(RelativePath)file).ToImmutableArray()
-            };
+                return new MarkupResult
+                {
+                    Html = Markdown.ToHtml(content, pipeline),
+                    Dependency = InclusionContext.Dependencies.Select(file => (string)(RelativePath)file).ToImmutableArray()
+                };
+            }
         }
 
         public MarkdownDocument Parse(string content, string filePath)
@@ -77,15 +80,22 @@ namespace Microsoft.DocAsCode.MarkdigEngine
                 throw new ArgumentException("file path can't be null or empty.");
             }
 
-            var options = CreateOptions(content, filePath, isInline);
-            var pipeline = new MarkdownPipelineBuilder()
-                .UseDocfxExtensions(options)
-                .Build();
+            var options = CreateOptions(isInline);
+            var builder = new MarkdownPipelineBuilder()
+                .UseDocfxExtensions(options);
 
-            var document = Markdown.Parse(content, pipeline);
-            document.SetData("filePath", filePath);
+            if (isInline)
+            {
+                builder.UseInlineOnly();
+            }
 
-            return document;
+            using (InclusionContext.PushFile((RelativePath)filePath))
+            {
+                var document = Markdown.Parse(content, builder.Build());
+                document.SetData("filePath", filePath);
+
+                return document;
+            }
         }
 
         public MarkupResult Render(MarkdownDocument document)
@@ -106,27 +116,32 @@ namespace Microsoft.DocAsCode.MarkdigEngine
                 throw new ArgumentNullException("file path can't be found in AST.");
             }
 
-            var options = CreateOptions(null, filePath, isInline);
-            var pipeline = new MarkdownPipelineBuilder()
-                .UseDocfxExtensions(options)
-                .Build();
+            var options = CreateOptions(isInline);
+            var builder = new MarkdownPipelineBuilder()
+                .UseDocfxExtensions(options);
 
+            if (isInline)
+            {
+                builder.UseInlineOnly();
+            }
+
+            using (InclusionContext.PushFile((RelativePath)filePath))
             using (var writer = new StringWriter())
             {
                 var renderer = new HtmlRenderer(writer);
-                pipeline.Setup(renderer);
+                builder.Build().Setup(renderer);
                 renderer.Render(document);
                 writer.Flush();
 
                 return new MarkupResult
                 {
                     Html = writer.ToString(),
-                    Dependency = options.Dependencies.Select(file => (string)(RelativePath)file).ToImmutableArray()
+                    Dependency = InclusionContext.Dependencies.Select(file => (string)(RelativePath)file).ToImmutableArray()
                 };
             }
         }
 
-        private MarkdownContext CreateOptions(string content, string filePath, bool isInline, bool enableValidation = false)
+        private MarkdownContext CreateOptions(bool enableValidation)
         {
             object enableSourceInfoObj = null;
             _parameters?.Extensions?.TryGetValue(LineNumberExtension.EnableSourceInfo, out enableSourceInfoObj);
@@ -135,8 +150,6 @@ namespace Microsoft.DocAsCode.MarkdigEngine
             var enableSourceInfo = enabled == null || enabled.Value;
 
             return new MarkdownContext(
-                (RelativePath)filePath,
-                isInline,
                 enableSourceInfo,
                 _parameters.Tokens,
                 _mvb,

--- a/src/Microsoft.DocAsCode.MarkdigEngine/MarkdigMarkdownService.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine/MarkdigMarkdownService.cs
@@ -80,7 +80,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine
                 throw new ArgumentException("file path can't be null or empty.");
             }
 
-            var options = CreateOptions(isInline);
+            var options = CreateOptions(false);
             var builder = new MarkdownPipelineBuilder()
                 .UseDocfxExtensions(options);
 
@@ -116,7 +116,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine
                 throw new ArgumentNullException("file path can't be found in AST.");
             }
 
-            var options = CreateOptions(isInline);
+            var options = CreateOptions(false);
             var builder = new MarkdownPipelineBuilder()
                 .UseDocfxExtensions(options);
 


### PR DESCRIPTION
This PR creates a thread static `InclusionContext` to house per document properties like `file`...

By doing so, `MarkdownContext` does not depend on per document properties and can become global, `MarkdownPipeline` (who depend on `MarkdownContext`) now does not depend on per document properties, thus it can be used as a simple input arg to `Markdown.Parse` or `Markdown.ToHtml`.

This allows us to create specialized `MarkdownPipeline` for different purposes, allow us to toggle or customize features like validation, yaml header, source line support using `pipeline.UseXXX` convention.