### PR TITLE
Fix e2e name and ordinal mismatch

### DIFF
--- a/test/docfx.Test/e2e/E2ETest.cs
+++ b/test/docfx.Test/e2e/E2ETest.cs
@@ -96,8 +96,11 @@ namespace Microsoft.Docs.Build
                         i++;
                         continue;
                     }
-
+#if DEBUG
                     var only = header.Contains("[ONLY]", StringComparison.OrdinalIgnoreCase);
+#else
+                    var only = false;
+#endif
                     specNames.Add(($"{Path.GetFileNameWithoutExtension(file)}/{i++:D2}. {header}", only));
                 }
             }


### PR DESCRIPTION
Sometimes, debugging an e2e test finds the wrong test case, this PR fix that.