### PR TITLE
Restore git path too long

### DIFF
--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -93,8 +93,6 @@ inputs:
   docfx.yml: |
     dependencies:
       dep: https://github.com/docascode/docfx-test-dependencies#restore/long-path
-    rules:
-      heading-not-found: false
   docs/test.md: 
     "[!INCLUDE[](~/dep/for-long-path-file-test-for-long-path-file-test-for-long-path-file-test-for-long-path-\
     file-test-for-long-path-file-test-for-long-path-file-test-for-long-path-file-test-for-long-path-file-tes\

--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -92,6 +92,18 @@ outputs:
 inputs:
   docfx.yml: |
     dependencies:
-      docfx-test-dependencies: https://github.com/docascode/docfx-test-dependencies#restore/long-path
+      dep: https://github.com/docascode/docfx-test-dependencies#restore/long-path
+    rules:
+      heading-not-found: false
+  docs/test.md: 
+    "[!INCLUDE[](~/dep/for-long-path-file-test-for-long-path-file-test-for-long-path-file-test-for-long-path-\
+    file-test-for-long-path-file-test-for-long-path-file-test-for-long-path-file-test-for-long-path-file-tes\
+    t-for-l/for-long-path-file-test-for-long-path-file-test-for-long-path-file-test-for-long-path-file-test-\
+    for-long-path-file-test-for-long-path-file-test-for-long-path-file-test-for-long-path-file-test-for-long\
+    -path-file-test-for-long-path-file-test-fo/for-long-path-test.md)]"
 outputs:
+  docs/test.json: |
+    {
+      "content": "<p>for long file path test.</p>"
+    }
   build.manifest:

--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -87,3 +87,11 @@ inputs:
 outputs:
   build.log: |
     ["error","download-failed","Download 'https://this-url-does-not-exit.com/this-is-a-bad-url' failed: No such host is known"]
+---
+# Restore longpath repo
+inputs:
+  docfx.yml: |
+    dependencies:
+      docfx-test-dependencies: https://github.com/docascode/docfx-test-dependencies#restore/long-path
+outputs:
+  build.manifest:

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -132,8 +132,6 @@ namespace Microsoft.Docs.Build
             return ExecuteNonQuery(cwd, cmd);
         }
 
-
-
         /// <summary>
         /// Fetch update from remote
         /// </summary>

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Microsoft.Docs.Build
@@ -118,15 +119,20 @@ namespace Microsoft.Docs.Build
         public static Task Clone(string cwd, string remote, string path, string branch = null, bool bare = false)
         {
             Directory.CreateDirectory(cwd);
+
+            // clone with configuration core.longpaths turned-on
+            // https://stackoverflow.com/questions/22575662/filename-too-long-in-git-for-windows#answer-40909460
             var cmd = string.IsNullOrEmpty(branch)
-                ? $"clone {remote} \"{path.Replace("\\", "/")}\""
-                : $"clone -b {branch} --single-branch {remote} \"{path.Replace("\\", "/")}\"";
+                ? $"clone -c core.longpaths=true {remote} \"{path.Replace("\\", "/")}\""
+                : $"clone -c core.longpaths=true -b {branch} --single-branch {remote} \"{path.Replace("\\", "/")}\"";
 
             if (bare)
                 cmd += " --bare";
 
             return ExecuteNonQuery(cwd, cmd);
         }
+
+
 
         /// <summary>
         /// Fetch update from remote
@@ -178,6 +184,13 @@ namespace Microsoft.Docs.Build
         /// <param name="cwd">The current working directory</param>
         public static Task PruneWorkTrees(string cwd)
             => ExecuteNonQuery(cwd, $"worktree prune");
