### PR TITLE
dot not update cache when call github api failed

### DIFF
--- a/src/docfx/lib/github/GitHubAccessor.cs
+++ b/src/docfx/lib/github/GitHubAccessor.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Docs.Build
             catch (NotFoundException)
             {
                 // GitHub will return 404 "Not Found" if the user doesn't exist
-                return (Errors.GitHubUserNotFound(login), new GitHubUser { Login = login });
+                return default;
             }
             catch (RateLimitExceededException ex)
             {

--- a/src/docfx/lib/github/GitHubUserCache.cs
+++ b/src/docfx/lib/github/GitHubUserCache.cs
@@ -89,8 +89,10 @@ namespace Microsoft.Docs.Build
                 new Lazy<Task<(Error, GitHubUser)>>(
                     () => _getUserByLoginFromGitHub(login))).Value;
 
-            if (user != null || error.Code != "github-api-failed")
+            if (error == null)
             {
+                if (user == null)
+                    (error, user) = (Errors.GitHubUserNotFound(login), new GitHubUser { Login = login });
                 user.Expiry = NextExpiry();
                 UpdateUser(user);
             }
@@ -115,7 +117,7 @@ namespace Microsoft.Docs.Build
                 new Lazy<Task<(Error, string)>>(
                     () => _getLoginByCommitFromGitHub(repoOwner, repoName, commitSha))).Value;
 
-            if (error?.Code != "github-api-failed")
+            if (error == null)
                 UpdateUser(new GitHubUser { Login = login, Emails = new[] { authorEmail }, Expiry = NextExpiry() });
 
             if (login == null)

--- a/src/docfx/lib/github/GitHubUserCache.cs
+++ b/src/docfx/lib/github/GitHubUserCache.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Docs.Build
                 new Lazy<Task<(Error, GitHubUser)>>(
                     () => _getUserByLoginFromGitHub(login))).Value;
 
-            if (user != null)
+            if (user != null || error.Code != "github-api-failed")
             {
                 user.Expiry = NextExpiry();
                 UpdateUser(user);
@@ -115,7 +115,8 @@ namespace Microsoft.Docs.Build
                 new Lazy<Task<(Error, string)>>(
                     () => _getLoginByCommitFromGitHub(repoOwner, repoName, commitSha))).Value;
 
-            UpdateUser(new GitHubUser { Login = login, Emails = new[] { authorEmail }, Expiry = NextExpiry() });
+            if (error?.Code != "github-api-failed")
+                UpdateUser(new GitHubUser { Login = login, Emails = new[] { authorEmail }, Expiry = NextExpiry() });
 
             if (login == null)
                 return (error, null);

--- a/test/docfx.Test/lib/GitHubAccessorTest.cs
+++ b/test/docfx.Test/lib/GitHubAccessorTest.cs
@@ -11,16 +11,15 @@ namespace Microsoft.Docs.Build
         private GitHubAccessor _github = new GitHubAccessor();
 
         [Theory]
-        [InlineData("docascode", null, 14800732)]
-        [InlineData("N1o2t3E4x5i6s7t8N9a0m9e", "github-user-not-found", null)]
-        public async Task GetUserByLogin(string login, string errorCode, int? id)
+        [InlineData("docascode", 14800732)]
+        [InlineData("N1o2t3E4x5i6s7t8N9a0m9e", null)]
+        public async Task GetUserByLogin(string login, int? id)
         {
             var (error, profile) = await _github.GetUserByLogin(login);
 
             // skip check if the machine exceeds the GitHub API rate limit
-            if (error?.Code != "github-api-failed")
+            if (error == null)
             {
-                Assert.Equal(errorCode, error?.Code);
                 Assert.Equal(id, profile?.Id);
             }
         }

--- a/test/docfx.Test/lib/GitHubUserCacheTest.cs
+++ b/test/docfx.Test/lib/GitHubUserCacheTest.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Docs.Build
                     case "github-fail":
                         return Task.FromResult<(Error, GitHubUser)>((Errors.GitHubApiFailed("API call failed for some reasons", new Exception()), null));
                     default:
-                        return Task.FromResult((Errors.GitHubUserNotFound(login), new GitHubUser() { Login = login }));
+                        return Task.FromResult<(Error, GitHubUser)>(default);
                 }
             }
 

