### PR TITLE
fix toc ui of static template

### DIFF
--- a/src/docfx.website.themes/statictoc/partials/li.tmpl.partial
+++ b/src/docfx.website.themes/statictoc/partials/li.tmpl.partial
@@ -1,30 +1,20 @@
 {{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
 
-<ul class="nav level{{level}} navbar-nav">
-  {{#items}}
-    {{^dropdown}}
-      <li>
-        {{^leaf}}
-          <span class="expand-stub"></span>
-        {{/leaf}}
-        {{#topicHref}}
-          <a href="{{topicHref}}" name="{{tocHref}}" title="{{name}}">{{name}}</a>
-        {{/topicHref}}
-        {{^topicHref}}
-          <a>{{{name}}}</a>
-        {{/topicHref}}
-        {{^leaf}}
-          {{>partials/li}}
-        {{/leaf}}
-      </li>
-    {{/dropdown}}
-    {{#dropdown}}
-      <li class="dropdown">
-        <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">{{name}} <span class="caret"></span></a>
-        <ul class="dropdown-menu level{{level}}">
-          {{>partials/dd-li}}
-        </ul>
-      </li>
-    {{/dropdown}}
-  {{/items}}
+<ul class="nav level{{level}}">
+{{#items}}
+  <li class="{{#active}}active{{/active}}">
+    {{^leaf}}
+    <span class="expand-stub"></span>
+    {{/leaf}}
+    {{#href}}
+    <a href="{{href}}" title="{{name}}" class="{{#active}}active{{/active}}">{{name}}</a>
+    {{/href}}
+    {{^href}}
+    <a class="{{#active}}active{{/active}}">{{{name}}}</a>
+    {{/href}}
+    {{^leaf}}
+      {{>partials/li}}
+    {{/leaf}}
+  </li>
+{{/items}}
 </ul>

--- a/src/docfx.website.themes/statictoc/partials/navbar-li.tmpl.partial
+++ b/src/docfx.website.themes/statictoc/partials/navbar-li.tmpl.partial
@@ -1,0 +1,30 @@
+{{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
+
+<ul class="nav level{{level}} navbar-nav">
+  {{#items}}
+    {{^dropdown}}
+      <li>
+        {{^leaf}}
+          <span class="expand-stub"></span>
+        {{/leaf}}
+        {{#topicHref}}
+          <a href="{{topicHref}}" name="{{tocHref}}" title="{{name}}">{{name}}</a>
+        {{/topicHref}}
+        {{^topicHref}}
+          <a>{{{name}}}</a>
+        {{/topicHref}}
+        {{^leaf}}
+          {{>partials/navbar-li}}
+        {{/leaf}}
+      </li>
+    {{/dropdown}}
+    {{#dropdown}}
+      <li class="dropdown">
+        <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">{{name}} <span class="caret"></span></a>
+        <ul class="dropdown-menu level{{level}}">
+          {{>partials/dd-li}}
+        </ul>
+      </li>
+    {{/dropdown}}
+  {{/items}}
+</ul>

--- a/src/docfx.website.themes/statictoc/partials/navbar.tmpl.partial
+++ b/src/docfx.website.themes/statictoc/partials/navbar.tmpl.partial
@@ -18,7 +18,7 @@
         </div>
       </form>
       {{#_nav}}
-        {{>partials/li}}
+        {{>partials/navbar-li}}
       {{/_nav}}
     </div>
   </div>


### PR DESCRIPTION
#3168 shares `li.tmpl` in navbar and sidetoc, then sidetoc has an additional HTML class `nav-bar` which caused page style change. This change split the code to fix the issue.

#3606 