### PR TITLE
Do not serialize to JSON if monikers list is empty

### DIFF
--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -37,8 +37,7 @@ outputs:
     }
   docs/a.json: |
     {
-      "content": "<p>No version</p>",
-      "monikers": []
+      "content": "<p>No version</p>"
     }
 ---
 # Apply moniker range setting in the config and yaml header to markdown file's output path and output content
@@ -75,8 +74,7 @@ inputs:
 outputs:
   docs/a.json: |
     {
-      "content": "<p>No version</p>",
-      "monikers": []
+      "content": "<p>No version</p>"
     }
   218c13d0/docs/a.json: |
     {
@@ -94,8 +92,7 @@ outputs:
           {
               "siteUrl": "/docs/a",
               "outputPath": "docs/a.json",
-              "sourcePath": "docs/a.md",
-              "monikers": []
+              "sourcePath": "docs/a.md"
           },
           {
               "siteUrl": "/docs/a",
@@ -403,13 +400,11 @@ inputs:
 outputs:
   docs/b.json: |
     {
-      "content": "<p>Link to <a href=\"/docs/a?view=netcore-1.1\">netcore-1.1</a></p>",
-      "monikers": []
+      "content": "<p>Link to <a href=\"/docs/a?view=netcore-1.1\">netcore-1.1</a></p>"
     }
   docs/a.json: |
     {
-      "content": "<p>No version</p>",
-      "monikers": []
+      "content": "<p>No version</p>"
     }
   218c13d0/docs/a.json: |
     {
@@ -465,13 +460,11 @@ inputs:
 outputs:
   docs/b.json: |
     {
-      "content": "<p>Link to <a href=\"/docs/a\">netcore-2.0</a></p>",
-      "monikers": []
+      "content": "<p>Link to <a href=\"/docs/a\">netcore-2.0</a></p>"
     }
   docs/a.json: |
     {
-      "content": "<p>No version</p>",
-      "monikers": []
+      "content": "<p>No version</p>"
     }
   218c13d0/docs/a.json: |
     {
@@ -567,8 +560,7 @@ inputs:
 outputs:
   docs/b.json: |
     {
-      "content": "<p>Link to <a href=\"/docs/a?view=netcore-1.0\">netcore-2.0</a></p>",
-      "monikers": [] 
+      "content": "<p>Link to <a href=\"/docs/a?view=netcore-1.0\">netcore-2.0</a></p>"
     }
   218c13d0/docs/a.json: |
     {
@@ -630,13 +622,11 @@ inputs:
 outputs:
   docs/b.json: |
     {
-      "content": "<p>Link to <a href=\"/docs/a\">no version</a></p>",
-      "monikers": []
+      "content": "<p>Link to <a href=\"/docs/a\">no version</a></p>"
     }
   docs/a.json: |
     {
-      "content": "<p>No version</p>",
-      "monikers": []
+      "content": "<p>No version</p>"
     }
   218c13d0/docs/a.json: |
     {
@@ -702,13 +692,11 @@ outputs:
   docs/b.json:
   docs/c.json: |
     {
-      "content": "<p>Link to @a</p>",
-      "monikers": []
+      "content": "<p>Link to @a</p>"
     }
   docs/a.json: |
     {
-      "content": "<p>No version</p>",
-      "monikers": []
+      "content": "<p>No version</p>"
     }
   218c13d0/docs/a.json: |
     {

--- a/src/Microsoft.Docs.Template/Models/PageModel.cs
+++ b/src/Microsoft.Docs.Template/Models/PageModel.cs
@@ -51,7 +51,9 @@ namespace Microsoft.Docs.Build
 
         public bool Bilingual { get; set; }
 
-        public List<string> Monikers { get; set; }
+        public List<string> Monikers { get; } = new List<string>();
+
+        public bool ShouldSerializeMonikers() => Monikers.Count > 0;
     }
 
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/Microsoft.Docs.Template/Models/RedirectionModel.cs
+++ b/src/Microsoft.Docs.Template/Models/RedirectionModel.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Docs.Build
 
         public string RedirectUrl { get; set; }
 
-        public List<string> Monikers { get; set; }
+        public List<string> Monikers { get; } = new List<string>();
+
+        public bool ShouldSerializeMonikers() => Monikers.Count > 0;
     }
 }

--- a/src/Microsoft.Docs.Template/Models/TableOfContents.cs
+++ b/src/Microsoft.Docs.Template/Models/TableOfContents.cs
@@ -18,7 +18,9 @@ namespace Microsoft.Docs.Build
 
     public class TableOfContentsMetadata
     {
-        public List<string> Monikers { get; set; }
+        public List<string> Monikers { get; } = new List<string>();
+
+        public bool ShouldSerializeMonikers() => Monikers.Count > 0;
 
         [JsonExtensionData]
         public JObject ExtensionData { get; set; }
@@ -48,7 +50,9 @@ namespace Microsoft.Docs.Build
         public List<TableOfContentsItem> Children { get; set; }
 
         [JsonProperty(PropertyName = "monikers")]
-        public List<string> Monikers { get; set; }
+        public List<string> Monikers { get; } = new List<string>();
+
+        public bool ShouldSerializeMonikers() => Monikers.Count > 0;
 
         [JsonExtensionData]
         public JObject ExtensionData { get; set; }

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -196,9 +196,9 @@ namespace Microsoft.Docs.Build
                 {
                     SourcePath = file.FilePath,
                     SiteUrl = file.SiteUrl,
-                    Monikers = monikers,
                     OutputPath = GetOutputPath(file, monikers),
                 };
+                manifest.Monikers.AddRange(monikers);
 
                 if (manifestBuilder.TryAdd(file, manifest, monikers))
                 {

--- a/src/docfx/build/legacy/files/LegacyTableOfContents.cs
+++ b/src/docfx/build/legacy/files/LegacyTableOfContents.cs
@@ -67,6 +67,9 @@ namespace Microsoft.Docs.Build
         {
             [JsonProperty(PropertyName = "pdf_absolute_path")]
             public string PdfAbsolutePath { get; set; }
+
+            [JsonProperty("monikers")]
+            public List<string> Monikers { get; set; }
         }
 
         private class LegacyTableOfContentsExperimentMetadata

--- a/src/docfx/build/manifest/FileManifest.cs
+++ b/src/docfx/build/manifest/FileManifest.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Docs.Build
 
         public string SourcePath { get; set; }
 
-        public List<string> Monikers { get; set; }
+        public List<string> Monikers { get; } = new List<string>();
+
+        public bool ShouldSerializeMonikers() => Monikers.Count > 0;
     }
 }

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -125,8 +125,8 @@ namespace Microsoft.Docs.Build
                 Title = title,
                 RawTitle = markup.HtmlTitle,
                 WordCount = wordCount,
-                Monikers = monikers,
             };
+            model.Monikers.AddRange(monikers);
 
             var bookmarks = HtmlUtility.GetBookmarks(htmlDom).Concat(HtmlUtility.GetBookmarks(htmlTitleDom)).ToHashSet();
 
@@ -185,7 +185,6 @@ namespace Microsoft.Docs.Build
                 Content = content,
                 Title = title,
                 RawTitle = file.Docset.Legacy ? $"<h1>{obj?.Value<string>("title")}</h1>" : null,
-                Monikers = new List<string>(),
             };
 
             return (errors, schema, model, metadata);

--- a/src/docfx/build/redirection/BuildRedirection.cs
+++ b/src/docfx/build/redirection/BuildRedirection.cs
@@ -1,11 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build
 {
@@ -22,12 +19,13 @@ namespace Microsoft.Docs.Build
             var (error, monikers) = file.Docset.MonikersProvider.GetFileLevelMonikers(file, metadata.MonikerRange);
             errors.AddIfNotNull(error);
 
-            return (errors, new RedirectionModel
+            var redirectionModel = new RedirectionModel
             {
                 RedirectUrl = file.RedirectionUrl,
                 Locale = file.Docset.Locale,
-                Monikers = monikers,
-            });
+            };
+            redirectionModel.Monikers.AddRange(monikers);
+            return (errors, redirectionModel);
         }
     }
 }

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Docs.Build
             var metadata = file.Docset.Metadata.GetMetadata(file, tocMetadata).ToObject<TableOfContentsMetadata>();
 
             // Monikers of toc file is the collection of every node's monikers
