### PR TITLE
🧹clean up version support for file downloading

### DIFF
--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -223,7 +223,6 @@ namespace Microsoft.Docs.Build
                     ? null
                     : new DependencyLockModel
                     {
-                        Downloads = sourceDependencyLock.Downloads,
                         Hash = sourceDependencyLock.Hash,
                         Commit = sourceDependencyLock.Commit,
                         Git = new Dictionary<string, DependencyLockModel>(sourceDependencyLock.Git.Concat(new[] { KeyValuePair.Create($"{sourceRemote}#{sourceBranch}", sourceDependencyLock) })),

--- a/src/docfx/config/ConfigLoader.cs
+++ b/src/docfx/config/ConfigLoader.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Docs.Build
                 {
                     if (extend is JValue value && value.Value is string str)
                     {
-                        var (_, filePath) = RestoreMap.GetFileRestorePath(docsetPath, str, dependencyVersion: null);
+                        var (_, filePath) = RestoreMap.GetFileRestorePath(docsetPath, str);
                         var (extendErros, extendConfigObject) = LoadConfigObject(str, filePath);
                         errors.AddRange(extendErros);
                         JsonUtility.Merge(result, extendConfigObject);

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -85,14 +85,11 @@ namespace Microsoft.Docs.Build
 
                 // restore urls except extend url
                 var restoreUrls = extendedConfig.GetFileReferences().Where(HrefUtility.IsHttpHref).ToList();
-                var downloadVersions = await RestoreFile.Restore(restoreUrls, extendedConfig, dependencyLock, @implicit);
+                await RestoreFile.Restore(restoreUrls, extendedConfig, @implicit);
 
                 var generatedLock = new DependencyLockModel
                 {
                     Git = gitVersions.OrderBy(g => g.Key).ToDictionary(k => k.Key, v => v.Value),
-
-                    // Downloads' dependency lock is not supported by the services which store these files to be downloaded
-                    // Downloads = downloadVersions.OrderBy(g => g.Key).ToDictionary(k => k.Key, v => v.Value),
                 };
 
                 // save dependency lock if it's root entry

--- a/src/docfx/restore/RestoreGit.cs
+++ b/src/docfx/restore/RestoreGit.cs
@@ -70,7 +70,6 @@ namespace Microsoft.Docs.Build
                     new DependencyLockModel
                     {
                         Git = childDependencyLock.Git,
-                        Downloads = childDependencyLock.Downloads,
                         Commit = child.Restored.gitVersion.Commit,
                     });
             }

--- a/src/docfx/restore/lock/DependencyLock.cs
+++ b/src/docfx/restore/lock/DependencyLock.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Docs.Build
                 }
             }
 
-            var (_, restoredLockFile) = RestoreMap.GetFileRestorePath(docset, dependencyLockPath, dependencyVersion: null);
+            var (_, restoredLockFile) = RestoreMap.GetFileRestorePath(docset, dependencyLockPath);
 
             var content = await ProcessUtility.ReadFile(restoredLockFile);
 

--- a/src/docfx/restore/lock/DependencyLockModel.cs
+++ b/src/docfx/restore/lock/DependencyLockModel.cs
@@ -8,7 +8,5 @@ namespace Microsoft.Docs.Build
     internal class DependencyLockModel : DependencyVersion
     {
         public IReadOnlyDictionary<string, DependencyLockModel> Git { get; set; } = new Dictionary<string, DependencyLockModel>();
-
-        public IReadOnlyDictionary<string, DependencyVersion> Downloads { get; set; } = new Dictionary<string, DependencyVersion>();
     }
 }


### PR DESCRIPTION
this is the first step to support dependency file -> clean up versioning support for file downloading

right now our file system doesn't provide any file version supporting, so we are going to:

1. always download file to one fixed place, re-use this place.
2. always add process lock to before reading/writing to this file
3. file should be released after content being loaded to process
4. same url/file should always be loaded once and used forever during this `build`,  in case the file changed in the second loading.