### PR TITLE
Fix yaml header line info off by one error

### DIFF
--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -26,7 +26,7 @@ inputs:
 outputs:
   docs/a.json:
   build.log: |
-    ["info","null-value","'title' contains null value","docs/a.md","title",1,1]
+    ["info","null-value","'title' contains null value","docs/a.md","title",2,1]
 ---
 # title metadata overrides h1
 inputs:
@@ -304,7 +304,7 @@ inputs:
 outputs:
   docs/b.json:
   build.log: |
-    ["error","yaml-duplicate-key","Key 'a' is already defined, remove the duplicate key.","docs/a.md","",2,1]
+    ["error","yaml-duplicate-key","Key 'a' is already defined, remove the duplicate key.","docs/a.md","",3,1]
 ---
 # do not allow custom js, styles and css
 inputs:

--- a/docs/specs/metadata.yml
+++ b/docs/specs/metadata.yml
@@ -24,7 +24,7 @@ outputs:
   docs/a.json: |
     { "metadata": { "ms.custom-metadata": null } }
   build.log: |
-    ["info","null-value","'ms.custom-metadata' contains null value","docs/a.md","['ms.custom-metadata']",1,1]
+    ["info","null-value","'ms.custom-metadata' contains null value","docs/a.md","['ms.custom-metadata']",2,1]
 ---
 # Report error for invalid yaml header value type
 inputs:
@@ -35,7 +35,7 @@ inputs:
     ---
 outputs:
   build.log: |
-    ["error","violate-schema","Expected type String, please input String or type compatible with String.","docs/a.md","locale",1,9]
+    ["error","violate-schema","Expected type String, please input String or type compatible with String.","docs/a.md","locale",2,9]
 ---
 # generate normal document id and version id
 # backward compatible to docs.com
@@ -352,7 +352,7 @@ inputs:
     ---
 outputs:
   build.log: |
-    ["warning","reserved-metadata","Metadata 'redirect_url' is reserved by docfx, remove this metadata: 'redirect_url'","docs/a.md","",1,15]
+    ["warning","reserved-metadata","Metadata 'redirect_url' is reserved by docfx, remove this metadata: 'redirect_url'","docs/a.md","",2,15]
     ["error","publish-url-conflict","Two or more files publish to the same url '/docs/a': 'docs/a.md', 'docs/a.md <redirection>'"]
 ---
 # redirection defined in file metadata is not supported

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -172,7 +172,7 @@ inputs:
     ---
 outputs:
   build.log: |
-    ["error","violate-schema","Expected type String, please input String or type compatible with String.","docs/TOC.md","monikerRange",1,15]
+    ["error","violate-schema","Expected type String, please input String or type compatible with String.","docs/TOC.md","monikerRange",2,15]
 ---
 # Absolute file reference
 inputs:

--- a/src/docfx/lib/markdown/ExtractYamlHeader.cs
+++ b/src/docfx/lib/markdown/ExtractYamlHeader.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Docs.Build
     {
         public static (List<Error> errors, JObject metadata) Extract(TextReader reader)
         {
-            var builder = new StringBuilder();
+            var builder = new StringBuilder("\n");
             var errors = new List<Error>();
             if (reader.ReadLine()?.TrimEnd() != "---")
             {


### PR DESCRIPTION
The first line of yaml header should be 2 since we start from 1