--- a/test/docfx.Test/lib/GitHubUserCacheTest.cs
+++ b/test/docfx.Test/lib/GitHubUserCacheTest.cs
@@ -12,36 +12,63 @@ namespace Microsoft.Docs.Build
 {
     public class GitHubUserCacheTest
     {
+        private static readonly Dictionary<string, TestCase> TestCases = PrepareTestCases();
+
         [Theory]
         [MemberData(nameof(GetData))]
-        internal async Task VerifyOutputcache(
-            Func<GitHubUserCache, Task> test,
-            string cacheUsersJson,
-            string expectedOutputCacheUsersJson,
-            int expectedGetUserByLoginCall,
-            int expectedGetLoginByCommitCall)
+        internal async Task TestCache(string name)
         {
             // Arrange
-            var users = JsonUtility.Deserialize<GitHubUser[]>(cacheUsersJson.Replace("\'", "\""));
+            var testCase = TestCases[name];
+            var users = JsonUtility.Deserialize<GitHubUser[]>(testCase.CacheUsersJson.Replace("\'", "\""));
             var cache = new GitHubUserCache(users, "cache.json", 7 * 24);
             var accessor = new MockGitHubAccessor();
             cache._getUserByLoginFromGitHub = accessor.GetUserByLogin;
             cache._getLoginByCommitFromGitHub = accessor.GetLoginByCommit;
 
             // Act
-            await test(cache);
+            await testCase.Test(cache);
 
             // Assert
-            Assert.Equal(expectedGetUserByLoginCall, accessor.GetUserByLoginCallCount);
-            Assert.Equal(expectedGetLoginByCommitCall, accessor.GetLoginByCommitCallCount);
-            var expectedUsers = JsonUtility.Deserialize<GitHubUser[]>(expectedOutputCacheUsersJson.Replace("\'", "\""));
+            Assert.Equal(testCase.ExpectedGetUserByLoginCall, accessor.GetUserByLoginCallCount);
+            Assert.Equal(testCase.ExpectedGetLoginByCommitCall, accessor.GetLoginByCommitCallCount);
+            var expectedUsers = JsonUtility.Deserialize<GitHubUser[]>(testCase.ExpectedOutputCacheUsersJson.Replace("\'", "\""));
             AssertUsersEqual(expectedUsers, cache.Users.ToArray());
         }
 
-        public static IEnumerable<object[]> GetData()
+        public static TheoryData<string> GetData()
+        {
+            var result = new TheoryData<string>();
+            foreach (var data in TestCases)
+            {
+                result.Add(data.Key);
+            }
+            return result;
+        }
+
+        private static Dictionary<string, TestCase> PrepareTestCases()
+        {
+            var result = new Dictionary<string, TestCase>();
+            foreach (var data in PrepareDataCore())
+            {
+                result[(string)data[0]] =
+                    new TestCase
+                    {
+                        Test = (Func<GitHubUserCache, Task>)data[1],
+                        CacheUsersJson = (string)data[2],
+                        ExpectedOutputCacheUsersJson = (string)data[3],
+                        ExpectedGetUserByLoginCall = (int)data[4],
+                        ExpectedGetLoginByCommitCall = (int)data[5],
+                    };
+            }
+            return result;
+        }
+
+        private static IEnumerable<object[]> PrepareDataCore()
         {
             yield return new object[]
             {
+                "Get user by login",
                  (Func<GitHubUserCache, Task>) ( async (cache) => await cache.GetByLogin("alice")),
                 "[]",
                 "[{'id':1,'login':'alice','name':'Alice','emails':['alice@contoso.com']}]",
@@ -50,6 +77,7 @@ namespace Microsoft.Docs.Build
             };
             yield return new object[]
             {
+                "Get same user by login multiple times should call GitHub once",
                 (Func<GitHubUserCache, Task>)(async (cache) =>
                     {
                         await ParallelUtility.ForEach(Enumerable.Range(0, 20), async (_) => await cache.GetByLogin("alice"));
@@ -61,6 +89,7 @@ namespace Microsoft.Docs.Build
             };
             yield return new object[]
             {
+                "Get user by login from cache",
                  (Func<GitHubUserCache, Task>) ( async (cache) => await cache.GetByLogin("alice")),
                 "[{'id':1,'login':'alice','name':'Alice','emails':['alice@contoso.com']}]",
                 "[{'id':1,'login':'alice','name':'Alice','emails':['alice@contoso.com']}]",
@@ -69,6 +98,7 @@ namespace Microsoft.Docs.Build
             };
             yield return new object[]
             {
+                "Get user by commit",
                 (Func<GitHubUserCache, Task>) ( async (cache) => await cache.GetByCommit("alice@contoso.com", "owner", "name", "1")),
                 "[]",
                 "[{'id':1,'login':'alice','name':'Alice','emails':['alice@contoso.com']}]",
@@ -77,6 +107,7 @@ namespace Microsoft.Docs.Build
             };
             yield return new object[]
             {
+                "Get same user by commit multiple times should call GitHub once",
                 (Func<GitHubUserCache, Task>) ( async (cache) =>
                 {
                     await ParallelUtility.ForEach(
@@ -90,6 +121,7 @@ namespace Microsoft.Docs.Build
             };
             yield return new object[]
             {
+                "Get user by commit from cache",
                 (Func<GitHubUserCache, Task>) ( async (cache) => await cache.GetByCommit("alice@contoso.com", "owner", "name", "1")),
                 "[{'id':1,'login':'alice','name':'Alice','emails':['alice@contoso.com']}]",
                 "[{'id':1,'login':'alice','name':'Alice','emails':['alice@contoso.com']}]",
@@ -98,6 +130,7 @@ namespace Microsoft.Docs.Build
             };
             yield return new object[]
             {
+                "Get user by commit with new email",
                 (Func<GitHubUserCache, Task>) ( async (cache) => await cache.GetByCommit("alice_new@contoso.com", "owner", "name", "1")),
                 "[]",
                 "[{'id':1,'login':'alice','name':'Alice','emails':['alice@contoso.com','alice_new@contoso.com']}]",
@@ -106,6 +139,7 @@ namespace Microsoft.Docs.Build
             };
             yield return new object[]
             {
+                "Get user by commit with new email can complete cache",
                 (Func<GitHubUserCache, Task>) ( async (cache) => await cache.GetByCommit("alice_new@contoso.com", "owner", "name", "1")),
                 "[{'id':1,'login':'alice','name':'Alice','emails':['alice@contoso.com']}]",
                 "[{'id':1,'login':'alice','name':'Alice','emails':['alice@contoso.com','alice_new@contoso.com']}]",
@@ -114,6 +148,7 @@ namespace Microsoft.Docs.Build
             };
             yield return new object[]
             {
+                "Get user by invalid login",
                 (Func<GitHubUserCache, Task>) ( async (cache) => await cache.GetByLogin("invalid")),
                 "[]",
                 "[{'login':'invalid','emails':[]}]",
@@ -122,11 +157,25 @@ namespace Microsoft.Docs.Build
             };
             yield return new object[]
             {
+                "Get user by invalid login from cache",
                (Func<GitHubUserCache, Task>) ( async (cache) => await cache.GetByLogin("invalid")),
                 "[{'login':'invalid','emails':[]}]",
                 "[{'login':'invalid','emails':[]}]",
                 0,
                 0
+            };
+            yield return new object[]
+            {
+                "Dot not update cache when call GitHub API failed",
+                (Func<GitHubUserCache, Task>)(async (cache) =>
+                    {
+                        await cache.GetByLogin("github-fail");
+                        await cache.GetByCommit("github-fail@contoso.com", "owner", "name", "2");
+                    }),
+                "[]",
+                "[]",
+                1,
+                1
             };
         }
 
@@ -163,6 +212,8 @@ namespace Microsoft.Docs.Build
                 {
                     case "alice":
                         return Task.FromResult<(Error, GitHubUser)>((null, new GitHubUser() { Id = 1, Login = "alice", Name = "Alice", Emails = new[] { "alice@contoso.com" } }));
+                    case "github-fail":
+                        return Task.FromResult<(Error, GitHubUser)>((Errors.GitHubApiFailed("API call failed for some reasons", new Exception()), null));
                     default:
                         return Task.FromResult((Errors.GitHubUserNotFound(login), new GitHubUser() { Login = login }));
                 }
@@ -175,10 +226,21 @@ namespace Microsoft.Docs.Build
                 {
                     case "owner/name/1":
                         return Task.FromResult<(Error, string)>((null, "alice"));
+                    case "owner/name/2":
+                        return Task.FromResult<(Error, string)>((Errors.GitHubApiFailed("API call failed for some reasons", new Exception()), null));
                     default:
                         return Task.FromResult<(Error, string)>(default);
                 }
             }
+        }
+
+        private sealed class TestCase
+        {
+            public Func<GitHubUserCache, Task> Test { get; set; }
+            public string CacheUsersJson { get; set; }
+            public string ExpectedOutputCacheUsersJson { get; set; }
+            public int ExpectedGetUserByLoginCall { get; set; }
+            public int ExpectedGetLoginByCommitCall { get; set; }
         }
     }
 }


### PR DESCRIPTION
otherwise a record is added to cache, which makes next build think the user/email doesn't exist and it will not call GitHub again.