### PR TITLE
🐞Check publish items before writing output

### DIFF
--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -156,7 +156,6 @@ namespace Microsoft.Docs.Build
         {
             try
             {
-                var model = default(object);
                 var publishItem = default(PublishItem);
                 var errors = Enumerable.Empty<Error>();
 
@@ -166,11 +165,11 @@ namespace Microsoft.Docs.Build
                         (errors, publishItem) = BuildResource.Build(context, file);
                         break;
                     case ContentType.Page:
-                        (errors, model, publishItem) = await BuildPage.Build(context, file, tocMap, buildChild);
+                        (errors, publishItem) = await BuildPage.Build(context, file, tocMap, buildChild);
                         break;
                     case ContentType.TableOfContents:
                         // TODO: improve error message for toc monikers overlap
-                        (errors, model, publishItem) = BuildTableOfContents.Build(context, file, monikerMap);
+                        (errors, publishItem) = BuildTableOfContents.Build(context, file, monikerMap);
                         break;
                     case ContentType.Redirection:
                         (errors, publishItem) = BuildRedirection.Build(context, file);
@@ -181,19 +180,6 @@ namespace Microsoft.Docs.Build
                 if (hasErrors)
                 {
                     context.PublishModelBuilder.MarkError(file);
-                    return publishItem.Monikers;
-                }
-
-                if (context.PublishModelBuilder.TryAdd(file, publishItem))
-                {
-                    if (model is string str)
-                    {
-                        publishItem.Hash = context.Output.WriteTextWithHash(str, publishItem.Path);
-                    }
-                    else if (model != null)
-                    {
-                        publishItem.Hash = context.Output.WriteJsonWithHash(model, publishItem.Path);
-                    }
                 }
 
                 return publishItem.Monikers;

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Docs.Build
 {
     internal static class BuildPage
     {
-        public static async Task<(IEnumerable<Error> errors, object result, PublishItem publishItem)> Build(
+        public static async Task<(IEnumerable<Error> errors, PublishItem publishItem)> Build(
             Context context,
             Document file,
             TableOfContentsMap tocMap,
@@ -48,7 +48,8 @@ namespace Microsoft.Docs.Build
                 errors.AddRange(contributorErrors);
 
             var isPage = schema.Attribute is PageSchemaAttribute;
-            var (output, outputPath, extensionData) = ApplyTemplate(context, file, model, isPage);
+            var outputPath = file.GetOutputPath(model.Monikers, isPage);
+            var (output, extensionData) = ApplyTemplate(file, model, isPage);
 
             var publishItem = new PublishItem
             {
@@ -59,7 +60,25 @@ namespace Microsoft.Docs.Build
                 ExtensionData = extensionData,
             };
 
-            return (errors, output, publishItem);
+            if (context.PublishModelBuilder.TryAdd(file, publishItem))
+            {
+                if (output is string str)
+                {
+                    publishItem.Hash = context.Output.WriteTextWithHash(str, publishItem.Path);
+                }
+                else
+                {
+                    publishItem.Hash = context.Output.WriteJsonWithHash(output, publishItem.Path);
+                }
+
+                if (file.Docset.Legacy && extensionData != null)
+                {
+                    var metadataPath = outputPath.Substring(0, outputPath.Length - ".raw.page.json".Length) + ".mta.json";
+                    context.Output.WriteJson(extensionData, metadataPath);
+                }
+            }
+
+            return (errors, publishItem);
         }
 
         private static async Task<(List<Error> errors, Schema schema, PageModel model, FileMetadata metadata)>
@@ -192,31 +211,24 @@ namespace Microsoft.Docs.Build
             return string.IsNullOrEmpty(html.OuterHtml) ? "<div></div>" : html.OuterHtml;
         }
 
-        private static (object output, string outputPath, JObject extensionData) ApplyTemplate(
-            Context context, Document file, PageModel model, bool isPage)
+        private static (object output, JObject extensionData) ApplyTemplate(Document file, PageModel model, bool isPage)
         {
-            var outputPath = file.GetOutputPath(model.Monikers, isPage);
-
             if (!file.Docset.Config.Output.Json && file.Docset.Template != null)
             {
-                return (file.Docset.Template.Render(model, file), outputPath, null);
+                return (file.Docset.Template.Render(model, file), null);
             }
 
             if (file.Docset.Legacy)
             {
                 if (isPage)
                 {
-                    var (output, extensionData) = TemplateTransform.Transform(model, file);
-                    var metadataPath = outputPath.Substring(0, outputPath.Length - ".raw.page.json".Length) + ".mta.json";
-                    context.Output.WriteJson(extensionData, metadataPath);
-
-                    return (output, outputPath, extensionData);
+                    return TemplateTransform.Transform(model, file);
                 }
 
-                return (model, outputPath, null);
+                return (model, null);
             }
 
-            return (model, outputPath, isPage ? JsonUtility.ToJObject(model.Metadata) : null);
+            return (model, isPage ? JsonUtility.ToJObject(model.Metadata) : null);
         }
     }
 }

--- a/src/docfx/build/redirection/BuildRedirection.cs
+++ b/src/docfx/build/redirection/BuildRedirection.cs
@@ -14,7 +14,15 @@ namespace Microsoft.Docs.Build
 
             var (errors, monikers) = context.MonikerProvider.GetFileLevelMonikers(file, context.MetadataProvider);
 
-            if (file.Docset.Legacy)
+            var publishItem = new PublishItem
+            {
+                Url = file.SiteUrl,
+                Locale = file.Docset.Locale,
+                RedirectUrl = file.RedirectionUrl,
+                Monikers = monikers,
+            };
+
+            if (context.PublishModelBuilder.TryAdd(file, publishItem) && file.Docset.Legacy)
             {
                 var outputPath = file.GetOutputPath(monikers, rawPage: true);
                 var metadataPath = outputPath.Substring(0, outputPath.Length - ".raw.page.json".Length) + ".mta.json";
@@ -30,14 +38,6 @@ namespace Microsoft.Docs.Build
                 context.Output.WriteText("{}", outputPath);
                 context.Output.WriteJson(metadata, metadataPath);
             }
-
-            var publishItem = new PublishItem
-            {
-                Url = file.SiteUrl,
-                Locale = file.Docset.Locale,
-                RedirectUrl = file.RedirectionUrl,
-                Monikers = monikers,
-            };
 
             return (errors, publishItem);
         }


### PR DESCRIPTION
Fixes #4113. Even though we had a test case, the error is unlikely to happen during test because test files are small.

This PR ensures we always check publish manifest before writing any output.