### PR TITLE
fix cache corruption when shrink multiple times

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/DocumentBuilder.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/DocumentBuilder.cs
@@ -244,6 +244,16 @@ namespace Microsoft.DocAsCode.Build.Engine
                     ManifestUtility.RemoveDuplicateOutputFiles(generatedManifest.Files);
                     ManifestUtility.ApplyLogCodes(generatedManifest.Files, logCodesLogListener.Codes);
 
+                    // We can only globally shrink once to avoid invalid reference.
+                    // Shrink multiplie times may remove files that are already linked in saved manifest.
+                    if (_intermediateFolder != null)
+                    {
+                        // TODO: shrink here is not safe as post processor may update it.
+                        //       should shrink once at last to handle everything, or make FAL support copy on writes
+                        generatedManifest.Files.Shrink(_intermediateFolder, parameters[0].MaxParallelism);
+                        currentBuildInfo.SaveVersionsManifet(_intermediateFolder);
+                    }
+
                     EnvironmentContext.FileAbstractLayerImpl =
                         FileAbstractLayerBuilder.Default
                         .ReadFromManifest(generatedManifest, parameters[0].OutputBaseDir)

--- a/src/Microsoft.DocAsCode.Build.Engine/Incrementals/BuildInfo.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/Incrementals/BuildInfo.cs
@@ -108,6 +108,16 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
             return buildInfo;
         }
 
