### PR TITLE
Make git operations support committish

### DIFF
--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -3,7 +3,7 @@
 inputs:
   docfx.yml: |
     dependencies:
-      docfx-test-dependencies1: https://github.com/docascode/docfx-test-dependencies
+      docfx-test-dependencies1: https://github.com/docascode/docfx-test-dependencies#9ab3912
       docfx-test-dependencies2: https://github.com/docascode/docfx-test-dependencies
 restores:
   git/github.com/docascode/docfx-test-dependencies/9ab39126f6d6642131084e741ca6206989db505a-master/dep.md: DEP

--- a/impact.ps1
+++ b/impact.ps1
@@ -20,7 +20,7 @@ $githubAuth = "-c http.https://github.com.extraheader=""AUTHORIZATION: basic $en
 
 exec "git init"
 git remote add origin https://ceapex.visualstudio.com/Engineering/_git/Docs.DocFX.Impact
-exec "git $devopsAuth $githubAuth fetch --progress"
+exec "git $devopsAuth $githubAuth fetch --prune --progress"
 exec "git checkout origin/master --force --progress"
 exec "git $devopsAuth $githubAuth submodule update --init --progress"
 exec "git clean -xdf"

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -120,8 +120,8 @@ namespace Microsoft.Docs.Build
         public static Error GitNotFound()
             => new Error(ErrorLevel.Error, "git-not-found", $"Cannot find git, install git https://git-scm.com/");
 
-        public static Error GitBranchNotFound(string repo, string branch)
-            => new Error(ErrorLevel.Error, "git-branch-not-found", $"Cannot find branch '{branch}'for repo '{repo}'.");
+        public static Error CommittishNotFound(string repo, string committish)
+            => new Error(ErrorLevel.Error, "committish-not-found", $"Cannot find branch, tag or commit '{committish}'for repo '{repo}'.");
 
         public static Error BookmarkNotFound(Document relativeTo, Document reference, string bookmark, IEnumerable<string> candidateBookmarks)
             => new Error(ErrorLevel.Warning, "bookmark-not-found", $"Cannot find bookmark '#{bookmark}' in '{reference}'{(FindBestMatch(bookmark, candidateBookmarks, out string matchedBookmark) ? $", did you mean '#{matchedBookmark}'?" : null)}", relativeTo.ToString());

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -114,8 +114,8 @@ namespace Microsoft.Docs.Build
         public static Error RedirectionDocumentIdConflict(IEnumerable<Document> redirectFromDocs, string redirectTo)
             => new Error(ErrorLevel.Warning, "redirected-id-conflict", $"Multiple documents redirected to '{redirectTo}' with document id: {string.Join(", ", redirectFromDocs.OrderBy(f => f.FilePath).Select(f => $"'{f}'"))}");
 
-        public static Error GitShadowClone(string repoPath)
-            => new Error(ErrorLevel.Error, "git-shadow-clone", $"Does not support git shallow clone: '{repoPath}'");
+        public static Error GitLogError(string repoPath, int errorCode)
+            => new Error(ErrorLevel.Error, "git-log-error", $"Error computing git log [{errorCode}] for '{repoPath}', did you used a shadow clone?");
 
         public static Error GitNotFound()
             => new Error(ErrorLevel.Error, "git-not-found", $"Cannot find git, install git https://git-scm.com/");

--- a/src/docfx/lib/git/GitCommitProvider.cs
+++ b/src/docfx/lib/git/GitCommitProvider.cs
@@ -255,14 +255,16 @@ namespace Microsoft.Docs.Build
             {
                 var error = git_revwalk_next(out var commitId, walk);
                 if (error == -31 /* GIT_ITEROVER */)
+                {
                     break;
+                }
 
                 // https://github.com/libgit2/libgit2sharp/issues/1351
-                if (error == -3 /* GIT_ENOTFOUND */)
-                    throw Errors.GitShadowClone(_repoPath).ToException();
-
-                if (error != 0)
-                    throw new InvalidOperationException($"Unknown error calling git_revwalk_next: {error}");
+                if (error != 0 /* GIT_ENOTFOUND */)
+                {
+                    git_revwalk_free(walk);
+                    throw Errors.GitLogError(_repoPath, error).ToException();
+                }
 
                 git_object_lookup(out var commit, _repo, &commitId, 1 /* GIT_OBJ_COMMIT */);
                 var author = git_commit_author(commit);

--- a/src/docfx/lib/git/GitCommitProvider.cs
+++ b/src/docfx/lib/git/GitCommitProvider.cs
@@ -65,14 +65,14 @@ namespace Microsoft.Docs.Build
             return new GitCommitProvider(repoPath, cacheFilePath, await LoadCommitCache(cacheFilePath));
         }
 
