### PR TITLE
Model well known metadata, well known metadata keys are case insensitive

### DIFF
--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -81,10 +81,7 @@ outputs:
       "content": "<p>hello</p>",
       "raw_title": "<h1 id=\"title-from-h1\">Title from H1</h1>",
       "title": "Title from H1",
-      "metadata":
-      {
-          "Title": "Title from yaml header"
-      }
+      "metadata": { "title": "Title from yaml header" }
     }
   build.manifest:
 ---

--- a/docs/specs/metadata.yml
+++ b/docs/specs/metadata.yml
@@ -1,3 +1,15 @@
+# known metadata keys are case insensitive
+inputs:
+  docfx.yml:
+  docs/a.md: |
+    ---
+    Robots: noindex, nofollow
+    ---
+outputs:
+  docs/a.json: |
+    { "metadata": { "robots": "noindex, nofollow" } }
+  build.manifest:
+---
 # generate normal document id and version id
 # backward compatible to docs.com
 # document id = md5("Win.sccm|mdt/release-notes.md")

--- a/src/Microsoft.Docs.Template/Models/FileMetadata.cs
+++ b/src/Microsoft.Docs.Template/Models/FileMetadata.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
+
+namespace Microsoft.Docs.Build
+{
+    [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
+    public class FileMetadata
+    {
+        public string Layout { get; set; }
+
+        public string Locale { get; set; }
+
+        public string Title { get; set; }
+
+        public string Author { get; set; }
+
+        public string Robots { get; set; }
+
+        [JsonExtensionData]
+        public JObject ExtensionData { get; set; }
+    }
+}

--- a/src/Microsoft.Docs.Template/Models/PageModel.cs
+++ b/src/Microsoft.Docs.Template/Models/PageModel.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Docs.Build
@@ -47,7 +46,7 @@ namespace Microsoft.Docs.Build
 
         public string Gitcommit { get; set; }
 
-        public JObject Metadata { get; set; }
+        public FileMetadata Metadata { get; set; }
     }
 
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/build/legacy/metadata/LegacyMetadata.cs
+++ b/src/docfx/build/legacy/metadata/LegacyMetadata.cs
@@ -146,16 +146,7 @@ namespace Microsoft.Docs.Build
                         content = item.Value.ToString();
                     }
 
-                    if (key.Equals("robots", StringComparison.OrdinalIgnoreCase))
-                    {
-                        // Add to the first line
-                        key = "ROBOTS";
-                        pageMetadataOutput.Insert(0, $"<meta name=\"{key}\" content=\"{HttpUtility.HtmlEncode(content)}\" />{Environment.NewLine}");
-                    }
-                    else
-                    {
-                        pageMetadataOutput.AppendLine($"<meta name=\"{key}\" content=\"{HttpUtility.HtmlEncode(content)}\" />");
-                    }
+                    pageMetadataOutput.AppendLine($"<meta name=\"{key}\" content=\"{HttpUtility.HtmlEncode(content)}\" />");
                 }
             }
 

