### PR TITLE
Do not write output in cases of error

### DIFF
--- a/docs/specs/manifest.yml
+++ b/docs/specs/manifest.yml
@@ -190,7 +190,6 @@ outputs:
   build.log: |
     ["warning","circular-reference","Found circular reference: docs/b.md --> docs/a.md --> docs/b.md","docs/b.md"]
     ["warning","circular-reference","Found circular reference: docs/a.md --> docs/b.md --> docs/a.md","docs/a.md"]
-
 ---
 # Manifest link circular reference
 inputs:
@@ -240,3 +239,16 @@ outputs:
           ]
        }
     }
+---
+# Manifest does not include files with errors
+inputs:
+  docfx.yml: |
+    rules:
+      link-is-empty: error
+  docs/a.md: |
+    a []()
+outputs:
+  build.manifest: |
+    { files: [] }
+  build.log: |
+    ["error","link-is-empty","Link is empty","docs/a.md"]

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -739,7 +739,7 @@ outputs:
     }
   build.manifest:
 ---
-# Topic href cann't reference a local toc file or folder
+# Topic href cannot reference a local TOC file or folder
 inputs:
   docfx.yml:
   docs/TOC.yml: |
@@ -753,28 +753,13 @@ inputs:
   docs/f1/TOC.md:
 outputs:
   docs/f1/TOC.json:
-  docs/TOC.json: |
-    {  
-       "items":[  
-          {  
-             "toc_title":"Invalid Topic Reference1"
-          },
-          {  
-             "toc_title":"Invalid Topic Reference2"
-          },
-          {  
-             "toc_title":"Invalid Topic Reference3",
-             "href":"/abc/def"
-          }
-       ]
-    }
   build.manifest:
   build.log: |
     ["error","invalid-topic-href","The topic href 'f1/' can only reference to a local file or absolute path","docs/TOC.yml"]
     ["error","invalid-topic-href","The topic href 'f1/TOC.md' can only reference to a local file or absolute path","docs/TOC.yml"]
     ["error","invalid-topic-href","The topic href 'f1/TOC.md' can only reference to a local file or absolute path","docs/TOC.yml"]
 ---
-# Toc href cann't reference a local file
+# Toc href cannot reference a local file
 inputs:
   docfx.yml:
   docs/TOC.yml: |
@@ -788,18 +773,6 @@ inputs:
 outputs:
   docs/f1/TOC.json:
   docs/f1/a.json:
-  docs/TOC.json: |
-    {  
-       "items":[  
-          {  
-             "toc_title":"Invalid Toc Reference1"
-          },
-          {  
-             "toc_title":"Invalid Toc Reference2",
-             "href":"/abc/def"
-          }
-       ]
-    }
   build.manifest:
   build.log: |
     ["error","invalid-toc-href","The toc href 'f1/a.md' can only reference to a local TOC file, folder or absolute path","docs/TOC.yml"]
@@ -823,7 +796,7 @@ outputs:
   build.log: |
     ["error","yaml-duplicate-key","(Line: 3, Character: 3) - (Line: 3, Character: 12): Key 'topicHref' is already defined, remove the duplicate key.","docs/TOC.yml"]
 ---
-# The included toc' errors/warning should be assigned to itself, not its parent
+# The included TOC's errors/warning should be assigned to itself, not its parent
 inputs:
   docfx.yml: |
     content:
@@ -837,7 +810,6 @@ inputs:
     - name: Invalid TocHref Reference
       tocHref: index.md
 outputs:
-  docs/TOC.json:
   build.manifest:
   build.log: |
     ["warning","file-not-found","Cannot find file 'index.md' relative to 'docs/f1/TOC.yml'","docs/f1/TOC.yml"]

--- a/src/docfx/build/manifest/DocumentListBuilder.cs
+++ b/src/docfx/build/manifest/DocumentListBuilder.cs
@@ -14,11 +14,11 @@ namespace Microsoft.Docs.Build
         private readonly ConcurrentDictionary<string, Document> _filesByUrl = new ConcurrentDictionary<string, Document>(PathUtility.PathComparer);
         private readonly ConcurrentDictionary<string, Document> _filesByOutputPath = new ConcurrentDictionary<string, Document>(PathUtility.PathComparer);
 
