### PR TITLE
🌐Bulk get GitHub commits

### DIFF
--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -84,6 +84,7 @@ namespace Microsoft.Docs.Build
         public void Dispose()
         {
             GitCommitProvider.Dispose();
+            GitHubUserCache.Dispose();
         }
     }
 }

--- a/src/docfx/config/GitHubConfig.cs
+++ b/src/docfx/config/GitHubConfig.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Determines how long at most a user remains valid in cache.
         /// </summary>
-        public readonly int UserCacheExpirationInHours = 7 * 24;
+        public readonly int UserCacheExpirationInHours = 30 * 24;
 
         /// <summary>
         /// Determines whether to resolve git commit user and GitHub user.

--- a/src/docfx/lib/github/GitHubAccessor.cs
+++ b/src/docfx/lib/github/GitHubAccessor.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Octokit;
 

--- a/src/docfx/lib/github/GitHubUser.cs
+++ b/src/docfx/lib/github/GitHubUser.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Docs.Build
 
         public DateTime? Expiry { get; set; }
 
-        public bool IsValid() => Id.HasValue;
+        public bool IsValid() => Id.HasValue && !IsExpired();
 
         public bool IsExpired() => Expiry != null && Expiry < DateTime.UtcNow;
 

--- a/src/docfx/lib/github/GitHubUserCache.cs
+++ b/src/docfx/lib/github/GitHubUserCache.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -15,7 +14,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Docs.Build
 {
-    internal class GitHubUserCache
+    internal class GitHubUserCache : IDisposable
     {
         public IEnumerable<GitHubUser> Users => _usersByLogin.Values.Concat(_usersByEmail.Values).Distinct();
 
@@ -23,7 +22,7 @@ namespace Microsoft.Docs.Build
         internal Func<string, Task<(Error, GitHubUser)>> _getUserByLoginFromGitHub;
 
         // calls GitHubAccessor.GetLoginByCommit, which ohly for private use, and tests can swap this out
-        internal Func<string, string, string, Task<(Error, GitHubUser)>> _getUserByCommitFromGitHub;
+        internal Func<string, string, string, Task<(Error, IEnumerable<GitHubUser>)>> _getUsersByCommitFromGitHub;
 
         private static int s_randomSeed = Environment.TickCount;
         private static ThreadLocal<Random> t_random = new ThreadLocal<Random>(() => new Random(Interlocked.Increment(ref s_randomSeed)));
@@ -31,11 +30,7 @@ namespace Microsoft.Docs.Build
         private readonly Dictionary<string, GitHubUser> _usersByLogin = new Dictionary<string, GitHubUser>(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, GitHubUser> _usersByEmail = new Dictionary<string, GitHubUser>(StringComparer.OrdinalIgnoreCase);
 
-        // A lock to ensure mutations to `_usersByLogin` and `_usersByEmail` is sequential.
-        private readonly object _lock = new object();
-
-        // A lock to ensure async operations with the same key are sequential.
-        private readonly ConcurrentDictionary<string, SemaphoreSlim> _syncRoots = new ConcurrentDictionary<string, SemaphoreSlim>(StringComparer.OrdinalIgnoreCase);
+        private readonly SemaphoreSlim _syncRoot = new SemaphoreSlim(1, 1);
 
         private readonly string _url = null;
         private readonly string _content = null;
@@ -51,7 +46,7 @@ namespace Microsoft.Docs.Build
         {
             _cachePath = cachePath;
             _expirationInHours = expirationInHours;
-            UnsafeUpdateUsers(users);
+            UpdateUsers(users);
         }
 
         private GitHubUserCache(Docset docset, string cachePath)
@@ -60,7 +55,7 @@ namespace Microsoft.Docs.Build
 
             var github = new GitHubAccessor(docset.Config.GitHub.AuthToken);
             _getUserByLoginFromGitHub = github.GetUserByLogin;
-            _getUserByCommitFromGitHub = github.GetUserByCommit;
+            _getUsersByCommitFromGitHub = github.GetUsersByCommit;
             _expirationInHours = docset.Config.GitHub.UserCacheExpirationInHours;
             _cachePath = cachePath;
         }
@@ -106,13 +101,13 @@ namespace Microsoft.Docs.Build
             if (string.IsNullOrEmpty(login))
                 return default;
 
-            return Synchronized(login, GetByLoginCore);
+            return Synchronized(GetByLoginCore);
 
             async Task<(Error error, GitHubUser user)> GetByLoginCore()
             {
                 Telemetry.TrackCacheTotalCount(TelemetryName.GitHubUserCache);
-                var existingUser = TryGetByLogin(login);
-                if (existingUser != null)
+
+                if (_usersByLogin.TryGetValue(login, out var existingUser))
                 {
                     if (existingUser.IsValid())
                         return (null, existingUser);
@@ -138,13 +133,13 @@ namespace Microsoft.Docs.Build
             if (string.IsNullOrEmpty(authorEmail))
                 return default;
 
-            return Synchronized(authorEmail, GetByCommitCore);
+            return Synchronized(GetByCommitCore);
 
             async Task<(Error, GitHubUser)> GetByCommitCore()
             {
                 Telemetry.TrackCacheTotalCount(TelemetryName.GitHubUserCache);
-                var existingUser = TryGetByEmail(authorEmail);
-                if (existingUser != null || string.IsNullOrEmpty(repoOwner) || string.IsNullOrEmpty(repoName))
+
+                if (_usersByEmail.TryGetValue(authorEmail, out var existingUser) || string.IsNullOrEmpty(repoOwner) || string.IsNullOrEmpty(repoName))
                 {
                     if (existingUser?.IsValid() ?? false)
                         return (null, existingUser);
@@ -154,55 +149,59 @@ namespace Microsoft.Docs.Build
                 Log.Write($"Calling GitHub commit API to resolve {authorEmail}");
                 Telemetry.TrackCacheMissCount(TelemetryName.GitHubUserCache);
 
-                var (error, user) = await _getUserByCommitFromGitHub(repoOwner, repoName, commitSha);
+                var (error, users) = await _getUsersByCommitFromGitHub(repoOwner, repoName, commitSha);
 
                 // When GetUserByCommit failed, it could either the commit is not found or the user is not found,
                 // only mark the email as invalid when the user is not found
-                if (user != null)
+                if (users != null)
                 {
-                    UpdateUser(user);
+                    UpdateUsers(users);
                 }
-                return (error, user);
+
+                return (error, _usersByEmail.TryGetValue(authorEmail, out var user) && user.IsValid() ? user : null);
             }
         }
 
-        public async Task<Error> SaveChanges(Config config)
+        public Task<Error> SaveChanges(Config config)
         {
             if (!_updated)
             {
-                return null;
+                return Task.FromResult<Error>(null);
             }
 
-            var remainingRetries = 3;
-            var (error, collide) = await SaveChangesCore(config, _etag);
-            while (collide && remainingRetries-- > 0)
+            return Synchronized(SaveChangesCore);
+
+            async Task<Error> SaveChangesCore()
             {
-                HttpResponseMessage response;
-                try
+                var remainingRetries = 3;
+                var (error, collide) = await SaveChanges(config, _etag);
+                while (collide && remainingRetries-- > 0)
                 {
-                    response = await HttpClientUtility.GetAsync(_url, config);
+                    HttpResponseMessage response;
+                    try
+                    {
+                        response = await HttpClientUtility.GetAsync(_url, config);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw Errors.DownloadFailed(_url, ex.Message).ToException(ex);
+                    }
+                    var content = await response.EnsureSuccessStatusCode().Content.ReadAsStringAsync();
+                    ReadCache(content);
+                    (error, collide) = await SaveChanges(config, response.Headers.ETag);
                 }
-                catch (Exception ex)
-                {
-                    throw Errors.DownloadFailed(_url, ex.Message).ToException(ex);
-                }
-                var content = await response.EnsureSuccessStatusCode().Content.ReadAsStringAsync();
-                ReadCache(content);
-                (error, collide) = await SaveChangesCore(config, response.Headers.ETag);
+                return error;
             }
-            return error;
         }
 
-        public async Task<(Error error, bool collide)> SaveChangesCore(Config config, EntityTagHeaderValue etag)
+        public void Dispose()
         {
-            string file;
-            lock (_lock)
-            {
-                file = JsonUtility.Serialize(new GitHubUserCacheFile
-                {
-                    Users = Users.ToArray(),
-                });
-            }
+            _syncRoot.Dispose();
+        }
+
+        private async Task<(Error error, bool collide)> SaveChanges(Config config, EntityTagHeaderValue etag)
+        {
+            var file = JsonUtility.Serialize(new GitHubUserCacheFile { Users = Users.ToArray() });
 
             await SaveLocal(file);
             if (config.GitHub.UpdateRemoteUserCache && _url != null)
@@ -242,36 +241,6 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private GitHubUser TryGetByLogin(string login)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(login));
-
-            lock (_lock)
-            {
-                return _usersByLogin.TryGetValue(login, out var user) && !user.IsExpired() ? user : null;
-            }
-        }
-
-        private GitHubUser TryGetByEmail(string email)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(email));
-
-            lock (_lock)
-            {
-                return _usersByEmail.TryGetValue(email, out var user) && !user.IsExpired() ? user : null;
-            }
-        }
-
-        private void UpdateUser(GitHubUser user)
-        {
-            lock (_lock)
-            {
-                UnsafeUpdateUser(user);
-
-                _updated = true;
-            }
-        }
-
         /// <summary>
         /// Update the cache index by login/email. It can have 3 forms:
         ///
@@ -279,7 +248,7 @@ namespace Microsoft.Docs.Build
         /// 2. User missing with the specified login: { "login": "..." }
         /// 3. User missing with the specified email: { "emails": [ "..." ] }
         /// </summary>
-        private void UnsafeUpdateUser(GitHubUser user)
+        private void UpdateUser(GitHubUser user)
         {
             Debug.Assert(user != null);
 
@@ -307,6 +276,16 @@ namespace Microsoft.Docs.Build
 
             foreach (var email in user.Emails)
                 _usersByEmail[email] = user;
+
+            _updated = true;
+        }
+
+        private void UpdateUsers(IEnumerable<GitHubUser> users)
+        {
+            foreach (var user in users)
+            {
+                UpdateUser(user);
+            }
         }
 
         private DateTime NextExpiry()
@@ -336,36 +315,20 @@ namespace Microsoft.Docs.Build
             var users = JsonUtility.Deserialize<GitHubUserCacheFile>(content).Users;
             if (users != null)
             {
-                lock (_lock)
-                {
-                    UnsafeUpdateUsers(users);
-                }
+                UpdateUsers(users);
             }
         }
 
