### PR TITLE
Update TripleColonParser.cs for zone correct closed

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/TripleColonParser.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/TripleColonParser.cs
@@ -68,6 +68,11 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
             processor.NewBlocks.Push(block);
 
+            if (extension.SelfClosing)
+            {
+                return BlockState.BreakDiscard;
+            }
+
             return BlockState.ContinueDiscard;
         }
 

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/TripleColonParser.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/TripleColonParser.cs
@@ -68,12 +68,6 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
             processor.NewBlocks.Push(block);
 
-            if (extension.SelfClosing)
-            {
-                block.Closed = true;
-                return BlockState.BreakDiscard;
-            }
-
             return BlockState.ContinueDiscard;
         }
 
@@ -123,7 +117,6 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             if (tripleColonBlock.Extension.SelfClosing)
             {
                 block.IsOpen = false;
-                (block as TripleColonBlock).Closed = true;
                 return true;
             }
 
@@ -131,9 +124,6 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             if (block.IsOpen)
             {
                 _context.LogWarning($"invalid-{extensionName}", $"Invalid {extensionName} on line {block.Line}. No \"::: {extensionName}-end\" found. Blocks should be explicitly closed.");
-            } else
-            {
-                (block as TripleColonBlock).Closed = true;
             }
             return true;
         }

--- a/test/Microsoft.DocAsCode.MarkdigEngine.Tests/TripleColonTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdigEngine.Tests/TripleColonTest.cs
@@ -9,6 +9,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Tests
     using Microsoft.DocAsCode.Plugins;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Text;
     using Xunit;
 
     public class TripleColonTest
@@ -102,9 +103,63 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Tests
                 
                 foreach (var block in blocks)
                 {
-                    Assert.True(block.Closed);
                     Assert.False(block.IsOpen);
                 }
+            }
+            Logger.UnregisterListener(listener);
+        }
+
+        [Fact]
+        public void TripleColonWithInMonikerTestBlockClosed()
+        {
+            var source = new StringBuilder()
+                .AppendLine("::: moniker range=\"chromeless\"")
+                .AppendLine("::: zone target=\"docs\"")
+                .AppendLine("## Alt text")
+                .AppendLine("::: zone-end")
+                .AppendLine("::: moniker-end")
+                .ToString();
+
+            var listener = TestLoggerListener.CreateLoggerListenerWithPhaseEqualFilter(LoggerPhase);
+
+            Logger.RegisterListener(listener);
+            using (new LoggerPhaseScope(LoggerPhase))
+            {
+                var service = TestUtility.CreateMarkdownService();
+                var document = service.Parse(source, "fakepath.md");
+
+                var monikerBlock = document.OfType<MonikerRangeBlock>().FirstOrDefault();
+                Assert.NotNull(monikerBlock);
+                var nestedZoneBlock = monikerBlock.OfType<TripleColonBlock>().FirstOrDefault();
+                Assert.NotNull(nestedZoneBlock);
+                Assert.True(nestedZoneBlock.Closed);
+            }
+            Logger.UnregisterListener(listener);
+        }
+
+        [Fact]
+        public void TripleColonWithInMonikerTestBlockUnClosed()
+        {
+            var source = new StringBuilder()
+                .AppendLine("::: moniker range=\"chromeless\"")
+                .AppendLine("::: zone target=\"docs\"")
+                .AppendLine("## Alt text")
+                .AppendLine("::: moniker-end")
+                .ToString();
+
+            var listener = TestLoggerListener.CreateLoggerListenerWithPhaseEqualFilter(LoggerPhase);
+
+            Logger.RegisterListener(listener);
+            using (new LoggerPhaseScope(LoggerPhase))
+            {
+                var service = TestUtility.CreateMarkdownService();
+                var document = service.Parse(source, "fakepath.md");
+
+                var monikerBlock = document.OfType<MonikerRangeBlock>().FirstOrDefault();
+                Assert.NotNull(monikerBlock);
+                var nestedZoneBlock = monikerBlock.OfType<TripleColonBlock>().FirstOrDefault();
+                Assert.NotNull(nestedZoneBlock);
+                Assert.False(nestedZoneBlock.Closed);
             }
             Logger.UnregisterListener(listener);
         }


### PR DESCRIPTION
**Related Work:** [User Story 44737: Markdig parser DCR to enable zone end validation](https://ceapex.visualstudio.com/Engineering/_workitems/edit/44737)

**Root cause:** The `SelfClosing` has only the default value of false, which causes the value of the `Closed` to always be true.