### PR TITLE
Share inline only pipeline used by InclusionExtension

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionInline/HtmlInclusionInlineRenderer.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionInline/HtmlInclusionInlineRenderer.cs
@@ -12,10 +12,10 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         private readonly MarkdownContext _context;
         private readonly MarkdownPipeline _inlinePipeline;
 
-        public HtmlInclusionInlineRenderer(MarkdownContext context, MarkdownPipeline pipeline)
+        public HtmlInclusionInlineRenderer(MarkdownContext context, MarkdownPipeline inlinePipeline)
         {
             _context = context;
-            _inlinePipeline = CreateInlineOnlyPipeline(pipeline);
+            _inlinePipeline = inlinePipeline;
         }
 
         protected override void Write(HtmlRenderer renderer, InclusionInline inclusion)
@@ -40,20 +40,6 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             {
                 renderer.Write(Markdown.ToHtml(content, _inlinePipeline));
             }
-        }
-
-        private static MarkdownPipeline CreateInlineOnlyPipeline(MarkdownPipeline pipeline)
-        {
-            var builder = new MarkdownPipelineBuilder();
-            
-            foreach (var extension in pipeline.Extensions)
-            {
-                builder.Extensions.Add(extension);
-            }
-
-            builder.UseInlineOnly();
-
-            return builder.Build();
         }
     }
 }


### PR DESCRIPTION
This PR caches an inline only pipeline for InlineInclusion renderer inside InclusionExtension, to avoid constructing a new MarkdownPipeline for every article.

It reduces _azure-docs-pr_ markdown build time from 2 minutes to 34 seconds.

#2972 