### PR TITLE
restore always generate and save dependency lock for build

### DIFF
--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -1200,3 +1200,85 @@ repos:
 outputs:
   docs/a.json: |
     { "content_git_url": "*dotnet/docfx.loc/blob/live.zh-cn/*"}
+---
+# loc build with different dependency git repository 1
+# [repo mapping] & bilingual
+commands:
+  - build --locale zh-cn
+repos:
+  https://github.com/locconfig2/c:
+    - files:
+        docfx.yml: |
+          dependencies:
+            child1: https://github.com/locconfig2/d#master
+          localization:
+            bilingual: true
+          "locales: [zh-cn]":
+            dependencies:
+              child1: https://github.com/locconfig2/d#live
+        docs/a.md:
+  https://github.com/locconfig2/c.zh-cn#master-sxs:
+    - files:
+        docs/a.md: |
+          [!include[include child](~/child1/token.md)
+        docfx.yml: |
+          dependencies:
+            child1: https://github.com/locconfig2/d#live
+          localization:
+            bilingual: true
+  https://github.com/locconfig2/c.zh-cn:
+    - files:
+        docs/a.md:
+  https://github.com/locconfig2/d#live:
+    - files:
+        token.md: |
+          live branch
+  https://github.com/locconfig2/d#master:
+    - files:
+        token.md: |
+          master branch
+outputs:
+  docs/a.json: |
+    { "content": "<p>live branch</p>\n" }
+---
+# loc build with different dependency git repository 2
+# [branch mapping] & bilingual
+commands:
+  - build --locale zh-cn
+repos:
+  https://github.com/locconfig3/c:
+    - files:
+        docfx.yml: |
+          dependencies:
+            child1: https://github.com/locconfig3/f#master
+          localization:
+            bilingual: true
+            mapping: Branch
+          "locales: [zh-cn]":
+            dependencies:
+              child1: https://github.com/locconfig3/f#live
+        docs/a.md:
+  https://github.com/locconfig3/c.loc#master-sxs.zh-cn:
+    - files:
+        docs/a.md: |
+          [!include[include child](~/child1/token.md)
+        docfx.yml: |
+          dependencies:
+            child1: https://github.com/locconfig3/f#live
+          localization:
+            bilingual: true
+            mapping: Branch
+  https://github.com/locconfig3/c.loc#master.zh-cn:
+    - files:
+        docs/a.md:
+  https://github.com/locconfig3/f#live:
+    - files:
+        token.md: |
+          live branch
+  https://github.com/locconfig3/f#master:
+    - files:
+        token.md: |
+          master branch
+outputs:
+  docs/a.json: |
+    { "content": "<p>live branch</p>\n" }

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Docs.Build
             // todo: abort the process if configuration loading has errors
             var repository = Repository.Create(docsetPath, branch: null);
 
-            var dependencyLock = await DependencyLock.Load(docsetPath, options);
+            var dependencyLock = await DependencyLock.Load(docsetPath, repository, options);
             var (configErrors, config) = LocalizationUtility.GetBuildConfig(docsetPath, repository, options, dependencyLock);
             report.Configure(docsetPath, config);
             report.Write(config.ConfigFileName, configErrors);

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -21,7 +22,7 @@ namespace Microsoft.Docs.Build
             // todo: abort the process if configuration loading has errors
             var repository = Repository.Create(docsetPath, branch: null);
 
-            var dependencyLock = await DependencyLock.Load(docsetPath, repository, options);
+            var dependencyLock = await LoadBuildDependencyLock(docsetPath, repository, options);
             var (configErrors, config) = LocalizationUtility.GetBuildConfig(docsetPath, repository, options, dependencyLock);
             report.Configure(docsetPath, config);
             report.Write(config.ConfigFileName, configErrors);
@@ -186,6 +187,31 @@ namespace Microsoft.Docs.Build
                 context.PublishModelBuilder.MarkError(file);
                 return new List<string>();
             }
+        }
+
+        private static async Task<DependencyLockModel> LoadBuildDependencyLock(string docset, Repository repository, CommandLineOptions commandLineOptions)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(docset));
+
+            var (errors, config) = ConfigLoader.TryLoad(docset, commandLineOptions);
+
+            var dependencyLock = await DependencyLock.Load(docset, string.IsNullOrEmpty(config.DependencyLock) ? AppData.GetDependencyLockFile(docset) : config.DependencyLock);
+
+            if (LocalizationUtility.TryGetSourceRepository(repository, out var sourceRemote, out var sourceBranch, out var locale))
+            {
+                var sourceDependencyLock = dependencyLock?.GetGitLock(sourceRemote, sourceBranch);
+                dependencyLock = sourceDependencyLock == null
+                    ? null
+                    : new DependencyLockModel
+                    {
+                        Downloads = sourceDependencyLock.Downloads,
+                        Hash = sourceDependencyLock.Hash,
+                        Commit = sourceDependencyLock.Commit,
+                        Git = new Dictionary<string, DependencyLockModel>(sourceDependencyLock.Git.Concat(new[] { KeyValuePair.Create($"{sourceRemote}#{sourceBranch}", sourceDependencyLock) })),
+                    };
+            }
+
+            return dependencyLock ?? new DependencyLockModel();
         }
     }
 }

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -197,9 +197,12 @@ namespace Microsoft.Docs.Build
 
             var dependencyLock = await DependencyLock.Load(docset, string.IsNullOrEmpty(config.DependencyLock) ? AppData.GetDependencyLockFile(docset) : config.DependencyLock);
 
