### PR TITLE
Codify docfx deployment process

### DIFF
--- a/.deploy.yml
+++ b/.deploy.yml
@@ -5,8 +5,7 @@ queue:
 steps:
 - powershell: ./impact.ps1
   env:
-    GITHUB_PAT: $(GitHubPAT)
-    DEVOPS_PAT: $(DevOpsPAT)
+    GITHUB_BASIC_AUTH: $(GitHubBasicAuth)
     SYSTEM_ACCESS_TOKEN: $(System.AccessToken)
   displayName: Impact Test
 

--- a/.deploy.yml
+++ b/.deploy.yml
@@ -1,0 +1,22 @@
+trigger:
+- v3
+queue:
+  name: DocFX
+steps:
+- powershell: ./impact.ps1
+  env:
+    GITHUB_PAT: $(GitHubPAT)
+    DEVOPS_PAT: $(DevOpsPAT)
+    SYSTEM_ACCESS_TOKEN: $(System.AccessToken)
+  displayName: Impact Test
+
+- powershell: ./build.ps1
+  displayName: Build
+
+- task: NuGetCommand@2
+  displayName: Push to MyGet
+  inputs:
+    command: push
+    packagesToPush: drop/**/*.nupkg
+    nuGetFeedType: external
+    publishFeedCredentials: myget.docfx-v3

--- a/impact.ps1
+++ b/impact.ps1
@@ -17,17 +17,14 @@ Write-Host "Use docfx at: $env:DOCFX_PATH"
 
 pushd D:/docfx-impact
 
-$DevOpsPATBase64 = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$($env:DEVOPS_PAT)"))
-$env:DEVOPS_GIT_AUTH = "-c http.https://ceapex.visualstudio.com.extraheader=""AUTHORIZATION: basic $DevOpsPATBase64"""
-
-$GitHubPATBase64 = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes("$($env:GITHUB_PAT)"))
-$env:GITHUB_GIT_AUTH = "-c http.https://github.com.extraheader=""AUTHORIZATION: basic $GitHubPATBase64"""
+$devopsAuth = "-c http.https://ceapex.visualstudio.com.extraheader=""AUTHORIZATION: bearer $env:SYSTEM_ACCESS_TOKEN"""
+$githubAuth = "-c http.https://github.com.extraheader=""AUTHORIZATION: basic $env:GITHUB_BASIC_AUTH"""
 
 exec "git init"
 git remote add origin https://ceapex.visualstudio.com/Engineering/_git/Docs.DocFX.Impact
-exec "git $env:GITHUB_GIT_AUTH $env:DEVOPS_GIT_AUTH fetch --progress"
+exec "git $devopsAuth $githubAuth fetch --progress"
 exec "git checkout origin/master --force --progress"
-exec "git $env:GITHUB_GIT_AUTH $env:DEVOPS_GIT_AUTH submodule update --init --progress"
+exec "git $devopsAuth $githubAuth submodule update --init --progress"
 
 exec "npm install"
 exec "npm run impact -- --push"

--- a/impact.ps1
+++ b/impact.ps1
@@ -1,0 +1,35 @@
+function exec([string] $cmd) {
+    Write-Host $cmd -ForegroundColor Green
+    & ([scriptblock]::Create($cmd))
+    if ($lastexitcode -ne 0) {
+        throw ("Error: " + $cmd)
+    }
+}
+
+# Disable prompt for credentials on build server
+$env:GIT_TERMINAL_PROMPT = 0
+$env:DOCFX_APPDATA_PATH = "D:/appdata"
+$env:DOCFX_PATH = [System.IO.Directory]::GetCurrentDirectory()
+
+Write-Host "Use docfx at: $env:DOCFX_PATH"
+
+[System.IO.Directory]::CreateDirectory('D:/docfx-impact')
+
+pushd D:/docfx-impact
+
+$DevOpsPATBase64 = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$($env:DEVOPS_PAT)"))
+$env:DEVOPS_GIT_AUTH = "-c http.https://ceapex.visualstudio.com.extraheader=""AUTHORIZATION: basic $DevOpsPATBase64"""
+
+$GitHubPATBase64 = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes("$($env:GITHUB_PAT)"))
+$env:GITHUB_GIT_AUTH = "-c http.https://github.com.extraheader=""AUTHORIZATION: basic $GitHubPATBase64"""
+
+exec "git init"
+git remote add origin https://ceapex.visualstudio.com/Engineering/_git/Docs.DocFX.Impact
+exec "git $env:GITHUB_GIT_AUTH $env:DEVOPS_GIT_AUTH fetch --progress"
+exec "git checkout origin/master --force --progress"
+exec "git $env:GITHUB_GIT_AUTH $env:DEVOPS_GIT_AUTH submodule update --init --progress"
+
+exec "npm install"
+exec "npm run impact -- --push"
+
+popd


### PR DESCRIPTION
- Codify deployment process using azure pipeline yaml build definition
- Ensure build don't hang due to invalid git credential by setting `GIT_TERMINAL_PROMPT = 0`
- Does not pollute global git config by using `git -c http.extraheader` for authentication
- Use only one build pipeline `docfx-deploy` for deployment (NOTE: pending corresponding changes in impact repo)

#3473 