### PR TITLE
TocInclusion --> inclusion, uidInclusion --> uid

### DIFF
--- a/docs/specs/manifest.yml
+++ b/docs/specs/manifest.yml
@@ -148,7 +148,7 @@ outputs:
           "docs/TOC.md":[
              {  
                 "source":"docs/a/TOC.md",
-                "type":"tocInclusion"
+                "type":"inclusion"
              }
           ],
           "docs/a/TOC.md":[  

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -79,7 +79,7 @@ outputs:
           "docs/c.md": [
               {
                   "source": "docs/a.md",
-                  "type": "uidInclusion"
+                  "type": "uid"
               }
           ]
       }
@@ -114,7 +114,7 @@ outputs:
           "docs/c.md": [
               {
                   "source": "docs/a.json",
-                  "type": "uidInclusion"
+                  "type": "uid"
               }
           ]
       }
@@ -174,7 +174,7 @@ outputs:
           "docs/b.json": [
               {
                   "source": "docs/a.json",
-                  "type": "uidInclusion"
+                  "type": "uid"
               }
           ]
       }

--- a/src/docfx/build/dependency/DependencyType.cs
+++ b/src/docfx/build/dependency/DependencyType.cs
@@ -5,11 +5,26 @@ namespace Microsoft.Docs.Build
 {
     public enum DependencyType
     {
-        Link, // file reference
-        Bookmark, // file reference with fragment
-        UidInclusion, // uid reference with display property
-        Inclusion, // token or codesnippet
-        Overwrite, // overwrite markdown reference
-        TocInclusion, // toc reference toc
+        /// <summary>
+        /// Link to a file.
+        /// </summary>
+        Link,
+
+        /// <summary>
+        /// Link to a file with bookmark.
+        /// </summary>
+        Bookmark,
+
+        /// <summary>
+        /// Link to a file using uid.
+        /// <summary>
+        Uid,
+
+        /// <summary>
+        /// Include the content of another file,
+        /// like an article including a markdown token, codesnippet,
+        /// or table of content file include the content of another table of content.
+        /// </summary>
+        Inclusion,
     }
 }

--- a/src/docfx/build/dependency/Resolve.cs
+++ b/src/docfx/build/dependency/Resolve.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Docs.Build
                 return null;
 
             var (xrefSpec, doc) = xrefMap.Resolve(uid, moniker);
-            dependencyMapBuilder.AddDependencyItem(file, doc, DependencyType.UidInclusion);
+            dependencyMapBuilder.AddDependencyItem(file, doc, DependencyType.Uid);
             return xrefSpec;
         }
 

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Docs.Build
                     {
                         // add to referenced toc list
                         referencedTocs.Add(referencedToc);
-                        dependencyMapBuilder?.AddDependencyItem(file, referencedToc, DependencyType.TocInclusion);
+                        dependencyMapBuilder?.AddDependencyItem(file, referencedToc, DependencyType.Inclusion);
                     }
                     return (referencedTocContent, referencedToc);
                 },


### PR DESCRIPTION
Turn TOC inclusion into plain inclusion. This cleans up dependency type to be consistent with resolve, so we could later introduce a `DependencyResolver` that handles dependency map internally. We only need 3 types of dependencies to resolve: `ResolveContent`, `ResolveLink` and `ResolveXref`. Bookmark is a special type of link.