### PR TITLE
Revert "🍂support multiple hashtags for fragment (#4351)"

### DIFF
--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -339,14 +339,12 @@ inputs:
     [link to title 3](#title-3)
     [link to html title](#html-title)
     [link to yaml](c.yml#no-such-bookmark) does not warn, only validate against markdown files
-    [link to title 2 again](####title-2)
     ## title 2
     <h2 id="html-title">title</h2>
     [!include[](d.md)]
   docs/b.md: |
     [link to title 2](a.md#title-2)
     [link to title 3](a.md#title-3)
-    [link to title 2 again](a.md##title-2)
   docs/c.yml: |
     #YamlMime:LandingData
     title: test

--- a/src/docfx/lib/HrefUtility.cs
+++ b/src/docfx/lib/HrefUtility.cs
@@ -50,25 +50,7 @@ namespace Microsoft.Docs.Build
                 }
             }
 
-            return (path, query, TrimStart(fragment));
-
-            // TODO: this is to support a legacy behavior
-            // we will remove it once we want to expose this error
-            string TrimStart(string fragmentToTrim)
-            {
-                var lastFragmentIndex = -1;
-                foreach (var ch in fragmentToTrim)
-                {
-                    if (ch == '#')
-                    {
-                        lastFragmentIndex++;
-                        continue;
-                    }
-
-                    break;
-                }
-                return fragmentToTrim.Substring(lastFragmentIndex < 0 ? 0 : lastFragmentIndex);
-            }
+            return (path, query, fragment);
         }
 
         /// <summary>

--- a/test/docfx.Test/lib/HrefUtilityTest.cs
+++ b/test/docfx.Test/lib/HrefUtilityTest.cs
@@ -17,10 +17,6 @@ namespace Microsoft.Docs.Build
         [InlineData("a#b?c=d", "a", "", "#b?c=d")]
         [InlineData("a?b#c?d=e", "a", "?b", "#c?d=e")]
         [InlineData("a?b#c#d", "a", "?b", "#c#d")]
-        [InlineData("a####b", "a", "", "#b")]
-        [InlineData("a?b###c#d", "a", "?b", "#c#d")]
-        [InlineData("a?b##d", "a", "?b", "#d")]
-        [InlineData("a###b?c=d", "a", "", "#b?c=d")]
         public static void SplitHref(string href, string path, string query, string fragment)
         {
             var (apath, aquery, afragment) = HrefUtility.SplitHref(href);


### PR DESCRIPTION
This reverts commit 88e49072ab6c4b31f785049e7aef09e594a89514.

If user want to link to a bookmark like `<h1 id="#test"></h1>`, it should use `<a href="##test"></a>`. Merging mutiple `#` into one is wrong in this case. This is a valid case as [HTML5 allows any character except any type of space character](http://xahlee.info/js/html_allowed_chars_in_attribute.html)

So this diff is actually a [v2 bug](https://github.com/dotnet/docfx/blob/f1ff9c21dd5e7c9cd21185bca3693d9e460f1263/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/ValidateBookmark.cs#L85), we can fisrt fix it in diff tool.
https://ceapex.visualstudio.com/Engineering/_workitems/edit/79102?src=WorkItemMention&src-action=artifact_link



