### PR TITLE
avoid unneeded GetFullPath

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/DocumentBuildContext.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/DocumentBuildContext.cs
@@ -592,7 +592,7 @@ namespace Microsoft.DocAsCode.Build.Engine
 
             TocMap.AddOrUpdate(
                 fileKey,
-                new HashSet<string>(FilePathComparer.OSPlatformSensitiveComparer) { tocFileKey },
+                new HashSet<string>(FilePathComparer.OSPlatformSensitiveRelativePathComparer) { tocFileKey },
                 (k, v) =>
                 {
                     lock (v)


### PR DESCRIPTION
This is called in `GetHashCode` a lot.

![image](https://user-images.githubusercontent.com/3831744/49791560-b54f4800-fd6b-11e8-9f47-bd8880d030b7.png)

Although it saves only 3s for azure-docs-pr, it can also save much CPU time for further improvement with parallelism.