### PR TITLE
use latest version Microsoft.DocAsCode.MarkdigEngine.Extensions

### DIFF
--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.DocAsCode.MarkdigEngine.Extensions" Version="2.38.0-alpha-0018-ga5c5db6" />
+    <PackageReference Include="Microsoft.DocAsCode.MarkdigEngine.Extensions" Version="2.40.0-b-180911011-g40480e2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Jint" Version="2.11.58" />
     <PackageReference Include="Octokit" Version="0.31.0" />


### PR DESCRIPTION
which fix the inline inclusion yaml-header bug
#3405 