### PR TITLE
Upgrade NuGet packages

### DIFF
--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -285,7 +285,7 @@ inputs:
     http://*.windowsupdate.microsoft.com
 outputs:
   docs/a.json: |
-    { "content": "<p><a href=\"http://*.windowsupdate.microsoft.com\">http://*.windowsupdate.microsoft.com</a></p>" }
+    { "content": "<p>http://*.windowsupdate.microsoft.com</p>" }
   build.manifest:
 ---
 # validate bookmarks in markdown documents

--- a/src/Microsoft.Docs.Template/Microsoft.Docs.Template.csproj
+++ b/src/Microsoft.Docs.Template/Microsoft.Docs.Template.csproj
@@ -7,6 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
   </ItemGroup>
 </Project>

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -17,20 +17,20 @@
 
   <ItemGroup>
     <PackageReference Include="DotLiquid" Version="2.0.298" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.8.7" />
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.233" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.2" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.8.9" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.235" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.DocAsCode.MarkdigEngine.Extensions" Version="2.40.0-b-180913014-g200c02e" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.DocAsCode.MarkdigEngine.Extensions" Version="2.40.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Jint" Version="2.11.58" />
     <PackageReference Include="Octokit" Version="0.32.0" />
-    <PackageReference Include="Stubble.Core" Version="1.0.112" />
+    <PackageReference Include="Stubble.Core" Version="1.1.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="All" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-e171109-2" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
-    <PackageReference Include="YamlDotNet" Version="5.0.1" />
+    <PackageReference Include="YamlDotNet" Version="5.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/docfx/lib/git/NativeMethods.cs
+++ b/src/docfx/lib/git/NativeMethods.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Docs.Build
 {
     internal static class NativeMethods
     {
-        private const string LibName = "git2-b0d9952";
+        private const string LibName = "git2-8e0b172";
         private static readonly DateTimeOffset s_epoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
         static NativeMethods()

--- a/test/docfx.Test/docfx.Test.csproj
+++ b/test/docfx.Test/docfx.Test.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />


### PR DESCRIPTION
Fixes YamlDotNet security, incorporate latest markdig changes. #3272 https://github.com/dotnet/docfx/issues/3508