### PR TITLE
Move author to the first contributor

### DIFF
--- a/docs/specs/git.yml
+++ b/docs/specs/git.yml
@@ -30,9 +30,8 @@ inputs:
 outputs:
   docs/index.json: |
     {
-      "author": 
-        { "name": "charlie", "profile_url": "https://github.com/charlie", "display_name": "Charlie", "id": "3" },
       "contributors": [
+        { "name": "charlie", "profile_url": "https://github.com/charlie", "display_name": "Charlie", "id": "3" },
         { "name": "bob", "profile_url": "https://github.com/bob", "display_name": "Bob", "id": "2" },
         { "name": "alice", "profile_url": "https://github.com/alice", "display_name": "Alice", "id": "1" }
       ],
@@ -82,9 +81,8 @@ inputs:
 outputs:
   docs/index.json: |
     {
-      "author": 
-        { "name": "charlie", "profile_url": "https://github.com/charlie", "display_name": "Charlie", "id": "3" },
       "contributors": [
+        { "name": "charlie", "profile_url": "https://github.com/charlie", "display_name": "Charlie", "id": "3" },
         { "name": "bob", "profile_url": "https://github.com/bob", "display_name": "Bob", "id": "2" },
         { "name": "alice", "profile_url": "https://github.com/alice", "display_name": "Alice", "id": "1" }
       ],
@@ -144,9 +142,8 @@ inputs:
 outputs:
   docs/index.json: |
     {
-      "author": 
-        { "name": "charlie", "profile_url": "https://github.com/charlie", "display_name": "Charlie", "id": "3" },
       "contributors": [
+        { "name": "charlie", "profile_url": "https://github.com/charlie", "display_name": "Charlie", "id": "3" },
         { "name": "bob", "profile_url": "https://github.com/bob", "display_name": "Bob", "id": "2" },
         { "name": "alice", "profile_url": "https://github.com/alice", "display_name": "Alice", "id": "1" }
       ]
@@ -193,9 +190,9 @@ inputs:
 outputs:
   docs/index.json: |
     {
-      "author": 
-        { "name": "charlie", "profile_url": "https://github.com/charlie", "display_name": "Charlie", "id": "3" },
-      "contributors": []
+      "contributors": [
+        { "name": "charlie", "profile_url": "https://github.com/charlie", "display_name": "Charlie", "id": "3" }
+      ]
     }
 ---
 # Use the earliest contributor as author if author not specified in YAML header
@@ -225,8 +222,10 @@ inputs:
 outputs:
   docs/index.json: |
     {
-      "author": 
+      "contributors": [
         { "name": "alice", "profile_url": "https://github.com/alice", "display_name": "Alice", "id": "1" },
+        { "name": "bob", "profile_url": "https://github.com/bob", "display_name": "Bob", "id": "2" }
+      ]
     }
 ---
 # Author can be excluded, it's case insensitive
@@ -268,7 +267,6 @@ inputs:
 outputs:
   docs/index.json: |
     {
-      "!author": null,
       "contributors": [
         { "name": "bob", "profile_url": "https://github.com/bob", "display_name": "Bob", "id": "2" },
         { "name": "alice", "profile_url": "https://github.com/alice", "display_name": "Alice", "id": "1" }
@@ -321,7 +319,9 @@ inputs:
 outputs:
   docs/index.json: |
     {
-      "contributors": [],
+      "contributors": [
+        { "display_name": "docfx", "id": "docfx@microsoft.com" }
+      ],
       "gitcommit": "https://github.com/testowner/testrepo/blob/e662dbc7c5e582a14b863d6a6a82e495d6272f91/docs/index.md",
     }
 ---

--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -146,7 +146,13 @@ repos:
         docs/d.md: d
 outputs:
   docs/a.json: |
-    {"content":"<p>d</p>\n","author":{"display_name":"Osmond Jiang","id":"19990166"},"contributors":[{"display_name":"Yufei Huang","id":"511355"}]}
+    {
+      "content":"<p>d</p>\n",
+      "contributors": [
+        { "display_name": "Osmond Jiang", "id": "19990166"},
+        { "display_name": "Yufei Huang", "id": "511355"}
+      ]
+    }
 ---
 # loc docset share the source docset's restore map 2
 # [branch mapping] & bilingual
@@ -217,7 +223,13 @@ repos:
         docs/d.md: d
 outputs:
   docs/a.json: |
-    {"content":"<p>d</p>\n","author":{"display_name":"Osmond Jiang","id":"19990166"},"contributors":[{"display_name":"Yufei Huang","id":"511355"}]}
+    {
+      "content": "<p>d</p>\n",
+      "contributors": [
+        { "display_name": "Osmond Jiang", "id": "19990166"},
+        { "display_name": "Yufei Huang", "id": "511355" }
+      ]
+    }
 ---
 # edit url convention without source locale 1
 # [repository mapping] 
@@ -890,7 +902,13 @@ repos:
       email: terry@contoso.com
 outputs:
   docs/a.json: |
-    {"author":{"display_name":"Terry","id": "terry@contoso.com"},"contributors":[{"display_name":"Bob","id":"bob@contoso.com"}],"bilingual": true}
+    {
+      "bilingual": true,
+      "contributors":[
+        {"display_name": "Terry", "id": "terry@contoso.com"},
+        {"display_name": "Bob", "id": "bob@contoso.com" }
+      ]
+    }
 ---
 # bilingual page's `gitcommit` url follows sxs content's commit history
 commands:

--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -33,7 +33,11 @@ repos:
       email: xinjiang@microsoft.com
 outputs:
   docs/a.json: |
-    {"author":{"name":"OsmondJiang","profile_url":"https://github.com/OsmondJiang","display_name":"Osmond Jiang","id":"19990166"}}
+    {
+      "contributors": [
+        { "name": "OsmondJiang", "profile_url": "https://github.com/OsmondJiang", "display_name": "Osmond Jiang", "id": "19990166" }
+      ]
+    }
 ---
 # Restore urls with extends
 repos:
@@ -46,7 +50,11 @@ repos:
       email: xinjiang@microsoft.com
 outputs:
   docs/a.json: |
-    {"author":{"name":"OsmondJiang","profile_url":"https://github.com/OsmondJiang","display_name":"Osmond Jiang","id":"19990166"}}
+    {
+      "contributors": [
+        { "name": "OsmondJiang", "profile_url": "https://github.com/OsmondJiang", "display_name": "Osmond Jiang", "id": "19990166" }
+      ]
+    }
 ---
 # Restore dependencies with extends
 repos:

--- a/src/docfx/build/legacy/metadata/LegacyMetadata.cs
+++ b/src/docfx/build/legacy/metadata/LegacyMetadata.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Docs.Build
             {
                 rawMetadata["_op_gitContributorInformation"] = new JObject
                 {
-                    ["author"] = pageModel.Author?.ToJObject(),
+                    ["author"] = pageModel.Contributors.FirstOrDefault()?.ToJObject(),
                     ["contributors"] = pageModel.Contributors != null
                         ? new JArray(pageModel.Contributors.Select(c => c.ToJObject()))
                         : null,
@@ -120,8 +120,8 @@ namespace Microsoft.Docs.Build
                     ["updated_at_date_time"] = pageModel.UpdatedAt,
                 };
             }
-            if (!string.IsNullOrEmpty(pageModel.Author?.Name))
-                rawMetadata["author"] = pageModel.Author?.Name;
+
+            rawMetadata["author"] = pageModel.Metadata.Author;
             if (pageModel.UpdatedAt != default)
                 rawMetadata["updated_at"] = pageModel.UpdatedAt.ToString("yyyy-MM-dd hh:mm tt");
 

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Docs.Build
             return result;
         }
 
-        public async Task<(List<Error> error, Contributor author, List<Contributor> contributors, DateTime updatedAt)> GetAuthorAndContributors(
+        public async Task<(List<Error> error, List<Contributor> contributors, DateTime updatedAt)> GetContributors(
             Document document,
             string authorName)
         {
@@ -76,9 +76,10 @@ namespace Microsoft.Docs.Build
             if (author != null)
             {
                 contributors.RemoveAll(c => c.Id == author.Id);
+                contributors.Insert(0, author);
             }
 
-            return (errors, author, contributors, updatedDateTime);
+            return (errors, contributors, updatedDateTime);
 
             async Task<Contributor> GetContributor(GitCommit commit)
             {

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Docs.Build
             (model.ContentGitUrl, model.OriginalContentGitUrl, model.OriginalContentGitUrlTemplate, model.Gitcommit) = await context.ContributionProvider.GetGitUrls(file);
 
             List<Error> contributorErrors;
-            (contributorErrors, model.Author, model.Contributors, model.UpdatedAt) = await context.ContributionProvider.GetAuthorAndContributors(file, metadata.Author);
+            (contributorErrors, model.Contributors, model.UpdatedAt) = await context.ContributionProvider.GetContributors(file, metadata.Author);
             if (contributorErrors != null)
                 errors.AddRange(contributorErrors);
 

--- a/src/docfx/build/page/Contributor.cs
+++ b/src/docfx/build/page/Contributor.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/docfx/build/page/PageModel.cs
+++ b/src/docfx/build/page/PageModel.cs
@@ -33,8 +33,6 @@ namespace Microsoft.Docs.Build
 
         public string DocumentVersionIndependentId { get; set; }
 
-        public Contributor Author { get; set; }
-
         public List<Contributor> Contributors { get; set; }
 
         public DateTime UpdatedAt { get; set; }

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Docs.Build
         public readonly string Theme = string.Empty;
 
         /// <summary>
-        /// Gets the config file name.
+        /// Gets or sets the config file name.
         /// </summary>
         [JsonIgnore]
         public string ConfigFileName { get; set; } = "docfx.yml";


### PR DESCRIPTION
#3856 

- Remove _author_ from PageModel, there is already a `string Author` defined in metadata, it is problematic for flattened data model expected from template.
- docs expect the first contributor to be author, this was incorrectly done in impact tool.

@superyyrrzz @928PJY 