### PR TITLE
violate schema return warning, and don't fail build

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/HostService.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/HostService.cs
@@ -39,6 +39,8 @@ namespace Microsoft.DocAsCode.Build.Engine
 
         public ImmutableDictionary<string, FileAndType> SourceFiles { get; set; }
 
+        public ImmutableList<string> InvalidSourceFiles { get; set; }
+
         public ImmutableDictionary<string, FileIncrementalInfo> IncrementalInfos { get; set; }
 
         public Dictionary<FileAndType, FileAndType> FileMap { get; } = new Dictionary<FileAndType, FileAndType>();

--- a/src/Microsoft.DocAsCode.Build.Engine/IHostServiceCreator.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/IHostServiceCreator.cs
@@ -11,8 +11,22 @@ namespace Microsoft.DocAsCode.Build.Engine
     internal interface IHostServiceCreator
     {
         bool ShouldProcessorTraceInfo(IDocumentProcessor processor);
+
         bool CanProcessorIncremental(IDocumentProcessor processor);
-        FileModel Load(IDocumentProcessor processor, ImmutableDictionary<string, object> metadata, FileMetadata fileMetadata, FileAndType file);
+
+        /// <summary>
+        /// Load file into model
+        /// </summary>
+        /// <returns>
+        /// model: the file Model, returns null if no need to load in incremental build or loading file failed
+        /// valid: whether loading file succeeds
+        /// </returns>
+        (FileModel model, bool valid) Load(
+            IDocumentProcessor processor,
+            ImmutableDictionary<string, object> metadata,
+            FileMetadata fileMetadata,
+            FileAndType file);
+
         HostService CreateHostService(
             DocumentBuildParameters parameters,
             TemplateProcessor templateProcessor,

--- a/src/Microsoft.DocAsCode.Build.Engine/Incrementals/IncrementalBuildContext.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/Incrementals/IncrementalBuildContext.cs
@@ -457,6 +457,13 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
                 Logger.LogVerbose(message);
                 return false;
             }
+            if (lpi.InvalidSourceFiles.Count > 0)
+            {
+                string message = $"Processor {processor.Name} disable incremental build because last build contains invalid input files";
+                IncrementalInfo.ReportProcessorStatus(processor.Name, false, message);
+                Logger.LogVerbose(message);
+                return false;
+            }
             if (cpi.IncrementalContextHash != lpi.IncrementalContextHash)
             {
                 string message = $"Processor {processor.Name} disable incremental build because incremental context hash changed.";

--- a/src/Microsoft.DocAsCode.Build.Engine/Incrementals/ProcessorInfo.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/Incrementals/ProcessorInfo.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.DocAsCode.Build.Engine.Incrementals
 {
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.IO;
 
     using Newtonsoft.Json;
@@ -14,10 +15,17 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
         /// The information for steps.
         /// </summary>
         public List<ProcessorStepInfo> Steps { get; } = new List<ProcessorStepInfo>();
+
         /// <summary>
         /// The file link for the BuildModel manifest file(type is <see cref="ModelManifest"/>).
         /// </summary>
         public string IntermediateModelManifestFile { get; set; }
+
+        /// <summary>
+        /// Get the list of invalid source files that fail to load.
+        /// </summary>
+        public ImmutableList<string> InvalidSourceFiles { get; set; } = ImmutableList.Create<string>();
+
         /// <summary>
         /// Deserialized build intermediate model manifest.
         /// </summary>

--- a/src/Microsoft.DocAsCode.Common/Loggers/ErrorCodes.cs
+++ b/src/Microsoft.DocAsCode.Common/Loggers/ErrorCodes.cs
@@ -8,7 +8,6 @@ namespace Microsoft.DocAsCode.Common
         public static class Build
         {
             public const string InvalidPropertyFormat = "InvalidPropertyFormat";
-            public const string InvalidInputFile = "InvalidInputFile";
         }
     }
 }

--- a/src/Microsoft.DocAsCode.Common/Loggers/WarningCodes.cs
+++ b/src/Microsoft.DocAsCode.Common/Loggers/WarningCodes.cs
@@ -30,6 +30,7 @@ namespace Microsoft.DocAsCode.Common
             public const string UidNotFound = "UidNotFound";
             public const string UnknownContentType = "UnknownContentType";
             public const string UnknownContentTypeForTemplate = "UnknownContentTypeForTemplate";
+            public const string InvalidInputFile = "InvalidInputFile";
         }
 
         public static class Markdown

