### PR TITLE
Replace some process mutex with ProcessUtility.ReadFile/WriteFile

### DIFF
--- a/src/docfx/build/metadata/ContributionInfo.cs
+++ b/src/docfx/build/metadata/ContributionInfo.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Docs.Build
             }
 
             var path = docset.RestoreMap.GetUrlRestorePath(docset.DocsetPath, docset.Config.Contribution.GitCommitsTime);
-            var content = ProcessUtility.ReadFile(path).Result; // TODO:
+            var content = ProcessUtility.ReadFile(path).Result; // TODO: Merge with https://github.com/dotnet/docfx/pull/3530
             return JsonUtility.Deserialize<GitCommitsTime>(content).Item2.ToDictionary();
         }
 

--- a/src/docfx/lib/ProcessUtility.cs
+++ b/src/docfx/lib/ProcessUtility.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Docs.Build
         /// </summary>
         public static bool IsFileUsedByAnotherProcessException(IOException ex)
         {
-            return ex.HResult == 35 /*|| ex.HResult == 17*/;
+            return ex.HResult == 35 || ex.HResult == -2147024864;
         }
 
         /// <summary>

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Docs.Build
             {
                 return parser(await ProcessUtility.Execute("git", commandLineArgs, cwd, redirectOutput));
             }
-            catch (Win32Exception ex) when (ProcessUtility.IsNotFound(ex))
+            catch (Win32Exception ex) when (ProcessUtility.IsExeNotFoundException(ex))
             {
                 throw Errors.GitNotFound().ToException(ex);
             }

--- a/src/docfx/lib/github/GitHubUserCache.cs
+++ b/src/docfx/lib/github/GitHubUserCache.cs
@@ -125,19 +125,18 @@ namespace Microsoft.Docs.Build
 
         public Task SaveChanges()
         {
-            return _updated ? ProcessUtility.RunInsideMutex(_cachePath, WriteCache) : Task.CompletedTask;
-
-            Task WriteCache()
+            if (!_updated)
             {
-                lock (_lock)
-                {
-                    var file = new GitHubUserCacheFile
-                    {
-                        Users = Users.ToArray(),
-                    };
-                    JsonUtility.WriteJsonFile(_cachePath, file);
-                }
                 return Task.CompletedTask;
+            }
+
+            lock (_lock)
+            {
+                var file = new GitHubUserCacheFile
+                {
+                    Users = Users.ToArray(),
+                };
+                return ProcessUtility.WriteFile(_cachePath, JsonUtility.Serialize(file));
             }
         }
 
@@ -214,24 +213,19 @@ namespace Microsoft.Docs.Build
         private DateTime NextExpiry()
             => DateTime.UtcNow.AddHours((_expirationInHours / 2) + (t_random.Value.NextDouble() * _expirationInHours));
 
-        private Task ReadCacheFile()
+        private async Task ReadCacheFile()
         {
-            return ProcessUtility.RunInsideMutex(_cachePath, UpdateCache);
-
-            Task UpdateCache()
+            if (File.Exists(_cachePath))
             {
-                if (File.Exists(_cachePath))
+                var content = await ProcessUtility.ReadFile(_cachePath);
+                var users = JsonUtility.Deserialize<GitHubUserCacheFile>(content).Item2?.Users;
+                if (users != null)
                 {
-                    var users = JsonUtility.ReadJsonFile<GitHubUserCacheFile>(_cachePath)?.Users;
-                    if (users != null)
+                    lock (_lock)
                     {
-                        lock (_lock)
-                        {
-                            UnsafeUpdateUsers(users);
-                        }
+                        UnsafeUpdateUsers(users);
                     }
                 }
-                return Task.CompletedTask;
             }
         }
 

--- a/test/docfx.Test/lib/ProcessUtilityTest.cs
+++ b/test/docfx.Test/lib/ProcessUtilityTest.cs
@@ -14,32 +14,67 @@ namespace Microsoft.Docs.Build
 {
     public static class ProcessUtilityTest
     {
+        static ProcessUtilityTest()
+        {
+            Directory.CreateDirectory("process-test");
+        }
+
         [Fact]
         public static void ExeNotFoundMessage()
         {
             var ex = Assert.Throws<Win32Exception>(() => Process.Start("a-fake-exe"));
-            Assert.True(ProcessUtility.IsNotFound(ex), ex.ErrorCode + " " + ex.NativeErrorCode + " " + ex.Message);
+            Assert.True(ProcessUtility.IsExeNotFoundException(ex), ex.ErrorCode + " " + ex.NativeErrorCode + " " + ex.Message);
         }
 
         [Fact]
-        public static async Task CreateFilesInMutexInParallelDoesNotThrow()
+        public static void FileUsedByAnotherProcessMessage()
         {
-            var fileName = $"process-test\\{Guid.NewGuid()}";
-            await Task.WhenAll(Enumerable.Range(0, 5).AsParallel().Select(
-                i => ProcessUtility.RunInsideMutex(
-                    fileName,
-                    () =>
-                    {
-                        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(fileName)));
-                        using (var streamWriter = File.CreateText(fileName))
-                        {
-                            Thread.Sleep(100);
-                            streamWriter.WriteLine(fileName);
-                        }
+            var path = $"process-test/{Guid.NewGuid()}";
+            var content = Guid.NewGuid().ToString();
+            File.WriteAllText(path, content);
 
-                        File.Delete(fileName);
-                        return Task.FromResult(0);
-                    })));
+            using (Read())
+            {
+                using (Read()) { }
+                var ex = Assert.Throws<IOException>(Write);
+                Assert.True(ProcessUtility.IsFileUsedByAnotherProcessException(ex), ex.HResult + " " + ex.Message);
+            }
+
+            using (Write())
+            {
+                Assert.True(ProcessUtility.IsFileUsedByAnotherProcessException(Assert.Throws<IOException>(Read)));
+                Assert.True(ProcessUtility.IsFileUsedByAnotherProcessException(Assert.Throws<IOException>(Write)));
+            }
+
+            using (Read()) { }
+
+            Stream Read() => new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            Stream Write() => new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
+        }
+
+        [Fact]
+        public static async Task FileMutexTest()
+        {
+            var concurrencyLevel = 0;
+            var fileName = $"process-test/{Guid.NewGuid()}";
+
+            try
+            {
+                await ParallelUtility.ForEach(
+                    Enumerable.Range(0, 5),
+                    i => ProcessUtility.RunInsideMutex(
+                        fileName,
+                        async () =>
+                        {
+                            Assert.Equal(1, Interlocked.Increment(ref concurrencyLevel));
+                            await Task.Delay(100);
+                            Assert.Equal(0, Interlocked.Decrement(ref concurrencyLevel));
+                        }));
+            }
+            catch (IOException ex)
+            {
+                Assert.False(ProcessUtility.IsFileAlreadyExistsException(ex), ex.HResult + " " + ex.Message);
+            }
         }
     }
 }


### PR DESCRIPTION
- Add `ProcessUtility.ReadFile/WriteFile` for better inter-process single file read write. It uses `FileShare` to control access, it does not use a separate file lock, provide concurrent read on the same file.
- Replace git commits time with the new methods
- Will replace git commit history cache read/write when https://github.com/dotnet/docfx/pull/3530 is in.