### PR TITLE
Add source info and callstack to js crashes

### DIFF
--- a/src/docfx/build/legacy/template/LegacyTemplate.cs
+++ b/src/docfx/build/legacy/template/LegacyTemplate.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Docs.Build
         private readonly string _templateDir;
         private readonly string _locale;
         private readonly LiquidTemplate _liquid;
-        private readonly JavaScript _js;
+        private readonly JavascriptEngine _js;
 
         public JObject Global { get; }
 
@@ -25,7 +25,7 @@ namespace Microsoft.Docs.Build
             _templateDir = templateDir;
             _locale = locale.ToLowerInvariant();
             _liquid = new LiquidTemplate(templateDir);
-            _js = new JavaScript(contentTemplateDir);
+            _js = new JavascriptEngine(contentTemplateDir);
             Global = LoadGlobalTokens(templateDir, _locale);
         }
 

--- a/test/docfx.Test/data/javascript/foo.js
+++ b/test/docfx.Test/data/javascript/foo.js
@@ -1,0 +1,5 @@
+function bar (obj) {
+    return obj
+}
+
+exports.bar = bar

--- a/test/docfx.Test/data/javascript/index.js
+++ b/test/docfx.Test/data/javascript/index.js
@@ -1,0 +1,14 @@
+var foo = require('./foo.js')
+
+function fail(a) {
+    a.go()
+}
+
+exports.transform = function (obj) {
+    if (obj.error) {
+        fail()
+    }
+    return {
+        content: JSON.stringify(foo.bar(obj))
+    }
+}

--- a/test/docfx.Test/template/JavascriptEngineTest.cs
+++ b/test/docfx.Test/template/JavascriptEngineTest.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Docs.Build
+{
+    public class JavascriptEngineTest
+    {
+        private readonly JavascriptEngine _js = new JavascriptEngine("data/javascript");
+
+        [Theory]
+        [InlineData("{'a':'hello','tags':[1,2],'page':{'value':3}}", "{'a':'hello','tags':[1,2],'page':{'value':3}}")]
+        public void RunJavascript(string input, string output)
+        {
+            var inputJson = JObject.Parse(input.Replace('\'', '"'));
+            var outputJson = _js.Run("index.js", inputJson);
+            Assert.Equal(output.Replace('\'', '"'), outputJson.ToString(Formatting.None));
+        }
+
+        [Theory]
+        [InlineData("{'error': true}", "TypeError: a is undefined | fail | index.js")]
+        public void RunJavascriptError(string input, string errors)
+        {
+            var inputJson = JObject.Parse(input.Replace('\'', '"'));
+            var exception = Assert.ThrowsAny<Exception>(() => _js.Run("index.js", inputJson));
+
+            foreach (var error in errors.Split('|'))
+            {
+                Assert.Contains(error.Trim(), exception.ToString());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Makes it easier to troubleshoot jint failures like https://github.com/dotnet/docfx/issues/3895