### PR TITLE
👨‍🏭support link to deleted resource to get ride of tons of noisy warnings

### DIFF
--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -989,6 +989,8 @@ outputs:
     {"content":"<p><a href=\"resource.png\">link to deleted resource</a>\n<a href=\"b.md\">link to deleted markdown doesnt work</a></p>\n"}
   build.log: |
     ["warning","file-not-found","Cannot find file 'b.md' relative to 'docs/a.md'","docs/a.md",2,1]
+  .dependencymap.json: |
+    {"dependencies":{"docs/a.md":[{"source":"docs/resource.png","type":"link"}]}}
 ---
 # fallback to deleted toc
 commands:

--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -966,6 +966,30 @@ outputs:
   .dependencymap.json: |
     {"dependencies": {"!docs/tokena.md": null}}
 ---
+# fallback to deleted resource
+commands:
+  - build --locale zh-cn
+repos:
+  https://github.com/deletedres/a:
+    - files:
+        docfx.yml:
+      author: a
+    - files:
+        docfx.yml:
+        docs/resource.png:
+        docs/b.md:
+      author: b
+  https://github.com/deletedres/a.zh-cn:
+    - files:
+        docs/a.md: |
+          [link to deleted resource](resource.png)
+          [link to deleted markdown doesnt work](b.md)
+outputs:
+  docs/a.json: |
+    {"content":"<p><a href=\"resource.png\">link to deleted resource</a>\n<a href=\"b.md\">link to deleted markdown doesnt work</a></p>\n"}
+  build.log: |
+    ["warning","file-not-found","Cannot find file 'b.md' relative to 'docs/a.md'","docs/a.md",2,1]
+---
 # fallback to deleted toc
 commands:
   - build --locale zh-cn
@@ -1014,7 +1038,7 @@ outputs:
   docs/b/toc.json: |
     {"items":[{"name":"reference toc a"}]}
 ---
-# fallback to deleted token/codesnippet only works for loc docset build
+# fallback to deleted token/codesnippet/resource only works for loc docset build
 commands:
   - build
 repos:
@@ -1023,6 +1047,7 @@ repos:
         docfx.yml:
         docs/a.md: |
           [!include[include deleted tokena](tokena.md)
+          [link to deleted resource](resource.png)
     - files:
         docfx.yml:
         docs/tokena.md: |
@@ -1030,9 +1055,11 @@ repos:
           [!code-csharp[Main](program.cs)]
         docs/tokenb.md: b
         docs/program.cs:
+        docs/resource.png:
 outputs:
   docs/a.json:
   build.log: |
+    ["warning","file-not-found","Cannot find file 'resource.png' relative to 'docs/a.md'","docs/a.md",2,1]
     ["warning","include-not-found","Cannot resolve 'tokena.md' relative to 'docs/a.md'.","docs/a.md",1,1]
 ---
 # fallback to inclusion parent toc

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Docs.Build
                 }
 
                 (error, file) = TryResolveResourceFromHistory(_gitCommitProvider, relativeTo.Docset, pathToDocset);
-                if (error != null || file == null)
+                if (error != null || file is null)
                 {
                     return (error, href, fragment, hrefType, null);
                 }

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -151,15 +151,11 @@ namespace Microsoft.Docs.Build
                     return (error, href, fragment, hrefType, null);
                 }
 
-                var (errorFromHistory, resourceFromHistory) = TryResolveResourceFromHistory(_gitCommitProvider, relativeTo.Docset, pathToDocset);
-                if (errorFromHistory != null || resourceFromHistory == null)
+                (error, file) = TryResolveResourceFromHistory(_gitCommitProvider, relativeTo.Docset, pathToDocset);
+                if (error != null || file == null)
                 {
-                    return (errorFromHistory ?? error, href, fragment, hrefType, null);
+                    return (error, href, fragment, hrefType, null);
                 }
-
-                // set file to resource got from histroy, reset the error
-                file = resourceFromHistory;
-                error = null;
             }
 
             // Self reference, don't build the file, leave href as is


### PR DESCRIPTION
actually that's a missing feature in v2, with this feature, we can get ride of lots of noisy warning about "file-not-found":

https://opbuildstoragesandbox2.blob.core.windows.net/report/2019%5C4%5C9%5C4709ceea-246d-76fd-3615-65fb72516268%5CCommit%5C201904090844459536-docfx-v3-e2e-test-sxs%5Cworkflow_report.html?sv=2015-02-21&sr=b&sig=ML%2BFm4dTXklAc%2FNO%2FiORKhJ8qoVXTnPB964iiP6bAV4%3D&st=2019-04-09T09%3A08%3A27Z&se=2019-05-10T09%3A13%3A27Z&sp=r