### PR TITLE
Allow $schema in generated json schema

### DIFF
--- a/schemas/Conceptual.json
+++ b/schemas/Conceptual.json
@@ -13,6 +13,9 @@
     },
     "wordCount": {
       "type": "integer"
+    },
+    "$schema": {
+      "type": "string"
     }
   }
 }

--- a/schemas/ContextObject.json
+++ b/schemas/ContextObject.json
@@ -29,6 +29,9 @@
     "uhfheaderId": {
       "description": "The UHFHeaderID to use for the content. Overrides the default docset value. Example: MSDocsHeader-Dynamics365",
       "type": "string"
+    },
+    "$schema": {
+      "type": "string"
     }
   }
 }

--- a/schemas/LandingData.json
+++ b/schemas/LandingData.json
@@ -183,6 +183,9 @@
     },
     "documentType": {
       "type": "string"
+    },
+    "$schema": {
+      "type": "string"
     }
   }
 }

--- a/schemas/TOC.json
+++ b/schemas/TOC.json
@@ -46,6 +46,9 @@
       "items": {
         "$ref": "#/definitions/TableOfContentsInputItem"
       }
+    },
+    "$schema": {
+      "type": "string"
     }
   }
 }

--- a/schemas/TestData.json
+++ b/schemas/TestData.json
@@ -25,6 +25,9 @@
     },
     "data": {
       "$ref": "#"
+    },
+    "$schema": {
+      "type": "string"
     }
   }
 }

--- a/schemas/TestPage.json
+++ b/schemas/TestPage.json
@@ -13,6 +13,9 @@
     },
     "href": {
       "type": "string"
+    },
+    "$schema": {
+      "type": "string"
     }
   }
 }

--- a/schemas/docfx.json
+++ b/schemas/docfx.json
@@ -250,6 +250,9 @@
     },
     "monikerDefinitionUrl": {
       "type": "string"
+    },
+    "$schema": {
+      "type": "string"
     }
   }
 }

--- a/src/docfx/lib/JsonUtility.cs
+++ b/src/docfx/lib/JsonUtility.cs
@@ -379,7 +379,7 @@ namespace Microsoft.Docs.Build
                     var prop = item as JProperty;
 
                     // skip the special property
-                    if (prop.Name.StartsWith('$'))
+                    if (prop.Name == "$schema")
                         continue;
 
                     var nestedType = GetNestedTypeAndCheckForUnknownField(type, prop, errors);

--- a/tools/CreateJsonSchema/Program.cs
+++ b/tools/CreateJsonSchema/Program.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Docs.Build;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Schema;
 using Newtonsoft.Json.Schema.Generation;
 using Newtonsoft.Json.Serialization;
 
@@ -72,6 +73,8 @@ class Program
         var schema = generator.Generate(type, rootSchemaNullable: false);
 
         VerifyContract(generator.ContractResolver, type);
+
+        schema.Properties.Add("$schema", new JSchema { Type = JSchemaType.String });
 
         File.WriteAllText(Path.Combine("schemas", name + ".json"), schema.ToString());
     }


### PR DESCRIPTION
Otherwise vscode blames $schema is not allowed:
![image](https://user-images.githubusercontent.com/511355/48593657-b7023780-e988-11e8-8f92-a6f53bb554d8.png)
