### PR TITLE
toc needn't report own filename as uid

### DIFF
--- a/src/Microsoft.DocAsCode.Build.TableOfContents/TocDocumentProcessorBase.cs
+++ b/src/Microsoft.DocAsCode.Build.TableOfContents/TocDocumentProcessorBase.cs
@@ -43,7 +43,6 @@ namespace Microsoft.DocAsCode.Build.TableOfContents
 
             return new FileModel(file, toc)
             {
-                Uids = new[] { new UidDefinition(file.File, displayLocalPath) }.ToImmutableArray(),
                 LocalPathFromRoot = displayLocalPath
             };
         }


### PR DESCRIPTION
This code originates from an early out-of-date design, which takes file name as uid. This fix can prevent unnecessary call to xref service introduced in #2867 .