### PR TITLE
Fix debug test hang caused by upgrading to .net 2.1

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -11,5 +11,6 @@ $commitSha = & { git describe --always }
 $commitCount = & { git rev-list --count HEAD }
 $version = "3.0.0-preview1-$commitCount-$commitSha"
 
+exec "dotnet test test\docfx.Test"
 exec "dotnet test test\docfx.Test -c Release"
 exec "dotnet pack src\docfx -c Release -o $PSScriptRoot\drop /p:Version=$version /p:InformationalVersion=$version /p:PackAsTool=true"

--- a/test/docfx.Test/common/TestFramework.cs
+++ b/test/docfx.Test/common/TestFramework.cs
@@ -29,10 +29,10 @@ namespace Microsoft.Docs.Build
             // This only works for .NET core
             // https://github.com/dotnet/corefx/blob/master/src/Common/src/CoreLib/System/Diagnostics/Debug.cs
             // https://github.com/dotnet/corefx/blob/8dbeee99ce48a46c3cee9d1b765c3b31af94e172/src/System.Diagnostics.Debug/tests/DebugTests.cs
-            var showDialogHook = typeof(Debug).GetField("s_ShowAssertDialog", BindingFlags.Static | BindingFlags.NonPublic);
-            showDialogHook?.SetValue(null, new Action<string, string, string>(Throw));
+            var showDialogHook = typeof(Debug).GetField("s_ShowDialog", BindingFlags.Static | BindingFlags.NonPublic);
+            showDialogHook?.SetValue(null, new Action<string, string, string, string>(Throw));
 
-            void Throw(string stackTrace, string message, string detailMessage)
+            void Throw(string stackTrace, string message, string detailMessage, string info)
             {
                 Assert.True(false, $"Debug.Assert failed: {message} {detailMessage}\n{stackTrace}");
             }


### PR DESCRIPTION
Run debug test in CI to help capture this in the future.