### PR TITLE
Add publish manifest file spec

### DIFF
--- a/docs/designs/output.md
+++ b/docs/designs/output.md
@@ -52,7 +52,7 @@ https://docs.microsoft.com/en-us/netstandard-2.0/dotnet/api/system.string.html#I
 > When a docset is not localized, we will not create the `{locale}` folder.
 > This allows static websites with minimal url when localized and verioning is not needed.
 
-## File Outputs
+## Content Outputs
 
 Each input file transforms to zero or more output files depending on its content type. `docfx` places output files in `output-path` relative to output directory. **Regardless of static rendering or dynamic rendering, output path shares the same schema**:
 
@@ -114,80 +114,16 @@ Different files can share the same `{site-url}` or `{site-path}` due to versioni
     | `site-path` | dotnet/api/thumbnail.png |
     | `output-path` | en-us/netstandard-2.0/dotnet/api/thumbnail.png |
 
-## Manifest
+## System Generated Outputs
 
-### Files
+System generated outputs are put under the folder `_site/_build`, it contains miscellaneous files generated during build.
 
-To efficiently look up a file from URL for dynamic rendering, 
-`docfx` produces a manifest file at `_site/build.manifest` that lists all the output files and properties needed for lookup.
+> JSON files should end with `.json` for faster DHS download speed.
 
-*locale*, *moniker* are special properties that flows dynamically when users navigate from page to page.
-These are called *browser navigation properties* and are stored in manifest.
+File name           | Description
+--------------------|-----------------
+publish.json        | A manifest of files to publish as described in [publish](publish.md)
+xrefmap.json        | A manifest of `uid` and xref specs as described in [xref](xref.md)
+report.log          | A report file that contains build errors and warnings. Each line is a json array: `[{level}, {code}, {message}, {file?}, {line?}, {column?}]`.
 
-```javascript
-{
-    "files": [
-        {
-            "siteUrl": "/dotnet/api/system.string",
-            "outputPath": "en-us/netstandard-2.0/dotnet/api/system.string.json",
-            "locale": "en-us",
-            "moniker": "netstandard-2.0", 
 
-            // other browser navigation properties...
-            // other properties needed for backward compatibility
-        }, 
-        {
-            "siteUrl": "/dotnet/api/system.string",
-
-            // when `outputPath` does not exist,
-            // use `sourcePath` relative to source docset folder to locate the file
-            "sourcePath": "en-us/netstandard-2.0/dotnet/api/system.string.json"
-        }
-    ]
-}
-```
-
-We only save *browser navigation properties* for images in `build.manifest`. Other image metadata are discarded.
-
-Different verions of the same document, or difference locales of the same document may have the same output content.
-It is nessesary to duplicate them for static rendering. To save space for dynamic rendering, set the `path`
-property to the same location.
-
-### Dependencies
-
-To efficiently look up the impacted files for a given file,
-`docfx` produces a dependency list at `_site/build.manifest` that lists all the relationships between different files.
-
-*Dependency impacts* means the impacts(build/publish) to the referenced file causing by one or more file changes:
-
-  - **Content impact** means the changing file content has impact to the referenced file(s), like token/codesnippet, overwrite markdown.
-    - Inclusion(token/codesnippet) reference, like `![include](token file path)`.
-    - Overwrite markdown reference(TODO).
-  - **URL impact** means the changing file output URL has impact to the referenced file(s), like file link, UID reference.
-    - File link reference, like `[link title](file path)`.
-    - UID reference, like `<xref:System.Char>`.
-    - Metadata reference, like `toc_rel: ../TOC.json`.
-
-```json
-{  
-   "dependencies":[  
-      {  
-         "dotnet/azure/service-less-app.md": [
-            {  
-               "source":"dotnet/azure/service-less-app-dependent.md",
-               "type":"link"
-            },
-            {  
-               "source":"dotnet/azure/service-less-app-token.md",
-               "type":"inclusion"
-            }
-         ]
-      }
-   ]
-}
-```
-
-## Report
-
-`docfx` produces a report file at `_site/build.log`.
-Each line is a *json array*: `[{level}, {code}, {message}, {file?}, {line?}, {column?}]`.

--- a/docs/designs/publish.md
+++ b/docs/designs/publish.md
@@ -1,0 +1,43 @@
+# Publish
+
+## Publish Process
+
+## Pull Request Publish
+
+## Publish Manifest File
+
+To efficiently look up a file from URL for dynamic rendering, 
+`docfx` produces a manifest file at `_site/build.manifest` that lists all the output files and properties needed for lookup.
+
+*locale*, *moniker* are special properties that flows dynamically when users navigate from page to page.
+These are called *browser navigation properties* and are stored in manifest.
+
+```javascript
+{
+    "files": [
+        {
+            "siteUrl": "/dotnet/api/system.string",
+            "outputPath": "en-us/netstandard-2.0/dotnet/api/system.string.json",
+            "locale": "en-us",
+            "moniker": "netstandard-2.0", 
+
+            // other browser navigation properties...
+            // other properties needed for backward compatibility
+        }, 
+        {
+            "siteUrl": "/dotnet/api/system.string",
+
+            // when `outputPath` does not exist,
+            // use `sourcePath` relative to source docset folder to locate the file
+            "sourcePath": "en-us/netstandard-2.0/dotnet/api/system.string.json"
+        }
+    ]
+}
+```
+
+We only save *browser navigation properties* for images in `build.manifest`. Other image metadata are discarded.
+
+Different verions of the same document, or difference locales of the same document may have the same output content.
+It is nessesary to duplicate them for static rendering. To save space for dynamic rendering, set the `path`
+property to the same location.
+