-            if (LocalizationUtility.TryGetSourceRepository(repository, out var sourceRemote, out var sourceBranch, out var locale))
+            if (LocalizationUtility.TryGetSourceRepository(repository, out var sourceRemote, out var sourceBranch, out var locale) &&
+                !ConfigLoader.TryGetConfigPath(docset, out _))
             {
-                var sourceDependencyLock = dependencyLock?.GetGitLock(sourceRemote, sourceBranch);
+                // build from loc repo directly with overwrite config
+                // which means it's using source repo's dependency lock
+                var sourceDependencyLock = dependencyLock.GetGitLock(sourceRemote, sourceBranch);
                 dependencyLock = sourceDependencyLock == null
                     ? null
                     : new DependencyLockModel

--- a/src/docfx/config/AppData.cs
+++ b/src/docfx/config/AppData.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Docs.Build
 
         public static string CacheRoot => Path.Combine(s_root, "cache");
 
+        public static string DependencyLockRoot => Path.Combine(s_root, "lock");
+
         public static string GlobalConfigPath => GetGlobalConfigPath();
 
         public static string DefaultGitHubUserCachePath => Path.Combine(CacheRoot, "github-users.json");
@@ -32,6 +34,11 @@ namespace Microsoft.Docs.Build
         public static string GetFileDownloadDir(string url)
         {
             return PathUtility.NormalizeFolder(Path.Combine(DownloadsRoot, PathUtility.UrlToShortName(url)));
+        }
+
+        public static string GetDependencyLockFile(string docsetPath)
+        {
+            return PathUtility.NormalizeFile(Path.Combine(DependencyLockRoot, PathUtility.UrlToShortName(docsetPath), ".lock.json"));
         }
 
         public static string GetCommitCachePath(string remote)

--- a/src/docfx/config/ConfigLoader.cs
+++ b/src/docfx/config/ConfigLoader.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Docs.Build
                 {
                     if (extend is JValue value && value.Value is string str)
                     {
-                        var (_, filePath) = RestoreMap.GetFileRestorePath(docsetPath, str);
+                        var (_, filePath) = RestoreMap.GetFileRestorePath(docsetPath, str, null);
                         var (extendErros, extendConfigObject) = LoadConfigObject(str, filePath);
                         errors.AddRange(extendErros);
                         result.Merge(extendConfigObject, JsonUtility.MergeSettings);

--- a/src/docfx/localization/LocalizationUtility.cs
+++ b/src/docfx/localization/LocalizationUtility.cs
@@ -312,6 +312,7 @@ namespace Microsoft.Docs.Build
                 return ConfigLoader.Load(docset, options);
             }
 
+            Debug.Assert(dependencyLock != null);
             var (sourceDocsetPath, _) = RestoreMap.GetGitRestorePath(sourceRemote, sourceBranch, dependencyLock);
             return ConfigLoader.Load(sourceDocsetPath, options, locale);
         }

--- a/src/docfx/localization/LocalizationUtility.cs
+++ b/src/docfx/localization/LocalizationUtility.cs
@@ -318,7 +318,7 @@ namespace Microsoft.Docs.Build
 
         public static (bool fromUrl, string path) GetFileRestorePath(this Docset docset, string url)
         {
-            return RestoreMap.GetFileRestorePath(docset.DocsetPath, url, docset.FallbackDocset?.DocsetPath);
+            return RestoreMap.GetFileRestorePath(docset.DocsetPath, url, docset.DependencyLock, docset.FallbackDocset?.DocsetPath);
         }
 
         public static string GetBuildLocale(Repository repository, CommandLineOptions options)

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Docs.Build
                 var restoreUrls = extendedConfig.GetFileReferences().Where(HrefUtility.IsHttpHref).ToList();
                 var downloadVersions = await RestoreFile.Restore(restoreUrls, extendedConfig, dependencyLock, @implicit);
 
-                var generatedLock = new DependencyLockModel() { Git = gitVersions.OrderBy(g => g.Key).ToDictionary(k => k.Key, v => v.Value), Downloads = downloadVersions.OrderBy(g => g.Key).ToDictionary(k => k.Key, v => v.Value)};
+                var generatedLock = new DependencyLockModel() { Git = gitVersions.OrderBy(g => g.Key).ToDictionary(k => k.Key, v => v.Value), Downloads = downloadVersions.OrderBy(g => g.Key).ToDictionary(k => k.Key, v => v.Value) };
 
                 // save dependency lock if need
                 // only save it when the dependency lock is NOT from parent

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Docs.Build
                 var restoreUrls = extendedConfig.GetFileReferences().Where(HrefUtility.IsHttpHref).ToList();
                 var downloadVersions = await RestoreFile.Restore(restoreUrls, extendedConfig, dependencyLock, @implicit);
 
-                var generatedLock = new DependencyLockModel(gitVersions, downloadVersions);
+                var generatedLock = new DependencyLockModel() { Git = gitVersions.OrderBy(g => g.Key).ToDictionary(k => k.Key, v => v.Value), Downloads = downloadVersions.OrderBy(g => g.Key).ToDictionary(k => k.Key, v => v.Value)};
 
                 // save dependency lock if need
                 // only save it when the dependency lock is NOT from parent

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -81,15 +81,16 @@ namespace Microsoft.Docs.Build
 
                 // restore urls except extend url
                 var restoreUrls = extendedConfig.GetFileReferences().Where(HrefUtility.IsHttpHref).ToList();
-                var downloadVersions = await RestoreFile.Restore(restoreUrls, extendedConfig, @implicit);
+                var downloadVersions = await RestoreFile.Restore(restoreUrls, extendedConfig, dependencyLock, @implicit);
 
                 var generatedLock = new DependencyLockModel(gitVersions, downloadVersions);
 
                 // save dependency lock if need
                 // only save it when the dependency lock is NOT from parent
-                if (!parentLock && !string.IsNullOrEmpty(extendedConfig.DependencyLock))
+                if (!parentLock)
                 {
-                    await DependencyLock.Save(docset, extendedConfig.DependencyLock, generatedLock);
+                    var dependencyLockFilePath = string.IsNullOrEmpty(extendedConfig.DependencyLock) ? AppData.GetDependencyLockFile(docset) : extendedConfig.DependencyLock;
+                    await DependencyLock.Save(docset, dependencyLockFilePath, generatedLock);
                 }
 
                 return generatedLock;

--- a/src/docfx/restore/RestoreFile.cs
+++ b/src/docfx/restore/RestoreFile.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Docs.Build
     internal static class RestoreFile
     {
         // todo: support specific version from dependency lock
-        public static async Task<IReadOnlyDictionary<string, DependencyVersion>> Restore(List<string> urls, Config config, bool @implicit = false)
+        public static async Task<IReadOnlyDictionary<string, DependencyVersion>> Restore(List<string> urls, Config config, DependencyLockModel dependencyLock, bool @implicit = false)
         {
             var downloadVersions = new ConcurrentDictionary<string, DependencyVersion>();
 
@@ -23,14 +23,14 @@ namespace Microsoft.Docs.Build
                     urls,
                     async restoreUrl =>
                     {
-                        var version = await Restore(restoreUrl, config, @implicit);
+                        var version = await Restore(restoreUrl, config, @implicit, dependencyLock?.Downloads.GetValueOrDefault(restoreUrl));
                         downloadVersions.TryAdd(restoreUrl, version);
                     });
 
             return downloadVersions;
         }
 
-        public static async Task<DependencyVersion> Restore(string url, Config config, bool @implicit = false)
+        public static async Task<DependencyVersion> Restore(string url, Config config, bool @implicit = false, DependencyVersion dependencyVersion = null)
         {
             var restoredPath = await RestoreUrl();
 
@@ -41,7 +41,7 @@ namespace Microsoft.Docs.Build
 
             async Task<string> RestoreUrl()
             {
-                if (RestoreMap.TryGetFileRestorePath(url, out var existingPath) && @implicit)
+                if (RestoreMap.TryGetFileRestorePath(url, dependencyVersion, out var existingPath) && @implicit)
                 {
                     return existingPath;
                 }

--- a/src/docfx/restore/RestoreGit.cs
+++ b/src/docfx/restore/RestoreGit.cs
@@ -65,7 +65,14 @@ namespace Microsoft.Docs.Build
             foreach (var child in children)
             {
                 var childDependencyLock = await restoreChild(child.ToRestore.path, child.ToRestore.dependencyLock);
-                gitVersions.TryAdd($"{child.Restored.remote}#{child.Restored.branch}", new DependencyLockModel(childDependencyLock.Git, childDependencyLock.Downloads, child.Restored.gitVersion));
+                gitVersions.TryAdd(
+                    $"{child.Restored.remote}#{child.Restored.branch}",
+                    new DependencyLockModel
+                    {
+                        Git = childDependencyLock.Git,
+                        Downloads = childDependencyLock.Downloads,
+                        Commit = child.Restored.gitVersion.Commit,
+                    });
             }
 
             return gitVersions;

--- a/src/docfx/restore/RestoreGit.cs
+++ b/src/docfx/restore/RestoreGit.cs
@@ -89,7 +89,8 @@ namespace Microsoft.Docs.Build
                 {
                     foreach (var branch in branches)
                     {
-                        if (RestoreMap.TryGetGitRestorePath(remote, branch, dependencyLock, out var existingPath, out var subDependencyLock))
+                        var gitVersion = dependencyLock?.GetGitLock(remote, branch);
+                        if (RestoreMap.TryGetGitRestorePath(remote, branch, gitVersion, out var existingPath))
                         {
                             {
                                 branchesToFetch.Remove(branch);
@@ -97,8 +98,8 @@ namespace Microsoft.Docs.Build
                                     existingPath,
                                     remote,
                                     branch,
-                                    subDependencyLock,
-                                    new DependencyVersion(subDependencyLock?.Commit ?? Path.GetFileName(existingPath).Split("-").Last())));
+                                    gitVersion,
+                                    new DependencyVersion(gitVersion?.Commit ?? Path.GetFileName(existingPath).Split("-").Last())));
                             }
                         }
                     }

