### PR TITLE
 Move PackAsTool to csproj

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -16,4 +16,4 @@ Remove-Item ./drop -Force -Recurse -ErrorAction Ignore
 exec "dotnet run -p tools/CreateJsonSchema"
 exec "dotnet test test\docfx.Test"
 exec "dotnet test test\docfx.Test -c Release"
-exec "dotnet pack src\docfx -c Release -o $PSScriptRoot\drop /p:Version=$version /p:InformationalVersion=$version /p:PackAsTool=true"
+exec "dotnet pack src\docfx -c Release -o $PSScriptRoot\drop /p:Version=$version /p:InformationalVersion=$version"

--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,4 @@ set -e
 dotnet run -p tools/CreateJsonSchema
 dotnet test test/docfx.Test
 dotnet test test/docfx.Test -c Release
-dotnet pack src/docfx -c Release /p:PackAsTool=true
+dotnet pack src/docfx -c Release

--- a/src/Microsoft.Docs.Template/Microsoft.Docs.Template.csproj
+++ b/src/Microsoft.Docs.Template/Microsoft.Docs.Template.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>Latest</LangVersion>
     <TreatWarningsAsErrors Condition="'$(Configuration)'=='Release'">true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -7,6 +7,7 @@
     <CodeAnalysisRuleSet>../../stylecop.ruleset</CodeAnalysisRuleSet>
     <RootNamespace>Microsoft.Docs.Build</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PackAsTool>true</PackAsTool>
     <TreatWarningsAsErrors Condition="'$(Configuration)'=='Release'">true</TreatWarningsAsErrors>
   </PropertyGroup>
 


### PR DESCRIPTION
We used to put `PackAsTool` outside because test project cannot reference dotnet tool project in the early days. Now the restriction seems to be fixed, so put them inside csproj.

Fixes `NETSDK1054`