### PR TITLE
Don't copy resource on legacy mode

### DIFF
--- a/src/docfx/cli/CommandLineOptions.cs
+++ b/src/docfx/cli/CommandLineOptions.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Docs.Build
                 {
                     ["path"] = Output != null ? (JValue)Output : JValue.CreateNull(),
                     ["json"] = Legacy ? (JValue)true : JValue.CreateNull(),
+                    ["copyResources"] = Legacy ? (JValue)false : JValue.CreateNull(),
                 },
                 ["gitHub"] = new JObject
                 {


### PR DESCRIPTION
This is a performance optimization, now we turn it on by default for --legacy