### PR TITLE
support sdp(yaml/json) toc uid reference

### DIFF
--- a/docs/designs/table-of-contents.md
+++ b/docs/designs/table-of-contents.md
@@ -1,7 +1,5 @@
 # Tabe of Contents
 
-[//]: # (todo: uid cross reference definition will be added later.)
-
 ## Introduction
 
 Table of contents file which is also called TOC file is used to organize file structure and to provide navigation in the published page. TOC Files must have file name toc.md or toc.yml, notice that file name is case-insensitive.
@@ -62,12 +60,13 @@ Property Name                    | Type                       | Description
 -------------------------------- | -------------------------- | ---------------------------
 *name*                           | string                     | Specifies the title of the *TOC Item*.
 *href*                           | string                     | Specifies the hyperlink of the *TOC Item*. When its value is another TOC file, it is a TOC include, and all the items inside the included toc are considered as the child of current *TOC Item*
+*uid*                            | string                     | Specifies the `uid` of referenced *TOC Item*. If the value is set, it overwrites the value of *href*.
 *items*                          | array of *TOC Item Object* | Specifies the children *TOC Items* of current *TOC Item*.
 *topicHref*<sub>*advanced*</sub> | string                     | Specifies the topic href of the *TOC Item*. It is useful when *href* is linking to a folder or linking to a toc.
-*topicUid*<sub>*advanced*</sub>  | string                     | Specifies the `uid` of the *topicHref* file. If the value is set, it overwrites the value of *topicHref*.
+
 
 > [!Note]
-> *advanced*: These properties are useful when a TOC links another TOC, or links to a uid.
+> *advanced*: These properties are useful when a TOC links another TOC.
 
 ## Toc Item Link `href`
 

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -1079,3 +1079,85 @@ outputs:
         { "toc_title":"Title","href":"a#bookmark","monikers":[] }
       ]
     }
+---
+# uid reference
+inputs:
+  docfx.yml:
+  docs/a.md: |
+    ---
+    title: Title from yaml header a
+    uid: a
+    ---
+  docs/TOC.yml: |
+    - name: Uid Ref
+      uid: a
+outputs:
+  docs/a.json:
+  docs/toc.json: |
+    {
+      "items": [
+        { "toc_title":"Uid Ref","href":"a","monikers":[] }
+      ]
+    }
+---
+# uid reference first
+inputs:
+  docfx.yml:
+  docs/a.md: |
+    ---
+    title: Title from yaml header a
+    uid: a
+    ---
+  docs/b.md:
+  docs/TOC.yml: |
+    - name: Uid Ref
+      uid: a
+      href: b.md
+    - name: Uid Not Found
+      uid: c
+      href: b.md
+outputs:
+  docs/a.json:
+  docs/b.json:
+  docs/toc.json: |
+    {
+      "items": [
+        { "toc_title":"Uid Ref","href":"a","monikers":[] },
+        { "toc_title":"Uid Not Found","href":"b","monikers":[] }
+      ]
+    }
+  build.log: |
+    ["warning","uid-not-found","Cannot find uid 'c' using xref 'c'","docs/TOC.yml"]
+---
+# uid reference with monikers
+inputs:
+  docfx.yml: |
+    monikerRange:
+      'docs/**': '>= netcore-1.1'
+    monikerDefinition: monikerDefinition.json
+  monikerDefinition.json: |
+    {
+      "monikers": [
+        { "name": "netcore-1.0", "product": ".NET Core" },
+        { "name": "netcore-1.1", "product": ".NET Core" },
+        { "name": "netcore-1.2", "product": ".NET Core" },
+        { "name": "netcore-1.3", "product": ".NET Core" },
+      ]
+    }
+  docs/a.md: |
+    ---
+    monikerRange: netcore-1.1 || netcore-1.2
+    uid: a
+    ---
+  docs/TOC.yml: |
+    - name: Uid Ref
+      uid: a
+outputs:
+  e300a7df/docs/a.json:
+  8169d1ea/docs/toc.json: |
+    {
+      "items": [
+        { "toc_title":"Uid Ref","href":"a","monikers": ["netcore-1.1", "netcore-1.2"] }
+      ],
+      "metadata": {"monikers": ["netcore-1.1", "netcore-1.2", "netcore-1.3" ]}
+    }

--- a/schemas/TOC.json
+++ b/schemas/TOC.json
@@ -18,6 +18,9 @@
         "tocHref": {
           "type": "string"
         },
