### PR TITLE
Consolidate json serializers

### DIFF
--- a/src/docfx/build/metadata/MetadataProvider.cs
+++ b/src/docfx/build/metadata/MetadataProvider.cs
@@ -41,13 +41,13 @@ namespace Microsoft.Docs.Build
             }
 
             var result = new JObject();
-            result.Merge(_config.GlobalMetadata, JsonUtility.MergeSettings);
-            result.Merge(fileMetadata, JsonUtility.MergeSettings);
+            JsonUtility.Merge(result, _config.GlobalMetadata);
+            JsonUtility.Merge(result, fileMetadata);
 
             if (yamlHeader != null)
             {
                 erros.AddRange(MetadataValidator.Validate(yamlHeader, "yaml header"));
-                result.Merge(yamlHeader, JsonUtility.MergeSettings);
+                JsonUtility.Merge(result, yamlHeader);
             }
 
             return (erros, result);

--- a/src/docfx/build/metadata/MetadataValidator.cs
+++ b/src/docfx/build/metadata/MetadataValidator.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Docs.Build
 {
@@ -34,17 +33,11 @@ namespace Microsoft.Docs.Build
 
         private static HashSet<string> GetReservedMetadata()
         {
-            var blackList = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            var outputProperties = ((JsonObjectContract)JsonUtility.DefaultSerializer.ContractResolver.ResolveContract(typeof(PageModel))).Properties;
-            foreach (var property in outputProperties)
-            {
-                blackList.Add(property.PropertyName);
-            }
+            var blackList = new HashSet<string>(JsonUtility.GetPropertyNames(typeof(PageModel)), StringComparer.OrdinalIgnoreCase);
 
-            var inputProperties = ((JsonObjectContract)JsonUtility.DefaultSerializer.ContractResolver.ResolveContract(typeof(FileMetadata))).Properties;
-            foreach (var property in inputProperties)
+            foreach (var name in JsonUtility.GetPropertyNames(typeof(FileMetadata)))
             {
-                blackList.Remove(property.PropertyName);
+                blackList.Remove(name);
             }
 
             return blackList;

--- a/src/docfx/config/ConfigLoader.cs
+++ b/src/docfx/config/ConfigLoader.cs
@@ -53,27 +53,28 @@ namespace Microsoft.Docs.Build
 
             // apply options
             var optionConfigObject = Expand(options?.ToJObject());
-            var finalConfigObject = JsonUtility.Merge(configObject, optionConfigObject);
+
+            JsonUtility.Merge(configObject, optionConfigObject);
             errors.AddRange(loadErrors);
 
             // apply global config
             var globalErrors = new List<Error>();
-            (globalErrors, finalConfigObject) = ApplyGlobalConfig(finalConfigObject);
+            (globalErrors, configObject) = ApplyGlobalConfig(configObject);
             errors.AddRange(globalErrors);
 
             // apply extends
             if (extend)
             {
                 var extendErrors = new List<Error>();
-                (extendErrors, finalConfigObject) = ExtendConfigs(finalConfigObject, docsetPath);
+                (extendErrors, configObject) = ExtendConfigs(configObject, docsetPath);
                 errors.AddRange(extendErrors);
             }
 
             // apply overwrite
-            finalConfigObject = OverwriteConfig(finalConfigObject, locale ?? options.Locale, GetBranch());
+            configObject = OverwriteConfig(configObject, locale ?? options.Locale, GetBranch());
 
             var deserializeErrors = new List<Error>();
-            (deserializeErrors, config) = JsonUtility.ToObjectWithSchemaValidation<Config>(finalConfigObject);
+            (deserializeErrors, config) = JsonUtility.ToObjectWithSchemaValidation<Config>(configObject);
             errors.AddRange(deserializeErrors);
 
             // validate metadata
@@ -119,7 +120,7 @@ namespace Microsoft.Docs.Build
                 (errors, result) = LoadConfigObject(globalConfigPath, globalConfigPath);
             }
 
-            result.Merge(config, JsonUtility.MergeSettings);
+            JsonUtility.Merge(result, config);
             return (errors, result);
         }
 
@@ -137,12 +138,12 @@ namespace Microsoft.Docs.Build
                         var (_, filePath) = RestoreMap.GetFileRestorePath(docsetPath, str);
                         var (extendErros, extendConfigObject) = LoadConfigObject(str, filePath);
                         errors.AddRange(extendErros);
