### PR TITLE
Allow mutex name to be any unique string

### DIFF
--- a/src/docfx/config/AppData.cs
+++ b/src/docfx/config/AppData.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Docs.Build
 
         public static string RestoreLockDir => Path.Combine(AppDataDir, "restore-lock");
 
-        public static string FileMutexDir => Path.Combine(AppDataDir, "file-mutex");
+        public static string MutexDir => Path.Combine(AppDataDir, "mutex");
 
         public static string CacheDir => Path.Combine(AppDataDir, "cache");
 

--- a/src/docfx/docset/Document.cs
+++ b/src/docfx/docset/Document.cs
@@ -396,7 +396,7 @@ namespace Microsoft.Docs.Build
             var sitePathWithoutExtension = Path.Combine(Path.GetDirectoryName(SitePath), Path.GetFileNameWithoutExtension(SitePath));
             var sitePath = PathUtility.NormalizeFile(Path.GetRelativePath(Docset.Config.DocumentId.SiteBasePath, sitePathWithoutExtension));
 
-            return (HashUtility.GetMd5String($"{depotName}|{sourcePath.ToLowerInvariant()}"), HashUtility.GetMd5String($"{depotName}|{sitePath.ToLowerInvariant()}"));
+            return (HashUtility.GetMd5Hash($"{depotName}|{sourcePath.ToLowerInvariant()}"), HashUtility.GetMd5Hash($"{depotName}|{sitePath.ToLowerInvariant()}"));
         }
     }
 }

