### PR TITLE
Implementation for yaml/json field type not found in target object type 

### DIFF
--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -112,8 +112,8 @@ namespace Microsoft.Docs.Build
         public static Error NullValue(Range range, string name)
             => new Error(ErrorLevel.Info, "null-value", $"{range} '{name}' contains null value", line: range.StartLine, column: range.StartCharacter);
 
-        public static Error UnknownFieldType(Range range, string propName, string typeName)
-            => new Error(ErrorLevel.Warning, "unknown-field-type", $"{range} Could not find member '{propName}' on object of type '{typeName}'", line: range.StartLine, column: range.StartCharacter);
+        public static Error UnknownField(Range range, string propName, string typeName, string path)
+            => new Error(ErrorLevel.Warning, "unknown-field", $"{range} Path:{path} Could not find member '{propName}' on object of type '{typeName}'", line: range.StartLine, column: range.StartCharacter);
 
         public static Error ViolateSchema(Range range, string message)
             => new Error(ErrorLevel.Error, "violate-schema", $"{range} {message}", line: range.StartLine, column: range.StartCharacter);

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -115,8 +115,8 @@ namespace Microsoft.Docs.Build
         public static Error UnknownFieldType(Range range, string propName, string typeName)
             => new Error(ErrorLevel.Warning, "unknown-field-type", $"{range} Could not find member '{propName}' on object of type '{typeName}'", line: range.StartLine, column: range.StartCharacter);
 
-        public static Error InvalidSchema(Range range, string message)
-            => new Error(ErrorLevel.Error, "invalid-schema", $"{range} {message}", line: range.StartLine, column: range.StartCharacter);
+        public static Error ViolateSchema(Range range, string message)
+            => new Error(ErrorLevel.Error, "violate-schema", $"{range} {message}", line: range.StartLine, column: range.StartCharacter);
 
         public static Error SchemaNotFound(string schema)
             => new Error(ErrorLevel.Error, "schema-not-found", $"Unknown schema '{schema}'");

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -112,6 +112,12 @@ namespace Microsoft.Docs.Build
         public static Error NullValue(Range range, string name)
             => new Error(ErrorLevel.Info, "null-value", $"{range} '{name}' contains null value", line: range.StartLine, column: range.StartCharacter);
 
+        public static Error UnknownFieldType(Range range, string propName, string typeName)
+            => new Error(ErrorLevel.Warning, "unknown-field-type", $"{range} Could not find member '{propName}' on object of type '{typeName}'", line: range.StartLine, column: range.StartCharacter);
+
+        public static Error InvalidSchema(Range range, string message)
+            => new Error(ErrorLevel.Error, "invalid-schema", $"{range} {message}", line: range.StartLine, column: range.StartCharacter);
+
         public static Error SchemaNotFound(string schema)
             => new Error(ErrorLevel.Error, "schema-not-found", $"Unknown schema '{schema}'");
 

--- a/src/docfx/build/schema/BuildSchemaDocument.cs
+++ b/src/docfx/build/schema/BuildSchemaDocument.cs
@@ -29,7 +29,8 @@ namespace Microsoft.Docs.Build
                 throw Errors.SchemaNotFound(schema).ToException();
             }
 
-            var content = token.ToObject(schemaType);
+            var (mismatchingErrors, content) = JsonUtility.ToObject(token, schemaType);
+            errors.AddRange(mismatchingErrors);
 
             // TODO: consolidate this with BuildMarkdown
             var locale = file.Docset.Config.Locale;

--- a/src/docfx/lib/JsonUtility.cs
+++ b/src/docfx/lib/JsonUtility.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Docs.Build
             {
                 return (token.ValidateMismatchingFieldType(type), token.ToObject(type, DefaultDeserializer));
             }
-            catch (JsonException ex) when(ex is JsonSerializationException || ex is JsonReaderException)
+            catch (JsonException ex) when (ex is JsonSerializationException || ex is JsonReaderException)
             {
                 var range = ParseRangeFromExceptionMessage(ex.Message);
                 throw Errors.ViolateSchema(range, ex.Message).ToException();

--- a/src/docfx/lib/JsonUtility.cs
+++ b/src/docfx/lib/JsonUtility.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 
 using Newtonsoft.Json;
@@ -23,6 +25,8 @@ namespace Microsoft.Docs.Build
             NullValueHandling = NullValueHandling.Ignore,
             ContractResolver = new JsonContractResolver(),
         };