--- a/src/docfx/restore/RestoreMap.cs
+++ b/src/docfx/restore/RestoreMap.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Docs.Build
             Debug.Assert(HrefUtility.IsHttpHref(url));
 
             var fileName = dependencyVersion?.Hash;
-            var locked = string.IsNullOrEmpty(fileName);
+            var locked = !string.IsNullOrEmpty(fileName);
             result = s_downloadPath.AddOrUpdate(
                 (url, fileName),
                 new Lazy<string>(FindFile),

--- a/src/docfx/restore/RestoreMap.cs
+++ b/src/docfx/restore/RestoreMap.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Docs.Build
                 // return specificed version
                 if (locked)
                 {
-                    if (TryGetWorkTreePath(repoPath, true, out var workTree) || TryGetWorkTreePath(repoPath, false, out workTree))
+                    if (TryGetLockedWorkTreePath(repoPath, true, out var workTree) || TryGetLockedWorkTreePath(repoPath, false, out workTree))
                     {
                         return workTree;
                     }
@@ -71,7 +71,7 @@ namespace Microsoft.Docs.Build
                     select path).FirstOrDefault();
             }
 
-            bool TryGetWorkTreePath(string root, bool isLocked, out string workTreePath)
+            bool TryGetLockedWorkTreePath(string root, bool isLocked, out string workTreePath)
             {
                 var workTreeName = $"{RestoreGit.GetWorkTreeHeadPrefix(branch, isLocked)}{commit}";
                 workTreePath = Path.Combine(root, workTreeName);
@@ -139,13 +139,7 @@ namespace Microsoft.Docs.Build
                 // return specified version
                 if (locked)
                 {
-                    var filePath = Path.Combine(restoreDir, fileName);
-                    if (File.Exists(filePath))
-                    {
-                        return filePath;
-                    }
-
-                    return null;
+                    return Path.Combine(restoreDir, fileName);
                 }
 
                 // return the latest version

--- a/src/docfx/restore/RestoreMap.cs
+++ b/src/docfx/restore/RestoreMap.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Docs.Build
                     return null;
                 }
 
