### PR TITLE
add resolve alias config to support ~

### DIFF
--- a/docs/specs/resolve.yml
+++ b/docs/specs/resolve.yml
@@ -286,7 +286,8 @@ outputs:
 # Link or Image with `~`
 inputs:
   docfx.yml: |
-    tildePath: docs
+    resolveAlias:
+      ~: docs
   docs/a.md: |
     Link to [B1](~/b.md)
     Link to [B2](~/docs/b.md)
@@ -304,7 +305,8 @@ outputs:
 # <a> or <img> tag with `~`
 inputs:
   docfx.yml: |
-    tildePath: docs
+    resolveAlias:
+      ~: docs
   docs/a.md: |
     Link to <a href="~/b.md">b</a>
     <div>Link to <img src="~/c.png" /></div>
@@ -320,7 +322,8 @@ outputs:
 inputs:
   docfx.yml: |
     exclude: '*'
-    tildePath: docs/
+    resolveAlias:
+      ~: docs
   docs/a.md: |
     [!include[B1](~/b.md)]
     [!include[B2](~/../b.md)]

--- a/docs/specs/resolve.yml
+++ b/docs/specs/resolve.yml
@@ -57,19 +57,6 @@ outputs:
   docs/dir-b/b.json: |
     { "content": "<p>Link to <a href=\"../dir-a/a\">a</a></p>" }
 ---
-# Path starting with ~ resolves from docset root directory
-inputs:
-  docfx.yml:
-  docs/dir-a/a.md: Link to [b](~/docs/dir-b/b.md)
-  docs/dir-b/b.md: Link to [a](~docs/dir-a/a.md)
-outputs:
-  docs/dir-a/a.json: |
-    { "content": "<p>Link to <a href=\"../dir-b/b\">b</a></p>" }
-  docs/dir-b/b.json: |
-    { "content": "<p>Link to <a href=\"%7Edocs/dir-a/a.md\">a</a></p>" }
-  build.log: |
-    ["warning","file-not-found","Cannot find file '~docs/dir-a/a.md' relative to 'docs/dir-b/b.md'","docs/dir-b/b.md"]
----
 # Links in include files are resolved relative to the include file
 inputs:
   docfx.yml:
@@ -87,7 +74,7 @@ outputs:
 inputs:
   docfx.yml:
   docs/a.md: Link to <a href="b.md" target="_blank"><em>b</em></a>
-  docs/b.md: <div>Link to <img src="~/docs/c.png" /></div>
+  docs/b.md: <div>Link to <img src="c.png" /></div>
   docs/c.png:
 outputs:
   docs/a.json: |
@@ -263,12 +250,12 @@ inputs:
   docfx.yml: |
     dependencies:
       dep: https://github.com/docascode/docfx-test-dependencies
-  docs/a.md: 'Link to [dep](~/dep/logo.svg)'
+  docs/a.md: 'Link to [dep](../dep/logo.svg)'
 outputs:
   docs/a.json: |
-    {"content":"<p>Link to <a href=\"%7E/dep/logo.svg\">dep</a></p>"}
+    {"content":"<p>Link to <a href=\"../dep/logo.svg\">dep</a></p>"}
   build.log: |
-    ["warning","link-is-dependency","File 'logo.svg' referenced by link '~/dep/logo.svg' will not be built because it is from a dependency docset","docs/a.md"]
+    ["warning","link-is-dependency","File 'logo.svg' referenced by link '../dep/logo.svg' will not be built because it is from a dependency docset","docs/a.md"]
 ---
 # Don't show warning if include a file from dependency repo
 inputs:
@@ -279,3 +266,67 @@ inputs:
 outputs:
   docs/a.json: |
     {"content":"<p>DEP</p>"}