-        public List<GitCommit> GetCommitHistory(string file, string branch = null)
+        public List<GitCommit> GetCommitHistory(string file, string committish = null)
         {
             Debug.Assert(!file.Contains('\\'));
 
             const int MaxParentBlob = 32;
 
             var (commits, commitsBySha) = _commits.GetOrAdd(
-                branch ?? "",
+                committish ?? "",
                 key => new Lazy<(List<Commit>, Dictionary<long, Commit>)>(() => LoadCommits(key))).Value;
 
             if (commits.Count <= 0)
@@ -228,8 +228,13 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private unsafe (List<Commit>, Dictionary<long, Commit>) LoadCommits(string branchName = null)
+        private unsafe (List<Commit>, Dictionary<long, Commit>) LoadCommits(string committish = null)
         {
+            if (string.IsNullOrEmpty(committish))
+            {
+                committish = "HEAD";
+            }
+
             var commits = new List<Commit>();
             var commitsBySha = new Dictionary<long, Commit>();
 
@@ -237,23 +242,14 @@ namespace Microsoft.Docs.Build
             git_revwalk_new(out var walk, _repo);
             git_revwalk_sorting(walk, 1 << 0 | 1 << 1 /* GIT_SORT_TOPOLOGICAL | GIT_SORT_TIME */);
 
-            if (string.IsNullOrEmpty(branchName))
+            if (git_revparse_single(out var headCommit, _repo, committish) != 0)
             {
-                git_revwalk_push_head(walk);
+                git_object_free(walk);
+                throw Errors.CommittishNotFound(_repoPath, committish).ToException();
             }
-            else
-            {
-                if (git_branch_lookup(out var refBranch, _repo, $"{branchName}", 1 /*locale branch*/) != 0 &&
-                    git_branch_lookup(out refBranch, _repo, $"origin/{branchName}", 2 /*remote branch*/) != 0)
-                {
-                    git_object_free(walk);
-                    throw Errors.GitBranchNotFound(_repoPath, branchName).ToException();
-                }
 
-                var commit = git_reference_target(refBranch);
-                git_revwalk_push(walk, commit);
-                git_object_free(refBranch);
-            }
+            git_revwalk_push(walk, git_object_id(headCommit));
+            git_object_free(headCommit);
 
             while (true)
             {

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Threading;
 using System.Threading.Tasks;
 
 using static Microsoft.Docs.Build.LibGit2;
@@ -130,27 +129,28 @@ namespace Microsoft.Docs.Build
         /// </summary>
         /// <param name="cwd">The current working directory</param>
         public static Task<List<string>> ListWorkTrees(string cwd, bool includeMain)
-            => ExecuteQuery(
-                cwd,
-                $"worktree list",
-                lines =>
+        {
+            return Execute(cwd, $"worktree list", ParseWorkTreeList);
+
+            List<string> ParseWorkTreeList(string stdout, string stderr)
+            {
+                Debug.Assert(stdout != null);
+                var worktreeLines = stdout.Split(s_newline, StringSplitOptions.RemoveEmptyEntries);
+                var workTreePaths = new List<string>();
+
+                var i = 0;
+                foreach (var workTreeLine in worktreeLines)
                 {
-                    Debug.Assert(lines != null);
-                    var worktreeLines = lines.Split(s_newline, StringSplitOptions.RemoveEmptyEntries);
-                    var workTreePaths = new List<string>();
-
-                    var i = 0;
-                    foreach (var workTreeLine in worktreeLines)
+                    if (i++ > 0 || includeMain)
                     {
-                        if (i++ > 0 || includeMain)
-                        {
-                            // The main worktree is listed first, followed by each of the linked worktrees.
-                            workTreePaths.Add(workTreeLine.Split(s_newlineTab, StringSplitOptions.RemoveEmptyEntries)[0]);
-                        }
+                        // The main worktree is listed first, followed by each of the linked worktrees.
+                        workTreePaths.Add(workTreeLine.Split(s_newlineTab, StringSplitOptions.RemoveEmptyEntries)[0]);
                     }
+                }
 
-                    return workTreePaths;
-                });
+                return workTreePaths;
+            }
+        }
 
         /// <summary>
         /// Create a work tree for a given repo
@@ -174,10 +174,30 @@ namespace Microsoft.Docs.Build
 
         /// <summary>
         /// Retrieve git head version
-        /// TODO: For testing purpose only, move it to test
         /// </summary>
-        public static Task<string> Revision(string cwd, string branch = "HEAD")
-           => ExecuteQuery(cwd, $"rev-parse {branch}");
+        public static unsafe string RevParse(string repoPath, string committish = null)
+        {
+            string result = null;
+
+            if (string.IsNullOrEmpty(committish))
+            {
+                committish = "HEAD";
+            }
+
+            if (git_repository_open(out var repo, repoPath) != 0)
+            {
+                throw new InvalidOperationException($"Not a git repo {repoPath}");
+            }
+
+            if (git_revparse_single(out var reference, repo, committish) == 0)
+            {
+                result = git_object_id(reference)->ToString();
+                git_object_free(reference);
+            }
+
+            git_repository_free(repo);
+            return result;
+        }
 
         public static void CheckMergeConflictMarker(string content, string file)
         {
@@ -224,9 +244,9 @@ namespace Microsoft.Docs.Build
 
             try
             {
-                await ExecuteNonQuery(path, $"{httpConfig} fetch --tags --prune --progress --update-head-ok \"{url}\" {refspecs}");
+                await ExecuteNonQuery(path, $"{httpConfig} fetch --tags --prune --progress --update-head-ok \"{url}\" {refspecs}", stderr: true);
             }
-            catch (InvalidOperationException)
+            catch (InvalidOperationException ex) when (ex.Message.Contains("fatal: Couldn't find remote ref"))
             {
                 // Fallback to fetch all branches and tags if the input committish is not supported by fetch
                 refspecs = "+refs/heads/*:refs/heads/* +refs/tags/*:refs/tags/*";
@@ -234,16 +254,12 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static Task ExecuteNonQuery(string cwd, string commandLineArgs)
-            => Execute(cwd, commandLineArgs, x => x, redirectOutput: false);
+        private static Task ExecuteNonQuery(string cwd, string commandLineArgs, bool stderr = false)
+        {
+            return Execute(cwd, commandLineArgs, (a, b) => 0, stdout: false, stderr: stderr);
+        }
 
-        private static Task<T> ExecuteQuery<T>(string cwd, string commandLineArgs, Func<string, T> parser)
-            => Execute(cwd, commandLineArgs, parser, redirectOutput: true);
-
-        private static Task<string> ExecuteQuery(string cwd, string commandLineArgs)
-            => Execute(cwd, commandLineArgs, x => x, redirectOutput: true);
-
-        private static async Task<T> Execute<T>(string cwd, string commandLineArgs, Func<string, T> parser, bool redirectOutput)
+        private static async Task<T> Execute<T>(string cwd, string commandLineArgs, Func<string, string, T> parser, bool stdout = true, bool stderr = true)
         {
             if (!Directory.Exists(cwd))
             {
@@ -252,7 +268,8 @@ namespace Microsoft.Docs.Build
 
             try
             {
-                return parser(await ProcessUtility.Execute("git", commandLineArgs, cwd, redirectOutput));
+                var (output, error) = await ProcessUtility.Execute("git", commandLineArgs, cwd, stdout, stderr);
+                return parser(output, error);
             }
             catch (Win32Exception ex) when (ProcessUtility.IsExeNotFoundException(ex))
             {

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Docs.Build
             }
 
             var httpConfig = GetGitCommandLineConfig(url, config);
-            var refspecs = string.Join(' ', committishes.Select(rev => $"+{rev}"));
+            var refspecs = string.Join(' ', committishes.Select(rev => $"+{rev}:{rev}"));
 
             try
             {

--- a/src/docfx/lib/git/LibGit2.cs
+++ b/src/docfx/lib/git/LibGit2.cs
@@ -68,12 +68,18 @@ namespace Microsoft.Docs.Build
 
         [DllImport(LibName)]
         public static unsafe extern git_oid* git_reference_target(IntPtr reference);
-
+        
         [DllImport(LibName)]
         public static unsafe extern void git_reference_free(IntPtr reference);
 
         [DllImport(LibName)]
+        public static unsafe extern int git_revparse_single(out IntPtr @out, IntPtr repo, [MarshalAs(UnmanagedType.LPUTF8Str)]string spec);
+
+        [DllImport(LibName)]
         public static unsafe extern int git_object_lookup(out IntPtr obj, IntPtr repo, git_oid* id, int type);
+
+        [DllImport(LibName)]
+        public static unsafe extern git_oid* git_object_id(IntPtr obj);
 
         [DllImport(LibName)]
         public static unsafe extern void git_object_free(IntPtr obj);

--- a/src/docfx/lib/git/LibGit2.cs
+++ b/src/docfx/lib/git/LibGit2.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Docs.Build
 
         [DllImport(LibName)]
         public static unsafe extern git_oid* git_reference_target(IntPtr reference);
-        
+
         [DllImport(LibName)]
         public static unsafe extern void git_reference_free(IntPtr reference);
 

--- a/src/docfx/restore/RestoreWorkTree.cs
+++ b/src/docfx/restore/RestoreWorkTree.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Docs.Build
                 await ParallelUtility.ForEach(hrefs, async href =>
                 {
                     var (_, rev) = GitUtility.GetGitRemoteInfo(href);
-                    var workTreeHead = $"{await GitUtility.Revision(restorePath, rev)}-{PathUtility.Encode(rev)}";
+                    var workTreeHead = $"{GitUtility.RevParse(restorePath, rev)}-{PathUtility.Encode(rev)}";
                     var workTreePath = GetRestoreWorkTreeDir(restoreDir, workTreeHead);
                     if (existingWorkTrees.TryAdd(workTreePath, 0))
                     {

--- a/test/docfx.Test/lib/GitUtilityTest.cs
+++ b/test/docfx.Test/lib/GitUtilityTest.cs
@@ -48,8 +48,8 @@ namespace Microsoft.Docs.Build
                     string.Join("\n", lib.Select(c => $"{c.Sha}|{c.Time.ToString("s")}{c.Time.ToString("zzz")}|{c.AuthorName}|{c.AuthorEmail}")));
 
                 // another branch
-                exe = Exec("git", $"--no-pager log --format=\"%H|%cI|%an|%ae\" origin/test -- \"{pathToRepo}\"", repo);
-                lib = commitsProvider.GetCommitHistory(pathToRepo, "test");
+                exe = Exec("git", $"--no-pager log --format=\"%H|%cI|%an|%ae\" a050eaf -- \"{pathToRepo}\"", repo);
+                lib = commitsProvider.GetCommitHistory(pathToRepo, "a050eaf");
 
                 Assert.Equal(
                     exe.Replace("\r", ""),

--- a/test/docfx.Test/lib/GitUtilityTest.cs
+++ b/test/docfx.Test/lib/GitUtilityTest.cs
@@ -59,16 +59,6 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        [Fact]
-        public static async Task GitCommandConcurreny()
-        {
-            var cwd = GitUtility.FindRepo(Path.GetFullPath("README.md"));
-
-            var results = await Task.WhenAll(Enumerable.Range(0, 10).AsParallel().Select(i => GitUtility.Revision(cwd)));
-
-            Assert.True(results.All(r => r.Any()));
-        }
-
         private static string Exec(string name, string args, string cwd)
         {
             var p = Process.Start(new ProcessStartInfo { FileName = name, Arguments = args, WorkingDirectory = cwd, RedirectStandardOutput = true });

--- a/test/docfx.Test/lib/ProcessUtilityTest.cs
+++ b/test/docfx.Test/lib/ProcessUtilityTest.cs
@@ -20,6 +20,16 @@ namespace Microsoft.Docs.Build
         }
 
         [Fact]
+        public static async Task RunCommandsInParallel()
+        {
+            var cwd = GitUtility.FindRepo(Path.GetFullPath("README.md"));
+
+            var results = await Task.WhenAll(Enumerable.Range(0, 10).AsParallel().Select(i => ProcessUtility.Execute("git", "rev-parse HEAD", cwd)));
+
+            Assert.True(results.All(r => !string.IsNullOrEmpty(r.stdout)));
+        }
+
+        [Fact]
         public static void ExeNotFoundMessage()
         {
             var ex = Assert.Throws<Win32Exception>(() => Process.Start("a-fake-exe"));

--- a/tools/CreateJsonSchema/Program.cs
+++ b/tools/CreateJsonSchema/Program.cs
@@ -36,19 +36,19 @@ class Program
         if (skip + take >= schemas.Count)
         {
             var diff = await ProcessUtility.Execute("git", "diff --ignore-all-space --ignore-blank-lines schemas");
-            if (!string.IsNullOrEmpty(diff))
+            if (!string.IsNullOrEmpty(diff.stdout))
             {
                 Console.ForegroundColor = ConsoleColor.Red;
                 Console.WriteLine("Json schema change detected. Run ./build.ps1 locally and commit these json schema changes:");
                 Console.ResetColor();
                 Console.WriteLine("");
-                Console.WriteLine(diff);
+                Console.WriteLine(diff.stdout);
                 return 1;
             }
         }
         else
         {
-            await ProcessUtility.Execute("dotnet", $"run -p tools/CreateJsonSchema --no-build --no-restore -- {skip + take}", redirectOutput: false);
+            await ProcessUtility.Execute("dotnet", $"run -p tools/CreateJsonSchema --no-build --no-restore -- {skip + take}", stdout: false, stderr: false);
         }
         return 0;
     }


### PR DESCRIPTION
This PR makes all git operations support committish: branch, tags, short hash, etc... Unblocks deployment due to impact test uses commit hash in dependency configuration.

- Make GetCommitHistory, Fetch support committish (fetch will first attempt to fetch single branch, then fallback to fetch all tags and branches)
- Split stdout and stderr from process exec, to detect fetch errors while preserving fetch progress
- Adjust a test case to use short hash

