### PR TITLE
clean up localization naming conventions

### DIFF
--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -141,7 +141,7 @@ outputs:
 commands:
   - build --locale zh-cn
 repos: 
-  https://docfx.com/abc.en-us#loc-contribution2:
+  https://docfx.com/abc#loc-contribution2:
     - files:
         docfx.yml: |
           contribution:
@@ -151,7 +151,7 @@ repos:
         docs/a.md:
 outputs:
   docs/a.json: |
-    { "content_git_url": "*dotnet/docfx.zh-cn/blob/master/*"}
+    { "content_git_url": "*dotnet/docfx.en-us.zh-cn/blob/master/*"}
 ---
 # edit url convention with source locale 3
 # all loc files are in one repo under different branch
@@ -163,7 +163,7 @@ repos:
     - files:
         docfx.yml: |
           contribution:
-            repository: https://github.com/dotnet/docfx.en-us
+            repository: https://github.com/dotnet/docfx
           localization:
             mapping: Branch
   https://docfx.com/abc.loc#loc-contribution4.zh-cn:

--- a/src/docfx/localization/LocalizationConvention.cs
+++ b/src/docfx/localization/LocalizationConvention.cs
@@ -51,11 +51,6 @@ namespace Microsoft.Docs.Build
             var newLocale = mapping == LocalizationMapping.Repository ? $".{locale}" : ".loc";
             var newBranch = bilingual ? GetLocalizationBranch(mapping, GetBilingualBranch(branch), locale) : GetLocalizationBranch(mapping, branch, locale);
 
-            if (remote.EndsWith($".{defaultLocale}", StringComparison.OrdinalIgnoreCase))
-            {
-                remote = remote.Substring(0, remote.Length - $".{defaultLocale}".Length);
-            }
-
             if (remote.EndsWith(newLocale, StringComparison.OrdinalIgnoreCase))
             {
                 return (remote, newBranch);
@@ -192,9 +187,9 @@ namespace Microsoft.Docs.Build
                 return false;
             }
 
-            if (TryRemoveLocale(branch, out var branchWithouLocale, out locale))
+            if (TryRemoveLocale(branch, out var branchWithoutLocale, out locale))
             {
-                branch = branchWithouLocale;
+                branch = branchWithoutLocale;
             }
 
             if (branch.EndsWith("-sxs"))
@@ -311,11 +306,6 @@ namespace Microsoft.Docs.Build
             if (string.Equals(locale, defaultLocale))
             {
                 return (remote, branch);
-            }
-
-            if (remote.EndsWith($".{defaultLocale}", StringComparison.OrdinalIgnoreCase))
-            {
-                remote = remote.Substring(0, remote.Length - $".{defaultLocale}".Length);
             }
 
             if (remote.EndsWith($".{locale}", StringComparison.OrdinalIgnoreCase))

--- a/test/docfx.Test/build/ConfigTest.cs
+++ b/test/docfx.Test/build/ConfigTest.cs
@@ -37,19 +37,17 @@ namespace Microsoft.Docs.Build
         [InlineData(LocalizationMapping.Repository, "https://github.com/docfx/name", null, "https://github.com/docfx/name")]
         [InlineData(LocalizationMapping.Folder, "https://github.com/docfx/name", "zh-cn", "https://github.com/docfx/name")]
         [InlineData(LocalizationMapping.Repository, "https://github.com/docfx/name", "zh-cn", "https://github.com/docfx/name.zh-cn")]
-        [InlineData(LocalizationMapping.Repository, "https://github.com/docfx/name.en-us", "zh-cn", "https://github.com/docfx/name.zh-cn")]
-        [InlineData(LocalizationMapping.Repository, "https://github.com/docfx/name.en-US", "zh-cn", "https://github.com/docfx/name.zh-cn")]
-        [InlineData(LocalizationMapping.Repository, "https://github.com/docfx/name.en-US", "zh-CN", "https://github.com/docfx/name.zh-CN")]
+        [InlineData(LocalizationMapping.Repository, "https://github.com/docfx/name.en-us", "zh-cn", "https://github.com/docfx/name.en-us.zh-cn")]
+        [InlineData(LocalizationMapping.Repository, "https://github.com/docfx/name.zh-cn", "zh-cn", "https://github.com/docfx/name.zh-cn")]
         [InlineData(LocalizationMapping.Repository, "https://github.com/docfx/name.en", "zh-cn", "https://github.com/docfx/name.en.zh-cn")]
