### PR TITLE
Prefer existing user name when updating user cache from commit

### DIFF
--- a/src/docfx/lib/github/GitHubUserCache.cs
+++ b/src/docfx/lib/github/GitHubUserCache.cs
@@ -299,7 +299,9 @@ namespace Microsoft.Docs.Build
                     user.Id = existingUser.Id;
                 if (user.Login is null)
                     user.Login = existingUser.Login;
-                if (user.Name is null || preferExistingName)
+                if (user.Name is null)
+                    user.Name = existingUser.Name;
+                if (preferExistingName && existingUser.Name != null)
                     user.Name = existingUser.Name;
                 user.Emails = user.Emails.Concat(existingUser.Emails).Distinct().ToArray();
             }

--- a/src/docfx/lib/github/GitHubUserCache.cs
+++ b/src/docfx/lib/github/GitHubUserCache.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Docs.Build
                 // only mark the email as invalid when the user is not found
                 if (users != null)
                 {
-                    UpdateUsers(users);
+                    UpdateUsers(users, preferExistingName: true);
                 }
 
                 return (error, _usersByEmail.TryGetValue(authorEmail, out var user) && user.IsValid() ? user : null);
@@ -248,7 +248,7 @@ namespace Microsoft.Docs.Build
         /// 2. User missing with the specified login: { "login": "..." }
         /// 3. User missing with the specified email: { "emails": [ "..." ] }
         /// </summary>
-        private void UpdateUser(GitHubUser user)
+        private void UpdateUser(GitHubUser user, bool preferExistingName = false)
         {
             Debug.Assert(user != null);
 
@@ -263,7 +263,7 @@ namespace Microsoft.Docs.Build
             {
                 if (_usersByLogin.TryGetValue(user.Login, out var existingUser))
                 {
-                    MergeUser(user, existingUser);
+                    MergeUser(user, existingUser, preferExistingName);
                 }
             }
             else
@@ -273,7 +273,7 @@ namespace Microsoft.Docs.Build
                 {
                     if (_usersByEmail.TryGetValue(email, out var existingUser))
                     {
-                        MergeUser(user, existingUser);
+                        MergeUser(user, existingUser, preferExistingName);
                         break;
                     }
                 }
@@ -291,7 +291,7 @@ namespace Microsoft.Docs.Build
             _updated = true;
         }
 
-        private static void MergeUser(GitHubUser user, GitHubUser existingUser)
+        private static void MergeUser(GitHubUser user, GitHubUser existingUser, bool preferExistingName)
         {
             if (existingUser.IsValid())
             {
@@ -299,17 +299,17 @@ namespace Microsoft.Docs.Build
                     user.Id = existingUser.Id;
                 if (user.Login is null)
                     user.Login = existingUser.Login;
-                if (user.Name is null)
+                if (user.Name is null || preferExistingName)
                     user.Name = existingUser.Name;
                 user.Emails = user.Emails.Concat(existingUser.Emails).Distinct().ToArray();
             }
         }
 
-        private void UpdateUsers(IEnumerable<GitHubUser> users)
+        private void UpdateUsers(IEnumerable<GitHubUser> users, bool preferExistingName = false)
         {
             foreach (var user in users)
             {
-                UpdateUser(user);
+                UpdateUser(user, preferExistingName);
             }
         }
 

--- a/test/docfx.Test/lib/GitHubUserCacheTest.cs
+++ b/test/docfx.Test/lib/GitHubUserCacheTest.cs
@@ -196,6 +196,19 @@ namespace Microsoft.Docs.Build
                 1,
                 1
             };
+            yield return new object[]
+            {
+                "Prefer existing email name",
+                (Func<GitHubUserCache, Task>)(async (cache) =>
+                    {
+                        await cache.GetByCommit("bob1@contoso.com", "owner", "name", "4");
+                        await cache.GetByCommit("bob2@contoso.com", "owner", "name", "5");
+                    }),
+                "[]",
+                "[{'id':2,'login':'bob','name':'bob1','emails':['bob1@contoso.com','bob2@contoso.com']}]",
+                0,
+                2
+            };
         }
 
         private void AssertUsersEqual(GitHubUser[] expectedUsers, GitHubUser[] actualUsers)
@@ -249,6 +262,10 @@ namespace Microsoft.Docs.Build
                         return Task.FromResult<(Error, IEnumerable<GitHubUser>)>((Errors.GitHubApiFailed("API call failed for some reasons", new Exception()), null));
                     case "owner/name/3":
                         return Task.FromResult<(Error, IEnumerable<GitHubUser>)>((null, new[] { new GitHubUser { Emails = new[] { "me@contoso.com" } } }));
+                    case "owner/name/4":
+                        return Task.FromResult<(Error, IEnumerable<GitHubUser>)>((null, new[] { new GitHubUser { Id = 2, Login = "bob", Name = "bob1", Emails = new[] { "bob1@contoso.com" } } }));
+                    case "owner/name/5":
+                        return Task.FromResult<(Error, IEnumerable<GitHubUser>)>((null, new[] { new GitHubUser { Id = 2, Login = "bob", Name = "bob2", Emails = new[] { "bob2@contoso.com" } } }));
                     default:
                         return Task.FromResult<(Error, IEnumerable<GitHubUser>)>(default);
                 }


### PR DESCRIPTION
This makes github user cache stable before an record is expired. Fixes PR unexpected change caused by display name.

![image](https://user-images.githubusercontent.com/511355/54892607-15b65f80-4eed-11e9-966d-642fc47fdd44.png)
