### PR TITLE
Exclude original_content_git_url_template from html meta tags

### DIFF
--- a/src/docfx/build/legacy/metadata/LegacyMetadata.cs
+++ b/src/docfx/build/legacy/metadata/LegacyMetadata.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Docs.Build
             "canonical_url",
             "content_git_url",
             "open_to_public_contributors",
+            "original_content_git_url_template",
             "fileRelativePath",
             "layout",
             "title",


### PR DESCRIPTION
Otherwise it'll appear as `<meta name="original_content_git_url_template" content="{repo}/blob/{branch}/articles/active-directory/b2b/index.yml" />` which is silly.

https://ceapex.visualstudio.com/Engineering/_git/Docs.DocFX.Impact/pullrequest/7571?_a=files