### PR TITLE
Fix dropdown issue

### DIFF
--- a/src/docfx.website.themes/default/partials/dd-li.tmpl.partial
+++ b/src/docfx.website.themes/default/partials/dd-li.tmpl.partial
@@ -1,0 +1,3 @@
+{{#items}}
+  <li><a href="{{topicHref}}">{{name}}</a></li>
+{{/items}}

--- a/src/docfx.website.themes/default/partials/li.tmpl.partial
+++ b/src/docfx.website.themes/default/partials/li.tmpl.partial
@@ -1,20 +1,30 @@
 {{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
 
 <ul class="nav level{{level}}">
-{{#items}}
-  <li>
-    {{^leaf}}
-    <span class="expand-stub"></span>
-    {{/leaf}}
-    {{#topicHref}}
-    <a href="{{topicHref}}" name="{{tocHref}}" title="{{name}}">{{name}}</a>
-    {{/topicHref}}
-    {{^topicHref}}
-    <a>{{{name}}}</a>
-    {{/topicHref}}
-    {{^leaf}}
-      {{>partials/li}}
-    {{/leaf}}
-  </li>
-{{/items}}
+  {{#items}}
+    {{^dropdown}}
+      <li>
+        {{^leaf}}
+          <span class="expand-stub"></span>
+        {{/leaf}}
+        {{#topicHref}}
+          <a href="{{topicHref}}" name="{{tocHref}}" title="{{name}}">{{name}}</a>
+        {{/topicHref}}
+        {{^topicHref}}
+          <a>{{{name}}}</a>
+        {{/topicHref}}
+        {{^leaf}}
+          {{>partials/li}}
+        {{/leaf}}
+      </li>
+    {{/dropdown}}
+    {{#dropdown}}
+      <li class="dropdown">
+        <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">{{name}} <span class="caret"></span></a>
+        <ul class="dropdown-menu level{{level}}">
+          {{>partials/dd-li}}
+        </ul>
+      </li>
+    {{/dropdown}}
+  {{/items}}
 </ul>

--- a/src/docfx.website.themes/default/styles/docfx.js
+++ b/src/docfx.website.themes/default/styles/docfx.js
@@ -391,7 +391,9 @@ $(function () {
               }
             }
             if (isActive) {
-              $(e).addClass(active);
+              if ((window.location.pathname != '/index.html') && (window.location.pathname != '/')) {
+                $(e).addClass(active);
+              }
             }
           }
         });


### PR DESCRIPTION
- Allows dropdowns in the navbar
- Testing steps
  - `docfx init -q`
  - Add: 
    ```
    - name: More
      dropdown: true
      items:
      - name: Item 1
        topicHref: /abc
      - name: Item 2
        topicHref: /def
      - name: Item 3
        topicHref: /ghi
    ```
  to toc.yml
  - `docfx docfx.json --serve

Dropdown should appear alongside 'Api Documentation'

Relating to issue #2544