### PR TITLE
Do not serialize monikers if list is empty

### DIFF
--- a/src/Microsoft.Docs.Template/Models/RedirectionModel.cs
+++ b/src/Microsoft.Docs.Template/Models/RedirectionModel.cs
@@ -15,5 +15,9 @@ namespace Microsoft.Docs.Build
         public string RedirectUrl { get; set; }
 
         public List<string> Monikers { get; set; }
+
+        // Customize if the property should be serialized
+        // https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm
+        public bool ShouldSerializeMonikers() => Monikers.Count > 0;
     }
 }

--- a/src/Microsoft.Docs.Template/Models/RedirectionModel.cs
+++ b/src/Microsoft.Docs.Template/Models/RedirectionModel.cs
@@ -15,9 +15,5 @@ namespace Microsoft.Docs.Build
         public string RedirectUrl { get; set; }
 
         public List<string> Monikers { get; set; }
-
-        // Customize if the property should be serialized
-        // https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm
-        public bool ShouldSerializeMonikers() => Monikers.Count > 0;
     }
 }

--- a/src/docfx/build/legacy/manifest/LegacyManifest.cs
+++ b/src/docfx/build/legacy/manifest/LegacyManifest.cs
@@ -110,11 +110,11 @@ namespace Microsoft.Docs.Build
                 context.WriteJson(
                 new
                 {
-                    groups = monikerGroups.Select(item => new
+                    groups = monikerGroups.Count > 0 ? monikerGroups.Select(item => new
                     {
                         group = item.Key,
                         monikers = item.Value,
-                    }),
+                    }) : null,
                     default_version_info = new
                     {
                         name = string.Empty,

--- a/src/docfx/build/manifest/FileManifest.cs
+++ b/src/docfx/build/manifest/FileManifest.cs
@@ -14,9 +14,5 @@ namespace Microsoft.Docs.Build
         public string SourcePath { get; set; }
 
         public List<string> Monikers { get; set; }
-
-        // Customize if the property should be serialized
-        // https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm
-        public bool ShouldSerializeMonikers() => Monikers.Count > 0;
     }
 }

--- a/src/docfx/build/manifest/FileManifest.cs
+++ b/src/docfx/build/manifest/FileManifest.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using Newtonsoft.Json;
 
 namespace Microsoft.Docs.Build
 {
@@ -15,5 +14,9 @@ namespace Microsoft.Docs.Build
         public string SourcePath { get; set; }
 
         public List<string> Monikers { get; set; }
+
+        // Customize if the property should be serialized
+        // https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm
+        public bool ShouldSerializeMonikers() => Monikers.Count > 0;
     }
 }


### PR DESCRIPTION
Also remove empty `groups` for legacy manifest