### PR TITLE
support build loc repo with docfx config

### DIFF
--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -1093,3 +1093,111 @@ repos:
 outputs:
   build.log: |
     ["error","config-not-found","Cannot find 'docfx.yml/docfx.json' at *"]
+---
+# loc build gets docfx config 1
+# from current docset firstly, then from fallback docset
+# [repo mapping]
+commands:
+  - build --locale zh-cn
+repos:
+  https://github.com/buildhistory/a:
+    - files:
+        docfx.yml: |
+          contribution:
+            repository: https://github.com/dotnet/docfx
+        docs/a.md:
+  https://github.com/buildhistory/a.zh-cn:
+    - files:
+        docs/a.md:
+        docfx.yml: |
+          contribution:
+            repository: https://github.com/dotnet/docfx.zh-cn
+outputs:
+  docs/a.json: |
+    { "content_git_url": "*dotnet/docfx.zh-cn/blob/master/*"}
+---
+# loc build gets docfx config 2
+# from current docset firstly, then from fallback docset
+# [branch mapping]
+commands:
+  - build --locale zh-cn
+repos:
+  https://github.com/buildhistory/b:
+    - files:
+        docfx.yml: |
+          contribution:
+            repository: https://github.com/dotnet/docfx#live
+          localization:
+            mapping: Branch
+        docs/a.md:
+  https://github.com/buildhistory/b.loc#master.zh-cn:
+    - files:
+        docs/a.md:
+        docfx.yml: |
+          contribution:
+            repository: https://github.com/dotnet/docfx.loc#live
+          localization:
+            mapping: Branch
+outputs:
+  docs/a.json: |
+    { "content_git_url": "*dotnet/docfx.loc/blob/live.zh-cn/*"}
+---
+# loc build gets docfx config 3
+# from current docset firstly, then from fallback docset
+# [repo mapping] & bilingual
+commands:
+  - build --locale zh-cn
+repos:
+  https://github.com/buildhistory/c:
+    - files:
+        docfx.yml: |
+          contribution:
+            repository: https://github.com/dotnet/docfx
+          localization:
+            bilingual: true
+        docs/a.md:
+  https://github.com/buildhistory/c.zh-cn#master-sxs:
+    - files:
+        docs/a.md:
+        docfx.yml: |
+          contribution:
+            repository: https://github.com/dotnet/docfx.zh-cn
+          localization:
+            bilingual: true
+  https://github.com/buildhistory/c.zh-cn:
+    - files:
+        docs/a.md:
+outputs:
+  docs/a.json: |
+    { "content_git_url": "*dotnet/docfx.zh-cn/blob/master/*"}
+---
+# loc build gets docfx config 4
+# from current docset firstly, then from fallback docset
+# [branch mapping] & bilingual
+commands:
+  - build --locale zh-cn
+repos:
+  https://github.com/buildhistory/d:
+    - files:
+        docfx.yml: |
+          contribution:
+            repository: https://github.com/dotnet/docfx#live
+          localization:
+            mapping: Branch
+            bilingual: true
+        docs/a.md:
+  https://github.com/buildhistory/d.loc#master-sxs.zh-cn:
+    - files:
+        docs/a.md:
+        docfx.yml: |
+          contribution:
+            repository: https://github.com/dotnet/docfx.loc#live
+          localization:
+            mapping: Branch
+            bilingual: true
+  https://github.com/buildhistory/d.loc#master.zh-cn:
+    - files:
+        docs/a.md:
+outputs:
+  docs/a.json: |
+    { "content_git_url": "*dotnet/docfx.loc/blob/live.zh-cn/*"}

--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -1100,13 +1100,13 @@ outputs:
 commands:
   - build --locale zh-cn
 repos:
-  https://github.com/buildhistory/a:
+  https://github.com/locconfig/a:
     - files:
         docfx.yml: |
           contribution:
             repository: https://github.com/dotnet/docfx
         docs/a.md:
-  https://github.com/buildhistory/a.zh-cn:
+  https://github.com/locconfig/a.zh-cn:
     - files:
         docs/a.md:
         docfx.yml: |
@@ -1122,7 +1122,7 @@ outputs:
 commands:
   - build --locale zh-cn
 repos:
-  https://github.com/buildhistory/b:
+  https://github.com/locconfig/b:
     - files:
         docfx.yml: |
           contribution:
@@ -1130,7 +1130,7 @@ repos:
           localization:
             mapping: Branch
         docs/a.md:
-  https://github.com/buildhistory/b.loc#master.zh-cn:
+  https://github.com/locconfig/b.loc#master.zh-cn:
     - files:
         docs/a.md:
         docfx.yml: |
@@ -1148,7 +1148,7 @@ outputs:
 commands:
   - build --locale zh-cn
 repos:
-  https://github.com/buildhistory/c:
+  https://github.com/locconfig/c:
     - files:
         docfx.yml: |
           contribution:
@@ -1156,7 +1156,7 @@ repos:
           localization:
             bilingual: true
         docs/a.md:
-  https://github.com/buildhistory/c.zh-cn#master-sxs:
+  https://github.com/locconfig/c.zh-cn#master-sxs:
     - files:
         docs/a.md:
         docfx.yml: |
@@ -1164,7 +1164,7 @@ repos:
             repository: https://github.com/dotnet/docfx.zh-cn
           localization:
             bilingual: true
-  https://github.com/buildhistory/c.zh-cn:
+  https://github.com/locconfig/c.zh-cn:
     - files:
         docs/a.md:
 outputs:
@@ -1177,7 +1177,7 @@ outputs:
 commands:
   - build --locale zh-cn
 repos:
-  https://github.com/buildhistory/d:
+  https://github.com/locconfig/d:
     - files:
         docfx.yml: |
           contribution:
@@ -1186,7 +1186,7 @@ repos:
             mapping: Branch
             bilingual: true
         docs/a.md:
-  https://github.com/buildhistory/d.loc#master-sxs.zh-cn:
+  https://github.com/locconfig/d.loc#master-sxs.zh-cn:
     - files:
         docs/a.md:
         docfx.yml: |
@@ -1195,7 +1195,7 @@ repos:
           localization:
             mapping: Branch
             bilingual: true
-  https://github.com/buildhistory/d.loc#master.zh-cn:
+  https://github.com/locconfig/d.loc#master.zh-cn:
     - files:
         docs/a.md:
 outputs:

--- a/src/docfx/localization/LocalizationUtility.cs
+++ b/src/docfx/localization/LocalizationUtility.cs
@@ -19,40 +19,12 @@ namespace Microsoft.Docs.Build
         /// </summary>
         public static (string remote, string branch) GetLocalizedRepo(LocalizationMapping mapping, bool bilingual, string remote, string branch, string locale, string defaultLocale)
         {
-            if (mapping == LocalizationMapping.Folder)
-            {
-                return (remote, branch);
-            }
+            var newRemote = GetLocalizationName(mapping, remote, locale, defaultLocale);
+            var newBranch = bilingual
+                ? GetLocalizationBranch(mapping, GetBilingualBranch(mapping, branch), locale, defaultLocale)
+                : GetLocalizationBranch(mapping, branch, locale, defaultLocale);
 
-            if (string.Equals(locale, defaultLocale))
-            {
-                return (remote, branch);
-            }
-
-            if (string.IsNullOrEmpty(remote))
-            {
-                return (remote, branch);
-            }
-
-            if (string.IsNullOrEmpty(branch))
-            {
-                return (remote, branch);
-            }
-
-            if (string.IsNullOrEmpty(locale))
-            {
-                return (remote, branch);
-            }
-
-            var newLocale = mapping == LocalizationMapping.Repository ? $".{locale}" : ".loc";
-            var newBranch = bilingual ? GetLocalizationBranch(mapping, GetBilingualBranch(branch), locale) : GetLocalizationBranch(mapping, branch, locale);
-
-            if (remote.EndsWith(newLocale, StringComparison.OrdinalIgnoreCase))
-            {
-                return (remote, newBranch);
-            }
-
-            return ($"{remote}{newLocale}", newBranch);
+            return (newRemote, newBranch);
         }
 
         public static bool TryGetLocalizedDocsetPath(string docsetPath, Config config, string locale, out string localizationDocsetPath)