+
+        private static readonly ConcurrentDictionary<Type, bool> s_cache = new ConcurrentDictionary<Type, bool>();
 
         private static readonly JsonMergeSettings s_defaultMergeSettings = new JsonMergeSettings
         {
@@ -80,7 +84,32 @@ namespace Microsoft.Docs.Build
         public static (List<Error>, T) Deserialize<T>(string json)
         {
             var (errors, token) = Deserialize(json);
-            return (errors, (T)token.ToObject(typeof(T), DefaultDeserializer));
+            var (mismatchingErrors, result) = ToObject<T>(token);
+            errors.AddRange(mismatchingErrors);
+            return (errors, result);
+        }
+
+        /// <summary>
+        /// Creates an instance of the specified .NET type from the JToken
+        /// And validate mismatching field types
+        /// </summary>
+        public static (List<Error>, T) ToObject<T>(JToken token)
+        {
+            var (errors, obj) = ToObject(token, typeof(T));
+            return (errors, (T)obj);
+        }
+
+        public static (List<Error>, object) ToObject(JToken token, Type type)
+        {
+            try
+            {
+               return (token.ValidateMismatchingFieldType(type), token.ToObject(type, DefaultDeserializer));
+            }
+            catch (JsonReaderException ex)
+            {
+                var range = ParseRangeFromExceptionMessage(ex.Message);
+                throw Errors.InvalidSchema(range, ex.Message).ToException();
+            }
         }
 
         /// <summary>
@@ -132,16 +161,31 @@ namespace Microsoft.Docs.Build
             return result;
         }
 
-        public static (List<Error>, JToken) ValidateNullValue(this JToken token)
+        internal static (List<Error>, JToken) ValidateNullValue(this JToken token)
         {
             var errors = new List<Error>();
             var nullNodes = new List<JToken>();
-            token.Traverse(errors, nullNodes);
+            token.TraverseForNullValueValidation(errors, nullNodes);
             foreach (var node in nullNodes)
             {
                 node.Remove();
             }
             return (errors, token);
+        }
+
+        internal static List<Error> ValidateMismatchingFieldType(this JToken token, Type type)
+        {
+            var errors = new List<Error>();
+            token.TraverseForUnknownFieldType(errors, type);
+            return errors;
+        }
+
+        private static Range ParseRangeFromExceptionMessage(string message)
+        {
+            var parts = message.Remove(message.Length - 1).Split(',');
+            var lineNumber = int.Parse(parts.SkipLast(1).Last().Split(' ').Last());
+            var linePosition = int.Parse(parts.Last().Split(' ').Last());
+            return new Range(lineNumber, linePosition);
         }
 
         private static bool IsNullOrUndefined(this JToken token)
@@ -152,7 +196,7 @@ namespace Microsoft.Docs.Build
                 (token.Type == JTokenType.Undefined);
         }
 
-        private static void Traverse(this JToken token, List<Error> errors, List<JToken> nullNodes, string name = null)
+        private static void TraverseForNullValueValidation(this JToken token, List<Error> errors, List<JToken> nullNodes, string name = null)
         {
             if (token is JArray array)
             {
@@ -165,7 +209,7 @@ namespace Microsoft.Docs.Build
                     }
                     else
                     {
-                        Traverse(item, errors, nullNodes, name);
+                        item.TraverseForNullValueValidation(errors, nullNodes, name);
                     }
                 }
             }
@@ -181,10 +225,92 @@ namespace Microsoft.Docs.Build
                     }
                     else
                     {
-                        prop.Value.Traverse(errors, nullNodes, prop.Name);
+                        prop.Value.TraverseForNullValueValidation(errors, nullNodes, prop.Name);
                     }
                 }
             }
