### PR TITLE
Html: fix self link bug, redirection content is empty

### DIFF
--- a/docs/specs/build/manifest.yml
+++ b/docs/specs/build/manifest.yml
@@ -286,3 +286,27 @@ outputs:
         }
       ]
     }
+---
+# Treat `#` as link dependency
+inputs:
+  docfx.yml:
+  docs/a.md: |
+    Link to [link](#)
+outputs:
+  docs/a.json:
+  build.manifest: |
+    {
+      "dependencies":
+      [
+        {
+          "source": "docs/a.md",
+          "dependencies": 
+          [
+            {
+              "source": "docs/a.md",
+              "type": "link"
+            }
+          ]
+        }
+      ]
+    }

--- a/docs/specs/build/resolve.yml
+++ b/docs/specs/build/resolve.yml
@@ -26,9 +26,13 @@ inputs:
   docs/a.md: |
     ## Hello World
     Link to [bookmark](#hello-world)
+  docs/b.md: |
+    Link to [self](./b.md)
 outputs:
   docs/a.json: |
     { "content": "<h2 id=\"hello-world\">Hello World</h2><p>Link to <a href=\"#hello-world\">bookmark</a></p>" }
+  docs/b.json: |
+    { "content": "<p>Link to <a href=\"#\">self</a></p>" }
   build.manifest:
 ---
 # Support both / and \ as directory seperator
@@ -161,7 +165,7 @@ outputs:
   docs/b&/c~.json:
   build.manifest:
 ---
-# Reference to a redirection file(absolute)
+# Absolute link to a redirection file
 inputs:
   docfx.yml: |
     redirections:
@@ -173,9 +177,9 @@ outputs:
   docs/a.json: |
     {"content":"<p><a href=\"/absolute/path\">redirect</a></p>\n"}
   docs/redirect.json: |
-    {"content":"<p></p>", "redirectionUrl":"/absolute/path"}
+    {"redirectionUrl":"/absolute/path"}
 ---
-# Reference to a redirection file(relative)
+# Relative link to a redirection file
 inputs:
   docfx.yml: |
     redirections:
@@ -187,7 +191,7 @@ outputs:
   docs/a.json: |
     {"content":"<p><a href=\"relative/path\">redirect</a></p>\n"}
   docs/redirect.json: |
-    {"content":"<p></p>", "redirectionUrl":"relative/path"}
+    {"redirectionUrl":"relative/path"}
 ---
 # Incude a redirection file
 inputs:
@@ -201,7 +205,7 @@ outputs:
   docs/a.json: |
     {"content":"<p>Link to [!include[](redirect.md)]</p>\n"}
   docs/redirect.json: |
-    {"content":"<p></p>", "redirectionUrl":"/absolute/path"}
+    {"redirectionUrl":"/absolute/path"}
   build.log: |
     ["warning","include-is-redirection","Referenced inclusion redirect.md relative to 'docs/a.md' shouldn't belong to redirections","docs/a.md"]
     ["warning","include-not-found","Cannot resolve 'redirect.md' relative to 'docs/a.md'.","docs/a.md"]

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -117,7 +117,6 @@ namespace Microsoft.Docs.Build
 
             var model = new PageModel
             {
-                Content = "<p></p>",
                 RedirectionUrl = file.Docset.Redirections[file],
                 Locale = file.Docset.Config.Locale,
             };

--- a/src/docfx/build/legacy/files/LegacyMarkdown.cs
+++ b/src/docfx/build/legacy/files/LegacyMarkdown.cs
@@ -38,11 +38,11 @@ namespace Microsoft.Docs.Build
         private static void GenerateLegacyRawMetadata(LegacyPageModel legacyPageModel, PageModel pageModel, Docset docset, Document file, GitRepoInfoProvider repo)
         {
             legacyPageModel.RawMetadata = new LegacyPageMetadata();
-            legacyPageModel.RawMetadata.Metadata = pageModel.Metadata;
+            legacyPageModel.RawMetadata.Metadata = pageModel.Metadata ?? new JObject();
             legacyPageModel.RawMetadata.Metadata["toc_rel"] = pageModel.TocRelativePath;
             legacyPageModel.RawMetadata.Metadata["locale"] = pageModel.Locale;
             legacyPageModel.RawMetadata.Metadata["word_count"] = pageModel.WordCount;
-            legacyPageModel.RawMetadata.Metadata["_op_rawTitle"] = $"<h1>{HttpUtility.HtmlEncode(pageModel.Title)}</h1>";
+            legacyPageModel.RawMetadata.Metadata["_op_rawTitle"] = $"<h1>{HttpUtility.HtmlEncode(pageModel.Title ?? "")}</h1>";
 
             legacyPageModel.RawMetadata.Metadata["_op_canonicalUrlPrefix"] = $"https://{docset.Config.HostName}/{docset.Config.Locale}/{docset.Config.SiteBasePath}/";
             legacyPageModel.RawMetadata.Metadata["_op_pdfUrlPrefixTemplate"] = $"https://{docset.Config.HostName}/pdfstore/{pageModel.Locale}/{docset.Config.Name}/{{branchName}}{{pdfName}}";

--- a/src/docfx/build/manifest/DependencyType.cs
+++ b/src/docfx/build/manifest/DependencyType.cs
@@ -12,17 +12,4 @@ namespace Microsoft.Docs.Build
         Overwrite, // overwrite markdown reference
         TocInclusion, // toc reference toc
     }
-
-    internal static class DependencyTypeExtensions
-    {
-        public static DependencyType ToLink(string fragment)
-        {
-            if (string.IsNullOrEmpty(fragment))
-            {
-                return DependencyType.Link;
-            }
-
-            return DependencyType.Bookmark;
-        }
-    }
 }

--- a/src/docfx/build/markdown/Markup.cs
+++ b/src/docfx/build/markdown/Markup.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Docs.Build
             {
                 Debug.Assert(relativeTo is Document);
 
-                var (error, link, child, hasBookmark) = ((Document)relativeTo).TryResolveHref(path, file);
+                var (error, link, fragment, child) = ((Document)relativeTo).TryResolveHref(path, file);
 
                 if (error != null)
                 {
@@ -106,7 +106,7 @@ namespace Microsoft.Docs.Build
                 if (child != null)
                 {
                     buildChild(child);
-                    dependencyMap.AddDependencyItem((Document)relativeTo, child, hasBookmark ? DependencyType.Bookmark : DependencyType.Link);
+                    dependencyMap.AddDependencyItem((Document)relativeTo, child, HrefUtility.FragmentToDependencyType(fragment));
                 }
 
                 return link;

--- a/src/docfx/build/markdown/Markup.cs
+++ b/src/docfx/build/markdown/Markup.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Docs.Build
             {
                 Debug.Assert(relativeTo is Document);
 
-                var (error, link, fragment, child) = ((Document)relativeTo).TryResolveHref(path, file);
+                var (error, link, child, hasBookmark) = ((Document)relativeTo).TryResolveHref(path, file);
 
                 if (error != null)
                 {
@@ -106,7 +106,7 @@ namespace Microsoft.Docs.Build
                 if (child != null)
                 {
                     buildChild(child);
-                    dependencyMap.AddDependencyItem((Document)relativeTo, child, DependencyTypeExtensions.ToLink(fragment));
+                    dependencyMap.AddDependencyItem((Document)relativeTo, child, hasBookmark ? DependencyType.Bookmark : DependencyType.Link);
                 }
 
                 return link;

--- a/src/docfx/build/resolve/Resolve.cs
+++ b/src/docfx/build/resolve/Resolve.cs
@@ -21,26 +21,22 @@ namespace Microsoft.Docs.Build
             return file != null ? (error, file.ReadText(), file) : default;
         }
 
-        public static (DocfxException error, string href, Document file, bool hasBookmark) TryResolveHref(this Document relativeTo, string href, Document resultRelativeTo)
+        public static (DocfxException error, string href, string fragment, Document file) TryResolveHref(this Document relativeTo, string href, Document resultRelativeTo)
         {
             Debug.Assert(resultRelativeTo != null);
 
             var (error, file, redirectTo, fragment, query) = TryResolveFile(relativeTo, href);
 
-            Debug.Assert(string.IsNullOrEmpty(fragment) || fragment[0] == '#');
-
-            var hasBookmark = fragment != null && fragment.Length > 1;
-
             // Redirection
             if (!string.IsNullOrEmpty(redirectTo))
             {
-                return (error, redirectTo, file, hasBookmark);
+                return (error, redirectTo, fragment, file);
             }
 
             // Cannot resolve the file, leave href as is
             if (file == null)
             {
-                return (error, href, file, hasBookmark);
+                return (error, href, fragment, file);
             }
 
             // Self reference, leave href as is
@@ -50,14 +46,14 @@ namespace Microsoft.Docs.Build
                 {
                     fragment = "#";
                 }
-                return (error, fragment + query, file, hasBookmark);
+                return (error, fragment + query, fragment, file);
             }
 
             // Make result relative to `resultRelativeTo`
             var relativePath = PathUtility.GetRelativePathToFile(resultRelativeTo.SitePath, file.SitePath);
             var relativeUrl = Document.PathToRelativeUrl(relativePath, file.ContentType);
 
-            return (error, relativeUrl + fragment + query, file, hasBookmark);
+            return (error, relativeUrl + fragment + query, fragment, file);
         }
 
         private static (DocfxException error, Document file, string redirectTo, string fragment, string query) TryResolveFile(this Document relativeTo, string href)

--- a/src/docfx/build/resolve/Resolve.cs
+++ b/src/docfx/build/resolve/Resolve.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Docs.Build
             // Leave absolute file path as is
             if (Path.IsPathRooted(path))
             {
-                return (Errors.AbsoluteFilePath(relativeTo, path), null, null, fragment, query);
+                return (Errors.AbsoluteFilePath(relativeTo, path), null, null, null, null);
             }
 
             // Leave absolute URL path as is
@@ -107,7 +107,7 @@ namespace Microsoft.Docs.Build
             if (relativeTo.Docset.Config.Redirections.TryGetValue(pathToDocset, out var redirectTo))
             {
                 // redirectTo always is absolute href
-                return (null, null, redirectTo, fragment, query);
+                return (null, null, redirectTo, null, null);
             }
 
             var file = Document.TryCreateFromFile(relativeTo.Docset, pathToDocset);

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Docs.Build
                 {
                     // add to referenced document list
                     // only resolve href, no need to build
-                    var (error, link, buildItem, hasBookmark) = file.TryResolveHref(href, resultRelativeTo);
+                    var (error, link, fragment, buildItem) = file.TryResolveHref(href, resultRelativeTo);
                     if (error != null)
                     {
                         errors.Add(error);
@@ -98,7 +98,7 @@ namespace Microsoft.Docs.Build
                     if (buildItem != null)
                     {
                         referencedDocuments.Add(buildItem);
-                        dependencyMapBuilder?.AddDependencyItem(file, buildItem, hasBookmark ? DependencyType.Bookmark : DependencyType.Link);
+                        dependencyMapBuilder?.AddDependencyItem(file, buildItem, HrefUtility.FragmentToDependencyType(fragment));
                     }
                     return link;
                 });

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Docs.Build
                 {
                     // add to referenced document list
                     // only resolve href, no need to build
-                    var (error, link, fragment, buildItem) = file.TryResolveHref(href, resultRelativeTo);
+                    var (error, link, buildItem, hasBookmark) = file.TryResolveHref(href, resultRelativeTo);
                     if (error != null)
                     {
                         errors.Add(error);
@@ -98,7 +98,7 @@ namespace Microsoft.Docs.Build
                     if (buildItem != null)
                     {
                         referencedDocuments.Add(buildItem);
-                        dependencyMapBuilder?.AddDependencyItem(file, buildItem, DependencyTypeExtensions.ToLink(fragment));
+                        dependencyMapBuilder?.AddDependencyItem(file, buildItem, hasBookmark ? DependencyType.Bookmark : DependencyType.Link);
                     }
                     return link;
                 });

--- a/src/docfx/lib/HrefUtility.cs
+++ b/src/docfx/lib/HrefUtility.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 
 namespace Microsoft.Docs.Build
@@ -50,6 +51,13 @@ namespace Microsoft.Docs.Build
             }
 
             return (path, fragment, query);
+        }
+
+        public static DependencyType FragmentToDependencyType(string fragment)
+        {
+            Debug.Assert(string.IsNullOrEmpty(fragment) || fragment[0] == '#');
+
+            return fragment != null && fragment.Length > 1 ? DependencyType.Bookmark : DependencyType.Link;
         }
 
         public static bool IsRelativeHref(string str)

--- a/src/docfx/lib/HtmlUtility.cs
+++ b/src/docfx/lib/HtmlUtility.cs
@@ -162,15 +162,15 @@ namespace Microsoft.Docs.Build
                     node.SetAttributeValue("data-linktype", "self-bookmark");
                     continue;
                 }
