### PR TITLE
add JsonConverter for FileMetadata

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/FileMetadata.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/FileMetadata.cs
@@ -3,9 +3,11 @@
 
 namespace Microsoft.DocAsCode.Build.Engine
 {
+    using Newtonsoft.Json;
     using System.Collections.Generic;
     using System.Collections.Immutable;
 
+    [JsonConverter(typeof(FileMetadataConverter))]
     public sealed class FileMetadata : Dictionary<string, ImmutableArray<FileMetadataItem>>
     {
         public string BaseDir { get; }

--- a/src/Microsoft.DocAsCode.Build.Engine/FileMetadataConverter.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/FileMetadataConverter.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+
+    using Microsoft.DocAsCode.Build.Engine;
+    using Microsoft.DocAsCode.Common;
+    using Microsoft.DocAsCode.Glob;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    public class FileMetadataConverter : JsonConverter
+    {
+        private const string BaseDir = "baseDir";
+        private const string Dict = "dict";
+        private const string Glob = "glob";
+        private const string Key = "key";
+        private const string Value = "value";
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(FileMetadata);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            JToken token;
+            if (reader.TokenType == JsonToken.StartObject)
+            {
+                token = JToken.Load(reader);
+            }
+            else
+            {
+                throw new JsonReaderException($"{reader.TokenType.ToString()} is not a valid {objectType.Name}.");
+            }
+            var baseDir = (string)((JObject)token).GetValue(BaseDir);
+            if (!(token[Dict] is JObject dict))
+            {
+                throw new JsonReaderException($"Expect {token[Dict]} to be JObject.");
+            }
+            var metaDict = new Dictionary<string, ImmutableArray<FileMetadataItem>>();
+            foreach (var pair in dict)
+            {
+                metaDict.Add(pair.Key, GetFileMetadataItemArray(pair.Value));
+            }
+
+            return new FileMetadata(baseDir, metaDict);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var fileMetadata = (FileMetadata)value;
+            writer.WriteStartObject();
+
+            if (fileMetadata.BaseDir != null)
+            {
+                writer.WritePropertyName(BaseDir);
+                writer.WriteRawValue(JsonUtility.Serialize(fileMetadata.BaseDir));
+            }
+
+            writer.WritePropertyName(Dict);
+            writer.WriteStartObject();
+            foreach (var pair in fileMetadata)
+            {
+                writer.WritePropertyName(pair.Key);
+                writer.WriteStartArray();
+                foreach (var item in pair.Value)
+                {
+                    writer.WriteStartObject();
+                    writer.WritePropertyName(Glob);
+                    writer.WriteRawValue(JsonUtility.Serialize(item.Glob.Raw));
+                    writer.WritePropertyName(Key);
+                    writer.WriteRawValue(JsonUtility.Serialize(item.Key));
+                    writer.WritePropertyName(Value);
+                    writer.WriteRawValue(JsonUtility.Serialize(item.Value));
+                    writer.WriteEndObject();
+                }
+                writer.WriteEndArray();
+            }
+            writer.WriteEndObject();
+
+            writer.WriteEndObject();
+        }
+
+        private ImmutableArray<FileMetadataItem> GetFileMetadataItemArray(JToken value)
+        {
+            if (!(value is JArray arr))
+            {
+                throw new JsonReaderException($"Expect {value} to be JArray.");
+            }
+            return arr.Select(e =>
+            {
+                if (!(e is JObject obj))
+                {
+                    throw new JsonReaderException($"Expect {e} to be JObject.");
+                }
+                return new FileMetadataItem(
+                    new GlobMatcher((string)obj[Glob]),
+                    (string)obj[Key],
+                    ConvertToObjectHelper.ConvertJObjectToObject(obj[Value]));
+            }).ToImmutableArray();
+        }
+    }
+}