-                        result.Merge(extendConfigObject, JsonUtility.MergeSettings);
+                        JsonUtility.Merge(result, extendConfigObject);
                     }
                 }
             }
 
-            result.Merge(config, JsonUtility.MergeSettings);
+            JsonUtility.Merge(result, config);
             return (errors, result);
         }
 
@@ -163,7 +164,7 @@ namespace Microsoft.Docs.Build
 
             var result = new JObject();
             var overwriteConfigIdentifiers = new List<string>();
-            result.Merge(config, JsonUtility.MergeSettings);
+            JsonUtility.Merge(result, config);
             foreach (var (key, value) in config)
             {
                 if (OverwriteConfigIdentifier.TryMatch(key, out var identifier))
@@ -172,7 +173,7 @@ namespace Microsoft.Docs.Build
                         (identifier.Locales.Count == 0 || (!string.IsNullOrEmpty(locale) && identifier.Locales.Contains(locale))) &&
                         value is JObject overwriteConfig)
                     {
-                        result.Merge(Expand(overwriteConfig), JsonUtility.MergeSettings);
+                        JsonUtility.Merge(result, Expand(overwriteConfig));
                     }
 
                     overwriteConfigIdentifiers.Add(key);

--- a/src/docfx/lib/JsonUtility.cs
+++ b/src/docfx/lib/JsonUtility.cs
@@ -3,12 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using System.Threading;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
@@ -16,43 +16,40 @@ using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Docs.Build
 {
-    /// <summary>
-    /// Provide Utilities of Json
-    /// </summary>
     internal static class JsonUtility
     {
-        public static readonly JsonSerializer DefaultSerializer = new JsonSerializer
+        private static readonly NamingStrategy s_namingStrategy = new CamelCaseNamingStrategy();
+        private static readonly DefaultContractResolver s_rawContractResolver = new DefaultContractResolver { NamingStrategy = s_namingStrategy };
+        private static readonly JsonMergeSettings s_mergeSettings = new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Replace };
+
+        private static readonly JsonSerializer s_serializer = new JsonSerializer
         {
             NullValueHandling = NullValueHandling.Ignore,
-            ContractResolver = new SchemaValidationContractResolver(),
+            ContractResolver = new JsonContractResolver { NamingStrategy = s_namingStrategy },
+            Converters = { new StringEnumConverter { NamingStrategy = s_namingStrategy } },
         };
 
-        public static readonly JsonMergeSettings MergeSettings = new JsonMergeSettings
-        {
-            MergeArrayHandling = MergeArrayHandling.Replace,
-        };
-
-        private static readonly CamelCasePropertyNamesContractResolver s_contractResolver = new CamelCasePropertyNamesContractResolver();
-        private static readonly JsonSerializerSettings s_noneFormatJsonSerializerSettings = new JsonSerializerSettings
+        private static readonly JsonSerializer s_schemaValidationSerializer = new JsonSerializer
         {
             NullValueHandling = NullValueHandling.Ignore,
-            Converters = { new StringEnumConverter { NamingStrategy = new CamelCaseNamingStrategy() } },
-            ContractResolver = new JsonContractResolver(),
+            ContractResolver = new SchemaValidationContractResolver { NamingStrategy = s_namingStrategy },
+            Converters = { new StringEnumConverter { NamingStrategy = s_namingStrategy } },
         };
 
-        private static readonly JsonSerializerSettings s_indentedFormatJsonSerializerSettings = new JsonSerializerSettings
+        private static readonly JsonSerializer s_indentSerializer = new JsonSerializer
         {
-            NullValueHandling = NullValueHandling.Ignore,
             Formatting = Formatting.Indented,
-            Converters = { new StringEnumConverter { NamingStrategy = new CamelCaseNamingStrategy() } },
-            ContractResolver = new JsonContractResolver(),
+            NullValueHandling = NullValueHandling.Ignore,
+            ContractResolver = new JsonContractResolver { NamingStrategy = s_namingStrategy },
+            Converters = { new StringEnumConverter { NamingStrategy = s_namingStrategy } },
         };
 
-        private static readonly JsonSerializer s_defaultIndentedFormatSerializer = JsonSerializer.Create(s_indentedFormatJsonSerializerSettings);
-        private static readonly JsonSerializer s_defaultNoneFormatSerializer = JsonSerializer.Create(s_noneFormatJsonSerializerSettings);
+        private static ThreadLocal<Stack<Status>> t_status = new ThreadLocal<Stack<Status>>(() => new Stack<Status>());
 
-        [ThreadStatic]
-        private static ImmutableStack<Status> t_status;
+        static JsonUtility()
+        {
+            s_schemaValidationSerializer.Error += HandleError;
+        }
 
         /// <summary>
         /// Fast pass to read MIME from $schema attribute.
@@ -118,23 +115,28 @@ namespace Microsoft.Docs.Build
             }
         }
 
