### PR TITLE
Markdown TOC support UID referencing

### DIFF
--- a/docs/designs/table-of-contents.md
+++ b/docs/designs/table-of-contents.md
@@ -60,7 +60,7 @@ Property Name                    | Type                       | Description
 -------------------------------- | -------------------------- | ---------------------------
 *name*                           | string                     | Specifies the title of the *TOC Item*.
 *href*                           | string                     | Specifies the hyperlink of the *TOC Item*. When its value is another TOC file, it is a TOC include, and all the items inside the included toc are considered as the child of current *TOC Item*
-*uid*                            | string                     | Specifies the `uid` of referenced *TOC Item*. If the value is set, it overwrites the value of *href*.
+*uid*                            | string                     | Specifies the `uid` of referenced *TOC Item*. If the value is set, it overwrites the value of *href*., It will also fill the `name` of the *TOC Item* with uid display name if it's not set.
 *items*                          | array of *TOC Item Object* | Specifies the children *TOC Items* of current *TOC Item*.
 *topicHref*<sub>*advanced*</sub> | string                     | Specifies the topic href of the *TOC Item*. It is useful when *href* is linking to a folder or linking to a toc.
 

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -1080,7 +1080,7 @@ outputs:
       ]
     }
 ---
-# uid reference
+# uid reference in yaml toc
 inputs:
   docfx.yml:
   docs/a.md: |
@@ -1100,7 +1100,7 @@ outputs:
       ]
     }
 ---
-# uid reference first
+# uid reference first in yaml toc
 inputs:
   docfx.yml:
   docs/a.md: |
@@ -1129,7 +1129,7 @@ outputs:
   build.log: |
     ["warning","uid-not-found","Cannot find uid 'c' using xref 'c'","docs/TOC.yml"]
 ---
-# uid reference with monikers
+# uid reference with monikers in yaml toc
 inputs:
   docfx.yml: |
     monikerRange:
@@ -1161,3 +1161,56 @@ outputs:
       ],
       "metadata": {"monikers": ["netcore-1.1", "netcore-1.2", "netcore-1.3" ]}
     }
+---
+# uid reference in markdown toc
+inputs:
+  docfx.yml:
+  docs/TOC.md: |
+    # @b
+  docs/a.md: |
+    ---
+    title: Title A
+    uid: b
+    ---
+outputs:
+  docs/toc.json: |
+    {
+      "items": [
+        { "toc_title":"Title A","href":"a","monikers":[] }
+      ]
+    }
+  docs/a.json:
+---
+# uid reference with monikers in markdown toc
+inputs:
+  docfx.yml: |
+    monikerRange:
+      'docs/**': '>= netcore-1.1'
+    monikerDefinition: monikerDefinition.json
+  monikerDefinition.json: |
+    {
+      "monikers": [
+        { "name": "netcore-1.0", "product": ".NET Core" },
+        { "name": "netcore-1.1", "product": ".NET Core" },
+        { "name": "netcore-1.2", "product": ".NET Core" },
+        { "name": "netcore-1.3", "product": ".NET Core" },
+      ]
+    }
+  docs/a.md: |
+    ---
+    title: Title A
+    monikerRange: netcore-1.1 || netcore-1.2
+    uid: b
+    ---
+  docs/TOC.md: |
+    # @b
+outputs:
+  e300a7df/docs/a.json:
+  8169d1ea/docs/toc.json: |
+    {
+      "items": [
+        { "toc_title":"Title A","href":"a","monikers": ["netcore-1.1", "netcore-1.2"] }
+      ],
+      "metadata": {"monikers": ["netcore-1.1", "netcore-1.2", "netcore-1.3" ]}
+    }
+---

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -1214,3 +1214,21 @@ outputs:
       "metadata": {"monikers": ["netcore-1.1", "netcore-1.2", "netcore-1.3" ]}
     }
 ---
