### PR TITLE
fix ci on mac

### DIFF
--- a/src/Microsoft.Docs.Template/Microsoft.Docs.Template.csproj
+++ b/src/Microsoft.Docs.Template/Microsoft.Docs.Template.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>Latest</LangVersion>
     <TreatWarningsAsErrors Condition="'$(Configuration)'=='Release'">true</TreatWarningsAsErrors>
   </PropertyGroup>


### PR DESCRIPTION
https://ceapex.visualstudio.com/Engineering/_build/results?buildId=29614

2018-12-12T01:23:26.4658290Z /Users/vsts/.dotnet/sdk/2.2.100/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.PackTool.targets(74,5): error NETSDK1054: only supports .NET Core. [/Users/vsts/agent/2.142.1/work/1/s/src/Microsoft.Docs.Template/Microsoft.Docs.Template.csproj]
