### PR TITLE
Update System.CommandLine

### DIFF
--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Octokit" Version="0.32.0" />
     <PackageReference Include="Stubble.Core" Version="1.2.7" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="All" />
-    <PackageReference Include="System.CommandLine" Version="0.1.0-e171109-2" />
+    <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180503-2" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
     <PackageReference Include="YamlDotNet" Version="5.4.0" />
   </ItemGroup>


### PR DESCRIPTION
Fixes https://ceapex.visualstudio.com/Engineering/_build/results?buildId=45293

```
D:\a\1\s\src\docfx\docfx.csproj : warning NU1603: docfx depends on System.CommandLine (>= 0.1.0-e171109-2) but System.CommandLine 0.1.0-e171109-2 was not found. An approximate best match of System.CommandLine 1.0.0.1 was resolved. [D:\a\1\s\test\docfx.Test\docfx.Test.csproj]
D:\a\1\s\test\docfx.Test\docfx.Test.csproj : warning NU1603: docfx depends on System.CommandLine (>= 0.1.0-e171109-2) but System.CommandLine 0.1.0-e171109-2 was not found. An approximate best match of System.CommandLine 1.0.0.1 was resolved.
Build started, please wait...
D:\a\1\s\test\docfx.Test\docfx.Test.csproj : warning NU1603: docfx depends on System.CommandLine (>= 0.1.0-e171109-2) but System.CommandLine 0.1.0-e171109-2 was not found. An approximate best match of System.CommandLine 1.0.0.1 was resolved.
D:\a\1\s\src\docfx\docfx.csproj : warning NU1603: docfx depends on System.CommandLine (>= 0.1.0-e171109-2) but System.CommandLine 0.1.0-e171109-2 was not found. An approximate best match of System.CommandLine 1.0.0.1 was resolved.
cli\Program.cs(6,7): error CS0138: A 'using namespace' directive can only be applied to namespaces; 'CommandLine' is a type not a namespace. Consider a 'using static' directive instead [D:\a\1\s\src\docfx\docfx.csproj]
Error: dotnet test -c Debug
At D:\a\1\s\build.ps1:5 char:9
+         throw ("Error: " + $cmd)
+         ~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (Error: dotnet test -c Debug:String) [], RuntimeException
    + FullyQualifiedErrorId : Error: dotnet test -c Debug
```