### PR TITLE
[WIP]return errors instead of write errors everywhere for xref map and toc map

### DIFF
--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -654,3 +654,24 @@ inputs:
 outputs:
   build.log: |
     ["error","schema-not-found","Unknown schema ''","docs/a.json"]
+---
+# build A but with errors in B
+inputs:
+  docfx.yml:
+  docs/a.json: |
+    {
+      "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TestData.json",
+      "uid": "a",
+      "inlineDescription": "Link to @b?displayProperty=inlineDescription",
+    }
+  docs/b.json: |
+    {
+      "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TestData.json",
+      "uid": "b",
+      "inlineDescription": "Link to @c",
+    }
+outputs:
+  docs/a.json:
+  docs/b.json:
+  build.log: |
+    ["info","at-uid-not-found","Cannot find uid 'c' using xref '@c'","docs/b.json"]

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -427,6 +427,16 @@ namespace Microsoft.Docs.Build
             return result.value;
         }
 
+        public static List<Error> WithFile(this List<Error> errors, string file)
+        {
+            if (errors == null)
+            {
+                return errors;
+            }
+
+            return errors.Where(e => e != null).Select(e => e.WithFile(file)).ToList();
+        }
+
         private static string Join<T>(IEnumerable<T> source, Func<T, string> selector = null)
             => string.Join(", ", source.Select(item => $"{selector?.Invoke(item) ?? item.ToString()}").OrderBy(_ => _, StringComparer.Ordinal).Select(_ => $"'{_}'").Take(5));
 

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -417,6 +417,16 @@ namespace Microsoft.Docs.Build
         public static Error InvalidUidMoniker(string moniker, string uid)
             => new Error(ErrorLevel.Warning, "invalid-uid-moniker", $"Moniker '{moniker}' is not defined with uid '{uid}'");
 
+        public static T AddRange<T>(this List<Error> list, (List<Error> errors, T value) result) where T : class
+        {
+            if (!(result.errors is null))
+            {
+                list.AddRange(result.errors);
+            }
+
+            return result.value;
+        }
+
         private static string Join<T>(IEnumerable<T> source, Func<T, string> selector = null)
             => string.Join(", ", source.Select(item => $"{selector?.Invoke(item) ?? item.ToString()}").OrderBy(_ => _, StringComparer.Ordinal).Select(_ => $"'{_}'").Take(5));
 

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -32,14 +32,15 @@ namespace Microsoft.Docs.Build
 
             using (var context = await Context.Create(outputPath, report, docset, () => xrefMap))
             {
-                xrefMap = XrefMap.Create(context, docset);
+                xrefMap = errors.AddRange(XrefMap.Create(context, docset));
 
-                var tocMap = BuildTableOfContents.BuildTocMap(context, docset);
+                var tocMap = errors.AddRange(BuildTableOfContents.BuildTocMap(context, docset));
+
                 var (publishManifest, fileManifests, sourceDependencies) = await BuildFiles(context, docset, tocMap);
 
                 var saveGitHubUserCache = context.GitHubUserCache.SaveChanges(config);
 
-                xrefMap.OutputXrefMap(context);
+                errors.AddRange(xrefMap.OutputXrefMap(context));
                 context.Output.WriteJson(publishManifest, ".publish.json");
                 context.Output.WriteJson(sourceDependencies.ToDependencyMapModel(), ".dependencymap.json");
 

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Docs.Build
             // Link to dependent repo, don't build the file, leave href as is
             if (relativeTo.Docset.DependencyDocsets.Values.Any(v => file.Docset == v))
             {
-                return (new List<Error> { Errors.LinkIsDependency(relativeTo, file, href) }, href, fragment, null);
+                return (Errors.LinkIsDependency(relativeTo, file, href).ToList(), href, fragment, null);
             }
 
             // Make result relative to `resultRelativeTo`
@@ -179,7 +179,7 @@ namespace Microsoft.Docs.Build
                 && (file.ContentType == ContentType.Page || file.ContentType == ContentType.TableOfContents)
                 && !file.Docset.BuildScope.Contains(file))
             {
-                return (new List<Error> { Errors.LinkOutOfScope(relativeTo, file, href, file.Docset.Config.ConfigFileName) }, relativeUrl + query + fragment, fragment, null);
+                return (Errors.LinkOutOfScope(relativeTo, file, href, file.Docset.Config.ConfigFileName).ToList(), relativeUrl + query + fragment, fragment, null);
             }
 
             return (errors, relativeUrl + query + fragment, fragment, file);

