### PR TITLE
avoid more unneeded GetFullPath

### DIFF
--- a/src/Microsoft.DocAsCode.Common/Path/RelativePath.cs
+++ b/src/Microsoft.DocAsCode.Common/Path/RelativePath.cs
@@ -154,7 +154,7 @@ namespace Microsoft.DocAsCode.Common
             {
                 if (i >= leftParts.Length - 1)
                     break;
-                if (!FilePathComparer.OSPlatformSensitiveComparer.Equals(leftParts[i], rightParts[i]))
+                if (!FilePathComparer.OSPlatformSensitiveRelativePathComparer.Equals(leftParts[i], rightParts[i]))
                     break;
                 commonCount++;
             }


### PR DESCRIPTION
this can reduce the number of calls to `GetFullPath` from 124k to 2k for azure-docs-pr