### PR TITLE
Add support for "View Source" with Bitbucket repos

### DIFF
--- a/src/docfx.website.themes/common/common.js
+++ b/src/docfx.website.themes/common/common.js
@@ -106,6 +106,24 @@ var gitUrlPatternItems = {
         'generateNewFileUrl': function (gitInfo, uid) {
             return '';
         }
+    },
+    'bitbucket': {
+        // HTTPS form: https://{user}@bitbucket.org/{org}/{repo}.git
+        // SSH form: git@bitbucket.org:{org}/{repo}.git
+        // generate URL: https://bitbucket.org/{org}/{repo}/src/{branch}/{path}
+        'testRegex': /^(https?:\/\/)?(\S+\@)?(\S+\.)?bitbucket\.org(\/|:).*/i,
+        'generateUrl': function (gitInfo) {
+            var url = normalizeGitUrlToHttps(gitInfo.repo);
+            url = getRepoWithoutGitExtension(url);
+            url += '/src' + '/' + gitInfo.branch + '/' + gitInfo.path;
+            if (gitInfo.startLine && gitInfo.startLine > 0) {
+                url += '#lines-' + gitInfo.startLine;
+            }
+            return url;
+        },
+        'generateNewFileUrl': function (gitInfo, uid) {
+            return '';
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds support for the "View Source" button with Bitbucket repos.

- [x] CLA signed
- [ ] What tests, if any, are necessary?  This is my first contribution to the project and I'm unfamiliar with the test setup.