### PR TITLE
limit the repository creation, prepare for restore lock

### DIFF
--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -80,7 +80,7 @@ inputs:
       error: https://github.com/docascode/docfx-test-dependencies#bad-branch
 outputs:
   build.log: |
-    ["error","git-clone-failed","Cloning git repository 'https://github.com/docascode/docfx-test-dependencies' ('bad-branch') failed. bad-branch' can't be found"]
+    ["error","git-clone-failed","Cloning git repository 'https://github.com/docascode/docfx-test-dependencies' ('bad-branch') failed. 'bad-branch' can't be found"]
 ---
 # Show error when dependent repo can't be found
 commands:

--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -80,7 +80,7 @@ inputs:
       error: https://github.com/docascode/docfx-test-dependencies#bad-branch
 outputs:
   build.log: |
-    ["error","git-clone-failed","Cloning git repository 'https://github.com/docascode/docfx-test-dependencies' ('bad-branch') failed."]
+    ["error","git-clone-failed","Cloning git repository 'https://github.com/docascode/docfx-test-dependencies' ('bad-branch') failed. bad-branch' can't be found"]
 ---
 # Show error when dependent repo can't be found
 commands:

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -58,8 +58,8 @@ namespace Microsoft.Docs.Build
         public static Error UploadFailed(string url, string message)
             => new Error(ErrorLevel.Warning, "upload-failed", $"Upload '{url}' failed: {message}");
 
-        public static Error GitCloneFailed(string url, IEnumerable<string> branches)
-            => new Error(ErrorLevel.Error, "git-clone-failed", $"Cloning git repository '{url}' ({Join(branches)}) failed.");
+        public static Error GitCloneFailed(string url, IEnumerable<string> branches, string message = null)
+            => new Error(ErrorLevel.Error, "git-clone-failed", $"Cloning git repository '{url}' ({Join(branches)}) failed.{(string.IsNullOrEmpty(message) ? "" : " " + message)}");
 
         public static Error YamlHeaderNotObject(bool isArray)
             => new Error(ErrorLevel.Warning, "yaml-header-not-object", $"Expect yaml header to be an object, but got {(isArray ? "an array" : "a scalar")}");

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -19,12 +19,13 @@ namespace Microsoft.Docs.Build
             var errors = new List<Error>();
 
             // todo: abort the process if configuration loading has errors
-            var (configErrors, config) = LocalizationUtility.GetBuildConfig(docsetPath, options);
+            var repository = Repository.Create(docsetPath, branch: null);
+            var (configErrors, config) = LocalizationUtility.GetBuildConfig(docsetPath, repository, options);
             report.Configure(docsetPath, config);
             report.Write(config.ConfigFileName, configErrors);
 
-            var localeToBuild = LocalizationUtility.GetBuildLocale(docsetPath, options);
-            var docset = new Docset(report, docsetPath, localeToBuild, config, options).GetBuildDocset();
+            var localeToBuild = LocalizationUtility.GetBuildLocale(repository, options);
+            var docset = new Docset(report, docsetPath, localeToBuild, config, options, repository).GetBuildDocset();
             var outputPath = Path.Combine(docsetPath, config.Output.Path);
 
             using (var context = await Context.Create(outputPath, report, docset, () => xrefMap))

--- a/src/docfx/docset/Docset.cs
+++ b/src/docfx/docset/Docset.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Docs.Build
 
         private readonly CommandLineOptions _options;
         private readonly Report _report;
-        private readonly ConcurrentDictionary<string, Repository> _repositories;
+        private readonly ConcurrentDictionary<string, Lazy<Repository>> _repositories;
         private readonly Lazy<HashSet<Document>> _buildScope;
         private readonly Lazy<HashSet<Document>> _scanScope;
         private readonly Lazy<RedirectionMap> _redirections;
@@ -153,7 +153,7 @@ namespace Microsoft.Docs.Build
                 return new LegacyTemplate(RestoreMap.GetGitRestorePath($"{themeRemote}#{themeBranch}"), Locale);
             });
 
-            _repositories = new ConcurrentDictionary<string, Repository>();
+            _repositories = new ConcurrentDictionary<string, Lazy<Repository>>();
         }
 
         public Repository GetRepository(string filePath)
@@ -174,7 +174,7 @@ namespace Microsoft.Docs.Build
 
                 var parent = Path.GetDirectoryName(fullPath);
                 return !string.IsNullOrEmpty(parent)
