### PR TITLE
⏬ Keep using HtmlAgilityPack 1.4.9 during migration

### DIFF
--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -408,3 +408,23 @@ outputs:
   build.log: |
     ["warning","yaml-header-not-object","Expect yaml header to be an object, but got a scalar","docs/a.md"]
 ---
+# Handling malformed HTML tags using HtmlAgilityPack 1.4.9
+inputs:
+  docfx.yml:
+  docs/a.md: |
+    1.  a
+        <UL><LI><LI></UL>
+    2.  b
+        <UL><LI>
+    ## c
+outputs:
+  docs/a.json: |
+    content: |
+      <ol>
+        <li>a
+          <ul><li><li></li></li></ul>
+        <li>b
+          <ul><li></li></ul></li>
+        </li>
+      </ol>
+      <h2 id="c">c</h2>

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -18,7 +18,8 @@
   <ItemGroup>
     <PackageReference Include="DotLiquid" Version="2.0.298" />
     <PackageReference Include="Glob" Version="1.1.1" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.9.0" />
+    <!-- To keep HTML intact during v3 migration, keep using HtmlAgilityPack 1.4.9 -->
+    <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.267" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.9.1" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -8,6 +8,7 @@
     <RootNamespace>Microsoft.Docs.Build</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackAsTool>true</PackAsTool>
+    <NoWarn>NU1701</NoWarn>
     <TreatWarningsAsErrors Condition="'$(Configuration)'=='Release'">true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/docfx/lib/ReflectionUtility.cs
+++ b/src/docfx/lib/ReflectionUtility.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Microsoft.Docs.Build
+{
+    internal static class ReflectionUtility
+    {
+        public static Func<T, TField> CreateInstanceFieldGetter<T, TField>(string fieldName)
+        {
+            var field = typeof(T).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+            var getter = new DynamicMethod(Guid.NewGuid().ToString(), typeof(TField), new Type[1] { typeof(T) }, true);
+            var il = getter.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, field);
+            il.Emit(OpCodes.Ret);
+            return (Func<T, TField>)getter.CreateDelegate(typeof(Func<T, TField>));
+        }
+
+        internal static TDelegate CreateInstanceMethod<T, TDelegate>(string methodName, Type[] types = null) where TDelegate : Delegate
+        {
+            var methodInfo = typeof(T).GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance, null, types, null);
+
+            return (TDelegate)Delegate.CreateDelegate(typeof(TDelegate), null, methodInfo, throwOnBindFailure: true);
+        }
+    }
+}

--- a/src/docfx/lib/YamlUtility.cs
+++ b/src/docfx/lib/YamlUtility.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using System.Reflection;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
 
@@ -22,12 +21,8 @@ namespace Microsoft.Docs.Build
     {
         public const string YamlMimePrefix = "YamlMime:";
 
-        private static readonly MethodInfo s_setLineInfo = typeof(JToken).GetMethod(
-            "SetLineInfo",
-            BindingFlags.NonPublic | BindingFlags.Instance,
-            null,
-            new[] { typeof(int), typeof(int) },
-            null);
+        private static readonly Action<JToken, int, int> s_setLineInfo =
+            ReflectionUtility.CreateInstanceMethod<JToken, Action<JToken, int, int>>("SetLineInfo", new[] { typeof(int), typeof(int) });
 
         public static string ReadMime(TextReader reader)
         {
@@ -200,7 +195,7 @@ namespace Microsoft.Docs.Build
         private static JToken PopulateLineInfoToJToken(JToken token, YamlNode node)
         {
             Debug.Assert(token != null);
-            s_setLineInfo.Invoke(token, new object[] { node.Start.Line, node.Start.Column });
+            s_setLineInfo(token, node.Start.Line, node.Start.Column);
             return token;
         }
     }


### PR DESCRIPTION
Fixes HTML normalization problems caused by different HtmlAgilityPack version: https://ceapex.visualstudio.com/Engineering/_workitems/edit/73033/

A post migration solution might be to keep the original HTML intact when we do html transformation.