### PR TITLE
Jeahyoun/21139 context zones

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownExtensions.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownExtensions.cs
@@ -14,26 +14,26 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
     {
         public static MarkdownPipelineBuilder UseDocfxExtensions(this MarkdownPipelineBuilder pipeline, MarkdownContext context)
         {
-			return pipeline
-				//.UseMathematics()
-				.UseEmphasisExtras(EmphasisExtraOptions.Strikethrough)
-				.UseAutoIdentifiers(AutoIdentifierOptions.GitHub)
-				.UseMediaLinks()
-				.UsePipeTables()
-				.UseAutoLinks()
-				.UseHeadingIdRewriter()
-				.UseIncludeFile(context)
-				.UseCodeSnippet(context)
-				.UseDFMCodeInfoPrefix()
-				.UseQuoteSectionNote(context)
-				.UseXref()
-				.UseEmojiAndSmiley(false)
-				.UseTabGroup(context)
-				.UseMonikerRange(context)
-				.UseInteractiveCode()
-				.UseRow(context)
-				.UseNestedColumn(context)
-				.UseRenderZone(context)
+            return pipeline
+                //.UseMathematics()
+                .UseEmphasisExtras(EmphasisExtraOptions.Strikethrough)
+                .UseAutoIdentifiers(AutoIdentifierOptions.GitHub)
+                .UseMediaLinks()
+                .UsePipeTables()
+                .UseAutoLinks()
+                .UseHeadingIdRewriter()
+                .UseIncludeFile(context)
+                .UseCodeSnippet(context)
+                .UseDFMCodeInfoPrefix()
+                .UseQuoteSectionNote(context)
+                .UseXref()
+                .UseEmojiAndSmiley(false)
+                .UseTabGroup(context)
+                .UseMonikerRange(context)
+                .UseInteractiveCode()
+                .UseRow(context)
+                .UseNestedColumn(context)
+                .UseRenderZone(context)
                 .RemoveUnusedExtensions();
         }
 
@@ -42,7 +42,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             pipeline.Extensions.RemoveAll(extension => extension is CustomContainerExtension);
             return pipeline;
         }
-	
+    
         /// <summary>	
         /// This extension removes all the block parser except paragragh. Please use this extension in the last.	
         /// </summary>
@@ -131,10 +131,10 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             return pipeline;
         }
 
-		public static MarkdownPipelineBuilder UseRenderZone(this MarkdownPipelineBuilder pipeline, MarkdownContext context)
-		{
-			pipeline.Extensions.Insert(0, new RenderZoneExtension(context));
-			return pipeline;
-		}
-	}
+        public static MarkdownPipelineBuilder UseRenderZone(this MarkdownPipelineBuilder pipeline, MarkdownContext context)
+        {
+            pipeline.Extensions.Insert(0, new RenderZoneExtension(context));
+            return pipeline;
+        }
+    }
 }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownExtensions.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownExtensions.cs
@@ -14,25 +14,26 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
     {
         public static MarkdownPipelineBuilder UseDocfxExtensions(this MarkdownPipelineBuilder pipeline, MarkdownContext context)
         {
-            return pipeline
-                //.UseMathematics()
-                .UseEmphasisExtras(EmphasisExtraOptions.Strikethrough)
-                .UseAutoIdentifiers(AutoIdentifierOptions.GitHub)
-                .UseMediaLinks()
-                .UsePipeTables()
-                .UseAutoLinks()
-                .UseHeadingIdRewriter()
-                .UseIncludeFile(context)
-                .UseCodeSnippet(context)
-                .UseDFMCodeInfoPrefix()
-                .UseQuoteSectionNote(context)
-                .UseXref()
-                .UseEmojiAndSmiley(false)
-                .UseTabGroup(context)
-                .UseMonikerRange(context)
-                .UseInteractiveCode()
-                .UseRow(context)
-                .UseNestedColumn(context)
+			return pipeline
+				//.UseMathematics()
+				.UseEmphasisExtras(EmphasisExtraOptions.Strikethrough)
+				.UseAutoIdentifiers(AutoIdentifierOptions.GitHub)
+				.UseMediaLinks()
+				.UsePipeTables()
+				.UseAutoLinks()
+				.UseHeadingIdRewriter()
+				.UseIncludeFile(context)
+				.UseCodeSnippet(context)
+				.UseDFMCodeInfoPrefix()
+				.UseQuoteSectionNote(context)
+				.UseXref()
+				.UseEmojiAndSmiley(false)
+				.UseTabGroup(context)
+				.UseMonikerRange(context)
+				.UseInteractiveCode()
+				.UseRow(context)
+				.UseNestedColumn(context)
+				.UseRenderZone(context)
                 .RemoveUnusedExtensions();
         }
 
@@ -129,5 +130,11 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             pipeline.Extensions.AddIfNotAlready(new NestedColumnExtension(context));
             return pipeline;
         }
