### PR TITLE
Resolve unknown xref as fallback

### DIFF
--- a/docs/specs/build/xref.yml
+++ b/docs/specs/build/xref.yml
@@ -2,10 +2,21 @@
 # Unknown xrefs are output as is with a warning
 inputs:
   docfx.yml:
-  docs/a.md: Link to @xref
+  docs/a.md: Link to <xref:a>
 outputs:
   docs/a.json: |
-    { "content": "<p>Link to @xref</p>" }
+    { "content": "<p>Link to &lt;xref:a&gt;</p>" }
   build.log: |
-    ["warning","xref-not-found","Cannot find uid 'xref' using xref '@xref'","docs/a.md"]
+    ["warning","uid-not-found","Cannot find uid 'a' using xref '<xref:a>'","docs/a.md"]
+  build.manifest:
+---
+# Unknown xrefs using @ syntax are output as is with a informational message
+inputs:
+  docfx.yml:
+  docs/a.md: Link to @a
+outputs:
+  docs/a.json: |
+    { "content": "<p>Link to @a</p>" }
+  build.log: |
+    ["info","at-uid-not-found","Cannot find uid 'a' using xref '@a'","docs/a.md"]
   build.manifest:

--- a/docs/specs/build/xref.yml
+++ b/docs/specs/build/xref.yml
@@ -1,0 +1,11 @@
+---
+# Unknown xrefs are output as is with a warning
+inputs:
+  docfx.yml:
+  docs/a.md: Link to @xref
+outputs:
+  docs/a.json: |
+    { "content": "<p>Link to @xref</p>" }
+  build.log: |
+    ["warning","xref-not-found","Cannot find uid 'xref' using xref '@xref'","docs/a.md"]
+  build.manifest:

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -33,8 +33,11 @@ namespace Microsoft.Docs.Build
         public static DocfxException FileNotFound(Document relativeTo, string path)
             => new DocfxException(ReportLevel.Warning, "file-not-found", $"Cannot find file '{path}' relative to '{relativeTo}'", relativeTo.ToString());
 
-        public static DocfxException XrefNotFound(Document file, string uid, string rawXref)
-            => new DocfxException(ReportLevel.Warning, "xref-not-found", $"Cannot find uid '{uid}' using xref '{rawXref}'", file.ToString());
+        public static DocfxException UidNotFound(Document file, string uid, string rawXref)
+            => new DocfxException(ReportLevel.Warning, "uid-not-found", $"Cannot find uid '{uid}' using xref '{rawXref}'", file.ToString());
+
+        public static DocfxException AtUidNotFound(Document file, string uid, string rawXref)
+            => new DocfxException(ReportLevel.Info, "at-uid-not-found", $"Cannot find uid '{uid}' using xref '{rawXref}'", file.ToString());
 
         public static DocfxException PublishUrlConflict(string url, IEnumerable<Document> files)
             => new DocfxException(ReportLevel.Warning, "publish-url-conflict", $"Two or more documents publish to the same url '{url}': {string.Join(", ", files.OrderBy(file => file.FilePath).Select(file => $"'{file}'").Take(5))}");

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -33,6 +33,9 @@ namespace Microsoft.Docs.Build
         public static DocfxException FileNotFound(Document relativeTo, string path)
             => new DocfxException(ReportLevel.Warning, "file-not-found", $"Cannot find file '{path}' relative to '{relativeTo}'", relativeTo.ToString());
 
+        public static DocfxException XrefNotFound(Document file, string uid, string rawXref)
+            => new DocfxException(ReportLevel.Warning, "xref-not-found", $"Cannot find uid '{uid}' using xref '{rawXref}'", file.ToString());
+
         public static DocfxException PublishUrlConflict(string url, IEnumerable<Document> files)
             => new DocfxException(ReportLevel.Warning, "publish-url-conflict", $"Two or more documents publish to the same url '{url}': {string.Join(", ", files.OrderBy(file => file.FilePath).Select(file => $"'{file}'").Take(5))}");
 

--- a/src/docfx/build/markdown/Markup.cs
+++ b/src/docfx/build/markdown/Markup.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Docs.Build
                 .UseExtractYamlHeader(file, errors, metadata)
                 .UseExtractTitle(title)
                 .UseResolveHtmlLinks(markdownContext, hasHtml)
+                .UseResolveXref(errors, ResolveXref)
                 .Build();
 
             using (InclusionContext.PushFile(file))
@@ -109,6 +110,12 @@ namespace Microsoft.Docs.Build
                 }
 
                 return link;
+            }
+
+            string ResolveXref(string uid)
+            {
+                // TODO: implement xref resolve
+                return null;
             }
         }
     }

--- a/src/docfx/lib/markdown/ResolveXref.cs
+++ b/src/docfx/lib/markdown/ResolveXref.cs
@@ -25,7 +25,11 @@ namespace Microsoft.Docs.Build
                         if (string.IsNullOrEmpty(href))
                         {
                             var raw = xref.GetAttributes().Properties.First(p => p.Key == "data-raw-source").Value;
-                            errors.Add(Errors.XrefNotFound((Document)InclusionContext.File, xref.Href, raw));
+                            var error = raw.StartsWith("@")
+                                ? Errors.AtUidNotFound((Document)InclusionContext.File, xref.Href, raw)
+                                : Errors.UidNotFound((Document)InclusionContext.File, xref.Href, raw);
+
+                            errors.Add(error);
                             return new LiteralInline(raw);
                         }
                     }

--- a/src/docfx/lib/markdown/ResolveXref.cs
+++ b/src/docfx/lib/markdown/ResolveXref.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Markdig;
+using Markdig.Renderers.Html;
+using Markdig.Syntax.Inlines;
+using Microsoft.DocAsCode.MarkdigEngine.Extensions;
+
+namespace Microsoft.Docs.Build
+{
+    internal static class ResolveXref
+    {
+        public static MarkdownPipelineBuilder UseResolveXref(this MarkdownPipelineBuilder builder, List<DocfxException> errors, Func<string, string> resolveXref)
+        {
+            return builder.Use(document =>
+            {
+                document.Replace(node =>
+                {
+                    if (node is XrefInline xref)
+                    {
+                        var href = resolveXref(xref.Href);
+                        if (string.IsNullOrEmpty(href))
+                        {
+                            var raw = xref.GetAttributes().Properties.First(p => p.Key == "data-raw-source").Value;
+                            errors.Add(Errors.XrefNotFound((Document)InclusionContext.File, xref.Href, raw));
+                            return new LiteralInline(raw);
+                        }
+                    }
+                    return node;
+                });
+            });
+        }
+    }
+}


### PR DESCRIPTION
*edge-developer* content contains `@font-face` that are incorrectly parsed as xref. This PR lefts unknown xrefs as is and report an `xref-not-found` warning.

#2782 