### PR TITLE
Allow globally shared MarkdownPipeline

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionExtension.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionExtension.cs
@@ -81,7 +81,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
                 if (markdownObject is LinkInline linkInline && !linkInline.IsAutoLink)
                 {
-                    linkInline.GetDynamicUrl = () => context.GetLink(linkInline.Url, InclusionContext.File);
+                    linkInline.GetDynamicUrl = () => context.GetLink(linkInline.Url, InclusionContext.File, InclusionContext.RootFile);
                 }
             }
         }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownContext.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownContext.cs
@@ -26,6 +26,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         /// </summary>
         /// <param name="path">Path of the link</param>
         /// <param name="relativeTo">The source file that path is based on.</param>
+        /// <param name="resultRelativeTo">The entry file that returned URL should be rebased upon.</param>
         /// <returns>Url bound to the path</returns>
         public delegate string GetLinkDelegate(string path, object relativeTo, object resultRelativeTo);
 

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownContext.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownContext.cs
@@ -3,8 +3,7 @@
 
 namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 {
-    using System.Collections.Generic;
-    using System.Collections.Immutable;
+    using System;
     using System.IO;
 
     public class MarkdownContext
@@ -28,12 +27,8 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         /// <param name="path">Path of the link</param>
         /// <param name="relativeTo">The source file that path is based on.</param>
         /// <returns>Url bound to the path</returns>
-        public delegate string GetLinkDelegate(string path, object relativeTo);
+        public delegate string GetLinkDelegate(string path, object relativeTo, object resultRelativeTo);
 
-        /// <summary>
-        /// Localizable text tokens used for rendering notes.
-        /// </summary>
-        public IReadOnlyDictionary<string, string> Tokens { get; }
 
         /// <summary>
         /// Reads a file as text.
@@ -55,19 +50,26 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         /// </summary>
         public LogActionDelegate LogError { get; }
 
+        /// <summary>
+        /// Gets the localizable text tokens used for rendering notes.
+        /// </summary>
+        public string GetToken(string key) => _getToken(key);
+
+        private readonly Func<string, string> _getToken;
+
         public MarkdownContext(
-            IReadOnlyDictionary<string, string> tokens = null,
+            Func<string, string> getToken = null,
             LogActionDelegate logWarning = null,
             LogActionDelegate logError = null,
             ReadFileDelegate readFile = null,
             GetLinkDelegate getLink = null)
         {
-            Tokens = tokens ?? ImmutableDictionary<string, string>.Empty;
+            _getToken = getToken ?? (_ => null);
             ReadFile = readFile ?? ReadFileDefault;
-            GetLink = getLink ?? ((path, relativeTo) => path);
+            GetLink = getLink ?? ((path, a, b) => path);
 
-            LogWarning = logWarning;
-            LogError = logError;
+            LogWarning = logWarning ?? ((a, b, c, d) => { });
+            LogError = logError ?? ((a, b, c, d) => { });
         }
 
         private static (string content, object file) ReadFileDefault(string path, object relativeTo)

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/QuoteSectionNote/QuoteSectionNoteExtension.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/QuoteSectionNote/QuoteSectionNoteExtension.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             var htmlRenderer = renderer as HtmlRenderer;
             if (htmlRenderer != null)
             {
-                QuoteSectionNoteRender quoteSectionNoteRender = new QuoteSectionNoteRender(_context.Tokens);
+                QuoteSectionNoteRender quoteSectionNoteRender = new QuoteSectionNoteRender(_context);
 
                 if (!renderer.ObjectRenderers.Replace<QuoteBlockRenderer>(quoteSectionNoteRender))
                 {

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/QuoteSectionNote/QuoteSectionNoteRender.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/QuoteSectionNote/QuoteSectionNoteRender.cs
@@ -4,18 +4,17 @@
 namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 {
     using System;
-    using System.Collections.Generic;
 
     using Markdig.Renderers;
     using Markdig.Renderers.Html;
 
     public class QuoteSectionNoteRender : HtmlObjectRenderer<QuoteSectionNoteBlock>
     {
-        private IReadOnlyDictionary<string, string> _tokens;
+        private readonly MarkdownContext _context;
 
-        public QuoteSectionNoteRender(IReadOnlyDictionary<string, string> tokens)
+        public QuoteSectionNoteRender(MarkdownContext context)
         {
-            _tokens = tokens;
+            _context = context;
         }
 
         protected override void Write(HtmlRenderer renderer, QuoteSectionNoteBlock obj)
@@ -42,11 +41,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
         private void WriteNote(HtmlRenderer renderer, QuoteSectionNoteBlock obj)
         {
-            string noteHeading = string.Empty;
-            if (_tokens?.TryGetValue(obj.NoteTypeString.ToLower(), out noteHeading) != true)
-            {
-                noteHeading = $"<h5>{obj.NoteTypeString.ToUpper()}</h5>";
-            };
+            var noteHeading = _context.GetToken(obj.NoteTypeString.ToLower()) ?? $"<h5>{obj.NoteTypeString.ToUpper()}</h5>";
             renderer.Write("<div").Write($" class=\"{obj.NoteTypeString.ToUpper()}\"").WriteAttributes(obj).WriteLine(">");
             var savedImplicitParagraph = renderer.ImplicitParagraph;
             renderer.ImplicitParagraph = false;

--- a/src/Microsoft.DocAsCode.MarkdigEngine/MarkdigMarkdownService.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine/MarkdigMarkdownService.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine
             _parameters = parameters;
             _mvb = MarkdownValidatorBuilder.Create(parameters, container);
             _context = new MarkdownContext(
-                _parameters.Tokens,
+                key => _parameters.Tokens.TryGetValue(key, out var value) ? value : null,
                 (code, message, file, line) => Logger.LogWarning(message, null, file, line.ToString(), code),
                 (code, message, file, line) => Logger.LogError(message, null, file, line.ToString(), code),
                 ReadFile,
@@ -162,7 +162,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine
             return builder.Build();
         }
 
-        private static string GetLink(string path, object relativeTo)
+        private static string GetLink(string path, object relativeTo, object resultRelativeTo)
         {
             if (InclusionContext.IsInclude && RelativePath.IsRelativePath(path) && PathUtility.IsRelativePath(path) && !RelativePath.IsPathFromWorkingFolder(path) && !path.StartsWith("#"))
             {


### PR DESCRIPTION
This is to enable `MarkdownPipeline` sharing to address markdig performance issues in #2972

- Add `InclusionContext.RootFile`, this is always the first file pushed to the context,  `GetLink` reshould rebase relative URL against this file in v3.

- Modify `tokens` to be a function, to allow different locales using the same `MarkdownPipeline`

@qinezh @yishengjin1413 