+        public void SaveVersionsManifet(string baseDir)
+        {
+            var expanded = Path.GetFullPath(Environment.ExpandEnvironmentVariables(baseDir));
+            var targetDirectory = Path.Combine(expanded, DirectoryName);
+            foreach (var version in Versions)
+            {
+                version.SaveManifest();
+            }
+        }
+
         public void Save(string baseDir)
         {
             var expanded = Path.GetFullPath(Environment.ExpandEnvironmentVariables(baseDir));

--- a/src/Microsoft.DocAsCode.Build.Engine/Incrementals/BuildInfo.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/Incrementals/BuildInfo.cs
@@ -111,7 +111,6 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
         public void SaveVersionsManifet(string baseDir)
         {
             var expanded = Path.GetFullPath(Environment.ExpandEnvironmentVariables(baseDir));
-            var targetDirectory = Path.Combine(expanded, DirectoryName);
             foreach (var version in Versions)
             {
                 version.SaveManifest();

--- a/src/Microsoft.DocAsCode.Build.Engine/LinkPhaseHandlerWithIncremental.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/LinkPhaseHandlerWithIncremental.cs
@@ -245,9 +245,7 @@ namespace Microsoft.DocAsCode.Build.Engine
 
         private void UpdateManifest()
         {
-            Context.ManifestItems.Shrink(IncrementalContext.BaseDir);
             CurrentBuildVersionInfo.Manifest = Context.ManifestItems;
-            CurrentBuildVersionInfo.SaveManifest();
         }
 
         private void UpdateFileMap(IEnumerable<HostService> hostServices)

--- a/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/PostProcessorsHandlerWithIncremental.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/PostProcessorsHandlerWithIncremental.cs
@@ -128,8 +128,6 @@ namespace Microsoft.DocAsCode.Build.Engine
                 {
                     Logger.UnregisterListener(_increContext.CurrentInfo.MessageInfo.GetListener());
 
-                    manifest.Shrink(_increContext.CurrentBaseDir);
-
                     TraceIntermediateInfo(manifest);
 
                     // Update manifest items in current post processing info

--- a/src/Microsoft.DocAsCode.Common/FileAbstractLayer/ManifestFileHelper.cs
+++ b/src/Microsoft.DocAsCode.Common/FileAbstractLayer/ManifestFileHelper.cs
@@ -218,14 +218,6 @@ namespace Microsoft.DocAsCode.Common
                 });
         }
 
-        public static void Shrink(this Manifest manifest, string incrementalFolder, int parallism = 0)
-        {
-            lock (manifest)
-            {
-                Shrink(manifest.Files, incrementalFolder, parallism);
-            }
-        }
-
         public static void Shrink(this IEnumerable<ManifestItem> items, string incrementalFolder, int parallism = 0)
         {
             Parallel.ForEach(

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/IncrementalBuildTest.cs
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/IncrementalBuildTest.cs
@@ -18,7 +18,6 @@ namespace Microsoft.DocAsCode.Build.Engine.Tests
     using Microsoft.DocAsCode.Build.TableOfContents;
     using Microsoft.DocAsCode.Common;
     using Microsoft.DocAsCode.Plugins;
-    using Microsoft.DocAsCode.Dfm.MarkdownValidators;
 
     using Xunit;
 
@@ -117,7 +116,7 @@ namespace Microsoft.DocAsCode.Build.Engine.Tests
                 },
                 inputFolder);
             var overwriteFile = CreateFile("test/ow.md",
-                new[] 
+                new[]
                 {
                     "---",
                     "uid: System.Console",
@@ -431,7 +430,7 @@ tagRules : [
                     ClearListener();
                     File.Delete(codesnippet);
                     BuildDocument(
-                        files, 
+                        files,
                         inputFolder,
                         outputFolderThird,
                         new Dictionary<string, object>
@@ -1930,7 +1929,7 @@ tagRules : [
                         templateFolder: templateFolder,
                         intermediateFolder: intermediateFolder);
                     Assert.Equal(2, Listener.Items.Count);
-                    Assert.NotNull(Listener.Items.FirstOrDefault(s => s.Message.StartsWith("Illegal link: `[link](#invalid)` -- missing bookmark"))); 
+                    Assert.NotNull(Listener.Items.FirstOrDefault(s => s.Message.StartsWith("Illegal link: `[link](#invalid)` -- missing bookmark")));
                     ClearListener();
 
                     // update conceptualFile2
@@ -1947,7 +1946,7 @@ tagRules : [
                         templateFolder: templateFolder,
                         intermediateFolder: intermediateFolder);
                     Assert.Equal(2, Listener.Items.Count);
-                    Assert.NotNull(Listener.Items.FirstOrDefault(s => s.Message.StartsWith("Illegal link: `[link](#invalid)` -- missing bookmark"))); 
+                    Assert.NotNull(Listener.Items.FirstOrDefault(s => s.Message.StartsWith("Illegal link: `[link](#invalid)` -- missing bookmark")));
                     ClearListener();
 
                     // update conceptualFile2
@@ -1964,7 +1963,7 @@ tagRules : [
                         templateFolder: templateFolder,
                         intermediateFolder: intermediateFolder);
                     Assert.Equal(2, Listener.Items.Count);
-                    Assert.NotNull(Listener.Items.FirstOrDefault(s => s.Message.StartsWith("Illegal link: `[link](#invalid)` -- missing bookmark"))); 
+                    Assert.NotNull(Listener.Items.FirstOrDefault(s => s.Message.StartsWith("Illegal link: `[link](#invalid)` -- missing bookmark")));
                     ClearListener();
                 }
             }
@@ -4957,6 +4956,94 @@ tagRules : [
             }
         }
 
+        [Fact]
+        public void TestShrinkWithVersion()
+        {
+            #region Prepare test data
+            // arrange
+            const string intermediateFolderVariable = "%cache%";
+            var resourceFile = Path.GetFileName(typeof(IncrementalBuildTest).Assembly.Location);
+
+            var inputFolder = GetRandomFolder();
+            var outputFolder = GetRandomFolder();
+            var templateFolder = GetRandomFolder();
+            var intermediateFolder = GetRandomFolder();
+            Environment.SetEnvironmentVariable("cache", Path.GetFullPath(intermediateFolder));
+
+            CreateFile("conceptual.txt.primary.tmpl", "This is a fixed template to test shrinking cache", templateFolder);
+            var fileA = CreateFile("a.md", new[] { "test" }, inputFolder);
+            var fileB = CreateFile("b.md", new[] { "test" }, inputFolder);
+
+            FileCollection files = new FileCollection(Directory.GetCurrentDirectory());
+            files.Add(DocumentType.Article, new[] { fileA, fileB });
+            var filesWithVersion = new Dictionary<string, FileCollection>
+            {
+                ["v1"] = files,
+                ["v2"] = files,
+            };
+            #endregion
+
+            Init("IncrementalBuild.TestShrinkWithVersion");
+            var outputFolderFirst = Path.Combine(outputFolder, "IncrementalBuild.TestShrinkWithVersion");
+            var outputFolderForIncremental = Path.Combine(outputFolder, "IncrementalBuild.TestShrinkWithVersion.Second");
+            var outputFolderForCompare = Path.Combine(outputFolder, "IncrementalBuild.TestShrinkWithVersion.Second.ForceBuild");
+            try
+            {
+                using (new LoggerPhaseScope("IncrementalBuild.TestShrinkWithVersion-first"))
+                {
+                    BuildDocumentWithVersion(
+                        filesWithVersion,
+                        inputFolder,
+                        outputFolderFirst,
+                        new Dictionary<string, object> { ["meta"] = "Hello world!", },
+                        templateFolder: templateFolder,
+                        intermediateFolder: intermediateFolderVariable);
+                }
+                ClearListener();
+
+                var newIntermediateFolder = MoveIntermediateFolder(intermediateFolder);
+                using (new LoggerPhaseScope("IncrementalBuild.TestShrinkWithVersion-second"))
+                {
+                    BuildDocumentWithVersion(
+                        filesWithVersion,
+                        inputFolder,
+                        outputFolderForIncremental,
+                        new Dictionary<string, object> { ["meta"] = "Hello world!", },
+                        templateFolder: templateFolder,
+                        intermediateFolder: intermediateFolderVariable,
+                        cleanupCacheHistory: true);
+                }
+
+                using (new LoggerPhaseScope("IncrementalBuild.TestShrinkWithVersion-forcebuild-second"))
+                {
+                    BuildDocumentWithVersion(
+                        filesWithVersion,
+                        inputFolder,
+                        outputFolderForCompare,
+                        new Dictionary<string, object> { ["meta"] = "Hello world!", },
+                        templateFolder: templateFolder,
+                        forceRebuild: true);
+                }
+
+                {
+                    Assert.True(CompareDir(outputFolderForIncremental, outputFolderForCompare));
+                    Assert.Equal(
+                        GetLogMessages("IncrementalBuild.TestShrinkWithVersion-forcebuild-second"),
+                        GetLogMessages(new[] { "IncrementalBuild.TestShrinkWithVersion-second", "IncrementalBuild.TestShrinkWithVersion-first" }));
+
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("cache", null);
+                CleanUp();
+                if (File.Exists(MarkdownSytleConfig.MarkdownStyleFileName))
+                {
+                    File.Delete(MarkdownSytleConfig.MarkdownStyleFileName);
+                }
+            }
+        }
+
         [Fact(Skip = "wait for fix")]
         public void TestDestinationFolderUpdate()
         {
@@ -5151,6 +5238,49 @@ tagRules : [
             }
         }
 
+        private void BuildDocumentWithVersion(
+            Dictionary<string, FileCollection> files,
+            string inputFolder,
+            string outputFolder,
+            Dictionary<string, object> metadata = null,
+            ApplyTemplateSettings applyTemplateSettings = null,
+            string templateHash = null,
+            string templateFolder = null,
+            string intermediateFolder = null,
+            Dictionary<string, ChangeKindWithDependency> changes = null,
+            bool enableSplit = false,
+            bool forceRebuild = false,
+            bool cleanupCacheHistory = false)
+        {
+            using (var builder = new DocumentBuilder(LoadAssemblies(enableSplit), ImmutableArray<string>.Empty, templateHash, intermediateFolder, cleanupCacheHistory: cleanupCacheHistory))
+            {
+                var outputDir = Path.Combine(Directory.GetCurrentDirectory(), outputFolder);
+                if (applyTemplateSettings == null)
+                {
+                    applyTemplateSettings = new ApplyTemplateSettings(inputFolder, outputFolder);
+                }
+                var parametersList = new List<DocumentBuildParameters>();
+                foreach (var pair in files)
+                {
+                    parametersList.Add(new DocumentBuildParameters
+                    {
+                        Files = pair.Value,
+                        OutputBaseDir = outputDir,
+                        ApplyTemplateSettings = applyTemplateSettings,
+                        Metadata = metadata?.ToImmutableDictionary(),
+                        TemplateManager = new TemplateManager(null, null, new List<string> { templateFolder }, null, null),
+                        TemplateDir = templateFolder,
+                        Changes = changes?.ToImmutableDictionary(FilePathComparer.OSPlatformSensitiveStringComparer),
+                        ForcePostProcess = false,
+                        ForceRebuild = forceRebuild,
+                        VersionName = pair.Key,
+                        VersionDir = pair.Key,
+                    });
+                }
+                builder.Build(parametersList, outputDir);
+            }
+        }
+
         private IEnumerable<Assembly> LoadAssemblies(bool enableSplit = false)
         {
             yield return typeof(ConceptualDocumentProcessor).Assembly;
@@ -5162,6 +5292,13 @@ tagRules : [
             {
                 yield return typeof(SplitClassPageToMemberLevel).Assembly;
             }
+        }
+
+        private string MoveIntermediateFolder(string intermediateFolder)
+        {
+            var newIntermediateFolder = MoveToRandomFolder(intermediateFolder);
+            Environment.SetEnvironmentVariable("cache", Path.GetFullPath(newIntermediateFolder));
+            return newIntermediateFolder;
         }
     }
 }

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/IncrementalBuildTest.cs
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/IncrementalBuildTest.cs
@@ -5001,7 +5001,7 @@ tagRules : [
                 }
                 ClearListener();
 
-                var newIntermediateFolder = MoveIntermediateFolder(intermediateFolder);
+                MoveIntermediateFolder(intermediateFolder);
                 using (new LoggerPhaseScope("IncrementalBuild.TestShrinkWithVersion-second"))
                 {
                     BuildDocumentWithVersion(

--- a/test/Microsoft.DocAsCode.Tests.Common/TestBase.cs
+++ b/test/Microsoft.DocAsCode.Tests.Common/TestBase.cs
@@ -16,15 +16,7 @@ namespace Microsoft.DocAsCode.Tests.Common
 
         protected string GetRandomFolder()
         {
-            var folder = Path.GetRandomFileName();
-            if (Directory.Exists(folder))
-            {
-                folder = folder + DateTime.Now.ToString("HHmmssffff");
-                if (Directory.Exists(folder))
-                {
-                    throw new InvalidOperationException($"Random folder name collides {folder}");
-                }
-            }
+            var folder = GetFolder();
 
             lock (_locker)
             {
@@ -34,6 +26,35 @@ namespace Microsoft.DocAsCode.Tests.Common
             Directory.CreateDirectory(folder);
             return folder;
         }
+
+        protected string MoveToRandomFolder(string origin)
+        {
+            var folder = GetFolder();
+
+            lock (_locker)
+            {
+                _folderCollection.Remove(folder);
+                _folderCollection.Add(folder);
+            }
+
+            Directory.Move(origin, folder);
+            return folder;
+        }
+
+        private string GetFolder()
+        {
+            var folder = Path.GetRandomFileName();
+            if (Directory.Exists(folder))
+            {
+                folder = folder + DateTime.Now.ToString("HHmmssffff");
+                if (Directory.Exists(folder))
+                {
+                    throw new InvalidOperationException($"Random folder name collides {folder}");
+                }
+            }
+            return folder;
+        }
+
 
         #region IO related
 


### PR DESCRIPTION
If multiple outputs' content are same in cache, shrink can remove duplicate files and make these items point to the same file.

**Before**: First shrink per version, then shrink per PostProcessor in all versions. The second shrink can find duplicates cross versions, but will make the existing cache reference invalid, as version manifest has already been written to disk.

**this fix**: shrink only once before write version manifest on disk.