-    }
+
+		public static MarkdownPipelineBuilder UseRenderZone(this MarkdownPipelineBuilder pipeline, MarkdownContext context)
+		{
+			pipeline.Extensions.Insert(0, new RenderZoneExtension(context));
+			return pipeline;
+		}
+	}
 }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/RenderZone/RenderZoneBlock.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/RenderZone/RenderZoneBlock.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    using Markdig.Parsers;
+    using Markdig.Syntax;
+
+    public class RenderZoneBlock : ContainerBlock
+    {
+		public string Target { get; set; }
+        public int ColonCount { get; set; }
+        public bool Closed { get; set; }
+        public RenderZoneBlock(BlockParser parser) : base(parser)
+        {
+        }
+    }
+}

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/RenderZone/RenderZoneExtension.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/RenderZone/RenderZoneExtension.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
+{
+    using Markdig;
+    using Markdig.Extensions.CustomContainers;
+    using Markdig.Renderers;
+
+    public class RenderZoneExtension : IMarkdownExtension
+    {
+        private readonly MarkdownContext _context;
+
+        public RenderZoneExtension(MarkdownContext context)
+        {
+            _context = context;
+        }
+
+        public void Setup(MarkdownPipelineBuilder pipeline)
+        {
+            if (pipeline.BlockParsers.Contains<CustomContainerParser>())
+            {
+                pipeline.BlockParsers.InsertBefore<CustomContainerParser>(new RenderZoneParser(_context));
+            }
+            else
+            {
+                pipeline.BlockParsers.AddIfNotAlready(new RenderZoneParser(_context));
+            }            
+        }
+
+        public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
+        {
+            var htmlRenderer = renderer as HtmlRenderer;
+            if (htmlRenderer != null && !htmlRenderer.ObjectRenderers.Contains<RenderZoneRender>())
+            {
+                htmlRenderer.ObjectRenderers.Insert(0, new RenderZoneRender());
+            }
+        }
+    }
+}

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/RenderZone/RenderZoneParser.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/RenderZone/RenderZoneParser.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
             ExtensionsHelper.SkipSpaces(ref slice);
 
-            if (!ExtensionsHelper.MatchStart(ref slice, "zone", false))
+            if (!ExtensionsHelper.MatchStart(ref slice, StartString, false))
             {
                 return BlockState.None;
             }
@@ -72,7 +72,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
             if (c != '"')
             {
-                _context.LogWarning("invalid-render-zone", "MonikerRange does not have ending charactor (\").");
+                _context.LogWarning("invalid-render-zone", "Zone render does not have ending character (\").");
                 return BlockState.None;
             }
 
@@ -84,7 +84,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
             if (!c.IsZero())
             {
-                _context.LogWarning("invalid-render-zone", $"MonikerRange have some invalid chars in the starting.");
+                _context.LogWarning("invalid-render-zone", $"Zone render has some invalid chars in the beginning.");
             }
 
             processor.NewBlocks.Push(new RenderZoneBlock(this)
@@ -118,7 +118,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
             ExtensionsHelper.SkipSpaces(ref slice);
 
-            if (!ExtensionsHelper.MatchStart(ref slice, "zone-end", false))
+            if (!ExtensionsHelper.MatchStart(ref slice, EndString, false))
             {
                 return BlockState.Continue;
             }
@@ -127,7 +127,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
             if (!c.IsZero())
             {
-                _context.LogWarning("invalid-render-zone", $"MonikerRange have some invalid chars in the ending.");
+                _context.LogWarning("invalid-render-zone", $"Zone render has some invalid chars in the ending.");
             }
 
             block.UpdateSpanEnd(slice.End);
@@ -141,7 +141,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             var renderZone = (RenderZoneBlock)block;
             if (renderZone != null && renderZone.Closed == false)
             {
-                _context.LogWarning("invalid-render-zone", $"No \"::: {EndString}\" found for \"{renderZone.Target}\", MonikerRange does not end explictly.");
+                _context.LogWarning("invalid-render-zone", $"No \"::: {EndString}\" found for \"{renderZone.Target}\", zone does not end explictly.");
             }
             return true;
         }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/RenderZone/RenderZoneParser.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/RenderZone/RenderZoneParser.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
