### PR TITLE
walkaround json.net free-quota limit of 10 schema generations per hour

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,2 @@
 build_script:
   - ps: ./build.ps1
-environment:
-  JSON_SCHEMA_LICENSE:
-    secure: 4lzd2xtK+oxCL8mcVXyUxFzLqiYFqLA4PrRbyoxWbUHASzWf+7yFaREWdNu2p4lkt4vE+ymv0tAbPw7EIz8ebwdcSh2TGNt3AVUBW9HKQnEiRtjwfeRGtXVbA1oq8TiG1GBTBnk920Xn5T9+L8YpVzc4k85Us1DP6QUbQBpgXmsXiSAJA6frZxv1hR4iKQc+dqqwStmlJgqXWQjXkvFZBTbLCf7r4rnkp3FaTSzzvL6wIm+s8Q3jmNy3YHP97ytaTWg0ySnQUcb/jcaVc8v5TVR8zIS8ogGBeO13+Zp6t1KZRJ/uabdpbhKvTGl5KGcd9sWYlpE4+3o0QxDMqnZ5YeegKmIvgVwFDn4Ge7WHkcoEBBMPh6DAPptj6E8NyTWU

--- a/tools/CreateJsonSchema/Program.cs
+++ b/tools/CreateJsonSchema/Program.cs
@@ -1,11 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Docs.Build;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Schema;
 using Newtonsoft.Json.Schema.Generation;
 using Newtonsoft.Json.Serialization;
 
@@ -13,40 +13,54 @@ class Program
 {
     static async Task<int> Main(string[] args)
     {
-        var license = Environment.GetEnvironmentVariable("JSON_SCHEMA_LICENSE");
-        if (!string.IsNullOrEmpty(license))
+        var schemas = GetSchemas().ToList();
+        var skip = args.Length > 0 ? int.Parse(args[0]) : 0;
+        var take = 10;
+
+        if (skip == 0)
         {
-            Console.WriteLine("Found JSON schema license");
-            License.RegisterLicense(license);
+            if (Directory.Exists("schemas"))
+            {
+                Directory.Delete("schemas", recursive: true);
+            }
+            Directory.CreateDirectory("schemas");
         }
 
-        if (Directory.Exists("schemas"))
+        foreach (var (type, name) in schemas.Skip(skip).Take(take))
         {
-            Directory.Delete("schemas", recursive: true);
+            GenerateJSchema(type, name);
         }
-        Directory.CreateDirectory("schemas");
 
-        GenerateJSchema(typeof(Config), "docfx");
-        GenerateJSchema(typeof(TableOfContentsInputModel), "TOC");
+        if (skip + take >= schemas.Count)
+        {
+            var diff = await ProcessUtility.Execute("git", "diff --ignore-all-space --ignore-blank-lines schemas");
+            if (!string.IsNullOrEmpty(diff))
+            {
+                Console.WriteLine("Json schema change detected. Run ./build.ps1 locally and commit these json schema changes:");
+                Console.WriteLine("");
+                Console.WriteLine(diff);
+                return 1;
+            }
+        }
+        else
+        {
+            await ProcessUtility.Execute("dotnet", $"run -p tools/CreateJsonSchema --no-build --no-restore -- {skip + take}", redirectOutput: false);
+        }
+        return 0;
+    }
+
+    static IEnumerable<(Type type, string name)> GetSchemas()
+    {
+        yield return ((typeof(Config), "docfx"));
+        yield return ((typeof(TableOfContentsInputModel), "TOC"));
 
         foreach (var type in typeof(PageModel).Assembly.ExportedTypes)
         {
             if (type.GetCustomAttribute<DataSchemaAttribute>() != null)
             {
-                GenerateJSchema(type, type.Name);
+                yield return (type, type.Name);
             }
         }
-
-        var diff = await ProcessUtility.Execute("git", "diff --ignore-all-space --ignore-blank-lines schemas");
-        if (!string.IsNullOrEmpty(diff))
-        {
-            Console.WriteLine("Json schema change detected. Run ./build.ps1 locally and commit these json schema changes:");
-            Console.WriteLine("");
-            Console.WriteLine(diff);
-            return 1;
-        }
-
-        return 0;
     }
 
     static void GenerateJSchema(Type type, string name)
@@ -62,24 +76,16 @@ class Program
 
         generator.GenerationProviders.Add(new StringEnumGenerationProvider { CamelCaseText = true });
 
-        try
-        {
-            var schema = generator.Generate(type, rootSchemaNullable: false);
+        var schema = generator.Generate(type, rootSchemaNullable: false);
 
-            // If type contains JsonExtensinDataAttribute, additional properties are allowed
-            // TODO: Set AllowAdditionalProperties on nested type, not the entry type
-            if (!HasJsonExtensionData(type))
-            {
-                schema.AllowAdditionalProperties = false;
-            }
-
-            File.WriteAllText(Path.Combine("schemas", name + ".json"), schema.ToString());
-        }
-        catch (JSchemaException)
+        // If type contains JsonExtensinDataAttribute, additional properties are allowed
+        // TODO: Set AllowAdditionalProperties on nested type, not the entry type
+        if (!HasJsonExtensionData(type))
         {
-            Console.Error.WriteLine("Json schema rate limit exceeded");
-            Environment.Exit(0);
+            schema.AllowAdditionalProperties = false;
         }
+
+        File.WriteAllText(Path.Combine("schemas", name + ".json"), schema.ToString());
     }
 
     static bool HasJsonExtensionData(Type type)


### PR DESCRIPTION
start a new process whenever quota exceeded 🥇 

#3050 