### PR TITLE
perf: cut resource meta

### DIFF
--- a/src/Microsoft.DocAsCode.Build.ResourceFiles/ResourceDocumentProcessor.cs
+++ b/src/Microsoft.DocAsCode.Build.ResourceFiles/ResourceDocumentProcessor.cs
@@ -47,17 +47,12 @@ namespace Microsoft.DocAsCode.Build.ResourceFiles
 
         public override FileModel Load(FileAndType file, ImmutableDictionary<string, object> metadata)
         {
-            var pp = EnvironmentContext.FileAbstractLayer.GetPhysicalPath(file.File);
-            var metafile = pp.TrimEnd('.') + ".meta";
-            var content = File.Exists(metafile)
-                ? YamlUtility.Deserialize<Dictionary<string, object>>(metafile)
-                : new Dictionary<string, object>();
-            var localPathFromRoot = PathUtility.MakeRelativePath(EnvironmentContext.BaseDirectory, EnvironmentContext.FileAbstractLayer.GetPhysicalPath(file.File));
-
-            return new FileModel(file, content)
+            return new FileModel(file, new Dictionary<string, object>())
             {
                 Uids = ImmutableArray<UidDefinition>.Empty,
-                LocalPathFromRoot = localPathFromRoot
+                LocalPathFromRoot = PathUtility.MakeRelativePath(
+                    EnvironmentContext.BaseDirectory,
+                    EnvironmentContext.FileAbstractLayer.GetPhysicalPath(file.File)),
             };
         }
 

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/DocumentBuilderTest.cs
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/DocumentBuilderTest.cs
@@ -59,7 +59,6 @@ namespace Microsoft.DocAsCode.Build.Engine.Tests
         {
             #region Prepare test data
             var resourceFile = Path.GetFileName(typeof(DocumentBuilderTest).Assembly.Location);
-            var resourceMetaFile = resourceFile + ".meta";
 
             CreateFile("conceptual.html.primary.tmpl", "{{{conceptual}}}", _templateFolder);
 
@@ -128,7 +127,6 @@ namespace Microsoft.DocAsCode.Build.Engine.Tests
                 },
                 _inputFolder);
 
-            File.WriteAllText(resourceMetaFile, @"{ abc: ""xyz"", uid: ""r1"" }");
             File.WriteAllText(MarkdownSytleConfig.MarkdownStyleFileName, @"{
 rules : [
     ""foo"",
@@ -289,18 +287,13 @@ tagRules : [
                     Assert.True(File.Exists(Path.Combine(_outputFolder, resourceFile)));
                     Assert.True(File.Exists(Path.Combine(_outputFolder, resourceFile + RawModelFileExtension)));
                     var meta = JsonUtility.Deserialize<Dictionary<string, object>>(Path.Combine(_outputFolder, resourceFile + RawModelFileExtension));
-                    Assert.Equal(3, meta.Count);
+                    Assert.Single(meta);
                     Assert.True(!meta.ContainsKey("meta"));
-                    Assert.True(meta.ContainsKey("abc"));
-                    Assert.Equal("xyz", meta["abc"]);
-                    Assert.True(meta.ContainsKey(Constants.PropertyName.Uid));
-                    Assert.Equal("r1", meta[Constants.PropertyName.Uid]);
                 }
             }
             finally
             {
                 CleanUp();
-                File.Delete(resourceMetaFile);
             }
         }
 


### PR DESCRIPTION
#4185 has nearly no impovement as the bottleneck is `File.Exists`. 1/3 is from `File.Exists("xx.meta")`, 2/3 is from `FAL.GetPhysicalPath`. 

After this change, it will only remain 1/3 `FAL.GetPhysicalPath`.