### PR TITLE
Fix concurrent dictionary race condition

### DIFF
--- a/src/docfx/lib/git/GitCommitProvider.cs
+++ b/src/docfx/lib/git/GitCommitProvider.cs
@@ -193,9 +193,12 @@ namespace Microsoft.Docs.Build
                 using (var writer = new BinaryWriter(stream))
                 {
                     // Create a snapshot of commit cache to ensure count and items matches.
-                    var commitCache = _commitCache.ToList();
+                    //
+                    // There is a race condition in Linq ToList() method, use ConcurrentDictionary.ToArray() to create a snapshot
+                    // https://stackoverflow.com/questions/11692389/getting-argument-exception-in-concurrent-dictionary-when-sorting-and-displaying
+                    var commitCache = _commitCache.ToArray();
 
-                    writer.Write(commitCache.Count);
+                    writer.Write(commitCache.Length);
                     foreach (var (file, value) in commitCache)
                     {
                         lock (value)


### PR DESCRIPTION
Fixes #3700 :

```
2018-11-27T13:55:31.8552675Z System.ArgumentException : The index is equal to or greater than the length of the array, or the number of elements in the dictionary is greater than the available space from index to the end of the destination array.
2018-11-27T13:55:31.8553039Z Stack Trace:
2018-11-27T13:55:31.8553196Z at System.Collections.Concurrent.ConcurrentDictionary`2.System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.CopyTo(KeyValuePair`2[] array, Int32 index)
2018-11-27T13:55:31.8553617Z at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
2018-11-27T13:55:31.8553805Z at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
2018-11-27T13:55:31.8553923Z at Microsoft.Docs.Build.GitCommitProvider.<SaveCache>b__16_0(Stream stream) in /home/vsts/work/1/s/src/docfx/lib/git/GitCommitProvider.cs:line 204
2018-11-27T13:55:31.8554060Z at Microsoft.Docs.Build.ProcessUtility.<>c__DisplayClass5_0.<WriteFile>b__0() in /home/vsts/work/1/s/src/docfx/lib/ProcessUtility.cs:line 151
2018-11-27T13:55:31.8555942Z at Microsoft.Docs.Build.ProcessUtility.RunInsideMutex(String mutexName, Func`1 action) in /home/vsts/work/1/s/src/docfx/lib/ProcessUtility.cs:line 184
2018-11-27T13:55:31.8556114Z at Microsoft.Docs.Build.ContributionProvider.LoadCommits(Docset docset) in /home/vsts/work/1/s/src/docfx/build/metadata/ContributionProvider.cs:line 259
2018-11-27T13:55:31.8556835Z at Microsoft.Docs.Build.ContributionProvider.Create(Docset docset, GitHubUserCache cache) in /home/vsts/work/1/s/src/docfx/build/metadata/ContributionProvider.cs:line 32
2018-11-27T13:55:31.8557428Z at Microsoft.Docs.Build.Build.Run(String docsetPath, CommandLineOptions options, Report report) in /home/vsts/work/1/s/src/docfx/build/Build.cs:line 30
2018-11-27T13:55:31.8557585Z at Microsoft.Docs.Build.Program.Run(String[] args) in /home/vsts/work/1/s/src/docfx/cli/Program.cs:line 60
2018-11-27T13:55:31.8557817Z at Microsoft.Docs.Build.E2ETest.RunCore(String docsetPath, E2ESpec spec) in /home/vsts/work/1/s/test/docfx.Test/e2e/E2ETest.cs:line 86
2018-11-27T13:55:31.8557984Z at Microsoft.Docs.Build.E2ETest.Run(String name) in /home/vsts/work/1/s/test/docfx.Test/e2e/E2ETest.cs:line 68
```