### PR TITLE
sxs page's git commit url should follow sxs content commit history

### DIFF
--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -652,3 +652,25 @@ outputs:
   docs/b.json: |
     { "content":"<p><a href=\"/docs/b\">link to a</a></p>\n", "document_id":"fa697b4e-3e52-77f6-2219-39040f6070da","document_version_independent_id":"7c88e748-ed5e-a29a-c057-6f89857c3591"}
 ---
+# bilingual page's `gitcommit` url follows sxs content's commit history
+commands:
+  - restore --locale zh-cn
+  - build --locale zh-cn
+repos:
+  https://github.com/bilingual/a:
+    - files:
+        docs/a.md: a
+        docfx.yml: |
+          localization:
+            bilingual: true
+  https://github.com/bilingual/a.zh-cn#master-sxs:
+    - files:
+        docs/a.md: |
+          loc sxs content
+  https://github.com/bilingual/a.zh-cn#master:
+    - files:
+        docs/a.md: |
+          loc content
+outputs:
+  docs/a.json: |
+    {"gitcommit":"https://github.com/bilingual/a.zh-cn/blob/b1990a2c68f76bcf400e766c38480834a40e80fc/docs/a.md"}

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Docs.Build
                             pair =>
                             {
                                 _commitsByFile[pair.file.FilePath] = commitsProvider.GetCommitHistory(pair.pathToRepo);
-                                if (contributionBranch != repo.Branch)
+                                if (!string.IsNullOrEmpty(contributionBranch))
                                 {
                                     _contributionCommitsByFile[pair.file.FilePath] = commitsProvider.GetCommitHistory(pair.pathToRepo, contributionBranch);
                                 }

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -267,8 +267,15 @@ namespace Microsoft.Docs.Build
                             group,
                             pair =>
                             {
-                                _contributionCommitsByFile[pair.file.FilePath] = commitsProvider.GetCommitHistory(pair.pathToRepo, contributionBranch);
                                 _commitsByFile[pair.file.FilePath] = commitsProvider.GetCommitHistory(pair.pathToRepo);
+                                if (contributionBranch != repo.Branch)
+                                {
+                                    _contributionCommitsByFile[pair.file.FilePath] = commitsProvider.GetCommitHistory(pair.pathToRepo, contributionBranch);
+                                }
+                                else
+                                {
+                                    _contributionCommitsByFile[pair.file.FilePath] = _commitsByFile[pair.file.FilePath];
+                                }
                             },
                             Progress.Update);
 

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -19,7 +19,9 @@ namespace Microsoft.Docs.Build
 
         private readonly ConcurrentDictionary<string, Repository> _repositoryByFolder = new ConcurrentDictionary<string, Repository>();
 
-        private readonly ConcurrentDictionary<string, (Repository, List<GitCommit> commits)> _commitsByFile = new ConcurrentDictionary<string, (Repository, List<GitCommit> commits)>();
+        private readonly ConcurrentDictionary<string, List<GitCommit>> _contributionCommitsByFile = new ConcurrentDictionary<string, List<GitCommit>>();
+
+        private readonly ConcurrentDictionary<string, List<GitCommit>> _commitsByFile = new ConcurrentDictionary<string, List<GitCommit>>();
 
         private ContributionProvider(GitHubUserCache gitHubUserCache)
         {
@@ -39,8 +41,14 @@ namespace Microsoft.Docs.Build
             string authorName)
         {
             Debug.Assert(document != null);
+            var (repo, _) = GetRepository(document);
+            if (repo == null)
+            {
+                return default;
+            }
 
-            var (repo, commits) = _commitsByFile.TryGetValue(document.FilePath, out var value) ? value : default;
+            var commits = _contributionCommitsByFile.TryGetValue(document.FilePath, out var value) ? value : default;
+
             var excludes = document.Docset.Config.Contribution.ExcludedContributors;
 
             var contributors = new List<Contributor>();
@@ -136,8 +144,8 @@ namespace Microsoft.Docs.Build
                 return default;
 
             var repoHost = GitHubUtility.TryParse(repo.Remote, out _, out _) ? GitHost.GitHub : GitHost.Unknown;
-            var commit = _commitsByFile.TryGetValue(document.FilePath, out var value) && value.commits.Count > 0
-                ? value.commits[0].Sha
+            var commit = _commitsByFile.TryGetValue(document.FilePath, out var value) && value.Count > 0
+                ? value[0].Sha
                 : repo.Commit;
 
             return (GetEditUrl(), GetContentUrl(), GetCommitUrl());
@@ -249,7 +257,7 @@ namespace Microsoft.Docs.Build
                 {
                     var repo = group.Key;
                     var repoPath = repo.Path;
-                    var repoBranch = bilingual && repo.Branch.EndsWith("-sxs") ? repo.Branch.Substring(0, repo.Branch.Length - 4) : null;
+                    var contributionBranch = bilingual && repo.Branch.EndsWith("-sxs") ? repo.Branch.Substring(0, repo.Branch.Length - 4) : null;
                     var commitCachePath = Path.Combine(AppData.CacheDir, "commits", HashUtility.GetMd5Hash(repo.Remote));
 
                     using (Progress.Start($"Loading commits for '{repoPath}'"))
@@ -257,7 +265,11 @@ namespace Microsoft.Docs.Build
                     {
                         ParallelUtility.ForEach(
                             group,
-                            pair => _commitsByFile[pair.file.FilePath] = (group.Key, commitsProvider.GetCommitHistory(pair.pathToRepo, repoBranch)),
+                            pair =>
+                            {
+                                _contributionCommitsByFile[pair.file.FilePath] = commitsProvider.GetCommitHistory(pair.pathToRepo, contributionBranch);
+                                _commitsByFile[pair.file.FilePath] = commitsProvider.GetCommitHistory(pair.pathToRepo);
+                            },
                             Progress.Update);
 
                         await commitsProvider.SaveCache();


### PR DESCRIPTION
as title, the `git commit` url should be the real git commit url points to sxs, for debugging and BI, should not follow contribution commits

https://ceapex.visualstudio.com/Engineering/_git/Docs.DocFX.Impact/pullrequest/5882?_a=files&path=%2Fsource%2Fazure-docs-pr.ja-jp.output%2Fazure%2Factive-directory-domain-services%2Factive-directory-ds-getting-started-password-sync.mta.json