### PR TITLE
Fix GC crash caused by removing directory while enumerating it

### DIFF
--- a/src/docfx/gc/GarbageCollector.cs
+++ b/src/docfx/gc/GarbageCollector.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Docs.Build
 
             using (Progress.Start("Cleaning git repositories"))
             {
-                var gitWorkTreeRoots = Directory.EnumerateDirectories(AppData.GitRoot, ".git", SearchOption.AllDirectories);
+                var gitWorkTreeRoots = Directory.GetDirectories(AppData.GitRoot, ".git", SearchOption.AllDirectories);
 
                 await ParallelUtility.ForEach(gitWorkTreeRoots, CleanWorkTrees, Progress.Update);
             }


### PR DESCRIPTION

```
[xUnit.net 00:00:06.24]     Microsoft.Docs.Build.RestoreTest.RestoreGitWorkTrees [FAIL]
Failed   Microsoft.Docs.Build.RestoreTest.RestoreGitWorkTrees
Error Message:
 System.IO.DirectoryNotFoundException : Could not find a part of the path '/Users/yufeih/docfx/test/docfx.Test/bin/Debug/netcoreapp2.1/appdata/git/github.com+docascode+docfx-te..es-clean+0336104e/.git/worktrees/test-4-clean-01fa8106eb0b1de66fa75fefe49f1ce35cb239de/logs'.
Stack Trace:
   at System.IO.Enumeration.FileSystemEnumerator`1.CreateDirectoryHandle(String path)
   at System.IO.Enumeration.FileSystemEnumerator`1.DirectoryFinished()
   at System.IO.Enumeration.FileSystemEnumerator`1.FindNextEntry()
   at System.IO.Enumeration.FileSystemEnumerator`1.MoveNext()
   at Microsoft.Docs.Build.ParallelUtility.ForEach[T](IEnumerable`1 source, Func`2 action, Action`2 progress) in /Users/yufeih/docfx/src/docfx/lib/ParallelUtility.cs:line 41
   at Microsoft.Docs.Build.GarbageCollector.CollectGit(Int32 retentionDays) in /Users/yufeih/docfx/src/docfx/gc/GarbageCollector.cs:line 35
   at Microsoft.Docs.Build.GarbageCollector.Collect(Int32 retentionDays) in /Users/yufeih/docfx/src/docfx/gc/GarbageCollector.cs:line 18
   at Microsoft.Docs.Build.Program.Run(String[] args) in /Users/yufeih/docfx/src/docfx/cli/Program.cs:line 68
   at Microsoft.Docs.Build.RestoreTest.RestoreGitWorkTrees() in /Users/yufeih/docfx/test/docfx.Test/restore/RestoreTest.cs:line 68
--- End of stack trace from previous location where exception was thrown ---
```