### PR TITLE
🎫Clean up legacy tests

### DIFF
--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -105,7 +105,9 @@ inputs:
     [link](redirect.md)
 outputs:
   a.raw.page.json: |
-    { "content": "<p>\n<a data-linktype=\"relative-path\" href=\"redirect\">link</a></p>" }
+    { "content": "<p>\n<a data-linktype=\"relative-path\" href=\"redirect\">link</a></p>" }  
+  redirect.mta.json:
+  redirect.raw.page.json:
 ---
 # Legacy metadata black list
 inputs:

--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -105,7 +105,7 @@ inputs:
     [link](redirect.md)
 outputs:
   a.raw.page.json: |
-    { "content": "<p>\n<a data-linktype=\"relative-path\" href=\"redirect\">link</a></p>" }  
+    { "content": "<p>\n<a data-linktype=\"relative-path\" href=\"redirect\">link</a></p>" }
   redirect.mta.json:
   redirect.raw.page.json:
 ---

--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -64,10 +64,6 @@ outputs:
     { "locale": "en-us", "ms.author": "yufeih", "is_dynamic_rendering": true }
   toc.json:
   toc.mta.json:
-  .manifest.json:
-  .dependency-map.json:
-  filemap.json:
-  op_aggregated_file_map_info.json:
 ---
 # Resolve link for landing page
 inputs:
@@ -97,10 +93,6 @@ inputs:
   docs/a.md:
 outputs:
   build.log:
-  .manifest.json:
-  .dependency-map.json:
-  filemap.json:
-  op_aggregated_file_map_info.json:
 ---
 # Redirection file href shouldn't have extension
 commands:
@@ -114,14 +106,6 @@ inputs:
 outputs:
   a.raw.page.json: |
     { "content": "<p>\n<a data-linktype=\"relative-path\" href=\"redirect\">link</a></p>" }
-  redirect.mta.json:
-  redirect.raw.page.json:
-  .manifest.json:
-  .dependency-map.json:
-  filemap.json:
-  op_aggregated_file_map_info.json:
-  .publish.json:
-  xrefmap.json:
 ---
 # Legacy metadata black list
 inputs:

--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -64,6 +64,12 @@ outputs:
     { "locale": "en-us", "ms.author": "yufeih", "is_dynamic_rendering": true }
   toc.json:
   toc.mta.json:
+  .manifest.json:
+  .dependency-map.json:
+  filemap.json:
+  op_aggregated_file_map_info.json:
+  .publish.json:
+  xrefmap.json:
 ---
 # Resolve link for landing page
 inputs:

--- a/src/docfx/lib/json/JsonUtility.cs
+++ b/src/docfx/lib/json/JsonUtility.cs
@@ -236,6 +236,8 @@ namespace Microsoft.Docs.Build
 
         public static void Merge(JObject container, JObject overwrite)
         {
+            if (overwrite is null)
+                return;
             foreach (var property in overwrite.Properties())
             {
                 var key = property.Name;

--- a/test/docfx.Test/e2e/E2ESpec.cs
+++ b/test/docfx.Test/e2e/E2ESpec.cs
@@ -21,7 +21,10 @@ namespace Microsoft.Docs.Build
 
         public readonly string[] Environments = Array.Empty<string>();
 
-        public readonly string[] SkippableOutputs = new[] { "xrefmap.json", ".publish.json", ".dependencymap.json" };
+        public readonly string[] SkippableOutputs = new[] { "xrefmap.json", ".publish.json", ".dependencymap.json",
+                                                            // legacy
+                                                            "redirect.mta.json", "redirect.raw.page.json", ".manifest.json", ".dependency-map.json",
+                                                            "filemap.json", "op_aggregated_file_map_info.json", ".publish.json", "xrefmap.json" };
 
         public readonly Dictionary<string, E2ECommit[]> Repos = new Dictionary<string, E2ECommit[]>();
 

--- a/test/docfx.Test/e2e/E2ESpec.cs
+++ b/test/docfx.Test/e2e/E2ESpec.cs
@@ -23,8 +23,7 @@ namespace Microsoft.Docs.Build
 
         public readonly string[] SkippableOutputs = new[] { "xrefmap.json", ".publish.json", ".dependencymap.json",
                                                             // legacy
-                                                            "redirect.mta.json", "redirect.raw.page.json", ".manifest.json", ".dependency-map.json",
-                                                            "filemap.json", "op_aggregated_file_map_info.json", ".publish.json", "xrefmap.json" };
+                                                            ".manifest.json", ".dependency-map.json", "filemap.json", "op_aggregated_file_map_info.json", ".publish.json", "xrefmap.json" };
 
         public readonly Dictionary<string, E2ECommit[]> Repos = new Dictionary<string, E2ECommit[]>();
 


### PR DESCRIPTION
- make empty output files optional for legacy tests
- add null check for `JsonUtility.Merge`