### PR TITLE
Remove FilePathHasInvalidChars, we are on .NET core

### DIFF
--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -67,7 +67,6 @@ namespace Microsoft.Docs.Build
         /// </summary>
         public static Config Load(string docsetPath, CommandLineOptions options)
         {
-            ValidateDocsetPath(docsetPath);
             var configPath = PathUtility.NormalizeFile(Path.Combine(docsetPath, "docfx.yml"));
             if (!File.Exists(configPath))
             {
@@ -82,19 +81,10 @@ namespace Microsoft.Docs.Build
         /// <returns>Whether config exists under <paramref name="docsetPath"/></returns>
         public static bool LoadIfExists(string docsetPath, CommandLineOptions options, out Config config)
         {
-            ValidateDocsetPath(docsetPath);
             var configPath = Path.Combine(docsetPath, "docfx.yml");
             var exists = File.Exists(configPath);
             config = exists ? LoadCore(configPath, options) : new Config();
             return exists;
-        }
-
-        private static void ValidateDocsetPath(string docsetPath)
-        {
-            if (PathUtility.FolderPathHasInvalidChars(docsetPath))
-            {
-                throw Errors.ConfigNotFound(docsetPath);
-            }
         }
 
         private static Config LoadCore(string configPath, CommandLineOptions options = null)
@@ -129,8 +119,6 @@ namespace Microsoft.Docs.Build
             foreach (var path in GetExtendConfigPaths(objExtend))
             {
                 var extendConfigPath = PathUtility.NormalizeFile(Path.Combine(Path.GetDirectoryName(configPath), path));
-                if (PathUtility.FilePathHasInvalidChars(extendConfigPath))
-                    throw new Exception($"Invalid extend config path: {extendConfigPath}");
                 extendedConfig.Merge(LoadOriginalConfigObject(extendConfigPath, parents, false));
             }
             extendedConfig.Merge(config);

--- a/src/docfx/docset/Document.cs
+++ b/src/docfx/docset/Document.cs
@@ -134,7 +134,6 @@ namespace Microsoft.Docs.Build
         {
             Debug.Assert(docset != null);
             Debug.Assert(!string.IsNullOrEmpty(path));
-            Debug.Assert(!PathUtility.FilePathHasInvalidChars(path));
             Debug.Assert(!Path.IsPathRooted(path));
 
             path = PathUtility.NormalizeFile(path);
@@ -257,8 +256,7 @@ namespace Microsoft.Docs.Build
         {
             return path != null &&
                 path.IndexOf('\\') == -1 &&
-                !path.StartsWith('/') &&
-                !PathUtility.FilePathHasInvalidChars(path);
+                !path.StartsWith('/');
         }
     }
 }

--- a/src/docfx/lib/PathUtility.cs
+++ b/src/docfx/lib/PathUtility.cs
@@ -40,8 +40,6 @@ namespace Microsoft.Docs.Build
         /// <returns>The normalized folder path</returns>
         public static string NormalizeFolder(string path)
         {
-            Debug.Assert(!FolderPathHasInvalidChars(path));
-
             var str = Normalize(path);
             if (str.Length == 0 || str == "/")
             {
@@ -74,44 +72,7 @@ namespace Microsoft.Docs.Build
         /// <returns>The normalized file path</returns>
         public static string NormalizeFile(string path)
         {
-            Debug.Assert(!FilePathHasInvalidChars(path));
-
             return Normalize(path);
-        }
-
-        /// <summary>
-        /// Check if the folder path has invalid chars
-        /// </summary>
-        /// <param name="path">The folder path</param>
-        /// <returns>Has invalid chars or not</returns>
-        public static bool FolderPathHasInvalidChars(string path)
-        {
-            path = !path.EndsWith('\\') && !path.EndsWith('/') ? path + "/" : path;
-
-            return FilePathHasInvalidChars(path);
-        }
-
-        /// <summary>
-        /// Check if the file path has invalid chars
-        /// </summary>
-        /// <param name="path">The file chars</param>
-        /// <returns>Has invalid chars or not</returns>
-        public static bool FilePathHasInvalidChars(string path)
-        {
-            bool ret = false;
-            if (!string.IsNullOrEmpty(path))
-            {
-                try
-                {
-                    var fileName = Path.GetFileName(path);
-                    var fileDirectory = Path.GetDirectoryName(path);
-                }
-                catch (ArgumentException)
-                {
-                    ret = true;
-                }
-            }
-            return ret;
         }
 
         private static string Normalize(string path)

--- a/src/docfx/lib/ProcessUtility.cs
+++ b/src/docfx/lib/ProcessUtility.cs
@@ -122,7 +122,6 @@ namespace Microsoft.Docs.Build
         {
             Debug.Assert(!string.IsNullOrEmpty(lockRelativePath));
             Debug.Assert(!Path.IsPathRooted(lockRelativePath));
-            Debug.Assert(!PathUtility.FilePathHasInvalidChars(lockRelativePath));
 
             var lockPath = Path.Combine(s_lockDir, lockRelativePath);
             Directory.CreateDirectory(Path.GetDirectoryName(lockPath));

--- a/src/docfx/lib/git/GitUtility.Native.cs
+++ b/src/docfx/lib/git/GitUtility.Native.cs
@@ -28,8 +28,6 @@ namespace Microsoft.Docs.Build
         /// <returns>A collection of git commits</returns>
         public static unsafe List<GitCommit>[] GetCommits(string repoPath, List<string> files, Action<int, int> progress = null)
         {
-            Debug.Assert(files.All(file => !PathUtility.FilePathHasInvalidChars(file)));
-
             var pathToParent = BuildPathToParentPath(files);
             var pathToParentByRef = pathToParent.ToDictionary(p => p.Key, p => p.Value, RefComparer.Instance);
             var repo = OpenRepo(repoPath);

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -25,8 +25,6 @@ namespace Microsoft.Docs.Build
         /// <returns>The git repo root path. null if the repo root is not found</returns>
         public static string FindRepo(string path)
         {
-            Debug.Assert(!PathUtility.FolderPathHasInvalidChars(path));
-
             var repo = path;
             while (!string.IsNullOrEmpty(repo))
             {
@@ -49,7 +47,6 @@ namespace Microsoft.Docs.Build
         public static bool IsRepo(string path)
         {
             Debug.Assert(!string.IsNullOrEmpty(path));
-            Debug.Assert(!PathUtility.FolderPathHasInvalidChars(path));
 
             var gitPath = Path.Combine(path, ".git");
 
@@ -65,8 +62,6 @@ namespace Microsoft.Docs.Build
         /// <returns>Task status</returns>
         public static Task Clone(string cwd, string remote, string path, string branch = null)
         {
-            Debug.Assert(!PathUtility.FolderPathHasInvalidChars(path));
-
             Directory.CreateDirectory(cwd);
             var cmd = string.IsNullOrEmpty(branch)
                 ? $"clone {remote} {path.Replace("\\", "/", StringComparison.Ordinal)}"
@@ -165,7 +160,6 @@ namespace Microsoft.Docs.Build
         private static async Task<T> Execute<T>(string cwd, string commandLineArgs, TimeSpan? timeout, Func<string, T> parser, Action<string, bool> outputHandler)
         {
             Debug.Assert(!string.IsNullOrEmpty(cwd));
-            Debug.Assert(!PathUtility.FolderPathHasInvalidChars(cwd));
 
             // todo: check git exist or not
             var response = await ProcessUtility.Execute("git", commandLineArgs, cwd, timeout, outputHandler);

--- a/src/docfx/resolve/Resolve.cs
+++ b/src/docfx/resolve/Resolve.cs
@@ -68,12 +68,6 @@ namespace Microsoft.Docs.Build
                 return default;
             }
 
-            // Leave invalid file path as is
-            if (PathUtility.FilePathHasInvalidChars(path))
-            {
-                return default;
-            }
-
             // Resolve path relative to docset
             if (path.StartsWith("~\\") || path.StartsWith("~/"))
             {

--- a/test/docfx.Test/lib/PathUtilityTest.cs
+++ b/test/docfx.Test/lib/PathUtilityTest.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.IO;
+using System.Linq;
 using Xunit;
 
 namespace Microsoft.Docs.Build
@@ -40,5 +42,13 @@ namespace Microsoft.Docs.Build
         [InlineData("a/b", "c/d", "../c/d")]
         public static void GetRelativePathToFile(string relativeTo, string path, string expected)
             => Assert.Equal(expected, PathUtility.GetRelativePathToFile(relativeTo, path).Replace("\\", "/", StringComparison.Ordinal));
+
+        [Fact]
+        public static void PathDoesNotThrowForInvalidChar()
+        {
+            var str = new string(Path.GetInvalidFileNameChars().Concat(Path.GetInvalidPathChars()).ToArray());
+            Path.GetFileName(str);
+            Path.GetDirectoryName(str);
+        }
     }
 }


### PR DESCRIPTION
@fenxu use dotnet core and `Path` won't throw 🚀 

Love deleting code like this