### PR TITLE
Add lowercaseUrl option to lowercase links and output filenames

### DIFF
--- a/docs/specs/casing.yml
+++ b/docs/specs/casing.yml
@@ -6,7 +6,7 @@ inputs:
   docs/b.md:
 outputs:
   docs/a.json: |
-    { "content": "<p>Link to <a href=\"B\">b</a></p>" }
+    { "content": "<p>Link to <a href=\"b\">b</a></p>" }
   docs/b.json:
   build.manifest:
 ---
@@ -59,7 +59,35 @@ inputs:
   docs/A.md:
   docs/b/b.md:
 outputs:
-  output/A.json:
+  output/a.json:
   output/b.json:
+  build.manifest:
+---
+# Resolve to the same lowercase image on windows and mac
+os: windows, osx
+inputs:
+  docfx.yml:
+  docs/a.md: '![](IMAGE.png)'
+  docs/b.md: '![](image.PNG)'
+  docs/IMAGE.PNG:
+outputs:
+  docs/a.json: |
+    {"content":"<p><img src=\"image.png\" alt=\"\" /></p>"}
+  docs/b.json: |
+    {"content":"<p><img src=\"image.png\" alt=\"\" /></p>"}
+  docs/image.png:
+  build.manifest:
+---
+# Preserve URL casing when lowercaseUrl is false
+inputs:
+  docfx.yml: |
+    output:
+      lowercaseUrl: false
+  docs/A.md: '[](B.md)'
+  docs/B.md:
+outputs:
+  docs/A.json: |
+    {"content":"<p><a href=\"B\"></a></p>"}
+  docs/B.json:
   build.manifest:
 ---

--- a/docs/specs/casing.yml
+++ b/docs/specs/casing.yml
@@ -11,7 +11,6 @@ outputs:
   build.manifest:
 ---
 # URL is case insensitive on windows and mac
-os: windows, osx
 inputs:
   docfx.yml:
   docs/A.png.md: '![](a.png)'

--- a/docs/specs/config.yml
+++ b/docs/specs/config.yml
@@ -216,9 +216,9 @@ outputs:
   output/a.json:
   output/b.json:
   output/d.svg:
-  outputB/docs/c.png:
-  outputB/docs/g/a.json:
-  outputB/docs/g/e.jpg:
+  outputb/docs/c.png:
+  outputb/docs/g/a.json:
+  outputb/docs/g/e.jpg:
   build.manifest:
 ---
 # latter routes rule takes precedence - 1
@@ -232,8 +232,8 @@ inputs:
     [link](c.gif)
   docs/a/c.gif:
 outputs:
-  outputB/b.json:
-  outputC/c.gif:
+  outputb/b.json:
+  outputc/c.gif:
   build.manifest:
 ---
 # latter routes rule takes precedence - 2

--- a/docs/specs/git.yml
+++ b/docs/specs/git.yml
@@ -2,7 +2,7 @@
 # Show git contribution info when userProfile & commitsTime is set to URL
 repo: https://github.com/docascode/docfx-test-dependencies#github-user-cache-url
 outputs:
-  README.json: |
+  readme.json: |
     {
       "author": {
         "name": "superyyrrzz",
@@ -38,7 +38,7 @@ inputs:
   contribution:
     gitCommitsTime: build_history.json
 outputs:
-  README.json: |
+  readme.json: |
     {
       "author": {
         "name": "superyyrrzz",
@@ -82,7 +82,7 @@ inputs:
       ]
     }
 outputs:
-  README.json:
+  readme.json:
   build.manifest:
   build.log: |
     ["warning","github-user-not-found","Cannot find user 'invalid_user' on GitHub","README.md"]
@@ -105,7 +105,7 @@ inputs:
       ]
     }
 outputs:
-  README.json: |
+  readme.json: |
     {
       "author": {
         "name": "real_author",
@@ -154,7 +154,7 @@ inputs:
         - superyyrrZZ
         - YUFEIH
 outputs:
-  README.json: |
+  readme.json: |
     {
       "author":  {
         "name": "OsmondJiang",
@@ -193,7 +193,7 @@ inputs:
       excludedContributors:
         - superyyrrZZ
 outputs:
-  README.json: |
+  readme.json: |
     {
       "!author": null,
       "contributors": [
@@ -216,7 +216,7 @@ outputs:
 # Show content_git_url, original_content_git_url and gitcommit
 repo: https://github.com/docascode/docfx-test-dependencies#github-user-cache-file
 outputs:
-  README.json: |
+  readme.json: |
     {
       "open_to_public_contributors": true,
       "content_git_url": "https://github.com/docascode/docfx-test-dependencies/blob/github-user-cache-file/README.md",
@@ -236,7 +236,7 @@ inputs:
     contribution:
       repository: https://github.com/test-org/test-repo#contribution
 outputs:
-  README.json: |
+  readme.json: |
     {
       "content_git_url": "https://github.com/test-org/test-repo/blob/contribution/README.md",
       "original_content_git_url": "https://github.com/docascode/docfx-test-dependencies/blob/github-user-cache-file/README.md",
@@ -247,7 +247,7 @@ outputs:
 # Don't load git commits when showContributors is set to false
 repo: https://github.com/docascode/docfx-test-dependencies#no-load-commits
 outputs:
-  README.json: |
+  readme.json: |
     {
       "contributors": [],
       "gitcommit": "https://github.com/docascode/docfx-test-dependencies/blob/5087ddfc6ee4886bcabe8cc93673edd8605fe15c/README.md"
@@ -264,7 +264,7 @@ inputs:
       resolveUsers: true
     contribution:
 outputs:
-  README.json: |
+  readme.json: |
     {
       "updated_at": "2018-07-27T02:15:49Z",
     }
@@ -273,12 +273,12 @@ outputs:
 # Support git submodule
 repo: https://github.com/docascode/docfx-test-dependencies#docset-with-submodule
 outputs:
-  README.json: |
+  readme.json: |
     {
       "gitcommit": "https://github.com/docascode/docfx-test-dependencies/blob/c467c848311ccd2550fdb25a77ef26f9d8a33d00/README.md",
       "updated_at": "2018-04-23T03:23:37Z"
     }
-  docfx-test-submodule/README.json: |
+  docfx-test-submodule/readme.json: |
     {
       "gitcommit": "https://github.com/docascode/docfx-test-submodule/blob/b6601c200859547c7fcd44a44788f77a08576505/README.md",
       "updated_at": "2018-07-18T05:03:26Z"

--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -253,10 +253,10 @@ inputs:
 outputs:
   build.manifest:
   docs/a.json: |
-    {"toc_rel": "TOC.json"}
+    {"toc_rel": "toc.json"}
   docs/b.json: |
-    {"toc_rel": "TOC.json"}
-  docs/TOC.json: |
+    {"toc_rel": "toc.json"}
+  docs/toc.json: |
     {"items": [{"toc_title": "reference a", "href": "a"},{"toc_title": "reference b", "href": "b"}]}
 ---
 # loc build with mixed toc map
@@ -282,8 +282,8 @@ inputs:
 outputs:
   build.manifest:
   docs/b/b.json: |
-    {"toc_rel": "TOC.json"}
-  docs/a/TOC.json: |
+    {"toc_rel": "toc.json"}
+  docs/a/toc.json: |
     {"items": [{"toc_title": "reference a", "href": "a"}]}
 ---
 # loc build with mixed toc map, all loc files are in source repo under different locale folder
@@ -310,8 +310,8 @@ inputs:
 outputs:
   build.manifest:
   docs/b/b.json: |
-    {"toc_rel": "TOC.json"}
-  docs/a/TOC.json: |
+    {"toc_rel": "toc.json"}
+  docs/a/toc.json: |
     {"items": [{"toc_title": "reference a", "href": "a"}]}
 ---
 # loc build with xref map, loc file has higher priority

--- a/docs/specs/manifest.yml
+++ b/docs/specs/manifest.yml
@@ -8,7 +8,7 @@ inputs:
   docs/index.md:
 outputs:
   docs/a.json:
-  docs/TOC.json:
+  docs/toc.json:
   docs/folder/b~$.json:
   docs/index.json:
   build.manifest: |
@@ -17,7 +17,7 @@ outputs:
         { "siteUrl": "/docs/a", "outputPath": "docs/a.json" },
         { "siteUrl": "/docs/folder/b~$", "outputPath": "docs/folder/b~$.json" },
         { "siteUrl": "/docs/", "outputPath": "docs/index.json" },
-        { "siteUrl": "/docs/TOC.json", "outputPath": "docs/TOC.json" }
+        { "siteUrl": "/docs/toc.json", "outputPath": "docs/toc.json" }
       ]
     }
 ---
@@ -44,7 +44,7 @@ inputs:
     # [file reference](a.md)
 outputs:
   docs/a.json:
-  docs/TOC.json:
+  docs/toc.json:
   build.manifest: |
     {  
        "dependencies":{  
@@ -140,21 +140,21 @@ inputs:
     # [b](b.md)
   docs/a/b.md:
 outputs:
-  docs/TOC.json:
+  docs/toc.json:
   docs/a/b.json:
   build.manifest: |
     {  
-       "dependencies":{  
+       "dependencies":{
+          "docs/TOC.md":[
+             {  
+                "source":"docs/a/TOC.md",
+                "type":"tocInclusion"
+             }
+          ],
           "docs/a/TOC.md":[  
              {  
                 "source":"docs/a/b.md",
                 "type":"link"
-             }
-          ],
-          "docs/TOC.md":[  
-             {  
-                "source":"docs/a/TOC.md",
-                "type":"tocInclusion"
              }
           ]
        }

--- a/docs/specs/metadata.yml
+++ b/docs/specs/metadata.yml
@@ -172,12 +172,12 @@ inputs:
     items:
       - name: title
 outputs:
-  docs/json/TOC.json: |
+  docs/json/toc.json: |
     {  
       "metadata": {"a": "b"},
       "items":[{"toc_title":"title"}]
     }
-  docs/yaml/TOC.json: |
+  docs/yaml/toc.json: |
     {  
       "metadata": {"a": "b"},
       "items":[{"toc_title":"title"}]
@@ -193,11 +193,11 @@ inputs:
     - name: title
       a: b
 outputs:
-  docs/json/TOC.json: |
+  docs/json/toc.json: |
     {  
       "items":[{"toc_title":"title", "a": "b"}]
     }
-  docs/yaml/TOC.json: |
+  docs/yaml/toc.json: |
     {  
       "items":[{"toc_title":"title", "a": "b"}]
     }
@@ -216,7 +216,7 @@ inputs:
     - name: toc reference
       tocHref: ../json/TOC.json
 outputs:
-  docs/yaml/TOC.json: |
+  docs/yaml/toc.json: |
     {  
       "items":[{"toc_title":"toc reference", "children": [{"toc_title":"title", "c": "d"}]}]
     }
@@ -237,15 +237,15 @@ inputs:
   docs/md/TOC.md: |
     # title
 outputs:
-  docs/yaml/TOC.json: |
+  docs/yaml/toc.json: |
     {  
       "items":[{"toc_title":"title"}], "metadata": {"a":"b", "c": "d"}
     }
-  docs/json/TOC.json: |
+  docs/json/toc.json: |
     {  
       "items":[{"toc_title":"title"}], "metadata": {"a":"b"}
     }
-  docs/md/TOC.json: |
+  docs/md/toc.json: |
     {  
       "items":[{"toc_title":"title"}], "metadata": {"a":"b"}
     }

--- a/docs/specs/schema.yml
+++ b/docs/specs/schema.yml
@@ -68,10 +68,10 @@ inputs:
     breadcrumb_path: TOC.yml
     toc_rel: ../TOC.yml
 outputs:
-  docs/TOC.json:
+  docs/toc.json:
   docs/a.json: |
     {
-      "content": { "brand": "azure", "breadcrumb_path": "TOC.json", "toc_rel": "../TOC.json" },
+      "content": { "brand": "azure", "breadcrumb_path": "toc.json", "toc_rel": "../toc.json" },
     }
   build.manifest: |
     {  
@@ -101,7 +101,7 @@ inputs:
     breadcrumb_path: {}
     toc_rel: ../TOC.yml
 outputs:
-  docs/TOC.json:
+  docs/toc.json:
   build.manifest:
   build.log: |
     ["error","violate-schema","Cannot deserialize the current JSON object * into type 'System.String' because the type requires a JSON primitive value *","docs/a.yml","breadcrumb_path",3,18]

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -17,7 +17,7 @@ outputs:
   docs/index.json:
   docs/n1.json:
   docs/f1/n1.json:
-  docs/TOC.json: |
+  docs/toc.json: |
     {  
       "items":[  
           {  
@@ -59,7 +59,7 @@ inputs:
   docs/TOC.json: |
     [{ "name": "title" }]
 outputs:
-  docs/TOC.json: |
+  docs/toc.json: |
     {  
       "items":[
           {
@@ -88,7 +88,7 @@ inputs:
     [{ "name": "b", "href": "b.md" }]
   docs/a/b.md:
 outputs:
-  docs/TOC.json: |
+  docs/toc.json: |
     {
       "items": [
         {
@@ -97,7 +97,7 @@ outputs:
         }
       ]
     }
-  docs/a/TOC.json: |
+  docs/a/toc.json: |
     {
       "items": [
         {
@@ -122,7 +122,7 @@ inputs:
     ### [Reference No-Existing File 4](~/docs/no-existing.md)
 outputs:
   docs/index.json:
-  docs/TOC.json: |
+  docs/toc.json: |
     {  
       "items":[  
           {  
@@ -172,7 +172,7 @@ inputs:
     ### [Reference Absolute Path 2](/help/style/style-how-to-accessibility?toc=/help/contribute/TOC.json&bc=toc=%2Fazure%2Fapi-management%2Ftoc.json)
 outputs:
   docs/index.json:
-  docs/TOC.json: |
+  docs/toc.json: |
     {  
       "items":[  
           {  
@@ -211,7 +211,7 @@ inputs:
   docs/f1/index.md:
 outputs:
   docs/f1/index.json:
-  docs/TOC.json: |
+  docs/toc.json: |
     {  
        "items":[  
           {  
@@ -264,7 +264,7 @@ inputs:
   docs/f1/f11/index.md:
 outputs:
   docs/f1/f11/index.json:
-  docs/TOC.json: |
+  docs/toc.json: |
    {  
        "items":[  
           {  
@@ -307,7 +307,7 @@ inputs:
   docs/index.md:
 outputs:
   docs/index.json:
-  docs/TOC.json: |
+  docs/toc.json: |
     {  
       "items":[  
           {  
@@ -400,7 +400,7 @@ inputs:
 outputs:
   docs/f1/a.json:
   docs/f1/index.json:
-  docs/TOC.json: |
+  docs/toc.json: |
     {  
        "items":[  
           {  
@@ -435,7 +435,7 @@ inputs:
   docs/f1/index.md:
 outputs:
   docs/f1/index.json:
-  docs/TOC.json: |
+  docs/toc.json: |
    {  
        "items":[  
           {  
@@ -444,7 +444,7 @@ outputs:
           }
        ]
     }
-  docs/f1/TOC.json:
+  docs/f1/toc.json:
   build.manifest:
 ---
 # Reference to a folder, first child
@@ -468,7 +468,7 @@ inputs:
 outputs:
   docs/f2/a.json:
   docs/f1/b.json:
-  docs/TOC.json: |
+  docs/toc.json: |
    {  
        "items":[  
           {  
@@ -481,8 +481,8 @@ outputs:
           }
        ]
     }
-  docs/f1/TOC.json:
-  docs/f2/TOC.json:
+  docs/f1/toc.json:
+  docs/f2/toc.json:
   build.manifest:
   build.log: |
     ["warning","file-not-found","Cannot find file 'b.md' relative to 'docs/f2/TOC.md'","docs/f2/TOC.md"]
@@ -496,7 +496,7 @@ inputs:
   docs/f1/a.md:
 outputs:
   docs/f1/a.json:
-  docs/TOC.json: |
+  docs/toc.json: |
     {  
        "items":[  
           {  
@@ -519,7 +519,7 @@ inputs:
     # [Reference a](a.md)
 outputs:
   docs/f1/a.json:
-  docs/TOC.json: |
+  docs/toc.json: |
     {  
        "items":[  
           {  
@@ -548,7 +548,7 @@ inputs:
     # [Reference a](a.md)
 outputs:
   docs/f1/a.json:
-  docs/TOC.json: |
+  docs/toc.json: |
     {  
        "items":[  
           {  
@@ -578,8 +578,8 @@ inputs:
     # [Reference a](a.md)
 outputs:
   docs/f2/a.json:
-  docs/f1/TOC.json:
-  docs/TOC.json: |
+  docs/f1/toc.json:
+  docs/toc.json: |
     {  
        "items":[  
           {  
@@ -606,7 +606,7 @@ inputs:
       href: ~/docs/f1/n1.md
       topicHref: ~/docs/f1/n2.md
 outputs:
-  docs/f1/TOC.json: |
+  docs/f1/toc.json: |
     {  
        "items":[  
           {  
@@ -634,7 +634,7 @@ inputs:
     # [Index Reference](n1.md)
   docs/f1/f11/n1.md:
 outputs:
-  docs/f1/TOC.json: |
+  docs/f1/toc.json: |
     {  
        "items":[  
           {  
@@ -669,8 +669,8 @@ inputs:
   docs/f1/TOC.md:
 outputs:
   docs/f1/a.json:
-  docs/f1/TOC.json:
-  docs/TOC.json: |
+  docs/f1/toc.json:
+  docs/toc.json: |
     {  
        "items":[  
           {  
@@ -695,8 +695,8 @@ inputs:
 outputs:
   docs/f1/a.json:
   docs/f1/b.json:
-  docs/f1/TOC.json:
-  docs/TOC.json: |
+  docs/f1/toc.json:
+  docs/toc.json: |
     {  
        "items":[  
           {  
@@ -724,8 +724,8 @@ inputs:
 outputs:
   docs/f1/a.json:
   docs/f1/b.json:
-  docs/f1/TOC.json:
-  docs/TOC.json: |
+  docs/f1/toc.json:
+  docs/toc.json: |
     {  
        "items":[  
           {  
@@ -749,7 +749,7 @@ inputs:
       href: /abc/def
   docs/f1/TOC.md:
 outputs:
-  docs/f1/TOC.json:
+  docs/f1/toc.json:
   build.manifest:
   build.log: |
     ["error","invalid-topic-href","The topic href 'f1/' can only reference to a local file or absolute path","docs/TOC.yml"]
@@ -767,7 +767,7 @@ inputs:
   docs/f1/TOC.md:
   docs/f1/a.md:
 outputs:
-  docs/f1/TOC.json:
+  docs/f1/toc.json:
   docs/f1/a.json:
   build.manifest:
   build.log: |
@@ -824,11 +824,11 @@ inputs:
 outputs:
   docs/index.json:
   build.manifest:
-  docs/f1/TOC.experimental.json: |
+  docs/f1/toc.experimental.json: |
     {"items":[{"toc_title":"Index Reference","href":"../"}]}
-  docs/f2/TOC.experimental.json: |
+  docs/f2/toc.experimental.json: |
     {"items":[{"toc_title":"Index Reference","href":"../"}]}
-  docs/f3/TOC.experimental.json: |
+  docs/f3/toc.experimental.json: |
     {"items":[{"toc_title":"Index Reference","href":"../"}]}
 ---
 # Paired experimental TOC should be built 
@@ -841,8 +841,8 @@ inputs:
 outputs:
   docs/index.json:
   build.manifest:
-  docs/f1/TOC.json:
-  docs/f1/TOC.experimental.json: |
+  docs/f1/toc.json:
+  docs/f1/toc.experimental.json: |
     {"items":[{"toc_title":"Index Reference","href":"../"}]}
 ---
 # Paired experimental markdown TOCs' metadata
@@ -863,9 +863,9 @@ inputs:
 outputs:
   docs/index.json:
   build.manifest:
-  docs/f1/TOC.json: |
+  docs/f1/toc.json: |
     {"metadata": {"experimental": true, "experiment_id": "d1c17cc0-2ae0-4b"}}
-  docs/f1/TOC.experimental.json: |
+  docs/f1/toc.experimental.json: |
     {"items":[{"toc_title":"Index Reference","href":"../"}], "metadata": {"experimental": false, "experiment_id": "d1c17cc0-2ae0-4b"}}
 ---
 # Paired experimental yml TOCs' metadata
@@ -883,9 +883,9 @@ inputs:
       experiment_id: "d1c17cc0-2ae0-4b"
 outputs:
   build.manifest:
-  docs/f1/TOC.json: |
+  docs/f1/toc.json: |
     {"metadata": {"experimental": true, "experiment_id": "d1c17cc0-2ae0-4b"}}
-  docs/f1/TOC.experimental.json: |
+  docs/f1/toc.experimental.json: |
     {"items":[{"toc_title":"title"}], "metadata": {"experimental": false, "experiment_id": "d1c17cc0-2ae0-4b"}}
 ---
 # Experimental TOC should be removed from toc map
@@ -900,12 +900,12 @@ inputs:
   docs/a.md:
 outputs:
   docs/index.json: |
-    {"toc_rel": "f1/TOC.json"}
+    {"toc_rel": "f1/toc.json"}
   docs/a.json: |
     {"!toc_rel": null}
   build.manifest:
-  docs/f1/TOC.json:
-  docs/f1/TOC.experimental.json:
+  docs/f1/toc.json:
+  docs/f1/toc.experimental.json:
 ---
 # Experimental TOC should be included using toc ref
 inputs:
@@ -918,7 +918,7 @@ inputs:
 outputs:
   docs/index.json:
   build.manifest:
-  docs/f1/TOC.json: |
+  docs/f1/toc.json: |
     {"items":[{"toc_title":"TOC Reference","children":[{"toc_title": "Index Reference", "href": "../"}]}]}
 ---
 # Experimental TOC should be excluded using folder ref
@@ -932,8 +932,8 @@ inputs:
 outputs:
   docs/index.json:
   build.manifest:
-  docs/f2/TOC.experimental.json:
-  docs/f1/TOC.json: |
+  docs/f2/toc.experimental.json:
+  docs/f1/toc.json: |
     {"items":[{"toc_title":"TOC Reference"}]}
 ---
 # Toc with null value
@@ -949,7 +949,7 @@ inputs:
 outputs:
   docs/f1/a.json:
   docs/f1/b.json:
-  docs/TOC.json:
+  docs/toc.json:
   build.manifest:
   build.log: |
     ["info","null-value","'tocHref' contains null value","docs/TOC.yml","[0].tocHref",3,3]
@@ -981,11 +981,11 @@ inputs:
   docs/file-with-no-toc.md:
   docs/dir1/dir2/file-with-toc.md:
 outputs:
-  docs/dir1/TOC.json:
+  docs/dir1/toc.json:
   docs/file-with-no-toc.json: |
     {"!toc_rel": null}
   docs/dir1/dir2/file-with-toc.json: |
-    {"toc_rel": "../TOC.json"}
+    {"toc_rel": "../toc.json"}
   build.manifest:
 ---
 # File referenced by multiple toc with same parent and subdir count, use order alphabetical. For other tests, reference build/TocTest.
@@ -1002,11 +1002,11 @@ inputs:
       href: ../c/file1.md
   docs/dir1/c/file1.md:
 outputs:
-  docs/dir1/a/TOC.json:
-  docs/dir1/b/TOC.json:
-  docs/dir1/aa/TOC.json:
+  docs/dir1/a/toc.json:
+  docs/dir1/b/toc.json:
+  docs/dir1/aa/toc.json:
   docs/dir1/c/file1.json: |
-    {"toc_rel": "../a/TOC.json"}
+    {"toc_rel": "../a/toc.json"}
   build.manifest:
 ---
 # Bad Toc markdown
@@ -1057,7 +1057,7 @@ inputs:
   docs/TOC.md: |
     # Title **Title2** [Title3](https://github.com/docfx)
 outputs:
-  docs/TOC.json: |
+  docs/toc.json: |
     {"items":[{"toc_title":"Title3", "href": "https://github.com/docfx"}]}
   build.manifest:
 ---
@@ -1070,6 +1070,6 @@ inputs:
       expanded: true
       name: "test"
 outputs:
-  docs/TOC.json: |
+  docs/toc.json: |
     {"items": [{"maintainContext": true, "expanded": true}]}
   build.manifest:

--- a/schemas/docfx.json
+++ b/schemas/docfx.json
@@ -158,6 +158,9 @@
         "uglifyUrl": {
           "type": "boolean"
         },
+        "lowerCaseUrl": {
+          "type": "boolean"
+        },
         "copyResources": {
           "type": "boolean"
         },

--- a/src/docfx/config/OutputConfig.cs
+++ b/src/docfx/config/OutputConfig.cs
@@ -32,6 +32,11 @@ namespace Microsoft.Docs.Build
         public readonly bool UglifyUrl = false;
 
         /// <summary>
+        /// Gets whether to lowercase all URLs and output file path.
+        /// </summary>
+        public readonly bool LowerCaseUrl = true;
+
+        /// <summary>
         /// Gets whether resources are copied to output.
         /// </summary>
         public readonly bool CopyResources = true;

--- a/src/docfx/docset/Document.cs
+++ b/src/docfx/docset/Document.cs
@@ -215,6 +215,11 @@ namespace Microsoft.Docs.Build
             var routedFilePath = ApplyRoutes(filePath, docset.Config.Routes);
 
             var sitePath = FilePathToSitePath(routedFilePath, type, schema, docset.Config.Output.Json, docset.Config.Output.UglifyUrl);
+            if (docset.Config.Output.LowerCaseUrl)
+            {
+                sitePath = sitePath.ToLowerInvariant();
+            }
+
             var siteUrl = PathToAbsoluteUrl(sitePath, type, schema, docset.Config.Output.Json);
             var outputPath = sitePath;
             var contentType = redirectionUrl != null ? ContentType.Redirection : type;

--- a/test/docfx.Test/build/TocTest.cs
+++ b/test/docfx.Test/build/TocTest.cs
@@ -17,35 +17,35 @@ namespace Microsoft.Docs.Build
 
         [Theory]
         // same level
-        [InlineData(new[] { "TOC.md" }, "b.md", "TOC.json")]
-        [InlineData(new[] { "TOC.md", "a/TOC.md" }, "b.md", "TOC.json")]
-        [InlineData(new[] { "TOC.md", "a/TOC.md" }, "a/b.md", "TOC.json")]
-        [InlineData(new[] { "b/TOC.md", "a/TOC.md" }, "a/b.md", "TOC.json")]
-        [InlineData(new[] { "TOC.md", "a/b/TOC.md" }, "a/b/b.md", "TOC.json")]
-        [InlineData(new[] { "c/a/d/TOC.md", "c/a/TOC.md" }, "c/a/d/b.md", "TOC.json")]
+        [InlineData(new[] { "TOC.md" }, "b.md", "toc.json")]
+        [InlineData(new[] { "TOC.md", "a/TOC.md" }, "b.md", "toc.json")]
+        [InlineData(new[] { "TOC.md", "a/TOC.md" }, "a/b.md", "toc.json")]
+        [InlineData(new[] { "b/TOC.md", "a/TOC.md" }, "a/b.md", "toc.json")]
+        [InlineData(new[] { "TOC.md", "a/b/TOC.md" }, "a/b/b.md", "toc.json")]
+        [InlineData(new[] { "c/a/d/TOC.md", "c/a/TOC.md" }, "c/a/d/b.md", "toc.json")]
 
         // next level(nearest)
-        [InlineData(new[] { "b/c/TOC.md", "a/TOC.md" }, "b.md", "a/TOC.json")]
-        [InlineData(new[] { "b/TOC.md", "a/b/TOC.md" }, "b.md", "b/TOC.json")]
-        [InlineData(new[] { "b/./TOC.md", "a/b/TOC.md" }, "b.md", "b/TOC.json")]
-        [InlineData(new[] { "b/../b/./TOC.md", "a/b/TOC.md" }, "b.md", "b/TOC.json")]
-        [InlineData(new[] { "b/../b/./TOC.md", "a/b/TOC.md" }, "a/../b.md", "b/TOC.json")]
-        [InlineData(new[] { "a/TOC.md", "a/b/TOC.md" }, "a/../b.md", "a/TOC.json")]
+        [InlineData(new[] { "b/c/TOC.md", "a/TOC.md" }, "b.md", "a/toc.json")]
+        [InlineData(new[] { "b/TOC.md", "a/b/TOC.md" }, "b.md", "b/toc.json")]
+        [InlineData(new[] { "b/./TOC.md", "a/b/TOC.md" }, "b.md", "b/toc.json")]
+        [InlineData(new[] { "b/../b/./TOC.md", "a/b/TOC.md" }, "b.md", "b/toc.json")]
+        [InlineData(new[] { "b/../b/./TOC.md", "a/b/TOC.md" }, "a/../b.md", "b/toc.json")]
+        [InlineData(new[] { "a/TOC.md", "a/b/TOC.md" }, "a/../b.md", "a/toc.json")]
 
         // order by folder name
-        [InlineData(new[] { "b/c/TOC.md", "b/d/TOC.md" }, "b.md", "b/c/TOC.json")]
+        [InlineData(new[] { "b/c/TOC.md", "b/d/TOC.md" }, "b.md", "b/c/toc.json")]
 
         // up level(nearest)
-        [InlineData(new[] { "TOC.md", "a/TOC.md" }, "b/b.md", "../TOC.json")]
-        [InlineData(new[] { "TOC.md", "c/a/TOC.md" }, "c/a/d/b.md", "../TOC.json")]
-        [InlineData(new[] { "c/b/TOC.md", "c/a/TOC.md" }, "c/a/d/b.md", "../TOC.json")]
+        [InlineData(new[] { "TOC.md", "a/TOC.md" }, "b/b.md", "../toc.json")]
+        [InlineData(new[] { "TOC.md", "c/a/TOC.md" }, "c/a/d/b.md", "../toc.json")]
+        [InlineData(new[] { "c/b/TOC.md", "c/a/TOC.md" }, "c/a/d/b.md", "../toc.json")]
 
         // order by levenshtein distance
-        [InlineData(new[] { "a/TOC.md", "b/TOC.md" }, "b.md", "b/TOC.json")]
-        [InlineData(new[] { "c/b/TOC.md", "c/a/TOC.md" }, "c/e/b.md", "../b/TOC.json")]
-        [InlineData(new[] { "a/multi-factor-authentication/TOC.md", "a/active-directory-domain-services/TOC.md" },
+        [InlineData(new[] { "a/TOC.md", "b/TOC.md" }, "b.md", "b/toc.json")]
+        [InlineData(new[] { "c/b/TOC.md", "c/a/TOC.md" }, "c/e/b.md", "../b/toc.json")]
+        [InlineData(new[] { "a/multi-factor-authentication/TOC.md", "a/active-directory-domain-services/toc.md" },
                     "a/multi-factor-authentication.md",
-                    "multi-factor-authentication/TOC.json")]
+                    "multi-factor-authentication/toc.json")]
         public static void FindTocRelativePath(string[] tocFiles, string file, string expectedTocPath)
         {
             var builder = new TableOfContentsMapBuilder();


### PR DESCRIPTION
This is to fix #3540 , the preferred approach is to lowercase all URLs, which is also the default docs behavior (parity with v2), users can opt-out of lowercase by setting `output/lowercaseUrl` to `false`. Similarly, Grav also has an [force_lowercase_urls](https://learn.getgrav.org/basics/grav-configuration#basic-options) that defaults to true.

Most of the changes are adjusting expected output of existing test cases. Source code only has ~2 lines of change in `Document.cs`. 2 new test cases are added in `casing.yml`