+        }
+
+        private static void TraverseForUnknownFieldType(this JToken token, List<Error> errors, Type type)
+        {
+            // if type contains JsonExtensionDataAttribute, additional properties are allowed
+            if (TypeContainsJsonExtensionData(type))
+                return;
+
+            if (token is JArray array)
+            {
+                foreach (var item in token.Children())
+                {
+                    item.TraverseForUnknownFieldType(errors, type);
+                }
+            }
+            else if (token is JObject obj)
+            {
+                foreach (var item in token.Children())
+                {
+                    var prop = item as JProperty;
+
+                    // skip the special property
+                    if (prop.Name.StartsWith('$'))
+                        continue;
+
+                    var nestedType = CheckForUnknownFieldType(type, prop, errors);
+                    prop.Value.TraverseForUnknownFieldType(errors, nestedType);
+                }
+            }
+        }
+
+        private static bool TypeContainsJsonExtensionData(Type type)
+        {
+            if (!s_cache.TryGetValue(type, out var containsJsonExtensionData))
+            {
+                containsJsonExtensionData = type.GetProperties().Any(prop => prop.GetCustomAttribute<JsonExtensionDataAttribute>() != null);
+                s_cache.TryAdd(type, containsJsonExtensionData);
+            }
+            return containsJsonExtensionData;
+        }
+
+        private static Type CheckForUnknownFieldType(Type type, JProperty prop, List<Error> errors)
+        {
+            var contract = DefaultDeserializer.ContractResolver.ResolveContract(type);
+            JsonPropertyCollection jsonProperties;
+            if (contract is JsonObjectContract objectContract)
+            {
+                jsonProperties = objectContract.Properties;
+            }
+            else if (contract is JsonArrayContract arrayContract)
+            {
+                jsonProperties = GetPropertiesFromJsonArrayContract(arrayContract);
+            }
+            else
+            {
+                return type;
+            }
+
+            // if mismatching field type found, add error
+            // else, pass along with nested type
+            var matchingProperty = jsonProperties.GetClosestMatchProperty(prop.Name);
+            if (matchingProperty is null)
+            {
+                var lineInfo = prop as IJsonLineInfo;
+                errors.Add(Errors.UnknownFieldType(
+                    new Range(lineInfo.LineNumber, lineInfo.LinePosition), prop.Name, type.Name));
+                return type;
+            }
+            else
+            {
+                return matchingProperty.PropertyType;
+            }
+        }
+
+        private static JsonPropertyCollection GetPropertiesFromJsonArrayContract(JsonArrayContract arrayContract)
+        {
+            var itemContract = DefaultDeserializer.ContractResolver.ResolveContract(arrayContract.CollectionItemType);
+            if (itemContract is JsonObjectContract objectContract)
+                return objectContract.Properties;
+            else if (itemContract is JsonArrayContract contract)
+                return GetPropertiesFromJsonArrayContract(contract);
+            return null;
         }
 
         private static void LogInfoForNullValue(IJsonLineInfo token, List<Error> errors, string name)

--- a/src/docfx/lib/JsonUtility.cs
+++ b/src/docfx/lib/JsonUtility.cs
@@ -104,12 +104,16 @@ namespace Microsoft.Docs.Build
         {
             try
             {
-               return (token.ValidateMismatchingFieldType(type), token.ToObject(type, DefaultDeserializer));
+                return (token.ValidateMismatchingFieldType(type), token.ToObject(type, DefaultDeserializer));
             }
-            catch (JsonReaderException ex)
+            catch (JsonException ex)
             {
-                var range = ParseRangeFromExceptionMessage(ex.Message);
-                throw Errors.ViolateSchema(range, ex.Message).ToException();
+                if (ex is JsonSerializationException || ex is JsonReaderException)
+                {
+                    var range = ParseRangeFromExceptionMessage(ex.Message);
+                    throw Errors.ViolateSchema(range, ex.Message).ToException();
+                }
+                throw;
             }
         }
 

--- a/src/docfx/lib/JsonUtility.cs
+++ b/src/docfx/lib/JsonUtility.cs
@@ -293,7 +293,7 @@ namespace Microsoft.Docs.Build
                 return type;
             }
 
-            // if mismatching field type found, add error
+            // if mismatching field found, add error
             // else, pass along with nested type
             var matchingProperty = jsonProperties.GetClosestMatchProperty(prop.Name);
             if (matchingProperty is null)

--- a/src/docfx/lib/JsonUtility.cs
+++ b/src/docfx/lib/JsonUtility.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Docs.Build
             catch (JsonReaderException ex)
             {
                 var range = ParseRangeFromExceptionMessage(ex.Message);
-                throw Errors.InvalidSchema(range, ex.Message).ToException();
+                throw Errors.ViolateSchema(range, ex.Message).ToException();
             }
         }
 

--- a/src/docfx/lib/JsonUtility.cs
+++ b/src/docfx/lib/JsonUtility.cs
@@ -106,14 +106,10 @@ namespace Microsoft.Docs.Build
             {
                 return (token.ValidateMismatchingFieldType(type), token.ToObject(type, DefaultDeserializer));
             }
-            catch (JsonException ex)
+            catch (JsonException ex) when(ex is JsonSerializationException || ex is JsonReaderException)
             {
-                if (ex is JsonSerializationException || ex is JsonReaderException)
-                {
-                    var range = ParseRangeFromExceptionMessage(ex.Message);
-                    throw Errors.ViolateSchema(range, ex.Message).ToException();
-                }
-                throw;
+                var range = ParseRangeFromExceptionMessage(ex.Message);
+                throw Errors.ViolateSchema(range, ex.Message).ToException();
             }
         }
 

