### PR TITLE
Toc href takes predecance over href

### DIFF
--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -487,7 +487,7 @@ outputs:
        ]
     }
 ---
-# Toc href takes predecance over href
+# Toc href takes predecance over topic href
 inputs:
   docfx.yml:
   docs/TOC.yml: |

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -487,6 +487,26 @@ outputs:
        ]
     }
 ---
+# Toc href takes predecance over href
+inputs:
+  docfx.yml:
+  docs/TOC.yml: |
+    - name: Azure
+      tocHref: /azure/
+      topicHref: /azure/index
+outputs:
+  docs/toc.json: |
+    {
+      "items": [
+        {
+          "name": "Azure",
+          "href": "/azure/",
+          "tocHref": "/azure/",
+          "topicHref": "/azure/index"
+        }
+      ]
+    }
+---
 # Combine toc href, topic href => href + items
 inputs:
   docfx.yml:

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -487,7 +487,7 @@ outputs:
        ]
     }
 ---
-# Toc href takes predecance over topic href
+# Toc href takes precedence over topic href
 inputs:
   docfx.yml:
   docs/TOC.yml: |

--- a/src/docfx/build/toc/parser/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsParser.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Docs.Build
                 var (resolvedTopicHref, resolvedTopicName, document) = ProcessTopicItem(topicUid, topicHref);
 
                 // set resolved href back
-                tocModelItem.Href = resolvedTopicHref ?? resolvedTopicItemFromTocHref?.Href;
+                tocModelItem.Href = resolvedTocHref ?? resolvedTopicHref ?? resolvedTopicItemFromTocHref?.Href;
                 tocModelItem.TocHref = resolvedTocHref;
                 tocModelItem.Name = tocModelItem.Name ?? resolvedTopicName;
                 if (subChildren != null)


### PR DESCRIPTION
This is to fix https://ceapex.visualstudio.com/Engineering/_git/Docs.DocFX.Impact/pullrequest/8270?_a=files

The logic used to sit [here](https://github.com/dotnet/docfx/commit/a15dfbf71195468d425f8ec30c9bcd3c8e2ec7c3#diff-ce731c2056d902c67ef27c307fa338abL56)