--- a/docs/designs/publish.md
+++ b/docs/designs/publish.md
@@ -1,43 +1,32 @@
 # Publish
 
-## Publish Process
-
-## Pull Request Publish
-
 ## Publish Manifest File
 
-To efficiently look up a file from URL for dynamic rendering, 
-`docfx` produces a manifest file at `_site/build.manifest` that lists all the output files and properties needed for lookup.
-
-*locale*, *moniker* are special properties that flows dynamically when users navigate from page to page.
-These are called *browser navigation properties* and are stored in manifest.
+`docfx` generates a manifest file for publishing at `{output-path}/_build/publish.json` after build. It is the entry point for publishing. An example `publish.json` looks like this:
 
 ```javascript
 {
-    "files": [
+    "publish": [
         {
-            "siteUrl": "/dotnet/api/system.string",
-            "outputPath": "en-us/netstandard-2.0/dotnet/api/system.string.json",
+            "url": "/dotnet/api/system.string",
+            "path": "dotnet/api/system.string.json",
+            "hash": "d41d8cd98f00b204e9800998ecf8427e",
             "locale": "en-us",
-            "moniker": "netstandard-2.0", 
+            "monikers": ["netstandard-2.0"],
 
-            // other browser navigation properties...
-            // other properties needed for backward compatibility
-        }, 
-        {
-            "siteUrl": "/dotnet/api/system.string",
-
-            // when `outputPath` does not exist,
-            // use `sourcePath` relative to source docset folder to locate the file
-            "sourcePath": "en-us/netstandard-2.0/dotnet/api/system.string.json"
+            // additional properties needed for publish
         }
     ]
 }
 ```
 
-We only save *browser navigation properties* for images in `build.manifest`. Other image metadata are discarded.
+The format is a json file that contains a list of files to be published. Each item under `publish` section contains the following properties:
 
-Different verions of the same document, or difference locales of the same document may have the same output content.
-It is nessesary to duplicate them for static rendering. To save space for dynamic rendering, set the `path`
-property to the same location.
-
+Name        | Description
+------------|-----------------
+url         | site url without locale.
+path        | location of the content file relative to `{output-path}`. Different files may share the same `{path}` if their contents are the same.
+hash        | MD5 hash of the content file specified by `{path}`.
+locale      | locale of the file.
+monikers    | monikers of the file.
+*additional properties | Additional properties can be added here if they are required by publish. For backward compatibility reasons, article metadata is required by publish, thus they are also put here.

--- a/docs/designs/xref.md
+++ b/docs/designs/xref.md
@@ -42,7 +42,7 @@ inputs:
     }
 outputs:
   docs/a.json:
-  xrefmap.json: | 
+  _build/xrefmap.json: | 
     {"references":[{"uid":"a","href":"docs/a.json","summary":"<pre><code>Hello `docfx`!\n</code></pre>\n"}]}
 ```
 Since the xref map would be outputted for external reference, if markdown contains a linking url, should it be resolved to an absolute url? It is resolved as relative url for now as below:
@@ -59,12 +59,12 @@ inputs:
 outputs:
   docs/a.json:
   docs/b.json:
-  xrefmap.json: | 
+  _build/xrefmap.json: | 
     {"references":[{"uid":"a","href":"docs/a.json","summary":"<p>Link to <a href=\"b\">b</a></p>\n"}]}
 ```
 
 ## Output xref map
-Docfx will output a JSON file named `xrefmap.json`. In V2, docfx used to output `xrefmap.yml`, it took much longer to be de-serialized compared to JSON format.
+Docfx will output a JSON file named `_build/xrefmap.json`. In V2, docfx used to output `xrefmap.yml`, it took much longer to be de-serialized compared to JSON format.
 ```json
 {
     "references": [
@@ -82,14 +82,14 @@ This file will be updated to some central place, and there would be a step to me
 ## Create xref map
 There are two parts of xref map, internal and external.
 ### Internal xref map
-User can define uids in the same repository and reference to them, and these defined uids will be outputted as `xrefmap.json`.
+User can define uids in the same repository and reference to them, and these defined uids will be outputted as `_build/xrefmap.json`.
 
 ### External xref map
-User can reference uids defined by other repositories as well, just define the urls of `xrefmap.json` in `docfx.yml`.
+User can reference uids defined by other repositories as well, just define the urls of `_build/xrefmap.json` in `docfx.yml`.
 ```yml
 xref:
-  - http://url1/xrefmap.json
-  - http://url2/xrefmap.json
+  - http://url1/_build/xrefmap.json
+  - http://url2/_build/xrefmap.json
 ```
 During `docfx restore`, all the JSON files will be restored and merged.
 


### PR DESCRIPTION
This is a draft design spec of publish manifest file, some notable changes:

- Group system generated outputs to `_build` folder as we have more and more generated output now.
- Creates a dedicated `publish.json` specifically for publish purposes.
- Puts article metadata to `publish.json`
- Remove dependency map from ideal map for now. We can design and add it to a standalone file later.

@fenxu 