### PR TITLE
📄 Add triage process

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -48,7 +48,7 @@ For proposals or large changes, we use the following process to pickup, review a
 
 2. We assign a team member when an issue is picked up in review meetings.
 
-3. Assignee label the issue as `read-for-review` for approval in review meetings only when the following conditions are met:
+3. Assignee label the issue as `ready-for-review` for approval in review meetings only when the following conditions are met:
 
     - Contains enough details for someone else to start work on it.
     - Contains work items to support the end to end scenario, including internal works needed beyond docfx.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -59,17 +59,15 @@ For proposals or large changes, we use the following process to pickup, review a
 
 Running the review meeting:
 
-1. Go through issues without assignees that are not in our backlog. Assign a team member and a milestone if the issue is ready to pickup, otherwise add it to backlog using the `backlog` label.
+1. Go through issues without assignees that is not labled as future. Assign a team member if the issue is ready to pickup, otherwise lable it as `future`. If the issue has a due date, assign a milestone. We usually have milestones for the next 2 quarters. Issues with assignees can start at any time based on priority and bandwidth.
 
-2. Go through issues with the `ready-for-review` label. Remove the `ready-for-review` label to indicate that reviewing is done. Add `approved` label to approve issues.
+2. Go through issues with the `ready-for-review` label. Remove the `ready-for-review` label to indicate that reviewing is done. Add `approved` label to approve the design so it is ready to accept pull requests.
 
 3. Go through issues with the `needs-disussion` label. Remove the `needs-disussion` label to indicate that disussion is done.
 
-4. Check our backlog from time to time and pick up from there when we have capacity.
+4. Check our issues with `future` label from time to time and pick up from there when we have capacity.
 
 Additional notes:
-
-- We usually have milestones for the next 2 quarters and a `future` milestone for work beyond that. The milestone specifies a deadline, work can start at any time when there is bandwidth.
 
 - For changes that potentially affect our internal partners, use the `needs-confirm` label to track these changes.
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -44,11 +44,13 @@ In general we perfer **Squash and merge** against `v3` or feature branches. When
 We are happy to accept small fixes and small enhancements through pull requests directly.
 For proposals or large changes, we use the following process to pickup, review and approve issues that aligns with our [roadmap](roadmap.md) and priority:
 
-1. Create an issue on GitHub to start a discussion of the proposal. We'll assign a team member once it is picked.
+1. Create an issue on GitHub to start a discussion of the proposal.
 
-2. Label it as `needs-discussion` for group discussion in review meetings.
+2. Assign a team member when an issue is picked up in review meetings.
 
-3. Label it as `read-for-review` for approval in review meetings when the following conditions are met:
+3. Issue assignee label it as `needs-discussion` for group discussion in review meetings.
+
+4. Issue assignee label it as `read-for-review` for approval in review meetings when the following conditions are met:
 
     - Contains enough details for someone else to start work on it.
     - Contains work items to support the end to end scenario, including internal works needed beyond docfx.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -46,11 +46,11 @@ For proposals or large changes, we use the following process to pickup, review a
 
 1. Create an issue on GitHub to start a discussion of the proposal.
 
-2. Assign a team member when an issue is picked up in review meetings.
+2. We assign a team member when an issue is picked up in review meetings.
 
-3. Issue assignee label it as `needs-discussion` for group discussion in review meetings.
+3. Assignee label the issue as `needs-discussion` for group discussion in review meetings.
 
-4. Issue assignee label it as `read-for-review` for approval in review meetings when the following conditions are met:
+4. Assignee label the issue as `read-for-review` for approval in review meetings when the following conditions are met:
 
     - Contains enough details for someone else to start work on it.
     - Contains work items to support the end to end scenario, including internal works needed beyond docfx.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -39,6 +39,38 @@ In general we perfer **Squash and merge** against `v3` or feature branches. When
 
     **At this stage, changes to ideal output, config, error message and line number are not considered breaking*
 
