### PR TITLE
Upload code coverage and test report

### DIFF
--- a/.deploy.yml
+++ b/.deploy.yml
@@ -1,8 +1,9 @@
 trigger:
   batch: true
   branches:
-  - v3
-  - feature/*
+    include:
+      - v3
+      - feature/*
 pr:
 - v3
 - feature/*

--- a/.deploy.yml
+++ b/.deploy.yml
@@ -5,7 +5,7 @@ pr:
 - v3
 - feature/*
 jobs:
-# unit & e2e test jobs
+# Test pull requests on windows, linux and mac
 - job: LinuxTest_ubuntu_16_04
   pool:
     vmImage: 'ubuntu-16.04'
@@ -24,13 +24,30 @@ jobs:
   condition: eq(variables['Build.Reason'], 'PullRequest')
   steps:
     - powershell: ./build.ps1
+
+    # Publish test results
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFormat: 'VSTest'
+        testResultsFiles: '**/*.trx'
+
+    # Publish code coverage results
+    - task: PublishCodeCoverageResults@1
+      inputs:
+        codeCoverageTool: 'cobertura'
+        summaryFileLocation: '**/coverage.cobertura.xml'
+        failIfCoverageEmpty: true
+
     # todo: conditional PR deploy, check myget limits
-# deployment job(impact, build, pack, push package)
+
+# Deploy commits
 - job: Deploy
   pool:
     name: DocFX
   condition: ne(variables['Build.Reason'], 'PullRequest')
   steps:
+
+  # Run impact regression tests
   - powershell: ./impact.ps1
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/v3')
     env:
@@ -39,9 +56,24 @@ jobs:
       SYSTEM_ACCESS_TOKEN: $(System.AccessToken)
     displayName: Impact Test
 
+  # Build and test
   - powershell: ./build.ps1
     displayName: Build
 
+  # Publish test results
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: 'VSTest'
+      testResultsFiles: '**/*.trx'
+
+  # Publish code coverage results
+  - task: PublishCodeCoverageResults@1
+    inputs:
+      codeCoverageTool: 'cobertura'
+      summaryFileLocation: '**/coverage.cobertura.xml'
+      failIfCoverageEmpty: true
+
+  # Push to sandbox MyGet feed
   - task: NuGetCommand@2
     displayName: Push to Sandbox MyGet Feed
     inputs:
@@ -50,6 +82,7 @@ jobs:
       nuGetFeedType: external
       publishFeedCredentials: myget.docfx-v3-sandbox
 
+  # Push to production MyGet feed
   - task: NuGetCommand@2
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/v3'))
     displayName: Push to Production MyGet Feed

--- a/.deploy.yml
+++ b/.deploy.yml
@@ -35,7 +35,8 @@ jobs:
     - task: PublishCodeCoverageResults@1
       inputs:
         codeCoverageTool: 'cobertura'
-        summaryFileLocation: '**/coverage.cobertura.xml'
+        summaryFileLocation: '**/cobertura.xml'
+        reportDirectory: '**/TestResults/cobertura'
         failIfCoverageEmpty: true
 
     # todo: conditional PR deploy, check myget limits
@@ -70,7 +71,8 @@ jobs:
   - task: PublishCodeCoverageResults@1
     inputs:
       codeCoverageTool: 'cobertura'
-      summaryFileLocation: '**/coverage.cobertura.xml'
+      summaryFileLocation: '**/cobertura.xml'
+      reportDirectory: '**/TestResults/cobertura'
       failIfCoverageEmpty: true
 
   # Push to sandbox MyGet feed

--- a/.deploy.yml
+++ b/.deploy.yml
@@ -1,6 +1,8 @@
 trigger:
-- v3
-- feature/*
+  batch: true
+  branches:
+    - v3
+    - feature/*
 pr:
 - v3
 - feature/*

--- a/.deploy.yml
+++ b/.deploy.yml
@@ -1,8 +1,8 @@
 trigger:
   batch: true
   branches:
-    - v3
-    - feature/*
+  - v3
+  - feature/*
 pr:
 - v3
 - feature/*

--- a/.deploy.yml
+++ b/.deploy.yml
@@ -38,7 +38,7 @@ jobs:
     - task: PublishCodeCoverageResults@1
       inputs:
         codeCoverageTool: 'cobertura'
-        summaryFileLocation: '**/cobertura.xml'
+        summaryFileLocation: '**/coverage.cobertura.xml'
         reportDirectory: '**/TestResults/cobertura'
         failIfCoverageEmpty: true
 
@@ -74,7 +74,7 @@ jobs:
   - task: PublishCodeCoverageResults@1
     inputs:
       codeCoverageTool: 'cobertura'
-      summaryFileLocation: '**/cobertura.xml'
+      summaryFileLocation: '**/coverage.cobertura.xml'
       reportDirectory: '**/TestResults/cobertura'
       failIfCoverageEmpty: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@ obj
 
 _site
 