-                    ? _repositories.GetOrAdd(PathUtility.NormalizeFile(parent), GetRepositoryInternal)
+                    ? _repositories.GetOrAdd(PathUtility.NormalizeFile(parent), k => new Lazy<Repository>(() => GetRepositoryInternal(k))).Value
                     : null;
             }
         }

--- a/src/docfx/docset/Docset.cs
+++ b/src/docfx/docset/Docset.cs
@@ -67,6 +67,11 @@ namespace Microsoft.Docs.Build
         public IReadOnlyDictionary<string, string> Routes { get; }
 
         /// <summary>
+        /// Gets the root repository of docset
+        /// </summary>
+        public Repository Repository { get; }
+
+        /// <summary>
         /// Gets the redirection map.
         /// </summary>
         public RedirectionMap Redirections => _redirections.Value;
@@ -85,30 +90,33 @@ namespace Microsoft.Docs.Build
 
         private readonly CommandLineOptions _options;
         private readonly Report _report;
+        private readonly Dictionary<string, Repository> _repositories;
         private readonly Lazy<HashSet<Document>> _buildScope;
         private readonly Lazy<HashSet<Document>> _scanScope;
         private readonly Lazy<RedirectionMap> _redirections;
         private readonly Lazy<LegacyTemplate> _legacyTemplate;
 
-        public Docset(Report report, string docsetPath, string locale, Config config, CommandLineOptions options, bool isDependency = false)
-            : this(report, docsetPath, !string.IsNullOrEmpty(locale) ? locale : config.Localization.DefaultLocale, config, options, null, null)
+        public Docset(Report report, string docsetPath, string locale, Config config, CommandLineOptions options, Repository repository = null, bool isDependency = false)
+            : this(report, docsetPath, !string.IsNullOrEmpty(locale) ? locale : config.Localization.DefaultLocale, config, options, repository, null, null)
         {
             if (!isDependency && !string.Equals(Locale, config.Localization.DefaultLocale, StringComparison.OrdinalIgnoreCase))
             {
                 // localization/fallback docset will share the same context, config, build locale and options with source docset
                 // source docset configuration will be overwritten by build locale overwrite configuration
-                if (LocalizationUtility.TryGetSourceDocsetPath(DocsetPath, out var sourceDocsetPath))
+                if (LocalizationUtility.TryGetSourceDocsetPath(this, out var sourceDocsetPath, out var sourceBranch))
                 {
-                    FallbackDocset = new Docset(report, sourceDocsetPath, Locale, config, options, localizedDocset: this);
+                    var repo = Repository.Create(sourceDocsetPath, sourceBranch);
+                    FallbackDocset = new Docset(report, sourceDocsetPath, Locale, config, options, repo, localizedDocset: this);
                 }
-                else if (LocalizationUtility.TryGetLocalizedDocsetPath(DocsetPath, Config, Locale, out var localizationDocsetPath))
+                else if (LocalizationUtility.TryGetLocalizedDocsetPath(this, Config, Locale, out var localizationDocsetPath, out var localizationBranch))
                 {
-                    LocalizationDocset = new Docset(report, localizationDocsetPath, Locale, config, options, fallbackDocset: this);
+                    var repo = Repository.Create(localizationDocsetPath, localizationBranch);
+                    LocalizationDocset = new Docset(report, localizationDocsetPath, Locale, config, options, repo, fallbackDocset: this);
                 }
             }
         }
 