--- a/src/docfx/build/page/AttributeTransformer.cs
+++ b/src/docfx/build/page/AttributeTransformer.cs
@@ -21,7 +21,9 @@ namespace Microsoft.Docs.Build
             (List<Error> error, object content) Transform(IEnumerable<DataTypeAttribute> attributes, object value, string jsonPath)
             {
                 var attribute = attributes.SingleOrDefault(attr => !(attr is XrefPropertyAttribute));
-                return TransformContent(context, attribute, value, file, buildChild);
+                var (errors, content) = TransformContent(context, attribute, value, file, buildChild);
+
+                return (errors.WithFile(file.ToString()), content);
             }
         }
 
@@ -40,7 +42,7 @@ namespace Microsoft.Docs.Build
                     () =>
                     {
                         var (errors, content) = TransformContent(context, attribute, value, file, buildChild);
-                        return (errors, new JValue(content));
+                        return (errors.WithFile(file.ToString()), new JValue(content));
                     },
                     LazyThreadSafetyMode.PublicationOnly);
 

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -54,10 +54,10 @@ namespace Microsoft.Docs.Build
                     tocFiles,
                     file =>
                     {
-                        var errorsPerFile = BuildTocMap(context, file, builder);
-                        foreach (var errorPerFile in errorsPerFile)
+                        var mapErros = BuildTocMap(context, file, builder).WithFile(file.ToString());
+                        foreach (var error in mapErros)
                         {
-                            errors.Add(errorPerFile.WithFile(file.ToString()));
+                            errors.Add(error);
                         }
                     },
                     Progress.Update);

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -26,10 +26,13 @@ namespace Microsoft.Docs.Build
             if (propertyName is null)
                 return (errors, null);
 
-            if (ExtensionData.TryGetValue(propertyName, out var internalValue) && internalValue.Value.jValue.Value is string value)
+            if (ExtensionData.TryGetValue(propertyName, out var internalValue))
             {
-                errors.AddRange(errors);
-                return (errors, value);
+                var jValue = errors.AddRange(internalValue.Value);
+                if (jValue.Value is string value)
+                {
+                    return (errors, value);
+                }
             }
 
             return (errors, null);

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Docs.Build
                     errors.Add(ex.Error);
                 }
             }
-            return (errors, spec);
+            return (errors.WithFile(file.ToString()), spec);
         }
     }
 }

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Docs.Build
 
         public (List<Error> errors, string value) GetName() => GetXrefPropertyValue("name");
 
-        public (List<Error> errors, XrefSpec xrefSpec) ToExternalXrefSpec(Context context, Document file)
+        public (List<Error> errors, XrefSpec xrefSpec) ToExternalXrefSpec(Document file)
         {
             var errors = new List<Error>();
             var spec = new XrefSpec

--- a/src/docfx/build/xref/XrefMap.cs
+++ b/src/docfx/build/xref/XrefMap.cs
@@ -278,10 +278,10 @@ namespace Microsoft.Docs.Build
                     files.Where(f => f.ContentType == ContentType.Page),
                     file =>
                     {
-                        var errorsPerFile = Load(context, xrefsByUid, file);
-                        foreach (var errorPerFile in errorsPerFile)
+                        var xrefErrors = Load(context, xrefsByUid, file).WithFile(file.ToString());
+                        foreach (var error in xrefErrors)
                         {
-                            errors.Add(errorPerFile.WithFile(file.ToString()));
+                            errors.Add(error);
                         }
                     },
                     Progress.Update);