+{
+    using Markdig.Helpers;
+    using Markdig.Parsers;
+    using Markdig.Syntax;
+
+    public class RenderZoneParser : BlockParser
+    {
+        private const string StartString = "zone";
+        private const string EndString = "zone-end";
+        private const char Colon = ':';
+
+        private readonly MarkdownContext _context;
+
+        public RenderZoneParser(MarkdownContext context)
+        {
+            OpeningCharacters = new[] { ':' };
+            _context = context;
+        }
+
+        public override BlockState TryOpen(BlockProcessor processor)
+        {
+            if (processor.IsCodeIndent)
+            {
+                return BlockState.None;
+            }
+
+            var slice = processor.Line;
+            if (ExtensionsHelper.IsEscaped(slice))
+            {
+                return BlockState.None;
+            }
+
+            var column = processor.Column;
+            var sourcePosition = processor.Start;
+            var colonCount = 0;
+
+            var c = slice.CurrentChar;
+            while (c == Colon)
+            {
+                c = slice.NextChar();
+                colonCount++;
+            }
+
+            if (colonCount < 3) return BlockState.None;
+
+            ExtensionsHelper.SkipSpaces(ref slice);
+
+            if (!ExtensionsHelper.MatchStart(ref slice, "zone", false))
+            {
+                return BlockState.None;
+            }
+
+            ExtensionsHelper.SkipSpaces(ref slice);
+
+            if (!ExtensionsHelper.MatchStart(ref slice, "render=\"", false))
+            {
+                return BlockState.None;
+            }
+
+            var range = StringBuilderCache.Local();
+            c = slice.CurrentChar;
+
+            while (c != '\0' && c != '"')
+            {
+                range.Append(c);
+                c = slice.NextChar();
+            }
+
+            if (c != '"')
+            {
+                _context.LogWarning("invalid-render-zone", "MonikerRange does not have ending charactor (\").");
+                return BlockState.None;
+            }
+
+            c = slice.NextChar();
+            while (c.IsSpace())
+            {
+                c = slice.NextChar();
+            }
+
+            if (!c.IsZero())
+            {
+                _context.LogWarning("invalid-render-zone", $"MonikerRange have some invalid chars in the starting.");
+            }
+
+            processor.NewBlocks.Push(new RenderZoneBlock(this)
+            {
+                Closed = false,
+                ColonCount = colonCount,
+                Column = column,
+                Span = new SourceSpan(sourcePosition, slice.End),
+				Target = range.ToString(),
+			});
+
+            return BlockState.ContinueDiscard;
+        }
+
+        public override BlockState TryContinue(BlockProcessor processor, Block block)
+        {
+            if (processor.IsBlankLine)
+            {
+                return BlockState.Continue;
+            }
+
+            var slice = processor.Line;
+            var renderZone = (RenderZoneBlock)block;
+
+            ExtensionsHelper.SkipSpaces(ref slice);
+
+            if(!ExtensionsHelper.MatchStart(ref slice, new string(':', renderZone.ColonCount)))
+            {
+                return BlockState.Continue;
+            }
+
+            ExtensionsHelper.SkipSpaces(ref slice);
+
+            if (!ExtensionsHelper.MatchStart(ref slice, "zone-end", false))
+            {
+                return BlockState.Continue;
+            }
+
+            var c = ExtensionsHelper.SkipSpaces(ref slice);
+
+            if (!c.IsZero())
+            {
+                _context.LogWarning("invalid-render-zone", $"MonikerRange have some invalid chars in the ending.");
+            }
+
+            block.UpdateSpanEnd(slice.End);
+            renderZone.Closed = true;
+
+            return BlockState.BreakDiscard;
+        }
+
+        public override bool Close(BlockProcessor processor, Block block)
+        {
+            var renderZone = (RenderZoneBlock)block;
+            if (renderZone != null && renderZone.Closed == false)
+            {
+                _context.LogWarning("invalid-render-zone", $"No \"::: {EndString}\" found for \"{renderZone.Target}\", MonikerRange does not end explictly.");
+            }
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/RenderZone/RenderZoneParser.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/RenderZone/RenderZoneParser.cs
@@ -87,27 +87,27 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
                 _context.LogWarning("invalid-render-zone", $"Zone render has some invalid chars in the beginning.");
             }
 
-			// Check the blockprocessor context to see if we are already inside of a zone
-			// container. If so, break.
-			var containerBlock = processor.CurrentContainer;
-			do
-			{
-				if (processor.CurrentContainer.GetType() == typeof(RenderZoneBlock))
-				{
-					_context.LogError("invalid-render-zone", "Zone render cannot be nested.");
-					return BlockState.None;
-				}
-				containerBlock = containerBlock.Parent;
-			} while (containerBlock != null);
+            // Check the blockprocessor context to see if we are already inside of a zone
+            // container. If so, break.
+            var containerBlock = processor.CurrentContainer;
+            do
+            {
+                if (processor.CurrentContainer.GetType() == typeof(RenderZoneBlock))
+                {
+                    _context.LogError("invalid-render-zone", "Zone render cannot be nested.");
+                    return BlockState.None;
+                }
+                containerBlock = containerBlock.Parent;
+            } while (containerBlock != null);
 
-			processor.NewBlocks.Push(new RenderZoneBlock(this)
+            processor.NewBlocks.Push(new RenderZoneBlock(this)
             {
                 Closed = false,
                 ColonCount = colonCount,
                 Column = column,
                 Span = new SourceSpan(sourcePosition, slice.End),
-				Target = range.ToString(),
-			});
+                Target = range.ToString(),
+            });
 
             return BlockState.ContinueDiscard;
         }