-        private Docset(Report report, string docsetPath, string locale, Config config, CommandLineOptions options, Docset fallbackDocset = null, Docset localizedDocset = null)
+        private Docset(Report report, string docsetPath, string locale, Config config, CommandLineOptions options, Repository repository = null, Docset fallbackDocset = null, Docset localizedDocset = null)
         {
             Debug.Assert(fallbackDocset == null || localizedDocset == null);
 
@@ -125,6 +133,7 @@ namespace Microsoft.Docs.Build
             var configErrors = new List<Error>();
             (configErrors, DependencyDocsets) = LoadDependencies(Config);
             ResolveAlias = LoadResolveAlias(Config);
+            Repository = repository ?? Repository.Create(DocsetPath, branch: null);
 
             // pass on the command line options to its children
             _buildScope = new Lazy<HashSet<Document>>(() => CreateBuildScope(Redirections.Files));
@@ -140,9 +149,23 @@ namespace Microsoft.Docs.Build
             _legacyTemplate = new Lazy<LegacyTemplate>(() =>
             {
                 Debug.Assert(!string.IsNullOrEmpty(Config.Theme));
-                var (themeRemote, branch) = LocalizationUtility.GetLocalizedTheme(Config.Theme, Locale, Config.Localization.DefaultLocale);
-                return new LegacyTemplate(RestoreMap.GetGitRestorePath($"{themeRemote}#{branch}"), Locale);
+                var (themeRemote, themeBranch) = LocalizationUtility.GetLocalizedTheme(Config.Theme, Locale, Config.Localization.DefaultLocale);
+                return new LegacyTemplate(RestoreMap.GetGitRestorePath($"{themeRemote}#{themeBranch}"), Locale);
             });
+
+            _repositories = LoadRepositories();
+        }
+
+        public Repository GetRepository(string filePath)
+        {
+            var documentFolder = PathUtility.NormalizeFolder(Path.GetDirectoryName(Path.Combine(DocsetPath, filePath)));
+
+            if (_repositories.TryGetValue(documentFolder, out var repository))
+            {
+                return repository;
+            }
+
+            return null;
         }
 
         private static IReadOnlyDictionary<string, string> NormalizeRoutes(Dictionary<string, string> routes)
@@ -196,6 +219,36 @@ namespace Microsoft.Docs.Build
                 result.TryAdd(PathUtility.NormalizeFolder(name), new Docset(_report, dir, Locale, subConfig, _options, isDependency: true));
             }
             return (errors, result);
+        }
+
+        private Dictionary<string, Repository> LoadRepositories()
+        {
+            var repositoryByFolder = new ConcurrentDictionary<string, Repository>();
+
+            ParallelUtility.ForEach(
+                    Directory.EnumerateFiles(DocsetPath, "*.*", SearchOption.AllDirectories),
+                    file => GetRepository(file));
+
+            Repository GetRepository(string fullPath)
+            {
+                fullPath = PathUtility.NormalizeFolder(fullPath);
+                if (GitUtility.IsRepo(fullPath))
+                {
+                    if (string.Equals(fullPath, DocsetPath, PathUtility.PathComparison))
+                    {
+                        return Repository;
+                    }
+
+                    return Repository.Create(fullPath, branch: null);
+                }
+
+                var parent = PathUtility.NormalizeFolder(Path.GetDirectoryName(fullPath));
+                return !string.IsNullOrEmpty(parent)
+                    ? repositoryByFolder.GetOrAdd(parent, GetRepository)
+                    : null;
+            }
+
+            return repositoryByFolder.ToDictionary(k => k.Key, v => v.Value);
         }
 
         private HashSet<Document> CreateBuildScope(IEnumerable<Document> redirections)

--- a/src/docfx/docset/Docset.cs
+++ b/src/docfx/docset/Docset.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Docs.Build
 
         private readonly CommandLineOptions _options;
         private readonly Report _report;
-        private readonly Dictionary<string, Repository> _repositories;
+        private readonly ConcurrentDictionary<string, Repository> _repositories;
         private readonly Lazy<HashSet<Document>> _buildScope;
         private readonly Lazy<HashSet<Document>> _scanScope;
         private readonly Lazy<RedirectionMap> _redirections;
@@ -153,19 +153,30 @@ namespace Microsoft.Docs.Build
                 return new LegacyTemplate(RestoreMap.GetGitRestorePath($"{themeRemote}#{themeBranch}"), Locale);
             });
 
-            _repositories = LoadRepositories();
+            _repositories = new ConcurrentDictionary<string, Repository>();
         }
 
         public Repository GetRepository(string filePath)
         {
-            var documentFolder = PathUtility.NormalizeFolder(Path.GetDirectoryName(Path.Combine(DocsetPath, filePath)));
+            return GetRepositoryInternal(Path.Combine(DocsetPath, filePath));
 
-            if (_repositories.TryGetValue(documentFolder, out var repository))
+            Repository GetRepositoryInternal(string fullPath)
             {
-                return repository;
-            }
+                if (GitUtility.IsRepo(fullPath))
+                {
+                    if (string.Equals(fullPath, DocsetPath.Substring(0, DocsetPath.Length - 1), PathUtility.PathComparison))
+                    {
+                        return Repository;
+                    }
 
-            return null;
+                    return Repository.Create(fullPath, branch: null);
+                }
+
+                var parent = Path.GetDirectoryName(fullPath);
+                return !string.IsNullOrEmpty(parent)
+                    ? _repositories.GetOrAdd(PathUtility.NormalizeFile(parent), GetRepositoryInternal)
+                    : null;
+            }
         }
 
         private static IReadOnlyDictionary<string, string> NormalizeRoutes(Dictionary<string, string> routes)