+---
+# Link with `~` - default TildePath config
+inputs:
+  docfx.yml:
+  docs/a.md: |
+    Link to [B1](~/b.md)
+    Link to [B2](~/docs/b.md)
+    Link to [B3](~docs/b.md)
+  docs/b.md:
+outputs:
+  docs/a.json: |
+    { "content": "<p>Link to <a href=\"%7E/b.md\">B1</a>Link to <a href=\"b\">B2</a>Link to <a href=\"%7Edocs/b.md\">B3</a></p>" }
+  docs/b.json:
+  build.log: |
+    ["warning","file-not-found","Cannot find file '~/b.md' relative to 'docs/a.md'","docs/a.md"]
+    ["warning","file-not-found","Cannot find file '~docs/b.md' relative to 'docs/a.md'","docs/a.md"]
+---
+# Link or Image with `~`
+inputs:
+  docfx.yml: |
+    tildePath: docs
+  docs/a.md: |
+    Link to [B1](~/b.md)
+    Link to [B2](~/docs/b.md)
+    ![C](~/c.png)
+  docs/b.md:
+  docs/c.png:
+outputs:
+  docs/a.json: |
+    { "content": "<p>Link to <a href=\"b\">B1</a>\nLink to <a href=\"%7E/docs/b.md\">B2</a>\n<img src=\"c.png\" alt=\"C\" /></p>\n" }
+  docs/b.json:
+  docs/c.png:
+  build.log: |
+    ["warning","file-not-found","Cannot find file '~/docs/b.md' relative to 'docs/a.md'","docs/a.md"]
+---
+# <a> or <img> tag with `~`
+inputs:
+  docfx.yml: |
+    tildePath: docs
+  docs/a.md: |
+    Link to <a href="~/b.md">b</a>
+    <div>Link to <img src="~/c.png" /></div>
+  docs/b.md:
+  docs/c.png:
+outputs:
+  docs/a.json: |
+    { "content": "<p>Link to <a href=\"b\">b</a></p>\n<div>Link to <img src=\"c.png\"></div>\n" }
+  docs/b.json:
+  docs/c.png:
+---
+# Include with `~`
+inputs:
+  docfx.yml: |
+    exclude: '*'
+    tildePath: docs/
+  docs/a.md: |
+    [!include[B1](~/b.md)]
+    [!include[B2](~/../b.md)]
+  b.md: Token
+outputs:
+  docs/a.json: |
+    { "content": "[!include[B1](~/b.md)]<p>Token</p>\n" }
+  build.log: |
+    ["warning","include-not-found","Cannot resolve '~/b.md' relative to 'docs/a.md'.","docs/a.md"]

--- a/docs/specs/resolve.yml
+++ b/docs/specs/resolve.yml
@@ -319,6 +319,24 @@ outputs:
     { "content": "<p>Link to <a href=\"b\">B1</a>\nLink to <a href=\"b\">B2</a></p>\n" }
   docs/b.json:
 ---
+# If the alias is conflict with the physical path, peek the physical path
+inputs:
+  docfx.yml: |
+    resolveAlias:
+      test: docs/test-test
+  docs/a.md: |
+    Link to [B](test/b.md)
+    Link to [C](test/c.md)
+  docs/test/b.md:
+  docs/test-test/b.md:
+  docs/test-test/c.md:
+outputs:
+  docs/a.json: |
+    { "content": "<p>Link to <a href=\"test/b\">B</a>\nLink to <a href=\"test-test/c\">C</a></p>\n" }
+  docs/test/b.json:
+  docs/test-test/b.json:
+  docs/test-test/c.json:
+---
 # <a> or <img> tag with resolve alias
 inputs:
   docfx.yml: |

--- a/docs/specs/resolve.yml
+++ b/docs/specs/resolve.yml
@@ -267,7 +267,7 @@ outputs:
   docs/a.json: |
     {"content":"<p>DEP</p>"}
 ---
-# Link with `~` - default TildePath config
+# Link with `~` - default resolveAlias config
 inputs:
   docfx.yml:
   docs/a.md: |
