### PR TITLE
Improve backslash replace in getOverrideFolder.

### DIFF
--- a/src/docfx.website.themes/common/common.js
+++ b/src/docfx.website.themes/common/common.js
@@ -191,7 +191,7 @@ function getPatternName(repo, gitUrlPattern) {
 
 function getOverrideFolder(path) {
     if (!path) return "";
-    path = path.replace('\\', '/');
+    path = path.replace(/\\/g, '/');
     if (path.charAt(path.length - 1) == '/') path = path.substring(0, path.length - 1);
     return path;
 }


### PR DESCRIPTION
The current `getOverrideFolder` function looks like it has a minor bug, where `.replace('\\', '/')` only replaces the first occurrence of a backslash with a forward slash. From the context, I'm guessing that the intent is to replace them all, so a regex-based match seems like a reasonable approach.