### PR TITLE
Do not mess up with global appdata during test

### DIFF
--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Docs.Build
                         (errors, model, dependencies) = BuildTableOfContents.Build(file, tocMap, buildChild);
                         break;
                     case ContentType.Redirection:
-                        model = BuildRedirectionItem(file);
+                        model = BuildRedirection(file);
                         break;
                 }
 
@@ -133,7 +133,7 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static PageModel BuildRedirectionItem(Document file)
+        private static PageModel BuildRedirection(Document file)
         {
             Debug.Assert(file.ContentType == ContentType.Redirection);
 

--- a/src/docfx/config/AppData.cs
+++ b/src/docfx/config/AppData.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Docs.Build
                 docfxAppData = Path.GetFullPath(docfxAppData);
             }
 
-            return Path.Combine(!string.IsNullOrEmpty(docfxAppData) ? docfxAppData : Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".docfx");
+            return !string.IsNullOrEmpty(docfxAppData) ? docfxAppData : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".docfx");
         }
     }
 }

--- a/test/docfx.Test/common/TestFramework.cs
+++ b/test/docfx.Test/common/TestFramework.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -25,6 +26,7 @@ namespace Microsoft.Docs.Build
 
         protected override ITestFrameworkExecutor CreateExecutor(AssemblyName assemblyName)
         {
+            Environment.SetEnvironmentVariable("DOCFX_APPDATA_PATH", Path.GetFullPath("app-data"));
             MakeDebugAssertThrowException();
             return new ParallelExecutor(assemblyName, SourceInformationProvider, DiagnosticMessageSink);
         }

--- a/test/docfx.Test/common/TestFramework.cs
+++ b/test/docfx.Test/common/TestFramework.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Docs.Build
 
         protected override ITestFrameworkExecutor CreateExecutor(AssemblyName assemblyName)
         {
-            Environment.SetEnvironmentVariable("DOCFX_APPDATA_PATH", Path.GetFullPath("app-data"));
+            Environment.SetEnvironmentVariable("DOCFX_APPDATA_PATH", Path.GetFullPath("appdata"));
             MakeDebugAssertThrowException();
             return new ParallelExecutor(assemblyName, SourceInformationProvider, DiagnosticMessageSink);
         }

--- a/test/docfx.Test/config/ConfigTest.cs
+++ b/test/docfx.Test/config/ConfigTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Docs.Build
         [Fact]
         public static void TestConigWithGlobalMetadata()
         {
-            var docsetPath = "ConfigTest/ConfigWithGlobalMetadata";
+            var docsetPath = "config/ConfigWithGlobalMetadata";
             var configYaml = @"globalMetadata:
   key1: value
   key2: 2";
@@ -27,7 +27,7 @@ namespace Microsoft.Docs.Build
         [Fact]
         public static void TestConfigWithObjectFileMetadata()
         {
-            var docsetPath = "ConfigTest/ConfigWithObjectFileMetadata";
+            var docsetPath = "config/ConfigWithObjectFileMetadata";
             var configYaml = @"fileMetadata:
   folder/:
     key1: value1
@@ -51,7 +51,7 @@ namespace Microsoft.Docs.Build
         [Fact]
         public static void TestConfigWithArrayFileMetadata()
         {
-            var docsetPath = "ConfigTest/ConfigWithArrayFileMetadata";
+            var docsetPath = "config/ConfigWithArrayFileMetadata";
             var configYaml = @"fileMetadata:
 - include: folder1/**
   exclude: folder1/exclude/**

--- a/test/docfx.Test/e2e/E2ETest.cs
+++ b/test/docfx.Test/e2e/E2ETest.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Docs.Build
             var sections = File.ReadAllText(Path.Combine("specs", specPath)).Split("\n---", StringSplitOptions.RemoveEmptyEntries);
             var yaml = sections[ordinal].Trim('\r', '\n', '-');
             var (_, spec) = YamlUtility.Deserialize<E2ESpec>(yaml, false);
-            var docsetPath = Path.Combine("specs.drop", specName.Replace("<", "").Replace(">", ""));
+            var docsetPath = Path.Combine("specs-drop", specName.Replace("<", "").Replace(">", ""));
 
             if (Directory.Exists(docsetPath))
             {

--- a/test/docfx.Test/lib/ProcessUtilityTest.cs
+++ b/test/docfx.Test/lib/ProcessUtilityTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Docs.Build
         [Fact]
         public static async Task ConcurrencyCreatingFileShouldNotThrowNoException()
         {
-            var fileName = $".process_test\\{Guid.NewGuid()}";
+            var fileName = $"process-test\\{Guid.NewGuid()}";
             await Task.WhenAll(Enumerable.Range(0, 5).AsParallel().Select(
                 i => ProcessUtility.CreateFileMutex(
                     fileName,

--- a/test/docfx.Test/restore/RestoreTest.cs
+++ b/test/docfx.Test/restore/RestoreTest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Docs.Build
         [Fact]
         public static async Task RestoreGitWorkTrees()
         {
-            var docsetPath = ".restore_worktrees";
+            var docsetPath = "restore-worktrees";
             var gitUrl = "https://github.com/docascode/docfx-test-dependencies-clean";
             Directory.CreateDirectory(docsetPath);
             var restorePath = PathUtility.NormalizeFolder(Path.Combine(RestoreGit.GetRestoreRootDir(gitUrl), ".git"));
@@ -72,7 +72,7 @@ dependencies:
         public static async Task RestoreUrls()
         {
             // prepare versions
-            var docsetPath = ".restore_urls";
+            var docsetPath = "restore-urls";
             Directory.CreateDirectory(docsetPath);
             var url = "https://raw.githubusercontent.com/docascode/docfx-test-dependencies-clean/master/README.md";
             var restoreDir = RestoreUrl.GetRestoreRootDir(url);


### PR DESCRIPTION
- Set DOCFX_APPDATA_PATH to a local folder during test
- Do not append .docfx is DOCFX_APPDATA_PATH is set from environment variable
- Rename some test output directorys