-        private void UnsafeUpdateUsers(GitHubUser[] users)
+        private async Task<T> Synchronized<T>(Func<Task<T>> action)
         {
-            foreach (var user in users)
-            {
-                UnsafeUpdateUser(user);
-            }
-        }
-
-        private async Task<T> Synchronized<T>(string key, Func<Task<T>> action)
-        {
-            var semaphore = _syncRoots.GetOrAdd(key, _ => new SemaphoreSlim(1, 1));
-
             try
             {
-                await semaphore.WaitAsync();
+                await _syncRoot.WaitAsync();
                 return await action();
             }
             finally
             {
-                if (semaphore.Release() == 0)
-                {
-                    _syncRoots.TryRemove(key, out _);
-                }
+                _syncRoot.Release();
             }
         }
     }

--- a/test/docfx.Test/lib/GitHubAccessorTest.cs
+++ b/test/docfx.Test/lib/GitHubAccessorTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -30,11 +31,12 @@ namespace Microsoft.Docs.Build
         [InlineData("docascode", "this-repo-does-not-exists", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", null, null, null)]
         public async Task GetUserByCommit(string repoOwner, string repoName, string commit, string errorCode, string login, int? id)
         {
-            var (error, user) = await _github.GetUserByCommit(repoOwner, repoName, commit);
+            var (error, users) = await _github.GetUsersByCommit(repoOwner, repoName, commit);
 
             // skip check if the machine exceeds the GitHub API rate limit
             if (error?.Code != "github-api-failed")
             {
+                var user = users?.FirstOrDefault();
                 Assert.Equal(login, user?.Login);
                 Assert.Equal(id, user?.Id);
                 Assert.Equal(errorCode, error?.Code);

--- a/test/docfx.Test/lib/GitHubUserCacheTest.cs
+++ b/test/docfx.Test/lib/GitHubUserCacheTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Docs.Build
             var cache = new GitHubUserCache(users, "cache.json", 7 * 24);
             var accessor = new MockGitHubAccessor();
             cache._getUserByLoginFromGitHub = accessor.GetUserByLogin;
-            cache._getUserByCommitFromGitHub = accessor.GetUserByCommit;
+            cache._getUsersByCommitFromGitHub = accessor.GetUsersByCommit;
 
             // Act
             await testCase.Test(cache);
@@ -238,19 +238,19 @@ namespace Microsoft.Docs.Build
                 }
             }
 
-            public Task<(Error, GitHubUser)> GetUserByCommit(string repoOwner, string repoName, string commitSha)
+            public Task<(Error, IEnumerable<GitHubUser>)> GetUsersByCommit(string repoOwner, string repoName, string commitSha)
             {
                 Interlocked.Increment(ref _getLoginByCommitCallCount);
                 switch ($"{repoOwner}/{repoName}/{commitSha}")
                 {
                     case "owner/name/1":
-                        return Task.FromResult<(Error, GitHubUser)>((null, new GitHubUser { Id = 1, Login = "alice", Name = "Alice", Emails = new[] { "alice@contoso.com" } }));
+                        return Task.FromResult<(Error, IEnumerable<GitHubUser>)>((null, new[] { new GitHubUser { Id = 1, Login = "alice", Name = "Alice", Emails = new[] { "alice@contoso.com" } } }));
                     case "owner/name/2":
-                        return Task.FromResult<(Error, GitHubUser)>((Errors.GitHubApiFailed("API call failed for some reasons", new Exception()), null));
+                        return Task.FromResult<(Error, IEnumerable<GitHubUser>)>((Errors.GitHubApiFailed("API call failed for some reasons", new Exception()), null));
                     case "owner/name/3":
-                        return Task.FromResult<(Error, GitHubUser)>((null, new GitHubUser { Emails = new[] { "me@contoso.com" } }));
+                        return Task.FromResult<(Error, IEnumerable<GitHubUser>)>((null, new[] { new GitHubUser { Emails = new[] { "me@contoso.com" } } }));
                     default:
-                        return Task.FromResult<(Error, GitHubUser)>(default);
+                        return Task.FromResult<(Error, IEnumerable<GitHubUser>)>(default);
                 }
             }
         }


### PR DESCRIPTION
This PR fixes GitHub API abuse/rate limit and performance problem by:

- Using bulk API calls to get commits and cache users more aggressively (bulk API consumes the same rate as non-bulk API)
- Make GitHubUserCache serial, to avoid API abuse
- Make default cache expiration in 15 ~ 30 days

Test Result:

Repo | User profile cache | # of GitHub API calls | Build Time | Abused / rate limited?
------|--------------------------|------------------------|------------|-------
azure-docs-pr | no | 2091 |  00:26:50 | no
azure-docs-pr | yes (today's sandbox cache, may have expired records) | 210 | 00:03:36 | no
azure-docs-pr | yes (impact test cache, full) | 0 | 00:01:43 | no
edge-developer | no | 13 | 10s | no
edge-developer | yes (today's sandbox cache, may have expired records) | 1 | 3s | no

#4139 