### PR TITLE
show wanings on page when codesnippet not found

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         private readonly MarkdownContext _context;
         private const string tagPrefix = "snippet";
         private const string warningMessageId = "codeIncludeNotFound";
-        private const string defaultWarningMessage = "It looks like the sample you are looking for has moved!  Rest assured we are working on resolving this.";
+        private const string defaultWarningMessage = "It looks like the sample you are looking for does not exist.";
         private const string warningTitleId = "warning";
         private const string defaultWarningTitle = "<h5>WARNING</h5>";
 

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
@@ -17,6 +17,10 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
     {
         private readonly MarkdownContext _context;
         private const string tagPrefix = "snippet";
+        private const string warningMessageId = "codeIncludeNotFound";
+        private const string defaultWarningMessage = "It looks like the sample you are looking for has moved!  Rest assured we are working on resolving this.";
+        private const string warningTitleId = "warning";
+        private const string defaultWarningTitle = "<h5>WARNING</h5>";
 
         private static readonly IReadOnlyDictionary<string, List<string>> LanguageAlias = new Dictionary<string, List<string>>
         {
@@ -173,7 +177,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             if (content == null)
             {
                 _context.LogWarning("codesnippet-not-found", $"Cannot resolve '{codeSnippet.CodePath}' relative to '{InclusionContext.File}'.");
-                renderer.WriteEscape(codeSnippet.Raw);
+                renderer.Write(GetWarning());
                 return;
             }
 
@@ -368,6 +372,18 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             }
 
             return -1;
+        }
+
+        private string GetWarning()
+        {
+            var warningTitle = _context.GetToken(warningTitleId) ?? defaultWarningTitle;
+            var warningMessage = _context.GetToken(warningMessageId) ?? defaultWarningMessage;
+
+            return string.Format(@"<div class=""WARNING"">
+{0}
+<p>{1}</p>
+</div>", warningTitle, warningMessage);
+
         }
     }
 }


### PR DESCRIPTION
Refer to this feature: https://ceapex.visualstudio.com/Engineering/_workitems/edit/20848/.
Spec is here: https://review.docs.microsoft.com/en-us/new-hope/specs/ops/missing-sample-build?branch=master#design

We want to show a warning on page when the codesnippt is not found.