### PR TITLE
Optimize ParseHeading by removing linq

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Aggregator/TabGroupAggregator.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Aggregator/TabGroupAggregator.cs
@@ -127,8 +127,8 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
         private static Tuple<string, string, LinkInline> ParseHeading(HeadingBlock block)
         {
-            var inlines = block.Inline.ToList();
-            if (inlines.Count == 1 && inlines.First() is LinkInline link)
+            var child = block.Inline.FirstChild;
+            if (child != null && child.NextSibling == null && child is LinkInline link && link.Url.StartsWith("#tab/"))
             {
                 var m = HrefRegex.Match(link.Url);
                 if (m.Success)

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Aggregator/TabGroupAggregator.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Aggregator/TabGroupAggregator.cs
@@ -128,7 +128,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         private static Tuple<string, string, LinkInline> ParseHeading(HeadingBlock block)
         {
             var child = block.Inline.FirstChild;
-            if (child != null && child.NextSibling == null && child is LinkInline link && link.Url.StartsWith("#tab/"))
+            if (child != null && child.NextSibling == null && child is LinkInline link)
             {
                 var m = HrefRegex.Match(link.Url);
                 if (m.Success)


### PR DESCRIPTION
`ParseHeading` method is executed for each heading in each article, the LINQ expression causes too much allocation and slows markdown significantly.

#4037 #4041  cc @qinezh 