+# uid reference in toc inclusion
+inputs:
+  docfx.yml:
+  docs/a.md: |
+    ---
+    title: Title from yaml header a
+    uid: a
+    ---
+  docs/TOC.yml: |
+    - name: TOC Ref
+      tocHref: a/TOC.yml
+  docs/a/TOC.yml: |
+    - name: Uid Ref
+      uid: a
+outputs:
+  docs/a.json:
+  docs/toc.json: |
+    {"items":[{"toc_title":"TOC Ref","children":[{"toc_title":"Uid Ref","href":"a","monikers":[]}],"monikers":[]}]}

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -35,9 +35,7 @@ namespace Microsoft.Docs.Build
 
                 // Xrefmap and dependency resolver has a circular dependency.
                 xrefMap = XrefMap.Create(context, docset, metadataProvider, monikerProvider, dependencyResolver);
-
-                // TODO: toc map and xref map should always use source docset?
-                var tocMap = BuildTableOfContents.BuildTocMap(context, docset, monikerProvider, dependencyResolver);
+                var tocMap = BuildTableOfContents.BuildTocMap(context, docset, dependencyResolver);
 
                 var githubUserCache = await GitHubUserCache.Create(docset, config.GitHub.AuthToken);
                 var (manifest, fileManifests, sourceDependencies) = await BuildFiles(context, docset, tocMap, githubUserCache, metadataProvider, monikerProvider, dependencyResolver, gitCommitProvider);

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Docs.Build
                 return (Enumerable.Empty<Error>(), null, new List<string>());
             }
 
-            var (errors, tocModel, tocMetadata, refArticles, refTocs) = Load(context, file, monikerProvider, dependencyResolver, monikerMap);
+            var (errors, tocModel, tocMetadata, refArticles, refTocs) = Load(context, file, dependencyResolver, monikerMap, monikerProvider.Comparer);
 
             var metadata = metadataProvider.GetMetadata(file, tocMetadata).ToObject<TableOfContentsMetadata>();
 
@@ -45,7 +45,7 @@ namespace Microsoft.Docs.Build
             return (errors, model, metadata.Monikers);
         }
 
-        public static TableOfContentsMap BuildTocMap(Context context, Docset docset, MonikerProvider monikerProvider, DependencyResolver dependencyResolver)
+        public static TableOfContentsMap BuildTocMap(Context context, Docset docset, DependencyResolver dependencyResolver)
         {
             using (Progress.Start("Loading TOC"))
             {
@@ -56,20 +56,20 @@ namespace Microsoft.Docs.Build
                     return builder.Build();
                 }
 
-                ParallelUtility.ForEach(tocFiles, file => BuildTocMap(context, file, builder, monikerProvider, dependencyResolver), Progress.Update);
+                ParallelUtility.ForEach(tocFiles, file => BuildTocMap(context, file, builder, dependencyResolver), Progress.Update);
 
                 return builder.Build();
             }
         }
 
