### PR TITLE
always need refresh the last write time for restored items

### DIFF
--- a/src/docfx/build/legacy/LegacyCrossRepoReferenceInfo.cs
+++ b/src/docfx/build/legacy/LegacyCrossRepoReferenceInfo.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Docs.Build
 
             if (!string.IsNullOrEmpty(docset.Config.Theme))
             {
-                var (url, branch) = HrefUtility.SplitGitHref(docset.Config.Theme);
+                var (url, branch) = LocalizationUtility.GetLocalizedTheme(docset.Config.Theme, docset.Locale, docset.Config.Localization.DefaultLocale);
 
                 legacyCrrInfoItems.Add(new LegacyCrossRepoReferenceInfoItem
                 {

--- a/src/docfx/restore/RestoreGit.cs
+++ b/src/docfx/restore/RestoreGit.cs
@@ -27,9 +27,18 @@ namespace Microsoft.Docs.Build
                 group (git.branch, git.flags)
                 by git.remote;
 
-            var workTrees = new List<string>();
+            var workTrees = new ConcurrentBag<string>();
 
-            await ParallelUtility.ForEach(gitDependencies, async group => { workTrees.AddRange(await RestoreGitRepo(group)); }, Progress.Update);
+            await ParallelUtility.ForEach(
+                gitDependencies,
+                async group =>
+                {
+                    foreach (var worktree in await RestoreGitRepo(group))
+                    {
+                        workTrees.Add(worktree);
+                    }
+                },
+                Progress.Update);
 
             foreach (var workTree in workTrees)
             {


### PR DESCRIPTION
no matter it's implicit or matching etag or not.

Try to fix the small problem of #3891, let's consider the lock file and big size later. 