@@ -219,36 +230,6 @@ namespace Microsoft.Docs.Build
                 result.TryAdd(PathUtility.NormalizeFolder(name), new Docset(_report, dir, Locale, subConfig, _options, isDependency: true));
             }
             return (errors, result);
-        }
-
-        private Dictionary<string, Repository> LoadRepositories()
-        {
-            var repositoryByFolder = new ConcurrentDictionary<string, Repository>();
-
-            ParallelUtility.ForEach(
-                    Directory.EnumerateFiles(DocsetPath, "*.*", SearchOption.AllDirectories),
-                    file => GetRepository(file));
-
-            Repository GetRepository(string fullPath)
-            {
-                fullPath = PathUtility.NormalizeFolder(fullPath);
-                if (GitUtility.IsRepo(fullPath))
-                {
-                    if (string.Equals(fullPath, DocsetPath, PathUtility.PathComparison))
-                    {
-                        return Repository;
-                    }
-
-                    return Repository.Create(fullPath, branch: null);
-                }
-
-                var parent = PathUtility.NormalizeFolder(Path.GetDirectoryName(fullPath));
-                return !string.IsNullOrEmpty(parent)
-                    ? repositoryByFolder.GetOrAdd(parent, GetRepository)
-                    : null;
-            }
-
-            return repositoryByFolder.ToDictionary(k => k.Key, v => v.Value);
         }
 
         private HashSet<Document> CreateBuildScope(IEnumerable<Document> redirections)

--- a/src/docfx/docset/Document.cs
+++ b/src/docfx/docset/Document.cs
@@ -105,9 +105,10 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Gets the repository
         /// </summary>
-        public Repository Repository { get; }
+        public Repository Repository => _repository.Value;
 
         private readonly Lazy<(string docId, string versionIndependentId)> _id;
+        private readonly Lazy<Repository> _repository;
 
         // TODO:
         // This is a temporary property just so that legacy can access OutputPath,
@@ -129,7 +130,6 @@ namespace Microsoft.Docs.Build
             string mime,
             Schema schema,
             bool isExperimental,
-            Repository repository,
             string redirectionUrl = null,
             bool isFromHistory = false)
         {
@@ -148,9 +148,9 @@ namespace Microsoft.Docs.Build
             IsExperimental = isExperimental;
             RedirectionUrl = redirectionUrl;
             IsFromHistory = isFromHistory;
-            Repository = repository;
 
             _id = new Lazy<(string docId, string versionId)>(() => LoadDocumentId());
+            _repository = new Lazy<Repository>(() => Docset.GetRepository(FilePath));
 
             Debug.Assert(IsValidRelativePath(FilePath));
             Debug.Assert(IsValidRelativePath(SitePath));
@@ -249,14 +249,13 @@ namespace Microsoft.Docs.Build
             var contentType = redirectionUrl != null ? ContentType.Redirection : type;
             var canonicalUrl = GetCanonicalUrl(siteUrl, sitePath, docset, isExperimental, contentType, schema);
             var canonicalUrlWithoutLocale = GetCanonicalUrl(siteUrl, sitePath, docset, isExperimental, contentType, schema, false);
-            var repository = docset.GetRepository(filePath);
 
             if (contentType == ContentType.Redirection && type != ContentType.Page)
             {
                 return (Errors.InvalidRedirection(filePath, type), null);
             }
 
-            return (null, new Document(docset, filePath, sitePath, siteUrl, canonicalUrlWithoutLocale, canonicalUrl, contentType, mime, schema, isExperimental, repository, redirectionUrl, isFromHistory));
+            return (null, new Document(docset, filePath, sitePath, siteUrl, canonicalUrlWithoutLocale, canonicalUrl, contentType, mime, schema, isExperimental, redirectionUrl, isFromHistory));
         }
 
         /// <summary>

--- a/src/docfx/docset/Document.cs
+++ b/src/docfx/docset/Document.cs
@@ -102,6 +102,11 @@ namespace Microsoft.Docs.Build
         /// </summary>
         public bool IsSchemaData => Schema != null && Schema.Attribute as PageSchemaAttribute == null;
 
+        /// <summary>
+        /// Gets the repository
+        /// </summary>
+        public Repository Repository { get; }
+
         private readonly Lazy<(string docId, string versionIndependentId)> _id;
 
         // TODO:
@@ -124,6 +129,7 @@ namespace Microsoft.Docs.Build
             string mime,
             Schema schema,
             bool isExperimental,
+            Repository repository,
             string redirectionUrl = null,
             bool isFromHistory = false)
         {
@@ -142,6 +148,7 @@ namespace Microsoft.Docs.Build
             IsExperimental = isExperimental;
             RedirectionUrl = redirectionUrl;
             IsFromHistory = isFromHistory;
+            Repository = repository;
 
             _id = new Lazy<(string docId, string versionId)>(() => LoadDocumentId());
 
@@ -242,13 +249,14 @@ namespace Microsoft.Docs.Build
             var contentType = redirectionUrl != null ? ContentType.Redirection : type;
             var canonicalUrl = GetCanonicalUrl(siteUrl, sitePath, docset, isExperimental, contentType, schema);
             var canonicalUrlWithoutLocale = GetCanonicalUrl(siteUrl, sitePath, docset, isExperimental, contentType, schema, false);
+            var repository = docset.GetRepository(filePath);
 
             if (contentType == ContentType.Redirection && type != ContentType.Page)
             {
                 return (Errors.InvalidRedirection(filePath, type), null);
             }
 
-            return (null, new Document(docset, filePath, sitePath, siteUrl, canonicalUrlWithoutLocale, canonicalUrl, contentType, mime, schema, isExperimental, redirectionUrl, isFromHistory));
+            return (null, new Document(docset, filePath, sitePath, siteUrl, canonicalUrlWithoutLocale, canonicalUrl, contentType, mime, schema, isExperimental, repository, redirectionUrl, isFromHistory));
         }
 
         /// <summary>

--- a/src/docfx/docset/Repository.cs
+++ b/src/docfx/docset/Repository.cs
@@ -24,7 +24,10 @@ namespace Microsoft.Docs.Build
             Path = path ?? throw new ArgumentNullException(nameof(path));
         }
 
-        public static Repository Create(string path)
+        /// <summary>
+        /// Our repository's branch info should NOT depends on git, unless you are pretty sure about that
+        /// </summary>
+        public static Repository Create(string path, string branch)
         {
             Debug.Assert(!string.IsNullOrEmpty(path));
 
@@ -33,13 +36,13 @@ namespace Microsoft.Docs.Build
             if (repoPath == null)
                 return null;
 
-            var (remote, branch, commit) = GitUtility.GetRepoInfo(repoPath);
+            var (remote, repoBranch, commit) = GitUtility.GetRepoInfo(repoPath);
             var gitIndex = remote.IndexOf(".git");
             if (gitIndex >= 0)
             {
                 remote = remote.Remove(gitIndex);
             }
-            return new Repository(remote, branch, commit, PathUtility.NormalizeFolder(repoPath));
+            return new Repository(remote, branch ?? repoBranch, commit, PathUtility.NormalizeFolder(repoPath));
         }
     }
 }

--- a/src/docfx/docset/Repository.cs
+++ b/src/docfx/docset/Repository.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Docs.Build
         }
 
         /// <summary>
-        /// Our repository's branch info should NOT depends on git, unless you are pretty sure about that
+        /// Our repository's branch info should NOT depend on git, unless you are pretty sure about that
         /// </summary>
         public static Repository Create(string path, string branch)
         {

--- a/src/docfx/localization/LocalizationUtility.cs
+++ b/src/docfx/localization/LocalizationUtility.cs
@@ -27,19 +27,20 @@ namespace Microsoft.Docs.Build
             return (newRemote, newBranch);
         }
 