@@ -151,12 +151,12 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
         public override bool Close(BlockProcessor processor, Block block)
         {
-			if (processor.CurrentContainer != block)
-			{
-				_context.LogError("invalid-render-zone", "Invalid stack order. A render zone cannot end before other nested blocks have ended.");
-				return true;
-			}
-			var renderZone = (RenderZoneBlock)block;
+            if (processor.CurrentContainer != block)
+            {
+                _context.LogError("invalid-render-zone", "Invalid stack order. A render zone cannot end before other nested blocks have ended.");
+                return true;
+            }
+            var renderZone = (RenderZoneBlock)block;
             if (renderZone != null && renderZone.Closed == false)
             {
                 _context.LogWarning("invalid-render-zone", $"No \"::: {EndString}\" found for \"{renderZone.Target}\", zone does not end explictly.");

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/RenderZone/RenderZoneRender.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/RenderZone/RenderZoneRender.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
     {
         protected override void Write(HtmlRenderer renderer, RenderZoneBlock obj)
         {
-            renderer.Write("<div").WriteAttributes(obj).Write($" zone=\"{obj.Target}\"").WriteLine(">");
+            renderer.Write("<div").WriteAttributes(obj).Write($" data-zone=\"{obj.Target}\"").WriteLine(">");
             renderer.WriteChildren(obj);
             renderer.WriteLine("</div>");
         }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/RenderZone/RenderZoneRender.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/RenderZone/RenderZoneRender.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
+{
+    using System;
+
+    using Markdig.Renderers;
+    using Markdig.Renderers.Html;
+
+    public class RenderZoneRender : HtmlObjectRenderer<RenderZoneBlock>
+    {
+        protected override void Write(HtmlRenderer renderer, RenderZoneBlock obj)
+        {
+            renderer.Write("<div").WriteAttributes(obj).Write($" zone=\"{obj.Target}\"").WriteLine(">");
+            renderer.WriteChildren(obj);
+            renderer.WriteLine("</div>");
+        }
+    }
+}

--- a/test/Microsoft.DocAsCode.MarkdigEngine.Tests/RenderZoneTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdigEngine.Tests/RenderZoneTest.cs
@@ -6,7 +6,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Tests
     using Microsoft.DocAsCode.Common;
     using Microsoft.DocAsCode.Plugins;
     using Xunit;
-	using System.Linq;
+    using System.Linq;
 
     public class RenderZoneTest
     {
@@ -58,100 +58,100 @@ Inline ::: should not end moniker zone.</p>
             Assert.Equal(expected.Replace("\r\n", "\n"), marked.Html);
         }
 
-		[Fact]
-		public void RenderZoneTestInvalid()
-		{
-			//arange
-			var source = @"::: zone render=""chromeless";
+        [Fact]
+        public void RenderZoneTestInvalid()
+        {
+            //arange
+            var source = @"::: zone render=""chromeless";
 
-			// assert
-			var expected = @"<p>::: zone render=&quot;chromeless</p>
+            // assert
+            var expected = @"<p>::: zone render=&quot;chromeless</p>
 ";
-			var listener = TestLoggerListener.CreateLoggerListenerWithPhaseEqualFilter(LoggerPhase);
+            var listener = TestLoggerListener.CreateLoggerListenerWithPhaseEqualFilter(LoggerPhase);
 
-			Logger.RegisterListener(listener);
-			using (new LoggerPhaseScope(LoggerPhase))
-			{
-				TestUtility.AssertEqual(expected, source, TestUtility.MarkupWithoutSourceInfo);
-			}
-			Logger.UnregisterListener(listener);
+            Logger.RegisterListener(listener);
+            using (new LoggerPhaseScope(LoggerPhase))
+            {
+                TestUtility.AssertEqual(expected, source, TestUtility.MarkupWithoutSourceInfo);
+            }
+            Logger.UnregisterListener(listener);
 
-			Assert.Single(listener.Items);
-			Assert.Equal("Zone render does not have ending character (\").", listener.Items[0].Message);
-		}
+            Assert.Single(listener.Items);
+            Assert.Equal("Zone render does not have ending character (\").", listener.Items[0].Message);
+        }
 
-		[Fact]
-		public void RenderZoneTestNotClosed()
-		{
-			//arange
-			var source1 = @"::: zone render=""chromeless""";
-			var source2 = @"::: zone render=""chromeless""
+        [Fact]
+        public void RenderZoneTestNotClosed()
+        {
+            //arange
+            var source1 = @"::: zone render=""chromeless""";
+            var source2 = @"::: zone render=""chromeless""
 ::: zone-end";
 
-			// assert
-			var expected = @"<div data-zone=""chromeless"">
+            // assert
+            var expected = @"<div data-zone=""chromeless"">
 </div>
 ";
-			var listener = TestLoggerListener.CreateLoggerListenerWithPhaseEqualFilter(LoggerPhase);
+            var listener = TestLoggerListener.CreateLoggerListenerWithPhaseEqualFilter(LoggerPhase);
 
-			Logger.RegisterListener(listener);
-			using (new LoggerPhaseScope(LoggerPhase))
-			{
-				TestUtility.AssertEqual(expected, source2, TestUtility.MarkupWithoutSourceInfo);
+            Logger.RegisterListener(listener);
+            using (new LoggerPhaseScope(LoggerPhase))
+            {
+                TestUtility.AssertEqual(expected, source2, TestUtility.MarkupWithoutSourceInfo);
 
-				Assert.Empty(listener.Items);
+                Assert.Empty(listener.Items);
 
-				TestUtility.AssertEqual(expected, source1, TestUtility.MarkupWithoutSourceInfo);
-			}
-			Logger.UnregisterListener(listener);
+                TestUtility.AssertEqual(expected, source1, TestUtility.MarkupWithoutSourceInfo);
+            }
+            Logger.UnregisterListener(listener);
 
-			Assert.Single(listener.Items);
-			Assert.Equal("No \"::: zone-end\" found for \"chromeless\", zone does not end explictly.", listener.Items[0].Message);
-		}
+            Assert.Single(listener.Items);
+            Assert.Equal("No \"::: zone-end\" found for \"chromeless\", zone does not end explictly.", listener.Items[0].Message);
+        }
 
-		[Fact]
-		public void RenderZoneTestNotNested()
-		{
-			//arange
-			var content = @"::: zone render=""chromeless""
+        [Fact]
+        public void RenderZoneTestNotNested()
+        {
+            //arange
+            var content = @"::: zone render=""chromeless""
 ::: zone render=""pdf""
 ::: zone-end
 ::: zone-end
 ";
 
-			var listener = TestLoggerListener.CreateLoggerListenerWithPhaseEqualFilter(LoggerPhase);
+            var listener = TestLoggerListener.CreateLoggerListenerWithPhaseEqualFilter(LoggerPhase);
 
-			Logger.RegisterListener(listener);
-			using (new LoggerPhaseScope(LoggerPhase))
-			{
-				TestUtility.MarkupWithoutSourceInfo(content);
-			}
-			Logger.UnregisterListener(listener);
+            Logger.RegisterListener(listener);
+            using (new LoggerPhaseScope(LoggerPhase))
+            {
+                TestUtility.MarkupWithoutSourceInfo(content);
+            }
+            Logger.UnregisterListener(listener);
 
-			Assert.Single(listener.Items);
-			Assert.Equal("Zone render cannot be nested.", listener.Items[0].Message);
-		}
+            Assert.Single(listener.Items);
+            Assert.Equal("Zone render cannot be nested.", listener.Items[0].Message);
+        }
 
-		[Fact]
-		public void RenderZoneTestNoOverlap()
-		{
-			//arange
-			var content = @"::: zone render=""chromeless""
+        [Fact]
+        public void RenderZoneTestNoOverlap()
+        {
+            //arange
+            var content = @"::: zone render=""chromeless""
 ::: moniker range=""start""
 ::: zone-end
 ::: moniker-end
 ";
 
-			var listener = TestLoggerListener.CreateLoggerListenerWithPhaseEqualFilter(LoggerPhase);
+            var listener = TestLoggerListener.CreateLoggerListenerWithPhaseEqualFilter(LoggerPhase);
 
-			Logger.RegisterListener(listener);
-			using (new LoggerPhaseScope(LoggerPhase))
-			{
-				TestUtility.MarkupWithoutSourceInfo(content);
-			}
-			Logger.UnregisterListener(listener);
+            Logger.RegisterListener(listener);
+            using (new LoggerPhaseScope(LoggerPhase))
+            {
+                TestUtility.MarkupWithoutSourceInfo(content);
+            }
+            Logger.UnregisterListener(listener);
 
-			Assert.Equal("Invalid stack order. A render zone cannot end before other nested blocks have ended.", listener.Items.First(x => x.Code == "invalid-render-zone").Message);
-		}
-	}
+            Assert.Equal("Invalid stack order. A render zone cannot end before other nested blocks have ended.", listener.Items.First(x => x.Code == "invalid-render-zone").Message);
+        }
+    }
 }