-                // return specificed version
+                // return specified version
                 if (locked)
                 {
                     if (TryGetLockedWorkTreePath(repoPath, true, out var workTree) || TryGetLockedWorkTreePath(repoPath, false, out workTree))

--- a/src/docfx/restore/RestoreMap.cs
+++ b/src/docfx/restore/RestoreMap.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Docs.Build
     internal static class RestoreMap
     {
         private static readonly ConcurrentDictionary<(string remote, string branch, string commit), Lazy<string>> s_gitPath = new ConcurrentDictionary<(string remote, string branch, string commit), Lazy<string>>();
-        private static readonly ConcurrentDictionary<string, Lazy<string>> s_downloadPath = new ConcurrentDictionary<string, Lazy<string>>();
+        private static readonly ConcurrentDictionary<(string url, string version), Lazy<string>> s_downloadPath = new ConcurrentDictionary<(string url, string version), Lazy<string>>();
 
         public static (string path, DependencyLockModel subDependencyLock) GetGitRestorePath(string url, DependencyLockModel dependencyLock)
         {
@@ -51,18 +51,40 @@ namespace Microsoft.Docs.Build
                     return null;
                 }
 
+                // return specificed version
+                if (locked)
+                {
+                    if (TryGetWorkTreePath(repoPath, true, out var workTree) || TryGetWorkTreePath(repoPath, false, out workTree))
+                    {
+                        return workTree;
+                    }
+
+                    return null;
+                }
+
+                // return the latest version
                 return (
                     from path in Directory.GetDirectories(repoPath, "*", SearchOption.TopDirectoryOnly)
                     let name = Path.GetFileName(path)
-                    where GitUtility.IsWorkTreeCheckoutComplete(repoPath, name) &&
-                        ((locked && (name == $"{RestoreGit.GetWorkTreeHeadPrefix(branch, locked)}{commit}" || name.EndsWith($"-{commit}"))) ||
-                        (!locked && name.StartsWith(RestoreGit.GetWorkTreeHeadPrefix(branch))))
+                    where GitUtility.IsWorkTreeCheckoutComplete(repoPath, name) && name.StartsWith(RestoreGit.GetWorkTreeHeadPrefix(branch))
                     orderby new DirectoryInfo(path).LastWriteTimeUtc
                     select path).FirstOrDefault();
             }
+
+            bool TryGetWorkTreePath(string root, bool isLocked, out string workTreePath)
+            {
+                var workTreeName = $"{RestoreGit.GetWorkTreeHeadPrefix(branch, isLocked)}{commit}";
+                workTreePath = Path.Combine(root, workTreeName);
+                if (Directory.Exists(workTreePath) && GitUtility.IsWorkTreeCheckoutComplete(root, workTreeName))
+                {
+                    return true;
+                }
+
+                return false;
+            }
         }
 
