### PR TITLE
Ensure restore map is a valid git repo

### DIFF
--- a/src/docfx/build/legacy/LegacyCrossRepoReferenceInfo.cs
+++ b/src/docfx/build/legacy/LegacyCrossRepoReferenceInfo.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Docs.Build
 
             foreach (var dependentRepo in docset.Config.Dependencies)
             {
-                var (url, branch) = GitUtility.GetGitRemoteInfo(dependentRepo.Value);
+                var (url, branch) = HrefUtility.SplitGitHref(dependentRepo.Value);
                 legacyCrrInfoItems.Add(new LegacyCrossRepoReferenceInfoItem
                 {
                     PathToRoot = dependentRepo.Key,

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Docs.Build
                 var (locRemote, locBranch) = (repo.Remote, repo.Branch);
                 if (!string.IsNullOrEmpty(document.Docset.Config.Contribution.Repository))
                 {
-                    (locRemote, locBranch) = GitUtility.GetGitRemoteInfo(document.Docset.Config.Contribution.Repository);
+                    (locRemote, locBranch) = HrefUtility.SplitGitHref(document.Docset.Config.Contribution.Repository);
                     (locRemote, _) = LocalizationConvention.GetLocalizationRepo(
                         document.Docset.Config.Localization.Mapping,
                         document.Docset.Config.Localization.Bilingual,

--- a/src/docfx/lib/HrefUtility.cs
+++ b/src/docfx/lib/HrefUtility.cs
@@ -52,6 +52,21 @@ namespace Microsoft.Docs.Build
             return (path, query, fragment);
         }
 
+        /// <summary>
+        /// Get the git remote information from remote href
+        /// </summary>
+        /// <param name="remoteHref">The git remote href like https://github.com/dotnet/docfx#master</param>
+        public static (string remote, string refspec) SplitGitHref(string remoteHref)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(remoteHref));
+
+            var (path, _, fragment) = SplitHref(remoteHref);
+
+            var refspec = (string.IsNullOrEmpty(fragment) || fragment.Length <= 1) ? "master" : fragment.Substring(1);
+
+            return (path, refspec);
+        }
+
         public static DependencyType FragmentToDependencyType(string fragment)
         {
             Debug.Assert(string.IsNullOrEmpty(fragment) || fragment[0] == '#');

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -145,6 +145,18 @@ namespace Microsoft.Docs.Build
         }
 
         /// <summary>
+        /// Determines if a worktree has completed checkout
+        /// </summary>
+        public static bool IsWorkTreeCheckoutComplete(string repoPath, string worktreeName)
+        {
+            // Adding the HEAD file is the last step in a worktree checkout, use it to
+            // filter out worktrees that are still in progress.
+            //
+            // list_work_tree https://github.com/git/git/blob/e146cc97be4c054c60d38e9f4edcdc33205bf563/worktree.c#L93
+            return File.Exists(Path.Combine(repoPath, ".git/worktrees", worktreeName, "HEAD"));
+        }
+
+        /// <summary>
         /// Create a work tree for a given repo
         /// </summary>
         /// <param name="cwd">The current working directory</param>

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -22,21 +22,6 @@ namespace Microsoft.Docs.Build
         internal static Func<string, string> GitRemoteProxy;
 
         /// <summary>
-        /// Get the git remote information from remote href
-        /// </summary>
-        /// <param name="remoteHref">The git remote href like https://github.com/dotnet/docfx#master</param>
-        public static (string remote, string refspec) GetGitRemoteInfo(string remoteHref)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(remoteHref));
-
-            var (path, _, fragment) = HrefUtility.SplitHref(remoteHref);
-
-            var refspec = (string.IsNullOrEmpty(fragment) || fragment.Length <= 1) ? "master" : fragment.Substring(1);
-
-            return (path, refspec);
-        }
-
-        /// <summary>
         /// Find git repo directory
         /// </summary>
         /// <param name="path">The git repo entry point</param>

--- a/test/docfx.Test/e2e/E2ETest.cs
+++ b/test/docfx.Test/e2e/E2ETest.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Docs.Build
                     {
                         t_mockedRepos.Value = mockedRepos;
 
-                        var (remote, refspec) = GitUtility.GetGitRemoteInfo(inputRepo);
+                        var (remote, refspec) = HrefUtility.SplitGitHref(inputRepo);
                         await GitUtility.CloneOrUpdate(docsetPath, remote, refspec);
                         Process.Start(new ProcessStartInfo("git", "submodule update --init") { WorkingDirectory = docsetPath }).WaitForExit();
                     }
@@ -275,7 +275,7 @@ namespace Microsoft.Docs.Build
             var result = new ConcurrentDictionary<string, string>();
             var repos =
                 from pair in spec.Repos
-                let info = GitUtility.GetGitRemoteInfo(pair.Key)
+                let info = HrefUtility.SplitGitHref(pair.Key)
                 group (info.refspec, pair.Value)
                 by info.remote;
 

--- a/test/docfx.Test/restore/RestoreTest.cs
+++ b/test/docfx.Test/restore/RestoreTest.cs
@@ -52,7 +52,7 @@ dependencies:
             var workTreeList = await GitUtility.ListWorkTree(restorePath);
             Assert.Equal(6, workTreeList.Count);
 
-            foreach(var wirkTreeFolder in workTreeList.Where(w => w.Contains("clean")))
+            foreach(var wirkTreeFolder in workTreeList.Where(w => w.Contains("-clean-")))
             {
                 Directory.SetLastWriteTimeUtc(wirkTreeFolder, DateTime.UtcNow - TimeSpan.FromDays(20));
             }

--- a/test/docfx.Test/restore/RestoreTest.cs
+++ b/test/docfx.Test/restore/RestoreTest.cs
@@ -19,10 +19,10 @@ namespace Microsoft.Docs.Build
         [InlineData("https://github.com/dotnet/docfx#986127a", "https://github.com/dotnet/docfx", "986127a")]
         [InlineData("https://github.com/dotnet/docfx#a#a", "https://github.com/dotnet/docfx", "a#a")]
         [InlineData("https://github.com/dotnet/docfx#a\\b/d<e>f*h|i%3C", "https://github.com/dotnet/docfx", "a\\b/d<e>f*h|i%3C")]
-        public static void GetGitInfo(string remote, string expectedUrl, string expectedRev)
+        public static void SplitGitHref(string remote, string expectedUrl, string expectedRev)
         {
             // Act
-            var (url, rev) = GitUtility.GetGitRemoteInfo(remote);
+            var (url, rev) = HrefUtility.SplitGitHref(remote);
 
             // Assert
             Assert.Equal(expectedUrl, url);
@@ -52,7 +52,7 @@ dependencies:
             var workTreeList = await GitUtility.ListWorkTree(restorePath);
             Assert.Equal(6, workTreeList.Count);
 
-            foreach(var wirkTreeFolder in workTreeList.Where(w => w.EndsWith("clean")))
+            foreach(var wirkTreeFolder in workTreeList.Where(w => w.Contains("clean")))
             {
                 Directory.SetLastWriteTimeUtc(wirkTreeFolder, DateTime.UtcNow - TimeSpan.FromDays(20));
             }


### PR DESCRIPTION
- Do not checkout original branch when bilingual is on (only fetch)
- Use `HEAD` file to check if a worktree is valid
- `GetGitRemoteInfo` -> `SplitGitHref` to align with `SplitHref`