### PR TITLE
Fix e2e test directory stall in case of failure

### DIFF
--- a/test/docfx.Test/e2e/E2ETest.cs
+++ b/test/docfx.Test/e2e/E2ETest.cs
@@ -179,16 +179,10 @@ namespace Microsoft.Docs.Build
                 !spec.Environments.Any(env => string.IsNullOrEmpty(Environment.GetEnvironmentVariable(env)));
 
             var docsetPath = Path.Combine("specs-drop", name);
+            var docsetCreatedFlag = Path.Combine("specs-flags", name);
             var mockedRepos = MockGitRepos(name, spec);
 
-            if (Directory.Exists(docsetPath))
-            {
-                if (Directory.Exists(Path.Combine(docsetPath, "_site")))
-                {
-                    Directory.Delete(Path.Combine(docsetPath, "_site"), recursive: true);
-                }
-            }
-            else
+            if (!File.Exists(docsetCreatedFlag))
             {
                 var inputRepo = spec.Repo ?? spec.Repos.Select(item => item.Key).FirstOrDefault();
                 if (!string.IsNullOrEmpty(inputRepo))
@@ -221,6 +215,14 @@ namespace Microsoft.Docs.Build
                     }
                     File.WriteAllText(filePath, mutableContent);
                 }
+
+                PathUtility.CreateDirectoryFromFilePath(docsetCreatedFlag);
+                File.Create(docsetCreatedFlag);
+            }
+
+            if (Directory.Exists(Path.Combine(docsetPath, "_site")))
+            {
+                Directory.Delete(Path.Combine(docsetPath, "_site"), recursive: true);
             }
 
             return (docsetPath, spec, mockedRepos);


### PR DESCRIPTION
https://github.com/dotnet/docfx/commit/a050eaf9a23a8adbaecf09b406d53465805f6e21 changes test docset path to include yaml spec hash, this avoids deleting docset everytime a test runs.

But if all the tests are running in parallel and one of the test failed, it is likely that some test are still preparing the test docset, this leaves a stall state and make subsequent test runs fail.

This PR adds a file based flag. Instead of relying on the non-atomic `Directory.Exists` check, use a file to mark if a test docset has been prepared.

#3452 