@@ -332,13 +304,13 @@ namespace Microsoft.Docs.Build
 
         public static (List<Error> errors, Config config) GetBuildConfig(string docset, CommandLineOptions options)
         {
-            if (TryGetSourceRepository(docset, out var sourceRemote, out var sourceBranch, out var locale))
+            if (ConfigLoader.TryGetConfigPath(docset, out _) || !TryGetSourceRepository(docset, out var sourceRemote, out var sourceBranch, out var locale))
             {
-                var sourceDocsetPath = RestoreMap.GetGitRestorePath(sourceRemote, sourceBranch);
-                return ConfigLoader.Load(sourceDocsetPath, options, locale);
+                return ConfigLoader.Load(docset, options);
             }
 
-            return ConfigLoader.Load(docset, options);
+            var sourceDocsetPath = RestoreMap.GetGitRestorePath(sourceRemote, sourceBranch);
+            return ConfigLoader.Load(sourceDocsetPath, options, locale);
         }
 
         public static (bool fromUrl, string path) GetFileRestorePath(this Docset docset, string url)
@@ -360,22 +332,7 @@ namespace Microsoft.Docs.Build
             Debug.Assert(!string.IsNullOrEmpty(theme));
             var (remote, branch) = HrefUtility.SplitGitHref(theme);
 
-            if (string.IsNullOrEmpty(locale))
-            {
-                return (remote, branch);
-            }
-
-            if (string.Equals(locale, defaultLocale))
-            {
-                return (remote, branch);
-            }
-
-            if (remote.EndsWith($".{locale}", StringComparison.OrdinalIgnoreCase))
-            {
-                return (remote, branch);
-            }
-
-            return ($"{remote}.{locale}", branch);
+            return (GetLocalizationName(LocalizationMapping.Repository, remote, locale, defaultLocale), branch);
         }
 
         public static bool TryRemoveLocale(string name, out string nameWithoutLocale, out string locale)
@@ -399,13 +356,24 @@ namespace Microsoft.Docs.Build
             return false;
         }
 
-        private static string GetBilingualBranch(string branch) => $"{branch}-sxs";
-
-        private static string GetLocalizationBranch(LocalizationMapping mapping, string sourceBranch, string locale)
+        private static string GetBilingualBranch(LocalizationMapping mapping, string branch)
         {
-            Debug.Assert(!string.IsNullOrEmpty(sourceBranch));
+            if (mapping == LocalizationMapping.Folder)
+            {
+                return branch;
+            }
 
+            return string.IsNullOrEmpty(branch) ? branch : $"{branch}-sxs";
+        }
+
+        private static string GetLocalizationBranch(LocalizationMapping mapping, string sourceBranch, string locale, string defaultLocale)
+        {
             if (mapping != LocalizationMapping.Branch)
+            {
+                return sourceBranch;
+            }
+
+            if (string.IsNullOrEmpty(sourceBranch))
             {
                 return sourceBranch;
             }
@@ -415,7 +383,43 @@ namespace Microsoft.Docs.Build
                 return sourceBranch;
             }
 
+            if (string.Equals(locale, defaultLocale))
+            {
+                return sourceBranch;
+            }
+
             return $"{sourceBranch}.{locale}";
+        }
+
+        private static string GetLocalizationName(LocalizationMapping mapping, string name, string locale, string defaultLocale)
+        {
+            if (mapping == LocalizationMapping.Folder)
+            {
+                return name;
+            }
+
+            if (string.Equals(locale, defaultLocale))
+            {
+                return name;
+            }
+
+            if (string.IsNullOrEmpty(name))
+            {
+                return name;
+            }
+
+            if (string.IsNullOrEmpty(locale))
+            {
+                return name;
+            }
+
+            var newLocale = mapping == LocalizationMapping.Repository ? $".{locale}" : ".loc";
+            if (name.EndsWith(newLocale, StringComparison.OrdinalIgnoreCase))
+            {
+                return name;
+            }
+
+            return $"{name}{newLocale}";
         }
     }
 }


### PR DESCRIPTION
if loc repo has docfx config file, we will use it, otherwise, we use source docset's config + overwrite config