-        public static (bool fromUrl, string path) GetFileRestorePath(string docsetPath, string url, string fallbackDocset = null)
+        public static (bool fromUrl, string path) GetFileRestorePath(string docsetPath, string url, DependencyVersion dependencyVersion, string fallbackDocset = null)
         {
             var fromUrl = HrefUtility.IsHttpHref(url);
             if (!fromUrl)
@@ -76,13 +98,13 @@ namespace Microsoft.Docs.Build
 
                 if (!string.IsNullOrEmpty(fallbackDocset))
                 {
-                    return GetFileRestorePath(fallbackDocset, url);
+                    return GetFileRestorePath(fallbackDocset, url, dependencyVersion);
                 }
 
                 throw Errors.FileNotFound(docsetPath, url).ToException();
             }
 
-            if (!TryGetFileRestorePath(url, out var result))
+            if (!TryGetFileRestorePath(url, dependencyVersion, out var result))
             {
                 throw Errors.NeedRestore(url).ToException();
             }
@@ -90,19 +112,21 @@ namespace Microsoft.Docs.Build
             return (fromUrl, result);
         }
 
-        public static bool TryGetFileRestorePath(string url, out string result)
+        public static bool TryGetFileRestorePath(string url, DependencyVersion dependencyVersion, out string result)
         {
             Debug.Assert(!string.IsNullOrEmpty(url));
             Debug.Assert(HrefUtility.IsHttpHref(url));
 
+            var fileName = dependencyVersion?.Hash;
+            var locked = string.IsNullOrEmpty(fileName);
             result = s_downloadPath.AddOrUpdate(
-                url,
-                new Lazy<string>(FindLastModifiedFile),
-                (_, existing) => existing.Value != null ? existing : new Lazy<string>(FindLastModifiedFile)).Value;
+                (url, fileName),
+                new Lazy<string>(FindFile),
+                (_, existing) => existing.Value != null ? existing : new Lazy<string>(FindFile)).Value;
 
             return File.Exists(result);
 
