### PR TITLE
Output xref map href as external accessible URL

### DIFF
--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -697,7 +697,7 @@ outputs:
   docs/b.json: |
     {"content":"<p>link to <a href=\"a\">a</a>\nlink to <a href=\"c\">c</a></p>\n"}
   xrefmap.json: |
-    {"references":[{"uid":"a","href":"/docs/a","name":"a"},{"uid":"c","href":"/docs/c","name":"c"}]}
+    {"references":[{"uid":"a","href":"https://docs.com/docs/a","name":"a"},{"uid":"c","href":"https://docs.com/docs/c","name":"c"}]}
 ---
 # loc folder should be excluded from source docset during loc docset build
 commands:

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -423,7 +423,7 @@ outputs:
       "monikers": ["netcore-2.0"]
     }
   xrefmap.json: | 
-    {"references":[{"uid":"a","href":"/docs/a","name":"netcore-2.0"}]}
+    {"references":[{"uid":"a","href":"https://docs.com/docs/a","name":"netcore-2.0"}]}
 ---
 # Define same uid with multiple moniker ranges, 
 # reference to it without moniker in the same docset, shoule take the latest one
@@ -485,7 +485,7 @@ outputs:
       "monikers": ["netcore-2.0"]
     }
   xrefmap.json: | 
-    {"references":[{"uid":"a","href":"/docs/a","name":"netcore-2.0"}]}
+    {"references":[{"uid":"a","href":"https://docs.com/docs/a","name":"netcore-2.0"}]}
 ---
 # Define same uid with overlapping moniker range
 inputs:
@@ -582,7 +582,7 @@ outputs:
       "monikers": ["netcore-2.0"]
     }
   xrefmap.json: | 
-    {"references":[{"uid":"a","href":"/docs/a","name":"netcore-2.0"}]}
+    {"references":[{"uid":"a","href":"https://docs.com/docs/a","name":"netcore-2.0"}]}
   build.log: |
     ["warning","invalid-uid-moniker","Moniker 'netcore-1.0' is not defined with uid 'a'"]
 ---
@@ -650,7 +650,7 @@ outputs:
       "monikers": ["netcore-2.0"]
     }
   xrefmap.json: | 
-    {"references":[{"uid":"a","href":"/docs/a","name":"netcore-2.0"}]}
+    {"references":[{"uid":"a","href":"https://docs.com/docs/a","name":"netcore-2.0"}]}
 ---
 # Define multiple uid without moniker range, and also uid with moniker range
 inputs:

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -80,12 +80,12 @@ outputs:
       "references":[
         {
           "uid": "a",
-          "href": "/docs/a",
+          "href": "https://docs.com/docs/a",
           "name": "Title from yaml header a"
         },
         {
           "uid": "b",
-          "href": "/docs/b",
+          "href": "https://docs.com/docs/b",
           "name": "Title from yaml header b"
         }
       ]
@@ -124,7 +124,7 @@ outputs:
     {"content":"<p>Link to <a href=\"a.json\">test.test</a>\nLink to <a href=\"a.json\">test.test</a>\nLink to <a href=\"a.json\">test</a></p>\n"}
   docs/a.json:
   xrefmap.json: | 