+        public static IEnumerable<string> GetPropertyNames(Type type)
+        {
+            return ((JsonObjectContract)s_serializer.ContractResolver.ResolveContract(type)).Properties.Select(prop => prop.PropertyName);
+        }
+
         /// <summary>
         /// Serialize an object to TextWriter
         /// </summary>
-        public static void Serialize(TextWriter writer, object graph, Formatting formatting = Formatting.None)
+        public static void Serialize(TextWriter writer, object graph, bool indent = false)
         {
-            var localSerializer = formatting == Formatting.Indented ? s_defaultIndentedFormatSerializer : s_defaultNoneFormatSerializer;
-            localSerializer.Serialize(writer, graph);
+            var serializer = indent ? s_indentSerializer : s_serializer;
+            serializer.Serialize(writer, graph);
         }
 
         /// <summary>
         /// Serialize an object to string
         /// </summary>
-        public static string Serialize(object graph, Formatting formatting = Formatting.None)
+        public static string Serialize(object graph, bool indent = false)
         {
             using (StringWriter writer = new StringWriter())
             {
-                Serialize(writer, graph, formatting);
+                Serialize(writer, graph, indent);
                 return writer.ToString();
             }
         }
@@ -161,7 +163,7 @@ namespace Microsoft.Docs.Build
             {
                 try
                 {
-                    return DefaultSerializer.Deserialize<T>(reader);
+                    return s_serializer.Deserialize<T>(reader);
                 }
                 catch (JsonReaderException ex)
                 {
@@ -188,7 +190,7 @@ namespace Microsoft.Docs.Build
         {
             try
             {
-                var obj = token.ToObject(typeof(T), JsonUtility.DefaultSerializer);
+                var obj = token.ToObject(typeof(T), JsonUtility.s_serializer);
                 return (T)obj;
             }
             catch (JsonReaderException ex)
@@ -203,44 +205,22 @@ namespace Microsoft.Docs.Build
             Type type,
             Func<IEnumerable<DataTypeAttribute>, object, string, object> transform = null)
         {
-            var errors = new List<Error>();
             try
             {
-                var status = new Status
-                {
-                    SchemaViolationErrors = new List<Error>(),
-                    Transform = transform,
-                };
-                t_status = t_status is null ? ImmutableStack.Create(status) : t_status.Push(status);
+                var errors = new List<Error>();
+                var status = new Status { Errors = errors, Transform = transform };
+
+                t_status.Value.Push(status);
 
                 token.ReportUnknownFields(errors, type);
-                var serializer = new JsonSerializer
-                {
-                    NullValueHandling = NullValueHandling.Ignore,
-                    ContractResolver = DefaultSerializer.ContractResolver,
-                };
-                serializer.Error += HandleError;
-                var value = token.ToObject(type, serializer);
-                errors.AddRange(t_status.Peek().SchemaViolationErrors);
+
+                var value = token.ToObject(type, s_schemaValidationSerializer);
+
                 return (errors, value);
             }
             finally
             {
-                t_status = t_status.Pop();
-            }
-
-            void HandleError(object sender, Newtonsoft.Json.Serialization.ErrorEventArgs args)
-            {
-                // only log an error once
-                if (args.CurrentObject == args.ErrorContext.OriginalObject)
-                {
-                    if (args.ErrorContext.Error is JsonReaderException || args.ErrorContext.Error is JsonSerializationException jse)
-                    {
-                        var (range, message, path) = ParseException(args.ErrorContext.Error);
-                        errors.Add(Errors.ViolateSchema(range, message, path));
-                        args.ErrorContext.Handled = true;
-                    }
-                }
+                t_status.Value.Pop();
             }
         }
 
@@ -267,26 +247,9 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public static JObject Merge(JObject a, JObject b)
+        public static void Merge(JObject container, JObject overwrite)
         {
-            var result = new JObject();
-            result.Merge(a, MergeSettings);
-            result.Merge(b, MergeSettings);
-            return result;
-        }
-
-        public static JObject Merge(JObject first, IEnumerable<JObject> objs)
-        {
-            var result = new JObject();
-            result.Merge(first);
-            foreach (var obj in objs)
-            {
-                if (obj != null)
-                {
-                    result.Merge(obj, MergeSettings);
-                }
-            }
-            return result;
+            container.Merge(overwrite, s_mergeSettings);
         }
 
         /// <summary>
@@ -330,6 +293,20 @@ namespace Microsoft.Docs.Build
             }
 
             return false;
+        }
+
+        private static void HandleError(object sender, Newtonsoft.Json.Serialization.ErrorEventArgs args)
+        {
+            // only log an error once
+            if (args.CurrentObject == args.ErrorContext.OriginalObject)
+            {
+                if (args.ErrorContext.Error is JsonReaderException || args.ErrorContext.Error is JsonSerializationException jse)
+                {
+                    var (range, message, path) = ParseException(args.ErrorContext.Error);
+                    t_status.Value.Peek().Errors.Add(Errors.ViolateSchema(range, message, path));
+                    args.ErrorContext.Handled = true;
+                }
+            }
         }
 
         private static (Range, string message, string path) ParseException(Exception ex)
