### PR TITLE
revert localization redirection changes

### DIFF
--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -632,26 +632,6 @@ outputs:
   docs/a.json: |
     {"author":{"display_name":"Osmond Jiang","id":"xinjiang@microsoft.com"},"contributors":[{"display_name":"Wei Hu","id":"huwe@microsoft.com"}],"bilingual": true}
 ---
-# redirections are not in loc build outputs
-# redirection document id works
-# redirection link works
-commands:
-  - restore --locale zh-cn
-  - build --locale zh-cn
-repos: 
-  https://docs.com/redirection#master:
-    - files:
-        docfx.yml: |
-          redirections:
-            docs/a.md: /docs/b
-  https://docs.com/redirection.zh-cn#master:
-    - files:
-        docs/b.md: |
-          [link to a](a.md)
-outputs:
-  docs/b.json: |
-    { "content":"<p><a href=\"/docs/b\">link to a</a></p>\n", "document_id":"fa697b4e-3e52-77f6-2219-39040f6070da","document_version_independent_id":"7c88e748-ed5e-a29a-c057-6f89857c3591"}
----
 # bilingual page's `gitcommit` url follows sxs content's commit history
 commands:
   - restore --locale zh-cn

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -109,12 +109,6 @@ namespace Microsoft.Docs.Build
                         return false;
                     }
 
-                    // loc redirection files
-                    if (docset.FallbackDocset != null && file.Docset.FallbackDocset != null && file.ContentType == ContentType.Redirection)
-                    {
-                        return false;
-                    }
-
                     return file.ContentType != ContentType.Unknown && recurseDetector.TryAdd(file);
                 }
 


### PR DESCRIPTION
the redirection impact changes were caused by the inconsistent redirection configuration between source and loc repo, so reverting this change