--- a/src/docfx/lib/YamlUtility.cs
+++ b/src/docfx/lib/YamlUtility.cs
@@ -57,7 +57,9 @@ namespace Microsoft.Docs.Build
         public static (List<Error>, T) Deserialize<T>(string input, bool nullValidation = true)
         {
             var (errors, json) = Deserialize(input, nullValidation);
-            return (errors, json.ToObject<T>(JsonUtility.DefaultDeserializer));
+            var (mismatchingErrors, result) = JsonUtility.ToObject<T>(json);
+            errors.AddRange(mismatchingErrors);
+            return (errors, result);
         }
 
         /// <summary>
@@ -141,7 +143,8 @@ namespace Microsoft.Docs.Build
                     if (key is YamlScalarNode scalarKey)
                     {
                         var token = ToJson(value);
-                        obj[scalarKey.Value] = token;
+                        var prop = PopulateLineInfoToJToken(new JProperty(scalarKey.Value, token), key);
+                        obj.Add(prop);
                     }
                     else
                     {

--- a/src/docfx/models/schemas/LandingData.cs
+++ b/src/docfx/models/schemas/LandingData.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Docs.Build
 
         public LandingDataSection[] Sections { get; set; }
 
+        public string DocumentType { get; set; }
+
         internal class LandingDataAbstract
         {
             public string Description { get; set; }

--- a/test/docfx.Test/lib/JsonUtilityTest.cs
+++ b/test/docfx.Test/lib/JsonUtilityTest.cs
@@ -261,27 +261,27 @@ namespace Microsoft.Docs.Build
         }
 
         [Theory]
-        [InlineData(@"{""mismatchType"": ""name""}", 1, 16, ErrorLevel.Warning, "unknown-field-type")]
+        [InlineData(@"{""mismatchField"": ""name""}", 1, 17, ErrorLevel.Warning, "unknown-field")]
         [InlineData(@"{
         ""ValueBasic"":
           {""B"": 1,
           ""C"": ""c"",
-          ""E"": ""e""}}", 5, 14, ErrorLevel.Warning, "unknown-field-type")]
+          ""E"": ""e""}}", 5, 14, ErrorLevel.Warning, "unknown-field")]
         [InlineData(@"{
         ""Items"":
           [{ ""B"": 1,
             ""C"": ""c"",
-            ""E"": ""e""}]}", 5, 16, ErrorLevel.Warning, "unknown-field-type")]
+            ""E"": ""e""}]}", 5, 16, ErrorLevel.Warning, "unknown-field")]
         [InlineData(@"{
         ""AnotherItems"":
           [{ ""F"": 1,
             ""G"": ""c"",
-            ""E"": ""e""}]}", 5, 16, ErrorLevel.Warning, "unknown-field-type")]
+            ""E"": ""e""}]}", 5, 16, ErrorLevel.Warning, "unknown-field")]
         [InlineData(@"{
 ""NestedItems"":
   [[{ ""F"": 1,
     ""G"": ""c"",
-    ""E"": ""e""}]]}", 5, 8, ErrorLevel.Warning, "unknown-field-type")]
+    ""E"": ""e""}]]}", 5, 8, ErrorLevel.Warning, "unknown-field")]
         internal void TestUnknownFieldType(string json, int expectedLine, int expectedColumn, ErrorLevel expectedErrorLevel, string expectedErrorCode)
         {
             var (errors, result) = JsonUtility.Deserialize<ClassWithMoreMembers>(json);
@@ -297,25 +297,25 @@ namespace Microsoft.Docs.Build
         [Fact]
         public void TestMultipleUnknownFieldType()
         {
-            var json = @"{""mismatchType1"": ""name"",
-""mismatchType2"": ""name""}";
+            var json = @"{""mismatchField1"": ""name"",
+""mismatchField2"": ""name""}";
             var (errors, result) = JsonUtility.Deserialize<BasicClass>(json);
             Assert.Collection(errors,
             error =>
             {
                 Assert.Equal(ErrorLevel.Warning, error.Level);
-                Assert.Equal("unknown-field-type", error.Code);
+                Assert.Equal("unknown-field", error.Code);
                 Assert.Equal(1, error.Line);
-                Assert.Equal(17, error.Column);
-                Assert.Equal("(Line: 1, Character: 17) Could not find member 'mismatchType1' on object of type 'BasicClass'", error.Message);
+                Assert.Equal(18, error.Column);
+                Assert.Equal("(Line: 1, Character: 18) Path:BasicClass.mismatchField1 Could not find member 'mismatchField1' on object of type 'BasicClass'", error.Message);
             },
             error =>
             {
                 Assert.Equal(ErrorLevel.Warning, error.Level);
-                Assert.Equal("unknown-field-type", error.Code);
+                Assert.Equal("unknown-field", error.Code);
                 Assert.Equal(2, error.Line);
-                Assert.Equal(16, error.Column);
-                Assert.Equal("(Line: 2, Character: 16) Could not find member 'mismatchType2' on object of type 'BasicClass'", error.Message);
+                Assert.Equal(17, error.Column);
+                Assert.Equal("(Line: 2, Character: 17) Path:BasicClass.mismatchField2 Could not find member 'mismatchField2' on object of type 'BasicClass'", error.Message);
             });
         }
 

