### PR TITLE
schema determines properties included in output page model

### DIFF
--- a/docs/specs/schema.yml
+++ b/docs/specs/schema.yml
@@ -149,3 +149,12 @@ outputs:
   docs/page.json:
   build.manifest:
 ---
+# Do not include contributors in output when schema says so
+inputs:
+  docfx.yml:
+  docs/a.yml: |
+    #YamlMime:TestPage
+outputs:
+  docs/a.json: |
+    { "!contributors": null, "!author": null, "!updatedAt": null }
+  build.manifest:

--- a/src/Microsoft.Docs.Template/Models/Attributes.cs
+++ b/src/Microsoft.Docs.Template/Models/Attributes.cs
@@ -9,35 +9,47 @@ namespace Microsoft.Docs.Build
     /// Exports a type to be processed by build pipeline into a JSON model.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class)]
-    public class DataSchemaAttribute : Attribute{ }
+    public class DataSchemaAttribute : Attribute { }
 
     /// <summary>
     /// Exports a type to be processed by build pipeline into an HTML page.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class)]
-    public class PageSchemaAttribute : DataSchemaAttribute { }
+    public class PageSchemaAttribute : DataSchemaAttribute
+    {
+        public bool Contributors { get; }
+
+        public bool GitUrl { get; }
+
+        public bool DocumentId { get; }
+
+        public bool Toc { get; }
+
+        public PageSchemaAttribute(
+            bool contributors = true,
+            bool gitUrl = true,
+            bool documentId = true,
+            bool toc = true)
+        {
+            Contributors = contributors;
+            GitUrl = gitUrl;
+            DocumentId = documentId;
+            Toc = toc;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    public abstract class SchemaFeatureAttribute : Attribute { }
 
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
     public abstract class DataTypeAttribute : Attribute
     {
-        public Type RequiredType { get; set; }
+        public virtual Type TargetType => typeof(string);
     }
 
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class HrefAttribute : DataTypeAttribute
-    {
-        public HrefAttribute() => RequiredType = typeof(string);
-    }
+    public class HrefAttribute : DataTypeAttribute { }
 
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class MarkdownAttribute : DataTypeAttribute
-    {
-        public MarkdownAttribute() => RequiredType = typeof(string);
-    }
+    public class MarkdownAttribute : DataTypeAttribute { }
 
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public class InlineMarkdownAttribute : DataTypeAttribute
-    {
-        public InlineMarkdownAttribute() => RequiredType = typeof(string);
-    }
+    public class InlineMarkdownAttribute : DataTypeAttribute { }
 }

--- a/src/Microsoft.Docs.Template/Models/Conceptual.cs
+++ b/src/Microsoft.Docs.Template/Models/Conceptual.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Docs.Build
     //   Conceptual model is more than just an html string, it also contain other properties.
     //   We currently bake these other properties into PageModel to make the output flat,
     //   but it makes conceptual kinda special. We may consider lift them outside PageModel.
+    [PageSchema]
     public class Conceptual
     {
         public string Html { get; set; }

--- a/src/Microsoft.Docs.Template/Models/LandingData.cs
+++ b/src/Microsoft.Docs.Template/Models/LandingData.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build
 {
-    [PageSchema]
+    [PageSchema(contributors: false)]
     public class LandingData
     {
         public string Title { get; set; }

--- a/src/Microsoft.Docs.Template/Models/TestPage.cs
+++ b/src/Microsoft.Docs.Template/Models/TestPage.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Docs.Build
 {
-    [PageSchema]
+    [PageSchema(contributors: false)]
     public class TestPage
     {
         [Markdown]

--- a/src/docfx/build/legacy/metadata/LegacyMetadata.cs
+++ b/src/docfx/build/legacy/metadata/LegacyMetadata.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Docs.Build
             rawMetadata["wordCount"] = rawMetadata["word_count"] = pageModel.WordCount;
 
             rawMetadata["title"] = pageModel.Title;
-            rawMetadata["rawTitle"] = pageModel.HtmlTitle ?? "";
+            rawMetadata["rawTitle"] = pageModel.HtmlTitle ?? $"<h1>{pageModel.Title}</h1>";
 
             rawMetadata["_op_canonicalUrlPrefix"] = $"{docset.Config.BaseUrl}/{docset.Config.Locale}/{docset.Config.SiteBasePath}/";
 

--- a/src/docfx/lib/HtmlUtility.cs
+++ b/src/docfx/lib/HtmlUtility.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Docs.Build
                     node.SetAttributeValue("data-linktype", "self-bookmark");
                     continue;
                 }
-                if (href[0] == '/' || href[0] == '\\')
+                if ((href[0] == '/' || href[0] == '\\') && !href.StartsWith("//"))
                 {
                     node.SetAttributeValue(attribute, AddLocaleIfMissing(href, locale));
                     node.SetAttributeValue("data-linktype", "absolute-path");
@@ -190,7 +190,7 @@ namespace Microsoft.Docs.Build
         private static bool IsUri(string href, bool legacy = false)
         {
             return legacy
-                ? s_uriWithProtocol.IsMatch(href)
+                ? href.StartsWith("//") || s_uriWithProtocol.IsMatch(href)
                 : Uri.TryCreate(href, UriKind.Absolute, out _);
         }
 


### PR DESCRIPTION
Some schemas like `LandingData` does not show contributors, we should exclude it from output, and may save some time by not calculating contributors.