### PR TITLE
📈 Limit telemetry flush time to 2s

### DIFF
--- a/src/docfx/lib/log/Telemetry.cs
+++ b/src/docfx/lib/log/Telemetry.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Metrics;

--- a/src/docfx/lib/log/Telemetry.cs
+++ b/src/docfx/lib/log/Telemetry.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Metrics;
 
@@ -63,8 +65,9 @@ namespace Microsoft.Docs.Build
 
         public static void Flush()
         {
-            // Default timeout of 100 sec is used
-            s_telemetryClient.Flush();
+            // Default timeout of TelemetryClient.Flush is 100 seconds,
+            // but we only want to wait for 2 seconds at most.
+            Task.WaitAny(Task.Run(s_telemetryClient.Flush), Task.Delay(2000));
         }
     }
 }


### PR DESCRIPTION
We've seen problems with flushing telemetry