-                if (Uri.TryCreate(href, UriKind.Absolute, out _))
-                {
-                    node.SetAttributeValue("data-linktype", "external");
-                    continue;
-                }
                 if (href[0] == '/' || href[0] == '\\')
                 {
                     node.SetAttributeValue(attribute, AddLocaleIfMissing(HrefToLower(href), locale));
                     node.SetAttributeValue("data-linktype", "absolute-path");
+                    continue;
+                }
+                if (Uri.TryCreate(href, UriKind.Absolute, out _))
+                {
+                    node.SetAttributeValue("data-linktype", "external");
                     continue;
                 }
                 node.SetAttributeValue(attribute, HrefToLower(href));

--- a/src/docfx/lib/HtmlUtility.cs
+++ b/src/docfx/lib/HtmlUtility.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Docs.Build
                     node.SetAttributeValue("data-linktype", "self-bookmark");
                     continue;
                 }
-                if (href.Contains(":"))
+                if (Uri.TryCreate(href, UriKind.Absolute, out _))
                 {
                     node.SetAttributeValue("data-linktype", "external");
                     continue;

--- a/test/docfx.Test/lib/HtmlUtilityTest.cs
+++ b/test/docfx.Test/lib/HtmlUtilityTest.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Docs.Build
     {
         [Theory]
         [InlineData("<a href='a.md' />", "<a href='a.md' data-linktype='relative-path' />")]
+        [InlineData("<a href='(https://a)' />", "<a href='(https://a)' data-linktype='relative-path' />")]
         [InlineData("<a href='#aA' />", "<a href='#aA' data-linktype='self-bookmark' />")]
         [InlineData("<a href='/a' />", "<a href='/zh-cn/a' data-linktype='absolute-path' />")]
         [InlineData("<a href='/Alink#fraGMENT' />", "<a href='/zh-cn/alink#fraGMENT' data-linktype='absolute-path' />")]


### PR DESCRIPTION
With this PR, html in `edge-developer` produces the exact same result except the following known differences:

|  | v2 | v3 |
|---|---|---|
|Links to redirected files  | file path | redirected url|
|Links to self | filename itself | `#`|