### PR TITLE
👨‍🏭remove un-necessary await/async method and prepare for mutex changes

### DIFF
--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -58,19 +58,19 @@ namespace Microsoft.Docs.Build
             Template = template;
         }
 
-        public static async Task<Context> Create(string outputPath, Report report, Docset docset, Func<XrefMap> xrefMap)
+        public static Context Create(string outputPath, Report report, Docset docset, Func<XrefMap> xrefMap)
         {
             var output = new Output(outputPath);
             var cache = new Cache();
             var metadataProvider = new MetadataProvider(docset.Config);
-            var monikerProvider = await MonikerProvider.Create(docset);
-            var gitHubUserCache = await GitHubUserCache.Create(docset);
+            var monikerProvider = new MonikerProvider(docset);
+            var gitHubUserCache = GitHubUserCache.Create(docset);
             var gitCommitProvider = new GitCommitProvider();
             var bookmarkValidator = new BookmarkValidator();
             var dependencyMapBuilder = new DependencyMapBuilder();
             var dependencyResolver = new DependencyResolver(gitCommitProvider, bookmarkValidator, dependencyMapBuilder, new Lazy<XrefMap>(xrefMap));
             var landingPageDependencyResolver = new DependencyResolver(gitCommitProvider, bookmarkValidator, dependencyMapBuilder, new Lazy<XrefMap>(xrefMap), forLandingPage: true);
-            var contributionProvider = await ContributionProvider.Create(docset, gitHubUserCache, gitCommitProvider);
+            var contributionProvider = new ContributionProvider(docset, gitHubUserCache, gitCommitProvider);
             var publishModelBuilder = new PublishModelBuilder();
             var template = TemplateEngine.Create(docset);
 

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -18,19 +18,14 @@ namespace Microsoft.Docs.Build
 
         private readonly GitCommitProvider _gitCommitProvider;
 
-        private ContributionProvider(GitHubUserCache gitHubUserCache, GitCommitProvider gitCommitProvider)
+        public ContributionProvider(Docset docset, GitHubUserCache gitHubUserCache, GitCommitProvider gitCommitProvider)
         {
             Debug.Assert(gitCommitProvider != null);
 
             _gitHubUserCache = gitHubUserCache;
             _gitCommitProvider = gitCommitProvider;
-        }
 
-        public static async Task<ContributionProvider> Create(Docset docset, GitHubUserCache cache, GitCommitProvider gitCommitProvider)
-        {
-            var result = new ContributionProvider(cache, gitCommitProvider);
-            await result.LoadCommitsTime(docset);
-            return result;
+            LoadCommitsTime(docset);
         }
 
         public async Task<(List<Error> error, Contributor author, List<Contributor> contributors, DateTime updatedAt)> GetAuthorAndContributors(
@@ -38,13 +33,13 @@ namespace Microsoft.Docs.Build
             string authorName)
         {
             Debug.Assert(document != null);
-            var (repo, pathToRepo, commits) = await _gitCommitProvider.GetCommitHistory(document);
+            var (repo, pathToRepo, commits) = _gitCommitProvider.GetCommitHistory(document);
             if (repo is null)
             {
                 return default;
             }
 
-            var contributionCommits = await GetContributionCommits();
+            var contributionCommits = GetContributionCommits();
 
             var excludes = document.Docset.Config.Contribution.ExcludedContributors;
 
@@ -123,14 +118,14 @@ namespace Microsoft.Docs.Build
                 return null;
             }
 
-            async Task<List<GitCommit>> GetContributionCommits()
+            List<GitCommit> GetContributionCommits()
             {
                 var result = commits;
                 var bilingual = document.Docset.IsLocalized() && document.Docset.Config.Localization.Bilingual;
                 var contributionBranch = bilingual && LocalizationUtility.TryGetContributionBranch(repo.Branch, out var cBranch) ? cBranch : null;
                 if (!string.IsNullOrEmpty(contributionBranch))
                 {
-                    (_, _, result) = await _gitCommitProvider.GetCommitHistory(document, contributionBranch);
+                    (_, _, result) = _gitCommitProvider.GetCommitHistory(document, contributionBranch);
                 }
 
                 return result;
@@ -148,12 +143,12 @@ namespace Microsoft.Docs.Build
             return File.GetLastWriteTimeUtc(Path.Combine(document.Docset.DocsetPath, document.FilePath));
         }
 
-        public async Task<(string contentGitUrl, string originalContentGitUrl, string originalContentGitUrlTemplate, string gitCommit)>
+        public (string contentGitUrl, string originalContentGitUrl, string originalContentGitUrlTemplate, string gitCommit)
             GetGitUrls(Document document)
         {
             Debug.Assert(document != null);
 
-            var (repo, pathToRepo, commits) = await _gitCommitProvider.GetCommitHistory(document);
+            var (repo, pathToRepo, commits) = _gitCommitProvider.GetCommitHistory(document);
             if (repo is null)
                 return default;
 
@@ -201,11 +196,11 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private async Task LoadCommitsTime(Docset docset)
+        private void LoadCommitsTime(Docset docset)
         {
             if (!string.IsNullOrEmpty(docset.Config.Contribution.GitCommitsTime))
             {
-                var (_, content, _) = await RestoreMap.GetRestoredFileContent(docset, docset.Config.Contribution.GitCommitsTime);
+                var (_, content, _) = RestoreMap.GetRestoredFileContent(docset, docset.Config.Contribution.GitCommitsTime);
 
                 foreach (var commit in JsonUtility.Deserialize<GitCommitsTime>(content).Commits)
                 {

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Docs.Build
             model.Bilingual = file.Docset.Config.Localization.Bilingual;
 
             (model.DocumentId, model.DocumentVersionIndependentId) = file.Docset.Redirections.TryGetDocumentId(file, out var docId) ? docId : file.Id;
-            (model.ContentGitUrl, model.OriginalContentGitUrl, model.OriginalContentGitUrlTemplate, model.Gitcommit) = await context.ContributionProvider.GetGitUrls(file);
+            (model.ContentGitUrl, model.OriginalContentGitUrl, model.OriginalContentGitUrlTemplate, model.Gitcommit) = context.ContributionProvider.GetGitUrls(file);
 
             List<Error> contributorErrors;
             (contributorErrors, model.Author, model.Contributors, model.UpdatedAt) = await context.ContributionProvider.GetAuthorAndContributors(file, metadata.Author);

--- a/src/docfx/build/xref/XrefMap.cs
+++ b/src/docfx/build/xref/XrefMap.cs
@@ -151,12 +151,12 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public static async Task<XrefMap> Create(Context context, Docset docset)
+        public static XrefMap Create(Context context, Docset docset)
         {
             Dictionary<string, XrefSpec> map = new Dictionary<string, XrefSpec>();
             foreach (var url in docset.Config.Xref)
             {
-                var (_, content, _) = await RestoreMap.GetRestoredFileContent(docset, url);
+                var (_, content, _) = RestoreMap.GetRestoredFileContent(docset, url);
                 XrefMapModel xrefMap = new XrefMapModel();
                 if (url.EndsWith(".yml", StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/docfx/config/ConfigLoader.cs
+++ b/src/docfx/config/ConfigLoader.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Docs.Build
                 {
                     if (extend is JValue value && value.Value is string str)
                     {
-                        var (_, content, _) = RestoreMap.GetRestoredFileContent(docsetPath, str).GetAwaiter().GetResult(); /*todo: remove GetResult()*/
+                        var (_, content, _) = RestoreMap.GetRestoredFileContent(docsetPath, str);
                         var (extendErros, extendConfigObject) = LoadConfigObjectContent(str, content);
                         errors.AddRange(extendErros);
                         JsonUtility.Merge(result, extendConfigObject);

--- a/src/docfx/lib/ProcessUtility.cs
+++ b/src/docfx/lib/ProcessUtility.cs
@@ -375,12 +375,7 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        /// <summary>
-        /// Create a file mutex to lock a resource/action
-        /// </summary>
-        /// <param name="mutexName">A globbaly unique mutext name</param>
-        /// <param name="action">The action/resource you want to lock</param>
-        /// TODO: remove this method if possible
+        // TODO: remove this method if possible
         public static Task RunInsideMutexAsync(string mutexName, Func<Task> action)
         {
             RunInsideMutex(mutexName, () => action().GetAwaiter().GetResult());

--- a/src/docfx/lib/ProcessUtility.cs
+++ b/src/docfx/lib/ProcessUtility.cs
@@ -22,20 +22,20 @@ namespace Microsoft.Docs.Build
         private const int _defaultLockExpireTimeInSecond = 60 * 60 * 6; /*six hours*/
         private static AsyncLocal<ImmutableStack<string>> t_innerCall = new AsyncLocal<ImmutableStack<string>>();
 
-        public static async Task<bool> IsExclusiveLockHeld(string lockName)
+        public static bool IsExclusiveLockHeld(string lockName)
         {
             Debug.Assert(!string.IsNullOrEmpty(lockName));
 
             var lockPath = GetLockFilePath(lockName);
             var held = false;
-            await ReadAndWriteFile<LockInfo>(lockPath, lockInfo =>
+            ReadAndWriteFile<LockInfo>(lockPath, lockInfo =>
             {
                 lockInfo = lockInfo ?? new LockInfo();
                 lockInfo = FilterExpiredAcquirers(lockInfo);
 
                 held = lockInfo.Type == LockType.Exclusive;
 
-                return Task.FromResult(lockInfo);
+                return lockInfo;
             });
 
             return held;
@@ -45,7 +45,7 @@ namespace Microsoft.Docs.Build
         /// Acquire a shared lock for input lock name
         /// The returned `acquirer` are used for tracking the acquired lock, instead of thread info, since the thread info may change in asynchronous programming model
         /// </summary>
-        public static async Task<(bool acquired, string acquirer)> AcquireSharedLock(string lockName)
+        public static (bool acquired, string acquirer) AcquireSharedLock(string lockName)
         {
             Debug.Assert(!string.IsNullOrEmpty(lockName));
 
@@ -53,27 +53,27 @@ namespace Microsoft.Docs.Build
             var acquirer = (string)null;
             var lockPath = GetLockFilePath(lockName);
 
-            await ReadAndWriteFile<LockInfo>(lockPath, lockInfo =>
+            ReadAndWriteFile<LockInfo>(lockPath, lockInfo =>
             {
                 lockInfo = lockInfo ?? new LockInfo();
                 lockInfo = FilterExpiredAcquirers(lockInfo);
 
                 if (lockInfo.Type == LockType.Exclusive)
                 {
-                    return Task.FromResult(lockInfo);
+                    return lockInfo;
                 }
 
                 acquired = true;
                 acquirer = Guid.NewGuid().ToString();
                 lockInfo.Type = LockType.Shared;
                 lockInfo.AcquiredBy.Add(new Acquirer { Id = acquirer, Date = DateTime.UtcNow });
-                return Task.FromResult(lockInfo);
+                return lockInfo;
             });
 
             return (acquired, acquirer);
         }
 
-        public static async Task<bool> ReleaseSharedLock(string lockName, string acquirer)
+        public static bool ReleaseSharedLock(string lockName, string acquirer)
         {
             Debug.Assert(!string.IsNullOrEmpty(lockName));
             Debug.Assert(!string.IsNullOrEmpty(acquirer));
@@ -81,13 +81,13 @@ namespace Microsoft.Docs.Build
             var released = false;
             var lockPath = GetLockFilePath(lockName);
 
-            await ReadAndWriteFile<LockInfo>(lockPath, lockInfo =>
+            ReadAndWriteFile<LockInfo>(lockPath, lockInfo =>
             {
                 lockInfo = lockInfo ?? new LockInfo();
 
                 if (lockInfo.Type != LockType.Shared)
                 {
-                    return Task.FromResult(lockInfo);
+                    return lockInfo;
                 }
 
                 var removed = lockInfo.AcquiredBy.RemoveAll(i => i.Id == acquirer);
@@ -95,7 +95,7 @@ namespace Microsoft.Docs.Build
 
                 if (removed <= 0)
                 {
-                    return Task.FromResult(lockInfo);
+                    return lockInfo;
                 }
 
                 if (!lockInfo.AcquiredBy.Any())
@@ -104,7 +104,7 @@ namespace Microsoft.Docs.Build
                 }
 
                 released = true;
-                return Task.FromResult(lockInfo);
+                return lockInfo;
             });
 
             return released;
@@ -114,7 +114,7 @@ namespace Microsoft.Docs.Build
         /// Acquire a exclusive lock for input lock name
         /// The returned `acquirer` are used for tracking the acquired lock, instead of thread info, since the thread info may change in asynchronous programming model
         /// </summary>
-        public static async Task<(bool acquired, string acquirer)> AcquireExclusiveLock(string lockName)
+        public static (bool acquired, string acquirer) AcquireExclusiveLock(string lockName)
         {
             Debug.Assert(!string.IsNullOrEmpty(lockName));
 
@@ -122,27 +122,27 @@ namespace Microsoft.Docs.Build
             var acquirer = (string)null;
             var lockPath = GetLockFilePath(lockName);
 
-            await ReadAndWriteFile<LockInfo>(lockPath, lockInfo =>
+            ReadAndWriteFile<LockInfo>(lockPath, lockInfo =>
             {
                 lockInfo = lockInfo ?? new LockInfo();
                 lockInfo = FilterExpiredAcquirers(lockInfo);
 
                 if (lockInfo.Type != LockType.None)
                 {
-                    return Task.FromResult(lockInfo);
+                    return lockInfo;
                 }
 
                 acquirer = Guid.NewGuid().ToString();
                 acquired = true;
                 lockInfo.Type = LockType.Exclusive;
                 lockInfo.AcquiredBy = new List<Acquirer> { new Acquirer { Id = acquirer, Date = DateTime.UtcNow } };
-                return Task.FromResult(lockInfo);
+                return lockInfo;
             });
 
             return (acquired, acquirer);
         }
 
-        public static async Task<bool> ReleaseExclusiveLock(string lockName, string acquirer)
+        public static bool ReleaseExclusiveLock(string lockName, string acquirer)
         {
             Debug.Assert(!string.IsNullOrEmpty(lockName));
             Debug.Assert(!string.IsNullOrEmpty(acquirer));
@@ -150,13 +150,13 @@ namespace Microsoft.Docs.Build
             var released = false;
             var lockPath = GetLockFilePath(lockName);
 
-            await ReadAndWriteFile<LockInfo>(lockPath, lockInfo =>
+            ReadAndWriteFile<LockInfo>(lockPath, lockInfo =>
             {
                 lockInfo = lockInfo ?? new LockInfo();
 
                 if (lockInfo.Type != LockType.Exclusive)
                 {
-                    return Task.FromResult(lockInfo);
+                    return lockInfo;
                 }
 
                 Debug.Assert(lockInfo.AcquiredBy.Count == 1);
@@ -165,7 +165,7 @@ namespace Microsoft.Docs.Build
 
                 if (removed <= 0)
                 {
-                    return Task.FromResult(lockInfo);
+                    return lockInfo;
                 }
 
                 if (!lockInfo.AcquiredBy.Any())
@@ -174,7 +174,7 @@ namespace Microsoft.Docs.Build
                 }
 
                 released = true;
-                return Task.FromResult(lockInfo);
+                return lockInfo;
             });
 
             return released;
@@ -261,9 +261,9 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Reads the content of a file, update content and write back to file in one atomic operation
         /// </summary>
-        public static async Task ReadAndWriteFile<T>(string path, Func<T, Task<T>> update)
+        public static void ReadAndWriteFile<T>(string path, Func<T, T> update)
         {
-            await RunInsideMutex(path, async () =>
+            RunInsideMutex(path, () =>
             {
                 using (var file = File.Open(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
                 {
@@ -271,7 +271,7 @@ namespace Microsoft.Docs.Build
                     var result = JsonUtility.Deserialize<T>(streamReader.ReadToEnd());
 
                     file.SetLength(0);
-                    var updatedResult = await update(result);
+                    var updatedResult = update(result);
                     var steamWriter = new StreamWriter(file);
                     steamWriter.Write(JsonUtility.Serialize(updatedResult));
                     steamWriter.Close();
@@ -283,26 +283,24 @@ namespace Microsoft.Docs.Build
         /// Reads the content of a file.
         /// When used together with <see cref="WriteFile(string,string)"/>, provides inter-process synchronized access to the file.
         /// </summary>
-        public static async Task<string> ReadFile(string path)
+        public static string ReadFile(string path)
         {
             string result = null;
-            await RunInsideMutex(path, () =>
+            RunInsideMutex(path, () =>
             {
                 result = File.ReadAllText(path);
-                return Task.CompletedTask;
             });
             return result;
         }
 
-        public static async Task<T> ReadFile<T>(string path, Func<Stream, T> read)
+        public static T ReadFile<T>(string path, Func<Stream, T> read)
         {
             T result = default;
-            await RunInsideMutex(path, () =>
+            RunInsideMutex(path, () =>
             {
                 using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 1024, FileOptions.SequentialScan))
                 {
                     result = read(fs);
-                    return Task.CompletedTask;
                 }
             });
             return result;
@@ -312,28 +310,26 @@ namespace Microsoft.Docs.Build
         /// Reads the content of a file.
         /// When used together with <see cref="ReadFile(string)"/>, provides inter-process synchronized access to the file.
         /// </summary>
-        public static Task WriteFile(string path, string content)
+        public static void WriteFile(string path, string content)
         {
-            return RunInsideMutex(path, () =>
+            RunInsideMutex(path, () =>
             {
                 using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 1024, FileOptions.SequentialScan))
                 using (var writer = new StreamWriter(fs))
                 {
                     writer.Write(content);
                 }
-                return Task.CompletedTask;
             });
         }
 
-        public static Task WriteFile(string path, Action<Stream> write)
+        public static void WriteFile(string path, Action<Stream> write)
         {
-            return RunInsideMutex(path, () =>
+            RunInsideMutex(path, () =>
             {
                 using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 1024, FileOptions.SequentialScan))
                 {
                     write(fs);
                 }
-                return Task.CompletedTask;
             });
         }
 
@@ -342,7 +338,8 @@ namespace Microsoft.Docs.Build
         /// </summary>
         /// <param name="mutexName">A globbaly unique mutext name</param>
         /// <param name="action">The action/resource you want to lock</param>
-        public static async Task RunInsideMutex(string mutexName, Func<Task> action)
+        /// TODO: implement this with system mutex
+        public static void RunInsideMutex(string mutexName, Action action)
         {
             Debug.Assert(!string.IsNullOrEmpty(mutexName));
             var lockPath = Path.Combine(AppData.MutexRoot, HashUtility.GetMd5Hash(mutexName));
@@ -359,9 +356,9 @@ namespace Microsoft.Docs.Build
             {
                 Directory.CreateDirectory(AppData.MutexRoot);
 
-                using (await RetryUntilSucceed(mutexName, IsFileAlreadyExistsException, CreateFile))
+                using (RetryUntilSucceed(mutexName, IsFileAlreadyExistsException, CreateFile))
                 {
-                    await action();
+                    action();
                 }
 
                 FileStream CreateFile() => new FileStream(
@@ -376,6 +373,18 @@ namespace Microsoft.Docs.Build
             {
                 t_innerCall.Value = t_innerCall.Value.Pop();
             }
+        }
+
+        /// <summary>
+        /// Create a file mutex to lock a resource/action
+        /// </summary>
+        /// <param name="mutexName">A globbaly unique mutext name</param>
+        /// <param name="action">The action/resource you want to lock</param>
+        /// TODO: remove this method if possible
+        public static Task RunInsideMutexAsync(string mutexName, Func<Task> action)
+        {
+            RunInsideMutex(mutexName, () => action().GetAwaiter().GetResult());
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -400,7 +409,7 @@ namespace Microsoft.Docs.Build
             return ex is UnauthorizedAccessException;
         }
 
-        private static async Task<T> RetryUntilSucceed<T>(string name, Func<Exception, bool> expectException, Func<T> action)
+        private static T RetryUntilSucceed<T>(string name, Func<Exception, bool> expectException, Func<T> action)
         {
             var retryDelay = 100;
             var lastWait = DateTime.UtcNow;
@@ -426,7 +435,7 @@ namespace Microsoft.Docs.Build
                         }
                     }
 
-                    await Task.Delay(retryDelay);
+                    Thread.Sleep(retryDelay);
                     retryDelay = Math.Min(retryDelay + 100, 1000);
                 }
             }

--- a/src/docfx/lib/git/FileCommitProvider.cs
+++ b/src/docfx/lib/git/FileCommitProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Docs.Build
         // Commit history LRU cache per file. Key is the file path relative to repository root.
         // Value is a dictionary of git commit history for a particular commit hash and file blob hash.
         // Only the last N = MaxCommitCacheCountPerFile commit histories are cached for a file, they are selected by least recently used order (lruOrder).
-        private readonly Lazy<Task<ConcurrentDictionary<string, Dictionary<(long commit, long blob), (long[] commitHistory, int lruOrder)>>>> _commitCache;
+        private readonly Lazy<ConcurrentDictionary<string, Dictionary<(long commit, long blob), (long[] commitHistory, int lruOrder)>>> _commitCache;
 
         private int _nextLruOrder;
         private int _nextStringId;
@@ -54,13 +54,13 @@ namespace Microsoft.Docs.Build
             _repoPath = repoPath;
             _cacheFilePath = cacheFilePath;
             _commits = new ConcurrentDictionary<string, Lazy<(List<Commit>, Dictionary<long, Commit>)>>();
-            _commitCache = new Lazy<Task<ConcurrentDictionary<string, Dictionary<(long commit, long blob), (long[] commitHistory, int lruOrder)>>>>(
+            _commitCache = new Lazy<ConcurrentDictionary<string, Dictionary<(long commit, long blob), (long[] commitHistory, int lruOrder)>>>(
                 () => LoadCommitCache(_cacheFilePath));
         }
 
-        public async Task<List<GitCommit>> GetCommitHistory(string file, string committish = null)
+        public List<GitCommit> GetCommitHistory(string file, string committish = null)
         {
-            var commitCache = await _commitCache.Value;
+            var commitCache = _commitCache.Value;
             var fileCommitCache = commitCache.GetOrAdd(file, _ => new Dictionary<(long, long), (long[], int)>());
 
             return GetCommitHistory(file, int.MaxValue, committish, fileCommitCache);
@@ -71,9 +71,9 @@ namespace Microsoft.Docs.Build
             return GetCommitHistory(file, top, committish, new Dictionary<(long, long), (long[], int)>());
         }
 
-        public Task SaveCache()
+        public void SaveCache()
         {
-            return SaveCacheCore();
+            SaveCacheCore();
         }
 
         public void Dispose()
@@ -345,7 +345,7 @@ namespace Microsoft.Docs.Build
             return _stringPool.GetOrAdd(value, _ => Interlocked.Increment(ref _nextStringId));
         }
 
-        private static async Task<ConcurrentDictionary<string, Dictionary<(long commit, long blob), (long[] commitHistory, int lruOrder)>>>
+        private static ConcurrentDictionary<string, Dictionary<(long commit, long blob), (long[] commitHistory, int lruOrder)>>
             LoadCommitCache(string cacheFilePath)
         {
             Telemetry.TrackCacheTotalCount(TelemetryName.GitCommitCache);
@@ -356,7 +356,7 @@ namespace Microsoft.Docs.Build
             }
 
             Log.Write($"Using git commit history cache file: '{cacheFilePath}'");
-            return await ProcessUtility.ReadFile(cacheFilePath, stream =>
+            return ProcessUtility.ReadFile(cacheFilePath, stream =>
             {
                 var result = new ConcurrentDictionary<string, Dictionary<(long commit, long blob), (long[] commitHistory, int lruOrder)>>();
                 using (var reader = new BinaryReader(stream))
@@ -387,16 +387,16 @@ namespace Microsoft.Docs.Build
             });
         }
 
-        private Task SaveCacheCore()
+        private void SaveCacheCore()
         {
-            if (!_cacheUpdated || string.IsNullOrEmpty(_cacheFilePath) || !_commitCache.IsValueCreated || !_commitCache.Value.IsCompletedSuccessfully)
+            if (!_cacheUpdated || string.IsNullOrEmpty(_cacheFilePath) || !_commitCache.IsValueCreated)
             {
-                return Task.CompletedTask;
+                return;
             }
 
             PathUtility.CreateDirectoryFromFilePath(_cacheFilePath);
 
-            return ProcessUtility.WriteFile(_cacheFilePath, stream =>
+            ProcessUtility.WriteFile(_cacheFilePath, stream =>
             {
                 using (var writer = new BinaryWriter(stream))
                 {
@@ -404,7 +404,7 @@ namespace Microsoft.Docs.Build
                     //
                     // There is a race condition in Linq ToList() method, use ConcurrentDictionary.ToArray() to create a snapshot
                     // https://stackoverflow.com/questions/11692389/getting-argument-exception-in-concurrent-dictionary-when-sorting-and-displaying
-                    var commitCache = _commitCache.Value.Result.ToArray();
+                    var commitCache = _commitCache.Value.ToArray();
 
                     writer.Write(commitCache.Length);
                     foreach (var (file, value) in commitCache)

--- a/src/docfx/lib/git/GitCommitProvider.cs
+++ b/src/docfx/lib/git/GitCommitProvider.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Docs.Build
             return (repo, pathToRepo, GetCommitProvider(repo).GetCommitHistory(pathToRepo, committish));
         }
 
+        // TODO: remove this method if possible
         public (Repository repo, string pathToRepo, List<GitCommit> commits) GetCommitHistoryNoCache(Docset docset, string filePath, int top, string committish = null)
         {
             var repo = docset.GetRepository(filePath);

--- a/src/docfx/lib/github/GitHubUserCache.cs
+++ b/src/docfx/lib/github/GitHubUserCache.cs
@@ -72,13 +72,13 @@ namespace Microsoft.Docs.Build
             _etag = new EntityTagHeaderValue(etag);
         }
 
-        public static async Task<GitHubUserCache> Create(Docset docset)
+        public static GitHubUserCache Create(Docset docset)
         {
-            var result = await Create();
-            await result.ReadCacheFiles();
+            var result = Create();
+            result.ReadCacheFiles();
             return result;
 
-            async Task<GitHubUserCache> Create()
+            GitHubUserCache Create()
             {
                 var path = docset.Config.GitHub.UserCache;
                 if (string.IsNullOrEmpty(path))
@@ -86,7 +86,7 @@ namespace Microsoft.Docs.Build
                     return new GitHubUserCache(docset, AppData.DefaultGitHubUserCachePath);
                 }
 
-                var (localPath, content, etag) = await RestoreMap.GetRestoredFileContent(docset, path);
+                var (localPath, content, etag) = RestoreMap.GetRestoredFileContent(docset, path);
                 if (string.IsNullOrEmpty(localPath))
                 {
                     return new GitHubUserCache(docset, path, content, etag, AppData.GetGitHubUserCachePath(path));
@@ -203,17 +203,17 @@ namespace Microsoft.Docs.Build
         {
             var file = JsonUtility.Serialize(new GitHubUserCacheFile { Users = Users.ToArray() });
 
-            await SaveLocal(file);
+            SaveLocal(file);
             if (config.GitHub.UpdateRemoteUserCache && _url != null)
             {
                 return await SaveRemote(file);
             }
             return default;
 
-            async Task SaveLocal(string content)
+            void SaveLocal(string content)
             {
                 PathUtility.CreateDirectoryFromFilePath(_cachePath);
-                await ProcessUtility.WriteFile(_cachePath, content);
+                ProcessUtility.WriteFile(_cachePath, content);
             }
 
             async Task<(Error error, bool collide)> SaveRemote(string content)
@@ -318,20 +318,20 @@ namespace Microsoft.Docs.Build
         private DateTime NextExpiry()
             => DateTime.UtcNow.AddHours((_expirationInHours / 2) + (t_random.Value.NextDouble() * _expirationInHours / 2));
 
-        private async Task ReadCacheFiles()
+        private void ReadCacheFiles()
         {
-            await ReadCacheFile(_cachePath);
+            ReadCacheFile(_cachePath);
 
             if (!string.IsNullOrEmpty(_content))
             {
                 ReadCache(_content);
             }
 
-            async Task ReadCacheFile(string path)
+            void ReadCacheFile(string path)
             {
                 if (path != null && File.Exists(path))
                 {
-                    var content = await ProcessUtility.ReadFile(path);
+                    var content = ProcessUtility.ReadFile(path);
                     ReadCache(content);
                 }
             }

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Docs.Build
                     await RestoreFile.Restore(extendedConfig.DependencyLock, extendedConfig, @implicit);
 
                 if (root)
-                    dependencyLock = await DependencyLock.Load(docset, extendedConfig.DependencyLock);
+                    dependencyLock = DependencyLock.Load(docset, extendedConfig.DependencyLock);
 
                 // restore git repos includes dependency repos, theme repo and loc repos
                 var gitVersions = await RestoreGit.Restore(extendedConfig, restoreChild, locale, @implicit, rootRepository, dependencyLock);
@@ -96,7 +96,7 @@ namespace Microsoft.Docs.Build
                 if (root)
                 {
                     var dependencyLockFilePath = string.IsNullOrEmpty(extendedConfig.DependencyLock) ? AppData.GetDependencyLockFile(docset, locale) : extendedConfig.DependencyLock;
-                    await DependencyLock.Save(docset, dependencyLockFilePath, generatedLock);
+                    DependencyLock.Save(docset, dependencyLockFilePath, generatedLock);
                 }
 
                 return generatedLock;

--- a/src/docfx/restore/RestoreFile.cs
+++ b/src/docfx/restore/RestoreFile.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Docs.Build
         {
             var filePath = GetRestoreContentPath(url);
 
-            var (existingContent, existingEtagContent) = await RestoreMap.TryGetRestoredFileContent(url);
+            var (existingContent, existingEtagContent) = RestoreMap.TryGetRestoredFileContent(url);
             if (!string.IsNullOrEmpty(existingContent) && @implicit)
                 return;
 
@@ -40,7 +40,7 @@ namespace Microsoft.Docs.Build
                 return;
             }
 
-            await ProcessUtility.RunInsideMutex(filePath, () =>
+            ProcessUtility.RunInsideMutex(filePath, () =>
             {
                 if (!File.Exists(filePath))
                 {
@@ -53,8 +53,6 @@ namespace Microsoft.Docs.Build
                 }
 
                 File.WriteAllText(GetRestoreEtagPath(url), etag?.ToString());
-
-                return Task.CompletedTask;
             });
         }
 

--- a/src/docfx/restore/RestoreGit.cs
+++ b/src/docfx/restore/RestoreGit.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Docs.Build
                 var repoPath = Path.GetFullPath(Path.Combine(AppData.GetGitDir(remote), ".git"));
                 var childRepos = new List<string>();
 
-                await ProcessUtility.RunInsideMutex(
+                await ProcessUtility.RunInsideMutexAsync(
                     remote,
                     async () =>
                     {
@@ -141,7 +141,7 @@ namespace Microsoft.Docs.Build
                         var gitDependencyLock = dependencyLock?.GetGitLock(remote, branch);
                         headCommit = gitDependencyLock?.Commit ?? headCommit;
 
-                        var (workTreePath, gitSlot) = await RestoreMap.AcquireExclusiveGit(remote, branch, headCommit);
+                        var (workTreePath, gitSlot) = RestoreMap.AcquireExclusiveGit(remote, branch, headCommit);
                         workTreePath = Path.GetFullPath(workTreePath).Replace('\\', '/');
                         var restored = true;
 
@@ -173,7 +173,7 @@ namespace Microsoft.Docs.Build
                         }
                         finally
                         {
-                            await RestoreMap.ReleaseGit(gitSlot, LockType.Exclusive, restored);
+                            RestoreMap.ReleaseGit(gitSlot, LockType.Exclusive, restored);
                         }
 
                         subChildren.Add(new RestoreChild(workTreePath, remote, branch, gitDependencyLock, headCommit));

--- a/src/docfx/restore/lock/DependencyLock.cs
+++ b/src/docfx/restore/lock/DependencyLock.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace Microsoft.Docs.Build
 {
@@ -34,7 +33,7 @@ namespace Microsoft.Docs.Build
             return dependencyLock.Git.ContainsKey(href) || dependencyLock.Git.Keys.Any(g => g.StartsWith($"{href}#"));
         }
 
-        public static async Task<DependencyLockModel> Load(string docset, string dependencyLockPath)
+        public static DependencyLockModel Load(string docset, string dependencyLockPath)
         {
             Debug.Assert(!string.IsNullOrEmpty(docset));
 
@@ -52,7 +51,7 @@ namespace Microsoft.Docs.Build
                 }
             }
 
-            var (_, content, _) = await RestoreMap.GetRestoredFileContent(docset, dependencyLockPath);
+            var (_, content, _) = RestoreMap.GetRestoredFileContent(docset, dependencyLockPath);
 
             if (string.IsNullOrEmpty(content))
             {
@@ -62,7 +61,7 @@ namespace Microsoft.Docs.Build
             return JsonUtility.Deserialize<DependencyLockModel>(content);
         }
 
-        public static async Task Save(string docset, string dependencyLockPath, DependencyLockModel dependencyLock)
+        public static void Save(string docset, string dependencyLockPath, DependencyLockModel dependencyLock)
         {
             Debug.Assert(!string.IsNullOrEmpty(docset));
             Debug.Assert(!string.IsNullOrEmpty(dependencyLockPath));
@@ -73,7 +72,7 @@ namespace Microsoft.Docs.Build
             {
                 var path = Path.Combine(docset, dependencyLockPath);
                 Directory.CreateDirectory(Path.GetDirectoryName(path));
-                await ProcessUtility.WriteFile(path, content);
+                ProcessUtility.WriteFile(path, content);
             }
 
             // todo: upload to remote file directly

--- a/test/docfx.Test/lib/GitUtilityTest.cs
+++ b/test/docfx.Test/lib/GitUtilityTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Docs.Build
 
         [Theory]
         [InlineData("README.md")]
-        public static async Task GetCommitsSameAsGitExe(string file)
+        public static void GetCommitsSameAsGitExe(string file)
         {
             Assert.False(GitUtility.IsRepo(Path.GetFullPath(file)));
 
@@ -41,7 +41,7 @@ namespace Microsoft.Docs.Build
 
                 // current branch
                 var exe = Exec("git", $"--no-pager log --format=\"%H|%cI|%an|%ae\" -- \"{pathToRepo}\"", repo.Path);
-                var (_, _, lib) = await gitCommitProvider.GetCommitHistory(Path.Combine(repo.Path, pathToRepo), repo);
+                var (_, _, lib) = gitCommitProvider.GetCommitHistory(Path.Combine(repo.Path, pathToRepo), repo);
 
                 Assert.Equal(
                     exe.Replace("\r", ""),
@@ -49,13 +49,13 @@ namespace Microsoft.Docs.Build
 
                 // another branch
                 exe = Exec("git", $"--no-pager log --format=\"%H|%cI|%an|%ae\" a050eaf -- \"{pathToRepo}\"", repo.Path);
-                (_, _, lib) = await gitCommitProvider.GetCommitHistory(Path.Combine(repo.Path, pathToRepo), repo, "a050eaf");
+                (_, _, lib) = gitCommitProvider.GetCommitHistory(Path.Combine(repo.Path, pathToRepo), repo, "a050eaf");
 
                 Assert.Equal(
                     exe.Replace("\r", ""),
                     string.Join("\n", lib.Select(c => $"{c.Sha}|{c.Time.ToString("s")}{c.Time.ToString("zzz")}|{c.AuthorName}|{c.AuthorEmail}")));
 
-                await gitCommitProvider.SaveGitCommitCache();
+                gitCommitProvider.SaveGitCommitCache();
             }
 
         }

--- a/test/docfx.Test/lib/ProcessUtilityTest.cs
+++ b/test/docfx.Test/lib/ProcessUtilityTest.cs
@@ -38,21 +38,21 @@ namespace Microsoft.Docs.Build
         }
 
         [Fact]
-        public static async Task FileMutexTest()
+        public static void FileMutexTest()
         {
             var concurrencyLevel = 0;
             var fileName = $"process-test/{Guid.NewGuid()}";
 
             try
             {
-                await ParallelUtility.ForEach(
+                Parallel.ForEach(
                     Enumerable.Range(0, 5),
                     i => ProcessUtility.RunInsideMutex(
                         fileName,
-                        async () =>
+                        () =>
                         {
                             Assert.Equal(1, Interlocked.Increment(ref concurrencyLevel));
-                            await Task.Delay(100);
+                            Thread.Sleep(100);
                             Assert.Equal(0, Interlocked.Decrement(ref concurrencyLevel));
                         }));
             }
@@ -63,37 +63,37 @@ namespace Microsoft.Docs.Build
         }
 
         [Fact]
-        public static async Task NestedRunInMutexWithDifferentNameTest()
+        public static void NestedRunInMutexWithDifferentNameTest()
         {
             // nested run works for different names
-            await ProcessUtility.RunInsideMutex($"process-test/{Guid.NewGuid()}",
-                async () =>
+            ProcessUtility.RunInsideMutex($"process-test/{Guid.NewGuid()}",
+                () =>
                 {
-                    await ProcessUtility.RunInsideMutex($"process-test/{Guid.NewGuid()}",
-                        async () =>
+                    ProcessUtility.RunInsideMutex($"process-test/{Guid.NewGuid()}",
+                        () =>
                         {
-                            await Task.Delay(100);
+                            // do nothing
                         });
                 });
         }
 
         [Fact]
-        public static async Task NestedRunInMutexWithSameNameTest()
+        public static void NestedRunInMutexWithSameNameTest()
         {
             // nested run doesn't work for sanme lock name
-            await Assert.ThrowsAnyAsync<Exception>(async () =>
+            Assert.ThrowsAny<Exception>(() =>
             {
                 var name = Guid.NewGuid().ToString();
-                await ProcessUtility.RunInsideMutex($"process-test/{name}",
-                    async () =>
+                ProcessUtility.RunInsideMutex($"process-test/{name}",
+                    () =>
                     {
-                        await ProcessUtility.RunInsideMutex($"process-test/{Guid.NewGuid()}",
-                            async () =>
+                        ProcessUtility.RunInsideMutex($"process-test/{Guid.NewGuid()}",
+                            () =>
                             {
-                                await ProcessUtility.RunInsideMutex($"process-test/{name}",
-                                    async () =>
+                                ProcessUtility.RunInsideMutex($"process-test/{name}",
+                                    () =>
                                     {
-                                        await Task.Delay(100);
+                                        // do nothing
                                     });
                             });
                     });
@@ -101,18 +101,18 @@ namespace Microsoft.Docs.Build
         }
 
         [Fact]
-        public static async Task ParallelNestedRunInMutexWithSameNameTest()
+        public static void ParallelNestedRunInMutexWithSameNameTest()
         {
             var name = Guid.NewGuid().ToString();
 
-            await ProcessUtility.RunInsideMutex($"process-test/123", async () =>
+            ProcessUtility.RunInsideMutex($"process-test/123", () =>
             {
-                await ParallelUtility.ForEach(new[] { 1, 2, 3, 4, 5 }, async i =>
+                Parallel.ForEach(new[] { 1, 2, 3, 4, 5 }, i =>
                 {
-                    await ProcessUtility.RunInsideMutex($"process-test/{name}",
+                    ProcessUtility.RunInsideMutex($"process-test/{name}",
                         () =>
                         {
-                            return Task.CompletedTask;
+                            // do nothing
                         });
                 });
             });
@@ -166,7 +166,7 @@ namespace Microsoft.Docs.Build
                 switch (parts[0])
                 {
                     case "a-s": // acquire shared lock
-                        (acquired, acquirer) = await ProcessUtility.AcquireSharedLock(guid + parts[1]);
+                        (acquired, acquirer) = ProcessUtility.AcquireSharedLock(guid + parts[1]);
                         Debug.Assert(acquired == results[i], $"{i}");
                         if (acquired)
                         {
@@ -179,7 +179,7 @@ namespace Microsoft.Docs.Build
                         }
                         break;
                     case "a-e": // acquire exclusive lock
-                        (acquired, acquirer) = await ProcessUtility.AcquireExclusiveLock(guid + parts[1]);
+                        (acquired, acquirer) = ProcessUtility.AcquireExclusiveLock(guid + parts[1]);
                         Debug.Assert(acquired == results[i], $"{i}");
                         if (acquired)
                         {
@@ -205,7 +205,7 @@ namespace Microsoft.Docs.Build
                                 acquirers.Remove("s" + parts[1]);
                             }
                         }
-                        var sharedReleased = await ProcessUtility.ReleaseSharedLock(guid + parts[1], sharedAcquirer ?? "not exists");
+                        var sharedReleased = ProcessUtility.ReleaseSharedLock(guid + parts[1], sharedAcquirer ?? "not exists");
                         Debug.Assert(sharedReleased == results[i], $"{i}");
                         break;
                     case "r-e": // release exclusive lock
@@ -218,8 +218,8 @@ namespace Microsoft.Docs.Build
                             acquirers.Remove("e" + parts[1]);
                         }
                         if (!string.IsNullOrEmpty(exclusiveAcquirer))
-                            Assert.True(await ProcessUtility.IsExclusiveLockHeld(guid + parts[1]));
-                        var exclusivedReleased = await ProcessUtility.ReleaseExclusiveLock(guid + parts[1], exclusiveAcquirer ?? "not exists");
+                            Assert.True(ProcessUtility.IsExclusiveLockHeld(guid + parts[1]));
+                        var exclusivedReleased = ProcessUtility.ReleaseExclusiveLock(guid + parts[1], exclusiveAcquirer ?? "not exists");
                         Debug.Assert(exclusivedReleased == results[i], $"{i}");
                         break;
                 }


### PR DESCRIPTION
a lot of async/await methods are caused by RunInsideMutex, but this method can be synchronous, and the actions executed inside mutex are mostly synchronous.

So remove un-necessary asynchronous methods, also a prepare work for mutex implementation changing work 