### PR TITLE
Refactor appdata path logic

### DIFF
--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Docs.Build
             var outputPath = file.SitePath;
             if (monikers.Count != 0)
             {
-                var monikerSeg = HashUtility.GetMd5Hash(string.Join(',', monikers)).Substring(0, 8);
+                var monikerSeg = HashUtility.GetMd5HashShort(string.Join(',', monikers));
                 outputPath = PathUtility.NormalizeFile(Path.Combine(monikerSeg, file.SitePath));
             }
             return outputPath;

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Docs.Build
         {
             if (!string.IsNullOrEmpty(docset.Config.Contribution.GitCommitsTime))
             {
-                var path = docset.RestoreMap.GetUrlRestorePath(docset.Config.Contribution.GitCommitsTime);
+                var path = docset.RestoreMap.GetFileRestorePath(docset.Config.Contribution.GitCommitsTime);
                 var content = await ProcessUtility.ReadFile(path);
 
                 foreach (var commit in JsonUtility.Deserialize<GitCommitsTime>(content).Item2.Commits)
@@ -258,10 +258,9 @@ namespace Microsoft.Docs.Build
                     var repo = group.Key;
                     var repoPath = repo.Path;
                     var contributionBranch = bilingual && repo.Branch.EndsWith("-sxs") ? repo.Branch.Substring(0, repo.Branch.Length - 4) : null;
-                    var commitCachePath = Path.Combine(AppData.CacheDir, "commits", HashUtility.GetMd5Hash(repo.Remote));
 
                     using (Progress.Start($"Loading commits for '{repoPath}'"))
-                    using (var commitsProvider = await GitCommitProvider.Create(repoPath, commitCachePath))
+                    using (var commitsProvider = await GitCommitProvider.Create(repoPath, AppData.GetCommitCachePath(repo.Remote)))
                     {
                         ParallelUtility.ForEach(
                             group,

--- a/src/docfx/build/xref/XrefMap.cs
+++ b/src/docfx/build/xref/XrefMap.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Docs.Build
             Dictionary<string, XrefSpec> map = new Dictionary<string, XrefSpec>();
             foreach (var url in docset.Config.Xref)
             {
-                var json = File.ReadAllText(docset.RestoreMap.GetUrlRestorePath(url));
+                var json = File.ReadAllText(docset.RestoreMap.GetFileRestorePath(url));
                 var (_, xRefMap) = JsonUtility.Deserialize<XrefMapModel>(json);
                 foreach (var sepc in xRefMap.References)
                 {

--- a/src/docfx/config/AppData.cs
+++ b/src/docfx/config/AppData.cs
@@ -8,34 +8,34 @@ namespace Microsoft.Docs.Build
 {
     internal static class AppData
     {
-        public static readonly string AppDataDir = GetAppDataDir();
+        private static readonly string s_root = GetAppDataRoot();
 
-        public static string GitDir => Path.Combine(AppDataDir, "git");
+        public static string GitRoot => Path.Combine(s_root, "git");
 
-        public static string DownloadsDir => Path.Combine(AppDataDir, "downloads");
+        public static string DownloadsRoot => Path.Combine(s_root, "downloads");
 
-        public static string MutexDir => Path.Combine(AppDataDir, "mutex");
+        public static string MutexRoot => Path.Combine(s_root, "mutex");
 
-        public static string CacheDir => Path.Combine(AppDataDir, "cache");
+        public static string CacheRoot => Path.Combine(s_root, "cache");
 
         public static string GlobalConfigPath => GetGlobalConfigPath();
 
-        public static string GitHubUserCachePath => Path.Combine(CacheDir, "github-users.json");
+        public static string GitHubUserCachePath => Path.Combine(CacheRoot, "github-users.json");
 
         public static string GetGitDir(string url)
         {
-            return PathUtility.NormalizeFolder(Path.Combine(GitDir, UrlToPath(url)));
+            return PathUtility.NormalizeFolder(Path.Combine(GitRoot, UrlToPath(url)));
         }
 
         public static string GetFileDownloadDir(string url)
         {
             // URL to a resource is case sensitive, query string matters, so hash the download path
-            return PathUtility.NormalizeFolder(Path.Combine(DownloadsDir, UrlToPath(url) + "-" + url.Trim().GetMd5HashShort()));
+            return PathUtility.NormalizeFolder(Path.Combine(DownloadsRoot, UrlToPath(url) + "-" + url.Trim().GetMd5HashShort()));
         }
 
         public static string GetCommitCachePath(string remote)
         {
-            return Path.Combine(AppData.CacheDir, "commits", HashUtility.GetMd5Hash(remote));
+            return Path.Combine(AppData.CacheRoot, "commits", HashUtility.GetMd5Hash(remote));
         }
 
         private static string UrlToPath(string url)
@@ -53,12 +53,12 @@ namespace Microsoft.Docs.Build
         }
 
         /// <summary>
-        /// Get the global configuration path, default is under <see cref="AppDataDir"/>
+        /// Get the global configuration path, default is under <see cref="s_root"/>
         /// </summary>
         private static string GetGlobalConfigPath()
         {
             var docfxGlobalConfig = Environment.GetEnvironmentVariable("DOCFX_GLOBAL_CONFIG_PATH");
-            Config.TryGetConfigPath(AppDataDir, out string configPath, out string configFile);
+            Config.TryGetConfigPath(s_root, out string configPath, out string configFile);
             return string.IsNullOrEmpty(docfxGlobalConfig) ? configPath : Path.GetFullPath(docfxGlobalConfig);
         }
 
@@ -66,7 +66,7 @@ namespace Microsoft.Docs.Build
         /// Get the application cache root dir, default is under user proflie dir.
         /// User can set the DOCFX_APPDATA_PATH environment to change the root
         /// </summary>
-        private static string GetAppDataDir()
+        private static string GetAppDataRoot()
         {
             // TODO: document this environment variable
             var docfxAppData = Environment.GetEnvironmentVariable("DOCFX_APPDATA_PATH");

--- a/src/docfx/config/AppData.cs
+++ b/src/docfx/config/AppData.cs
@@ -10,15 +10,47 @@ namespace Microsoft.Docs.Build
     {
         public static readonly string AppDataDir = GetAppDataDir();
 
-        public static string GitRestoreDir => Path.Combine(AppDataDir, "git");
+        public static string GitDir => Path.Combine(AppDataDir, "git");
 
-        public static string UrlRestoreDir => Path.Combine(AppDataDir, "url");
+        public static string DownloadsDir => Path.Combine(AppDataDir, "downloads");
 
         public static string MutexDir => Path.Combine(AppDataDir, "mutex");
 
         public static string CacheDir => Path.Combine(AppDataDir, "cache");
 
         public static string GlobalConfigPath => GetGlobalConfigPath();
+
+        public static string GitHubUserCachePath => Path.Combine(CacheDir, "github-users.json");
+
+        public static string GetGitDir(string url)
+        {
+            return PathUtility.NormalizeFolder(Path.Combine(GitDir, UrlToPath(url)));
+        }
+
+        public static string GetFileDownloadDir(string url)
+        {
+            // URL to a resource is case sensitive, query string matters, so hash the download path
+            return PathUtility.NormalizeFolder(Path.Combine(DownloadsDir, UrlToPath(url) + "-" + url.Trim().GetMd5HashShort()));
+        }
+
+        public static string GetCommitCachePath(string remote)
+        {
+            return Path.Combine(AppData.CacheDir, "commits", HashUtility.GetMd5Hash(remote));
+        }
+
+        private static string UrlToPath(string url)
+        {
+            (url, _, _) = HrefUtility.SplitHref(url);
+
+            // Trim https://
+            var i = url.IndexOf(':');
+            if (i > 0)
+            {
+                url = url.Substring(i);
+            }
+
+            return HrefUtility.EscapeUrl(url.TrimStart('/', '\\', '.', ':').Trim());
+        }
 
         /// <summary>
         /// Get the global configuration path, default is under <see cref="AppDataDir"/>

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -258,7 +258,7 @@ namespace Microsoft.Docs.Build
             var globalConfigPath = AppData.GlobalConfigPath;
             if (File.Exists(globalConfigPath))
             {
-                var filePath = restoreMap.GetUrlRestorePath(globalConfigPath);
+                var filePath = restoreMap.GetFileRestorePath(globalConfigPath);
                 (errors, result) = LoadConfigObject(filePath, filePath);
             }
 
@@ -268,7 +268,7 @@ namespace Microsoft.Docs.Build
                 {
                     if (extend is JValue value && value.Value is string str)
                     {
-                        var filePath = restoreMap.GetUrlRestorePath(str);
+                        var filePath = restoreMap.GetFileRestorePath(str);
                         var (extendErros, extendConfigObject) = LoadConfigObject(str, filePath);
                         errors.AddRange(extendErros);
                         result.Merge(extendConfigObject, JsonUtility.MergeSettings);

--- a/src/docfx/docset/Docset.cs
+++ b/src/docfx/docset/Docset.cs
@@ -241,7 +241,7 @@ namespace Microsoft.Docs.Build
             var monikerDefinition = new MonikerDefinitionModel();
             if (!string.IsNullOrEmpty(Config.MonikerDefinitionUrl))
             {
-                var path = RestoreMap.GetUrlRestorePath(Config.MonikerDefinitionUrl);
+                var path = RestoreMap.GetFileRestorePath(Config.MonikerDefinitionUrl);
                 (_, monikerDefinition) = JsonUtility.Deserialize<MonikerDefinitionModel>(File.ReadAllText(path));
             }
             return new MonikerRangeParser(monikerDefinition);

--- a/src/docfx/gc/GarbageCollector.cs
+++ b/src/docfx/gc/GarbageCollector.cs
@@ -23,12 +23,12 @@ namespace Microsoft.Docs.Build
         private static async Task<int> CollectGit(int retentionDays)
         {
             var cleaned = 0;
-            if (!Directory.Exists(AppData.GitDir))
+            if (!Directory.Exists(AppData.GitRoot))
             {
                 return cleaned;
             }
 
-            var gitWorkTreeRoots = Directory.EnumerateDirectories(AppData.GitDir, ".git", SearchOption.AllDirectories);
+            var gitWorkTreeRoots = Directory.EnumerateDirectories(AppData.GitRoot, ".git", SearchOption.AllDirectories);
 
             using (Progress.Start("Cleaning git repositories"))
             {
@@ -41,7 +41,7 @@ namespace Microsoft.Docs.Build
             Task CleanWorkTrees(string gitWorkTreeRoot)
             {
                 return ProcessUtility.RunInsideMutex(
-                       PathUtility.NormalizeFile(Path.GetRelativePath(AppData.GitDir, gitWorkTreeRoot)),
+                       PathUtility.NormalizeFile(Path.GetRelativePath(AppData.GitRoot, gitWorkTreeRoot)),
                        async () =>
                        {
                            var workTreeFolder = Path.GetDirectoryName(gitWorkTreeRoot);
@@ -67,12 +67,12 @@ namespace Microsoft.Docs.Build
         private static int CollectUrls(int retentionDays)
         {
             var cleaned = 0;
-            if (!Directory.Exists(AppData.DownloadsDir))
+            if (!Directory.Exists(AppData.DownloadsRoot))
             {
                 return cleaned;
             }
 
-            var downloadedFiles = Directory.EnumerateFiles(AppData.DownloadsDir, "*", SearchOption.AllDirectories);
+            var downloadedFiles = Directory.EnumerateFiles(AppData.DownloadsRoot, "*", SearchOption.AllDirectories);
 
             using (Progress.Start("Cleaning downloaded files"))
             {

--- a/src/docfx/gc/GarbageCollector.cs
+++ b/src/docfx/gc/GarbageCollector.cs
@@ -23,12 +23,12 @@ namespace Microsoft.Docs.Build
         private static async Task<int> CollectGit(int retentionDays)
         {
             var cleaned = 0;
-            if (!Directory.Exists(AppData.GitRestoreDir))
+            if (!Directory.Exists(AppData.GitDir))
             {
                 return cleaned;
             }
 
-            var gitWorkTreeRoots = Directory.EnumerateDirectories(AppData.GitRestoreDir, ".git", SearchOption.AllDirectories);
+            var gitWorkTreeRoots = Directory.EnumerateDirectories(AppData.GitDir, ".git", SearchOption.AllDirectories);
 
             using (Progress.Start("Cleaning git repositories"))
             {
@@ -41,7 +41,7 @@ namespace Microsoft.Docs.Build
             Task CleanWorkTrees(string gitWorkTreeRoot)
             {
                 return ProcessUtility.RunInsideMutex(
-                       PathUtility.NormalizeFile(Path.GetRelativePath(AppData.GitRestoreDir, gitWorkTreeRoot)),
+                       PathUtility.NormalizeFile(Path.GetRelativePath(AppData.GitDir, gitWorkTreeRoot)),
                        async () =>
                        {
                            var workTreeFolder = Path.GetDirectoryName(gitWorkTreeRoot);
@@ -67,12 +67,12 @@ namespace Microsoft.Docs.Build
         private static int CollectUrls(int retentionDays)
         {
             var cleaned = 0;
-            if (!Directory.Exists(AppData.UrlRestoreDir))
+            if (!Directory.Exists(AppData.DownloadsDir))
             {
                 return cleaned;
             }
 
-            var downloadedFiles = Directory.EnumerateFiles(AppData.UrlRestoreDir, "*", SearchOption.AllDirectories);
+            var downloadedFiles = Directory.EnumerateFiles(AppData.DownloadsDir, "*", SearchOption.AllDirectories);
 
             using (Progress.Start("Cleaning downloaded files"))
             {

--- a/src/docfx/lib/HashUtility.cs
+++ b/src/docfx/lib/HashUtility.cs
@@ -21,6 +21,14 @@ namespace Microsoft.Docs.Build
             }
         }
 
+        public static string GetMd5HashShort(this string input)
+        {
+            using (var md5 = MD5.Create())
+            {
+                return ToHexString(md5.ComputeHash(Encoding.UTF8.GetBytes(input)), 4);
+            }
+        }
+
         public static Guid GetMd5Guid(this string input)
         {
             using (var md5 = MD5.Create())
@@ -30,22 +38,33 @@ namespace Microsoft.Docs.Build
         }
 
         public static string GetSha1Hash(string input)
-            => GetSha1Hash(new MemoryStream(Encoding.UTF8.GetBytes(input)));
-
-        public static string GetSha1Hash(Stream stream)
         {
+            using (var sha1 = new SHA1CryptoServiceProvider())
+            {
+                return ToHexString(sha1.ComputeHash(Encoding.UTF8.GetBytes(input)));
+            }
+        }
+
+        public static string GetFileSha1Hash(string fileName)
+        {
+            using (var stream = File.OpenRead(fileName))
             using (var sha1 = new SHA1CryptoServiceProvider())
             {
                 return ToHexString(sha1.ComputeHash(stream));
             }
         }
 
-        private static string ToHexString(byte[] bytes)
+        private static string ToHexString(byte[] bytes, int digits = 0)
         {
             var formatted = new StringBuilder(2 * bytes.Length);
-            foreach (byte b in bytes)
+            if (digits == 0)
             {
-                formatted.AppendFormat("{0:x2}", b);
+                digits = bytes.Length;
+            }
+
+            for (var i = 0; i < digits; i++)
+            {
+                formatted.AppendFormat("{0:x2}", bytes[i]);
             }
             return formatted.ToString();
         }

--- a/src/docfx/lib/HrefUtility.cs
+++ b/src/docfx/lib/HrefUtility.cs
@@ -67,12 +67,22 @@ namespace Microsoft.Docs.Build
         }
 
         public static bool IsHttpHref(string str)
-            => !string.IsNullOrEmpty(str) && Uri.TryCreate(str, UriKind.Absolute, out var uriResult)
+        {
+            return !string.IsNullOrEmpty(str)
+                && Uri.TryCreate(str, UriKind.Absolute, out var uriResult)
                 && (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps);
+        }
 
         public static string EscapeUrl(string path)
         {
             return string.Join('/', path.Split('/', '\\').Select(segment => Uri.EscapeDataString(segment)));
+        }
+
+        public static string EscapeUrlSegment(string path)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(path));
+
+            return Uri.EscapeDataString(path);
         }
     }
 }

--- a/src/docfx/lib/PathUtility.cs
+++ b/src/docfx/lib/PathUtility.cs
@@ -105,18 +105,6 @@ namespace Microsoft.Docs.Build
         }
 
         /// <summary>
-        /// Encode file/folder name to a valide file/folder name
-        /// </summary>
-        /// <param name="path">The file path</param>
-        /// <returns>The encoded file path</returns>
-        public static string Encode(string path)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(path));
-
-            return Uri.EscapeDataString(path);
-        }
-
-        /// <summary>
         /// A normalized file cannot end with `/`, does not contain `\` and does not have consecutive `.` or `/`.
         /// </summary>
         /// <param name="path">The file path want to be normalized</param>

--- a/src/docfx/lib/ProcessUtility.cs
+++ b/src/docfx/lib/ProcessUtility.cs
@@ -175,9 +175,9 @@ namespace Microsoft.Docs.Build
 
             try
             {
-                Directory.CreateDirectory(AppData.MutexDir);
+                Directory.CreateDirectory(AppData.MutexRoot);
 
-                var lockPath = Path.Combine(AppData.MutexDir, HashUtility.GetMd5Hash(mutexName));
+                var lockPath = Path.Combine(AppData.MutexRoot, HashUtility.GetMd5Hash(mutexName));
 
                 using (await RetryUntilSucceed(mutexName, IsFileAlreadyExistsException, CreateFile))
                 {

--- a/src/docfx/lib/github/GitHubUserCache.cs
+++ b/src/docfx/lib/github/GitHubUserCache.cs
@@ -56,8 +56,8 @@ namespace Microsoft.Docs.Build
             _getUserByLoginFromGitHub = github.GetUserByLogin;
             _getLoginByCommitFromGitHub = github.GetLoginByCommit;
             _cachePath = string.IsNullOrEmpty(docset.Config.GitHub.UserCache)
-                ? Path.Combine(AppData.CacheDir, "github-users.json")
-                : docset.RestoreMap.GetUrlRestorePath(docset.Config.GitHub.UserCache);
+                ? AppData.GitHubUserCachePath
+                : docset.RestoreMap.GetFileRestorePath(docset.Config.GitHub.UserCache);
             _expirationInHours = docset.Config.GitHub.UserCacheExpirationInHours;
         }
 

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Docs.Build
                 GetRestoreUrls(config.Extend),
                 async restoreUrl =>
                 {
-                    await RestoreUrl.Restore(restoreUrl, config);
+                    await RestoreFile.Restore(restoreUrl, config);
                 });
 
             // extend the config before loading
@@ -93,7 +93,7 @@ namespace Microsoft.Docs.Build
                 GetRestoreUrls(extendedConfig.GetExternalReferences()),
                 async restoreUrl =>
                 {
-                    await RestoreUrl.Restore(restoreUrl, extendedConfig);
+                    await RestoreFile.Restore(restoreUrl, extendedConfig);
                 });
         }
     }

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -39,18 +39,6 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public static string GetRestoreRootDir(string url, string root)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(url));
-
-            var uri = new Uri(url);
-            var repo = Path.Combine(uri.Host, uri.AbsolutePath.Substring(1));
-            var dir = Path.Combine(root, repo);
-
-            // todo: encode the dir converted from url
-            return PathUtility.NormalizeFolder(dir);
-        }
-
         private static void ReportErrors(Report report, List<Error> errors)
         {
             foreach (var error in errors)

--- a/src/docfx/restore/RestoreFile.cs
+++ b/src/docfx/restore/RestoreFile.cs
@@ -11,12 +11,6 @@ namespace Microsoft.Docs.Build
 {
     internal static class RestoreFile
     {
-        public static string GetRestoreVersionPath(string restoreDir, string version)
-            => PathUtility.NormalizeFile(Path.Combine(restoreDir, version));
-
-        public static string GetRestoreRootDir(string address)
-            => Docs.Build.Restore.GetRestoreRootDir(address, AppData.DownloadsDir);
-
         public static async Task<string> Restore(string address, Config config)
         {
             var tempFile = await DownloadToTempFile(address, config);
@@ -24,8 +18,8 @@ namespace Microsoft.Docs.Build
             var fileHash = HashUtility.GetFileSha1Hash(tempFile);
             Debug.Assert(!string.IsNullOrEmpty(fileHash));
 
-            var restoreDir = GetRestoreRootDir(address);
-            var restorePath = GetRestoreVersionPath(restoreDir, fileHash);
+            var restoreDir = AppData.GetFileDownloadDir(address);
+            var restorePath = PathUtility.NormalizeFile(Path.Combine(restoreDir, fileHash));
             await ProcessUtility.RunInsideMutex(
                 PathUtility.NormalizeFile(Path.GetRelativePath(AppData.DownloadsDir, restoreDir)),
                 () =>

--- a/src/docfx/restore/RestoreFile.cs
+++ b/src/docfx/restore/RestoreFile.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Docs.Build
             var restoreDir = AppData.GetFileDownloadDir(address);
             var restorePath = PathUtility.NormalizeFile(Path.Combine(restoreDir, fileHash));
             await ProcessUtility.RunInsideMutex(
-                PathUtility.NormalizeFile(Path.GetRelativePath(AppData.DownloadsDir, restoreDir)),
+                PathUtility.NormalizeFile(Path.GetRelativePath(AppData.DownloadsRoot, restoreDir)),
                 () =>
                 {
                     if (!File.Exists(restorePath))
@@ -45,8 +45,8 @@ namespace Microsoft.Docs.Build
 
         private static async Task<string> DownloadToTempFile(string address, Config config)
         {
-            Directory.CreateDirectory(AppData.DownloadsDir);
-            var tempFile = Path.Combine(AppData.DownloadsDir, "." + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(AppData.DownloadsRoot);
+            var tempFile = Path.Combine(AppData.DownloadsRoot, "." + Guid.NewGuid().ToString("N"));
 
             try
             {

--- a/src/docfx/restore/RestoreGit.cs
+++ b/src/docfx/restore/RestoreGit.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Docs.Build
     internal static class RestoreGit
     {
         public static string GetRestoreRootDir(string url)
-            => Docs.Build.Restore.GetRestoreRootDir(url, AppData.GitRestoreDir);
+            => Docs.Build.Restore.GetRestoreRootDir(url, AppData.GitDir);
 
         public static async Task<IEnumerable<(string href, string workTreeHead)>> Restore(string docsetPath, Config config, Func<string, Task> restoreChild, string locale)
         {

--- a/src/docfx/restore/RestoreGit.cs
+++ b/src/docfx/restore/RestoreGit.cs
@@ -12,9 +12,6 @@ namespace Microsoft.Docs.Build
 {
     internal static class RestoreGit
     {
-        public static string GetRestoreRootDir(string url)
-            => Docs.Build.Restore.GetRestoreRootDir(url, AppData.GitDir);
-
         public static async Task<IEnumerable<(string href, string workTreeHead)>> Restore(string docsetPath, Config config, Func<string, Task> restoreChild, string locale)
         {
             var workTreeMappings = new ConcurrentBag<(string href, string workTreeHead)>();
@@ -53,7 +50,7 @@ namespace Microsoft.Docs.Build
         {
             var gitDependencies = config.Dependencies.Values.Concat(GetLocRestoreItem(docsetPath, config, locale));
 
-            return gitDependencies.GroupBy(d => GetRestoreRootDir(d), PathUtility.PathComparer).Select(g => (g.Key, g.Distinct().ToList())).ToList();
+            return gitDependencies.GroupBy(d => AppData.GetGitDir(d), PathUtility.PathComparer).Select(g => (g.Key, g.Distinct().ToList())).ToList();
         }
 
         private static IEnumerable<string> GetLocRestoreItem(string docsetPath, Config config, string locale)

--- a/src/docfx/restore/RestoreMap.cs
+++ b/src/docfx/restore/RestoreMap.cs
@@ -20,58 +20,58 @@ namespace Microsoft.Docs.Build
             _docsetPath = docsetPath;
         }
 
-        public string GetGitRestorePath(string remote)
+        public string GetGitRestorePath(string url)
         {
-            Debug.Assert(!string.IsNullOrEmpty(remote));
+            Debug.Assert(!string.IsNullOrEmpty(url));
 
             var gitRestorePath = s_mappings.GetOrAdd(
-                $"{remote}",
+                $"{url}",
                 new Lazy<string>(() =>
                 {
-                    var (url, branch) = GitUtility.GetGitRemoteInfo(remote);
-                    var restoreDir = RestoreGit.GetRestoreRootDir(url);
+                    var (remote, branch) = GitUtility.GetGitRemoteInfo(url);
+                    var restoreDir = RestoreGit.GetRestoreRootDir(remote);
 
                     if (!Directory.Exists(restoreDir))
                     {
-                        throw Errors.NeedRestore(remote).ToException();
+                        throw Errors.NeedRestore(url).ToException();
                     }
 
                     return Directory.EnumerateDirectories(restoreDir, "*", SearchOption.TopDirectoryOnly)
                         .Select(f => PathUtility.NormalizeFolder(f))
-                        .Where(f => f.EndsWith($"{PathUtility.Encode(branch)}/"))
+                        .Where(f => f.EndsWith($"{HrefUtility.EscapeUrlSegment(branch)}/"))
                         .OrderByDescending(f => new DirectoryInfo(f).LastAccessTimeUtc)
                         .FirstOrDefault();
                 })).Value;
 
             if (!Directory.Exists(gitRestorePath))
             {
-                throw Errors.NeedRestore(remote).ToException();
+                throw Errors.NeedRestore(url).ToException();
             }
 
             return gitRestorePath;
         }
 
-        public string GetUrlRestorePath(string path)
+        public string GetFileRestorePath(string url)
         {
-            Debug.Assert(!string.IsNullOrEmpty(path));
+            Debug.Assert(!string.IsNullOrEmpty(url));
 
-            if (!HrefUtility.IsHttpHref(path))
+            if (!HrefUtility.IsHttpHref(url))
             {
                 // directly return the relative path
-                var fullPath = Path.Combine(_docsetPath, path);
-                return File.Exists(fullPath) ? fullPath : throw Errors.FileNotFound(_docsetPath, path).ToException();
+                var fullPath = Path.Combine(_docsetPath, url);
+                return File.Exists(fullPath) ? fullPath : throw Errors.FileNotFound(_docsetPath, url).ToException();
             }
 
             var urlRestorePath = s_mappings.GetOrAdd(
-                $"{_docsetPath}:{path}",
+                $"{_docsetPath}:{url}",
                 new Lazy<string>(() =>
                 {
                     // get the file path from restore map
-                    var restoreDir = RestoreUrl.GetRestoreRootDir(path);
+                    var restoreDir = RestoreFile.GetRestoreRootDir(url);
 
                     if (!Directory.Exists(restoreDir))
                     {
-                        throw Errors.NeedRestore(path).ToException();
+                        throw Errors.NeedRestore(url).ToException();
                     }
 
                     return Directory.EnumerateFiles(restoreDir, "*", SearchOption.TopDirectoryOnly)
@@ -81,7 +81,7 @@ namespace Microsoft.Docs.Build
 
             if (!File.Exists(urlRestorePath))
             {
-                throw Errors.NeedRestore(path).ToException();
+                throw Errors.NeedRestore(url).ToException();
             }
 
             return urlRestorePath;

--- a/src/docfx/restore/RestoreMap.cs
+++ b/src/docfx/restore/RestoreMap.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Docs.Build
                 new Lazy<string>(() =>
                 {
                     // get the file path from restore map
-                    var restoreDir = AppData.GetGitDir(url);
+                    var restoreDir = AppData.GetFileDownloadDir(url);
 
                     if (!Directory.Exists(restoreDir))
                     {

--- a/src/docfx/restore/RestoreMap.cs
+++ b/src/docfx/restore/RestoreMap.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Docs.Build
                 new Lazy<string>(() =>
                 {
                     var (remote, branch) = GitUtility.GetGitRemoteInfo(url);
-                    var restoreDir = RestoreGit.GetRestoreRootDir(remote);
+                    var restoreDir = AppData.GetGitDir(remote);
 
                     if (!Directory.Exists(restoreDir))
                     {
@@ -67,7 +67,7 @@ namespace Microsoft.Docs.Build
                 new Lazy<string>(() =>
                 {
                     // get the file path from restore map
-                    var restoreDir = RestoreFile.GetRestoreRootDir(url);
+                    var restoreDir = AppData.GetGitDir(url);
 
                     if (!Directory.Exists(restoreDir))
                     {

--- a/src/docfx/restore/RestoreWorkTree.cs
+++ b/src/docfx/restore/RestoreWorkTree.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Docs.Build
             var workTreeHeads = new ConcurrentBag<(string href, string head)>();
 
             await ProcessUtility.RunInsideMutex(
-                PathUtility.NormalizeFile(Path.GetRelativePath(AppData.GitDir, restorePath)),
+                PathUtility.NormalizeFile(Path.GetRelativePath(AppData.GitRoot, restorePath)),
                 async () =>
                 {
                     try

--- a/src/docfx/restore/RestoreWorkTree.cs
+++ b/src/docfx/restore/RestoreWorkTree.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Docs.Build
             var workTreeHeads = new ConcurrentBag<(string href, string head)>();
 
             await ProcessUtility.RunInsideMutex(
-                PathUtility.NormalizeFile(Path.GetRelativePath(AppData.GitRestoreDir, restorePath)),
+                PathUtility.NormalizeFile(Path.GetRelativePath(AppData.GitDir, restorePath)),
                 async () =>
                 {
                     try
@@ -48,7 +48,7 @@ namespace Microsoft.Docs.Build
                 await ParallelUtility.ForEach(hrefs, async href =>
                 {
                     var (_, rev) = GitUtility.GetGitRemoteInfo(href);
-                    var workTreeHead = $"{GitUtility.RevParse(restorePath, rev)}-{PathUtility.Encode(rev)}";
+                    var workTreeHead = $"{GitUtility.RevParse(restorePath, rev)}-{HrefUtility.EscapeUrlSegment(rev)}";
                     var workTreePath = GetRestoreWorkTreeDir(restoreDir, workTreeHead);
                     if (existingWorkTrees.TryAdd(workTreePath, 0))
                     {

--- a/test/docfx.Test/restore/RestoreTest.cs
+++ b/test/docfx.Test/restore/RestoreTest.cs
@@ -78,10 +78,10 @@ dependencies:
             var docsetPath = "restore-urls";
             Directory.CreateDirectory(docsetPath);
             var url = "https://raw.githubusercontent.com/docascode/docfx-test-dependencies-clean/master/README.md";
-            var restoreDir = RestoreUrl.GetRestoreRootDir(url);
+            var restoreDir = RestoreFile.GetRestoreRootDir(url);
             await ParallelUtility.ForEach(Enumerable.Range(0, 10), version =>
             {
-                var restorePath = RestoreUrl.GetRestoreVersionPath(restoreDir, version.ToString());
+                var restorePath = RestoreFile.GetRestoreVersionPath(restoreDir, version.ToString());
                 PathUtility.CreateDirectoryFromFilePath(restorePath);
                 File.WriteAllText(restorePath, $"{version}");
                 File.SetLastWriteTimeUtc(restorePath, DateTime.UtcNow - TimeSpan.FromDays(20));

--- a/test/docfx.Test/restore/RestoreTest.cs
+++ b/test/docfx.Test/restore/RestoreTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Docs.Build
             var docsetPath = "restore-worktrees";
             var gitUrl = "https://github.com/docascode/docfx-test-dependencies-clean";
             Directory.CreateDirectory(docsetPath);
-            var restorePath = PathUtility.NormalizeFolder(Path.Combine(RestoreGit.GetRestoreRootDir(gitUrl), ".git"));
+            var restorePath = PathUtility.NormalizeFolder(Path.Combine(AppData.GetGitDir(gitUrl), ".git"));
 
             File.WriteAllText(Path.Combine(docsetPath, "docfx.yml"), $@"
 dependencies:
@@ -78,10 +78,10 @@ dependencies:
             var docsetPath = "restore-urls";
             Directory.CreateDirectory(docsetPath);
             var url = "https://raw.githubusercontent.com/docascode/docfx-test-dependencies-clean/master/README.md";
-            var restoreDir = RestoreFile.GetRestoreRootDir(url);
+            var restoreDir = AppData.GetFileDownloadDir(url);
             await ParallelUtility.ForEach(Enumerable.Range(0, 10), version =>
             {
-                var restorePath = RestoreFile.GetRestoreVersionPath(restoreDir, version.ToString());
+                var restorePath = Path.Combine(restoreDir, version.ToString());
                 PathUtility.CreateDirectoryFromFilePath(restorePath);
                 File.WriteAllText(restorePath, $"{version}");
                 File.SetLastWriteTimeUtc(restorePath, DateTime.UtcNow - TimeSpan.FromDays(20));


### PR DESCRIPTION
Consolidates all appdata path calculation logic to Appdata.cs,

_fixes_:
- git repository path should escape url
- file download path should respect query string

_renames_:
- RestoreUrl -> RestoreFile
- GetUrlRestorePath -> GetFileRestorePath
