### PR TITLE
🔒support cross process read write lock

### DIFF
--- a/src/docfx/lib/ProcessUtility.cs
+++ b/src/docfx/lib/ProcessUtility.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Docs.Build
     /// </summary>
     internal static class ProcessUtility
     {
-        private const int _defaultLockExpireTimeInSecond = 60 * 20;
+        private const int _defaultLockExpireTimeInSecond = 60 * 60 * 6; /*six hours*/
 
         /// <summary>
         /// Acquire a shared lock for input lock name

--- a/src/docfx/lib/ProcessUtility.cs
+++ b/src/docfx/lib/ProcessUtility.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,6 +18,135 @@ namespace Microsoft.Docs.Build
     /// </summary>
     internal static class ProcessUtility
     {
+        public static async Task<(bool acquired, string acquirer)> AcquireSharedLock(string lockName)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(lockName));
+
+            var acquired = false;
+            var acquirer = (string)null;
+            var lockPath = GetLockFilePath(lockName);
+
+            await ReadAndWriteFile<LockInfo>(lockPath, lockInfo =>
+            {
+                lockInfo = lockInfo ?? new LockInfo();
+
+                if (lockInfo.Type == LockType.Exclusive)
+                {
+                    return Task.FromResult(lockInfo);
+                }
+
+                acquired = true;
+                acquirer = Guid.NewGuid().ToString();
+                lockInfo.Type = LockType.Shared;
+                lockInfo.AcquiredBy.Add(new Acquirer { Id = acquirer, Date = DateTime.UtcNow });
+                return Task.FromResult(lockInfo);
+            });
+
+            return (acquired, acquirer);
+        }
+
+        public static async Task<bool> ReleaseSharedLock(string lockName, string acquirer)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(lockName));
+            Debug.Assert(!string.IsNullOrEmpty(acquirer));
+
+            var released = false;
+            var lockPath = GetLockFilePath(lockName);
+
+            await ReadAndWriteFile<LockInfo>(lockPath, lockInfo =>
+            {
+                lockInfo = lockInfo ?? new LockInfo();
+
+                if (lockInfo.Type != LockType.Shared)
+                {
+                    return Task.FromResult(lockInfo);
+                }
+
+                var removed = lockInfo.AcquiredBy.RemoveAll(i => i.Id == acquirer);
+                Debug.Assert(removed <= 1);
+
+                if (removed <= 0)
+                {
+                    return Task.FromResult(lockInfo);
+                }
+
+                if (!lockInfo.AcquiredBy.Any())
+                {
+                    lockInfo.Type = LockType.None;
+                }
+
+                released = true;
+                return Task.FromResult(lockInfo);
+            });
+
+            return released;
+        }
+
+        public static async Task<(bool acquired, string acquirer)> AcquireExclusiveLock(string lockName)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(lockName));
+
+            var acquired = false;
+            var acquirer = (string)null;
+            var lockPath = GetLockFilePath(lockName);
+
+            await ReadAndWriteFile<LockInfo>(lockPath, lockInfo =>
+            {
+                lockInfo = lockInfo ?? new LockInfo();
+
+                if (lockInfo.Type != LockType.None)
+                {
+                    return Task.FromResult(lockInfo);
+                }
+
+                acquirer = Guid.NewGuid().ToString();
+                acquired = true;
+                lockInfo.Type = LockType.Exclusive;
+                lockInfo.AcquiredBy = new List<Acquirer> { new Acquirer { Id = acquirer, Date = DateTime.UtcNow } };
+                return Task.FromResult(lockInfo);
+            });
+
+            return (acquired, acquirer);
+        }
+
+        public static async Task<bool> ReleaseExclusiveLock(string lockName, string acquirer)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(lockName));
+            Debug.Assert(!string.IsNullOrEmpty(acquirer));
+
+            var released = false;
+            var lockPath = GetLockFilePath(lockName);
+
+            await ReadAndWriteFile<LockInfo>(lockPath, lockInfo =>
+            {
+                lockInfo = lockInfo ?? new LockInfo();
+
+                if (lockInfo.Type != LockType.Exclusive)
+                {
+                    return Task.FromResult(lockInfo);
+                }
+
+                Debug.Assert(lockInfo.AcquiredBy.Count == 1);
+                var removed = lockInfo.AcquiredBy.RemoveAll(i => i.Id == acquirer);
+                Debug.Assert(removed <= 1);
+
+                if (removed <= 0)
+                {
+                    return Task.FromResult(lockInfo);
+                }
+
+                if (!lockInfo.AcquiredBy.Any())
+                {
+                    lockInfo.Type = LockType.None;
+                }
+
+                released = true;
+                return Task.FromResult(lockInfo);
+            });
+
+            return released;
+        }
+
         private static AsyncLocal<object> t_innerCall = new AsyncLocal<object>();
 
         /// <summary>