+        "uid": {
+          "type": "string"
+        },
         "maintainContext": {
           "type": "boolean"
         },

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Docs.Build
             return (error, link, file);
         }
 
-        public (Error error, string href, string display, Document file) ResolveXref(string href, Document file)
+        public (Error error, string href, string display, Document file) ResolveXref(string href, Document relativeTo)
         {
             var (uid, query, fragment) = HrefUtility.SplitHref(href);
             string moniker = null;
@@ -63,14 +63,14 @@ namespace Microsoft.Docs.Build
             var (xrefSpec, referencedFile) = _xrefMap.Value.Resolve(HttpUtility.UrlDecode(uid), moniker);
             if (xrefSpec is null)
             {
-                return (Errors.UidNotFound(file, uid, href), null, null, null);
+                return (Errors.UidNotFound(relativeTo, uid, href), null, null, null);
             }
 
-            DependencyMapBuilder.AddDependencyItem(file, referencedFile, DependencyType.UidInclusion);
+            DependencyMapBuilder.AddDependencyItem(relativeTo, referencedFile, DependencyType.UidInclusion);
             if (referencedFile != null)
             {
                 var spec = xrefSpec.Clone();
-                spec.Href = GetRelativeUrl(file, referencedFile);
+                spec.Href = GetRelativeUrl(relativeTo, referencedFile);
                 xrefSpec = spec;
             }
 

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -115,7 +115,6 @@ namespace Microsoft.Docs.Build
                 (file, href, resultRelativeTo) =>
                 {
                     // add to referenced document list
-                    // only resolve href, no need to build
                     var (error, link, buildItem) = dependencyResolver.ResolveLink(href, file, resultRelativeTo, null);
                     errors.AddIfNotNull(error);
 
@@ -129,7 +128,26 @@ namespace Microsoft.Docs.Build
                         }
                     }
                     return (link, itemMonikers);
-                }, monikersProvider);
+                },
+                (file, uid) =>
+                {
+                    // add to referenced document list
+                    var (error, link, _, buildItem) = dependencyResolver.ResolveXref(uid, file);
+                    errors.AddIfNotNull(error);
+
+                    var itemMonikers = new List<string>();
+                    if (buildItem != null)
+                    {
+                        referencedDocuments.Add(buildItem);
+                        if (monikersMap == null || !monikersMap.TryGetValue(buildItem, out itemMonikers))
+                        {
+                            itemMonikers = new List<string>();
+                        }
+                    }
+
+                    return (link, itemMonikers);
+                },
+                monikersProvider);
 
             errors.AddRange(loadErrors);
             return (errors, tocItems, tocMetadata, referencedDocuments, referencedTocs);

--- a/src/docfx/build/toc/parser/TableOfContentsInputItem.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsInputItem.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Docs.Build
 
         public string TocHref { get; set; }
 
+        public string Uid { get; set; }
+
         [JsonExtensionData]
         public JObject ExtensionData { get; set; }
 

--- a/src/docfx/build/toc/parser/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsParser.cs
@@ -17,12 +17,14 @@ namespace Microsoft.Docs.Build
 
         public delegate (string resolvedTopicHref, List<string> monikers) ResolveHref(Document relativeTo, string href, Document resultRelativeTo);
 
+        public delegate (string resolvedTopicHref, List<string> monikers) ResolveXref(Document relativeTo, string uid);
+
         public delegate (string content, Document file) ResolveContent(Document relativeTo, string href, bool isInclusion);
 
         public static (List<Error> errors, List<TableOfContentsItem> items, JObject metadata)
-            Load(Context context, Document file, ResolveContent resolveContent, ResolveHref resolveHref, MonikersProvider monikersProvider)
+            Load(Context context, Document file, ResolveContent resolveContent, ResolveHref resolveHref, ResolveXref resolveXref, MonikersProvider monikersProvider)
         {
-            var (errors, inputModel) = LoadInputModelItems(context, file, file, resolveContent, resolveHref, new List<Document>());
+            var (errors, inputModel) = LoadInputModelItems(context, file, file, resolveContent, resolveHref, resolveXref, new List<Document>());
 
             var items = inputModel?.Items?.Select(r => TableOfContentsInputItem.ToTableOfContentsModel(r, monikersProvider.Comparer)).ToList();
             return (errors, items, inputModel?.Metadata);
@@ -83,7 +85,7 @@ namespace Microsoft.Docs.Build
             return (new List<Error>(), new TableOfContentsInputModel());
         }
 
