### PR TITLE
extract monikers from toc resolve delegate

### DIFF
--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Docs.Build
             {
                 var recurseDetector = new ConcurrentHashSet<Document>();
                 var manifestBuilder = new ManifestBuilder();
-                var monikerMap = new MonikerMap();
+                var monikerMap = new ConcurrentDictionary<Document, List<string>>();
 
                 var contribution = await ContributionProvider.Create(docset, githubUserCache, gitCommitProvider);
                 await ParallelUtility.ForEach(
@@ -90,7 +90,7 @@ namespace Microsoft.Docs.Build
                 // Build TOC: since toc file depends on the build result of every node
                 await ParallelUtility.ForEach(
                     docset.BuildScope,
-                    (file, buildChild) => { return BuildOneFile(file, buildChild, monikerMap); },
+                    (file, buildChild) => { return BuildOneFile(file, buildChild, new MonikerMap(monikerMap)); },
                     file => { return ShouldBuildFile(file, new ContentType[] { ContentType.TableOfContents }); },
                     Progress.Update);
 

--- a/src/docfx/build/moniker/MonikerMap.cs
+++ b/src/docfx/build/moniker/MonikerMap.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Docs.Build
 {
@@ -11,23 +12,11 @@ namespace Microsoft.Docs.Build
     /// </summary>
     internal class MonikerMap
     {
-        private readonly HashSet<Document> _docs = new HashSet<Document>();
+        private readonly Dictionary<Document, List<string>> _documentToMonikers = new Dictionary<Document, List<string>>();
 
-        private readonly ConcurrentDictionary<Document, List<string>> _documentToMonikers = new ConcurrentDictionary<Document, List<string>>();
-
-        public bool Contains(Document doc) => _docs.Contains(doc);
-
-        public bool TryAdd(Document doc, List<string> monikers)
+        public MonikerMap(ConcurrentDictionary<Document, List<string>> monikerMap)
         {
-            if (_documentToMonikers.TryAdd(doc, monikers))
-            {
-                _docs.Add(doc);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            _documentToMonikers = monikerMap.ToDictionary(item => item.Key, item => item.Value);
         }
 
         public bool TryGetValue(Document doc, out List<string> monikers)

--- a/src/docfx/build/moniker/MonikerMap.cs
+++ b/src/docfx/build/moniker/MonikerMap.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace Microsoft.Docs.Build
+{
+    /// <summary>
+    /// The mappings between document and monikers
+    /// </summary>
+    internal class MonikerMap
+    {
+        private readonly HashSet<Document> _docs = new HashSet<Document>();
+
+        private readonly ConcurrentDictionary<Document, List<string>> _documentToMonikers = new ConcurrentDictionary<Document, List<string>>();
+
+        public bool Contains(Document doc) => _docs.Contains(doc);
+
+        public bool TryAdd(Document doc, List<string> monikers)
+        {
+            if (_documentToMonikers.TryAdd(doc, monikers))
+            {
+                _docs.Add(doc);
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public bool TryGetValue(Document doc, out List<string> monikers)
+        {
+            return _documentToMonikers.TryGetValue(doc, out monikers);
+        }
+    }
+}

--- a/src/docfx/build/moniker/MonikersProvider.cs
+++ b/src/docfx/build/moniker/MonikersProvider.cs
@@ -8,14 +8,14 @@ using System.Linq;
 
 namespace Microsoft.Docs.Build
 {
-    internal class MonikersProvider
+    internal class MonikerProvider
     {
         private readonly List<(Func<string, bool> glob, string monikerRange)> _rules = new List<(Func<string, bool>, string)>();
         private readonly MonikerRangeParser _rangeParser;
 
         public MonikerComparer Comparer { get; }
 
-        public MonikersProvider(Docset docset)
+        public MonikerProvider(Docset docset)
         {
             foreach (var (key, monikerRange) in docset.Config.MonikerRange)
             {

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -18,13 +18,13 @@ namespace Microsoft.Docs.Build
             TableOfContentsMap tocMap,
             ContributionProvider contribution,
             MetadataProvider metadataProvider,
-            MonikersProvider monikersProvider,
+            MonikerProvider monikerProvider,
             DependencyResolver dependencyResolver,
             Action<Document> buildChild)
         {
             Debug.Assert(file.ContentType == ContentType.Page);
 
-            var (errors, schema, model, metadata) = await Load(context, file, metadataProvider, monikersProvider, dependencyResolver, buildChild);
+            var (errors, schema, model, metadata) = await Load(context, file, metadataProvider, monikerProvider, dependencyResolver, buildChild);
 
             model.PageType = schema.Name;
             model.Locale = file.Docset.Locale;
@@ -74,11 +74,11 @@ namespace Microsoft.Docs.Build
 
         private static async Task<(List<Error> errors, Schema schema, PageModel model, FileMetadata metadata)>
             Load(
-            Context context, Document file, MetadataProvider metadataProvider, MonikersProvider monikersProvider, DependencyResolver dependencyResolver, Action<Document> buildChild)
+            Context context, Document file, MetadataProvider metadataProvider, MonikerProvider monikerProvider, DependencyResolver dependencyResolver, Action<Document> buildChild)
         {
             if (file.FilePath.EndsWith(".md", PathUtility.PathComparison))
             {
-                return LoadMarkdown(context, file, metadataProvider, monikersProvider, dependencyResolver, buildChild);
+                return LoadMarkdown(context, file, metadataProvider, monikerProvider, dependencyResolver, buildChild);
             }
             if (file.FilePath.EndsWith(".yml", PathUtility.PathComparison))
             {
@@ -91,7 +91,7 @@ namespace Microsoft.Docs.Build
 
         private static (List<Error> errors, Schema schema, PageModel model, FileMetadata metadata)
             LoadMarkdown(
-            Context context, Document file, MetadataProvider metadataProvider, MonikersProvider monikersProvider, DependencyResolver dependencyResolver, Action<Document> buildChild)
+            Context context, Document file, MetadataProvider metadataProvider, MonikerProvider monikerProvider, DependencyResolver dependencyResolver, Action<Document> buildChild)
         {
             var errors = new List<Error>();
             var content = file.ReadText();
@@ -103,7 +103,7 @@ namespace Microsoft.Docs.Build
             var (metaErrors, metadata) = JsonUtility.ToObjectWithSchemaValidation<FileMetadata>(metadataProvider.GetMetadata(file, yamlHeader));
             errors.AddRange(metaErrors);
 
-            var (error, monikers) = monikersProvider.GetFileLevelMonikers(file, metadata.MonikerRange);
+            var (error, monikers) = monikerProvider.GetFileLevelMonikers(file, metadata.MonikerRange);
             errors.AddIfNotNull(error);
 
             // TODO: handle blank page
@@ -112,7 +112,7 @@ namespace Microsoft.Docs.Build
                 file,
                 dependencyResolver,
                 buildChild,
-                (rangeString) => monikersProvider.GetZoneMonikers(rangeString, monikers, errors),
+                (rangeString) => monikerProvider.GetZoneMonikers(rangeString, monikers, errors),
                 MarkdownPipelineType.ConceptualMarkdown);
             errors.AddRange(markup.Errors);
 

--- a/src/docfx/build/redirection/BuildRedirection.cs
+++ b/src/docfx/build/redirection/BuildRedirection.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Docs.Build
     internal static class BuildRedirection
     {
         internal static (List<Error> errors, RedirectionModel model, List<string> monikers)
-            Build(Document file, MetadataProvider metadataProvider, MonikersProvider monikersProvider)
+            Build(Document file, MetadataProvider metadataProvider, MonikerProvider monikerProvider)
         {
             Debug.Assert(file.ContentType == ContentType.Redirection);
             var errors = new List<Error>();
@@ -17,7 +17,7 @@ namespace Microsoft.Docs.Build
             var (metaErrors, metadata) = JsonUtility.ToObjectWithSchemaValidation<FileMetadata>(metadataProvider.GetMetadata(file, null));
             errors.AddRange(metaErrors);
 
-            var (error, monikers) = monikersProvider.GetFileLevelMonikers(file, metadata.MonikerRange);
+            var (error, monikers) = monikerProvider.GetFileLevelMonikers(file, metadata.MonikerRange);
             errors.AddIfNotNull(error);
 
             return (errors, new RedirectionModel

--- a/src/docfx/build/resource/BuildResource.cs
+++ b/src/docfx/build/resource/BuildResource.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Docs.Build
     internal class BuildResource
     {
         internal static (List<Error> errors, ResourceModel model, List<string> monikers)
-            Build(Document file, MetadataProvider metadataProvider, MonikersProvider monikersProvider)
+            Build(Document file, MetadataProvider metadataProvider, MonikerProvider monikerProvider)
         {
             Debug.Assert(file.ContentType == ContentType.Resource);
 
@@ -18,7 +18,7 @@ namespace Microsoft.Docs.Build
             var (metaErrors, metadata) = JsonUtility.ToObjectWithSchemaValidation<FileMetadata>(metadataProvider.GetMetadata(file));
             errors.AddRange(metaErrors);
 
-            var (monikerError, monikers) = monikersProvider.GetFileLevelMonikers(file, metadata.MonikerRange);
+            var (monikerError, monikers) = monikerProvider.GetFileLevelMonikers(file, metadata.MonikerRange);
             errors.AddIfNotNull(monikerError);
 
             return (errors, new ResourceModel

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -16,24 +16,24 @@ namespace Microsoft.Docs.Build
             Document file,
             TableOfContentsMap tocMap,
             MetadataProvider metadataProvider,
-            MonikersProvider monikersProvider,
+            MonikerProvider monikerProvider,
             DependencyResolver dependencyResolver,
-            Dictionary<Document, List<string>> monikersMap)
+            MonikerMap monikerMap)
         {
             Debug.Assert(file.ContentType == ContentType.TableOfContents);
-            Debug.Assert(monikersMap != null);
+            Debug.Assert(monikerMap != null);
 
             if (!tocMap.Contains(file))
             {
                 return (Enumerable.Empty<Error>(), null, new List<string>());
             }
 
-            var (errors, tocModel, tocMetadata, refArticles, refTocs) = Load(context, file, monikersProvider, dependencyResolver, monikersMap);
+            var (errors, tocModel, tocMetadata, refArticles, refTocs) = Load(context, file, monikerProvider, dependencyResolver, monikerMap);
 
             var metadata = metadataProvider.GetMetadata(file, tocMetadata).ToObject<TableOfContentsMetadata>();
 
             Error monikerError;
-            (monikerError, metadata.Monikers) = monikersProvider.GetFileLevelMonikers(file, metadata.MonikerRange);
+            (monikerError, metadata.Monikers) = monikerProvider.GetFileLevelMonikers(file, metadata.MonikerRange);
             errors.AddIfNotNull(monikerError);
 
             var model = new TableOfContentsModel
@@ -45,7 +45,7 @@ namespace Microsoft.Docs.Build
             return (errors, model, metadata.Monikers);
         }
 
-        public static TableOfContentsMap BuildTocMap(Context context, Docset docset, MonikersProvider monikersProvider, DependencyResolver dependencyResolver)
+        public static TableOfContentsMap BuildTocMap(Context context, Docset docset, MonikerProvider monikerProvider, DependencyResolver dependencyResolver)
         {
             using (Progress.Start("Loading TOC"))
             {
@@ -56,20 +56,20 @@ namespace Microsoft.Docs.Build
                     return builder.Build();
                 }
 
-                ParallelUtility.ForEach(tocFiles, file => BuildTocMap(context, file, builder, monikersProvider, dependencyResolver), Progress.Update);
+                ParallelUtility.ForEach(tocFiles, file => BuildTocMap(context, file, builder, monikerProvider, dependencyResolver), Progress.Update);
 
                 return builder.Build();
             }
         }
 
-        private static void BuildTocMap(Context context, Document fileToBuild, TableOfContentsMapBuilder tocMapBuilder, MonikersProvider monikersProvider, DependencyResolver dependencyResolver)
+        private static void BuildTocMap(Context context, Document fileToBuild, TableOfContentsMapBuilder tocMapBuilder, MonikerProvider monikerProvider, DependencyResolver dependencyResolver)
         {
             try
             {
                 Debug.Assert(tocMapBuilder != null);
                 Debug.Assert(fileToBuild != null);
 
-                var (errors, _, _, referencedDocuments, referencedTocs) = Load(context, fileToBuild, monikersProvider, dependencyResolver);
+                var (errors, _, _, referencedDocuments, referencedTocs) = Load(context, fileToBuild, monikerProvider, dependencyResolver);
                 context.Report(fileToBuild.ToString(), errors);
 
                 tocMapBuilder.Add(fileToBuild, referencedDocuments, referencedTocs);
@@ -90,9 +90,9 @@ namespace Microsoft.Docs.Build
             Load(
             Context context,
             Document fileToBuild,
-            MonikersProvider monikersProvider,
+            MonikerProvider monikerProvider,
             DependencyResolver dependencyResolver,
-            Dictionary<Document, List<string>> monikersMap = null)
+            MonikerMap monikerMap = null)
         {
             var errors = new List<Error>();
             var referencedDocuments = new List<Document>();
@@ -101,6 +101,8 @@ namespace Microsoft.Docs.Build
             var (loadErrors, tocItems, tocMetadata) = TableOfContentsParser.Load(
                 context,
                 fileToBuild,
+                monikerProvider,
+                monikerMap,
                 (file, href, isInclude) =>
                 {
                     var (error, referencedTocContent, referencedToc) = dependencyResolver.ResolveContent(href, file, DependencyType.TocInclusion);
@@ -119,17 +121,12 @@ namespace Microsoft.Docs.Build
                     var (error, link, buildItem) = dependencyResolver.ResolveLink(href, file, resultRelativeTo, null);
                     errors.AddIfNotNull(error);
 
-                    var itemMonikers = new List<string>();
                     if (buildItem != null)
                     {
                         referencedDocuments.Add(buildItem);
-                        if (monikersMap == null || !monikersMap.TryGetValue(buildItem, out itemMonikers))
-                        {
-                            itemMonikers = new List<string>();
-                        }
                     }
-                    return (link, itemMonikers);
-                }, monikersProvider);
+                    return (link, buildItem);
+                });
 
             errors.AddRange(loadErrors);
             return (errors, tocItems, tocMetadata, referencedDocuments, referencedTocs);

--- a/src/docfx/build/toc/parser/TableOfContentsInputItem.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsInputItem.cs
@@ -35,18 +35,13 @@ namespace Microsoft.Docs.Build
 
         public List<string> Monikers { get; set; }
 
-        public static TableOfContentsItem ToTableOfContentsModel(TableOfContentsInputItem inputModel, MonikerComparer comparer)
+        public static TableOfContentsItem ToTableOfContentsModel(TableOfContentsInputItem inputModel)
         {
             if (inputModel == null)
             {
                 return null;
             }
 
-            var children = inputModel.Items?.Select(l => ToTableOfContentsModel(l, comparer));
-            var childrenMonikers = children?.SelectMany(child => child?.Monikers ?? new List<string>()) ?? new List<string>();
-
-            var monikers = childrenMonikers.Union(inputModel.Monikers).Distinct(comparer).ToList();
-            monikers.Sort(comparer);
             return new TableOfContentsItem
             {
                 TocTitle = inputModel.Name,
@@ -56,8 +51,8 @@ namespace Microsoft.Docs.Build
                 MaintainContext = inputModel.MaintainContext,
                 Expanded = inputModel.Expanded,
                 ExtensionData = inputModel.ExtensionData,
-                Children = children?.ToList(),
-                Monikers = monikers,
+                Children = inputModel.Items?.Select(l => ToTableOfContentsModel(l))?.ToList(),
+                Monikers = inputModel.Monikers,
             };
         }
     }

--- a/src/docfx/build/toc/parser/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsParser.cs
@@ -15,16 +15,16 @@ namespace Microsoft.Docs.Build
         private static readonly string[] s_tocFileNames = new[] { "TOC.md", "TOC.json", "TOC.yml" };
         private static readonly string[] s_experimentalTocFileNames = new[] { "TOC.experimental.md", "TOC.experimental.json", "TOC.experimental.yml" };
 
-        public delegate (string resolvedTopicHref, List<string> monikers) ResolveHref(Document relativeTo, string href, Document resultRelativeTo);
+        public delegate (string resolvedTopicHref, Document file) ResolveHref(Document relativeTo, string href, Document resultRelativeTo);
 
         public delegate (string content, Document file) ResolveContent(Document relativeTo, string href, bool isInclusion);
 
         public static (List<Error> errors, List<TableOfContentsItem> items, JObject metadata)
-            Load(Context context, Document file, ResolveContent resolveContent, ResolveHref resolveHref, MonikersProvider monikersProvider)
+            Load(Context context, Document file, MonikerProvider monikerProvider, MonikerMap monikerMap, ResolveContent resolveContent, ResolveHref resolveHref)
         {
-            var (errors, inputModel) = LoadInputModelItems(context, file, file, resolveContent, resolveHref, new List<Document>());
+            var (errors, inputModel) = LoadInputModelItems(context, file, file, monikerProvider, monikerMap, resolveContent, resolveHref, new List<Document>());
 
-            var items = inputModel?.Items?.Select(r => TableOfContentsInputItem.ToTableOfContentsModel(r, monikersProvider.Comparer)).ToList();
+            var items = inputModel?.Items?.Select(r => TableOfContentsInputItem.ToTableOfContentsModel(r)).ToList();
             return (errors, items, inputModel?.Metadata);
         }
 
@@ -83,7 +83,16 @@ namespace Microsoft.Docs.Build
             return (new List<Error>(), new TableOfContentsInputModel());
         }
 
-        private static (List<Error> errors, TableOfContentsInputModel model) LoadInputModelItems(Context context, Document file, Document rootPath, ResolveContent resolveContent, ResolveHref resolveHref, List<Document> parents, string content = null)
+        private static (List<Error> errors, TableOfContentsInputModel model) LoadInputModelItems(
+            Context context,
+            Document file,
+            Document rootPath,
+            MonikerProvider monikerProvider,
+            MonikerMap monikerMap,
+            ResolveContent resolveContent,
+            ResolveHref resolveHref,
+            List<Document> parents,
+            string content = null)
         {
             // add to parent path
             if (parents.Contains(file))
@@ -97,7 +106,7 @@ namespace Microsoft.Docs.Build
 
             if (models.Items.Any())
             {
-                errors.AddRange(ResolveTocModelItems(context, models.Items, parents, file, rootPath, resolveContent, resolveHref));
+                errors.AddRange(ResolveTocModelItems(context, models.Items, parents, file, rootPath, monikerProvider, monikerMap, resolveContent, resolveHref));
                 parents.RemoveAt(parents.Count - 1);
             }
 
@@ -105,29 +114,51 @@ namespace Microsoft.Docs.Build
         }
 
         // todo: uid support
-        private static List<Error> ResolveTocModelItems(Context context, List<TableOfContentsInputItem> tocModelItems, List<Document> parents, Document filePath, Document rootPath, ResolveContent resolveContent, ResolveHref resolveHref)
+        private static List<Error> ResolveTocModelItems(
+            Context context,
+            List<TableOfContentsInputItem> tocModelItems,
+            List<Document> parents,
+            Document filePath,
+            Document rootPath,
+            MonikerProvider monikerProvider,
+            MonikerMap monikerMap,
+            ResolveContent resolveContent,
+            ResolveHref resolveHref)
         {
             var errors = new List<Error>();
             foreach (var tocModelItem in tocModelItems)
             {
                 if (tocModelItem.Items != null && tocModelItem.Items.Any())
                 {
-                    errors.AddRange(ResolveTocModelItems(context, tocModelItem.Items, parents, filePath, rootPath, resolveContent, resolveHref));
+                    errors.AddRange(ResolveTocModelItems(context, tocModelItem.Items, parents, filePath, rootPath, monikerProvider, monikerMap, resolveContent, resolveHref));
                 }
 
                 var tocHref = GetTocHref(tocModelItem);
                 var topicHref = GetTopicHref(tocModelItem);
 
                 var (resolvedTocHref, resolvedTopicHrefFromTocHref, subChildren) = ProcessTocHref(tocHref);
-                var (resolvedTopicHref, monikers) = ProcessTopicHref(topicHref);
+                var (resolvedTopicHref, document) = ProcessTopicHref(topicHref);
 
                 // set resolved href back
                 tocModelItem.Href = resolvedTopicHref ?? resolvedTopicHrefFromTocHref;
                 tocModelItem.TocHref = resolvedTocHref;
-                tocModelItem.Monikers = monikers;
                 if (subChildren != null)
                 {
                     tocModelItem.Items = subChildren.Items;
+                }
+
+                if (monikerMap != null)
+                {
+                    List<string> monikers;
+                    if (document == null || !monikerMap.TryGetValue(document, out monikers))
+                    {
+                        monikers = new List<string>();
+                    }
+                    var childrenMonikers = tocModelItem.Items?.SelectMany(child => child?.Monikers ?? new List<string>()) ?? new List<string>();
+
+                    monikers = childrenMonikers.Union(monikers).Distinct(monikerProvider.Comparer).ToList();
+                    monikers.Sort(monikerProvider.Comparer);
+                    tocModelItem.Monikers = monikers;
                 }
             }
 
@@ -200,7 +231,7 @@ namespace Microsoft.Docs.Build
                 var (referencedTocContent, referenceTocFilePath) = ResolveTocHrefContent(tocHrefType, tocHref, filePath, resolveContent);
                 if (referencedTocContent != null)
                 {
-                    var (subErrors, nestedToc) = LoadInputModelItems(context, referenceTocFilePath, rootPath, resolveContent, resolveHref, parents, referencedTocContent);
+                    var (subErrors, nestedToc) = LoadInputModelItems(context, referenceTocFilePath, rootPath, monikerProvider, monikerMap, resolveContent, resolveHref, parents, referencedTocContent);
                     errors.AddRange(subErrors);
                     if (tocHrefType == TocHrefType.RelativeFolder)
                     {
@@ -215,11 +246,11 @@ namespace Microsoft.Docs.Build
                 return default;
             }
 
-            (string resolvedTopicHref, List<string> monikers) ProcessTopicHref(string topicHref)
+            (string resolvedTopicHref, Document doc) ProcessTopicHref(string topicHref)
             {
                 if (string.IsNullOrEmpty(topicHref))
                 {
-                    return (topicHref, new List<string>());
+                    return (topicHref, null);
                 }
 
                 var topicHrefType = GetHrefType(topicHref);


### PR DESCRIPTION
- Remove monikers from resolve callback
- Move moniker union logic to BuildTableOfContents
- MonikersMap, monikersProvider -> monikerMap, monikerProvider
- Extract a MonikerMap class like others