### PR TITLE
add cache to fix swagger parser perf issue

### DIFF
--- a/src/Microsoft.DocAsCode.Build.RestApi/Swagger/Internals/SwaggerJsonBuilder.cs
+++ b/src/Microsoft.DocAsCode.Build.RestApi/Swagger/Internals/SwaggerJsonBuilder.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DocAsCode.Build.RestApi.Swagger.Internals
         private const string ReferenceKey = "$ref";
         private const string InternalRefNameKey = "x-internal-ref-name";
         private const string InternalLoopRefNameKey = "x-internal-loop-ref-name";
-        private const string TokenNameKey = "Token";
+        private const string InternalLoopTokenKey = "x-internal-loop-token";
 
 
         public SwaggerJsonBuilder()
@@ -211,7 +211,7 @@ namespace Microsoft.DocAsCode.Build.RestApi.Swagger.Internals
                             {
                                 var loopRef = new SwaggerLoopReferenceObject();
                                 loopRef.Dictionary.Add(InternalLoopRefNameKey, new SwaggerValue { Token = swagger.ReferenceName });
-                                loopRef.Dictionary.Add(TokenNameKey, new SwaggerValue { Token = swagger.Token });
+                                loopRef.Dictionary.Add(InternalLoopTokenKey, new SwaggerValue { Token = swagger.Token });
                                 return loopRef;
                             }
 

--- a/test/Microsoft.DocAsCode.Build.RestApi.Tests/SwaggerJsonParserTest.cs
+++ b/test/Microsoft.DocAsCode.Build.RestApi.Tests/SwaggerJsonParserTest.cs
@@ -132,7 +132,8 @@ namespace Microsoft.DocAsCode.Build.RestApi.Tests
           ""errorDetail"": {
             ""type"": ""array"",
             ""items"": {
-              ""x-internal-loop-ref-name"": ""contact""
+              ""x-internal-loop-ref-name"": ""contact"",
+              ""Token"": {}
             }
           }
         },
@@ -170,7 +171,8 @@ namespace Microsoft.DocAsCode.Build.RestApi.Tests
           ""errorDetail"": {
             ""type"": ""array"",
             ""items"": {
-              ""x-internal-loop-ref-name"": ""contact""
+              ""x-internal-loop-ref-name"": ""contact"",
+              ""Token"": {}
             }
           }
         },

--- a/test/Microsoft.DocAsCode.Build.RestApi.Tests/SwaggerJsonParserTest.cs
+++ b/test/Microsoft.DocAsCode.Build.RestApi.Tests/SwaggerJsonParserTest.cs
@@ -133,7 +133,7 @@ namespace Microsoft.DocAsCode.Build.RestApi.Tests
             ""type"": ""array"",
             ""items"": {
               ""x-internal-loop-ref-name"": ""contact"",
-              ""Token"": {}
+              ""x-internal-loop-token"": {}
             }
           }
         },
@@ -172,7 +172,7 @@ namespace Microsoft.DocAsCode.Build.RestApi.Tests
             ""type"": ""array"",
             ""items"": {
               ""x-internal-loop-ref-name"": ""contact"",
-              ""Token"": {}
+              ""x-internal-loop-token"": {}
             }
           }
         },


### PR DESCRIPTION
1. when return type SwaggerLoopReferenceObject, we should also return the extension data such Token.
2. add _resolvedObjectCache, when the object is resolved we don't need to resolve again.