### PR TITLE
Provide a default config for test using DOCFX_CONFIG_EXTEND

### DIFF
--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -240,6 +240,13 @@ namespace Microsoft.Docs.Build
             }
 
             var extendedConfig = new JObject();
+            var configExtend = Environment.GetEnvironmentVariable("DOCFX_CONFIG_EXTEND");
+            if (!string.IsNullOrEmpty(configExtend))
+            {
+                var filePath = restoreMap.GetUrlRestorePath(docsetPath, configExtend);
+                extendedConfig = LoadConfigObject(docsetPath, filePath, false, restoreMap);
+            }
+
             foreach (var extendPath in arrayExtend)
             {
                 if (extendPath is JValue strExtendPath)

--- a/test/docfx.Test/common/TestFramework.cs
+++ b/test/docfx.Test/common/TestFramework.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Docs.Build
         protected override ITestFrameworkExecutor CreateExecutor(AssemblyName assemblyName)
         {
             Environment.SetEnvironmentVariable("DOCFX_APPDATA_PATH", Path.GetFullPath("appdata"));
+            Environment.SetEnvironmentVariable("DOCFX_CONFIG_EXTEND", Path.GetFullPath("docfx.test.yml"));
+
             MakeDebugAssertThrowException();
             return new ParallelExecutor(assemblyName, SourceInformationProvider, DiagnosticMessageSink);
         }

--- a/test/docfx.Test/docfx.Test.csproj
+++ b/test/docfx.Test/docfx.Test.csproj
@@ -16,7 +16,8 @@
 
   <ItemGroup>
     <None Include="../../docs/specs/**/*.yml" LinkBase="specs" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="*.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="*.yml" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/docfx.Test/docfx.test.yml
+++ b/test/docfx.Test/docfx.test.yml
@@ -1,0 +1,1 @@
+# default config for specs in docfx


### PR DESCRIPTION
Add a default config for test cases to derive from using `DOCFX_CONFIG_EXTEND` environment variable.

It is currently implemented as an environment variable over command line options because:

- The only foreseeable usage is for our own tests, environment variable is a more hidden switch over cmd option
- `--config` or `--extend` cmd option needs future design and consideration, it has different meanings in other systems like Hugo. 

Unblocks #3196 