### PR TITLE
Fixed searchbar not showing in statictoc template

### DIFF
--- a/src/docfx.website.themes/default/styles/docfx.js
+++ b/src/docfx.website.themes/default/styles/docfx.js
@@ -347,6 +347,14 @@ $(function () {
     } else {
       $('#navbar ul a.active').parents('li').addClass(active);
       renderBreadcrumb();
+      showSearch();
+    }
+    
+    function showSearch() {
+      if ($('#search-results').length !== 0) {
+          $('#search').show();
+          $('body').trigger("searchEvent");
+      }
     }
 
     function loadNavbar() {
@@ -359,10 +367,7 @@ $(function () {
       if (tocPath) tocPath = tocPath.replace(/\\/g, '/');
       $.get(navbarPath, function (data) {
         $(data).find("#toc>ul").appendTo("#navbar");
-        if ($('#search-results').length !== 0) {
-          $('#search').show();
-          $('body').trigger("searchEvent");
-        }
+        showSearch();
         var index = navbarPath.lastIndexOf('/');
         var navrel = '';
         if (index > -1) {


### PR DESCRIPTION
Added function showSearch() that is now also called when navbar is already defined (as e.g. in the statictoc template)

This pull request fixes #3109 