-        private static (List<Error> errors, TableOfContentsInputModel model) LoadInputModelItems(Context context, Document file, Document rootPath, ResolveContent resolveContent, ResolveHref resolveHref, List<Document> parents, string content = null)
+        private static (List<Error> errors, TableOfContentsInputModel model) LoadInputModelItems(Context context, Document file, Document rootPath, ResolveContent resolveContent, ResolveHref resolveHref, ResolveXref resolveXref, List<Document> parents, string content = null)
         {
             // add to parent path
             if (parents.Contains(file))
@@ -97,29 +99,29 @@ namespace Microsoft.Docs.Build
 
             if (models.Items.Any())
             {
-                errors.AddRange(ResolveTocModelItems(context, models.Items, parents, file, rootPath, resolveContent, resolveHref));
+                errors.AddRange(ResolveTocModelItems(context, models.Items, parents, file, rootPath, resolveContent, resolveHref, resolveXref));
                 parents.RemoveAt(parents.Count - 1);
             }
 
             return (errors, models);
         }
 
-        // todo: uid support
-        private static List<Error> ResolveTocModelItems(Context context, List<TableOfContentsInputItem> tocModelItems, List<Document> parents, Document filePath, Document rootPath, ResolveContent resolveContent, ResolveHref resolveHref)
+        private static List<Error> ResolveTocModelItems(Context context, List<TableOfContentsInputItem> tocModelItems, List<Document> parents, Document filePath, Document rootPath, ResolveContent resolveContent, ResolveHref resolveHref, ResolveXref resolveXref)
         {
             var errors = new List<Error>();
             foreach (var tocModelItem in tocModelItems)
             {
                 if (tocModelItem.Items != null && tocModelItem.Items.Any())
                 {
-                    errors.AddRange(ResolveTocModelItems(context, tocModelItem.Items, parents, filePath, rootPath, resolveContent, resolveHref));
+                    errors.AddRange(ResolveTocModelItems(context, tocModelItem.Items, parents, filePath, rootPath, resolveContent, resolveHref, resolveXref));
                 }
 
                 var tocHref = GetTocHref(tocModelItem);
                 var topicHref = GetTopicHref(tocModelItem);
+                var topicUid = tocModelItem.Uid;
 
                 var (resolvedTocHref, resolvedTopicHrefFromTocHref, subChildren) = ProcessTocHref(tocHref);
-                var (resolvedTopicHref, monikers) = ProcessTopicHref(topicHref);
+                var (resolvedTopicHref, monikers) = ProcessTopicItem(topicUid, topicHref);
 
                 // set resolved href back
                 tocModelItem.Href = resolvedTopicHref ?? resolvedTopicHrefFromTocHref;
@@ -200,7 +202,7 @@ namespace Microsoft.Docs.Build
                 var (referencedTocContent, referenceTocFilePath) = ResolveTocHrefContent(tocHrefType, tocHref, filePath, resolveContent);
                 if (referencedTocContent != null)
                 {
-                    var (subErrors, nestedToc) = LoadInputModelItems(context, referenceTocFilePath, rootPath, resolveContent, resolveHref, parents, referencedTocContent);
+                    var (subErrors, nestedToc) = LoadInputModelItems(context, referenceTocFilePath, rootPath, resolveContent, resolveHref, resolveXref, parents, referencedTocContent);
                     errors.AddRange(subErrors);
                     if (tocHrefType == TocHrefType.RelativeFolder)
                     {
@@ -215,8 +217,19 @@ namespace Microsoft.Docs.Build
                 return default;
             }
 
-            (string resolvedTopicHref, List<string> monikers) ProcessTopicHref(string topicHref)
+            (string resolvedTopicHref, List<string> monikers) ProcessTopicItem(string uid, string topicHref)
             {
+                // process uid first
+                if (!string.IsNullOrEmpty(uid))
+                {
+                    var (resolvedTopicHref, monikers) = resolveXref.Invoke(filePath, uid);
+                    if (!string.IsNullOrEmpty(resolvedTopicHref))
+                    {
+                        return (resolvedTopicHref, monikers);
+                    }
+                }
+
+                // process topicHref then
                 if (string.IsNullOrEmpty(topicHref))
                 {
                     return (topicHref, new List<string>());


### PR DESCRIPTION
yaml/json toc can use `uid` to reference topic files.
in docfx v2, we also support `topicUid`, but after searching the MicrosoftDocs org, there is no one using this new syntax, we in v3, we are not going to support that 