### PR TITLE
Add monikers to legacy resource

### DIFF
--- a/src/docfx/build/legacy/files/LegacyOutput.cs
+++ b/src/docfx/build/legacy/files/LegacyOutput.cs
@@ -3,13 +3,12 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace Microsoft.Docs.Build
 {
     internal static class LegacyOutput
     {
-        public static void Convert(Docset docset, Context context, MetadataProvider metadataProvider, List<(LegacyManifestItem manifestItem, Document document)> files)
+        public static void Convert(Docset docset, Context context, MetadataProvider metadataProvider, List<(LegacyManifestItem manifestItem, Document document, List<string> monikers)> files)
         {
             using (Progress.Start("Convert Legacy Files"))
             {
@@ -33,7 +32,7 @@ namespace Microsoft.Docs.Build
                 {
                     ParallelUtility.ForEach(
                         files.Where(f => f.document.ContentType == ContentType.Resource),
-                        file => LegacyResource.Convert(docset, context, file.document, file.manifestItem, metadataProvider),
+                        file => LegacyResource.Convert(docset, context, file.document, file.manifestItem, metadataProvider, file.monikers),
                         Progress.Update);
                 }
             }

--- a/src/docfx/build/legacy/files/LegacyResource.cs
+++ b/src/docfx/build/legacy/files/LegacyResource.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
 namespace Microsoft.Docs.Build
 {
     internal static class LegacyResource
@@ -10,11 +13,16 @@ namespace Microsoft.Docs.Build
             Context context,
             Document doc,
             LegacyManifestItem legacyManifestItem,
-            MetadataProvider metadataProvider)
+            MetadataProvider metadataProvider,
+            List<string> monikers)
         {
             var legacyManifestOutput = legacyManifestItem.Output;
             var metadata = metadataProvider.GetMetadata(doc);
             metadata = LegacyMetadata.GenerataCommonMetadata(metadata, docset);
+            if (monikers?.Count > 0)
+            {
+                metadata["monikers"] = new JArray(monikers);
+            }
             metadata.Remove("__global");
 
             if (docset.Config.Output.CopyResources)

--- a/src/docfx/build/legacy/manifest/LegacyManifest.cs
+++ b/src/docfx/build/legacy/manifest/LegacyManifest.cs
@@ -11,12 +11,12 @@ namespace Microsoft.Docs.Build
 {
     internal static class LegacyManifest
     {
-        public static List<(LegacyManifestItem manifestItem, Document doc)> Convert(Docset docset, Context context, Dictionary<Document, FileManifest> fileManifests)
+        public static List<(LegacyManifestItem manifestItem, Document doc, List<string> monikers)> Convert(Docset docset, Context context, Dictionary<Document, FileManifest> fileManifests)
         {
             using (Progress.Start("Convert Legacy Manifest"))
             {
                 var monikerGroups = new ConcurrentDictionary<string, List<string>>();
-                var convertedItems = new ConcurrentBag<(LegacyManifestItem manifestItem, Document doc)>();
+                var convertedItems = new ConcurrentBag<(LegacyManifestItem manifestItem, Document doc, List<string> monikers)>();
                 Parallel.ForEach(
                     fileManifests,
                     fileManifest =>
@@ -100,7 +100,7 @@ namespace Microsoft.Docs.Build
                             Group = groupId,
                         };
 
-                        convertedItems.Add((file, document));
+                        convertedItems.Add((file, document, fileManifest.Value.Monikers));
                         if (groupId != null)
                         {
                             monikerGroups.TryAdd(groupId, fileManifest.Value.Monikers);


### PR DESCRIPTION
`monikers` are missing from legacy resource files now
#3607 