### PR TITLE
file errors stops output of that file, but does not set process exit code to 1

### DIFF
--- a/src/docfx/cli/Program.cs
+++ b/src/docfx/cli/Program.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Docs.Build
                             Done(stopwatch.Elapsed, report.Summary);
                             break;
                     }
-                    return report.Summary.err > 0 ? 1 : 0;
+                    return 0;
                 }
                 catch (DocfxException ex)
                 {


### PR DESCRIPTION
#3210 