### PR TITLE
sync from origin dev to stable

### DIFF
--- a/tools/Deployment/lib/syncBranch.ts
+++ b/tools/Deployment/lib/syncBranch.ts
@@ -6,7 +6,7 @@ import { Common } from "./common";
 export class SyncBranch {
     static async runAsync(repoUrl: string, docfxHomeDir: string, fromBranch: string, targetBranch: string): Promise<void> {
         await Common.execAsync("git", ["remote", "set-url", "origin", repoUrl], docfxHomeDir);
-        await Common.execAsync("git", ["push", "origin", fromBranch + ":" + targetBranch], docfxHomeDir);
+        await Common.execAsync("git", ["push", "origin", "origin/" + fromBranch + ":" + targetBranch], docfxHomeDir);
         console.log("Sync successfully");
     }
 }


### PR DESCRIPTION
There is a step called `checkout` step in VSTS CI pipeline, which will fetch the reposity conten, and they will checkout to the commit which trigger the current CI, but there is a not a ref point to the current branch.
so we push to the target branch directly from the origin source branch.

there is the checkout command lines:
![image](https://user-images.githubusercontent.com/17958546/49195731-4238ef80-f3c3-11e8-94f7-259122ff3a38.png)