-            string FindLastModifiedFile()
+            string FindFile()
             {
                 // get the file path from restore map
                 var restoreDir = AppData.GetFileDownloadDir(url);
@@ -112,6 +136,19 @@ namespace Microsoft.Docs.Build
                     return null;
                 }
 
+                // return specified version
+                if (locked)
+                {
+                    var filePath = Path.Combine(restoreDir, fileName);
+                    if (File.Exists(filePath))
+                    {
+                        return filePath;
+                    }
+
+                    return null;
+                }
+
+                // return the latest version
                 return Directory.EnumerateFiles(restoreDir, "*", SearchOption.TopDirectoryOnly)
                        .OrderByDescending(f => new FileInfo(f).LastWriteTimeUtc)
                        .FirstOrDefault();

--- a/src/docfx/restore/lock/DependencyLock.cs
+++ b/src/docfx/restore/lock/DependencyLock.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Docs.Build
                 }
             }
 
-            var (_, restoredLockFile) = RestoreMap.GetFileRestorePath(docset, dependencyLockPath);
+            var (_, restoredLockFile) = RestoreMap.GetFileRestorePath(docset, dependencyLockPath, null);
 
             var content = await ProcessUtility.ReadFile(restoredLockFile);
 

--- a/src/docfx/restore/lock/DependencyLock.cs
+++ b/src/docfx/restore/lock/DependencyLock.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Docs.Build
 
             var (errors, config) = ConfigLoader.TryLoad(docset, commandLineOptions);
 
