### PR TITLE
Fix toc rel

### DIFF
--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -899,7 +899,7 @@ inputs:
   docs/f1/TOC.experimental.md: |
     # [Index Reference](../index.md)
     # [File Reference](../a.md)
-  docs/f1/TOC.md:
+  docs/f1/TOC.md: |
     # [Index Reference](../index.md)
   docs/index.md:
   docs/a.md:
@@ -907,7 +907,7 @@ outputs:
   docs/index.json: |
     {"toc": "f1/TOC.json"}
   docs/a.json: |
-    {"toc": "f1/TOC.json"}
+    {"!toc": null}
   build.manifest:
   docs/f1/TOC.json:
   docs/f1/TOC.experimental.json:
@@ -993,7 +993,7 @@ outputs:
     {"toc": "../TOC.json"}
   build.manifest:
 ---
-# File referenced by multiple toc with same parent and subdir count, use order alphabetical
+# File referenced by multiple toc with same parent and subdir count, use order alphabetical. For other tests, reference build/TocTest.
 inputs:
   docfx.yml: 
   docs/dir1/a/TOC.yml: |
@@ -1007,33 +1007,9 @@ inputs:
       href: ../c/file1.md
   docs/dir1/c/file1.md:
 outputs:
-  docs/dir1/a/TOC.json: |
-    {
-      "items": [
-        {
-          "toc_title": "TOC Ref",
-          "href": "../c/file1"
-        }
-      ]
-    }
-  docs/dir1/b/TOC.json: |
-    {
-      "items": [
-        {
-          "toc_title": "TOC Ref",
-          "href": "../c/file1"
-        }
-      ]
-    }
-  docs/dir1/aa/TOC.json: |
-    {
-      "items": [
-        {
-          "toc_title": "TOC Ref",
-          "href": "../c/file1"
-        }
-      ]
-    }
+  docs/dir1/a/TOC.json:
+  docs/dir1/b/TOC.json:
+  docs/dir1/aa/TOC.json:
   docs/dir1/c/file1.json: |
     {"toc": "../a/TOC.json"}
   build.manifest:

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -959,7 +959,7 @@ outputs:
   build.log: |
     ["info","null-value","(Line: 3, Character: 3) 'tocHref' contains null value","docs/TOC.yml",3,3]
 ---
-# Toc with schema vliolation
+# Toc with schema violation
 inputs:
   docfx.yml:
   docs/TOC.yml: |
@@ -979,3 +979,61 @@ outputs:
     ["error","violate-schema","(Line: 1, Character: 3) Required property 'Name' not found in JSON","docs/TOC.yml",1,3]
     ["error","violate-schema","(Line: 5, Character: 10) The field Items must be a string or array type with a minimum length of '1'.","docs/TOC.yml",5,10]
 ---
+# Orphan file(not explicitly referenced in toc file)'s toc, only look up parent folder toc files
+inputs:
+  docfx.yml: 
+  docs/dir1/TOC.md:
+  docs/file-with-no-toc.md:
+  docs/dir1/dir2/file-with-toc.md:
+outputs:
+  docs/dir1/TOC.json:
+  docs/file-with-no-toc.json: |
+    {"!toc": null}
+  docs/dir1/dir2/file-with-toc.json: |
+    {"toc": "../TOC.json"}
+  build.manifest:
+---
+# File referenced by multiple toc with same parent and subdir count, use order alphabetical
+inputs:
+  docfx.yml: 
+  docs/dir1/a/TOC.yml: |
+    - name: TOC Ref
+      href: ../c/file1.md
+  docs/dir1/b/TOC.yml: |
+    - name: TOC Ref
+      href: ../c/file1.md
+  docs/dir1/aa/TOC.yml: |
+    - name: TOC Ref
+      href: ../c/file1.md
+  docs/dir1/c/file1.md:
+outputs:
+  docs/dir1/a/TOC.json: |
+    {
+      "items": [
+        {
+          "toc_title": "TOC Ref",
+          "href": "../c/file1"
+        }
+      ]
+    }
+  docs/dir1/b/TOC.json: |
+    {
+      "items": [
+        {
+          "toc_title": "TOC Ref",
+          "href": "../c/file1"
+        }
+      ]
+    }
+  docs/dir1/aa/TOC.json: |
+    {
+      "items": [
+        {
+          "toc_title": "TOC Ref",
+          "href": "../c/file1"
+        }
+      ]
+    }
+  docs/dir1/c/file1.json: |
+    {"toc": "../a/TOC.json"}
+  build.manifest:

--- a/src/docfx/build/legacy/LegacyDependencyMap.cs
+++ b/src/docfx/build/legacy/LegacyDependencyMap.cs
@@ -30,12 +30,15 @@ namespace Microsoft.Docs.Build
                             return;
                         }
                         var toc = tocMap.GetNearestToc(document);
-                        legacyDependencyMap.Add(new LegacyDependencyMapItem
+                        if (toc != null)
                         {
-                            From = $"~/{document.ToLegacyPathRelativeToBasePath(docset)}",
-                            To = $"~/{toc.ToLegacyPathRelativeToBasePath(docset)}",
-                            Type = LegacyDependencyMapType.Metadata,
-                        });
+                            legacyDependencyMap.Add(new LegacyDependencyMapItem
+                            {
+                                From = $"~/{document.ToLegacyPathRelativeToBasePath(docset)}",
+                                To = $"~/{toc.ToLegacyPathRelativeToBasePath(docset)}",
+                                Type = LegacyDependencyMapType.Metadata,
+                            });
+                        }
                     });
 
                 foreach (var (source, dependencies) in dependencyMap)

--- a/src/docfx/build/toc/TableOfContentsMap.cs
+++ b/src/docfx/build/toc/TableOfContentsMap.cs
@@ -47,7 +47,9 @@ namespace Microsoft.Docs.Build
         /// Return the nearest toc relative to the current file
         /// "near" means less subdirectory count
         /// when subdirectory counts are same, "near" means less parent directory count
-        /// e.g. "../../a/TOC.md" is nearer than "b/c/TOC.md"
+        /// e.g. "../../a/TOC.md" is nearer than "b/c/TOC.md".
+        /// when the file is not referenced, return only toc in the same folder or parents folder.
+        /// i.e. relativePath only contains "..".
         /// </summary>
         public Document GetNearestToc(Document file)
         {
@@ -55,7 +57,7 @@ namespace Microsoft.Docs.Build
             var hasReferencedToc = _documentToTocs.TryGetValue(file, out var referencedTocFiles);
             var filteredTocFiles = hasReferencedToc ? (IEnumerable<Document>)referencedTocFiles : _tocs;
 
-            var nearstToc = (Document)null;
+            var nearestToc = (Document)null;
             var nearestSubDirCount = 0;
             var nearestParentDirCount = 0;
             foreach (var toc in filteredTocFiles)
@@ -67,16 +69,16 @@ namespace Microsoft.Docs.Build
                     continue;
                 }
                 var distance = Compare(nearestSubDirCount, nearestParentDirCount, subDirCount, parentDirCount);
-                if (nearstToc == null || distance > 0 ||
-                    (distance == 0 && string.Compare(nearstToc.SitePath, toc.SitePath, PathUtility.PathComparison) > 0))
+                if (nearestToc == null || distance > 0 ||
+                    (distance == 0 && string.Compare(nearestToc.SitePath, toc.SitePath, PathUtility.PathComparison) > 0))
                 {
-                    nearstToc = toc;
+                    nearestToc = toc;
                     nearestSubDirCount = subDirCount;
                     nearestParentDirCount = parentDirCount;
                 }
             }
 
-            return nearstToc;
+            return nearestToc;
         }
 
         private static int Compare(int xSubDirCount, int xParentDirCount, int ySubDirCount, int yParentDirCount)


### PR DESCRIPTION
1.  Fix toc_rel in metadata

    1. calculate relative path from doc-file=>toc-file
    2. when doc isn't referenced, only look up in parent folders
    3. don't export toc_rel when toc is null
2.  Add toc e2e test cases

    1. orphan file only look up in parent folders
    2. file referenced by multiple files sorted alphabetically


FYI V2 logic:
1. [GetNearestToc](https://github.com/dotnet/docfx/blob/dev/src/Microsoft.DocAsCode.Build.Engine/SystemMetadataGenerator.cs#LC138)
2. [GetDefaultToc](https://github.com/dotnet/docfx/blob/dev/src/Microsoft.DocAsCode.Build.Engine/SystemMetadataGenerator.cs#LC124)
3. ['-'](https://github.com/dotnet/docfx/blob/dev/src/Microsoft.DocAsCode.Common/Path/RelativePath.cs#LC528) & [MakeRelativeTo](https://github.com/dotnet/docfx/blob/dev/src/Microsoft.DocAsCode.Common/Path/RelativePath.cs#LC126)