--- a/test/docfx.Test/lib/JsonUtilityTest.cs
+++ b/test/docfx.Test/lib/JsonUtilityTest.cs
@@ -394,7 +394,7 @@ namespace Microsoft.Docs.Build
         public class ClassWithJsonExtensionData : BasicClass
         {
             [JsonExtensionData]
-            public IDictionary<string, JToken> AdditionalData { get; set; }
+            public JObject AdditionalData { get; set; }
         }
 
         public class ClassWithNestedTypeContainsJsonExtensionData : BasicClass

--- a/test/docfx.Test/lib/JsonUtilityTest.cs
+++ b/test/docfx.Test/lib/JsonUtilityTest.cs
@@ -407,17 +407,6 @@ namespace Microsoft.Docs.Build
             public List<List<AnotherBasicClass>> NestedItems { get; set; }
 
             public List<int> NumberList { get; set; }
-        }
-
-        public class ClassWithJsonExtensionData : BasicClass
-        {
-            [JsonExtensionData]
-            public JObject AdditionalData { get; set; }
-        }
-
-        public class ClassWithNestedTypeContainsJsonExtensionData : BasicClass
-        {
-            public ClassWithJsonExtensionData Data { get; set; }
 
             [RegularExpression("[a-z]")]
             public string RegPatternValue { get; set; }
@@ -429,6 +418,17 @@ namespace Microsoft.Docs.Build
             public List<string> ListValueWithLengthRestriction { get; set; }
 
             public NestedClass NestedMember { get; set; }
+        }
+
+        public class ClassWithJsonExtensionData : BasicClass
+        {
+            [JsonExtensionData]
+            public JObject AdditionalData { get; set; }
+        }
+
+        public class ClassWithNestedTypeContainsJsonExtensionData : BasicClass
+        {
+            public ClassWithJsonExtensionData Data { get; set; }
         }
 
         public class NestedClass

--- a/test/docfx.Test/lib/JsonUtilityTest.cs
+++ b/test/docfx.Test/lib/JsonUtilityTest.cs
@@ -322,8 +322,8 @@ namespace Microsoft.Docs.Build
         [Theory]
         [InlineData(@"{
 ""NumberList"":
-  [1, ""a""]}", ErrorLevel.Error, "invalid-schema", 3, 9)]
-        [InlineData(@"{""B"" : ""b""}", ErrorLevel.Error, "invalid-schema", 1, 10)]
+  [1, ""a""]}", ErrorLevel.Error, "violate-schema", 3, 9)]
+        [InlineData(@"{""B"" : ""b""}", ErrorLevel.Error, "violate-schema", 1, 10)]
         internal void TestMismatchingPrimitiveFieldType(string json, ErrorLevel expectedErrorLevel, string expectedErrorCode,
             int expectedErrorLine, int expectedErrorColumn)
         {

--- a/test/docfx.Test/lib/JsonUtilityTest.cs
+++ b/test/docfx.Test/lib/JsonUtilityTest.cs
@@ -325,6 +325,7 @@ namespace Microsoft.Docs.Build
 ""NumberList"":
   [1, ""a""]}", ErrorLevel.Error, "violate-schema", 3, 9)]
         [InlineData(@"{""B"" : ""b""}", ErrorLevel.Error, "violate-schema", 1, 10)]
+        [InlineData(@"{""ValueEnum"":""Four""}", ErrorLevel.Error, "violate-schema", 1, 19)]
         internal void TestMismatchingPrimitiveFieldType(string json, ErrorLevel expectedErrorLevel, string expectedErrorCode,
             int expectedErrorLine, int expectedErrorColumn)
         {
@@ -418,6 +419,9 @@ namespace Microsoft.Docs.Build
             public List<string> ListValueWithLengthRestriction { get; set; }
 
             public NestedClass NestedMember { get; set; }
+
+            // make it nullable, so that json serializer would not make a default value
+            public BasicEnum? ValueEnum { get; set; }
         }
 
         public class ClassWithJsonExtensionData : BasicClass