-        [InlineData(LocalizationMapping.Repository, "https://github.com/docfx/name.en-us", "en-us", "https://github.com/docfx/name.en-us")]
         [InlineData(LocalizationMapping.Repository, "https://github.com/docfx/test-repo", "en-us", "https://github.com/docfx/test-repo")]
         [InlineData(LocalizationMapping.Repository, "https://github.com/docfx/en-us", "zh-cn", "https://github.com/docfx/en-us.zh-cn")]
         [InlineData(LocalizationMapping.Repository, "https://github.com/docfx/test-repo", "bs-Cyrl-BA", "https://github.com/docfx/test-repo.bs-Cyrl-BA")]
-        [InlineData(LocalizationMapping.Repository, "https://github.com/docfx/test-repo.en-us", "bs-Cyrl-BA", "https://github.com/docfx/test-repo.bs-Cyrl-BA")]
-        [InlineData(LocalizationMapping.Repository, "https://github.com/docfx/test-repo.bs-Cyrl-BA", "sr-Latn-RS", "https://github.com/docfx/test-repo.sr-Latn-RS", "bs-Cyrl-BA")]
-        [InlineData(LocalizationMapping.Repository, "https://github.com/docfx/test-repo.bs-Cyrl-BA", "sr-Latn-RS", "https://github.com/docfx/test-repo.bs-Cyrl-BA.sr-Latn-RS")]
+        [InlineData(LocalizationMapping.Repository, "https://github.com/docfx/test-repo.en-us", "bs-Cyrl-BA", "https://github.com/docfx/test-repo.en-us.bs-Cyrl-BA")]
+        [InlineData(LocalizationMapping.Repository, "https://github.com/docfx/test-repo.bs-Cyrl-BA", "sr-Latn-RS", "https://github.com/docfx/test-repo.bs-Cyrl-BA.sr-Latn-RS", "bs-Cyrl-BA")]
         [InlineData(LocalizationMapping.Repository, "https://test.visualstudio.com/_git/TripleCrown.Backend", "sr-Latn-RS", "https://test.visualstudio.com/_git/TripleCrown.Backend.sr-Latn-RS")]
-        [InlineData(LocalizationMapping.Repository, "https://test.visualstudio.com/_git/TripleCrown.Backend.en-us", "sr-Latn-RS", "https://test.visualstudio.com/_git/TripleCrown.Backend.sr-Latn-RS")]
+        [InlineData(LocalizationMapping.Repository, "https://test.visualstudio.com/_git/TripleCrown.Backend.en-us", "sr-Latn-RS", "https://test.visualstudio.com/_git/TripleCrown.Backend.en-us.sr-Latn-RS")]
+        [InlineData(LocalizationMapping.Repository, "https://test.visualstudio.com/_git/TripleCrown.Backend.sr-Latn-RS", "sr-Latn-RS", "https://test.visualstudio.com/_git/TripleCrown.Backend.sr-Latn-RS")]
         public static void LocConfigConventionRepoRemote(LocalizationMapping locMappingType, string sourceName, string locale, string locName, string defaultLocale = "en-us")
             => Assert.Equal(locName, LocalizationConvention.GetLocalizationRepo(locMappingType, false, sourceName, "master", locale, defaultLocale).remote);
 
@@ -69,9 +67,9 @@ namespace Microsoft.Docs.Build
         [InlineData("https://github.com/docs/theme", "zh-cn", "en-us", "https://github.com/docs/theme.zh-cn#master")]
         [InlineData("https://github.com/docs/theme", "", "en-us", "https://github.com/docs/theme#master")]
         [InlineData("https://github.com/docs/theme.zh-cn", "zh-cn", "en-us", "https://github.com/docs/theme.zh-cn#master")]
-        [InlineData("https://github.com/docs/theme.en-us", "zh-cn", "en-us", "https://github.com/docs/theme.zh-cn#master")]
+        [InlineData("https://github.com/docs/theme.en-us", "zh-cn", "en-us", "https://github.com/docs/theme.en-us.zh-cn#master")]
         [InlineData("https://github.com/docs/theme#live", "zh-cn", "en-us", "https://github.com/docs/theme.zh-cn#live")]
-        [InlineData("https://github.com/docs/theme.en-us#live", "zh-cn", "en-us", "https://github.com/docs/theme.zh-cn#live")]
+        [InlineData("https://github.com/docs/theme.en-us#live", "zh-cn", "en-us", "https://github.com/docs/theme.en-us.zh-cn#live")]
         [InlineData("https://github.com/docs/theme.zh-cn#live", "zh-cn", "en-us", "https://github.com/docs/theme.zh-cn#live")]
         public static void LocConfigConventionTheme(string theme, string locale, string defaultLocale, string expectedTheme)
         {


### PR DESCRIPTION
we don't need support xxx.en-us naming convention anymore