+## Triage Process
+
+We are happy to accept small fixes and small enhancements through pull requests directly.
+For proposals or large changes, we use the following process to pickup, review and approve issues that aligns with our [roadmap](roadmap.md) and priority:
+
+1. Create an issue on GitHub to start a discussion of the proposal. We'll assign a team member once it is picked.
+
+2. Label it as `needs-discussion` for group discussion in review meetings.
+
+3. Label it as `read-for-review` for approval in review meetings when the following conditions are met:
+
+    - Contains enough details for someone else to start work on it.
+    - Contains work items to support the end to end scenario, including internal works needed beyond docfx.
+    - No open questions.
+    - A draft API proposal to illustrate the change if applicable.
+
+Running the review meeting:
+
+1. Go through issues without assignees that are not in our backlog. Assign a team member and a milestone if the issue is ready to pickup, otherwise add it to backlog using the `backlog` label.
+
+2. Go through issues with the `ready-for-review` label. Remove the `ready-for-review` label to indicate that reviewing is done. Add `approved` label to approve issues.
+
+3. Go through issues with the `needs-disussion` label. Remove the `needs-disussion` label to indicate that disussion is done.
+
+4. Check our backlog from time to time and pick up from there when we have capacity.
+
+Additional notes:
+
+- We usually have milestones for the next 2 quarters and a `future` milestone for work beyond that. The milestone specifies a deadline, work can start at any time when there is bandwidth.
+
+- For changes that potentially affect our internal partners, use the `needs-confirm` label to track these changes.
+
 ## Coding Guidelines
 
 ### C#

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -48,28 +48,29 @@ For proposals or large changes, we use the following process to pickup, review a
 
 2. We assign a team member when an issue is picked up in review meetings.
 
-3. Assignee label the issue as `needs-discussion` for group discussion in review meetings.
-
-4. Assignee label the issue as `read-for-review` for approval in review meetings when the following conditions are met:
+3. Assignee label the issue as `read-for-review` for approval in review meetings only when the following conditions are met:
 
     - Contains enough details for someone else to start work on it.
     - Contains work items to support the end to end scenario, including internal works needed beyond docfx.
     - No open questions.
     - A draft API proposal to illustrate the change if applicable.
 
+4. Assignee label the issue as `needs-discussion` for group discussion in review meeting only when the following conditions are met:
+
+    - The issue can be addressed by different solutions.
+    - Contains enough details for all possible solutions.
+    
+5. Label the issue as `needs-confirm` if the change potentially affects our partners.
+
 Running the review meeting:
 
-1. Go through issues without assignees that is not labled as future. Assign a team member if the issue is ready to pickup, otherwise lable it as `future`. If the issue has a due date, assign a milestone. We usually have milestones for the next 2 quarters. Issues with assignees can start at any time based on priority and bandwidth.
+1. Go through issues without assignees that is not labled as `future`. Assign a team member if the issue is ready to pickup, otherwise lable it as `future`. If the issue has a due date, assign a milestone. We usually have milestones for the next 2 quarters. Issues with assignees can start at any time based on priority and bandwidth.
 
 2. Go through issues with the `ready-for-review` label. Remove the `ready-for-review` label to indicate that reviewing is done. Add `approved` label to approve the design so it is ready to accept pull requests.
 
 3. Go through issues with the `needs-disussion` label. Remove the `needs-disussion` label to indicate that disussion is done.
 
-4. Check our issues with `future` label from time to time and pick up from there when we have capacity.
-
-Additional notes:
-
-- For changes that potentially affect our internal partners, use the `needs-confirm` label to track these changes.
+4. Check our issues with `future` label from every month and pick up from there when we have capacity.
 
 ## Coding Guidelines
 


### PR DESCRIPTION
Add triage process as discussed.

I use assignee to identify issues that are reviewed and picked up. I use the backlog label to identify issues that are reviewed but not eligible for pick up.