@@ -435,6 +439,13 @@ namespace Microsoft.Docs.Build
         {
             [MinLength(2), MaxLength(3)]
             public string ValueWithLengthRestriction { get; set; }
+        }
+
+        public enum BasicEnum
+        {
+            One,
+            Two,
+            Three,
         }
     }
 }

--- a/test/docfx.Test/lib/YamlUtilityTest.cs
+++ b/test/docfx.Test/lib/YamlUtilityTest.cs
@@ -417,9 +417,9 @@ mismatchType2: name";
         [Theory]
         [InlineData(@"numberList:
         - 1
-        - a", ErrorLevel.Error, "invalid-schema", 3, 11)]
+        - a", ErrorLevel.Error, "violate-schema", 3, 11)]
         [InlineData(@"
-B: b", ErrorLevel.Error, "invalid-schema", 2, 4)]
+B: b", ErrorLevel.Error, "violate-schema", 2, 4)]
         internal void TestMismatchingPrimitiveFieldType(string yaml, ErrorLevel expectedErrorLevel, string expectedErrorCode,
             int expectedErrorLine, int expectedErrorColumn)
         {

--- a/test/docfx.Test/lib/YamlUtilityTest.cs
+++ b/test/docfx.Test/lib/YamlUtilityTest.cs
@@ -490,7 +490,7 @@ Data:
         public class ClassWithJsonExtensionData : BasicClass
         {
             [JsonExtensionData]
-            public IDictionary<string, JToken> AdditionalData { get; set; }
+            public JObject AdditionalData { get; set; }
         }
 
         public class ClassWithNestedTypeContainsJsonExtensionData : BasicClass

--- a/test/docfx.Test/lib/YamlUtilityTest.cs
+++ b/test/docfx.Test/lib/YamlUtilityTest.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Docs.Build
@@ -261,7 +261,7 @@ ValueBasic:
   D: false
 ";
             var (errors, value) = YamlUtility.Deserialize<ClassWithMoreMembers>(yaml);
-            Assert.Empty(errors);
+            Assert.Empty(errors.Where(error => error.Level == ErrorLevel.Error));
             Assert.NotNull(value);
             Assert.Equal(1, value.B);
             Assert.Equal("Good1!", value.C);
@@ -353,6 +353,100 @@ items:
             Assert.Equal(expectedColumn, lineInfo.LinePosition);
         }
 
+        [Theory]
+        [InlineData("mismatchType: name", 1, 1, ErrorLevel.Warning, "unknown-field-type")]
+        [InlineData(@"
+        ValueBasic:
+          B: 1
+          C: c
+          E: e", 5, 11, ErrorLevel.Warning, "unknown-field-type")]
+        [InlineData(@"
+        Items:
+          - B: 1
+            C: c
+            E: e", 5, 13, ErrorLevel.Warning, "unknown-field-type")]
+        [InlineData(@"
+        AnotherItems:
+          - H: 1
+            G: c
+            E: e", 5, 13, ErrorLevel.Warning, "unknown-field-type")]
+        [InlineData(@"
+        NestedItems:
+          -
+            - H: 1
+              G: c
+              E: e", 6, 15, ErrorLevel.Warning, "unknown-field-type")]
+        internal void TestUnknownFieldType(string yaml, int expectedLine, int expectedColumn, ErrorLevel expectedErrorLevel, string expectedErrorCode)
+        {
+            var (errors, result) = YamlUtility.Deserialize<ClassWithMoreMembers>(yaml);
+            Assert.Collection(errors, error =>
+            {
+                Assert.Equal(expectedErrorLevel, error.Level);
+                Assert.Equal(expectedErrorCode, error.Code);
+                Assert.Equal(expectedLine, error.Line);
+                Assert.Equal(expectedColumn, error.Column);
+            });
+        }
+
+        [Fact]
+        public void TestMultipltUnknownFieldType()
+        {
+            var yaml = @"mismatchType1: name
+mismatchType2: name";
+
+            var (errors, result) = YamlUtility.Deserialize<BasicClass>(yaml);
+            Assert.Collection(errors,
+            error =>
+            {
+                Assert.Equal(ErrorLevel.Warning, error.Level);
+                Assert.Equal("unknown-field-type", error.Code);
+                Assert.Equal(1, error.Line);
+                Assert.Equal(1, error.Column);
+                Assert.Equal("(Line: 1, Character: 1) Could not find member 'mismatchType1' on object of type 'BasicClass'", error.Message);
+            },
+            error =>
+            {
+                Assert.Equal(ErrorLevel.Warning, error.Level);
+                Assert.Equal("unknown-field-type", error.Code);
+                Assert.Equal(2, error.Line);
+                Assert.Equal(1, error.Column);
+                Assert.Equal("(Line: 2, Character: 1) Could not find member 'mismatchType2' on object of type 'BasicClass'", error.Message);
+            });
+        }
+
+        [Theory]
+        [InlineData(@"numberList:
+        - 1
+        - a", ErrorLevel.Error, "invalid-schema", 3, 11)]
+        [InlineData(@"
+B: b", ErrorLevel.Error, "invalid-schema", 2, 4)]
+        internal void TestMismatchingPrimitiveFieldType(string yaml, ErrorLevel expectedErrorLevel, string expectedErrorCode,
+            int expectedErrorLine, int expectedErrorColumn)
+        {
+            var ex = Assert.Throws<DocfxException>(() => YamlUtility.Deserialize<ClassWithMoreMembers>(yaml));
+            Assert.Equal(expectedErrorLevel, ex.Error.Level);
+            Assert.Equal(expectedErrorCode, ex.Error.Code);
+            Assert.Equal(expectedErrorLine, ex.Error.Line);
+            Assert.Equal(expectedErrorColumn, ex.Error.Column);
+        }
+
+        [Theory]
+        [InlineData(@"
+B: 1
+C: c
+E: e", typeof(ClassWithJsonExtensionData))]
+        [InlineData(@"
+Data: 
+    B: 1
+    C: c
+    E: e", typeof(ClassWithNestedTypeContainsJsonExtensionData))]
+        public void TestObjectTypeWithJsonExtensionData(string json, Type type)
+        {
+            var (_, token) = YamlUtility.Deserialize(json);
+            var (errors, value) = JsonUtility.ToObject(token, type);
+            Assert.Empty(errors);
+        }
+
         public class BasicClass
         {
             public int B { get; set; }
@@ -360,6 +454,15 @@ items:
             public string C { get; set; }
 
             public bool D { get; set; }
+        }
+
+        public class AnotherBasicClass
+        {
+            public int F { get; set; }
+
+            public string G { get; set; }
+
+            public bool H { get; set; }
         }
 
         public class ClassWithReadOnlyField
@@ -374,6 +477,25 @@ items:
             public List<string> ValueList { get; set; }
 
             public BasicClass ValueBasic { get; set; }
+
+            public List<BasicClass> Items { get; set; }
+
+            public List<AnotherBasicClass> AnotherItems { get; set; }
+
+            public List<List<AnotherBasicClass>> NestedItems { get; set; }
+
+            public List<int> NumberList { get; set; }
+        }
+
+        public class ClassWithJsonExtensionData : BasicClass
+        {
+            [JsonExtensionData]
+            public IDictionary<string, JToken> AdditionalData { get; set; }
+        }
+
+        public class ClassWithNestedTypeContainsJsonExtensionData : BasicClass
+        {
+            public ClassWithJsonExtensionData Data { get; set; }
         }
     }
 }

--- a/test/docfx.Test/lib/YamlUtilityTest.cs
+++ b/test/docfx.Test/lib/YamlUtilityTest.cs
@@ -422,6 +422,7 @@ mismatchField2: name";
         - a", ErrorLevel.Error, "violate-schema", 3, 11)]
         [InlineData(@"
 B: b", ErrorLevel.Error, "violate-schema", 2, 4)]
+        [InlineData(@"ValueEnum: Four", ErrorLevel.Error, "violate-schema", 1, 12)]
         internal void TestMismatchingPrimitiveFieldType(string yaml, ErrorLevel expectedErrorLevel, string expectedErrorCode,
             int expectedErrorLine, int expectedErrorColumn)
         {
@@ -520,6 +521,8 @@ Data:
             public List<string> ListValueWithLengthRestriction { get; set; }
 
             public NestedClass NestedMember { get; set; }
+
+            public BasicEnum ValueEnum { get; set; }
         }
 
         public class ClassWithJsonExtensionData : BasicClass
@@ -537,6 +540,13 @@ Data:
         {
             [MinLength(2), MaxLength(3)]
             public string ValueWithLengthRestriction { get; set; }
+        }
+
+        public enum BasicEnum
+        {
+            One,
+            Two,
+            Three,
         }
     }
 }

--- a/test/docfx.Test/lib/YamlUtilityTest.cs
+++ b/test/docfx.Test/lib/YamlUtilityTest.cs
@@ -354,28 +354,28 @@ items:
         }
 
         [Theory]
-        [InlineData("mismatchType: name", 1, 1, ErrorLevel.Warning, "unknown-field-type")]
+        [InlineData("mismatchField: name", 1, 1, ErrorLevel.Warning, "unknown-field")]
         [InlineData(@"
         ValueBasic:
           B: 1
           C: c
-          E: e", 5, 11, ErrorLevel.Warning, "unknown-field-type")]
+          E: e", 5, 11, ErrorLevel.Warning, "unknown-field")]
         [InlineData(@"
         Items:
           - B: 1
             C: c
-            E: e", 5, 13, ErrorLevel.Warning, "unknown-field-type")]
+            E: e", 5, 13, ErrorLevel.Warning, "unknown-field")]
         [InlineData(@"
         AnotherItems:
           - H: 1
             G: c
-            E: e", 5, 13, ErrorLevel.Warning, "unknown-field-type")]
+            E: e", 5, 13, ErrorLevel.Warning, "unknown-field")]
         [InlineData(@"
         NestedItems:
           -
             - H: 1
               G: c
-              E: e", 6, 15, ErrorLevel.Warning, "unknown-field-type")]
+              E: e", 6, 15, ErrorLevel.Warning, "unknown-field")]
         internal void TestUnknownFieldType(string yaml, int expectedLine, int expectedColumn, ErrorLevel expectedErrorLevel, string expectedErrorCode)
         {
             var (errors, result) = YamlUtility.Deserialize<ClassWithMoreMembers>(yaml);
@@ -391,26 +391,26 @@ items:
         [Fact]
         public void TestMultipltUnknownFieldType()
         {
-            var yaml = @"mismatchType1: name
-mismatchType2: name";
+            var yaml = @"mismatchField1: name
+mismatchField2: name";
 
             var (errors, result) = YamlUtility.Deserialize<BasicClass>(yaml);
             Assert.Collection(errors,
             error =>
             {
                 Assert.Equal(ErrorLevel.Warning, error.Level);
-                Assert.Equal("unknown-field-type", error.Code);
+                Assert.Equal("unknown-field", error.Code);
                 Assert.Equal(1, error.Line);
                 Assert.Equal(1, error.Column);
-                Assert.Equal("(Line: 1, Character: 1) Could not find member 'mismatchType1' on object of type 'BasicClass'", error.Message);
+                Assert.Equal("(Line: 1, Character: 1) Path:BasicClass.mismatchField1 Could not find member 'mismatchField1' on object of type 'BasicClass'", error.Message);
             },
             error =>
             {
                 Assert.Equal(ErrorLevel.Warning, error.Level);
-                Assert.Equal("unknown-field-type", error.Code);
+                Assert.Equal("unknown-field", error.Code);
                 Assert.Equal(2, error.Line);
                 Assert.Equal(1, error.Column);
-                Assert.Equal("(Line: 2, Character: 1) Could not find member 'mismatchType2' on object of type 'BasicClass'", error.Message);
+                Assert.Equal("(Line: 2, Character: 1) Path:BasicClass.mismatchField2 Could not find member 'mismatchField2' on object of type 'BasicClass'", error.Message);
             });
         }
 

--- a/test/docfx.Test/lib/YamlUtilityTest.cs
+++ b/test/docfx.Test/lib/YamlUtilityTest.cs
@@ -509,17 +509,6 @@ Data:
             public List<List<AnotherBasicClass>> NestedItems { get; set; }
 
             public List<int> NumberList { get; set; }
-        }
-
-        public class ClassWithJsonExtensionData : BasicClass
-        {
-            [JsonExtensionData]
-            public JObject AdditionalData { get; set; }
-        }
-
-        public class ClassWithNestedTypeContainsJsonExtensionData : BasicClass
-        {
-            public ClassWithJsonExtensionData Data { get; set; }
 
             [RegularExpression("[a-z]")]
             public string RegPatternValue { get; set; }
@@ -531,6 +520,17 @@ Data:
             public List<string> ListValueWithLengthRestriction { get; set; }
 
             public NestedClass NestedMember { get; set; }
+        }
+
+        public class ClassWithJsonExtensionData : BasicClass
+        {
+            [JsonExtensionData]
+            public JObject AdditionalData { get; set; }
+        }
+
+        public class ClassWithNestedTypeContainsJsonExtensionData : BasicClass
+        {
+            public ClassWithJsonExtensionData Data { get; set; }
         }
 
         public class NestedClass


### PR DESCRIPTION
- Add mismatching type validation for Yaml and Json with line info
- Add tests for Yaml and Json
    - Field not found in existing type(e.g. A), warning should be added
    - Field in list item not found in existing type(e.g. List\<A\>), warning should be added
    - Field in nested list item not found in existing type(e.g. List<List\<A\>>), warning should be added
    - Object type contains JsonExtensionData attribute, no warning should be added
    - Nested object type contains JsonExtensionData attibute, no warning should be added for the nested object type
    - Mismatching primitive type(e.g. List\<int\>), error should be added
#3050 