### PR TITLE
 Rewrite js require implementation

### DIFF
--- a/src/docfx/build/legacy/template/JavascriptEngine.cs
+++ b/src/docfx/build/legacy/template/JavascriptEngine.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using Jint;
@@ -12,6 +11,7 @@ using Jint.Native;
 using Jint.Native.Object;
 using Jint.Parser;
 using Jint.Runtime;
+using Jint.Runtime.Interop;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build
@@ -29,52 +29,55 @@ namespace Microsoft.Docs.Build
 
         private static readonly Engine s_engine = new Engine();
 
-        private readonly ConcurrentDictionary<string, ThreadLocal<Func<JObject, JObject>>> _scripts = new ConcurrentDictionary<string, ThreadLocal<Func<JObject, JObject>>>();
         private readonly string _scriptDir;
+        private readonly ConcurrentDictionary<string, ThreadLocal<JsValue>> _scripts
+                   = new ConcurrentDictionary<string, ThreadLocal<JsValue>>();
 
         public JavascriptEngine(string scriptDir) => _scriptDir = scriptDir;
 
-        public JObject Run(string scriptName, JObject input)
+        public JToken Run(string scriptPath, string methodName, params JToken[] args)
         {
-            var transform = _scripts.GetOrAdd(
-                scriptName,
-                key => new ThreadLocal<Func<JObject, JObject>>(() => LoadTransform(Path.Combine(_scriptDir, key))));
+            var scriptFullPath = Path.GetFullPath(Path.Combine(_scriptDir, scriptPath));
+            var exports = _scripts.GetOrAdd(scriptFullPath, file => new ThreadLocal<JsValue>(() => Run(file))).Value;
+            var method = exports.AsObject().Get(methodName);
 
-            Debug.Assert(transform != null);
-
-            return transform.Value(input);
+            return ToJToken(Invoke(method, Array.ConvertAll(args, ToJsValue)));
         }
 
-        private static Func<JObject, JObject> LoadTransform(string scriptPath)
+        private static JsValue Run(string entryScriptPath)
         {
-            var exports = Load(scriptPath, new Dictionary<string, ObjectInstance>());
-            var transform = exports.Get("transform");
+            var modules = new Dictionary<string, JsValue>();
 
-            return model =>
+            return RunCore(entryScriptPath);
+
+            JsValue RunCore(string path)
             {
-                var output = Invoke(transform, ToJsValue(model));
-                var content = output.AsObject().Get("content").AsString();
-                return JObject.Parse(content);
-            };
-        }
+                var fullPath = Path.GetFullPath(path);
+                if (modules.TryGetValue(fullPath, out var module))
+                {
+                    return module;
+                }
 
-        private static ObjectInstance Load(string scriptPath, Dictionary<string, ObjectInstance> modules)
-        {
-            if (modules.TryGetValue(scriptPath, out var module))
-            {
-                return module;
-            }
+                var engine = new Engine(opt => opt.LimitRecursion(5000));
+                var exports = modules[fullPath] = MakeObject();
+                var sourceCode = File.ReadAllText(fullPath);
+                var parserOptions = new ParserOptions { Source = fullPath };
+                var script = $@"
+;(function (module, exports, __dirname, require) {{
+{sourceCode}
+}})
+";
+                var dirname = Path.GetDirectoryName(fullPath);
+                var require = new ClrFunctionInstance(engine, Require);
 
-            var engine = new Engine(opt => opt.LimitRecursion(5000));
-            engine.SetValue("exports", MakeObject());
-            engine.SetValue("require", new Func<string, ObjectInstance>(Require));
-            engine.Execute(File.ReadAllText(scriptPath), new ParserOptions { Source = scriptPath });
+                var func = engine.Execute(script, parserOptions).GetCompletionValue();
+                func.Invoke(MakeObject(), exports, dirname, require);
+                return exports;
 
-            return modules[scriptPath] = engine.GetValue("exports").AsObject();
-
-            ObjectInstance Require(string path)
-            {
-                return Load(Path.Combine(Path.GetDirectoryName(scriptPath), path), modules);
+                JsValue Require(JsValue self, JsValue[] arguments)
+                {
+                    return RunCore(Path.Combine(dirname, arguments[0].AsString()));
+                }
             }
         }
 
@@ -111,6 +114,7 @@ namespace Microsoft.Docs.Build
                 }
                 return result;
             }
+
             if (token is JObject obj)
             {
                 var result = MakeObject();
@@ -120,7 +124,13 @@ namespace Microsoft.Docs.Build
                 }
                 return result;
             }
+
             return JsValue.FromObject(s_engine, ((JValue)token).Value);
+        }
+
+        private static JToken ToJToken(JsValue token)
+        {
+            return JToken.Parse(s_engine.Json.Stringify(null, new[] { token }).AsString());
         }
     }
 }

--- a/src/docfx/build/legacy/template/LegacyTemplate.cs
+++ b/src/docfx/build/legacy/template/LegacyTemplate.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Docs.Build
 
         public JObject TransformMetadata(string schemaName, JObject metadata)
         {
-            return _js.Run($"{schemaName}.mta.json.js", metadata);
+            return JObject.Parse(((JObject)_js.Run($"{schemaName}.mta.json.js", "transform", metadata)).Value<string>("content"));
         }
 
         public void CopyTo(string outputPath)

--- a/src/docfx/build/legacy/template/LegacyTemplate.cs
+++ b/src/docfx/build/legacy/template/LegacyTemplate.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Docs.Build
         private readonly string _templateDir;
         private readonly string _locale;
         private readonly LiquidTemplate _liquid;
-        private readonly JavaScript _js;
+        private readonly JavascriptEngine _js;
 
         public JObject Global { get; }
 