@@ -417,7 +394,7 @@ namespace Microsoft.Docs.Build
 
         private static Type GetCollectionItemTypeIfArrayType(Type type)
         {
-            var contract = s_contractResolver.ResolveContract(type);
+            var contract = s_rawContractResolver.ResolveContract(type);
             if (contract is JsonObjectContract)
             {
                 return type;
@@ -439,7 +416,7 @@ namespace Microsoft.Docs.Build
 
         private static Type GetNestedTypeAndCheckForUnknownField(Type type, JProperty prop, List<Error> errors)
         {
-            var contract = s_contractResolver.ResolveContract(type);
+            var contract = s_rawContractResolver.ResolveContract(type);
 
             if (contract is JsonObjectContract objectContract)
             {
@@ -464,7 +441,7 @@ namespace Microsoft.Docs.Build
 
         private static JsonPropertyCollection GetPropertiesFromJsonArrayContract(JsonArrayContract arrayContract)
         {
-            var itemContract = DefaultSerializer.ContractResolver.ResolveContract(arrayContract.CollectionItemType);
+            var itemContract = s_serializer.ContractResolver.ResolveContract(arrayContract.CollectionItemType);
             if (itemContract is JsonObjectContract objectContract)
                 return objectContract.Properties;
             else if (itemContract is JsonArrayContract contract)
@@ -472,7 +449,7 @@ namespace Microsoft.Docs.Build
             return null;
         }
 
-        private class JsonContractResolver : CamelCasePropertyNamesContractResolver
+        private class JsonContractResolver : DefaultContractResolver
         {
             protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
             {
@@ -483,7 +460,7 @@ namespace Microsoft.Docs.Build
 
                 void ShouldNotSerializeEmptyArray()
                 {
-                    if (s_contractResolver.ResolveContract(prop.PropertyType) is JsonArrayContract)
+                    if (s_rawContractResolver.ResolveContract(prop.PropertyType) is JsonArrayContract)
                     {
                         prop.ShouldSerialize =
                               target =>
@@ -572,17 +549,18 @@ namespace Microsoft.Docs.Build
                     }
                     catch (Exception e)
                     {
-                        t_status.Peek().SchemaViolationErrors.Add(Errors.ViolateSchema(range, e.Message, reader.Path));
+                        t_status.Value.Peek().Errors.Add(Errors.ViolateSchema(range, e.Message, reader.Path));
                     }
                 }
 
-                return t_status.Peek().Transform != null ? t_status.Peek().Transform(_attributes, value, reader.Path) : value;
+                var transform = t_status.Value.Peek().Transform;
+                return transform != null ? transform(_attributes, value, reader.Path) : value;
             }
         }
 
         private sealed class Status
         {
-            public List<Error> SchemaViolationErrors { get; set; }
+            public List<Error> Errors { get; set; }
 
             public Func<IEnumerable<DataTypeAttribute>, object, string, object> Transform { get; set; }
         }

--- a/src/docfx/restore/lock/DependencyLock.cs
+++ b/src/docfx/restore/lock/DependencyLock.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Docs.Build
             Debug.Assert(!string.IsNullOrEmpty(docset));
             Debug.Assert(!string.IsNullOrEmpty(dependencyLockPath));
 
-            var content = JsonUtility.Serialize(dependencyLock, formatting: Newtonsoft.Json.Formatting.Indented);
+            var content = JsonUtility.Serialize(dependencyLock, indent: true);
 
             if (!HrefUtility.IsHttpHref(dependencyLockPath))
             {

--- a/test/docfx.Test/lib/JsonUtilityTest.cs
+++ b/test/docfx.Test/lib/JsonUtilityTest.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Docs.Build
         [Fact]
         public void TestBasicClass()
         {
-            var json = JsonUtility.Serialize(new BasicClass { B = 1, C = "Good!", D = true }, formatting: Formatting.Indented);
+            var json = JsonUtility.Serialize(new BasicClass { B = 1, C = "Good!", D = true }, indent: true);
             Assert.Equal(
                 @"{
   ""c"": ""Good!"",
@@ -156,7 +156,7 @@ namespace Microsoft.Docs.Build
                         C = "Amazing!",
                     },
                     ValueRequired = "a",
-                }, formatting: Formatting.Indented);
+                }, indent: true);
             var json = sw.ToString();
             Assert.Equal(
                 @"{
@@ -213,7 +213,9 @@ namespace Microsoft.Docs.Build
         {
             var targetJson = JsonUtility.Deserialize<JObject>(target);
             var sourceJson = JsonUtility.Deserialize<JObject>(source);
-            var resultJson = JsonUtility.Merge(targetJson, sourceJson);
+            var resultJson = new JObject();
+            JsonUtility.Merge(resultJson, targetJson);
+            JsonUtility.Merge(resultJson, sourceJson);
             var resultJsonString = JsonUtility.Serialize(resultJson);
             Assert.Equal(result, resultJsonString);
         }
@@ -446,22 +448,6 @@ namespace Microsoft.Docs.Build
             {
                 Assert.Equal(ErrorLevel.Error, error.Level);
                 Assert.Equal("violate-schema", error.Code);
-                Assert.Equal(6, error.Line);
-                Assert.Equal(19, error.Column);
-                Assert.Equal("Error converting value \"notArray\" to type 'System.Collections.Generic.List`1[Microsoft.Docs.Build.JsonUtilityTest+BasicClass]'.", error.Message);
-                Assert.Equal("Items", error.JsonPath);
-            }, error =>
-            {
-                Assert.Equal(ErrorLevel.Error, error.Level);
-                Assert.Equal("violate-schema", error.Code);
-                Assert.Equal(1, error.Line);
-                Assert.Equal(1, error.Column);
-                Assert.Equal("Required property 'valueRequired' not found in JSON.", error.Message);
-                Assert.Equal("", error.JsonPath);
-            }, error =>
-            {
-                Assert.Equal(ErrorLevel.Error, error.Level);
-                Assert.Equal("violate-schema", error.Code);
                 Assert.Equal(2, error.Line);
                 Assert.Equal(21, error.Column);
             }, error =>
@@ -486,6 +472,22 @@ namespace Microsoft.Docs.Build
                 Assert.Equal("violate-schema", error.Code);
                 Assert.Equal(5, error.Line);
                 Assert.Equal(52, error.Column);
+            }, error =>
+            {
+                Assert.Equal(ErrorLevel.Error, error.Level);
+                Assert.Equal("violate-schema", error.Code);
+                Assert.Equal(6, error.Line);
+                Assert.Equal(19, error.Column);
+                Assert.Equal("Error converting value \"notArray\" to type 'System.Collections.Generic.List`1[Microsoft.Docs.Build.JsonUtilityTest+BasicClass]'.", error.Message);
+                Assert.Equal("Items", error.JsonPath);
+            }, error =>
+            {
+                Assert.Equal(ErrorLevel.Error, error.Level);
+                Assert.Equal("violate-schema", error.Code);
+                Assert.Equal(1, error.Line);
+                Assert.Equal(1, error.Column);
+                Assert.Equal("Required property 'valueRequired' not found in JSON.", error.Message);
+                Assert.Equal("", error.JsonPath);
             });
         }
 


### PR DESCRIPTION
- Internalized json serializer settings inside `JsonUtility`
- Only initialize one serializer for schema validation
- Only one place to specify naming strategy
- Fix string enum converter not set on all serializers