--- a/src/docfx/lib/HashUtility.cs
+++ b/src/docfx/lib/HashUtility.cs
@@ -10,18 +10,10 @@ namespace Microsoft.Docs.Build
 {
     public static class HashUtility
     {
-        /// <summary>
-        /// Get md5 hash string
-        /// </summary>
-        /// <param name="input">The input string</param>
-        public static string GetMd5String(this string input)
-            => GetMd5String(new MemoryStream(Encoding.UTF8.GetBytes(input)));
+        public static string GetMd5Hash(this string input)
+            => GetMd5Hash(new MemoryStream(Encoding.UTF8.GetBytes(input)));
 
-        /// <summary>
-        /// Get md5 hash string from stream
-        /// </summary>
-        /// <param name="stream">The input stream</param>
-        public static string GetMd5String(Stream stream)
+        public static string GetMd5Hash(Stream stream)
         {
 #pragma warning disable CA5351 //Not used for encryption
             using (var md5 = MD5.Create())
@@ -31,10 +23,10 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public static string GetSha1HashString(string input)
-            => GetSha1HashString(new MemoryStream(Encoding.UTF8.GetBytes(input)));
+        public static string GetSha1Hash(string input)
+            => GetSha1Hash(new MemoryStream(Encoding.UTF8.GetBytes(input)));
 
-        public static string GetSha1HashString(Stream stream)
+        public static string GetSha1Hash(Stream stream)
         {
 #pragma warning disable CA5350 //Not used for encryption
             using (var sha1 = new SHA1CryptoServiceProvider())

--- a/src/docfx/lib/ProcessUtility.cs
+++ b/src/docfx/lib/ProcessUtility.cs
@@ -94,19 +94,16 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Create a file mutex to lock a resource/action
         /// </summary>
-        /// <param name="mutexFileRelativePath">The mutex file relative path</param>
+        /// <param name="mutexName">A globbaly unique mutext name</param>
         /// <param name="action">The action/resource you want to lock</param>
-        /// <param name="retry">The retry count, default is 600 times</param>
-        /// <param name="retryTimeSpanInterval">The retry interval, default is 1 seconds</param>
-        /// <returns>The task status</returns>
-        public static async Task CreateFileMutex(string mutexFileRelativePath, Func<Task> action, int retry = 600, TimeSpan? retryTimeSpanInterval = null)
+        public static async Task RunInMutex(string mutexName, Func<Task> action)
         {
-            Debug.Assert(!string.IsNullOrEmpty(mutexFileRelativePath));
-            Debug.Assert(!Path.IsPathRooted(mutexFileRelativePath));
+            Debug.Assert(!string.IsNullOrEmpty(mutexName));
 
-            var lockPath = Path.Combine(AppData.FileMutexDir, mutexFileRelativePath);
-            Directory.CreateDirectory(Path.GetDirectoryName(lockPath));
-            using (var lockFile = await AcquireFileMutex(lockPath, retry < 0 ? 0 : retry, retryTimeSpanInterval ?? TimeSpan.FromSeconds(1)))
+            var mutextId = HashUtility.GetMd5Hash(mutexName);
+            Directory.CreateDirectory(AppData.MutexDir);
+
+            using (await AcquireFileMutex(mutexName, Path.Combine(AppData.MutexDir, mutextId)))
             {
                 await action();
             }
@@ -121,20 +118,34 @@ namespace Microsoft.Docs.Build
                    ex.ErrorCode == 2; // ERROR_FILE_NOT_FOUND = 0x2, The system cannot find the file specified
         }
 
-        private static async Task<FileStream> AcquireFileMutex(string lockPath, int retry, TimeSpan retryTimeSpanInterval)
+        private static async Task<FileStream> AcquireFileMutex(string mutexName, string lockPath)
         {
-            var retryCount = 0;
+            var retryDelay = 100;
+            var lastWait = DateTime.UtcNow;
+
             while (true)
             {
                 try
                 {
                     return new FileStream(lockPath, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 1, FileOptions.DeleteOnClose);
                 }
-                catch when (retryCount++ < retry)
+                catch
                 {
-                    // TODO: error handling
-                    // TODO: notify user current waiting process
-                    await Task.Delay(retryTimeSpanInterval);
+                    if (DateTime.UtcNow - lastWait > TimeSpan.FromSeconds(30))
+                    {
+                        lastWait = DateTime.UtcNow;
+#pragma warning disable CA2002 // Do not lock on objects with weak identity
+                        lock (Console.Out)
+#pragma warning restore CA2002
+                        {
+                            Console.ForegroundColor = ConsoleColor.Yellow;
+                            Console.WriteLine($"Waiting for another process to access '{mutexName}'");
+                            Console.ResetColor();
+                        }
+                    }
+
+                    await Task.Delay(retryDelay);
+                    retryDelay = Math.Min(retryDelay + 100, 1000);
                 }
             }
         }

--- a/src/docfx/restore/RestoreGit.cs
+++ b/src/docfx/restore/RestoreGit.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Docs.Build
             var (url, _) = GitUtility.GetGitRemoteInfo(hrefs.First());
             var workTreeHeads = new ConcurrentBag<(string href, string head)>();
 
-            await ProcessUtility.CreateFileMutex(
+            await ProcessUtility.RunInMutex(
                 PathUtility.NormalizeFile(Path.GetRelativePath(AppData.GitRestoreDir, restorePath)),
                 async () =>
                 {
@@ -143,7 +143,7 @@ namespace Microsoft.Docs.Build
 
             var restorePath = PathUtility.NormalizeFolder(Path.Combine(restoreDir, ".git"));
 
-            await ProcessUtility.CreateFileMutex(
+            await ProcessUtility.RunInMutex(
                 PathUtility.NormalizeFile(Path.GetRelativePath(AppData.GitRestoreDir, restorePath)),
                 async () =>
                 {

--- a/src/docfx/restore/RestoreLocker.cs
+++ b/src/docfx/restore/RestoreLocker.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Docs.Build
             Debug.Assert(!string.IsNullOrEmpty(docset));
 
             var restoreLockFilePath = GetRestoreLockFilePath(docset);
-            await ProcessUtility.CreateFileMutex(
+            await ProcessUtility.RunInMutex(
                 Path.GetRelativePath(AppData.RestoreLockDir, restoreLockFilePath),
                 async () =>
                 {
@@ -47,7 +47,7 @@ namespace Microsoft.Docs.Build
             if (!File.Exists(restoreLockFilePath))
                 return restore;
 
-            await ProcessUtility.CreateFileMutex(
+            await ProcessUtility.RunInMutex(
                 Path.GetRelativePath(AppData.RestoreLockDir, restoreLockFilePath),
                 () =>
                 {
@@ -67,7 +67,7 @@ namespace Microsoft.Docs.Build
             var restoreLocks = new ConcurrentBag<RestoreLock>();
             await ParallelUtility.ForEach(Directory.EnumerateFiles(AppData.RestoreLockDir, "*", SearchOption.TopDirectoryOnly), async restoreLockFilePath =>
             {
-                await ProcessUtility.CreateFileMutex(
+                await ProcessUtility.RunInMutex(
                 Path.GetRelativePath(AppData.RestoreLockDir, restoreLockFilePath),
                 () =>
                 {
@@ -86,7 +86,7 @@ namespace Microsoft.Docs.Build
         public static string GetRestoreLockFilePath(string docset)
         {
             docset = PathUtility.NormalizeFile(Path.GetFullPath(docset));
-            var docsetKey = Path.GetFileName(docset) + "-" + HashUtility.GetSha1HashString(docset);
+            var docsetKey = Path.GetFileName(docset) + "-" + HashUtility.GetSha1Hash(docset);
 
             return Path.Combine(AppData.RestoreLockDir, $"{docsetKey}-lock.json");
         }

--- a/src/docfx/restore/RestoreUrl.cs
+++ b/src/docfx/restore/RestoreUrl.cs
@@ -32,14 +32,14 @@ namespace Microsoft.Docs.Build
             var fileVersion = "";
             using (var fileStream = File.Open(tempFile, FileMode.Open, FileAccess.Read))
             {
-                fileVersion = HashUtility.GetSha1HashString(fileStream);
+                fileVersion = HashUtility.GetSha1Hash(fileStream);
             }
 
             Debug.Assert(!string.IsNullOrEmpty(fileVersion));
 
             var restoreDir = GetRestoreRootDir(address);
             var restorePath = GetRestoreVersionPath(restoreDir, fileVersion);
-            await ProcessUtility.CreateFileMutex(
+            await ProcessUtility.RunInMutex(
                 PathUtility.NormalizeFile(Path.GetRelativePath(AppData.UrlRestoreDir, restoreDir)),
                 () =>
                 {
@@ -63,7 +63,7 @@ namespace Microsoft.Docs.Build
                 return;
             }
 
-            await ProcessUtility.CreateFileMutex(
+            await ProcessUtility.RunInMutex(
                 PathUtility.NormalizeFile(Path.GetRelativePath(AppData.UrlRestoreDir, restoreDir)),
                 async () =>
                 {

--- a/test/docfx.Test/lib/ProcessUtilityTest.cs
+++ b/test/docfx.Test/lib/ProcessUtilityTest.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -21,17 +22,18 @@ namespace Microsoft.Docs.Build
         }
 
         [Fact]
-        public static async Task ConcurrencyCreatingFileShouldNotThrowNoException()
+        public static async Task CreateFilesInMutexInParallelDoesNotThrow()
         {
             var fileName = $"process-test\\{Guid.NewGuid()}";
             await Task.WhenAll(Enumerable.Range(0, 5).AsParallel().Select(
-                i => ProcessUtility.CreateFileMutex(
+                i => ProcessUtility.RunInMutex(
                     fileName,
                     () =>
                     {
                         Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(fileName)));
                         using (var streamWriter = File.CreateText(fileName))
                         {
+                            Thread.Sleep(100);
                             streamWriter.WriteLine(fileName);
                         }
 


### PR DESCRIPTION
This PR relax interprocess mutex name to be any string, by hashing the input name. We will be using file mutex to sync access to other resources outside of restore. The original implementation left a lots of empty folders under `appdata/file-mutex` directory.

This PR also implement wait notification and retry duration back off. A warning message is print to the console every 30 seconds when waiting for a mutex.