### PR TITLE
Include xref reference to dependency map

### DIFF
--- a/docs/designs/xref.md
+++ b/docs/designs/xref.md
@@ -134,7 +134,7 @@ Link to <xref:a?displayProperty=fullName>
 The expected resolved result would be a `XrefSpec` instance for the referenced uid. The remaining problem here is that we want to output an object with a string input at the same `xref` property [Related issue](https://github.com/dotnet/docfx/issues/3497).
 
 ### Dependency map
-For xref reference to the internal document, the reference relationship should be included into the dependency map. If `displayProperty` is involved in the reference, the dependency type would be `UidInclusion`, otherwise, the type would be `Link`.
+For xref reference to the internal document, the reference relationship should be included into the dependency map. The dependency type should be `UidInclusion` since `@uid` implicitly means `@uid?displayProperty=name.
 The outpupt `build.manidest` would look like:
 ```json
     {

--- a/docs/designs/xref.md
+++ b/docs/designs/xref.md
@@ -134,7 +134,7 @@ Link to <xref:a?displayProperty=fullName>
 The expected resolved result would be a `XrefSpec` instance for the referenced uid. The remaining problem here is that we want to output an object with a string input at the same `xref` property [Related issue](https://github.com/dotnet/docfx/issues/3497).
 
 ### Dependency map
-For xref reference to the internal document, the reference relationship should be included into the dependency map. The dependency type should be `UidInclusion` since `@uid` implicitly means `@uid?displayProperty=name.
+For xref reference to the internal document, the reference relationship should be included into the dependency map. The dependency type should be `UidInclusion` since `@uid` implicitly means `@uid?displayProperty=name`.
 The outpupt `build.manidest` would look like:
 ```json
     {

--- a/docs/designs/xref.md
+++ b/docs/designs/xref.md
@@ -133,6 +133,21 @@ Link to <xref:a?displayProperty=fullName>
 ```
 The expected resolved result would be a `XrefSpec` instance for the referenced uid. The remaining problem here is that we want to output an object with a string input at the same `xref` property [Related issue](https://github.com/dotnet/docfx/issues/3497).
 
+### Dependency map
+For xref reference to the internal document, the reference relationship should be included into the dependency map. If `displayProperty` is involved in the reference, the dependency type would be `UidInclusion`, otherwise, the type would be `Link`.
+The outpupt `build.manidest` would look like:
+```json
+    {
+      "dependencies": {
+          "docs/c.md": [
+              {
+                  "source": "docs/a.md",
+                  "type": "UidInclusion"
+              }
+          ]
+      }
+    }
+```
 ### Others
 There are some other UID reference formats supported in docfx V2, which are not supported in V3 yet:
 - [Markdown link style](https://dotnet.github.io/docfx/tutorial/links_and_cross_references.html#markdown-link)

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -79,7 +79,7 @@ outputs:
           "docs/c.md": [
               {
                   "source": "docs/a.md",
-                  "type": "link"
+                  "type": "uidInclusion"
               }
           ]
       }
@@ -174,7 +174,7 @@ outputs:
           "docs/b.json": [
               {
                   "source": "docs/a.json",
-                  "type": "link"
+                  "type": "uidInclusion"
               }
           ]
       }

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -73,6 +73,17 @@ outputs:
         }
       ]
     }
+  build.manifest: |
+    {
+      "dependencies": {
+          "docs/c.md": [
+              {
+                  "source": "docs/a.md",
+                  "type": "link"
+              }
+          ]
+      }
+    }
 ---
 # Define uid in SDP
 # Resolve xref with display property in conceptual document
@@ -97,6 +108,17 @@ outputs:
   docs/a.json:
   xrefmap.json: | 
     {"references":[{"uid":"a","href":"/docs/a.json"}]}
+  build.manifest: |
+    {
+      "dependencies": {
+          "docs/c.md": [
+              {
+                  "source": "docs/a.json",
+                  "type": "uidInclusion"
+              }
+          ]
+      }
+    }
 ---
 # Define duplicate uid in conceptual and SDP 
 # should output error and uid cannot be resolved
@@ -146,6 +168,17 @@ outputs:
     }
   xrefmap.json: | 
     {"references":[{"uid":"a","href":"/docs/a.json"}]}
+  build.manifest: |
+    {
+      "dependencies": {
+          "docs/b.json": [
+              {
+                  "source": "docs/a.json",
+                  "type": "link"
+              }
+          ]
+      }
+    }
 ---
 # Define uid with error
 inputs:

--- a/src/docfx/build/manifest/DependencyType.cs
+++ b/src/docfx/build/manifest/DependencyType.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Docs.Build
     {
         Link, // file reference
         Bookmark, // file reference with fragment
-        Uid, // uid reference
+        UidInclusion, // uid reference with display property
         Inclusion, // token or codesnippet
         Overwrite, // overwrite markdown reference
         TocInclusion, // toc reference toc

--- a/src/docfx/build/page/AttributeTransformer.cs
+++ b/src/docfx/build/page/AttributeTransformer.cs
@@ -32,7 +32,6 @@ namespace Microsoft.Docs.Build
                     var (html, markup) = Markup.ToHtml((string)value, file, ReadFileDelegate, GetLinkDelegate, ResolveXrefDelegate, null, MarkdownPipelineType.Markdown);
                     errors.AddRange(markup.Errors);
                     result = html;
-                    XrefMap.HandleDependencyMap(markup, file, callback?.DependencyMapBuilder);
                 }
 
                 if (attribute is InlineMarkdownAttribute)
@@ -40,7 +39,6 @@ namespace Microsoft.Docs.Build
                     var (html, markup) = Markup.ToHtml((string)value, file, ReadFileDelegate, GetLinkDelegate, ResolveXrefDelegate, null, MarkdownPipelineType.InlineMarkdown);
                     errors.AddRange(markup.Errors);
                     result = html;
-                    XrefMap.HandleDependencyMap(markup, file, callback?.DependencyMapBuilder);
                 }
 
                 if (attribute is HtmlAttribute)
@@ -52,12 +50,7 @@ namespace Microsoft.Docs.Build
                 if (attribute is XrefAttribute)
                 {
                     // TODO: how to fill xref resolving data besides href
-                    var xrefSpec = Resolve.ResolveXref((string)value, callback?.XrefMap);
-                    result = xrefSpec?.Href;
-                    if (xrefSpec?.File != null)
-                    {
-                        callback.DependencyMapBuilder.AddDependencyItem(file, xrefSpec.File, DependencyType.UidInclusion);
-                    }
+                    return Resolve.ResolveXref((string)value, callback?.XrefMap, file, callback?.DependencyMapBuilder)?.Href;
                 }
 
                 if (extensionData != null && attributes.Any(attr => attr is XrefPropertyAttribute))
@@ -74,7 +67,7 @@ namespace Microsoft.Docs.Build
                     => Resolve.GetLink(path, relativeTo, resultRelativeTo, errors, callback?.BuildChild, callback?.DependencyMapBuilder, callback?.BookmarkValidator);
 
                 XrefSpec ResolveXrefDelegate(string uid, string moniker)
-                    => Resolve.ResolveXref(uid, callback?.XrefMap, moniker);
+                    => Resolve.ResolveXref(uid, callback?.XrefMap, file, callback?.DependencyMapBuilder, moniker);
             }
         }
     }

--- a/src/docfx/build/page/AttributeTransformer.cs
+++ b/src/docfx/build/page/AttributeTransformer.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Docs.Build
                 if (attribute is XrefAttribute)
                 {
                     // TODO: how to fill xref resolving data besides href
-                    return Resolve.ResolveXref((string)value, callback?.XrefMap, file, callback?.DependencyMapBuilder)?.Href;
+                    result = Resolve.ResolveXref((string)value, callback?.XrefMap, file, callback?.DependencyMapBuilder)?.Href;
                 }
 
                 if (extensionData != null && attributes.Any(attr => attr is XrefPropertyAttribute))

--- a/src/docfx/build/page/AttributeTransformer.cs
+++ b/src/docfx/build/page/AttributeTransformer.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Docs.Build
                     result = xrefSpec?.Href;
                     if (xrefSpec?.File != null)
                     {
-                        callback.DependencyMapBuilder.AddDependencyItem(file, xrefSpec.File, DependencyType.Link);
+                        callback.DependencyMapBuilder.AddDependencyItem(file, xrefSpec.File, DependencyType.UidInclusion);
                     }
                 }
 

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -113,6 +113,8 @@ namespace Microsoft.Docs.Build
                 MarkdownPipelineType.ConceptualMarkdown);
             errors.AddRange(markup.Errors);
 
+            XrefMap.HandleDependencyMap(markup, file, callback.DependencyMapBuilder);
+
             var htmlDom = HtmlUtility.LoadHtml(html);
             var htmlTitleDom = HtmlUtility.LoadHtml(markup.HtmlTitle);
             var title = yamlHeader.Value<string>("title") ?? HtmlUtility.GetInnerText(htmlTitleDom);

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -108,12 +108,10 @@ namespace Microsoft.Docs.Build
                 file,
                 (path, relativeTo) => Resolve.ReadFile(path, relativeTo, errors, callback.DependencyMapBuilder),
                 (path, relativeTo, resultRelativeTo) => Resolve.GetLink(path, relativeTo, resultRelativeTo, errors, callback.BuildChild, callback.DependencyMapBuilder, callback.BookmarkValidator),
-                (uid, moniker) => Resolve.ResolveXref(uid, callback.XrefMap, moniker),
+                (uid, moniker) => Resolve.ResolveXref(uid, callback.XrefMap, file, callback?.DependencyMapBuilder, moniker),
                 (rangeString) => file.Docset.MonikersProvider.GetZoneMonikers(file, rangeString, monikers, errors),
                 MarkdownPipelineType.ConceptualMarkdown);
             errors.AddRange(markup.Errors);
-
-            XrefMap.HandleDependencyMap(markup, file, callback.DependencyMapBuilder);
 
             var htmlDom = HtmlUtility.LoadHtml(html);
             var htmlTitleDom = HtmlUtility.LoadHtml(markup.HtmlTitle);

--- a/src/docfx/build/page/MarkupResult.cs
+++ b/src/docfx/build/page/MarkupResult.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace Microsoft.Docs.Build
@@ -15,8 +14,6 @@ namespace Microsoft.Docs.Build
         public List<Error> Errors = new List<Error>();
 
         public bool FirstBlockIsInclusionBlock = false;
-
-        public ConcurrentBag<Document> XrefReferences = new ConcurrentBag<Document>();
 
         public bool HasTitle => !string.IsNullOrEmpty(HtmlTitle);
     }

--- a/src/docfx/build/page/MarkupResult.cs
+++ b/src/docfx/build/page/MarkupResult.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
@@ -15,6 +16,8 @@ namespace Microsoft.Docs.Build
         public List<Error> Errors = new List<Error>();
 
         public bool FirstBlockIsInclusionBlock = false;
+
+        public ConcurrentBag<(Document xrefReferencedFile, bool uidInclusion)> XrefReferences = new ConcurrentBag<(Document xrefReferencedFile, bool uidInclusion)>();
 
         public bool HasTitle => !string.IsNullOrEmpty(HtmlTitle);
     }

--- a/src/docfx/build/page/MarkupResult.cs
+++ b/src/docfx/build/page/MarkupResult.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build
 {
@@ -17,7 +16,7 @@ namespace Microsoft.Docs.Build
 
         public bool FirstBlockIsInclusionBlock = false;
 
-        public ConcurrentBag<(Document xrefReferencedFile, bool uidInclusion)> XrefReferences = new ConcurrentBag<(Document xrefReferencedFile, bool uidInclusion)>();
+        public ConcurrentBag<Document> XrefReferences = new ConcurrentBag<Document>();
 
         public bool HasTitle => !string.IsNullOrEmpty(HtmlTitle);
     }

--- a/src/docfx/build/resolve/Resolve.cs
+++ b/src/docfx/build/resolve/Resolve.cs
@@ -44,9 +44,9 @@ namespace Microsoft.Docs.Build
             return link;
         }
 
-        public static XrefSpec ResolveXref(string uid, XrefMap xrefMap, string moniker = null)
+        public static XrefSpec ResolveXref(string uid, XrefMap xrefMap, Document file, DependencyMapBuilder dependencyMapBuilder, string moniker = null)
         {
-            return xrefMap?.Resolve(uid, moniker);
+            return xrefMap?.Resolve(uid, file, dependencyMapBuilder, moniker);
         }
 
         public static (Error error, string content, Document file) TryResolveContent(this Document relativeTo, string href)

--- a/src/docfx/build/resolve/Resolve.cs
+++ b/src/docfx/build/resolve/Resolve.cs
@@ -46,7 +46,12 @@ namespace Microsoft.Docs.Build
 
         public static XrefSpec ResolveXref(string uid, XrefMap xrefMap, Document file, DependencyMapBuilder dependencyMapBuilder, string moniker = null)
         {
-            return xrefMap?.Resolve(uid, file, dependencyMapBuilder, moniker);
+            if (xrefMap is null)
+                return null;
+
+            var (xrefSpec, doc) = xrefMap.Resolve(uid, moniker);
+            dependencyMapBuilder.AddDependencyItem(file, doc, DependencyType.UidInclusion);
+            return xrefSpec;
         }
 
         public static (Error error, string content, Document file) TryResolveContent(this Document relativeTo, string href)

--- a/src/docfx/build/xref/XRefSpec.cs
+++ b/src/docfx/build/xref/XRefSpec.cs
@@ -19,6 +19,9 @@ namespace Microsoft.Docs.Build
         [JsonExtensionData]
         public JObject ExtensionData { get; } = new JObject();
 
+        [JsonIgnore]
+        internal Document File { get; set; }
+
         public string GetName() => GetXrefPropertyValue("name");
 
         public string GetXrefPropertyValue(string property)

--- a/src/docfx/build/xref/XRefSpec.cs
+++ b/src/docfx/build/xref/XRefSpec.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Docs.Build
     {
         public string Uid { get; set; }
 
+        // not into output for now
         [JsonIgnore]
         public HashSet<string> Monikers { get; set; } = new HashSet<string>();
 
@@ -18,9 +19,6 @@ namespace Microsoft.Docs.Build
 
         [JsonExtensionData]
         public JObject ExtensionData { get; } = new JObject();
-
-        [JsonIgnore]
-        internal Document File { get; set; }
 
         public string GetName() => GetXrefPropertyValue("name");
 

--- a/src/docfx/build/xref/XrefMap.cs
+++ b/src/docfx/build/xref/XrefMap.cs
@@ -98,6 +98,24 @@ namespace Microsoft.Docs.Build
             return new XrefMap(map, CreateInternalXrefMap(context, docset.ScanScope), context, docset.MonikerRangeParser);
         }
 
+        public static void HandleDependencyMap(MarkupResult markup, Document file, DependencyMapBuilder dependencyMapBuilder)
+        {
+            if (dependencyMapBuilder is null)
+                return;
+            foreach (var group in markup.XrefReferences.Where(x => x.xrefReferencedFile != null).GroupBy(item => item.xrefReferencedFile, item => item.uidInclusion))
+            {
+                // if the xref referenced file contains any uid inclusion
+                if (group.Any(x => x))
+                {
+                    dependencyMapBuilder.AddDependencyItem(file, group.Key, DependencyType.UidInclusion);
+                }
+                else
+                {
+                    dependencyMapBuilder.AddDependencyItem(file, group.Key, DependencyType.Link);
+                }
+            }
+        }
+
         public void OutputXrefMap(Context context)
         {
             var models = new XrefMapModel();
@@ -270,6 +288,7 @@ namespace Microsoft.Docs.Build
             {
                 Uid = metadata.Uid,
                 Href = file.SiteUrl,
+                File = file,
             };
             xref.ExtensionData["name"] = string.IsNullOrEmpty(metadata.Title) ? metadata.Uid : metadata.Title;
 
@@ -300,6 +319,7 @@ namespace Microsoft.Docs.Build
             {
                 Uid = uid,
                 Href = file.SiteUrl,
+                File = file,
             };
             xref.ExtensionData.Merge(extensionData);
             return (errors, xref);

--- a/src/docfx/build/xref/XrefMap.cs
+++ b/src/docfx/build/xref/XrefMap.cs
@@ -275,7 +275,6 @@ namespace Microsoft.Docs.Build
             {
                 Uid = metadata.Uid,
                 Href = file.SiteUrl,
-                File = file,
             };
             xref.ExtensionData["name"] = string.IsNullOrEmpty(metadata.Title) ? metadata.Uid : metadata.Title;
 
@@ -306,7 +305,6 @@ namespace Microsoft.Docs.Build
             {
                 Uid = uid,
                 Href = file.SiteUrl,
-                File = file,
             };
             xref.ExtensionData.Merge(extensionData);
             return (errors, xref, file);

--- a/src/docfx/build/xref/XrefMap.cs
+++ b/src/docfx/build/xref/XrefMap.cs
@@ -102,17 +102,10 @@ namespace Microsoft.Docs.Build
         {
             if (dependencyMapBuilder is null)
                 return;
-            foreach (var group in markup.XrefReferences.Where(x => x.xrefReferencedFile != null).GroupBy(item => item.xrefReferencedFile, item => item.uidInclusion))
+
+            foreach (var reference in markup.XrefReferences.Where(x => x != null))
             {
-                // if the xref referenced file contains any uid inclusion
-                if (group.Any(x => x))
-                {
-                    dependencyMapBuilder.AddDependencyItem(file, group.Key, DependencyType.UidInclusion);
-                }
-                else
-                {
-                    dependencyMapBuilder.AddDependencyItem(file, group.Key, DependencyType.Link);
-                }
+                dependencyMapBuilder.AddDependencyItem(file, reference, DependencyType.UidInclusion);
             }
         }
 

--- a/src/docfx/build/xref/XrefMap.cs
+++ b/src/docfx/build/xref/XrefMap.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Docs.Build
     internal class XrefMap
     {
         // TODO: key could be uid+moniker+locale
-        private readonly IReadOnlyDictionary<string, List<Lazy<(List<Error>, XrefSpec)>>> _internalXrefMap;
+        private readonly IReadOnlyDictionary<string, List<Lazy<(List<Error>, XrefSpec, Document)>>> _internalXrefMap;
         private readonly IReadOnlyDictionary<string, XrefSpec> _externalXrefMap;
         private readonly Context _context;
         private readonly MonikerRangeParser _parser;
@@ -26,7 +26,7 @@ namespace Microsoft.Docs.Build
                 var loadedInternalSpecs = new List<XrefSpec>();
                 foreach (var (uid, specsWithSameUid) in _internalXrefMap)
                 {
-                    if (TryGetValidXrefSpecs(uid, specsWithSameUid, out var validInternalSpecs))
+                    if (TryGetValidXrefSpecs(uid, specsWithSameUid, out var validInternalSpecs, out var _))
                     {
                         loadedInternalSpecs.Add(GetLatestInternalXrefmap(validInternalSpecs));
                     }
@@ -35,12 +35,12 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public XrefSpec Resolve(string uid, Document file, DependencyMapBuilder dependencyMapBuilder, string moniker = null)
+        public (XrefSpec, Document) Resolve(string uid, string moniker = null)
         {
             if (_internalXrefMap.TryGetValue(uid, out var internalSpecs))
             {
-                if (!TryGetValidXrefSpecs(uid, internalSpecs, out var validInternalSpecs))
-                    return null;
+                if (!TryGetValidXrefSpecs(uid, internalSpecs, out var validInternalSpecs, out var referencedFile))
+                    return default;
 
                 if (!string.IsNullOrEmpty(moniker))
                 {
@@ -48,53 +48,41 @@ namespace Microsoft.Docs.Build
                     {
                         if (internalSpec.Monikers.Contains(moniker))
                         {
-                            HandleDependencyMap(internalSpec);
-                            return internalSpec;
+                            return (internalSpec, referencedFile);
                         }
                     }
 
                     // if the moniker is not defined with the uid
                     // log a warning and take the one with latest version
                     _context.Report(Errors.InvalidUidMoniker(moniker, uid));
-                    return GetLatestInternalXrefmap(validInternalSpecs);
+                    return (GetLatestInternalXrefmap(validInternalSpecs), referencedFile);
                 }
 
                 // For uid with and without moniker range, take the one without moniker range
                 var uidWithoutMoniker = validInternalSpecs.SingleOrDefault(spec => spec.Monikers.Count == 0);
                 if (uidWithoutMoniker != null)
                 {
-                    HandleDependencyMap(uidWithoutMoniker);
-                    return uidWithoutMoniker;
+                    return (uidWithoutMoniker, referencedFile);
                 }
 
                 // For uid with moniker range, take the latest moniker if no moniker defined while resolving
                 if (internalSpecs.Count > 1)
                 {
                     var latestInternalXrefMap = GetLatestInternalXrefmap(validInternalSpecs);
-                    HandleDependencyMap(latestInternalXrefMap);
-                    return latestInternalXrefMap;
+                    return (latestInternalXrefMap, referencedFile);
                 }
                 else
                 {
                     var validInternalSpec = validInternalSpecs.Single();
-                    HandleDependencyMap(validInternalSpec);
-                    return validInternalSpec;
+                    return (validInternalSpec, referencedFile);
                 }
             }
 
             if (_externalXrefMap.TryGetValue(uid, out var externalSpec))
             {
-                return externalSpec;
+                return (externalSpec, null);
             }
-            return null;
-
-            void HandleDependencyMap(XrefSpec spec)
-            {
-                if (spec?.File != null)
-                {
-                    dependencyMapBuilder?.AddDependencyItem(file, spec.File, DependencyType.UidInclusion);
-                }
-            }
+            return default;
         }
 
         public static XrefMap Create(Context context, Docset docset)
@@ -122,34 +110,37 @@ namespace Microsoft.Docs.Build
         private XrefSpec GetLatestInternalXrefmap(List<XrefSpec> specs)
             => specs.OrderBy(item => item.Monikers.FirstOrDefault(), new MonikerDescendingComparer(_parser)).FirstOrDefault();
 
-        private bool TryGetValidXrefSpecs(string uid, List<Lazy<(List<Error>, XrefSpec)>> specsWithSameUid, out List<XrefSpec> validSpecs)
+        private bool TryGetValidXrefSpecs(string uid, List<Lazy<(List<Error> errors, XrefSpec spec, Document doc)>> specsWithSameUid, out List<XrefSpec> validSpecs, out Document file)
         {
             var loadedSpecs = specsWithSameUid.Select(item => LoadXrefSpec(item));
             validSpecs = new List<XrefSpec>();
+            file = null;
 
             // no conflicts
             if (loadedSpecs.Count() == 1)
             {
-                validSpecs.AddRange(loadedSpecs);
+                validSpecs.AddRange(loadedSpecs.Select(x => x.Item1));
+                file = loadedSpecs.Single().Item2;
                 return true;
             }
 
             // multiple uid conflicts without moniker range definition, drop the uid and log an error
-            var conflictsWithoutMoniker = loadedSpecs.Where(item => item.Monikers.Count == 0);
+            var conflictsWithoutMoniker = loadedSpecs.Where(item => item.Item1.Monikers.Count == 0);
             if (conflictsWithoutMoniker.Count() > 1)
             {
-                var orderedConflict = conflictsWithoutMoniker.OrderBy(item => item.Href);
-                _context.Report(Errors.UidConflict(uid, orderedConflict));
+                var orderedConflict = conflictsWithoutMoniker.OrderBy(item => item.Item1.Href);
+                _context.Report(Errors.UidConflict(uid, orderedConflict.Select(x => x.Item1)));
                 return false;
             }
             else if (conflictsWithoutMoniker.Count() == 1)
             {
-                validSpecs.Add(conflictsWithoutMoniker.Single());
+                validSpecs.Add(conflictsWithoutMoniker.Single().Item1);
+                file = conflictsWithoutMoniker.Single().Item2;
             }
 
             // uid conflicts with overlapping monikers, drop the uid and log an error
-            var conflictsWithMoniker = specsWithSameUid.Where(x => LoadXrefSpec(x).Monikers.Count > 0).Select(item => LoadXrefSpec(item));
-            if (CheckOverlappingMonikers(loadedSpecs, out var overlappingMonikers))
+            var conflictsWithMoniker = specsWithSameUid.Where(x => LoadXrefSpec(x).Item1.Monikers.Count > 0).Select(item => LoadXrefSpec(item));
+            if (CheckOverlappingMonikers(loadedSpecs.Select(x => x.Item1), out var overlappingMonikers))
             {
                 _context.Report(Errors.MonikerOverlapping(overlappingMonikers));
                 return false;
@@ -158,17 +149,17 @@ namespace Microsoft.Docs.Build
             // define same uid with non-overlapping monikers, add them all
             else
             {
-                validSpecs.AddRange(conflictsWithMoniker);
+                validSpecs.AddRange(conflictsWithMoniker.Select(x => x.Item1));
                 return true;
             }
 
-            XrefSpec LoadXrefSpec(Lazy<(List<Error>, XrefSpec)> value)
+            (XrefSpec, Document) LoadXrefSpec(Lazy<(List<Error>, XrefSpec, Document)> value)
             {
                 if (value is null)
-                    return null;
+                    return default;
 
                 var isValueCreated = value.IsValueCreated;
-                var (errors, spec) = value.Value;
+                var (errors, spec, doc) = value.Value;
                 if (!isValueCreated)
                 {
                     foreach (var error in errors)
@@ -183,7 +174,7 @@ namespace Microsoft.Docs.Build
                         spec.Monikers = orderedMonikers;
                     }
                 }
-                return spec;
+                return (spec, doc);
             }
         }
 
@@ -206,9 +197,9 @@ namespace Microsoft.Docs.Build
             return isOverlapping;
         }
 
-        private static IReadOnlyDictionary<string, List<Lazy<(List<Error>, XrefSpec)>>> CreateInternalXrefMap(Context context, IEnumerable<Document> files)
+        private static IReadOnlyDictionary<string, List<Lazy<(List<Error>, XrefSpec, Document)>>> CreateInternalXrefMap(Context context, IEnumerable<Document> files)
         {
-            var xrefsByUid = new ConcurrentDictionary<string, ConcurrentBag<Lazy<(List<Error>, XrefSpec)>>>();
+            var xrefsByUid = new ConcurrentDictionary<string, ConcurrentBag<Lazy<(List<Error>, XrefSpec, Document)>>>();
             Debug.Assert(files != null);
             using (Progress.Start("Building Xref map"))
             {
@@ -217,7 +208,7 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private XrefMap(IReadOnlyDictionary<string, XrefSpec> externalXrefMap, IReadOnlyDictionary<string, List<Lazy<(List<Error>, XrefSpec)>>> internalXrefMap, Context context, MonikerRangeParser parser)
+        private XrefMap(IReadOnlyDictionary<string, XrefSpec> externalXrefMap, IReadOnlyDictionary<string, List<Lazy<(List<Error>, XrefSpec, Document)>>> internalXrefMap, Context context, MonikerRangeParser parser)
         {
             _externalXrefMap = externalXrefMap;
             _internalXrefMap = internalXrefMap;
@@ -225,7 +216,7 @@ namespace Microsoft.Docs.Build
             _parser = parser;
         }
 
-        private static void Load(Context context, ConcurrentDictionary<string, ConcurrentBag<Lazy<(List<Error>, XrefSpec)>>> xrefsByUid, Document file)
+        private static void Load(Context context, ConcurrentDictionary<string, ConcurrentBag<Lazy<(List<Error>, XrefSpec, Document)>>> xrefsByUid, Document file)
         {
             try
             {
@@ -241,8 +232,8 @@ namespace Microsoft.Docs.Build
                     {
                         TryAddXref(xrefsByUid, metadata.Uid, () =>
                         {
-                            var (error, spec) = LoadMarkdown(metadata, file);
-                            return (error is null ? new List<Error>() : new List<Error> { error }, spec);
+                            var (error, spec, _) = LoadMarkdown(metadata, file);
+                            return (error is null ? new List<Error>() : new List<Error> { error }, spec, file);
                         });
                     }
                 }
@@ -278,7 +269,7 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static (Error, XrefSpec) LoadMarkdown(FileMetadata metadata, Document file)
+        private static (Error error, XrefSpec spec, Document doc) LoadMarkdown(FileMetadata metadata, Document file)
         {
             var xref = new XrefSpec
             {
@@ -293,10 +284,10 @@ namespace Microsoft.Docs.Build
             {
                 xref.Monikers.Add(moniker);
             }
-            return (error, xref);
+            return (error, xref, file);
         }
 
-        private static (List<Error> errors, XrefSpec spec) LoadSchemaDocument(JObject obj, Document file, string uid)
+        private static (List<Error> errors, XrefSpec spec, Document doc) LoadSchemaDocument(JObject obj, Document file, string uid)
         {
             var extensionData = new JObject();
 
@@ -318,17 +309,17 @@ namespace Microsoft.Docs.Build
                 File = file,
             };
             xref.ExtensionData.Merge(extensionData);
-            return (errors, xref);
+            return (errors, xref, file);
         }
 
-        private static void TryAddXref(ConcurrentDictionary<string, ConcurrentBag<Lazy<(List<Error>, XrefSpec)>>> xrefsByUid, string uid, Func<(List<Error>, XrefSpec)> func)
+        private static void TryAddXref(ConcurrentDictionary<string, ConcurrentBag<Lazy<(List<Error>, XrefSpec, Document)>>> xrefsByUid, string uid, Func<(List<Error>, XrefSpec, Document)> func)
         {
             if (func is null)
             {
                 throw new ArgumentNullException(nameof(func));
             }
 
-            xrefsByUid.GetOrAdd(uid, _ => new ConcurrentBag<Lazy<(List<Error>, XrefSpec)>>()).Add(new Lazy<(List<Error>, XrefSpec)>(func));
+            xrefsByUid.GetOrAdd(uid, _ => new ConcurrentBag<Lazy<(List<Error>, XrefSpec, Document)>>()).Add(new Lazy<(List<Error>, XrefSpec, Document)>(func));
         }
 
         private class MonikerDescendingComparer : IComparer<string>

--- a/src/docfx/lib/markdown/ResolveXref.cs
+++ b/src/docfx/lib/markdown/ResolveXref.cs
@@ -42,6 +42,8 @@ namespace Microsoft.Docs.Build
                              return new LiteralInline(raw);
                          }
 
+                         Markup.Result.XrefReferences.Add((xrefSpec.File, queries != null && queries.AllKeys.Contains("displayProperty")));
+
                          // fallback order:
                          // xrefSpec.displayPropertyName -> xrefSpec.name -> uid
                          var name = xrefSpec.GetXrefPropertyValue("name");

--- a/src/docfx/lib/markdown/ResolveXref.cs
+++ b/src/docfx/lib/markdown/ResolveXref.cs
@@ -42,8 +42,6 @@ namespace Microsoft.Docs.Build
                              return new LiteralInline(raw);
                          }
 
-                         Markup.Result.XrefReferences.Add(xrefSpec.File);
-
                          // fallback order:
                          // xrefSpec.displayPropertyName -> xrefSpec.name -> uid
                          var name = xrefSpec.GetXrefPropertyValue("name");

--- a/src/docfx/lib/markdown/ResolveXref.cs
+++ b/src/docfx/lib/markdown/ResolveXref.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Docs.Build
                              return new LiteralInline(raw);
                          }
 
-                         Markup.Result.XrefReferences.Add((xrefSpec.File, queries != null && queries.AllKeys.Contains("displayProperty")));
+                         Markup.Result.XrefReferences.Add(xrefSpec.File);
 
                          // fallback order:
                          // xrefSpec.displayPropertyName -> xrefSpec.name -> uid


### PR DESCRIPTION
#3635 
- Include `xref` reference to the dependency map
- Update tests to verify `build.manifest`
- dependency type should always be `UidInclusion` since `@uid` implicitly means `@uid?displayProperty=name`