### PR TITLE
use relative string comparer

### DIFF
--- a/src/Microsoft.DocAsCode.Common/Path/RelativePath.cs
+++ b/src/Microsoft.DocAsCode.Common/Path/RelativePath.cs
@@ -154,7 +154,7 @@ namespace Microsoft.DocAsCode.Common
             {
                 if (i >= leftParts.Length - 1)
                     break;
-                if (!FilePathComparer.OSPlatformSensitiveRelativePathComparer.Equals(leftParts[i], rightParts[i]))
+                if (!FilePathComparer.OSPlatformSensitiveStringComparer.Equals(leftParts[i], rightParts[i]))
                     break;
                 commonCount++;
             }
@@ -345,7 +345,7 @@ namespace Microsoft.DocAsCode.Common
                 {
                     return true;
                 }
-                if (!FilePathComparer.OSPlatformSensitiveComparer.Equals(_parts[i], value._parts[i]))
+                if (!FilePathComparer.OSPlatformSensitiveStringComparer.Equals(_parts[i], value._parts[i]))
                 {
                     return false;
                 }

--- a/src/Microsoft.DocAsCode.Dfm/DfmInclusionLoader.cs
+++ b/src/Microsoft.DocAsCode.Dfm/DfmInclusionLoader.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DocAsCode.Dfm
                     currentPath = ((RelativePath)currentPath).BasedOn((RelativePath)parent);
                 }
 
-                if (parents.Contains(currentPath, FilePathComparer.OSPlatformSensitiveComparer))
+                if (parents.Contains(currentPath, FilePathComparer.OSPlatformSensitiveRelativePathComparer))
                 {
                     return GenerateErrorNodeWithCommentWrapper("INCLUDE", $"Circular dependency found in \"{parent}\"", sourceInfo);
                 }


### PR DESCRIPTION
use `OSPlatformSensitiveStringComparer` over `OSPlatformSensitiveRelativePathComparer` if no need to normalize `/` in path.
user `OSPlatformSensitiveRelativePathComparer` over `OSPlatformSensitiveComparer` if no need to `GetFullPath`.