### PR TITLE
Resolve Index.md to `./` over `.`

### DIFF
--- a/docs/specs/resolve.yml
+++ b/docs/specs/resolve.yml
@@ -143,7 +143,7 @@ outputs:
   docs/a/index.json: |
     { "content": "<p>Link to <a href=\"../a\">1</a> <a href=\"a\">2</a></p>" }
   docs/a/a.json: |
-    { "content": "<p>Link to <a href=\".\">index</a></p>" }
+    { "content": "<p>Link to <a href=\"./\">index</a></p>" }
   docs/a.json: |
     { "content": "<p>Link to <a href=\"a/\">index</a></p>" }
 ---

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -46,7 +46,7 @@ outputs:
                 }
             ],
             "name":"Index Reference",
-            "href":"."
+            "href":"./"
           }
       ]
     }
@@ -145,7 +145,7 @@ outputs:
                 }
             ],
             "name":"Index Reference",
-            "href":"."
+            "href":"./"
           }
       ]
     }
@@ -186,7 +186,7 @@ outputs:
                 }
             ],
             "name":"Index Reference",
-            "href":"."
+            "href":"./"
           }
       ]
     }
@@ -323,7 +323,7 @@ outputs:
                 }
             ],
             "name":"Topic1",
-            "href":"."
+            "href":"./"
           },
           {  
             "name":"Topic2",

--- a/src/docfx/docset/Document.cs
+++ b/src/docfx/docset/Document.cs
@@ -361,7 +361,7 @@ namespace Microsoft.Docs.Build
         internal static string PathToAbsoluteUrl(string path, ContentType contentType, Schema schema, bool json)
         {
             var url = PathToRelativeUrl(path, contentType, schema, json);
-            return url == "." ? "/" : "/" + url;
+            return url == "./" ? "/" : "/" + url;
         }
 
         internal static string PathToRelativeUrl(string path, ContentType contentType, Schema schema, bool json)
@@ -377,7 +377,7 @@ namespace Microsoft.Docs.Build
                         if (fileName.Equals("index", PathUtility.PathComparison))
                         {
                             var i = url.LastIndexOf('/');
-                            return i >= 0 ? url.Substring(0, i + 1) : ".";
+                            return i >= 0 ? url.Substring(0, i + 1) : "./";
                         }
                         if (json)
                         {

--- a/test/docfx.Test/build/DocumentTest.cs
+++ b/test/docfx.Test/build/DocumentTest.cs
@@ -24,9 +24,9 @@ namespace Microsoft.Docs.Build
         [InlineData("a.md", false, true, ContentType.Page, "a.html", "/a.html", "a.html")]
         [InlineData("a/index.md", false, false, ContentType.Page, "a/index.html", "/a/", "a/")]
         [InlineData("a/index.md", false, true, ContentType.Page, "a/index.html", "/a/", "a/")]
-        [InlineData("index.md", false, false, ContentType.Page, "index.html", "/", ".")]
-        [InlineData("index.md", false, true, ContentType.Page, "index.html", "/", ".")]
-        [InlineData("index.md", true, false, ContentType.Page, "index.json", "/", ".")]
+        [InlineData("index.md", false, false, ContentType.Page, "index.html", "/", "./")]
+        [InlineData("index.md", false, true, ContentType.Page, "index.html", "/", "./")]
+        [InlineData("index.md", true, false, ContentType.Page, "index.json", "/", "./")]
         internal static void FilePathToUrl(
             string path,
             bool json,


### PR DESCRIPTION
This is to fix https://ceapex.visualstudio.com/Engineering/_git/Docs.DocFX.Impact/pullrequest/8270?_a=files

In v2, index links in pages are resolved to `index`, index links in TOC are resolved to `./`. In v3, we used to resolve them both to `.`. But it is technically more correct to resolve it to `./` because an index page defines a directory.