### PR TITLE
Fix for ArgmentNullException when references section is missing in docfx.json

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/ExtractMetadataWorker.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/ExtractMetadataWorker.cs
@@ -343,7 +343,8 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
             if (assemblyFiles.Count > 0)
             {
-                var assemblyCompilation = CompilationUtility.CreateCompilationFromAssembly(assemblyFiles.Concat(_references));
+                var assemblyCompilation = CompilationUtility.CreateCompilationFromAssembly(
+                    assemblyFiles.Concat(_references ?? Enumerable.Empty<string>()));
                 if (assemblyCompilation != null)
                 {
                     var commentFiles = (from file in assemblyFiles


### PR DESCRIPTION
This seems to fix #3374