--- a/src/docfx/build/legacy/metadata/LegacyMetadata.cs
+++ b/src/docfx/build/legacy/metadata/LegacyMetadata.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Docs.Build
                 LegacyManifestOutput legacyManifestOutput,
                 TableOfContentsMap tocMap)
         {
-            var rawMetadata = pageModel.Metadata != null ? new JObject(pageModel.Metadata) : new JObject();
+            var rawMetadata = pageModel.Metadata != null ? JObject.FromObject(pageModel.Metadata) : new JObject();
 
             rawMetadata = GenerataCommonMetadata(rawMetadata, docset);
             rawMetadata["conceptual"] = content;

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
@@ -26,8 +25,9 @@ namespace Microsoft.Docs.Build
 
             var dependencies = new DependencyMapBuilder();
 
-            var (errors, schema, model) = await Load(file, dependencies, bookmarkValidator, buildChild, xrefMap);
-            var metadata = JsonUtility.Merge(Metadata.GetFromConfig(file), model.Metadata);
+            var (errors, schema, model, yamlHeader) = await Load(file, dependencies, bookmarkValidator, buildChild, xrefMap);
+            var (metaErrors, metadata) = JsonUtility.ToObject<FileMetadata>(JsonUtility.Merge(Metadata.GetFromConfig(file), yamlHeader));
+            errors.AddRange(metaErrors);
 
             model.PageType = schema.Name;
             model.Locale = file.Docset.Config.Locale;
@@ -39,9 +39,7 @@ namespace Microsoft.Docs.Build
             (model.DocumentId, model.DocumentVersionIndependentId) = file.Docset.Redirections.TryGetDocumentId(file, out var docId) ? docId : file.Id;
             (model.ContentGitUrl, model.OriginalContentGitUrl, model.Gitcommit) = contribution.GetGitUrls(file);
 
-            // TODO: add check before to avoid case failure
-            var authorName = metadata.Value<string>("author");
-            (error, model.Author, model.Contributors, model.UpdatedAt) = await contribution.GetContributorInfo(file, authorName);
+            (error, model.Author, model.Contributors, model.UpdatedAt) = await contribution.GetContributorInfo(file, metadata.Author);
             if (error != null)
                 errors.Add(error);
 
@@ -73,7 +71,7 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static async Task<(List<Error> errors, Schema schema, PageModel model)>
+        private static async Task<(List<Error> errors, Schema schema, PageModel model, JObject metadata)>
             Load(
             Document file, DependencyMapBuilder dependencies, BookmarkValidator bookmarkValidator, Action<Document> buildChild, XrefMap xrefMap)
         {
@@ -82,18 +80,15 @@ namespace Microsoft.Docs.Build
             {
                 return LoadMarkdown(file, content, dependencies, bookmarkValidator, buildChild, xrefMap);
             }
-            else if (file.FilePath.EndsWith(".yml", PathUtility.PathComparison))
+            if (file.FilePath.EndsWith(".yml", PathUtility.PathComparison))
             {
                 return await LoadYaml(content, file, dependencies, bookmarkValidator, buildChild, xrefMap);
             }
-            else
-            {
-                Debug.Assert(file.FilePath.EndsWith(".json", PathUtility.PathComparison));
-                return await LoadJson(content, file, dependencies, bookmarkValidator, buildChild, xrefMap);
-            }
+            Debug.Assert(file.FilePath.EndsWith(".json", PathUtility.PathComparison));
+            return await LoadJson(content, file, dependencies, bookmarkValidator, buildChild, xrefMap);
         }
 
-        private static (List<Error> errors, Schema schema, PageModel model)
+        private static (List<Error> errors, Schema schema, PageModel model, JObject metadata)
             LoadMarkdown(
             Document file, string content, DependencyMapBuilder dependencies, BookmarkValidator bookmarkValidator, Action<Document> buildChild, XrefMap xrefMap)
         {
@@ -108,7 +103,6 @@ namespace Microsoft.Docs.Build
             var model = new PageModel
             {
                 Content = finalHtml,
-                Metadata = markup.Metadata,
                 Title = title,
                 RawTitle = markup.HtmlTitle,
                 WordCount = wordCount,
@@ -118,10 +112,10 @@ namespace Microsoft.Docs.Build
 
             bookmarkValidator.AddBookmarks(file, bookmarks);
 
-            return (markup.Errors, Schema.Conceptual, model);
+            return (markup.Errors, Schema.Conceptual, model, markup.Metadata);
         }
 
-        private static async Task<(List<Error> errors, Schema schema, PageModel model)>
+        private static async Task<(List<Error> errors, Schema schema, PageModel model, JObject metadata)>
             LoadYaml(
             string content, Document file, DependencyMapBuilder dependencies, BookmarkValidator bookmarkValidator, Action<Document> buildChild, XrefMap xrefMap)
         {
@@ -130,7 +124,7 @@ namespace Microsoft.Docs.Build
             return await LoadSchemaDocument(errors, token, file, dependencies, bookmarkValidator, buildChild, xrefMap);
         }
 
-        private static async Task<(List<Error> errors, Schema schema, PageModel model)>
+        private static async Task<(List<Error> errors, Schema schema, PageModel model, JObject metadata)>
             LoadJson(
             string content, Document file, DependencyMapBuilder dependencies, BookmarkValidator bookmarkValidator, Action<Document> buildChild, XrefMap xrefMap)
         {
@@ -139,7 +133,7 @@ namespace Microsoft.Docs.Build
             return await LoadSchemaDocument(errors, token, file, dependencies, bookmarkValidator, buildChild, xrefMap);
         }
 
-        private static async Task<(List<Error> errors, Schema schema, PageModel model)>
+        private static async Task<(List<Error> errors, Schema schema, PageModel model, JObject metadata)>
             LoadSchemaDocument(
             List<Error> errors, JToken token, Document file, DependencyMapBuilder dependencies, BookmarkValidator bookmarkValidator, Action<Document> buildChild, XrefMap xrefMap)
         {
@@ -160,18 +154,18 @@ namespace Microsoft.Docs.Build
                 content = await RazorTemplate.Render(schema.Name, content);
             }
 
+            // TODO: add check before to avoid case failure
             var metadata = obj?.Value<JObject>("metadata") ?? new JObject();
             var title = metadata.Value<string>("title") ?? obj?.Value<string>("title");
 
             var model = new PageModel
             {
                 Content = content,
-                Metadata = metadata,
                 Title = title,
                 RawTitle = file.Docset.Legacy ? $"<h1>{obj?.Value<string>("title")}</h1>" : null,
             };
 
-            return (errors, schema, model);
+            return (errors, schema, model, metadata);
 
             object TransformContent(DataTypeAttribute attribute, object value)
             {


### PR DESCRIPTION
This turns `Robots` --> `robots`. #3434 