@@ -94,6 +225,37 @@ namespace Microsoft.Docs.Build
             }
 
             return tcs.Task;
+        }
+
+        /// <summary>
+        /// Reads the content of a file, update content and write back to file in one atomic operation
+        /// </summary>
+        public static async Task ReadAndWriteFile<T>(string path, Func<T, Task<T>> update)
+        {
+            await RunInsideMutex(path, async () =>
+            {
+                var content = File.Exists(path) ? File.ReadAllText(path) : string.Empty;
+                var result = JsonUtility.Deserialize<T>(content);
+
+                var updatedResult = await update(result);
+
+                File.WriteAllText(path, JsonUtility.Serialize(updatedResult));
+            });
+        }
+
+        /// <summary>
+        /// Reads the content of a file, update content and write back to file in one atomic operation
+        /// </summary>
+        public static async Task ReadAndWriteFile(string path, Func<string, Task<string>> update)
+        {
+            await RunInsideMutex(path, async () =>
+            {
+                var content = File.Exists(path) ? File.ReadAllText(path) : null;
+
+                var updatedContent = await update(content);
+
+                File.WriteAllText(path, updatedContent);
+            });
         }
 
         /// <summary>
@@ -250,6 +412,34 @@ namespace Microsoft.Docs.Build
                     retryDelay = Math.Min(retryDelay + 100, 1000);
                 }
             }
+        }
+
+        private static string GetLockFilePath(string lockName)
+        {
+            Directory.CreateDirectory(AppData.MutexRoot);
+            var lockPath = Path.Combine(AppData.MutexRoot, HashUtility.GetMd5Hash(lockName) + "-rw");
+            return lockPath;
+        }
+
+        private enum LockType
+        {
+            None,
+            Shared,
+            Exclusive,
+        }
+
+        private class LockInfo
+        {
+            public LockType Type { get; set; }
+
+            public List<Acquirer> AcquiredBy { get; set; } = new List<Acquirer>();
+        }
+
+        private class Acquirer
+        {
+            public string Id { get; set; }
+
+            public DateTime Date { get; set; }
         }
     }
 }

--- a/test/docfx.Test/common/TestFramework.cs
+++ b/test/docfx.Test/common/TestFramework.cs
@@ -32,8 +32,6 @@ namespace Microsoft.Docs.Build
             Log.ForceVerbose = true;
 
             MakeDebugAssertThrowException();
-            if (Directory.Exists(AppData.MutexRoot))
-                Directory.Delete(AppData.MutexRoot, true);
             return new ParallelExecutor(assemblyName, SourceInformationProvider, DiagnosticMessageSink);
         }
 

--- a/test/docfx.Test/common/TestFramework.cs
+++ b/test/docfx.Test/common/TestFramework.cs
@@ -32,7 +32,8 @@ namespace Microsoft.Docs.Build
             Log.ForceVerbose = true;
 
             MakeDebugAssertThrowException();
-            Directory.Delete(Path.Combine(AppData.MutexRoot), true);
+            if (Directory.Exists(AppData.MutexRoot))
+                Directory.Delete(AppData.MutexRoot, true);
             return new ParallelExecutor(assemblyName, SourceInformationProvider, DiagnosticMessageSink);
         }
 

--- a/test/docfx.Test/common/TestFramework.cs
+++ b/test/docfx.Test/common/TestFramework.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Docs.Build
             Log.ForceVerbose = true;
 
             MakeDebugAssertThrowException();
