### PR TITLE
Do not apply dynamic url for autolinks

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionExtension.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionExtension.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
                     UpdateLinks(subInline, context);
                 }
 
-                if (markdownObject is LinkInline linkInline)
+                if (markdownObject is LinkInline linkInline && !linkInline.IsAutoLink)
                 {
                     linkInline.GetDynamicUrl = () => context.GetLink(linkInline.Url, InclusionContext.File);
                 }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownContext.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownContext.cs
@@ -56,9 +56,9 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         public LogActionDelegate LogError { get; }
 
         public MarkdownContext(
-            IReadOnlyDictionary<string, string> tokens,
-            LogActionDelegate logWarning,
-            LogActionDelegate logError,
+            IReadOnlyDictionary<string, string> tokens = null,
+            LogActionDelegate logWarning = null,
+            LogActionDelegate logError = null,
             ReadFileDelegate readFile = null,
             GetLinkDelegate getLink = null)
         {

--- a/test/Microsoft.DocAsCode.MarkdigEngine.Tests/InclusionTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdigEngine.Tests/InclusionTest.cs
@@ -7,8 +7,9 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Tests
     using System.Collections.Immutable;
     using System.IO;
     using System.Linq;
-
+    using Markdig;
     using Microsoft.DocAsCode.Common;
+    using Microsoft.DocAsCode.MarkdigEngine.Extensions;
     using Microsoft.DocAsCode.Plugins;
 
     using Xunit;
@@ -716,6 +717,18 @@ body";
             var dependency = result.Dependency;
             var expectedDependency = new List<string> { "~/r/include/a.md" };
             Assert.Equal(expectedDependency.ToImmutableList(), dependency);
+        }
+
+        [Fact]
+        [Trait("Related", "Inclusion")]
+        public void TestBlockInclude_Does_Not_Replace_AutoLink()
+        {
+            var root = "https://docs.microsoft.com";
+            var context = new MarkdownContext(getLink: (path, relativeTo) => "REPLACE IT");
+            var pipeline = new MarkdownPipelineBuilder().UseDocfxExtensions(context).Build();
+            var result = Markdown.ToHtml(root, pipeline);
+
+            Assert.Equal("<p><a href=\"https://docs.microsoft.com\">https://docs.microsoft.com</a></p>", result.Trim());
         }
     }
 }


### PR DESCRIPTION
Do not set `GetDynamicUrl` for autolinks, they are always absolute links.

#2921 