@@ -283,26 +283,43 @@ outputs:
     ["warning","file-not-found","Cannot find file '~/b.md' relative to 'docs/a.md'","docs/a.md"]
     ["warning","file-not-found","Cannot find file '~docs/b.md' relative to 'docs/a.md'","docs/a.md"]
 ---
-# Link or Image with `~`
+# Link or Image with resolve alias
 inputs:
   docfx.yml: |
     resolveAlias:
       ~: docs
+      $ROOT: .
   docs/a.md: |
     Link to [B1](~/b.md)
-    Link to [B2](~/docs/b.md)
+    Link to [B2]($ROOT/docs/b.md)
+    Link to [B3](~/docs/b.md)
     ![C](~/c.png)
   docs/b.md:
   docs/c.png:
 outputs:
   docs/a.json: |
-    { "content": "<p>Link to <a href=\"b\">B1</a>\nLink to <a href=\"%7E/docs/b.md\">B2</a>\n<img src=\"c.png\" alt=\"C\" /></p>\n" }
+    { "content": "<p>Link to <a href=\"b\">B1</a>\nLink to <a href=\"b\">B2</a>\nLink to <a href=\"%7E/docs/b.md\">B3</a>\n<img src=\"c.png\" alt=\"C\" /></p>\n" }
   docs/b.json:
   docs/c.png:
   build.log: |
     ["warning","file-not-found","Cannot find file '~/docs/b.md' relative to 'docs/a.md'","docs/a.md"]
 ---
-# <a> or <img> tag with `~`
+# Multiple matched alias, use the last one
+inputs:
+  docfx.yml: |
+    resolveAlias:
+      ~: docs
+      ~/test: docs
+  docs/a.md: |
+    Link to [B1](~/b.md)
+    Link to [B2](~/test/b.md)
+  docs/b.md:
+outputs:
+  docs/a.json: |
+    { "content": "<p>Link to <a href=\"b\">B1</a>\nLink to <a href=\"b\">B2</a></p>\n" }
+  docs/b.json:
+---
+# <a> or <img> tag with resolve alias
 inputs:
   docfx.yml: |
     resolveAlias:
@@ -318,7 +335,7 @@ outputs:
   docs/b.json:
   docs/c.png:
 ---
-# Include with `~`
+# Include with resolve alias
 inputs:
   docfx.yml: |
     exclude: '*'

--- a/schemas/docfx.json
+++ b/schemas/docfx.json
@@ -248,6 +248,9 @@
     "theme": {
       "type": "string"
     },
+    "tildePath": {
+      "type": "string"
+    },
     "$schema": {
       "type": "string"
     }

--- a/schemas/docfx.json
+++ b/schemas/docfx.json
@@ -188,6 +188,12 @@
         "type": "string"
       }
     },
+    "resolveAlias": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
     "redirections": {
       "type": "object",
       "additionalProperties": {
@@ -246,9 +252,6 @@
       "type": "string"
     },
     "theme": {
-      "type": "string"
-    },
-    "tildePath": {
       "type": "string"
     },
     "$schema": {

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Docs.Build
             }
 
             // Resolve path relative to docset
-            pathToDocset = ResolveToRelativePath(path, relativeTo);
+            pathToDocset = ResolveToDocsetRelativePath(path, relativeTo);
 
             // resolve from redirection files
             pathToDocset = PathUtility.NormalizeFile(pathToDocset);
@@ -239,9 +239,9 @@ namespace Microsoft.Docs.Build
             return (file != null ? null : Errors.FileNotFound(relativeTo.ToString(), path), file, null, query, fragment, false, pathToDocset);
         }
 