-        public static bool TryGetLocalizedDocsetPath(string docsetPath, Config config, string locale, out string localizationDocsetPath)
+        public static bool TryGetLocalizedDocsetPath(Docset docset, Config config, string locale, out string localizationDocsetPath, out string localizationBranch)
         {
-            Debug.Assert(!string.IsNullOrEmpty(docsetPath));
+            Debug.Assert(docset != null);
             Debug.Assert(!string.IsNullOrEmpty(locale));
             Debug.Assert(config != null);
 
             localizationDocsetPath = null;
+            localizationBranch = null;
             switch (config.Localization.Mapping)
             {
                 case LocalizationMapping.Repository:
                 case LocalizationMapping.Branch:
                     {
-                        var repo = Repository.Create(Path.GetFullPath(docsetPath));
+                        var repo = docset.Repository;
                         if (repo == null)
                         {
                             return false;
@@ -52,6 +53,7 @@ namespace Microsoft.Docs.Build
                             locale,
                             config.Localization.DefaultLocale);
                         localizationDocsetPath = RestoreMap.GetGitRestorePath(locRemote, locBranch);
+                        localizationBranch = locBranch;
                         break;
                     }
                 case LocalizationMapping.Folder:
@@ -60,7 +62,8 @@ namespace Microsoft.Docs.Build
                         {
                             throw new NotSupportedException($"{config.Localization.Mapping} is not supporting bilingual build");
                         }
-                        localizationDocsetPath = Path.Combine(docsetPath, "localization", locale);
+                        localizationDocsetPath = Path.Combine(docset.DocsetPath, "localization", locale);
+                        localizationBranch = null;
                         break;
                     }
                 default:
@@ -70,21 +73,18 @@ namespace Microsoft.Docs.Build
             return true;
         }
 
-        public static bool TryGetSourceRepository(string docsetPath, out string sourceRemote, out string sourceBranch, out string locale)
+        public static bool TryGetSourceRepository(Repository repository, out string sourceRemote, out string sourceBranch, out string locale)
         {
-            Debug.Assert(!string.IsNullOrEmpty(docsetPath));
-
             sourceRemote = null;
             sourceBranch = null;
             locale = null;
 
-            var repo = Repository.Create(docsetPath);
-            if (repo == null || string.IsNullOrEmpty(repo.Remote))
+            if (repository == null || string.IsNullOrEmpty(repository.Remote))
             {
                 return false;
             }
 
-            return TryGetSourceRepository(repo.Remote, repo.Branch, out sourceRemote, out sourceBranch, out locale);
+            return TryGetSourceRepository(repository.Remote, repository.Branch, out sourceRemote, out sourceBranch, out locale);
         }
 
         /// <summary>
@@ -120,13 +120,14 @@ namespace Microsoft.Docs.Build
             return locale != null;
         }
 
-        public static bool TryGetSourceDocsetPath(string docsetPath, out string sourceDocsetPath)
+        public static bool TryGetSourceDocsetPath(Docset docset, out string sourceDocsetPath, out string sourceBranch)
         {
             sourceDocsetPath = null;
+            sourceBranch = null;
 
-            Debug.Assert(!string.IsNullOrEmpty(docsetPath));
+            Debug.Assert(docset != null);
 
-            if (TryGetSourceRepository(docsetPath, out var sourceRemote, out var sourceBranch, out var locale))
+            if (TryGetSourceRepository(docset.Repository, out var sourceRemote, out sourceBranch, out var locale))
             {
                 sourceDocsetPath = RestoreMap.GetGitRestorePath(sourceRemote, sourceBranch);
                 return true;
@@ -141,7 +142,7 @@ namespace Microsoft.Docs.Build
             var fallbackDocset = GetFallbackDocset();
             if (fallbackDocset != null)
             {
-                var (repo, pathToRepo, commits) = gitCommitProvider.GetCommitHistoryNoCache(Path.Combine(fallbackDocset.DocsetPath, pathToDocset), 2);
+                var (repo, pathToRepo, commits) = gitCommitProvider.GetCommitHistoryNoCache(fallbackDocset, pathToDocset, 2);
                 if (repo != null)
                 {
                     var repoPath = PathUtility.NormalizeFolder(repo.Path);
@@ -178,17 +179,16 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public static bool TryGetContributionBranch(string docset, out string contributionBranch, out Repository repo)
+        public static bool TryGetContributionBranch(Repository repository, out string contributionBranch)
         {
             contributionBranch = null;
 
-            repo = Repository.Create(docset);
-            if (repo == null)
+            if (repository == null)
             {
                 return false;
             }
 
-            return TryGetContributionBranch(repo.Branch, out contributionBranch);
+            return TryGetContributionBranch(repository.Branch, out contributionBranch);
         }
 
         public static bool TryGetContributionBranch(string branch, out string contributionBranch)
@@ -302,9 +302,9 @@ namespace Microsoft.Docs.Build
             return sourceDocset.LocalizationDocset ?? sourceDocset;
         }
 
-        public static (List<Error> errors, Config config) GetBuildConfig(string docset, CommandLineOptions options)
+        public static (List<Error> errors, Config config) GetBuildConfig(string docset, Repository repository, CommandLineOptions options)
         {
-            if (ConfigLoader.TryGetConfigPath(docset, out _) || !TryGetSourceRepository(docset, out var sourceRemote, out var sourceBranch, out var locale))
+            if (ConfigLoader.TryGetConfigPath(docset, out _) || !TryGetSourceRepository(repository, out var sourceRemote, out var sourceBranch, out var locale))
             {
                 return ConfigLoader.Load(docset, options);
             }
@@ -318,9 +318,9 @@ namespace Microsoft.Docs.Build
             return RestoreMap.GetFileRestorePath(docset.DocsetPath, url, docset.FallbackDocset?.DocsetPath);
         }
 
-        public static string GetBuildLocale(string docset, CommandLineOptions options)
+        public static string GetBuildLocale(Repository repository, CommandLineOptions options)
         {
-            return TryGetSourceRepository(docset, out _, out _, out var locale) ? locale : options.Locale;
+            return TryGetSourceRepository(repository, out _, out _, out var locale) ? locale : options.Locale;
         }
 
         public static bool IsLocalized(this Docset docset) => docset.FallbackDocset != null;

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -45,8 +45,7 @@ namespace Microsoft.Docs.Build
                             localeToRestore,
                             config,
                             async subDocset => await RestoreDocset(subDocset, root: false),
-                            rootRepository,
-                            dependencyLock);
+                            rootRepository);
                     }
                 }
             }