-        public List<Document> Build(Context context)
+        public ICollection<Document> Build(Context context)
         {
             HandleConflicts(context);
 
-            return _filesByUrl.Values.OrderBy(d => d.OutputPath).ToList();
+            return _filesByUrl.Values;
         }
 
         public bool TryAdd(Document file)

--- a/src/docfx/build/markdown/BuildMarkdown.cs
+++ b/src/docfx/build/markdown/BuildMarkdown.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -10,8 +11,7 @@ namespace Microsoft.Docs.Build
 {
     internal static class BuildMarkdown
     {
-        public static Task<DependencyMap> Build(
-            Context context,
+        public static Task<(IEnumerable<Error> errors, PageModel result, DependencyMap dependencies)> Build(
             Document file,
             TableOfContentsMap tocMap,
             ContributionInfo contribution,
@@ -58,11 +58,7 @@ namespace Microsoft.Docs.Build
                 EnableContribution = file.Docset.Config.Contribution.Enabled,
             };
 
-            // TODO: make build pure by not output using `context.Report/Write/Copy` here
-            context.Report(file, markup.Errors.Concat(repoErrors));
-            context.WriteJson(model, file.OutputPath);
-
-            return Task.FromResult(dependencyMapBuilder.Build());
+            return Task.FromResult((markup.Errors.Concat(repoErrors), model, dependencyMapBuilder.Build()));
         }
     }
 }

--- a/src/docfx/build/schema/BuildSchemaDocument.cs
+++ b/src/docfx/build/schema/BuildSchemaDocument.cs
@@ -2,15 +2,17 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Microsoft.Docs.Build
 {
     internal static class BuildSchemaDocument
     {
-        public static Task<DependencyMap> Build()
+        public static Task<(IEnumerable<Error> errors, PageModel result, DependencyMap dependencies)> Build()
         {
-            return Task.FromResult(DependencyMap.Empty);
+            return Task.FromResult((Enumerable.Empty<Error>(), (PageModel)null, DependencyMap.Empty));
         }
     }
 }

--- a/src/docfx/docset/Context.cs
+++ b/src/docfx/docset/Context.cs
@@ -18,29 +18,29 @@ namespace Microsoft.Docs.Build
             _outputPath = Path.GetFullPath(outputPath);
         }
 
-        public void Report(Document file, IEnumerable<Error> errors)
+        public bool Report(string file, IEnumerable<Error> errors)
         {
-            Report(file.ToString(), errors);
-        }
-
-        public void Report(string file, IEnumerable<Error> errors)
-        {
+            var hasErrors = false;
             foreach (var error in errors)
             {
-                Report(file, error);
+                if (Report(file, error))
+                {
+                    hasErrors = true;
+                }
             }
+            return hasErrors;
         }
 
-        public void Report(string file, Error error)
+        public bool Report(string file, Error error)
         {
-            Report(file == error.File || !string.IsNullOrEmpty(error.File)
+            return Report(file == error.File || !string.IsNullOrEmpty(error.File)
                     ? error
                     : new Error(error.Level, error.Code, error.Message, file, error.Line, error.Column));
         }
 
-        public void Report(Error error)
+        public bool Report(Error error)
         {
-            _report.Write(error);
+            return _report.Write(error);
         }
 
         /// <summary>

--- a/src/docfx/lib/log/Report.cs
+++ b/src/docfx/lib/log/Report.cs
@@ -29,12 +29,12 @@ namespace Microsoft.Docs.Build
             });
         }
 
-        public void Write(Error error)
+        public bool Write(Error error)
         {
             var level = _rules != null && _rules.TryGetValue(error.Code, out var overrideLevel) ? overrideLevel : error.Level;
             if (level == ErrorLevel.Off)
             {
-                return;
+                return false;
             }
 
             if (_output != null)
@@ -46,6 +46,8 @@ namespace Microsoft.Docs.Build
             }
 
             ConsoleLog(level, error);
+
+            return level == ErrorLevel.Error;
         }
 
         public void Dispose()


### PR DESCRIPTION
This PR:

- files with errors does not have output
- files with errors does not appear in manifest
- make build markdown pure by returning the model and errors