### PR TITLE
Improve json/yaml error line info

### DIFF
--- a/docs/specs/schema.yml
+++ b/docs/specs/schema.yml
@@ -184,3 +184,16 @@ outputs:
     }
   build.manifest:
 ---
+# Show yaml, json syntax error
+inputs:
+  docfx.yml:
+  docs/a.yml: |
+    #YamlMime:TestData
+    a: b:
+  docs/b.json: |
+    {
+outputs:
+  build.log: |
+    ["error","yaml-syntax-error","Mapping values are not allowed in this context.","docs/a.yml",2,5]
+    ["error","json-syntax-error","Error reading JObject from JsonReader. Path ''.","docs/b.json",2]
+  build.manifest:

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -77,7 +77,7 @@ inputs:
 outputs:
   build.manifest:
   build.log: |
-    ["error","json-syntax-error","JsonToken EndArray is not valid for closing JsonType Object. Path '[0]', line 1, position 20.","docs/TOC.json"]
+    ["error","json-syntax-error","JsonToken EndArray is not valid for closing JsonType Object. Path '[0]'.","docs/TOC.json",1,20]
 ---
 # Probe TOC in JSON format
 inputs:

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using YamlDotNet.Core;
 
 namespace Microsoft.Docs.Build
 {
@@ -49,10 +48,10 @@ namespace Microsoft.Docs.Build
         public static Error InvalidTocHref(Document relativeTo, string tocHref)
             => new Error(ErrorLevel.Error, "invalid-toc-href", $"The toc href '{tocHref}' can only reference to a local TOC file, folder or absolute path", relativeTo.ToString());
 
-        public static Error MissingTocHead(Range range, string filePath)
+        public static Error MissingTocHead(in Range range, string filePath)
             => new Error(ErrorLevel.Error, "missing-toc-head", $"The toc head name is missing", filePath, range);
 
-        public static Error InvalidTocSyntax(Range range, string filePath, string syntax)
+        public static Error InvalidTocSyntax(in Range range, string filePath, string syntax)
             => new Error(ErrorLevel.Error, "invalid-toc-syntax", $"The toc syntax '{syntax}' is invalided", filePath, range);
 
         public static Error InvalidTocLevel(string filePath, int from, int to)
@@ -64,20 +63,17 @@ namespace Microsoft.Docs.Build
         public static Error YamlHeaderNotObject(bool isArray)
             => new Error(ErrorLevel.Warning, "yaml-header-not-object", $"Expect yaml header to be an object, but got {(isArray ? "an array" : "a scalar")}");
 
-        public static Error YamlSyntaxError(YamlException ex)
-            => new Error(ErrorLevel.Error, "yaml-syntax-error", $"{ex.Message}. {ex.InnerException?.Message}");
+        public static Error YamlSyntaxError(in Range range, string message)
+            => new Error(ErrorLevel.Error, "yaml-syntax-error", message, range: range);
 
-        public static Error YamlDuplicateKey(YamlException ex)
-        {
-            var (range, message) = RedefineDuplicateKeyErrorMessage(ex);
-            return new Error(ErrorLevel.Error, "yaml-duplicate-key", message, range: range);
-        }
+        public static Error YamlDuplicateKey(in Range range, string key)
+            => new Error(ErrorLevel.Error, "yaml-duplicate-key", $"Key '{key}' is already defined, remove the duplicate key.", range: range);
 
         public static Error InvalidYamlHeader(Document file, Exception ex)
             => new Error(ErrorLevel.Warning, "invalid-yaml-header", ex.Message, file.ToString());
 
-        public static Error JsonSyntaxError(Exception ex)
-            => new Error(ErrorLevel.Error, "json-syntax-error", ex.Message);
+        public static Error JsonSyntaxError(string message, string path, int line, int column)
+            => new Error(ErrorLevel.Error, "json-syntax-error", $"{message}. Path '{path}'.", range: new Range(line, column));
 
         public static Error LinkIsEmpty(Document relativeTo)
             => new Error(ErrorLevel.Info, "link-is-empty", "Link is empty", relativeTo.ToString());
@@ -127,13 +123,13 @@ namespace Microsoft.Docs.Build
         public static Error BookmarkNotFound(Document relativeTo, Document reference, string bookmark)
             => new Error(ErrorLevel.Warning, "bookmark-not-found", $"Cannot find bookmark '#{bookmark}' in '{reference}'", relativeTo.ToString());
 
-        public static Error NullValue(Range range, string name)
+        public static Error NullValue(in Range range, string name)
             => new Error(ErrorLevel.Info, "null-value", $"'{name}' contains null value", range: range);
 
-        public static Error UnknownField(Range range, string propName, string typeName, string path)
+        public static Error UnknownField(in Range range, string propName, string typeName, string path)
             => new Error(ErrorLevel.Warning, "unknown-field", $"Path:{path} Could not find member '{propName}' on object of type '{typeName}'", range: range);
 
-        public static Error ViolateSchema(Range range, string message)
+        public static Error ViolateSchema(in Range range, string message)
             => new Error(ErrorLevel.Error, "violate-schema", message, range: range);
 
         public static Error SchemaNotFound(string schema)
@@ -141,19 +137,5 @@ namespace Microsoft.Docs.Build
 
         public static Error ExceedMaxErrors(int maxErrors)
             => new Error(ErrorLevel.Error, "exceed-max-errors", $"Error or warning count exceed '{maxErrors}'. Build will continue but newer logs will be ignored.");
-
-        private static Range ParseRangeFromYamlSyntaxException(YamlException ex)
-        {
-            return new Range(ex.Start.Line, ex.Start.Column, ex.End.Line, ex.End.Column);
-        }
-
-        private static (Range, string) RedefineDuplicateKeyErrorMessage(YamlException ex)
-        {
-            var range = ParseRangeFromYamlSyntaxException(ex);
-            var innerMessage = ex.InnerException.Message;
-            var keyIndex = innerMessage.LastIndexOf(':');
-            var key = innerMessage.Substring(keyIndex + 2, innerMessage.Length - keyIndex - 2);
-            return (range, $"Key '{key}' is already defined, remove the duplicate key.");
-        }
     }
 }

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -72,8 +72,8 @@ namespace Microsoft.Docs.Build
         public static Error InvalidYamlHeader(Document file, Exception ex)
             => new Error(ErrorLevel.Warning, "invalid-yaml-header", ex.Message, file.ToString());
 