+            Directory.Delete(Path.Combine(AppData.MutexRoot), true);
             return new ParallelExecutor(assemblyName, SourceInformationProvider, DiagnosticMessageSink);
         }
 

--- a/test/docfx.Test/lib/ProcessUtilityTest.cs
+++ b/test/docfx.Test/lib/ProcessUtilityTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -81,6 +82,112 @@ namespace Microsoft.Docs.Build
                                 });
                         });
             });
+        }
+
+        [Theory]
+        [InlineData(new[] { "a-s:a", "r-s:a" }, new[] { true, true })]
+        [InlineData(new[] { "a-s:a", "r-s:a", "a-s:a", "r-s:a" }, new[] { true, true, true, true })]
+        [InlineData(new[] { "a-s:a", "a-s:a", "r-s:a", "r-s:a" }, new[] { true, true, true, true })]
+        [InlineData(new[] { "a-s:a", "r-s:a", "r-s:a" }, new[] { true, true, false })]
+        [InlineData(new[] { "r-s:a" }, new[] { false })]
+        [InlineData(new[] { "r-s:a", "a-s:a", "r-s:a" }, new[] { false, true, true })]
+        [InlineData(new[] { "a-s:a", "a-s:b", "r-s:b", "r-s:a" }, new[] { true, true, true, true })]
+        [InlineData(new[] { "a-s:a", "a-s:b", "r-s:a", "r-s:b" }, new[] { true, true, true, true })]
+        [InlineData(new[] { "a-s:a", "r-s:a", "a-s:b", "r-s:b" }, new[] { true, true, true, true })]
+
+
+        [InlineData(new[] { "a-e:a", "r-e:a" }, new[] { true, true })]
+        [InlineData(new[] { "a-e:a", "r-e:a", "r-e:a" }, new[] { true, true, false })]
+        [InlineData(new[] { "a-e:a", "a-e:a", "r-e:a" }, new[] { true, false, true })]
+        [InlineData(new[] { "r-e:a" }, new[] { false })]
+        [InlineData(new[] { "r-e:a", "a-e:a", "r-e:a" }, new[] { false, true, true })]
+        [InlineData(new[] { "a-e:a", "r-e:a", "a-e:b", "r-e:b" }, new[] { true, true, true, true })]
+        [InlineData(new[] { "a-e:a", "a-e:b", "r-e:a", "r-e:b" }, new[] { true, true, true, true })]
+        [InlineData(new[] { "a-e:a", "a-e:b", "r-e:b", "r-e:a" }, new[] { true, true, true, true })]
+
+
+        [InlineData(new[] { "a-s:a", "r-s:a", "a-e:a", "r-e:a" }, new[] { true, true, true, true })]
+        [InlineData(new[] { "a-e:a", "r-e:a", "a-s:a", "r-s:a" }, new[] { true, true, true, true })]
+        [InlineData(new[] { "a-s:a", "a-e:a", "r-s:a", "r-e:a" }, new[] { true, false, true, false })]
+        [InlineData(new[] { "a-e:a", "a-s:a", "r-s:a", "r-e:a" }, new[] { true, false, false, true })]
+        [InlineData(new[] { "a-s:a", "a-e:b", "r-s:a", "r-e:b" }, new[] { true, true, true, true })]
+
+        public static async Task RunSharedAndExclusiveLockInOneThread(string[] steps, bool[] results)
+        {
+            Debug.Assert(steps != null);
+            Debug.Assert(results != null);
+            Debug.Assert(steps.Length == results.Length);
+            var guid = Guid.NewGuid().ToString();
+
+            int i = 0;
+            var acquirers = new Dictionary<string, List<string>>();
+            foreach (var step in steps)
+            {
+                var parts = step.Split(new[] { ':' });
+                Debug.Assert(parts.Length == 2);
+                string acquirer = null;
+                bool acquired = false;
+                switch (parts[0])
+                {
+                    case "a-s": // acquire shared lock
+                        (acquired, acquirer) = await ProcessUtility.AcquireSharedLock(guid + parts[1]);
+                        Debug.Assert(acquired == results[i], $"{i}");
+                        if (acquired)
+                        {
+                            var key = "s" + parts[1];
+                            if (!acquirers.TryGetValue(key, out var list))
+                            {
+                                acquirers[key] = list = new List<string>();
+                            }
+                            list.Add(acquirer);
+                        }
+                        break;
+                    case "a-e": // acquire exclusive lock
+                        (acquired, acquirer) = await ProcessUtility.AcquireExclusiveLock(guid + parts[1]);
+                        Debug.Assert(acquired == results[i], $"{i}");
+                        if (acquired)
+                        {
+                            var key = "e" + parts[1];
+                            if (!acquirers.TryGetValue(key, out var list))
+                            {
+                                acquirers[key] = list = new List<string>();
+                            }
+                            list.Add(acquirer);
+
+                            Debug.Assert(list.Count == 1, $"{i}");
+                        }
+                        break;
+                    case "r-s": // release shared lock
+                        string sharedAcquirer = null;
+                        if (acquirers.TryGetValue("s" + parts[1], out var sharedList))
+                        {
+                            Debug.Assert(sharedList.Count >= 1, $"{i}");
+                            sharedAcquirer = sharedList[sharedList.Count - 1];
+                            sharedList.RemoveAt(sharedList.Count - 1);
+                            if (!sharedList.Any())
+                            {
+                                acquirers.Remove("s" + parts[1]);
+                            }
+                        }
+                        var sharedReleased = await ProcessUtility.ReleaseSharedLock(guid + parts[1], sharedAcquirer ?? "not exists");
+                        Debug.Assert(sharedReleased == results[i], $"{i}");
+                        break;
+                    case "r-e": // release exclusive lock
+                        string exclusiveAcquirer = null;
+                        if (acquirers.TryGetValue("e" + parts[1], out var exclusiveList))
+                        {
+                            Debug.Assert(exclusiveList.Count == 1, $"{i}");
+                            exclusiveAcquirer = exclusiveList[exclusiveList.Count - 1];
+                            exclusiveList.RemoveAt(exclusiveList.Count - 1);
+                            acquirers.Remove("e" + parts[1]);
+                        }
+                        var exclusivedReleased = await ProcessUtility.ReleaseExclusiveLock(guid + parts[1], exclusiveAcquirer ?? "not exists");
+                        Debug.Assert(exclusivedReleased == results[i], $"{i}");
+                        break;
+                }
+
+                i++;
+            }
         }
     }
 }

