### PR TITLE
Let ParallelUtility throw on exception

### DIFF
--- a/src/docfx/lib/ParallelUtility.cs
+++ b/src/docfx/lib/ParallelUtility.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Docs.Build
             EnsureOrdered = false,
         };
 
-        public static Task ForEach<T>(IEnumerable<T> source, Func<T, Task> action, Action<int, int> progress = null, Action<Exception, T> error = null)
+        public static Task ForEach<T>(IEnumerable<T> source, Func<T, Task> action, Action<int, int> progress = null)
         {
             var done = 0;
             var total = 0;
@@ -28,7 +28,13 @@ namespace Microsoft.Docs.Build
             foreach (var item in source)
             {
                 var posted = queue.Post(item);
-                Debug.Assert(posted);
+
+                // https://github.com/dotnet/corefx/issues/21715
+                // Post on an ActionBlock that's unbounded should only return false
+                // if the ActionBlock has been closed to additional messages, which could happen for example
+                // if someone called Complete on the block
+                // or if the block's delegate threw an exception that went unhandled and caused the block to fault.
+                Debug.Assert(posted || queue.Completion.IsFaulted);
                 total++;
             }
 
@@ -37,53 +43,21 @@ namespace Microsoft.Docs.Build
 
             async Task Run(T item)
             {
-                try
-                {
-                    await action(item);
-                }
-                catch (Exception ex) when (error != null)
-                {
-                    error(ex, item);
-                }
-                finally
-                {
-                    progress?.Invoke(Interlocked.Increment(ref done), total);
-                }
+                await action(item);
+                progress?.Invoke(Interlocked.Increment(ref done), total);
             }
         }
 
         /// <summary>
         /// Parallel run actions including their returned children actions
         /// </summary>
-        public static Task ForEach<T>(IEnumerable<T> source, Func<T, Action<T>, Task> action, Func<T, bool> predicate = null, Action<int, int> progress = null, Action<Exception, T> error = null)
+        public static Task ForEach<T>(IEnumerable<T> source, Func<T, Action<T>, Task> action, Func<T, bool> predicate = null, Action<int, int> progress = null)
         {
             ActionBlock<T> queue = null;
 
             var total = 0;
             var done = 0;
-
-            queue = new ActionBlock<T>(
-                async item =>
-                {
-                    try
-                    {
-                        await action(item, Enqueue);
-                    }
-                    catch (Exception ex) when (error != null)
-                    {
-                        error(ex, item);
-                    }
-                    finally
-                    {
-                        var completed = Interlocked.Increment(ref done) == Volatile.Read(ref total);
-                        if (completed)
-                        {
-                            queue.Complete();
-                        }
-
-                        progress?.Invoke(done, total);
-                    }
-                }, s_dataflowOptions);
+            queue = new ActionBlock<T>(Run, s_dataflowOptions);
 
             foreach (var item in source)
             {
@@ -96,6 +70,18 @@ namespace Microsoft.Docs.Build
             }
 
             return queue.Completion;
+
+            async Task Run(T item)
+            {
+                await action(item, Enqueue);
+                var completed = Interlocked.Increment(ref done) == Volatile.Read(ref total);
+                if (completed)
+                {
+                    queue.Complete();
+                }
+
+                progress?.Invoke(done, total);
+            }
 
             void Enqueue(T item)
             {
@@ -110,7 +96,7 @@ namespace Microsoft.Docs.Build
 
                 var count = Interlocked.Increment(ref total);
                 var posted = queue.Post(item);
-                Debug.Assert(posted);
+                Debug.Assert(posted || queue.Completion.IsFaulted);
 
                 progress?.Invoke(done, count);
             }

--- a/test/docfx.Test/lib/ParallelUtilityTest.cs
+++ b/test/docfx.Test/lib/ParallelUtilityTest.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Docs.Build
+{
+    public static class ParallelUtilityTest
+    {
+        [Fact]
+        public static async Task ThrowsTheSameException()
+        {
+            await Assert.ThrowsAsync<Exception>(() => ParallelUtility.ForEach(Enumerable.Range(0, 10000), Run));
+
+            Task Run(int _) => throw new Exception();
+        }
+    }
+}

--- a/test/docfx.Test/lib/ParallelUtilityTest.cs
+++ b/test/docfx.Test/lib/ParallelUtilityTest.cs
@@ -17,5 +17,20 @@ namespace Microsoft.Docs.Build
 
             Task Run(int _) => throw new Exception();
         }
+
+        [Fact]
+        public static async Task PostToActionBlockAlwaysSucceed()
+        {
+            await ParallelUtility.ForEach(Enumerable.Range(0, 10), Run);
+
+            Task Run(int n, Action<int> queue)
+            {
+                for (var i = 0; i < n; i++)
+                {
+                    queue(i);
+                }
+                return Task.CompletedTask;
+            }
+        }
     }
 }


### PR DESCRIPTION
Removes `error` from `ParallelUtility.ForEach`, exceptions are thrown to the top level and breaks build execution.

Adjust assertion.

#2872 
