### PR TITLE
normalize topicHref like href in statictoc

### DIFF
--- a/src/docfx.website.themes/statictoc/partials/navbar-li.tmpl.partial
+++ b/src/docfx.website.themes/statictoc/partials/navbar-li.tmpl.partial
@@ -8,7 +8,7 @@
           <span class="expand-stub"></span>
         {{/leaf}}
         {{#topicHref}}
-          <a href="{{topicHref}}" name="{{tocHref}}" title="{{name}}">{{name}}</a>
+          <a href="{{topicHref}}" title="{{name}}">{{name}}</a>
         {{/topicHref}}
         {{^topicHref}}
           <a>{{{name}}}</a>

--- a/src/docfx.website.themes/statictoc/statictoc.util.js
+++ b/src/docfx.website.themes/statictoc/statictoc.util.js
@@ -57,6 +57,10 @@ function normalizeCore(item, rel, level, comparer) {
     item.href = rel + item.href;
   }
 
+  if (rel && common.isRelativePath(item.topicHref)) {
+    item.topicHref= rel + item.topicHref;
+  }
+
   if (item.items && item.items.length > 0) {
     item.leaf = false;
     for (var i = item.items.length - 1; i >= 0; i--) {


### PR DESCRIPTION
1. normalize topicHref as href to fix #3716 
2. `name` attribute does not apply to `a` tag. Remove it.See: https://www.w3schools.com/tags/att_name.asp