### PR TITLE
open_to_public_contributors is a template only metadata

### DIFF
--- a/docs/specs/git.yml
+++ b/docs/specs/git.yml
@@ -285,7 +285,6 @@ inputs:
 outputs:
   docs/index.json: |
     {
-      "open_to_public_contributors": true,
       "content_git_url": "https://github.com/testowner/testrepo/blob/master-content-git-url/docs/index.md",
       "original_content_git_url": "https://github.com/testowner/testrepo/blob/master-content-git-url/docs/index.md",
       "original_content_git_url_template": "{repo}/blob/{branch}/docs/index.md",

--- a/docs/specs/git.yml
+++ b/docs/specs/git.yml
@@ -308,22 +308,6 @@ outputs:
       "gitcommit": "https://github.com/testowner/testrepo/blob/e662dbc7c5e582a14b863d6a6a82e495d6272f91/docs/index.md",
     }
 ---
-# Don't load git commits when showContributors is set to false
-repos:
-  https://github.com/testowner/testrepo#master-no-load-commits:
-    - files:
-        docs/index.md: Alice creates this.
-inputs:
-  docfx.yml: |
-    contribution:
-      showContributors: false
-outputs:
-  docs/index.json: |
-    {
-      "gitcommit": "https://github.com/testowner/testrepo/blob/e662dbc7c5e582a14b863d6a6a82e495d6272f91/docs/index.md",
-      "!contributors": null
-    }
----
 # Use commit's time when gitCommitsTime file not given
 repos:
   https://github.com/testowner/testrepo#master-time-from-commit:

--- a/docs/specs/manifest.yml
+++ b/docs/specs/manifest.yml
@@ -55,7 +55,7 @@ outputs:
     {
       "files": [
         { "url": "/c", "!hash": null },
-        { "url": "/a", "hash": "d9f0ca10e7db6c5a0a5e0c3279d38576aea69869" },
+        { "url": "/a", "hash": "03e8df11acafdb65be70e2ce72d8ad2b751a6b80" },
         { "url": "/b.png", "hash": "da39a3ee5e6b4b0d3255bfef95601890afd80709" },
         { "url": "/toc.json", "hash": "ad75fac1a867d604c1df88742ed36d56aecd1926" }
       ]

--- a/schemas/docfx.json
+++ b/schemas/docfx.json
@@ -4,12 +4,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "showContributors": {
-          "type": "boolean"
-        },
-        "showEdit": {
-          "type": "boolean"
-        },
         "repository": {
           "type": "string"
         },

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -34,7 +34,6 @@ namespace Microsoft.Docs.Build
             model.SchemaType = schema.Name;
             model.Locale = file.Docset.Locale;
             model.Metadata = metadata;
-            model.OpenToPublicContributors = file.Docset.Config.Contribution.ShowEdit;
             model.TocRel = tocMap.FindTocRelativePath(file);
             model.CanonicalUrl = file.CanonicalUrl;
             model.Bilingual = file.Docset.Config.Localization.Bilingual;

--- a/src/docfx/build/page/PageModel.cs
+++ b/src/docfx/build/page/PageModel.cs
@@ -39,8 +39,6 @@ namespace Microsoft.Docs.Build
 
         public DateTime UpdatedAt { get; set; }
 
-        public bool OpenToPublicContributors { get; set; }
-
         public string ContentGitUrl { get; set; }
 
         public string OriginalContentGitUrl { get; set; }

--- a/src/docfx/config/ContributionConfig.cs
+++ b/src/docfx/config/ContributionConfig.cs
@@ -9,16 +9,6 @@ namespace Microsoft.Docs.Build
     internal sealed class ContributionConfig
     {
         /// <summary>
-        /// Determines whether to show contributors and update time based on commits.
-        /// </summary>
-        public readonly bool ShowContributors = true;
-
-        /// <summary>
-        /// Determines whether to show edit button for contribution.
-        /// </summary>
-        public readonly bool ShowEdit = true;
-
-        /// <summary>
         /// Specify the repository url for contribution:
         /// <protocol>://<hostname>[:<port>][:][/]<path>[#<branch>]
         /// Fallback to git origin if not set.

--- a/src/docfx/template/TemplateTransform.cs
+++ b/src/docfx/template/TemplateTransform.cs
@@ -153,9 +153,6 @@ namespace Microsoft.Docs.Build
             if (pageModel.Bilingual)
                 rawMetadata["bilingual_type"] = "hover over";
 
-            rawMetadata["_op_openToPublicContributors"] = docset.Config.Contribution.ShowEdit;
-            rawMetadata["open_to_public_contributors"] = docset.Config.Contribution.ShowEdit;
-
             if (!string.IsNullOrEmpty(pageModel.ContentGitUrl))
                 rawMetadata["content_git_url"] = pageModel.ContentGitUrl;
             if (!string.IsNullOrEmpty(pageModel.Gitcommit))


### PR DESCRIPTION
Fixes
![image](https://user-images.githubusercontent.com/511355/54800006-b3662080-4c9a-11e9-9593-c365e059e364.png)

We don't need to know this metadata, this is file level and only controls UI logic.

@mingwli , config migration tool needs to put it under global metadata, check with @fenxu  on the default value of `open_to_public_contributors`