### PR TITLE
cache toc model, avoid to load twice for building toc and building toc map

### DIFF
--- a/src/docfx/build/context/Cache.cs
+++ b/src/docfx/build/context/Cache.cs
@@ -41,12 +41,10 @@ namespace Microsoft.Docs.Build
             })).Value;
 
         public (List<Error>, TableOfContentsModel, List<(Document doc, string herf)>, List<Document>) LoadTocModel(Context context, Document file)
-        {
-            return _tocModelCache.GetOrAdd(
+            => _tocModelCache.GetOrAdd(
                 file.FilePath,
                 new Lazy<(List<Error>, TableOfContentsModel, List<(Document doc, string herf)>, List<Document>)>(
                     () => BuildTableOfContents.Load(context, file))).Value;
-        }
 
         private string GetKeyFromFile(Document file)
         {

--- a/src/docfx/build/context/Cache.cs
+++ b/src/docfx/build/context/Cache.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Docs.Build
     {
         private readonly ConcurrentDictionary<string, Lazy<(List<Error>, JToken)>> _tokenCache = new ConcurrentDictionary<string, Lazy<(List<Error>, JToken)>>();
         private readonly ConcurrentDictionary<string, Lazy<(List<Error>, JObject)>> _metadataCache = new ConcurrentDictionary<string, Lazy<(List<Error>, JObject)>>();
+        private readonly ConcurrentDictionary<string, Lazy<(List<Error>, TableOfContentsModel, List<(Document doc, string herf)>, List<Document>)>> _tocModelCache = new ConcurrentDictionary<string, Lazy<(List<Error>, TableOfContentsModel, List<(Document doc, string herf)>, List<Document>)>>();
 
         public (List<Error> errors, JToken token) LoadYamlFile(Document file)
             => _tokenCache.GetOrAdd(GetKeyFromFile(file), new Lazy<(List<Error>, JToken)>(() =>
@@ -38,6 +39,14 @@ namespace Microsoft.Docs.Build
                     return ExtractYamlHeader.Extract(reader);
                 }
             })).Value;
+
+        public (List<Error>, TableOfContentsModel, List<(Document doc, string herf)>, List<Document>) LoadTocModel(Context context, Document file)
+        {
+            return _tocModelCache.GetOrAdd(
+                file.FilePath,
+                new Lazy<(List<Error>, TableOfContentsModel, List<(Document doc, string herf)>, List<Document>)>(
+                    () => BuildTableOfContents.Load(context, file))).Value;
+        }
 
         private string GetKeyFromFile(Document file)
         {

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Docs.Build
             var (errors, model, refArticles, refTocs) = context.Cache.LoadTocModel(context, file);
             foreach (var (doc, href) in refArticles)
             {
-                if (!hrefMap.TryGetValue(href, out _) && monikerMap.TryGetValue(doc, out var monikers))
+                if (!hrefMap.ContainsKey(href) && monikerMap.TryGetValue(doc, out var monikers))
                 {
                     hrefMap[href] = monikers;
                 }

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Docs.Build
 
             // load toc model
             var hrefMap = new Dictionary<string, List<string>>();
-            var (errors, model, refArticles, refTocs) = Load(context, file);
+            var (errors, model, refArticles, refTocs) = context.Cache.LoadTocModel(context, file);
             foreach (var (doc, href) in refArticles)
             {
                 if (!hrefMap.TryGetValue(href, out _) && monikerMap.TryGetValue(doc, out var monikers))

--- a/src/docfx/build/toc/TableOfContentsMap.cs
+++ b/src/docfx/build/toc/TableOfContentsMap.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Docs.Build
                     var (errors, _, referencedDocuments, referencedTocs) = BuildTableOfContents.Load(context, fileToBuild);
                     context.Report.Write(fileToBuild.ToString(), errors);
 
-                    tocMapBuilder.Add(fileToBuild, referencedDocuments, referencedTocs);
+                    tocMapBuilder.Add(fileToBuild, referencedDocuments.Select(r => r.doc), referencedTocs);
                 }
                 catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
                 {

--- a/src/docfx/build/toc/TableOfContentsMap.cs
+++ b/src/docfx/build/toc/TableOfContentsMap.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Docs.Build
                     Debug.Assert(tocMapBuilder != null);
                     Debug.Assert(fileToBuild != null);
 
-                    var (errors, _, referencedDocuments, referencedTocs) = BuildTableOfContents.Load(context, fileToBuild);
+                    var (errors, _, referencedDocuments, referencedTocs) = context.Cache.LoadTocModel(context, fileToBuild);
                     context.Report.Write(fileToBuild.ToString(), errors);
 
                     tocMapBuilder.Add(fileToBuild, referencedDocuments.Select(r => r.doc), referencedTocs);


### PR DESCRIPTION
as title, we want to avoid toc model loading twice.

split toc model loading and moniker calculation to pure toc model loading for caching 
simplify the moniker calculation for toc