--- a/test/Microsoft.DocAsCode.Build.RestApi.Tests/RestApiDocumentProcessorTest.cs
+++ b/test/Microsoft.DocAsCode.Build.RestApi.Tests/RestApiDocumentProcessorTest.cs
@@ -183,16 +183,17 @@ namespace Microsoft.DocAsCode.Build.RestApi.Tests
         {
             var files = new FileCollection(Directory.GetCurrentDirectory());
             files.Add(DocumentType.Article, new[] { "TestData/swagger/externalRefNotExist.json" }, "TestData/");
-            try
+            var listener = TestLoggerListener.CreateLoggerListenerWithCodeFilter(WarningCodes.Build.InvalidInputFile);
+            Logger.RegisterListener(listener);
+
+            using (new LoggerPhaseScope(nameof(RestApiDocumentProcessorTest)))
             {
                 BuildDocument(files);
             }
-            catch (DocfxException ex)
-            {
-                Assert.True(ex.Message.Contains("External swagger path not exist"));
-                return;
-            }
-            Assert.True(false, $"Should throws {nameof(DocfxException)}.");
+
+            Assert.NotNull(listener.Items);
+            Assert.Single(listener.Items);
+            Assert.Contains("External swagger path not exist", listener.Items[0].Message);
         }
 
         [Fact]
@@ -200,16 +201,17 @@ namespace Microsoft.DocAsCode.Build.RestApi.Tests
         {
             var files = new FileCollection(Directory.GetCurrentDirectory());
             files.Add(DocumentType.Article, new[] { "TestData/swagger/externalRefWithRefInside.json" }, "TestData/");
-            try
+            var listener = TestLoggerListener.CreateLoggerListenerWithCodeFilter(WarningCodes.Build.InvalidInputFile);
+            Logger.RegisterListener(listener);
+
+            using (new LoggerPhaseScope(nameof(RestApiDocumentProcessorTest)))
             {
                 BuildDocument(files);
             }
-            catch (DocfxException ex)
-            {
-                Assert.Equal(ex.Message, "$ref in refWithRefInside.json is not supported in external reference currently.");
-                return;
-            }
-            Assert.True(false, $"Should throws {nameof(DocfxException)}.");
+
+            Assert.NotNull(listener.Items);
+            Assert.Single(listener.Items);
+            Assert.Contains("$ref in refWithRefInside.json is not supported in external reference currently.", listener.Items[0].Message);
         }
 
         [Fact]
@@ -452,7 +454,7 @@ namespace Microsoft.DocAsCode.Build.RestApi.Tests
         [Fact]
         public void SystemKeysListShouldBeComplete()
         {
-            var userKeys = new[] { "meta", "swagger", "securityDefinitions", "schemes"};
+            var userKeys = new[] { "meta", "swagger", "securityDefinitions", "schemes" };
             FileCollection files = new FileCollection(_defaultFiles);
             BuildDocument(files);
 

--- a/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/SchemaDrivenProcessorTest.cs
+++ b/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/SchemaDrivenProcessorTest.cs
@@ -503,8 +503,8 @@ metadata: Web Apps Documentation
 
                 FileCollection files = new FileCollection(_defaultFiles);
                 files.Add(DocumentType.Article, new[] { inputFile }, _inputFolder);
-                Assert.Throws<DocumentException>(() => BuildDocument(files));
-                var errors = listener.Items.Where(s => s.LogLevel == LogLevel.Error).ToList();
+                BuildDocument(files);
+                var errors = listener.Items.Where(s => s.LogLevel == LogLevel.Warning).ToList();
                 Assert.Single(errors);
                 Assert.Equal($"Unable to load file: {inputFile} via processor: MetadataReferenceTest: Validation against \"http://dotnet.github.io/docfx/schemas/v1.0/schema.json#\" failed: \nInvalid type. Expected Object but got String. Path 'metadata'.", errors[0].Message);
             }

--- a/test/Microsoft.DocAsCode.Build.UniversalReference.Tests/UniversalReferenceDocumentProcessorTest.cs
+++ b/test/Microsoft.DocAsCode.Build.UniversalReference.Tests/UniversalReferenceDocumentProcessorTest.cs
@@ -181,8 +181,13 @@ namespace Microsoft.DocAsCode.Build.UniversalReference.Tests
             var files = new FileCollection(Directory.GetCurrentDirectory());
             files.Add(DocumentType.Article, fileNames.Select(f => $"{YmlDataDirectory}/{f}"), TestDataDirectory);
 
-            var ex = Assert.Throws<ArgumentException>(() => BuildDocument(files));
-            Assert.Equal("Uid must not be null or empty", ex.Message);
+            using (var listener = new TestListenerScope(nameof(UniversalReferenceDocumentProcessorTest)))
+            {
+                BuildDocument(files);
+                Assert.NotNull(listener.Items);
+                Assert.Single(listener.Items);
+                Assert.Contains("Uid must not be null or empty", listener.Items[0].Message);
+            }
         }
 
         private void BuildDocument(FileCollection files)


### PR DESCRIPTION
1. change from error to warning when violating schema
2. log warning when loading file fails, instead of terminate build
3. when loading file fails, we need to force build this processor in next build

#3555