--- a/src/docfx/restore/RestoreGit.cs
+++ b/src/docfx/restore/RestoreGit.cs
@@ -116,7 +116,13 @@ namespace Microsoft.Docs.Build
                         {
                             return;
                         }
+
                         var headCommit = GitUtility.RevParse(repoPath, branch);
+                        if (string.IsNullOrEmpty(headCommit))
+                        {
+                            throw Errors.GitCloneFailed(remote, branches, $"'{branch}' can't be found").ToException();
+                        }
+
                         var workTreeHead = $"{HrefUtility.EscapeUrlSegment(branch)}-{branch.GetMd5HashShort()}-{headCommit}";
                         var workTreePath = Path.GetFullPath(Path.Combine(repoPath, "../", workTreeHead)).Replace('\\', '/');
 

--- a/src/docfx/restore/RestoreGit.cs
+++ b/src/docfx/restore/RestoreGit.cs
@@ -20,10 +20,15 @@ namespace Microsoft.Docs.Build
             DepthOne = 1 << 2,
         }
 
-        public static async Task Restore(string docsetPath, Config config, Func<string, Task> restoreChild, string locale, bool @implicit, bool isDependencyRepo)
+        public static async Task Restore(
+            Config config,
+            Func<string, Task> restoreChild,
+            string locale,
+            bool @implicit,
+            Repository rootRepository)
         {
             var gitDependencies =
-                from git in GetGitDependencies(docsetPath, config, locale, isDependencyRepo)
+                from git in GetGitDependencies(config, locale, rootRepository)
                 group (git.branch, git.flags)
                 by git.remote;
 
@@ -46,9 +51,10 @@ namespace Microsoft.Docs.Build
                 Directory.SetLastWriteTimeUtc(workTree, DateTime.UtcNow);
             }
 
-            if (!isDependencyRepo && LocalizationUtility.TryGetContributionBranch(docsetPath, out var contributionBranch, out var repo))
+            // fetch contribution branch
+            if (rootRepository != null && LocalizationUtility.TryGetContributionBranch(rootRepository, out var contributionBranch))
             {
-                await GitUtility.Fetch(repo.Path, repo.Remote, contributionBranch, config);
+                await GitUtility.Fetch(rootRepository.Path, rootRepository.Remote, contributionBranch, config);
             }
 
             async Task<List<string>> RestoreGitRepo(IGrouping<string, (string branch, GitFlags flags)> group)
@@ -110,17 +116,15 @@ namespace Microsoft.Docs.Build
                         {
                             return;
                         }
