### PR TITLE
🦑Fix GitHub user cache making unnecessary API calls

### DIFF
--- a/src/docfx/lib/github/GitHubAccessor.cs
+++ b/src/docfx/lib/github/GitHubAccessor.cs
@@ -87,8 +87,8 @@ namespace Microsoft.Docs.Build
 
                 return (null, new GitHubUser
                 {
-                    Id = commit.Author.Id,
-                    Login = commit.Author.Login,
+                    Id = commit.Author?.Id,
+                    Login = commit.Author?.Login,
                     Name = commit.Commit.Author.Name,
                     Emails = new[] { commit.Commit.Author.Email },
                 });

--- a/src/docfx/lib/github/GitHubAccessor.cs
+++ b/src/docfx/lib/github/GitHubAccessor.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public async Task<(Error, string login)> GetLoginByCommit(string repoOwner, string repoName, string commitSha)
+        public async Task<(Error, GitHubUser)> GetUserByCommit(string repoOwner, string repoName, string commitSha)
         {
             Debug.Assert(!string.IsNullOrEmpty(repoOwner));
             Debug.Assert(!string.IsNullOrEmpty(repoName));
@@ -84,7 +84,14 @@ namespace Microsoft.Docs.Build
                 var commit = await RetryUtility.Retry(
                     () => UseResource(() => _client.Repository.Commit.Get(repoOwner, repoName, commitSha)),
                     ex => ex is OperationCanceledException);
-                return (null, commit.Author?.Login);
+
+                return (null, new GitHubUser
+                {
+                    Id = commit.Author.Id,
+                    Login = commit.Author.Login,
+                    Name = commit.Commit.Author.Name,
+                    Emails = new[] { commit.Commit.Author.Email },
+                });
             }
             catch (NotFoundException)
             {

--- a/src/docfx/lib/github/GitHubUser.cs
+++ b/src/docfx/lib/github/GitHubUser.cs
@@ -22,8 +22,6 @@ namespace Microsoft.Docs.Build
 
         public bool IsExpired() => Expiry != null && Expiry < DateTime.UtcNow;
 
-        public bool IsPartial() => !Id.HasValue && !string.IsNullOrEmpty(Login) && Emails.Length > 0;
-
         public Contributor ToContributor()
         {
             return new Contributor
@@ -33,15 +31,6 @@ namespace Microsoft.Docs.Build
                 DisplayName = Name,
                 ProfileUrl = "https://github.com/" + Login,
             };
-        }
-
-        public void Merge(GitHubUser user)
-        {
-            Id = !user.IsValid() ? Id : user.Id;
-            Login = string.IsNullOrEmpty(user.Login) ? Login : user.Login;
-            Name = string.IsNullOrEmpty(user.Name) ? Name : user.Name;
-            Emails = Emails.Concat(user.Emails).Distinct().ToArray();
-            Expiry = Expiry > user.Expiry ? Expiry : user.Expiry;
         }
     }
 }

--- a/test/docfx.Test/lib/GitHubAccessorTest.cs
+++ b/test/docfx.Test/lib/GitHubAccessorTest.cs
@@ -25,17 +25,18 @@ namespace Microsoft.Docs.Build
         }
 
         [Theory]
-        [InlineData("docascode", "docfx-test-dependencies", "c467c848311ccd2550fdb25a77ef26f9d8a33d00", null, "OsmondJiang")]
-        [InlineData("docascode", "docfx-test-dependencies", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", null, null)]
-        [InlineData("docascode", "this-repo-does-not-exists", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", null, null)]
-        public async Task GetLoginByCommit(string repoOwner, string repoName, string commit, string errorCode, string login)
+        [InlineData("docascode", "docfx-test-dependencies", "c467c848311ccd2550fdb25a77ef26f9d8a33d00", null, "OsmondJiang", 19990166)]
+        [InlineData("docascode", "docfx-test-dependencies", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", null, null, null)]
+        [InlineData("docascode", "this-repo-does-not-exists", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", null, null, null)]
+        public async Task GetUserByCommit(string repoOwner, string repoName, string commit, string errorCode, string login, int? id)
         {
-            var (error, name) = await _github.GetLoginByCommit(repoOwner, repoName, commit);
+            var (error, user) = await _github.GetUserByCommit(repoOwner, repoName, commit);
 
             // skip check if the machine exceeds the GitHub API rate limit
             if (error?.Code != "github-api-failed")
             {
-                Assert.Equal(login, name);
+                Assert.Equal(login, user?.Login);
+                Assert.Equal(id, user?.Id);
                 Assert.Equal(errorCode, error?.Code);
             }
         }


### PR DESCRIPTION
- Make `GetUserByCommit` return a user to save a call to `GetUserByLogin`
- Ensure cache read and update are synchronized (per login or email) so we don't make duplicated calls of  same user. 
- Fix invalid user cache record when `GetUserByCommit` returns `default` due to commit not found

#4174 #4139 