--- a/src/docfx/build/xref/XrefMap.cs
+++ b/src/docfx/build/xref/XrefMap.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Docs.Build
                 if (TryGetValidXrefSpecs(uid, specsWithSameUid, out var validInternalSpecs))
                 {
                     var (internalSpec, referencedFile) = GetLatestInternalXrefMap(validInternalSpecs);
-                    loadedInternalSpecs.Add(errors.AddRange(internalSpec.ToExternalXrefSpec(_context, referencedFile)));
+                    loadedInternalSpecs.Add(errors.AddRange(internalSpec.ToExternalXrefSpec(referencedFile)));
                 }
             }
             return (errors, loadedInternalSpecs);

--- a/src/docfx/lib/log/Error.cs
+++ b/src/docfx/lib/log/Error.cs
@@ -76,6 +76,11 @@ namespace Microsoft.Docs.Build
             return new DocfxException(this, innerException);
         }
 
+        public List<Error> ToList()
+        {
+            return new List<Error> { this };
+        }
+
         private class EqualityComparer : IEqualityComparer<Error>
         {
             public bool Equals(Error x, Error y)

--- a/src/docfx/lib/log/Error.cs
+++ b/src/docfx/lib/log/Error.cs
@@ -49,6 +49,13 @@ namespace Microsoft.Docs.Build
             Range = range;
         }
 
+        public Error WithFile(string file)
+        {
+            return file == File || !string.IsNullOrEmpty(File)
+                ? this
+                : new Error(Level, Code, Message, file, Range, JsonPath);
+        }
+
         public override string ToString() => ToString(Level);
 
         public string ToString(ErrorLevel level)

--- a/src/docfx/lib/log/Report.cs
+++ b/src/docfx/lib/log/Report.cs
@@ -72,9 +72,7 @@ namespace Microsoft.Docs.Build
             if (error is null)
                 return false;
 
-            return Write(file == error.File || !string.IsNullOrEmpty(error.File)
-                    ? error
-                    : new Error(error.Level, error.Code, error.Message, file, error.Range, error.JsonPath));
+            return Write(error.WithFile(file));
         }
 
         public bool Write(Error error, bool force = false)

--- a/src/docfx/lib/markdown/MarkdownUtility.cs
+++ b/src/docfx/lib/markdown/MarkdownUtility.cs
@@ -181,12 +181,12 @@ namespace Microsoft.Docs.Build
         private static string GetLink(string path, object relativeTo, object resultRelativeTo)
         {
             var peek = t_status.Peek();
-            var (error, link, _) = peek.DependencyResolver.ResolveLink(path, (Document)relativeTo, (Document)resultRelativeTo, peek.BuildChild);
-            Result.Errors.AddIfNotNull(error);
+            var (errors, link, _) = peek.DependencyResolver.ResolveLink(path, (Document)relativeTo, (Document)resultRelativeTo, peek.BuildChild);
+            Result.Errors.AddRange(errors);
             return link;
         }
 
-        private static (Error error, string href, string display, Document file) ResolveXref(string href)
+        private static (List<Error> errors, string href, string display, Document file) ResolveXref(string href)
         {
             // TODO: now markdig engine combines all kinds of reference with inclusion, we need to split them out
             return t_status.Peek().DependencyResolver.ResolveXref(href, (Document)InclusionContext.File, (Document)InclusionContext.RootFile);

--- a/src/docfx/lib/markdown/ResolveXref.cs
+++ b/src/docfx/lib/markdown/ResolveXref.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Markdig;
 using Markdig.Renderers.Html;
@@ -12,7 +13,7 @@ namespace Microsoft.Docs.Build
 {
     internal static class ResolveXref
     {
-        public static MarkdownPipelineBuilder UseResolveXref(this MarkdownPipelineBuilder builder, Func<string, (Error error, string href, string display, Document file)> resolveXref)
+        public static MarkdownPipelineBuilder UseResolveXref(this MarkdownPipelineBuilder builder, Func<string, (List<Error> errors, string href, string display, Document file)> resolveXref)
         {
             return builder.Use(document =>
              {


### PR DESCRIPTION
1. make xref map and toc mp return errors
2. correct the files for errors without file info
3. will try to add file info to every file and remove `withFile` method later