+
+        /// <summary>
+        /// Turn core.longpaths to true in current git repository.
+        /// </summary>
+        /// <param name="cwd">The current working directory</param>
+        public static Task SetCoreLongPaths(string cwd, bool on)
+            => ExecuteNonQuery(cwd, $"config core.longpaths {on}");
 
         /// <summary>
         /// Retrieve git head version

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -186,9 +186,10 @@ namespace Microsoft.Docs.Build
             => ExecuteNonQuery(cwd, $"worktree prune");
 
         /// <summary>
-        /// Turn core.longpaths to true in current git repository.
+        /// Set core.longpaths to true in current git repository.
         /// </summary>
         /// <param name="cwd">The current working directory</param>
+        /// <param name="on"> core.longpaths on/off</param>
         public static Task SetCoreLongPaths(string cwd, bool on)
             => ExecuteNonQuery(cwd, $"config core.longpaths {on}");
 

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Docs.Build
             => ExecuteNonQuery(cwd, $"worktree prune");
 
         /// <summary>
-        /// Set core.longpaths to true in current git repository.
+        /// Set core.longpaths config in current git repository.
         /// </summary>
         /// <param name="cwd">The current working directory</param>
         /// <param name="on"> core.longpaths on/off</param>

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Microsoft.Docs.Build
@@ -182,14 +181,6 @@ namespace Microsoft.Docs.Build
         /// <param name="cwd">The current working directory</param>
         public static Task PruneWorkTrees(string cwd)
             => ExecuteNonQuery(cwd, $"worktree prune");
-
-        /// <summary>
-        /// Set core.longpaths config in current git repository.
-        /// </summary>
-        /// <param name="cwd">The current working directory</param>
-        /// <param name="on"> core.longpaths on/off</param>
-        public static Task SetCoreLongPaths(string cwd, bool on)
-            => ExecuteNonQuery(cwd, $"config core.longpaths {on}");
 
         /// <summary>
         /// Retrieve git head version

--- a/src/docfx/lib/github/GitHubAccessor.cs
+++ b/src/docfx/lib/github/GitHubAccessor.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Docs.Build
                 return (Errors.ResolveCommitFailed(commitSha, $"{repoOwner}/{repoName}", ex.Message), null);
             }
 
-            return (null, author.Login);
+            return (null, author?.Login);
         }
 
         private UserProfile ToUserProfile(User user)

--- a/src/docfx/restore/RestoreGit.cs
+++ b/src/docfx/restore/RestoreGit.cs
@@ -93,8 +93,11 @@ namespace Microsoft.Docs.Build
             {
                 if (GitUtility.IsRepo(restoreDir))
                 {
+                    // turn on core.longpaths before fetch
+                    await GitUtility.SetCoreLongPaths(restorePath, true);
+
                     // already exists, just pull the new updates from remote
-                    // fetch bare reop: https://stackoverflow.com/questions/3382679/how-do-i-update-my-bare-repo
+                    // fetch bare repo: https://stackoverflow.com/questions/3382679/how-do-i-update-my-bare-repo
                     await GitUtility.Fetch(restorePath, GitUtility.EmbedToken(url, token), "+refs/heads/*:refs/heads/*");
                 }
                 else

--- a/src/docfx/restore/RestoreGit.cs
+++ b/src/docfx/restore/RestoreGit.cs
@@ -93,9 +93,6 @@ namespace Microsoft.Docs.Build
             {
                 if (GitUtility.IsRepo(restoreDir))
                 {
-                    // turn on core.longpaths before fetch
-                    await GitUtility.SetCoreLongPaths(restorePath, true);
-
                     // already exists, just pull the new updates from remote
                     // fetch bare repo: https://stackoverflow.com/questions/3382679/how-do-i-update-my-bare-repo
                     await GitUtility.Fetch(restorePath, GitUtility.EmbedToken(url, token), "+refs/heads/*:refs/heads/*");


### PR DESCRIPTION
1. turn on core.longpaths on clone;
2. turn on core.longpaths before fetch;
[git-config bool case-insensitive](https://git-scm.com/docs/git-config#git-config-boolean)
