### PR TITLE
Make ListWorkTreePath use --porcelain output

### DIFF
--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -127,28 +127,38 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// List work trees for a given repo
         /// </summary>
-        /// <param name="cwd">The current working directory</param>
-        public static Task<List<string>> ListWorkTrees(string cwd, bool includeMain)
+        public static Task<List<string>> ListWorkTree(string repoPath)
         {
-            return Execute(cwd, $"worktree list", ParseWorkTreeList);
+            return Execute(repoPath, $"worktree list --porcelain", ParseWorkTreeList);
 
             List<string> ParseWorkTreeList(string stdout, string stderr)
             {
                 Debug.Assert(stdout != null);
-                var worktreeLines = stdout.Split(s_newline, StringSplitOptions.RemoveEmptyEntries);
-                var workTreePaths = new List<string>();
 
-                var i = 0;
-                foreach (var workTreeLine in worktreeLines)
+                // https://git-scm.com/docs/git-worktree#_porcelain_format
+                var result = new List<string>();
+                var isMain = true;
+                foreach (var property in stdout.Split("\n", StringSplitOptions.RemoveEmptyEntries))
                 {
-                    if (i++ > 0 || includeMain)
+                    var i = property.IndexOf(' ');
+                    if (i > 0)
                     {
-                        // The main worktree is listed first, followed by each of the linked worktrees.
-                        workTreePaths.Add(workTreeLine.Split(s_newlineTab, StringSplitOptions.RemoveEmptyEntries)[0]);
+                        var key = property.Substring(0, i);
+                        if (key == "worktree")
+                        {
+                            if (isMain)
+                            {
+                                // The main worktree is listed first, followed by each of the linked worktrees.
+                                isMain = false;
+                            }
+                            else
+                            {
+                                result.Add(property.Substring(i + 1).Trim());
+                            }
+                        }
                     }
                 }
-
-                return workTreePaths;
+                return result;
             }
         }
 

--- a/src/docfx/restore/RestoreWorkTree.cs
+++ b/src/docfx/restore/RestoreWorkTree.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Docs.Build
 
             async Task AddWorkTrees()
             {
-                var existingWorkTrees = new ConcurrentDictionary<string, int>((await GitUtility.ListWorkTrees(restorePath, false)).ToDictionary(k => k, v => 0));
+                var existingWorkTrees = new ConcurrentDictionary<string, int>((await GitUtility.ListWorkTree(restorePath)).ToDictionary(k => k, v => 0));
                 await ParallelUtility.ForEach(hrefs, async href =>
                 {
                     var (_, rev) = GitUtility.GetGitRemoteInfo(href);

--- a/test/docfx.Test/restore/RestoreTest.cs
+++ b/test/docfx.Test/restore/RestoreTest.cs
@@ -49,7 +49,7 @@ dependencies:
 
             // run restroe and check the work trees
             await Program.Run(new[] { "restore", docsetPath });
-            var workTreeList = await GitUtility.ListWorkTrees(restorePath, false);
+            var workTreeList = await GitUtility.ListWorkTree(restorePath);
             Assert.Equal(6, workTreeList.Count);
 
             foreach(var wirkTreeFolder in workTreeList.Where(w => w.EndsWith("clean")))
@@ -67,7 +67,7 @@ dependencies:
             await Program.Run(new[] { "restore", docsetPath });
             await Program.Run(new[] { "gc" });
 
-            workTreeList = await GitUtility.ListWorkTrees(restorePath, false);
+            workTreeList = await GitUtility.ListWorkTree(restorePath);
             Assert.Equal(2, workTreeList.Count);
         }
 


### PR DESCRIPTION
`--porcelain` is stable across git versions, the plan output is not.