### PR TITLE
Fix travis CI failure caused by git shallow clone

### DIFF
--- a/src/docfx/lib/git/GitUtility.Native.cs
+++ b/src/docfx/lib/git/GitUtility.Native.cs
@@ -98,13 +98,15 @@ namespace Microsoft.Docs.Build
             while (true)
             {
                 var error = NativeMethods.GitRevwalkNext(out var commitId, walk);
+                if (error == -31 /* GIT_ITEROVER */)
+                    break;
 
                 // https://github.com/libgit2/libgit2sharp/issues/1351
                 if (error == -3 /* GIT_ENOTFOUND */)
                     throw new NotSupportedException($"Does not support git shallow clone");
 
                 if (error != 0)
-                    break;
+                    throw new InvalidOperationException($"Unknown error calling git_revwalk_next: {error}");
 
                 NativeMethods.GitObjectLookup(out var commit, repo, &commitId, NativeMethods.GitObjectType.Commit);
                 var author = NativeMethods.GitCommitAuthor(commit);

--- a/test/docfx.Test/lib/GitUtilityTest.cs
+++ b/test/docfx.Test/lib/GitUtilityTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -22,9 +23,17 @@ namespace Microsoft.Docs.Build
             Assert.NotNull(repo);
 
             var pathToRepo = PathUtility.NormalizeFile(file);
-            var exe = await GitUtility.GetCommits(repo, pathToRepo);
-            var lib = GitUtility.GetCommits(repo, new List<string> { pathToRepo })[0].ToList();
-            Assert.Equal(JsonConvert.SerializeObject(exe), JsonConvert.SerializeObject(lib));
+
+            try
+            {
+                var exe = await GitUtility.GetCommits(repo, pathToRepo);
+                var lib = GitUtility.GetCommits(repo, new List<string> { pathToRepo })[0].ToList();
+                Assert.Equal(JsonConvert.SerializeObject(exe), JsonConvert.SerializeObject(lib));
+            }
+            catch (NotSupportedException ex)
+            {
+                Assert.Equal("Does not support git shallow clone", ex.Message);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Travis is using shallow clone `git clone --depth=50 --branch=v3 https://github.com/dotnet/docfx.git dotnet/docfx`

https://travis-ci.org/dotnet/docfx/builds/380017122