### PR TITLE
Speed up repo info retrieval by using gitlib2

### DIFF
--- a/src/docfx/build/markdown/BuildMarkdown.cs
+++ b/src/docfx/build/markdown/BuildMarkdown.cs
@@ -53,11 +53,9 @@ namespace Microsoft.Docs.Build
                 Author = author,
                 Contributors = contributors,
                 UpdatedAt = updatedAt,
+                EditLink = repo.GetEditLink(file),
                 EnableContribution = file.Docset.Config.Contribution.Enabled,
             };
-
-            if (file.Docset.Config.Contribution.Enabled)
-                model.EditLink = repo.GetEditLink(file);
 
             // TODO: make build pure by not output using `context.Report/Write/Copy` here
             context.Report(file, markup.Errors.Concat(repoErrors));

--- a/src/docfx/lib/git/GitHost.cs
+++ b/src/docfx/lib/git/GitHost.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Docs.Build
 {
     internal enum GitHost
     {
-        GitHub,
         Unknown,
+        GitHub,
     }
 }

--- a/src/docfx/lib/git/GitRepoInfo.cs
+++ b/src/docfx/lib/git/GitRepoInfo.cs
@@ -31,18 +31,27 @@ namespace Microsoft.Docs.Build
             Debug.Assert(GitUtility.IsRepo(cwd));
             Debug.Assert(Path.IsPathRooted(cwd));
 
+            var (host, account, repository) = default((GitHost, string, string));
             var (remote, branch, commit) = GitUtility.GetRepoInfo(cwd);
 
             // TODO: support VSTS, or others
