### PR TITLE
Update GitHubUserCache to handle multiple emails

### DIFF
--- a/src/docfx/lib/github/GitHubUser.cs
+++ b/src/docfx/lib/github/GitHubUser.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
 
 namespace Microsoft.Docs.Build
 {
@@ -18,9 +17,7 @@ namespace Microsoft.Docs.Build
 
         public DateTime? Expiry { get; set; }
 
-        public bool IsValid() => Id.HasValue && !IsExpired();
-
-        public bool IsExpired() => Expiry != null && Expiry < DateTime.UtcNow;
+        public bool IsValid() => Id.HasValue;
 
         public Contributor ToContributor()
         {


### PR DESCRIPTION
- When multiple users share the same email, pick the one with a valid GH account
- Ensure _usersXXX contains only non-expired users