-        private static void BuildTocMap(Context context, Document fileToBuild, TableOfContentsMapBuilder tocMapBuilder, MonikerProvider monikerProvider, DependencyResolver dependencyResolver)
+        private static void BuildTocMap(Context context, Document fileToBuild, TableOfContentsMapBuilder tocMapBuilder, DependencyResolver dependencyResolver)
         {
             try
             {
                 Debug.Assert(tocMapBuilder != null);
                 Debug.Assert(fileToBuild != null);
 
-                var (errors, _, _, referencedDocuments, referencedTocs) = Load(context, fileToBuild, monikerProvider, dependencyResolver);
+                var (errors, _, _, referencedDocuments, referencedTocs) = Load(context, fileToBuild, dependencyResolver);
                 context.Report(fileToBuild.ToString(), errors);
 
                 tocMapBuilder.Add(fileToBuild, referencedDocuments, referencedTocs);
@@ -90,10 +90,12 @@ namespace Microsoft.Docs.Build
             Load(
             Context context,
             Document fileToBuild,
-            MonikerProvider monikerProvider,
             DependencyResolver dependencyResolver,
-            MonikerMap monikerMap = null)
+            MonikerMap monikerMap = null,
+            MonikerComparer monikerComparer = null)
         {
+            Debug.Assert(!(monikerMap == null ^ monikerComparer == null));
+
             var errors = new List<Error>();
             var referencedDocuments = new List<Document>();
             var referencedTocs = new List<Document>();
@@ -101,7 +103,7 @@ namespace Microsoft.Docs.Build
             var (loadErrors, tocItems, tocMetadata) = TableOfContentsParser.Load(
                 context,
                 fileToBuild,
-                monikerProvider,
+                monikerComparer,
                 monikerMap,
                 (file, href, isInclude) =>
                 {

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Docs.Build
                 (file, uid) =>
                 {
                     // add to referenced document list
-                    var (error, link, _, buildItem) = dependencyResolver.ResolveXref(uid, file);
+                    var (error, link, display, buildItem) = dependencyResolver.ResolveXref(uid, file);
                     errors.AddIfNotNull(error);
 
                     if (buildItem != null)
@@ -139,7 +139,7 @@ namespace Microsoft.Docs.Build
                         referencedDocuments.Add(buildItem);
                     }
 
-                    return (link, buildItem);
+                    return (link, display, buildItem);
                 });
 
             errors.AddRange(loadErrors);

--- a/src/docfx/build/toc/parser/MarkdownTocMarkup.cs
+++ b/src/docfx/build/toc/parser/MarkdownTocMarkup.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Docs.Build
 
             try
             {
-                tocModel.Items = ConvertTo(file, headingBlocks.ToArray(), errors).children;
+                tocModel.Items = ConvertTo(file.FilePath, headingBlocks.ToArray(), errors).children;
             }
             catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
             {
@@ -54,7 +54,7 @@ namespace Microsoft.Docs.Build
             return (errors, tocModel);
         }
 
-        private static (List<TableOfContentsInputItem> children, int count) ConvertTo(Document file, HeadingBlock[] headingBlocks, List<Error> errors, int startIndex = 0)
+        private static (List<TableOfContentsInputItem> children, int count) ConvertTo(string filePath, HeadingBlock[] headingBlocks, List<Error> errors, int startIndex = 0)
         {
             if (headingBlocks.Length == 0)
             {
@@ -75,10 +75,10 @@ namespace Microsoft.Docs.Build
                 {
                     if (headingBlocks[i + 1].Level - currentLevel > 1)
                     {
-                        throw Errors.InvalidTocLevel(file.FilePath, currentLevel, headingBlocks[i + 1].Level).ToException();
+                        throw Errors.InvalidTocLevel(filePath, currentLevel, headingBlocks[i + 1].Level).ToException();
                     }
 
-                    var (children, count) = ConvertTo(file, headingBlocks, errors, i + 1);
+                    var (children, count) = ConvertTo(filePath, headingBlocks, errors, i + 1);
                     item.Items = children;
                     i += count;
                     childrenCount += count;
@@ -98,7 +98,7 @@ namespace Microsoft.Docs.Build
                 var currentItem = new TableOfContentsInputItem();
                 if (block.Inline == null || !block.Inline.Any())
                 {
-                    errors.Add(Errors.MissingTocHead(new Range(block.Line, block.Column), file.FilePath));
+                    errors.Add(Errors.MissingTocHead(new Range(block.Line, block.Column), filePath));
                     return currentItem;
                 }
 

--- a/src/docfx/build/toc/parser/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsParser.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Docs.Build
                 // process uid first
                 if (!string.IsNullOrEmpty(uid))
                 {
-                    var (uidHref, uidDisplayName, uidFile) = resolveXref.Invoke(filePath, uid);
+                    var (uidHref, uidDisplayName, uidFile) = resolveXref.Invoke(rootPath, uid);
                     if (!string.IsNullOrEmpty(uidHref))
                     {
                         return (uidHref, uidDisplayName, uidFile);


### PR DESCRIPTION
1. support uid reference in markdown toc
2. fill toc item name using uid display name if it's not set
3. fix bug of root file relative path