-            var match = GitHubRepoUrlRegex.Match(remote);
-            if (!match.Success)
-                return null;
+            // TODO: fallback branch to environment variable to support CIs
+            if (!string.IsNullOrEmpty(remote))
+            {
+                var match = GitHubRepoUrlRegex.Match(remote);
+                if (match.Success)
+                {
+                    account = match.Groups["account"].Value;
+                    repository = match.Groups["repository"].Value;
+                    host = GitHost.GitHub;
+                }
+            }
 
             return new GitRepoInfo
             {
-                Host = GitHost.GitHub,
-                Account = match.Groups["account"].Value,
-                Name = match.Groups["repository"].Value,
+                Host = host,
+                Account = account,
+                Name = repository,
                 Branch = branch,
                 Commit = commit,
                 RootPath = cwd,

--- a/src/docfx/lib/git/GitRepoInfo.cs
+++ b/src/docfx/lib/git/GitRepoInfo.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using System.IO;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace Microsoft.Docs.Build
 {
@@ -23,19 +22,19 @@ namespace Microsoft.Docs.Build
 
         public string Branch { get; set; }
 
-        public string HeadCommitId { get; set; }
+        public string Commit { get; set; }
 
         public string RootPath { get; set; }
 
-        public static async Task<GitRepoInfo> CreateAsync(string cwd)
+        public static GitRepoInfo Create(string cwd)
         {
             Debug.Assert(GitUtility.IsRepo(cwd));
             Debug.Assert(Path.IsPathRooted(cwd));
 
-            var url = await GitUtility.GetOriginalUrl(cwd);
+            var (remote, branch, commit) = GitUtility.GetRepoInfo(cwd);
 
             // TODO: support VSTS, or others
-            var match = GitHubRepoUrlRegex.Match(url);
+            var match = GitHubRepoUrlRegex.Match(remote);
             if (!match.Success)
                 return null;
 
@@ -44,8 +43,8 @@ namespace Microsoft.Docs.Build
                 Host = GitHost.GitHub,
                 Account = match.Groups["account"].Value,
                 Name = match.Groups["repository"].Value,
-                Branch = await GitUtility.GetLocalBranch(cwd), // TODO: handle detached HEAD/submodule/sourceBranchName
-                HeadCommitId = await GitUtility.GetLocalBranchCommitId(cwd),
+                Branch = branch,
+                Commit = commit,
                 RootPath = cwd,
             };
         }

--- a/src/docfx/lib/git/GitRepoInfoProvider.cs
+++ b/src/docfx/lib/git/GitRepoInfoProvider.cs
@@ -88,6 +88,9 @@ namespace Microsoft.Docs.Build
         {
             Debug.Assert(document != null);
 
+            if (!document.Docset.Config.Contribution.Enabled)
+                return null;
+
             var repoInfo = GetGitRepoInfo(document);
             if (repoInfo?.Host != GitHost.GitHub)
                 return null;
@@ -158,9 +161,10 @@ namespace Microsoft.Docs.Build
         private GitRepoInfo GetFolderGitRepoInfoCore(string folder)
         {
             if (GitUtility.IsRepo(folder))
-                return GitRepoInfo.CreateAsync(folder).Result;
+                return GitRepoInfo.Create(folder);
 
-            var parent = folder.Substring(0, folder.LastIndexOf("/", System.StringComparison.Ordinal));
+            // TODO: add GitUtility.Discover repo
+            var parent = folder.Substring(0, folder.LastIndexOf("/", StringComparison.Ordinal));
             return Directory.Exists(parent)
                 ? _folderRepoInfocache.GetOrAdd(parent, GetFolderGitRepoInfoCore)
                 : null;

--- a/src/docfx/lib/git/GitUtility.Native.cs
+++ b/src/docfx/lib/git/GitUtility.Native.cs
@@ -42,7 +42,6 @@ namespace Microsoft.Docs.Build
                 if (NativeMethods.GitBranchName(out var pName, pHead) == 0)
                 {
                     branch = NativeMethods.FromUtf8Native(pName);
-                    NativeMethods.GitObjectFree((IntPtr)pName);
                 }
                 NativeMethods.GitReferenceFree(pHead);
             }

--- a/src/docfx/lib/git/GitUtility.Native.cs
+++ b/src/docfx/lib/git/GitUtility.Native.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -19,6 +18,40 @@ namespace Microsoft.Docs.Build
     /// </summary>
     internal static partial class GitUtility
     {
+        /// <summary>
+        /// Retrieve git repo information.
+        /// </summary>
+        public static unsafe (string remote, string branch, string commit) GetRepoInfo(string repoPath)
+        {
+            var (remote, branch, commit) = default((string, string, string));
+            var pRepo = OpenRepo(repoPath);
+
+            // TODO: marshal strings
+            fixed (byte* pRemoteName = NativeMethods.ToUtf8Native("origin"))
+            {
+                if (NativeMethods.GitRemoteLookup(out var pRemote, pRepo, pRemoteName) == 0)
+                {
+                    remote = NativeMethods.FromUtf8Native(NativeMethods.GitRemoteUrl(pRemote));
+                    NativeMethods.GitRemoteFree(pRemote);
+                }
+            }
+
+            if (NativeMethods.GitRepositoryHead(out var pHead, pRepo) == 0)
+            {
+                commit = NativeMethods.GitReferenceTarget(pHead)->ToString();
+                if (NativeMethods.GitBranchName(out var pName, pHead) == 0)
+                {
+                    branch = NativeMethods.FromUtf8Native(pName);
+                    NativeMethods.GitObjectFree((IntPtr)pName);
+                }
+                NativeMethods.GitReferenceFree(pHead);
+            }
+
+            NativeMethods.GitRepositoryFree(pRepo);
+
+            return (remote, branch, commit);
+        }
+
         /// <summary>
         /// Get git commits group by files
         /// </summary>

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -112,40 +112,16 @@ namespace Microsoft.Docs.Build
 
         /// <summary>
         /// Retrieve git head version
-        /// TODO: use libgit2sharp
+        /// TODO: For testing purpose only, move it to test
         /// </summary>
-        /// <param name="cwd">The working directory</param>
         public static Task<string> HeadRevision(string cwd)
            => ExecuteQuery(cwd, "rev-parse HEAD", TimeSpan.FromMinutes(3));
 
-        /// <summary>
-        /// Retrieve original URL
-        /// TODO: use libgit2sharp
-        /// </summary>
-        public static Task<string> GetOriginalUrl(string cwd)
-            => ExecuteQuery(cwd, $"config --get remote.origin.url", TimeSpan.FromMinutes(1));
-
-        /// <summary>
-        /// Retrieve local branch name
-        /// TODO: use libgit2sharp
-        /// </summary>
-        public static Task<string> GetLocalBranch(string cwd)
-            => ExecuteQuery(cwd, $"rev-parse --abbrev-ref HEAD", TimeSpan.FromMinutes(1));
-
-        /// <summary>
-        /// Retrieve head commit id for local branch
-        /// TODO: use libgit2sharp
-        /// </summary>
-        public static Task<string> GetLocalBranchCommitId(string cwd)
-            => ExecuteQuery(cwd, $"rev-parse HEAD", TimeSpan.FromMinutes(1));
 
         /// <summary>
         /// Get commits (per file)
+        /// TODO: For testing purpose only, move it to test
         /// </summary>
-        /// <param name="cwd">The current working directory</param>
-        /// <param name="file">The file path, can be null</param>
-        /// <param name="count">The commit count you want to retrieve, defualt is all</param>
-        /// <returns>A collection of git commit info</returns>
         public static Task<IReadOnlyList<GitCommit>> GetCommits(string cwd, string file = null, int count = -1)
         {
             string formatter = "%H|%cI|%an|%ae|%cn|%ce";

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -16,8 +16,6 @@ namespace Microsoft.Docs.Build
     /// </summary>
     internal static partial class GitUtility
     {
-        private static readonly char[] s_newline = new[] { '\r', '\n' };
-
         /// <summary>
         /// Find git repo directory
         /// </summary>

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -117,33 +117,6 @@ namespace Microsoft.Docs.Build
         public static Task<string> HeadRevision(string cwd)
            => ExecuteQuery(cwd, "rev-parse HEAD", TimeSpan.FromMinutes(3));
 
-        /// <summary>
-        /// Get commits (per file)
-        /// TODO: For testing purpose only, move it to test
-        /// </summary>
-        public static Task<IReadOnlyList<GitCommit>> GetCommits(string cwd, string file = null, int count = -1)
-        {
-            string formatter = "%H|%cI|%an|%ae|%cn|%ce";
-            var argumentsBuilder = new StringBuilder();
-            argumentsBuilder.Append($@"--no-pager log --format=""{formatter}""");
-            if (count > 0)
-            {
-                argumentsBuilder.Append($" -{count}");
-            }
-
-            if (!string.IsNullOrEmpty(file))
-            {
-                argumentsBuilder.Append($@" -- ""{file}""");
-            }
-
-            return ExecuteQuery(cwd, argumentsBuilder.ToString(), ParseListCommitOutput);
-        }
-
-        private static IReadOnlyList<GitCommit> ParseListCommitOutput(string lines)
-            => (from line in lines.Split(s_newline, StringSplitOptions.RemoveEmptyEntries)
-                let parts = line.Split('|')
-                select new GitCommit { Sha = parts[0], Time = DateTimeOffset.Parse(parts[1], null), AuthorName = parts[2], AuthorEmail = parts[3] }).ToList();
-
         private static Task ExecuteNonQuery(string cwd, string commandLineArgs, TimeSpan? timeout = null, Action<string, bool> outputHandler = null)
             => Execute(cwd, commandLineArgs, timeout, x => x, outputHandler ?? DefaultOutputHandler);
 

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -117,7 +117,6 @@ namespace Microsoft.Docs.Build
         public static Task<string> HeadRevision(string cwd)
            => ExecuteQuery(cwd, "rev-parse HEAD", TimeSpan.FromMinutes(3));
 
-
         /// <summary>
         /// Get commits (per file)
         /// TODO: For testing purpose only, move it to test

--- a/test/docfx.Test/lib/GitUtilityTest.cs
+++ b/test/docfx.Test/lib/GitUtilityTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -13,6 +14,21 @@ namespace Microsoft.Docs.Build
 {
     public static class GitUtilityTest
     {
+        [Theory]
+        [InlineData("README.md")]
+        public static void GetRepoInfoSameAsGitExe(string file)
+        {
+            Assert.False(GitUtility.IsRepo(Path.GetFullPath(file)));
+
+            var repo = GitUtility.FindRepo(Path.GetFullPath(file));
+            Assert.NotNull(repo);
+
+            var (remote, branch, commit) = GitUtility.GetRepoInfo(repo);
+            Assert.Equal(Exec("config --get remote.origin.url"), remote);
+            Assert.Equal(Exec("rev-parse --abbrev-ref HEAD"), branch ?? "HEAD");
+            Assert.Equal(Exec("rev-parse HEAD"), commit);
+        }
+
         [Theory]
         [InlineData("README.md")]
         public static async Task GetCommitsSameAsGitLog(string file)
@@ -37,6 +53,13 @@ namespace Microsoft.Docs.Build
             var results = await Task.WhenAll(Enumerable.Range(0, 10).AsParallel().Select(i => GitUtility.HeadRevision(cwd)));
 
             Assert.True(results.All(r => r.Any()));
+        }
+
+        private static string Exec(string args)
+        {
+            var p = Process.Start(new ProcessStartInfo { FileName = "git", Arguments = args, RedirectStandardOutput = true });
+            p.WaitForExit();
+            return p.StandardOutput.ReadToEnd().Trim();
         }
     }
 }


### PR DESCRIPTION
This reduces test case running time from 48s to 26s on my machine.