-        public static Error JsonSyntaxError(string message, string path, int line, int column)
-            => new Error(ErrorLevel.Error, "json-syntax-error", $"{message}. Path '{path}'.", range: new Range(line, column));
+        public static Error JsonSyntaxError(string message, string path, in Range range)
+            => new Error(ErrorLevel.Error, "json-syntax-error", $"{message}. Path '{path}'.", range: range);
 
         public static Error LinkIsEmpty(Document relativeTo)
             => new Error(ErrorLevel.Info, "link-is-empty", "Link is empty", relativeTo.ToString());

--- a/src/docfx/lib/JsonUtility.cs
+++ b/src/docfx/lib/JsonUtility.cs
@@ -222,9 +222,10 @@ namespace Microsoft.Docs.Build
                     .ValidateNullValue();
                 return (errors, token ?? JValue.CreateNull());
             }
-            catch (Exception ex)
+            catch (JsonReaderException ex)
             {
-                throw Errors.JsonSyntaxError(ex).ToException();
+                var message = ex.Message.Split('.')[0];
+                throw Errors.JsonSyntaxError(message, ex.Path, ex.LineNumber, ex.LinePosition).ToException(ex);
             }
         }
 

--- a/src/docfx/lib/JsonUtility.cs
+++ b/src/docfx/lib/JsonUtility.cs
@@ -224,8 +224,7 @@ namespace Microsoft.Docs.Build
             }
             catch (JsonReaderException ex)
             {
-                var message = ex.Message.Split('.')[0];
-                throw Errors.JsonSyntaxError(message, ex.Path, ex.LineNumber, ex.LinePosition).ToException(ex);
+                throw Errors.JsonSyntaxError(ex.Message.Split('.')[0], ex.Path, new Range(ex.LineNumber, ex.LinePosition)).ToException(ex);
             }
         }
 