--- a/test/Microsoft.DocAsCode.MarkdigEngine.Tests/RenderZoneTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdigEngine.Tests/RenderZoneTest.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode.MarkdigEngine.Tests
+{
+    using Microsoft.DocAsCode.Common;
+    using Microsoft.DocAsCode.Plugins;
+    using Xunit;
+
+    public class RenderZoneTest
+    {
+        static public string LoggerPhase = "MonikerRange";
+
+        [Fact]
+        public void RenderZoneTestGeneral()
+        {
+            //arange
+            var content = @"# Article 2
+
+Shared content.
+
+## Section 1
+
+Shared content.
+
+::: zone render=""chromeless""
+## Section for chromeless only
+
+Some chromeless-specific content here...
+
+::: nested moniker zone is not allowed. So this line is in plain text.
+Inline ::: should not end moniker zone.
+
+::: zone-end
+
+## Section 2
+
+Shared content.
+";
+
+            var marked = TestUtility.Markup(content, "fake.md");
+
+            // assert
+            var expected = @"<h1 id=""article-2"" sourceFile=""fake.md"" sourceStartLineNumber=""1"">Article 2</h1>
+<p sourceFile=""fake.md"" sourceStartLineNumber=""3"">Shared content.</p>
+<h2 id=""section-1"" sourceFile=""fake.md"" sourceStartLineNumber=""5"">Section 1</h2>
+<p sourceFile=""fake.md"" sourceStartLineNumber=""7"">Shared content.</p>
+<div sourceFile=""fake.md"" sourceStartLineNumber=""9"" zone=""chromeless"">
+<h2 id=""section-for-chromeless-only"" sourceFile=""fake.md"" sourceStartLineNumber=""10"">Section for chromeless only</h2>
+<p sourceFile=""fake.md"" sourceStartLineNumber=""12"">Some chromeless-specific content here...</p>
+<p sourceFile=""fake.md"" sourceStartLineNumber=""14"">::: nested moniker zone is not allowed. So this line is in plain text.
+Inline ::: should not end moniker zone.</p>
+</div>
+<h2 id=""section-2"" sourceFile=""fake.md"" sourceStartLineNumber=""19"">Section 2</h2>
+<p sourceFile=""fake.md"" sourceStartLineNumber=""21"">Shared content.</p>
+".Replace("\r\n", "\n");
+            Assert.Equal(expected.Replace("\r\n", "\n"), marked.Html);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for the Zones plugin, which allows content authors to use delimiters to show or hide content based on the target zone (e.g. chromeless-only content, PDf-only content).

See https://ceapex.visualstudio.com/Engineering/_workitems/edit/21139.