### PR TITLE
Suppress `done in 00:00:00` message if the step runs faster than 2s

### DIFF
--- a/src/docfx/cli/Program.cs
+++ b/src/docfx/cli/Program.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Docs.Build
             {
                 Console.ResetColor();
                 Console.ForegroundColor = ConsoleColor.Green;
-                Console.WriteLine($"Done in {new TimeSpan(duration.Hours, duration.Minutes, duration.Seconds)}");
+                Console.WriteLine($"Done in {Progress.FormatTimeSpan(duration)}");
 
                 if (report.ErrorCount > 0 || report.WarningCount > 0)
                 {

--- a/src/docfx/lib/log/Progress.cs
+++ b/src/docfx/lib/log/Progress.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Docs.Build
 {
     internal static class Progress
     {
+        private const int ProgressDelayMs = 2000;
         private static readonly AsyncLocal<ImmutableStack<LogScope>> t_scope = new AsyncLocal<ImmutableStack<LogScope>>();
 
         public static IDisposable Start(string name)
@@ -28,7 +29,7 @@ namespace Microsoft.Docs.Build
 
             // Only write progress if it takes longer than 2 seconds
             var elapsedMs = scope.Stopwatch.ElapsedMilliseconds;
-            if (elapsedMs < 2000)
+            if (elapsedMs < ProgressDelayMs)
             {
                 return;
             }
@@ -56,7 +57,12 @@ namespace Microsoft.Docs.Build
             public void Dispose()
             {
                 t_scope.Value = t_scope.Value.Pop(out var scope);
-                Console.WriteLine($"{scope.Name} done in {TimeSpan.FromSeconds(Stopwatch.ElapsedMilliseconds / 1000)}");
+
+                var elapsedMs = Stopwatch.ElapsedMilliseconds;
+                if (elapsedMs > ProgressDelayMs)
+                {
+                    Console.WriteLine($"{Name} done in {TimeSpan.FromSeconds(elapsedMs / 1000)}");
+                }
             }
         }
     }

--- a/src/docfx/lib/log/Progress.cs
+++ b/src/docfx/lib/log/Progress.cs
@@ -48,6 +48,15 @@ namespace Microsoft.Docs.Build
             Console.Write($"{scope.Name}: {percent.PadLeft(3)}% ({done}/{total}), {duration} {eol}");
         }
 
+        public static string FormatTimeSpan(TimeSpan value)
+        {
+            if (value.TotalMinutes > 1)
+                return TimeSpan.FromSeconds(value.TotalSeconds).ToString();
+            if (value.TotalSeconds > 1)
+                return Math.Round(value.TotalSeconds, digits: 2) + "s";
+            return Math.Round(value.TotalMilliseconds, digits: 2) + "ms";
+        }
+
         private class LogScope : IDisposable
         {
             public string Name;
@@ -61,7 +70,7 @@ namespace Microsoft.Docs.Build
                 var elapsedMs = Stopwatch.ElapsedMilliseconds;
                 if (elapsedMs > ProgressDelayMs)
                 {
-                    Console.WriteLine($"{Name} done in {TimeSpan.FromSeconds(elapsedMs / 1000)}");
+                    Console.WriteLine($"{Name} done in {FormatTimeSpan(Stopwatch.Elapsed)}");
                 }
             }
         }


### PR DESCRIPTION
For most projects, we just build the whole thing in a fraction of seconds.