--- a/src/docfx/lib/Range.cs
+++ b/src/docfx/lib/Range.cs
@@ -10,7 +10,15 @@ namespace Microsoft.Docs.Build
         public readonly int EndLine;
         public readonly int EndCharacter;
 
-        public Range(int startLine, int startCharacter, int endLine = 0, int endCharacter = 0)
+        public Range(int line, int column)
+        {
+            StartLine = line;
+            StartCharacter = column;
+            EndLine = line;
+            EndCharacter = column;
+        }
+
+        public Range(int startLine, int startCharacter, int endLine, int endCharacter)
         {
             StartLine = startLine;
             StartCharacter = startCharacter;

--- a/src/docfx/lib/log/Error.cs
+++ b/src/docfx/lib/log/Error.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Docs.Build
             string code,
             string message,
             string file = null,
-            Range range = default)
+            in Range range = default)
         {
             Debug.Assert(!string.IsNullOrEmpty(code));
             Debug.Assert(Regex.IsMatch(code, "^[a-z0-9-]{5,32}$"), "Error code should only contain dash and letters in lowercase");

--- a/src/docfx/restore/RestoreUrl.cs
+++ b/src/docfx/restore/RestoreUrl.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Docs.Build
                         await Task.Delay(RetryInterval);
                         continue;
                     }
-                    throw Errors.DownloadFailed(address, ex.Message).ToException();
+                    throw Errors.DownloadFailed(address, ex.Message).ToException(ex);
                 }
                 return tempFile;
             }

--- a/test/docfx.Test/common/TestUtility.cs
+++ b/test/docfx.Test/common/TestUtility.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -12,7 +10,7 @@ using Xunit;
 
 namespace Microsoft.Docs.Build
 {
-    internal static class TestHelper
+    internal static class TestUtility
     {
         public static void VerifyJsonContainEquals(JToken expected, JToken actual, string parentKey = null)
         {
@@ -52,7 +50,7 @@ namespace Microsoft.Docs.Build
                     expectedHtml.StartsWith('<') && expectedHtml.EndsWith('>'))
                 {
                     // Treat `content` as html if the expected value looks like: <blablabla>
-                    Assert.Equal(TestHelper.NormalizeHtml(expectedHtml), TestHelper.NormalizeHtml(actualHtml));
+                    Assert.Equal(TestUtility.NormalizeHtml(expectedHtml), TestUtility.NormalizeHtml(actualHtml));
                 }
                 else
                 {

--- a/test/docfx.Test/e2e/E2ETest.cs
+++ b/test/docfx.Test/e2e/E2ETest.cs
@@ -180,11 +180,18 @@ namespace Microsoft.Docs.Build
                         JToken.Parse(File.ReadAllText(file)));
                     break;
                 case ".log":
-                    var expected = content.Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).OrderBy(_ => _).ToList();
-                    var actual = File.ReadAllLines(file).OrderBy(_ => _);
+                    var expected = content.Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).OrderBy(_ => _).ToArray();
+                    var actual = File.ReadAllLines(file).OrderBy(_ => _).ToArray();
                     // TODO: Configure github token in CI to get rid of github rate limit,
                     // then we could remove the wildcard match
