### PR TITLE
use tls 1.2 in entire app

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/XRefMaps/XRefMapDownloader.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/XRefMaps/XRefMapDownloader.cs
@@ -27,8 +27,6 @@ namespace Microsoft.DocAsCode.Build.Engine
             {
                 _baseFolder = Path.Combine(Directory.GetCurrentDirectory(), baseFolder);
             }
-            // GitHub doesn't support TLS 1.1 since Feb 23, 2018. See: https://github.com/blog/2507-weak-cryptographic-standards-removed
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
         }
 
         /// <summary>

--- a/src/docfx/Program.cs
+++ b/src/docfx/Program.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.DocAsCode
 {
     using System;
+    using System.Net;
 
     using Microsoft.DocAsCode.Common;
     using Microsoft.DocAsCode.Exceptions;
@@ -18,6 +19,9 @@ namespace Microsoft.DocAsCode
         {
             try
             {
+                // TLS best practices for .NET: https://docs.microsoft.com/en-us/dotnet/framework/network-programming/tls
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
                 var result = ExecSubCommand(args);
                 return Logger.HasError ? 1 : result;
             }

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/XRefMapDownloaderTest.cs
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/XRefMapDownloaderTest.cs
@@ -4,12 +4,12 @@
 namespace Microsoft.DocAsCode.Build.Engine.Tests
 {
     using System;
-    using System.IO;
     using System.Threading.Tasks;
 
     using Xunit;
 
     using Microsoft.DocAsCode.Build.Engine;
+    using System.Net;
 
     [Trait("Owner", "makaretu")]
     public class XRefMapDownloadTest
@@ -17,6 +17,9 @@ namespace Microsoft.DocAsCode.Build.Engine.Tests
         [Fact]
         public async Task BaseUrlIsSet()
         {
+            // GitHub doesn't support TLS 1.1 since Feb 23, 2018. See: https://github.com/blog/2507-weak-cryptographic-standards-removed
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
             var downloader = new XRefMapDownloader();
             var xrefs = await downloader.DownloadAsync(new Uri("https://dotnet.github.io/docfx/xrefmap.yml")) as XRefMap;
             Assert.NotNull(xrefs);


### PR DESCRIPTION
DocFX has 2 kinds of network communication:
* xrefmap: already changed to TLS 1.2 before
* xrefservice: also changed to TLS 1.2 in this PR. It's safe as https://xref.docs.microsoft.com already supports TLS 1.2