@@ -25,7 +25,7 @@ namespace Microsoft.Docs.Build
             _templateDir = templateDir;
             _locale = locale.ToLowerInvariant();
             _liquid = new LiquidTemplate(templateDir);
-            _js = new JavaScript(contentTemplateDir);
+            _js = new JavascriptEngine(contentTemplateDir);
             Global = LoadGlobalTokens(templateDir, _locale);
         }
 

--- a/test/docfx.Test/data/javascript/a/a.js
+++ b/test/docfx.Test/data/javascript/a/a.js
@@ -1,0 +1,5 @@
+var b = require('../b/b.js')
+
+exports.a = function () {
+    return ['a', b.b()]
+}

--- a/test/docfx.Test/data/javascript/b/b.js
+++ b/test/docfx.Test/data/javascript/b/b.js
@@ -1,0 +1,3 @@
+exports.b = function () {
+    return 'b'
+}

--- a/test/docfx.Test/data/javascript/foo.js
+++ b/test/docfx.Test/data/javascript/foo.js
@@ -1,0 +1,5 @@
+function bar (obj) {
+    return obj
+}
+
+exports.bar = bar

--- a/test/docfx.Test/data/javascript/foo.js
+++ b/test/docfx.Test/data/javascript/foo.js
@@ -1,4 +1,4 @@
-function bar (obj) {
+function bar(obj) {
     return obj
 }
 

--- a/test/docfx.Test/data/javascript/index.js
+++ b/test/docfx.Test/data/javascript/index.js
@@ -1,0 +1,14 @@
+var foo = require('./foo.js')
+
+function fail(a) {
+    a.go()
+}
+
+exports.transform = function (obj) {
+    if (obj.error) {
+        fail()
+    }
+    return {
+        content: JSON.stringify(foo.bar(obj))
+    }
+}

--- a/test/docfx.Test/data/javascript/index.js
+++ b/test/docfx.Test/data/javascript/index.js
@@ -1,14 +1,16 @@
 var foo = require('./foo.js')
+var a = require('./a/a.js')
 
 function fail(a) {
     a.go()
 }
 
-exports.transform = function (obj) {
+exports.main = function (obj) {
     if (obj.error) {
         fail()
     }
-    return {
-        content: JSON.stringify(foo.bar(obj))
+    if (obj.a) {
+        return a.a()
     }
+    return foo.bar(obj)
 }

--- a/test/docfx.Test/template/JavascriptEngineTest.cs
+++ b/test/docfx.Test/template/JavascriptEngineTest.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Docs.Build
+{
+    public class JavascriptEngineTest
+    {
+        private readonly JavascriptEngine _js = new JavascriptEngine("data/javascript");
+
+        [Theory]
+        [InlineData("{'a':'hello','tags':[1,2],'page':{'value':3}}", "{'a':'hello','tags':[1,2],'page':{'value':3}}")]
+        public void RunJavascript(string input, string output)
+        {
+            var inputJson = JObject.Parse(input.Replace('\'', '"'));
+            var outputJson = _js.Run("index.js", inputJson);
+            Assert.Equal(output.Replace('\'', '"'), outputJson.ToString(Formatting.None));
+        }
+
+        [Theory]
+        [InlineData("{'error': true}", "TypeError: a is undefined | fail | index.js")]
+        public void RunJavascriptError(string input, string errors)
+        {
+            var inputJson = JObject.Parse(input.Replace('\'', '"'));
+            var exception = Assert.ThrowsAny<Exception>(() => _js.Run("index.js", inputJson));
+
+            foreach (var error in errors.Split('|'))
+            {
+                Assert.Contains(error.Trim(), exception.ToString());
+            }
+        }
+    }
+}

--- a/test/docfx.Test/template/JavascriptEngineTest.cs
+++ b/test/docfx.Test/template/JavascriptEngineTest.cs
@@ -13,11 +13,12 @@ namespace Microsoft.Docs.Build
         private readonly JavascriptEngine _js = new JavascriptEngine("data/javascript");
 
         [Theory]
-        [InlineData("{'a':'hello','tags':[1,2],'page':{'value':3}}", "{'a':'hello','tags':[1,2],'page':{'value':3}}")]
+        [InlineData("{'scalar':'hello','tags':[1,2],'page':{'value':3}}", "{'scalar':'hello','tags':[1,2],'page':{'value':3}}")]
+        [InlineData("{'a':true}", "['a','b']")]
         public void RunJavascript(string input, string output)
         {
             var inputJson = JObject.Parse(input.Replace('\'', '"'));
-            var outputJson = _js.Run("index.js", inputJson);
+            var outputJson = _js.Run("index.js", "main", inputJson);
             Assert.Equal(output.Replace('\'', '"'), outputJson.ToString(Formatting.None));
         }
 
@@ -26,7 +27,7 @@ namespace Microsoft.Docs.Build
         public void RunJavascriptError(string input, string errors)
         {
             var inputJson = JObject.Parse(input.Replace('\'', '"'));
-            var exception = Assert.ThrowsAny<Exception>(() => _js.Run("index.js", inputJson));
+            var exception = Assert.ThrowsAny<Exception>(() => _js.Run("index.js", "main", inputJson));
 
             foreach (var error in errors.Split('|'))
             {


### PR DESCRIPTION
The current `require` implementation always uses path relative to `scriptDir`, this is wrong when `require` from a different base path:

```
{scriptDir}/a/a.js  --> `require('../b/b.js')` from here should resolves to `{scriptDir}/b/b.js` instead of `{scriptDir}/../b/b.js`
{scriptDir}/b/b.js
```


Pending on #3901 