-    {"references":[{"uid":"a","href":"/docs/a.json"}]}
+    {"references":[{"uid":"a","href":"https://docs.com/docs/a.json"}]}
   build.manifest: |
     {
       "dependencies": {
@@ -184,7 +184,7 @@ outputs:
       "content": {"xref": "a.json"}
     }
   xrefmap.json: | 
-    {"references":[{"uid":"a","href":"/docs/a.json"}]}
+    {"references":[{"uid":"a","href":"https://docs.com/docs/a.json"}]}
   build.manifest: |
     {
       "dependencies": {
@@ -241,7 +241,7 @@ outputs:
   build.log: |
     ["info","at-uid-not-found","Cannot find uid 'b' using xref '@b'","docs/b.md"]
   xrefmap.json: | 
-    {"references":[{"uid":"a","href":"/docs/a.json"}]}
+    {"references":[{"uid":"a","href":"https://docs.com/docs/a.json"}]}
 ---
 # Xref property field which supports markdown content
 inputs:
@@ -255,7 +255,7 @@ inputs:
 outputs:
   docs/a.json:
   xrefmap.json: | 
-    {"references":[{"uid":"a","href":"/docs/a.json","summary":"<pre><code>Hello `docfx`!\n</code></pre>\n"}]}
+    {"references":[{"uid":"a","href":"https://docs.com/docs/a.json","summary":"<pre><code>Hello `docfx`!\n</code></pre>\n"}]}
 ---
 # Xref property field which supports inline markdown content
 inputs:
@@ -269,7 +269,7 @@ inputs:
 outputs:
   docs/a.json:
   xrefmap.json: | 
-    {"references":[{"uid":"a","href":"/docs/a.json","inlineDescription":"Hello <code>docfx</code>!"}]}
+    {"references":[{"uid":"a","href":"https://docs.com/docs/a.json","inlineDescription":"Hello <code>docfx</code>!"}]}
 ---
 # Xref property field with dependecy
 inputs:
@@ -286,7 +286,7 @@ outputs:
   docs/a.json:
   docs/b.json:
   xrefmap.json: | 
-    {"references":[{"uid":"a","href":"/docs/a.json","inlineDescription":"Hello <code>docfx</code>!"}]}
+    {"references":[{"uid":"a","href":"https://docs.com/docs/a.json","inlineDescription":"Hello <code>docfx</code>!"}]}
 ---
 # Refer to uid with hashtag
 inputs:

--- a/src/docfx/build/xref/XrefMap.cs
+++ b/src/docfx/build/xref/XrefMap.cs
@@ -351,7 +351,7 @@ namespace Microsoft.Docs.Build
             var xref = new InternalXrefSpec
             {
                 Uid = metadata.Uid,
-                Href = file.SiteUrl,
+                Href = file.ExternalUrl,
                 ReferencedFile = file,
             };
             xref.ExtensionData["name"] = new Lazy<JValue>(() => new JValue(string.IsNullOrEmpty(metadata.Title) ? metadata.Uid : metadata.Title));
@@ -386,7 +386,7 @@ namespace Microsoft.Docs.Build
             var xref = new InternalXrefSpec
             {
                 Uid = uid,
-                Href = file.SiteUrl,
+                Href = file.ExternalUrl,
                 ReferencedFile = file,
             };
 

--- a/src/docfx/docset/Document.cs
+++ b/src/docfx/docset/Document.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Docs.Build
         /// _site/en-us/603b739b/dotnet/api/system.string/index.json
         ///
         ///  - Normalized using <see cref="PathUtility.NormalizeFile(string)"/>
-        ///  - Docs not start with '/'
+        ///  - Does not start with '/'
         ///  - Does not end with '/'
         /// </summary>
         public string SitePath { get; }
@@ -66,6 +66,11 @@ namespace Microsoft.Docs.Build
         ///  - Does not escape with <see cref="HrefUtility.EscapeUrl(string)"/>
         /// </summary>
         public string SiteUrl { get; }
+
+        /// <summary>
+        /// Gets the external accessible URL
+        /// </summary>
+        public string ExternalUrl { get; }
 
         /// <summary>
         /// Gets the document id and version independent id
@@ -108,6 +113,7 @@ namespace Microsoft.Docs.Build
             string filePath,
             string sitePath,
             string siteUrl,
+            string externalUrl,
             ContentType contentType,
             string mime,
             Schema schema,
@@ -122,6 +128,7 @@ namespace Microsoft.Docs.Build
             FilePath = filePath;
             SitePath = sitePath;
             SiteUrl = siteUrl;
+            ExternalUrl = externalUrl;
             ContentType = contentType;
             Mime = mime;
             Schema = schema;
@@ -225,6 +232,7 @@ namespace Microsoft.Docs.Build
             }
 
             var siteUrl = PathToAbsoluteUrl(sitePath, type, schema, docset.Config.Output.Json);
+            var externalUrl = SiteUrlToExternalUrl(siteUrl, docset);
             var contentType = redirectionUrl != null ? ContentType.Redirection : type;
 
             if (contentType == ContentType.Redirection && type != ContentType.Page)
@@ -232,7 +240,7 @@ namespace Microsoft.Docs.Build
                 return (Errors.InvalidRedirection(filePath, type), null);
             }
 
-            return (null, new Document(docset, filePath, sitePath, siteUrl, contentType, mime, schema, isExperimental, redirectionUrl, isFromHistory));
+            return (null, new Document(docset, filePath, sitePath, siteUrl, externalUrl, contentType, mime, schema, isExperimental, redirectionUrl, isFromHistory));
         }
 
         /// <summary>
@@ -361,6 +369,9 @@ namespace Microsoft.Docs.Build
                     return url;
             }
         }
+
+        private static string SiteUrlToExternalUrl(string siteUrl, Docset docset)
+            => docset.Config.BaseUrl + siteUrl;
 
         private static string ApplyRoutes(string path, IReadOnlyDictionary<string, string> routes)
         {

--- a/test/docfx.Test/docfx.test.yml
+++ b/test/docfx.Test/docfx.test.yml
@@ -1,4 +1,5 @@
 # default config for specs in docfx
+baseUrl: https://docs.com
 rules:
   heading-not-found: off
   resolve-author-failed: off


### PR DESCRIPTION
Trying to fix #3875 

In v2, docfx uses xref service to resolve uid:
https://xref.docs.microsoft.com/query?uid=Microsoft.AspNetCore.Routing.IRouter
```json
[
    {
        "uid": "Microsoft.AspNetCore.Routing.IRouter",
        "name": "IRouter",
        "fullName": "Microsoft.AspNetCore.Routing.IRouter",
        "href": "https://docs.microsoft.com/dotnet/api/microsoft.aspnetcore.routing.irouter",
        "commentId": "T:Microsoft.AspNetCore.Routing.IRouter",
        "nameWithType": "Microsoft.AspNetCore.Routing.IRouter",
        "tags": [
            "/dotnet",
            "public"
        ]
    }
]
```

In v3, docfx uses xrefmap.json to resolve the uid, and the outputted `xrefmap.json` contains:
```json
[
    {
        "uid": "Microsoft.AspNetCore.Routing.IRouter",
        "name": "IRouter",
        "fullName": "Microsoft.AspNetCore.Routing.IRouter",
        "href": "/dotnet/api/microsoft.aspnetcore.routing.irouter",
        "commentId": "T:Microsoft.AspNetCore.Routing.IRouter",
        "nameWithType": "Microsoft.AspNetCore.Routing.IRouter",
        "tags": [
            "/dotnet",
            "public"
        ]
    }
]
```
Seems like the OPS outputted `xrefmap.json` contains the absolute URL as  href, we need to fix it in OPS for v3 to use. 
Since docfx v3 has the information of `hostname`, adding it to `xrefmap.json` output.