### PR TITLE
Links in markdown include files should start with ~/

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdigEngine/MarkdigMarkdownService.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine/MarkdigMarkdownService.cs
@@ -164,9 +164,9 @@ namespace Microsoft.DocAsCode.MarkdigEngine
 
         private static string GetLink(string path, object relativeTo)
         {
-            if (RelativePath.IsRelativePath(path) && PathUtility.IsRelativePath(path) && !RelativePath.IsPathFromWorkingFolder(path) && !path.StartsWith("#"))
+            if (InclusionContext.IsInclude && RelativePath.IsRelativePath(path) && PathUtility.IsRelativePath(path) && !RelativePath.IsPathFromWorkingFolder(path) && !path.StartsWith("#"))
             {
-                return ((RelativePath)relativeTo + (RelativePath)path).RemoveWorkingFolder();
+                return ((RelativePath)relativeTo + (RelativePath)path).GetPathFromWorkingFolder();
             }
             return path;
         }

--- a/test/Microsoft.DocAsCode.MarkdigEngine.Tests/GeneralTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdigEngine.Tests/GeneralTest.cs
@@ -67,7 +67,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Tests
             var source = @"![scenario image][scenario]
 ## Scenario
 [scenario]: ./scenario.png";
-            var expected = @"<p><img src=""scenario.png"" alt=""scenario image"" /></p>
+            var expected = @"<p><img src=""./scenario.png"" alt=""scenario image"" /></p>
 <h2 id=""scenario"">Scenario</h2>
 ";
 

--- a/test/Microsoft.DocAsCode.MarkdigEngine.Tests/InclusionTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdigEngine.Tests/InclusionTest.cs
@@ -308,9 +308,9 @@ Paragraph1
             var marked = TestUtility.MarkupWithoutSourceInfo(root, "r/root.md");
             var dependency = marked.Dependency;
             var expected = @"<p>Paragraph1
-<a href=""r/b/a.md"">link</a>
-<a href=""r/link/md/c.md"">link</a>
-<img src=""r/b/img/img.jpg"" alt=""Image"" />
+<a href=""%7E/r/b/a.md"">link</a>
+<a href=""%7E/r/link/md/c.md"">link</a>
+<img src=""%7E/r/b/img/img.jpg"" alt=""Image"" />
 [!include[root](../root.md)]</p>
 <p><strong>Hello</strong></p>
 <p><strong>Hello</strong></p>
@@ -364,11 +364,11 @@ Paragraph1
             TestUtility.WriteToFile("r/b/token.md", token);
             TestUtility.WriteToFile("r/c/d/d.md", d);
             var marked = TestUtility.MarkupWithoutSourceInfo(a, "r/a/a.md");
-            var expected = @"<p><img src=""r/img/img.jpg"" alt="""" />
+            var expected = @"<p><img src=""%7E/r/img/img.jpg"" alt="""" />
 <a href=""#anchor""></a>
-<a href=""r/a/a.md"">a</a>
-<a href=""r/b/invalid.md""></a>
-<a href=""r/c/d/d.md#anchor"">d</a></p>".Replace("\r\n", "\n") + "\n";
+<a href=""%7E/r/a/a.md"">a</a>
+<a href=""%7E/r/b/invalid.md""></a>
+<a href=""%7E/r/c/d/d.md#anchor"">d</a></p>".Replace("\r\n", "\n") + "\n";
             var dependency = marked.Dependency;
             Assert.Equal(expected, marked.Html);
             Assert.Equal(
@@ -675,7 +675,7 @@ Test Include File
             var expected = @"<h1 id=""hello-world"">Hello World</h1>
 <p>Test Include File</p>
 <h1 id=""hello-include-file-a"">Hello Include File A</h1>
-<p><img src=""r/include/media/refb.png"" alt=""img"" /></p>
+<p><img src=""%7E/r/include/media/refb.png"" alt=""img"" /></p>
 ";
             Assert.Equal(expected.Replace("\r\n", "\n"), result.Html);
 


### PR DESCRIPTION
Reverts test cases in https://github.com/dotnet/docfx/commit/4ba3e43cf5f303a825335b0d0713b300d792cde8#diff-f83fd1c7ee84ca19c4ce6367e90529dc
