### PR TITLE
fix codesnippet tagname bug

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/CodeSnippet/CodeSnippetExtrator.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/CodeSnippet/CodeSnippetExtrator.cs
@@ -6,10 +6,12 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
     using System;
     using System.Collections.Generic;
     using System.Text;
+    using System.Text.RegularExpressions;
     using Markdig.Helpers;
 
     public class CodeSnippetExtrator
     {
+        private static readonly Regex TagnameFormat = new Regex(@"^[\w\.]+$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private readonly string StartLineTemplate;
         private readonly string EndLineTemplate;
         private readonly bool IsEndLineContainsTagName;
@@ -37,7 +39,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
                 string tagName;
 
-                if(MatchTag(line, EndLineTemplate, out tagName))
+                if(MatchTag(line, EndLineTemplate, out tagName, IsEndLineContainsTagName))
                 {
                     tagLines.Add(index);
                     if (!IsEndLineContainsTagName)
@@ -73,7 +75,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             return result;
         }
 
-        private bool MatchTag(string line, string template, out string tagName)
+        private bool MatchTag(string line, string template, out string tagName, bool containTagname = true)
         {
             tagName = string.Empty;
             if (string.IsNullOrEmpty(line) || string.IsNullOrEmpty(template)) return false;
@@ -121,8 +123,8 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
             if (index != afterTagName.Length) return false;
             while (column < line.Length && CharHelper.IsWhitespace(line[column])) column++;
-            
-            return column == line.Length;
+
+            return column == line.Length && (!containTagname || TagnameFormat.IsMatch(tagName));
         }
     }
 }

--- a/test/Microsoft.DocAsCode.MarkdigEngine.Tests/CodeSnippetTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdigEngine.Tests/CodeSnippetTest.cs
@@ -540,6 +540,28 @@ public static void Foo()
                 marked.Dependency.OrderBy(x => x));
         }
 
+        [Fact]
+        public void CodeSnippetShouldVerifyTagname()
+        {
+            //arange
+            var content = @"    line for start & end
+    // <tag1>
+    line1
+    // <Content=""my"">
+    // </tag1>
+" + " \tline for indent & range";
+
+            File.WriteAllText("Program.cs", content.Replace("\r\n", "\n"));
+
+            var marked = TestUtility.MarkupWithoutSourceInfo(@"[!code-csharp[name](Program.cs#tag1)]", "Topic.md");
+
+            // assert
+            var expected = @"<pre><code class=""lang-csharp"" name=""name"">line1
+// &lt;Content=&quot;my&quot;&gt;
+</code></pre>";
+            Assert.Equal(expected.Replace("\r\n", "\n"), marked.Html);
+        }
+
 
         [Fact(Skip = "won't support")]
         [Trait("Related", "DfmMarkdown")]


### PR DESCRIPTION
This PR is used to fix some codesnippet source content was misunderstood as tagname.  Add a validation for the tagname following DFM rule.