### PR TITLE
add line info to test which only run during deployment build

### DIFF
--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -169,7 +169,7 @@ environments:
 outputs:
   docs/a.json:
   build.log: |
-    ["warning","link-is-dependency","File 'README.md' referenced by link '~/dep/README.md' will not be built because it is from a dependency docset","docs/a.md"]
+    ["warning","link-is-dependency","File 'README.md' referenced by link '~/dep/README.md' will not be built because it is from a dependency docset","docs/a.md","",1,1]
 ---
 # Restored repo should be always retrieved
 repos:


### PR DESCRIPTION
fix https://ceapex.visualstudio.com/Engineering/_build/results?buildId=45858

the reason why it's not discovered during PR build and local build is that this test is not executed until deploy ci build.

