### PR TITLE
Fix link to Homebrew package

### DIFF
--- a/Documentation/tutorial/docfx_getting_started.md
+++ b/Documentation/tutorial/docfx_getting_started.md
@@ -26,7 +26,7 @@ For detailed description about DFM, please refer to [DFM](../spec/docfx_flavored
 *Step1.* DocFX ships as a [chocolatey package](https://chocolatey.org/packages/docfx).
 Install docfx through [Chocolatey](https://chocolatey.org/install) by calling `choco install docfx -y`.
 
-DocFX also ships as a [Homebrew package](http://brewformulas.org/docfx), install with `brew install docfx`.
+DocFX also ships as a [Homebrew package](https://formulae.brew.sh/formula/docfx), install with `brew install docfx`.
 
 Alternatively, you can download and unzip *docfx.zip* from https://github.com/dotnet/docfx/releases, extract it to a local folder, and add it to PATH so you can run it anywhere.
 


### PR DESCRIPTION
The link to unstable http://brewformulas.org is replaced with official https://formulae.brew.sh. Currently the former is down for me.