### PR TITLE
minor improve expiry random algorithm

### DIFF
--- a/src/docfx/config/GitHubConfig.cs
+++ b/src/docfx/config/GitHubConfig.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Docs.Build
         public readonly bool UpdateRemoteUserCache = false;
 
         /// <summary>
-        /// Determines how long a user remains valid in cache.
+        /// Determines how long at most a user remains valid in cache.
         /// </summary>
         public readonly int UserCacheExpirationInHours = 7 * 24;
 

--- a/src/docfx/lib/github/GitHubUserCache.cs
+++ b/src/docfx/lib/github/GitHubUserCache.cs
@@ -295,7 +295,7 @@ namespace Microsoft.Docs.Build
         }
 
         private DateTime NextExpiry()
-            => DateTime.UtcNow.AddHours((_expirationInHours / 2) + (t_random.Value.NextDouble() * _expirationInHours));
+            => DateTime.UtcNow.AddHours((_expirationInHours / 2) + (t_random.Value.NextDouble() * _expirationInHours / 2));
 
         private async Task ReadCacheFiles()
         {


### PR DESCRIPTION
To make `config.gitHub.userCacheExpirationInHours` more interpretable: it is the expiration time's upper bound.

I will update this value to 2 weeks in OPS.