-            metadata.Monikers = monikers;
+            metadata.Monikers.AddRange(monikers);
 
             var model = new TableOfContentsModel
             {

--- a/src/docfx/build/toc/parser/TableOfContentsInputItem.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsInputItem.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
@@ -33,7 +32,9 @@ namespace Microsoft.Docs.Build
         [MinLength(1)]
         public List<TableOfContentsInputItem> Items { get; set; }
 
-        public List<string> Monikers { get; set; }
+        public List<string> Monikers { get; } = new List<string>();
+
+        public bool ShouldSerializeMonikers() => Monikers.Count > 0;
 
         public static TableOfContentsItem ToTableOfContentsModel(TableOfContentsInputItem inputModel, MonikerComparer comparer)
         {
@@ -43,11 +44,11 @@ namespace Microsoft.Docs.Build
             }
 
             var children = inputModel.Items?.Select(l => ToTableOfContentsModel(l, comparer));
-            var childrenMonikers = children?.SelectMany(child => child?.Monikers ?? new List<string>());
+            var childrenMonikers = children?.SelectMany(child => child?.Monikers);
 
             var monikers = (childrenMonikers == null ? inputModel.Monikers : childrenMonikers.Union(inputModel.Monikers)).Distinct(comparer).ToList();
             monikers.Sort(comparer);
-            return new TableOfContentsItem
+            var tocItem = new TableOfContentsItem
             {
                 TocTitle = inputModel.Name,
                 DisplayName = inputModel.DisplayName,
@@ -57,8 +58,9 @@ namespace Microsoft.Docs.Build
                 Expanded = inputModel.Expanded,
                 ExtensionData = inputModel.ExtensionData,
                 Children = children?.ToList(),
-                Monikers = monikers,
             };
+            tocItem.Monikers.AddRange(monikers);
+            return tocItem;
         }
     }
 }

--- a/src/docfx/build/toc/parser/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsParser.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Docs.Build
                 // set resolved href back
                 tocModelItem.Href = resolvedTopicHref ?? resolvedTopicHrefFromTocHref;
                 tocModelItem.TocHref = resolvedTocHref;
-                tocModelItem.Monikers = monikers;
+                tocModelItem.Monikers.AddRange(monikers);
                 if (subChildren != null)
                 {
                     tocModelItem.Items = subChildren.Items;


### PR DESCRIPTION
- Use JSON .net to not serialize `Monikers` if empty
  https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm
- Change `Monikers` to read-only and initialize it with an empty list
- Add `Monikers` to legacy TOC model