-        private string ResolveToRelativePath(string path, Document relativeTo)
+        private string ResolveToDocsetRelativePath(string path, Document relativeTo)
         {
-            foreach (var (alias, aliasPath) in relativeTo.Docset.ResolveAlias)
+            foreach (var (alias, aliasPath) in relativeTo.Docset.ResolveAlias.Reverse())
             {
                 if (path.StartsWith(alias, PathUtility.PathComparison))
                 {

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Docs.Build
             // Resolve path relative to docset
             if (path.StartsWith("~\\") || path.StartsWith("~/"))
             {
-                pathToDocset = path.Substring(2);
+                pathToDocset = Path.Combine(relativeTo.Docset.Config.TildePath, path.Substring(2));
             }
             else
             {

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -242,7 +242,7 @@ namespace Microsoft.Docs.Build
             var docsetRelativePath = PathUtility.NormalizeFile(Path.Combine(Path.GetDirectoryName(relativeTo.FilePath), path));
             if (!File.Exists(Path.Combine(relativeTo.Docset.DocsetPath, docsetRelativePath)))
             {
-                foreach (var (alias, aliasPath) in relativeTo.Docset.ResolveAlias.Reverse())
+                foreach (var (alias, aliasPath) in relativeTo.Docset.ResolveAlias)
                 {
                     if (path.StartsWith(alias, PathUtility.PathComparison))
                     {

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -222,8 +222,6 @@ namespace Microsoft.Docs.Build
             pathToDocset = ResolveToDocsetRelativePath(path, relativeTo);
 
             // resolve from redirection files
-            pathToDocset = PathUtility.NormalizeFile(pathToDocset);
-
             if (relativeTo.Docset.Redirections.TryGetRedirectionUrl(pathToDocset, out var redirectTo))
             {
                 // redirectTo always is absolute href
@@ -241,14 +239,18 @@ namespace Microsoft.Docs.Build
 
         private string ResolveToDocsetRelativePath(string path, Document relativeTo)
         {
-            foreach (var (alias, aliasPath) in relativeTo.Docset.ResolveAlias.Reverse())
+            var docsetRelativePath = PathUtility.NormalizeFile(Path.Combine(Path.GetDirectoryName(relativeTo.FilePath), path));
+            if (!File.Exists(Path.Combine(relativeTo.Docset.DocsetPath, docsetRelativePath)))
             {
-                if (path.StartsWith(alias, PathUtility.PathComparison))
+                foreach (var (alias, aliasPath) in relativeTo.Docset.ResolveAlias.Reverse())
                 {
-                    return Path.Combine(aliasPath, path.Substring(alias.Length));
+                    if (path.StartsWith(alias, PathUtility.PathComparison))
+                    {
+                        return PathUtility.NormalizeFile(Path.Combine(aliasPath, path.Substring(alias.Length)));
+                    }
                 }
             }
-            return Path.Combine(Path.GetDirectoryName(relativeTo.FilePath), path);
+            return docsetRelativePath;
         }
     }
 }

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -155,5 +155,10 @@ namespace Microsoft.Docs.Build
         /// </summary>
         [JsonIgnore]
         public string ConfigFileName { get; set; } = "docfx.yml";
+
+        /// <summary>
+        /// Gets the relative path of tilde symbol `~` relatived to repository root path
+        /// </summary>
+        public readonly string TildePath = ".";
     }
 }

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -85,9 +85,9 @@ namespace Microsoft.Docs.Build
 
         /// <summary>
         /// Gets the map from resolve alias to relative path relatived to `docfx.yml` file
-        /// Default path of tilde symbol `~` is '.'
+        /// Default will be `~: .`
         /// </summary>
-        public readonly Dictionary<string, string> ResolveAlias = new Dictionary<string, string>(PathUtility.PathComparer);
+        public readonly Dictionary<string, string> ResolveAlias = new Dictionary<string, string>(PathUtility.PathComparer) { { "~",  "." } };
 
         /// <summary>
         /// Gets the redirection mappings

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -84,6 +84,12 @@ namespace Microsoft.Docs.Build
         public readonly Dictionary<string, string> Dependencies = new Dictionary<string, string>(PathUtility.PathComparer);
 
         /// <summary>
+        /// Gets the map from resolve alias to relative path relatived to `docfx.yml` file
+        /// Default path of tilde symbol `~` is '.'
+        /// </summary>
+        public readonly Dictionary<string, string> ResolveAlias = new Dictionary<string, string>(PathUtility.PathComparer);
+
+        /// <summary>
         /// Gets the redirection mappings
         /// The default value is empty mappings
         /// The redirection always transfer the document id
@@ -155,10 +161,5 @@ namespace Microsoft.Docs.Build
         /// </summary>
         [JsonIgnore]
         public string ConfigFileName { get; set; } = "docfx.yml";
-
-        /// <summary>
-        /// Gets the relative path of tilde symbol `~` relatived to repository root path
-        /// </summary>
-        public readonly string TildePath = ".";
     }
 }

--- a/src/docfx/docset/Docset.cs
+++ b/src/docfx/docset/Docset.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Gets the resolve alias
         /// </summary>
-        public IEnumerable<KeyValuePair<string, string>> ResolveAlias { get; }
+        public IReadOnlyDictionary<string, string> ResolveAlias { get; }
 
         /// <summary>
         /// Gets the localization docset, it will be set when the current build locale is different with default locale
@@ -169,7 +169,7 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private IEnumerable<KeyValuePair<string, string>> LoadResolveAlias(Config config)
+        private Dictionary<string, string> LoadResolveAlias(Config config)
         {
             var result = new Dictionary<string, string>(PathUtility.PathComparer);
 
@@ -178,7 +178,7 @@ namespace Microsoft.Docs.Build
                 result.TryAdd(PathUtility.NormalizeFolder(alias), PathUtility.NormalizeFolder(aliasPath));
             }
 
-            return result.Reverse();
+            return result.Reverse().ToDictionary(item => item.Key, item => item.Value);
         }
 
         private (List<Error>, Dictionary<string, Docset>) LoadDependencies(Config config)

--- a/src/docfx/docset/Docset.cs
+++ b/src/docfx/docset/Docset.cs
@@ -175,13 +175,9 @@ namespace Microsoft.Docs.Build
 
             foreach (var (alias, aliasPath) in config.ResolveAlias)
             {
-                result[PathUtility.NormalizeFolder(alias)] = PathUtility.NormalizeFolder(aliasPath);
+                result.TryAdd(PathUtility.NormalizeFolder(alias), PathUtility.NormalizeFolder(aliasPath));
             }
 
-            if (!result.ContainsKey("~/"))
-            {
-                result.Add("~/", "./");
-            }
             return result;
         }
 

--- a/src/docfx/docset/Docset.cs
+++ b/src/docfx/docset/Docset.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Gets the resolve alias
         /// </summary>
-        public IReadOnlyDictionary<string, string> ResolveAlias { get; }
+        public IEnumerable<KeyValuePair<string, string>> ResolveAlias { get; }
 
         /// <summary>
         /// Gets the localization docset, it will be set when the current build locale is different with default locale
@@ -169,7 +169,7 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private Dictionary<string, string> LoadResolveAlias(Config config)
+        private IEnumerable<KeyValuePair<string, string>> LoadResolveAlias(Config config)
         {
             var result = new Dictionary<string, string>(PathUtility.PathComparer);
 
@@ -178,7 +178,7 @@ namespace Microsoft.Docs.Build
                 result.TryAdd(PathUtility.NormalizeFolder(alias), PathUtility.NormalizeFolder(aliasPath));
             }
 
-            return result;
+            return result.Reverse();
         }
 
         private (List<Error>, Dictionary<string, Docset>) LoadDependencies(Config config)


### PR DESCRIPTION
in v2 `~` means the docset root path, which may be different from the repository root path.
so we add a `tildePath` config to support `~` in v3.