### PR TITLE
store splitted user emails in memory

### DIFF
--- a/src/docfx/lib/github/GitHubAccessor.cs
+++ b/src/docfx/lib/github/GitHubAccessor.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Docs.Build
                 EmailAddress = user.Email,
 
                 // UserEmails can only be obtained with current user's OAuth token, so we only get the user's public email
-                UserEmails = user.Email,
+                UserEmails = new List<string> { user.Email },
             };
         }
     }

--- a/src/docfx/lib/github/GitHubAccessor.cs
+++ b/src/docfx/lib/github/GitHubAccessor.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Docs.Build
                 EmailAddress = user.Email,
 
                 // UserEmails can only be obtained with current user's OAuth token, so we only get the user's public email
-                UserEmails = new List<string> { user.Email },
+                UserEmails = string.IsNullOrEmpty(user.Email) ? new List<string>() : new List<string> { user.Email },
             };
         }
     }

--- a/src/docfx/lib/github/UserProfile.cs
+++ b/src/docfx/lib/github/UserProfile.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 
 namespace Microsoft.Docs.Build
@@ -26,32 +24,6 @@ namespace Microsoft.Docs.Build
         public string EmailAddress { get; set; }
 
         [JsonProperty("user_emails")]
-        public string UserEmails { get; set; }
-
-        public string[] GetUserEmails() => UserEmails != null ? UserEmails.Split(";") : Array.Empty<string>();
-
-        public UserProfile AddEmail(string email)
-        {
-            return new UserProfile
-            {
-                ProfileUrl = ProfileUrl,
-                DisplayName = DisplayName,
-                Name = Name,
-                Id = Id,
-                EmailAddress = EmailAddress,
-                UserEmails = Merge(GetUserEmails(), email),
-            };
-
-            string Merge(string[] existingEmails, string newEmail)
-            {
-                var result = new HashSet<string>(existingEmails)
-                {
-                    newEmail,
-                };
-
-                // TODO: avoid split+join multiple times
-                return string.Join(';', result);
-            }
-        }
+        public List<string> UserEmails { get; set; } = new List<string>();
     }
 }

--- a/src/docfx/lib/github/UserProfileCache.cs
+++ b/src/docfx/lib/github/UserProfileCache.cs
@@ -163,6 +163,7 @@ namespace Microsoft.Docs.Build
             var result = _cacheByName.TryAdd(userName, profile);
             foreach (var email in profile.UserEmails)
             {
+                Debug.Assert(!string.IsNullOrEmpty(email));
                 _cacheByEmail.TryAdd(email, profile);
             }
         }

--- a/src/docfx/lib/github/UserProfileCache.cs
+++ b/src/docfx/lib/github/UserProfileCache.cs
@@ -146,7 +146,6 @@ namespace Microsoft.Docs.Build
             _cacheByName = new ConcurrentDictionary<string, UserProfile>(cache, StringComparer.OrdinalIgnoreCase);
             _cacheByEmail = new ConcurrentDictionary<string, UserProfile>(
                 from profile in cache.Values
-                where profile?.UserEmails != null
                 from email in profile.UserEmails
                 group profile by email into g
                 select new KeyValuePair<string, UserProfile>(g.Key, g.First()));

--- a/src/docfx/lib/github/UserProfileCache.cs
+++ b/src/docfx/lib/github/UserProfileCache.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build
 {
@@ -77,7 +78,8 @@ namespace Microsoft.Docs.Build
 
             try
             {
-                var (_, cache) = JsonUtility.Deserialize<Dictionary<string, UserProfile>>(json);
+                var (_, jObject) = JsonUtility.Deserialize<JObject>(json);
+                var (_, cache) = JsonUtility.ToObject<Dictionary<string, UserProfile>>(Normalize(jObject));
                 return new UserProfileCache(cache, cachePath, github);
             }
             catch (Exception ex)
@@ -86,10 +88,24 @@ namespace Microsoft.Docs.Build
             }
         }
 
+        private static JObject Normalize(JObject cache)
+        {
+            foreach (var pair in cache)
+            {
+                if (pair.Value is JObject profile
+                    && profile.TryGetValue("user_emails", out var userEmails)
+                    && userEmails is JValue userEmailsValue)
+                {
+                    profile["user_emails"] = new JArray(userEmailsValue.ToString().Split(';'));
+                }
+            }
+            return cache;
+        }
+
         private async Task UpdateCacheByCommit(GitCommit commit, Repository repo, List<Error> errors)
         {
-            var author = commit.AuthorEmail;
-            if (string.IsNullOrEmpty(author) || GetByUserEmail(author) != null)
+            var email = commit.AuthorEmail;
+            if (string.IsNullOrEmpty(email) || GetByUserEmail(email) != null)
                 return;
 
             var (authorError, authorName) = await _github.GetNameByCommit(repo.Owner, repo.Name, commit.Sha);
@@ -98,38 +114,26 @@ namespace Microsoft.Docs.Build
             if (authorName == null)
                 return;
 
+            if (_cacheByName.TryGetValue(authorName, out var existingProfile))
+            {
+                AddEmailToUserProfile(email, existingProfile);
+                return;
+            }
+
             var (getProfileError, profile) = await _github.GetUserProfileByName(authorName);
             if (getProfileError != null)
                 errors.Add(getProfileError);
             if (profile == null)
                 return;
 
-            profile.AddEmail(author);
-            AddOrUpdate(authorName, profile, (k, v) => v.AddEmail(author));
-            return;
+            TryAdd(authorName, profile);
+            AddEmailToUserProfile(email, profile);
         }
 
-        private UserProfile AddOrUpdate(string userName, UserProfile value, Func<string, UserProfile, UserProfile> updateValueFactory)
+        private void AddEmailToUserProfile(string email, UserProfile profile)
         {
-            var result = _cacheByName.AddOrUpdate(userName, value, updateValueFactory);
-            foreach (var email in result.GetUserEmails())
-            {
-                _cacheByEmail[email] = result;
-            }
-            return result;
-        }
-
-        private UserProfile AddOrUpdate(
-            string userName,
-            Func<string, UserProfile> addValueFactory,
-            Func<string, UserProfile, UserProfile> updateValueFactory)
-        {
-            var result = _cacheByName.AddOrUpdate(userName, addValueFactory, updateValueFactory);
-            foreach (var email in result.GetUserEmails())
-            {
-                _cacheByEmail[email] = result;
-            }
-            return result;
+            profile.UserEmails.Add(email);
+            _cacheByEmail[email] = profile;
         }
 
         private UserProfileCache(IDictionary<string, UserProfile> cache, string path, GitHubAccessor github)
@@ -143,7 +147,7 @@ namespace Microsoft.Docs.Build
             _cacheByEmail = new ConcurrentDictionary<string, UserProfile>(
                 from profile in cache.Values
                 where profile?.UserEmails != null
-                from email in profile.UserEmails.Split(";")
+                from email in profile.UserEmails
                 group profile by email into g
                 select new KeyValuePair<string, UserProfile>(g.Key, g.First()));
             _github = github;
@@ -157,7 +161,7 @@ namespace Microsoft.Docs.Build
             Debug.Assert(!string.IsNullOrEmpty(userName));
 
             var result = _cacheByName.TryAdd(userName, profile);
-            foreach (var email in profile.GetUserEmails())
+            foreach (var email in profile.UserEmails)
             {
                 _cacheByEmail.TryAdd(email, profile);
             }


### PR DESCRIPTION
To avoid duplicate split+join.

Another minor fix: if the docfx calls GitHub api for commit info, and find the commit author already contained in user profile cache, it needn't to call GitHub for user info again.