-            return Load(docset, config.DependencyLock);
+            return Load(docset, string.IsNullOrEmpty(config.DependencyLock) ? AppData.GetDependencyLockFile(docset) : config.DependencyLock);
         }
 
         public static async Task Save(string docset, string dependencyLockPath, DependencyLockModel dependencyLock)
@@ -82,7 +82,9 @@ namespace Microsoft.Docs.Build
 
             if (!HrefUtility.IsHttpHref(dependencyLockPath))
             {
-                await ProcessUtility.WriteFile(Path.Combine(docset, dependencyLockPath), content);
+                var path = Path.Combine(docset, dependencyLockPath);
+                Directory.CreateDirectory(Path.GetDirectoryName(path));
+                await ProcessUtility.WriteFile(path, content);
             }
 
             // todo: upload to remote file directly

--- a/src/docfx/restore/lock/DependencyLock.cs
+++ b/src/docfx/restore/lock/DependencyLock.cs
@@ -64,22 +64,6 @@ namespace Microsoft.Docs.Build
             return JsonUtility.Deserialize<DependencyLockModel>(content);
         }
 
-        public static async Task<DependencyLockModel> Load(string docset, Repository repository, CommandLineOptions commandLineOptions)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(docset));
-
-            var (errors, config) = ConfigLoader.TryLoad(docset, commandLineOptions);
-
-            var dependencyLock = await Load(docset, string.IsNullOrEmpty(config.DependencyLock) ? AppData.GetDependencyLockFile(docset) : config.DependencyLock);
-
-            if (LocalizationUtility.TryGetSourceRepository(repository, out var sourceRemote, out var sourceBranch, out var locale))
-            {
-                return dependencyLock.GetGitLock(sourceRemote, sourceBranch);
-            }
-
-            return dependencyLock;
-        }
-
         public static async Task Save(string docset, string dependencyLockPath, DependencyLockModel dependencyLock)
         {
             Debug.Assert(!string.IsNullOrEmpty(docset));

--- a/src/docfx/restore/lock/DependencyLockModel.cs
+++ b/src/docfx/restore/lock/DependencyLockModel.cs
@@ -12,24 +12,5 @@ namespace Microsoft.Docs.Build
         public IReadOnlyDictionary<string, DependencyLockModel> Git { get; set; } = new Dictionary<string, DependencyLockModel>();
 
         public IReadOnlyDictionary<string, DependencyVersion> Downloads { get; set; } = new Dictionary<string, DependencyVersion>();
-
-        public DependencyLockModel()
-        {
-        }
-
-        public DependencyLockModel(IReadOnlyDictionary<string, DependencyLockModel> gitVersions, IReadOnlyDictionary<string, DependencyVersion> downloads, DependencyVersion version = null)
-            : this(gitVersions, downloads, version?.Commit, version?.Hash)
-        {
-        }
-
-        public DependencyLockModel(IReadOnlyDictionary<string, DependencyLockModel> gitVersions, IReadOnlyDictionary<string, DependencyVersion> downloads, string commit, string hash)
-            : base(commit, hash)
-        {
-            Debug.Assert(gitVersions != null);
-            Debug.Assert(downloads != null);
-
-            Git = gitVersions.OrderBy(g => g.Key).ToDictionary(k => k.Key, v => v.Value);
-            Downloads = downloads.OrderBy(d => d.Key).ToDictionary(k => k.Key, v => v.Value);
-        }
     }
 }

--- a/test/docfx.Test/build/TocTest.cs
+++ b/test/docfx.Test/build/TocTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Docs.Build
             "en-us",
             JsonUtility.Deserialize<Config>("{'output': { 'json': true } }".Replace('\'', '\"')),
             new CommandLineOptions(),
-            null).Result;
+            new DependencyLockModel()).Result;
 
         [Theory]
         // same level


### PR DESCRIPTION
1. `restore` always generate and save dependency lock for build, to default/user's dependency file path
2. `build` always use dependency lock to retrieve git/file, otherwise errors will be thrown
3.  support version for downloads