+TestResults
+
+coverage.json
+coverage.cobertura.xml
+
 # Carried from DocFX v2
 artifacts
 src/docfx/Template/*.zip

--- a/build.ps1
+++ b/build.ps1
@@ -19,7 +19,7 @@ function getBranchName() {
     return $branch
 }
 
-# Running tests
+# Run tests
 exec "dotnet test test\docfx.Test"
 exec "dotnet test test\docfx.Test -c Release --logger trx"
 
@@ -32,7 +32,7 @@ if ($coverage -lt 0.8) {
 # Check schema
 exec "dotnet run -p tools/CreateJsonSchema"
 
-# Packing
+# Create NuGet package
 $commitSha = & { git describe --always }
 $commitCount = & { git rev-list --count HEAD }
 $revision = $commitCount.ToString().PadLeft(5, '0')

--- a/build.ps1
+++ b/build.ps1
@@ -24,7 +24,7 @@ pushd test/docfx.Test
 
 Remove-Item ./TestResults -Force -Recurse -ErrorAction Ignore
 
-exec "dotnet test -c Debug --logger trx"
+exec "dotnet test -c Debug"
 exec "dotnet test -c Release --logger trx"
 exec "dotnet reportgenerator -reports:coverage.cobertura.xml -reporttypes:HtmlInline_AzurePipelines -targetdir:TestResults/cobertura"
 

--- a/build.ps1
+++ b/build.ps1
@@ -21,7 +21,7 @@ function getBranchName() {
 # running tests
 exec "dotnet run -p tools/CreateJsonSchema"
 exec "dotnet test test\docfx.Test"
-exec "dotnet test test\docfx.Test -c Release"
+exec "dotnet test test\docfx.Test -c Release --logger trx"
 
 # packing
 $commitSha = & { git describe --always }

--- a/build.ps1
+++ b/build.ps1
@@ -20,8 +20,13 @@ function getBranchName() {
 }
 
 # Run tests
-exec "dotnet test test\docfx.Test"
-exec "dotnet test test\docfx.Test -c Release --logger trx"
+pushd test/docfx.Test
+
+exec "dotnet test -c Debug --logger trx"
+exec "dotnet test -c Release --logger trx"
+exec "dotnet reportgenerator -reports:coverage.cobertura.xml -reporttypes:HtmlInline_AzurePipelines -targetdir:TestResults/cobertura"
+
+popd
 
 # Check test coverage
 $coverage = Select-Xml -Path 'test\docfx.Test\coverage.cobertura.xml' -XPath "//package[@name='docfx']" | select -exp Node | select -exp line-rate

--- a/build.ps1
+++ b/build.ps1
@@ -22,6 +22,8 @@ function getBranchName() {
 # Run tests
 pushd test/docfx.Test
 
+Remove-Item ./TestResults -Force -Recurse -ErrorAction Ignore
+
 exec "dotnet test -c Debug --logger trx"
 exec "dotnet test -c Release --logger trx"
 exec "dotnet reportgenerator -reports:coverage.cobertura.xml -reporttypes:HtmlInline_AzurePipelines -targetdir:TestResults/cobertura"

--- a/test/docfx.Test/docfx.Test.csproj
+++ b/test/docfx.Test/docfx.Test.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>Microsoft.Docs.Build</RootNamespace>
     <CollectCoverage>true</CollectCoverage>
     <CoverletOutputFormat>cobertura</CoverletOutputFormat>
+    <Exclude>[xunit.*]*,[*.Views]*</Exclude>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/docfx.Test/docfx.Test.csproj
+++ b/test/docfx.Test/docfx.Test.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <DotNetCliToolReference Include="dotnet-reportgenerator-cli" Version="4.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/docfx.Test/docfx.Test.csproj
+++ b/test/docfx.Test/docfx.Test.csproj
@@ -5,14 +5,16 @@
     <IsPackable>false</IsPackable>
     <LangVersion>Latest</LangVersion>
     <RootNamespace>Microsoft.Docs.Build</RootNamespace>
+    <CollectCoverage>true</CollectCoverage>
+    <CoverletOutputFormat>cobertura</CoverletOutputFormat>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="2.5.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.25.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Right now we hit **>80%** test coverage, this is a very impressive starting point. 

This PR integrates test coverage reports into our CI pipeline, to continuously monitor test coverage data. We use **80%** as our baseline and newer commits should not break this.

```
+-------------------------+--------+--------+--------+
| Module                  | Line   | Branch | Method |
+-------------------------+--------+--------+--------+
| docfx                   | 80.9%  | 81.7%  | 84.6%  |
+-------------------------+--------+--------+--------+
| Microsoft.Docs.Template | 66.1%  | 100%   | 66.1%  |
+-------------------------+--------+--------+--------+

+---------+--------+--------+--------+
|         | Line   | Branch | Method |
+---------+--------+--------+--------+
| Total   | 80.7%  | 81.7%  | 82.4%  |
+---------+--------+--------+--------+
| Average | 40.35% | 40.85% | 41.2%  |
+---------+--------+--------+--------+
```

Reports in VSTS:
![image](https://user-images.githubusercontent.com/511355/50467467-09019880-09de-11e9-90ac-a56c2919749b.png)

