### PR TITLE
Remove unnecessary dictionary copy

### DIFF
--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -69,18 +69,20 @@ namespace Microsoft.Docs.Build
             using (Progress.Start("Building files"))
             {
                 var recurseDetector = new ConcurrentHashSet<Document>();
-                var monikerMap = new ConcurrentDictionary<Document, List<string>>();
+                var monikerMapBuilder = new MonikerMapBuilder();
 
                 await ParallelUtility.ForEach(
                     docset.BuildScope,
-                    async (file, buildChild) => { monikerMap.TryAdd(file, await BuildOneFile(file, buildChild, null)); },
-                    (file) => { return ShouldBuildFile(file, new ContentType[] { ContentType.Page, ContentType.Redirection, ContentType.Resource }); },
+                    async (file, buildChild) => { monikerMapBuilder.Add(file, await BuildOneFile(file, buildChild, null)); },
+                    (file) => ShouldBuildFile(file, new ContentType[] { ContentType.Page, ContentType.Redirection, ContentType.Resource }),
                     Progress.Update);
+
+                var monikerMap = monikerMapBuilder.Build();
 
                 // Build TOC: since toc file depends on the build result of every node
                 await ParallelUtility.ForEach(
                     GetTableOfContentsScope(docset, tocMap),
-                    (file, buildChild) => { return BuildOneFile(file, buildChild, new MonikerMap(monikerMap)); },
+                    (file, buildChild) => BuildOneFile(file, buildChild, monikerMap),
                     ShouldBuildTocFile,
                     Progress.Update);
 

--- a/src/docfx/build/moniker/MonikerMap.cs
+++ b/src/docfx/build/moniker/MonikerMap.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Microsoft.Docs.Build
 {
@@ -12,11 +11,11 @@ namespace Microsoft.Docs.Build
     /// </summary>
     internal class MonikerMap
     {
-        private readonly Dictionary<Document, List<string>> _documentToMonikers = new Dictionary<Document, List<string>>();
+        private readonly IReadOnlyDictionary<Document, List<string>> _documentToMonikers;
 
         public MonikerMap(ConcurrentDictionary<Document, List<string>> monikerMap)
         {
-            _documentToMonikers = monikerMap.ToDictionary(item => item.Key, item => item.Value);
+            _documentToMonikers = monikerMap;
         }
 
         public bool TryGetValue(Document doc, out List<string> monikers)

--- a/src/docfx/build/moniker/MonikerMapBuilder.cs
+++ b/src/docfx/build/moniker/MonikerMapBuilder.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Docs.Build
+{
+    internal class MonikerMapBuilder
+    {
+        private readonly Dictionary<Document, List<string>> _documentToMonikers;
+
+        public void Add(Document file, List<string> monikers)
+        {
+            _documentToMonikers.Add(file, monikers);
+        }
+
+        public MonikerMap Build()
+        {
+            return new MonikerMap(_documentToMonikers);
+        }
+    }
+}

--- a/src/docfx/build/moniker/MonikerMapBuilder.cs
+++ b/src/docfx/build/moniker/MonikerMapBuilder.cs
@@ -1,17 +1,18 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace Microsoft.Docs.Build
 {
     internal class MonikerMapBuilder
     {
-        private readonly Dictionary<Document, List<string>> _documentToMonikers;
+        private readonly ConcurrentDictionary<Document, List<string>> _documentToMonikers = new ConcurrentDictionary<Document, List<string>>();
 
         public void Add(Document file, List<string> monikers)
         {
-            _documentToMonikers.Add(file, monikers);
+            _documentToMonikers.TryAdd(file, monikers);
         }
 
         public MonikerMap Build()


### PR DESCRIPTION
The current implementation copys a new moniker map for each TOC file. This PR fixes that to use only one moniker map.

![image](https://user-images.githubusercontent.com/511355/53073563-5a805c80-3523-11e9-81a5-ec0eedf2a2bd.png)