--- a/src/Microsoft.DocAsCode.Build.Engine/Incrementals/BuildVersionInfo.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/Incrementals/BuildVersionInfo.cs
@@ -169,7 +169,10 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
         internal void Save(string baseDir)
         {
             IncrementalUtility.SaveDependency(Path.Combine(baseDir, DependencyFile), Dependency);
-            IncrementalUtility.SaveIntermediateFile(Path.Combine(baseDir, FileMetadataFile), FileMetadata);
+            if (FileMetadataFile != null)
+            {
+                IncrementalUtility.SaveIntermediateFile(Path.Combine(baseDir, FileMetadataFile), FileMetadata);
+            }
             IncrementalUtility.SaveIntermediateFile(Path.Combine(baseDir, AttributesFile), Attributes);
             IncrementalUtility.SaveIntermediateFile(Path.Combine(baseDir, OutputFile), BuildOutputs);
             IncrementalUtility.SaveIntermediateFile(Path.Combine(baseDir, XRefSpecMapFile), XRefSpecMap);

--- a/src/Microsoft.DocAsCode.Build.Engine/Incrementals/IncrementalBuildContext.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/Incrementals/IncrementalBuildContext.cs
@@ -91,7 +91,6 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
                 FileMetadataHash = ComputeFileMetadataHash(parameters.FileMetadata),
                 FileMetadata = parameters.FileMetadata,
                 AttributesFile = IncrementalUtility.CreateRandomFileName(baseDir),
-                FileMetadataFile = IncrementalUtility.CreateRandomFileName(baseDir),
                 DependencyFile = IncrementalUtility.CreateRandomFileName(baseDir),
                 ManifestFile = IncrementalUtility.CreateRandomFileName(baseDir),
                 OutputFile = IncrementalUtility.CreateRandomFileName(baseDir),
@@ -100,6 +99,10 @@ namespace Microsoft.DocAsCode.Build.Engine.Incrementals
                 BuildMessageFile = IncrementalUtility.CreateRandomFileName(baseDir),
                 TocRestructionsFile = IncrementalUtility.CreateRandomFileName(baseDir),
             };
+            if (parameters.FileMetadata != null)
+            {
+                cbv.FileMetadataFile = IncrementalUtility.CreateRandomFileName(baseDir);
+            }
             cb.Versions.Add(cbv);
             var context = new IncrementalBuildContext(baseDir, lastBaseDir, lastBuildStartTime, buildInfoIncrementalStatus, parameters, cbv, lbv)
             {

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/JsonConverterTest.cs
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/JsonConverterTest.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DocAsCode.Common;
+using Microsoft.DocAsCode.Glob;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.DocAsCode.Build.Engine.Tests
+{
+    public class JsonConverterTest
+    {
+        [Fact]
+        public void TestFileMetadataConverterCouldSerializeAndDeserialize()
+        {
+            var baseDir = "inputFolder";
+            var raw = new FileMetadata(baseDir, new Dictionary<string, ImmutableArray<FileMetadataItem>>
+            {
+                ["meta"] = ImmutableArray.Create(
+                    new FileMetadataItem(new GlobMatcher("*.md"), "meta", 1L),
+                    new FileMetadataItem(new GlobMatcher("*.m"), "meta", true),
+                    new FileMetadataItem(new GlobMatcher("abc"), "meta", "string"),
+                    new FileMetadataItem(new GlobMatcher("/[]\\*.cs"), "meta", new Dictionary<string, object> { ["key"] = "2" }),
+                    new FileMetadataItem(new GlobMatcher("*/*.cs"), "meta", new object[] { "1", "2" }),
+                    new FileMetadataItem(new GlobMatcher("**"), "meta", new Dictionary<string, object> { ["key"] = new object[] { "1", "2" } })
+                )
+            });
+            var serialized = JsonUtility.Serialize(raw);
+            var expected = "{'baseDir':'inputFolder','dict':{'meta':[{'glob':'*.md','key':'meta','value':1},{'glob':'*.m','key':'meta','value':true},{'glob':'abc','key':'meta','value':'string'},{'glob':'/[]\\\\*.cs','key':'meta','value':{'key':'2'}},{'glob':'*/*.cs','key':'meta','value':['1','2']},{'glob':'**','key':'meta','value':{'key':['1','2']}}]}}".Replace('\'', '\"');
+            Assert.Equal(expected, serialized);
+
+            using (var reader = new StringReader(serialized))
+            {
+                var actual = JsonUtility.Deserialize<FileMetadata>(reader);
+
+                Assert.Equal(baseDir, actual.BaseDir);
+                Assert.Equal(raw.Count, actual.Count);
+                foreach(var pair in raw)
+                {
+                    Assert.True(actual.TryGetValue(pair.Key, out var array));
+                    Assert.Equal(pair.Value.Length, array.Length);
+                    for (var i = 0; i < array.Length; i++)
+                    {
+                        Assert.Equal(pair.Value[i].Glob.Raw, array[i].Glob.Raw);
+                        Assert.Equal(pair.Value[i].Key, array[i].Key);
+                        Assert.Equal(pair.Value[i].Value, array[i].Value);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
In #3843, FileMetadataCache will fail to deserialize, which will cause all cache invalid. This PR adds the custom `JsonConverter` to fix it.