### PR TITLE
fix restore worktree path bug

### DIFF
--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -5,12 +5,12 @@ commands:
   - build
 repo: https://github.com/docascode/docfx-test-dependencies#master
 restores:
-  git/github.com/docascode/docfx-test-dependencies.zh-cn/1dc2455be4a78b4fd29b5641e6fb8d687f37464a/dep.md: loc-DEP
-  git/github.com/docascode/docfx-test-dependencies/5736374c0a142252063bbedafe5d98db495e263d/dep.md: child-DEP
+  git/github.com/docascode/docfx-test-dependencies.zh-cn/1dc2455be4a78b4fd29b5641e6fb8d687f37464a-master/dep.md: loc-DEP
+  git/github.com/docascode/docfx-test-dependencies/5736374c0a142252063bbedafe5d98db495e263d-child/dep.md: child-DEP
   restore-lock/* restore loc repo with dependencies-*-lock.json: |
-    {"git":{"https://github.com/docascode/docfx-test-dependencies.zh-cn#master":"1dc2455be4a78b4fd29b5641e6fb8d687f37464a", "https://github.com/docascode/docfx-test-dependencies#child":"5736374c0a142252063bbedafe5d98db495e263d"}}
+    {"git":{"https://github.com/docascode/docfx-test-dependencies.zh-cn#master":"1dc2455be4a78b4fd29b5641e6fb8d687f37464a-master", "https://github.com/docascode/docfx-test-dependencies#child":"5736374c0a142252063bbedafe5d98db495e263d-child"}}
   restore-lock/1dc2455be4a78b4fd29b5641e6fb8d687f37464a-*-lock.json: |
-    {"git":{"https://github.com/docascode/docfx-test-dependencies#child":"5736374c0a142252063bbedafe5d98db495e263d"}}
+    {"git":{"https://github.com/docascode/docfx-test-dependencies#child":"5736374c0a142252063bbedafe5d98db495e263d-child"}}
 outputs:
 ---
 # restore loc repo, all loc files are in one repo
@@ -24,9 +24,9 @@ inputs:
     localization:
       mapping: RepositoryAndFolder
 restores:
-  git/github.com/docascode/docfx-test-dependencies.localization/18d3d65979413ce8342fd709dbce1c78ab45ffeb/dep.md: loc-DEP
+  git/github.com/docascode/docfx-test-dependencies.localization/18d3d65979413ce8342fd709dbce1c78ab45ffeb-master/dep.md: loc-DEP
   restore-lock/*restore loc repo, all loc files are in one repo-*-lock.json: |
-    {"git":{"https://github.com/docascode/docfx-test-dependencies.localization#master":"18d3d65979413ce8342fd709dbce1c78ab45ffeb"}}
+    {"git":{"https://github.com/docascode/docfx-test-dependencies.localization#master":"18d3d65979413ce8342fd709dbce1c78ab45ffeb-master"}}
 outputs:
 ---
 # loc docset share the source docset's restore map

--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -56,12 +56,12 @@ inputs:
   docfx.yml: |
     extend: https://raw.githubusercontent.com/docascode/docfx-test-dependencies/extend-test-1/extend3.yml
 restores:
-  git/github.com/docascode/docfx-test-dependencies/9ab39126f6d6642131084e741ca6206989db505a/dep.md: DEP
-  git/github.com/docascode/docfx-test-dependencies/5736374c0a142252063bbedafe5d98db495e263d/dep.md: child-DEP
+  git/github.com/docascode/docfx-test-dependencies/9ab39126f6d6642131084e741ca6206989db505a-master/dep.md: DEP
+  git/github.com/docascode/docfx-test-dependencies/5736374c0a142252063bbedafe5d98db495e263d-child/dep.md: child-DEP
   restore-lock/*Restore dependencies with extends-*-lock.json: |
-    {"git":{"https://github.com/docascode/docfx-test-dependencies":"9ab39126f6d6642131084e741ca6206989db505a"}}
+    {"git":{"https://github.com/docascode/docfx-test-dependencies":"9ab39126f6d6642131084e741ca6206989db505a-master"}}
   restore-lock/9ab39126f6d6642131084e741ca6206989db505a-*-lock.json: |
-    {"git":{"https://github.com/docascode/docfx-test-dependencies#child":"5736374c0a142252063bbedafe5d98db495e263d"}}
+    {"git":{"https://github.com/docascode/docfx-test-dependencies#child":"5736374c0a142252063bbedafe5d98db495e263d-child"}}
 outputs:
 ---
 # Show error when download failed

--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -6,12 +6,12 @@ inputs:
       docfx-test-dependencies1: https://github.com/docascode/docfx-test-dependencies
       docfx-test-dependencies2: https://github.com/docascode/docfx-test-dependencies
 restores:
-  git/github.com/docascode/docfx-test-dependencies/9ab39126f6d6642131084e741ca6206989db505a/dep.md: DEP
-  git/github.com/docascode/docfx-test-dependencies/5736374c0a142252063bbedafe5d98db495e263d/dep.md: child-DEP
+  git/github.com/docascode/docfx-test-dependencies/9ab39126f6d6642131084e741ca6206989db505a-master/dep.md: DEP
+  git/github.com/docascode/docfx-test-dependencies/5736374c0a142252063bbedafe5d98db495e263d-child/dep.md: child-DEP
   restore-lock/*Restore dependencies with their children-*-lock.json: |
-    {"git":{"https://github.com/docascode/docfx-test-dependencies":"9ab39126f6d6642131084e741ca6206989db505a"}}
+    {"git":{"https://github.com/docascode/docfx-test-dependencies":"9ab39126f6d6642131084e741ca6206989db505a-master"}}
   restore-lock/9ab39126f6d6642131084e741ca6206989db505a-*-lock.json: |
-    {"git":{"https://github.com/docascode/docfx-test-dependencies#child":"5736374c0a142252063bbedafe5d98db495e263d"}}
+    {"git":{"https://github.com/docascode/docfx-test-dependencies#child":"5736374c0a142252063bbedafe5d98db495e263d-child"}}
 outputs:
 ---
 # Restore urls

--- a/src/docfx/restore/RestoreWorkTree.cs
+++ b/src/docfx/restore/RestoreWorkTree.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Docs.Build
                 await ParallelUtility.ForEach(hrefs, async href =>
                 {
                     var (_, rev) = GitUtility.GetGitRemoteInfo(href);
-                    var workTreeHead = await GitUtility.Revision(restorePath, rev);
+                    var workTreeHead = $"{await GitUtility.Revision(restorePath, rev)}-{rev}";
                     var workTreePath = GetRestoreWorkTreeDir(restoreDir, workTreeHead);
                     if (existingWorkTrees.TryAdd(workTreePath, 0))
                     {


### PR DESCRIPTION
if the master and live has the same HEAD, then they will be checked out to same worktree path, we want to avoid that