-
-                        // use branch name instead of commit hash
-                        // https://git-scm.com/docs/git-worktree#_commands
-                        var workTreeHead = $"{HrefUtility.EscapeUrlSegment(branch)}-{branch.GetMd5HashShort()}-{GitUtility.RevParse(repoPath, branch)}";
+                        var headCommit = GitUtility.RevParse(repoPath, branch);
+                        var workTreeHead = $"{HrefUtility.EscapeUrlSegment(branch)}-{branch.GetMd5HashShort()}-{headCommit}";
                         var workTreePath = Path.GetFullPath(Path.Combine(repoPath, "../", workTreeHead)).Replace('\\', '/');
 
                         if (existingWorkTreePath.TryAdd(workTreePath))
                         {
                             try
                             {
-                                await GitUtility.AddWorkTree(repoPath, branch, workTreePath);
+                                await GitUtility.AddWorkTree(repoPath, headCommit, workTreePath);
                             }
                             catch (Exception ex)
                             {
@@ -134,7 +138,7 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static IEnumerable<(string remote, string branch, GitFlags flags)> GetGitDependencies(string docsetPath, Config config, string locale, bool isDependencyRepo)
+        private static IEnumerable<(string remote, string branch, GitFlags flags)> GetGitDependencies(Config config, string locale, Repository rootRepository)
         {
             var dependencies = config.Dependencies.Values.Select(url =>
             {
@@ -144,9 +148,9 @@ namespace Microsoft.Docs.Build
 
             dependencies = dependencies.Concat(GetThemeGitDependencies(config, locale));
 
-            if (!isDependencyRepo)
+            if (rootRepository != null)
             {
-                dependencies = dependencies.Concat(GetLocalizationGitDependencies(docsetPath, config, locale));
+                dependencies = dependencies.Concat(GetLocalizationGitDependencies(rootRepository, config, locale));
             }
 
             return dependencies;
@@ -167,7 +171,7 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Get source repository or localized repository
         /// </summary>
-        private static IEnumerable<(string remote, string branch, GitFlags flags)> GetLocalizationGitDependencies(string docsetPath, Config config, string locale)
+        private static IEnumerable<(string remote, string branch, GitFlags flags)> GetLocalizationGitDependencies(Repository repo, Config config, string locale)
         {
             if (string.IsNullOrEmpty(locale))
             {
@@ -179,7 +183,6 @@ namespace Microsoft.Docs.Build
                 yield break;
             }
 
-            var repo = Repository.Create(docsetPath);
             if (repo == null || string.IsNullOrEmpty(repo.Remote))
             {
                 yield break;

--- a/test/docfx.Test/lib/GitUtilityTest.cs
+++ b/test/docfx.Test/lib/GitUtilityTest.cs
@@ -32,24 +32,24 @@ namespace Microsoft.Docs.Build
         {
             Assert.False(GitUtility.IsRepo(Path.GetFullPath(file)));
 
-            var repoPath = GitUtility.FindRepo(Path.GetFullPath(file));
-            Assert.NotNull(repoPath);
+            var repo = Repository.Create(Path.GetFullPath(file), branch: null);
+            Assert.NotNull(repo);
 
             using (var gitCommitProvider = new GitCommitProvider())
             {
                 var pathToRepo = PathUtility.NormalizeFile(file);
 
                 // current branch
-                var exe = Exec("git", $"--no-pager log --format=\"%H|%cI|%an|%ae\" -- \"{pathToRepo}\"", repoPath);
-                var (_, _, lib) = await gitCommitProvider.GetCommitHistory(Path.Combine(repoPath, pathToRepo));
+                var exe = Exec("git", $"--no-pager log --format=\"%H|%cI|%an|%ae\" -- \"{pathToRepo}\"", repo.Path);
+                var (_, _, lib) = await gitCommitProvider.GetCommitHistory(Path.Combine(repo.Path, pathToRepo), repo);
 
                 Assert.Equal(
                     exe.Replace("\r", ""),
                     string.Join("\n", lib.Select(c => $"{c.Sha}|{c.Time.ToString("s")}{c.Time.ToString("zzz")}|{c.AuthorName}|{c.AuthorEmail}")));
 
                 // another branch
-                exe = Exec("git", $"--no-pager log --format=\"%H|%cI|%an|%ae\" a050eaf -- \"{pathToRepo}\"", repoPath);
-                (_, _, lib) = await gitCommitProvider.GetCommitHistory(Path.Combine(repoPath, pathToRepo), "a050eaf");
+                exe = Exec("git", $"--no-pager log --format=\"%H|%cI|%an|%ae\" a050eaf -- \"{pathToRepo}\"", repo.Path);
+                (_, _, lib) = await gitCommitProvider.GetCommitHistory(Path.Combine(repo.Path, pathToRepo), repo, "a050eaf");
 
                 Assert.Equal(
                     exe.Replace("\r", ""),


### PR DESCRIPTION
- limit the repository creation, repository should be re-used.
- just create the repository at the entry of build/restore, for re-using
- repository branch info should not depends one git
- prepare for restoring git, check out a commit instead of branch to worktree