--- a/test/docfx.Test/lib/ProcessUtilityTest.cs
+++ b/test/docfx.Test/lib/ProcessUtilityTest.cs
@@ -119,15 +119,12 @@ namespace Microsoft.Docs.Build
             Debug.Assert(steps.Length == results.Length);
             var guid = Guid.NewGuid().ToString();
 
-            int index = 0;
+            int i = 0;
             var acquirers = new Dictionary<string, List<string>>();
-            var stepsWithIndex = steps.Select(s => (s, index++)).ToArray();
 
-            await ParallelUtility.ForEach(stepsWithIndex, async stepWithIndex =>
+            foreach(var step in steps)
             {
-                var (step, i) = stepWithIndex;
-                await Task.Delay(100 * i);
-
+                await Task.Yield();
                 var parts = step.Split(new[] { ':' });
                 Debug.Assert(parts.Length == 2);
                 string acquirer = null;
@@ -190,7 +187,9 @@ namespace Microsoft.Docs.Build
                         Debug.Assert(exclusivedReleased == results[i], $"{i}");
                         break;
                 }
-            });
+
+                i++;
+            }
         }
     }
 }


### PR DESCRIPTION
1. implement init cross process shared/exclusive lock.
2. add unit tests
3. add default expired time, in case lock holder crashed

> NOTE: All acquiring to shared/exclusive lock returns immediately, without waiting, the return value indicate whether lock is acquired or not. 

>NOTE: Since we using asynchronous programming model, the thread info can't be used for tracking acquired lock, we are using `acquirer` info returned from AcquireXXXLock, these info must be provided to ReleaseXXXLock.

generate way to implement share/exclusive lock
```c#
//process lock

//ref count

//process lock release
```