-                    Assert.Matches("^" + Regex.Escape(string.Join("\n", expected)).Replace("\\*", ".*") + "$", string.Join("\n", actual));
+                    if (expected.Contains("*"))
+                    {
+                        Assert.Matches("^" + Regex.Escape(string.Join("\n", expected)).Replace("\\*", ".*") + "$", string.Join("\n", actual));
+                    }
+                    else
+                    {
+                        Assert.Equal(expected, actual);
+                    }
                     break;
                 default:
                     Assert.Equal(

--- a/test/docfx.Test/e2e/E2ETest.cs
+++ b/test/docfx.Test/e2e/E2ETest.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Docs.Build
             {
                 case ".json":
                 case ".manifest":
-                    TestHelper.VerifyJsonContainEquals(
+                    TestUtility.VerifyJsonContainEquals(
                         JToken.Parse(content ?? "{}"),
                         JToken.Parse(File.ReadAllText(file)));
                     break;
@@ -184,13 +184,13 @@ namespace Microsoft.Docs.Build
                     var actual = File.ReadAllLines(file).OrderBy(_ => _).ToArray();
                     // TODO: Configure github token in CI to get rid of github rate limit,
                     // then we could remove the wildcard match
-                    if (expected.Contains("*"))
+                    if (expected.Any(str => str.Contains("*")))
                     {
                         Assert.Matches("^" + Regex.Escape(string.Join("\n", expected)).Replace("\\*", ".*") + "$", string.Join("\n", actual));
                     }
                     else
                     {
-                        Assert.Equal(expected, actual);
+                        Assert.Equal(string.Join("\n", expected), string.Join("\n", actual));
                     }
                     break;
                 default:

--- a/test/docfx.Test/lib/HtmlUtilityTest.cs
+++ b/test/docfx.Test/lib/HtmlUtilityTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Docs.Build
         {
             var actual = HtmlUtility.TransformHtml(input, node => node.AddLinkType("zh-cn"));
 
-            Assert.Equal(TestHelper.NormalizeHtml(output), TestHelper.NormalizeHtml(actual));
+            Assert.Equal(TestUtility.NormalizeHtml(output), TestUtility.NormalizeHtml(actual));
         }
 
         [Theory]
@@ -36,7 +36,7 @@ namespace Microsoft.Docs.Build
         {
             var actual = HtmlUtility.TransformHtml(input, node => node.RemoveRerunCodepenIframes());
 
-            Assert.Equal(TestHelper.NormalizeHtml(output), TestHelper.NormalizeHtml(actual));
+            Assert.Equal(TestUtility.NormalizeHtml(output), TestUtility.NormalizeHtml(actual));
         }
 
         [Theory]
@@ -49,7 +49,7 @@ namespace Microsoft.Docs.Build
         {
             var actual = HtmlUtility.TransformHtml(input, node => node.StripTags());
 
-            Assert.Equal(TestHelper.NormalizeHtml(output), TestHelper.NormalizeHtml(actual));
+            Assert.Equal(TestUtility.NormalizeHtml(output), TestUtility.NormalizeHtml(actual));
         }
 
         [Theory]

--- a/test/docfx.Test/lib/JsonUtilityTest.cs
+++ b/test/docfx.Test/lib/JsonUtilityTest.cs
@@ -255,13 +255,6 @@ namespace Microsoft.Docs.Build
             var exception = Assert.Throws<DocfxException>(() => JsonUtility.Deserialize(json));
         }
 
-        [Fact]
-        public void TestNull()
-        {
-            string json = null;
-            var exception = Assert.Throws<DocfxException>(() => JsonUtility.Deserialize(json));
-        }
-
         [Theory]
         [InlineData("1", 1, 1)]
         [InlineData(@"{""key"":""value""}", 1, 14)]

--- a/test/docfx.Test/lib/TemplateTest.cs
+++ b/test/docfx.Test/lib/TemplateTest.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Docs.Build
             var model = JsonConvert.DeserializeObject(json.Replace('\'', '"'), pageType);
 
             Assert.Equal(
-                TestHelper.NormalizeHtml(html),
-                TestHelper.NormalizeHtml(await Template.Render(pageType.Name, model)));
+                TestUtility.NormalizeHtml(html),
+                TestUtility.NormalizeHtml(await Template.Render(pageType.Name, model)));
         }
     }
 }


### PR DESCRIPTION
- Add [`in`](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/in-generic-modifier) before `Range` to speed up passing large struct
- Move error line column info to `Error.Range` property
- Improve line/column/key detection