### PR TITLE
Implemented the simplest warnings as errors.

### DIFF
--- a/src/Microsoft.DocAsCode.Common/Loggers/Logger.cs
+++ b/src/Microsoft.DocAsCode.Common/Loggers/Logger.cs
@@ -17,6 +17,7 @@ namespace Microsoft.DocAsCode.Common
         private static AsyncLogListener _asyncListener = new AsyncLogListener();
         private static int _warningCount = 0;
         public volatile static LogLevel LogLevelThreshold = LogLevel.Info;
+        public volatile static bool WarningsAsErrors = false;
 
         public static void RegisterListener(ILoggerListener listener)
         {
@@ -93,6 +94,11 @@ namespace Microsoft.DocAsCode.Common
 
             if (item.LogLevel == LogLevel.Warning)
             {
+                if (WarningsAsErrors)
+                {
+                    HasError = true;
+                }
+
                 var count = Interlocked.Increment(ref _warningCount);
                 if (count > WarningThrottling)
                 {

--- a/src/docfx/Models/LogOptions.cs
+++ b/src/docfx/Models/LogOptions.cs
@@ -20,5 +20,8 @@ namespace Microsoft.DocAsCode
 
         [Option("correlationId", HelpText = "Specify the correlation id used for logging.")]
         public string CorrelationId { get; set; }
+
+        [Option("warningsAsErrors", HelpText = "Specify if warnings should be treated as errors.")]
+        public bool WarningsAsErrors { get; set; }
     }
 }

--- a/src/docfx/SubCommands/CommandCreator.cs
+++ b/src/docfx/SubCommands/CommandCreator.cs
@@ -52,6 +52,8 @@ namespace Microsoft.DocAsCode.SubCommands
                     Logger.LogLevelThreshold = logOption.LogLevel.Value;
                 }
 
+                Logger.WarningsAsErrors = logOption.WarningsAsErrors;
+
                 if (!string.IsNullOrEmpty(logOption.CorrelationId))
                 {
                     if (AmbientContext.CurrentContext == null)


### PR DESCRIPTION
Added a new option as documented in #3229.

By adding `--warningsAsErrors true` to the command line, any warning would trigger a return code of `1` which can be used to fail CI builds or any other scripts relying on the return code.