### PR TITLE
Support use commit build time for updated at

### DIFF
--- a/docs/specs/config.yml
+++ b/docs/specs/config.yml
@@ -242,11 +242,8 @@ inputs:
       - docs/b.yml
     gitHub:
       userCache: docs/d.json
-    contribution:
-      gitCommitsTime: docs/c.json
   docs/a.yml:
   docs/b.yml:
-  docs/c.json: '{}'
   docs/d.json: '{}'
 outputs:
 ---

--- a/docs/specs/git.yml
+++ b/docs/specs/git.yml
@@ -1,5 +1,5 @@
 ---
-# Show git contribution info when userProfile & commitsTime is set to URL
+# Show git contribution info when userProfile is set to URL
 repos:
   https://github.com/testowner/testrepo#master-url-cache:
     - author: Charlie
@@ -25,8 +25,6 @@ inputs:
     gitHub:
       userCache: https://raw.githubusercontent.com/docascode/docfx-test-dependencies/master/user_profile.json
       resolveUsers: true
-    contribution:
-      gitCommitsTime: https://raw.githubusercontent.com/docascode/docfx-test-dependencies/master/build_history.json
 outputs:
   docs/index.json: |
     {
@@ -36,10 +34,10 @@ outputs:
         { "name": "bob", "profile_url": "https://github.com/bob", "display_name": "Bob", "id": "2" },
         { "name": "alice", "profile_url": "https://github.com/alice", "display_name": "Alice", "id": "1" }
       ],
-      "updated_at": "2018-01-01T00:00:00.0000000"
+      "updated_at": "2018-10-30T00:00:00Z"
     }
 ---
-# Show git contribution info when userProfile & commitsTime is set to relative file path
+# Show git contribution info when userProfile is set to relative file path
 repos:
   https://github.com/testowner/testrepo#master-file-cache:
     - author: Charlie
@@ -65,8 +63,6 @@ inputs:
     gitHub:
       userCache: user_profile.json
       resolveUsers: true
-    contribution:
-      gitCommitsTime: build_history.json
   user_profile.json: |
       { "users": [
           {"name": "Alice", "login": "alice", "id": 1, "emails": ["alice@contoso.com"]},
@@ -74,11 +70,6 @@ inputs:
           {"name": "Charlie", "login": "charlie", "id": 3, "emails": ["charlie@contoso.com"]}
         ]
       }
-  build_history.json: |
-    { "commits": [
-        { "sha": "6547e91b51bb7cd49d8fbf71f7c61d14f6a49937", "built_at": "2018-01-01" }
-      ]
-    }
 outputs:
   docs/index.json: |
     {
@@ -88,7 +79,7 @@ outputs:
         { "name": "bob", "profile_url": "https://github.com/bob", "display_name": "Bob", "id": "2" },
         { "name": "alice", "profile_url": "https://github.com/alice", "display_name": "Alice", "id": "1" }
       ],
-      "updated_at": "2018-01-01T00:00:00.0000000"
+      "updated_at": "2018-10-30T00:00:00Z"
     }
 ---
 # Specify invalid author in YAML header should log warning
@@ -334,7 +325,7 @@ outputs:
       "gitcommit": "https://github.com/testowner/testrepo/blob/e662dbc7c5e582a14b863d6a6a82e495d6272f91/docs/index.md",
     }
 ---
-# Use commit's time when gitCommitsTime file not given
+# Use commit's time as updated_at
 repos:
   https://github.com/testowner/testrepo#master-time-from-commit:
     - time: 2018-01-01T00:00:00Z
@@ -464,7 +455,6 @@ inputs:
       authToken: {GITHUB_ACCESS_TOKEN}
     contribution:
       repository: https://github.com/docascode/contribution-test
-      gitCommitsTime: build_history.json
   user_profile.json: |
       { "users": [
           {"name": "Alice", "login": "alice", "id": 1, "emails": ["alice@contoso.com"]},
@@ -472,11 +462,6 @@ inputs:
           {"name": "Charlie", "login": "charlie", "id": 3, "emails": ["charlie@contoso.com"]}
         ]
       }
-  build_history.json: |
-    { "commits": [
-        { "sha": "bc09224561ce6d13411cb48506b1900d6c6b94cb", "built_at": "2018-01-01" }
-      ]
-    }
 environments:
   - GITHUB_ACCESS_TOKEN
 outputs:
@@ -487,6 +472,5 @@ outputs:
       "contributors": [
         { "name": "bob", "profile_url": "https://github.com/bob", "display_name": "Bob", "id": "2" },
         { "name": "OsmondJiang", "profile_url": "https://github.com/OsmondJiang", "display_name": "osmondjiang", "id": "19990166" }
-      ],
-      "updated_at": "2018-01-01T00:00:00.0000000"
+      ]
     }

--- a/docs/specs/git.yml
+++ b/docs/specs/git.yml
@@ -325,18 +325,34 @@ outputs:
       "gitcommit": "https://github.com/testowner/testrepo/blob/e662dbc7c5e582a14b863d6a6a82e495d6272f91/docs/index.md",
     }
 ---
-# Use commit's time as updated_at
+# Use commit's time as updated_at when `updateTimeAsCommitBuildTime` is false
 repos:
   https://github.com/testowner/testrepo#master-time-from-commit:
-    - time: 2018-01-01T00:00:00Z
-      files:
+    - files:
+        docfx.yml:
         docs/index.md: Alice creates this.
-inputs:
-  docfx.yml:
 outputs:
   docs/index.json: |
     {
-      "updated_at": "2018-01-01T00:00:00Z",
+      "updated_at": "2018-10-30T00:00:00Z",
+    }
+---
+# Use commit build time as updated_at when `updateTimeAsCommitBuildTime` is true
+repos:
+  https://github.com/testowner/testrepo#master-time-from-commit-build-time:
+    - files:
+        docfx.yml: |
+          updateTimeAsCommitBuildTime: true
+        docs/index.md: Alice creates this.
+cache:
+  history/build_history_a93ce489-81ae-9608-7e1e-025405220e04_84336cc2-4f45-2d2d-9299-07fb71136125.json: |
+    {
+      "commits": [{ "sha": "7e6344c7275cccec2334ca04b73017bdeb7ecc2a", "built_at": "2019-04-23T00:00:00Z" }]
+    }
+outputs:
+  docs/index.json: |
+    {
+      "updated_at": "2019-04-23T00:00:00Z",
     }
 ---
 # Support git submodule

--- a/docs/specs/git.yml
+++ b/docs/specs/git.yml
@@ -339,13 +339,13 @@ outputs:
 ---
 # Use commit build time as updated_at when `updateTimeAsCommitBuildTime` is true
 repos:
-  https://github.com/testowner/testrepo#master-time-from-commit-build-time:
+  https://github.com/MicrosoftDocs/edge-developer#master:
     - files:
         docfx.yml: |
           updateTimeAsCommitBuildTime: true
         docs/index.md: Alice creates this.
 cache:
-  history/build_history_a93ce489-81ae-9608-7e1e-025405220e04_84336cc2-4f45-2d2d-9299-07fb71136125.json: |
+  history/build_history_0ad81e11-d18b-a417-bd25-94364d004cae_17190aeb-6297-d34d-a48f-a681d3061212.json: |
     {
       "commits": [{ "sha": "7e6344c7275cccec2334ca04b73017bdeb7ecc2a", "built_at": "2019-04-23T00:00:00Z" }]
     }

--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -1098,14 +1098,10 @@ repos:
   https://github.com/buildhistory/a:
     - files:
         docfx.yml: |
-          contribution:
-            gitCommitsTime: build_history.json
+          monikerDefinition: monikers.json
         docs/a.md:
-        build_history.json: |
-          { "commits": [
-              { "sha": "6547e91b51bb7cd49d8fbf71f7c61d14f6a49937", "built_at": "2018-01-01" }
-            ]
-          }
+        monikers.json: |
+          {}
   https://github.com/buildhistory/a.zh-cn:
     - files:
         docs/a.md:

--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -121,8 +121,7 @@ commands:
   - build --no-restore
 inputs:
   docfx.yml: |
-    contribution:
-      gitCommitsTime: https://docs.microsoft.com/bad-url
+    monikerDefinition: https://docs.microsoft.com/bad-url
 outputs:
   build.log: |
     ["error","need-restore","Cannot find dependency 'https://docs.microsoft.com/bad-url', did you forget to run `docfx restore`?"]
@@ -130,11 +129,10 @@ outputs:
 # Show error when dependent file can't be found
 inputs:
   docfx.yml: |
-    contribution:
-      gitCommitsTime: a.json
+    monikerDefinition: a.json
 outputs:
   build.log: |
-    ["error","file-not-found","*",2,19]
+    ["error","file-not-found","*",1,20]
 ---
 # Restore longpath repo
 inputs:

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -54,7 +54,6 @@ namespace Microsoft.Docs.Build
             if (report.Write(config.ConfigFileName, configErrors))
                 return;
 
-            var errors = new List<Error>();
             var docset = GetBuildDocset(new Docset(report, docsetPath, locale, config, options, dependencyLock, restoreMap, repository, fallbackRepo));
             var outputPath = Path.Combine(docsetPath, config.Output.Path);
 
@@ -84,8 +83,9 @@ namespace Microsoft.Docs.Build
                     }
                 }
 
-                errors.AddIfNotNull(await saveGitHubUserCache);
-                errors.ForEach(e => context.Report.Write(e));
+                context.Report.Write(await saveGitHubUserCache);
+
+                context.ContributionProvider.UpdateCommitBuildTime();
             }
         }
 

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Docs.Build
     {
         private readonly GitHubUserCache _gitHubUserCache;
 
-        private readonly Dictionary<string, DateTime> _updateTimeByCommit = new Dictionary<string, DateTime>();
+        private readonly CommitBuildTimeProvider _commitBuildTimeProvider;
 
         private readonly GitCommitProvider _gitCommitProvider;
 
@@ -24,8 +24,8 @@ namespace Microsoft.Docs.Build
 
             _gitHubUserCache = gitHubUserCache;
             _gitCommitProvider = gitCommitProvider;
-
-            LoadCommitsTime(docset);
+            _commitBuildTimeProvider = docset.Repository != null && docset.Config.UpdateTimeAsCommitBuildTime
+                ? new CommitBuildTimeProvider(docset.Repository) : null;
         }
 
         public async Task<(List<Error> error, Contributor author, List<Contributor> contributors, DateTime updatedAt)> GetAuthorAndContributors(
@@ -136,7 +136,7 @@ namespace Microsoft.Docs.Build
         {
             if (fileCommits?.Count > 0)
             {
-                return _updateTimeByCommit.TryGetValue(fileCommits[0].Sha, out var timeFromHistory)
+                return _commitBuildTimeProvider != null && _commitBuildTimeProvider.TryGetCommitBuildTime(fileCommits[0].Sha, out var timeFromHistory)
                     ? timeFromHistory
                     : fileCommits[0].Time.UtcDateTime;
             }
@@ -196,16 +196,11 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private void LoadCommitsTime(Docset docset)
+        public void UpdateCommitBuildTime()
         {
-            if (!string.IsNullOrEmpty(docset.Config.Contribution.GitCommitsTime))
+            if (_commitBuildTimeProvider != null)
             {
-                var (_, content, _) = RestoreMap.GetRestoredFileContent(docset, docset.Config.Contribution.GitCommitsTime);
-
-                foreach (var commit in JsonUtility.Deserialize<GitCommitsTime>(content).Commits)
-                {
-                    _updateTimeByCommit.Add(commit.Sha, commit.BuiltAt);
-                }
+                _commitBuildTimeProvider.UpdateAndSaveCache();
             }
         }
 

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Docs.Build
     {
         private readonly GitHubUserCache _gitHubUserCache;
 
+        // TODO: support CRR and multiple repositories
+        // TODO: support live SXS branch
         private readonly CommitBuildTimeProvider _commitBuildTimeProvider;
 
         private readonly GitCommitProvider _gitCommitProvider;

--- a/src/docfx/config/AppData.cs
+++ b/src/docfx/config/AppData.cs
@@ -46,6 +46,11 @@ namespace Microsoft.Docs.Build
             return Path.Combine(CacheRoot, "commits", HashUtility.GetMd5Hash(remote));
         }
 
+        public static string GetCommitBuildTimePath(string remote, string branch)
+        {
+            return Path.Combine(CacheRoot, "history", $"build_history_{HashUtility.GetMd5Guid(remote)}_{HashUtility.GetMd5Guid(branch)}.json");
+        }
+
         public static string GetGitHubUserCachePath(string url)
         {
             return Path.Combine(CacheRoot, "github-users", PathUtility.UrlToShortName(url));

--- a/src/docfx/config/AppData.cs
+++ b/src/docfx/config/AppData.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Docs.Build
         /// </summary>
         private static string GetAppDataRoot()
         {
-            return Path.GetFullPath(EnvironmentVariable.AppDataPath ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".docfx");
+            return Path.GetFullPath(EnvironmentVariable.AppDataPath ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".docfx"));
         }
     }
 }

--- a/src/docfx/config/AppData.cs
+++ b/src/docfx/config/AppData.cs
@@ -11,13 +11,16 @@ namespace Microsoft.Docs.Build
     {
         private static readonly string s_root = GetAppDataRoot();
 
+        // For testing purpose
+        internal static Func<string> GetCachePath;
+
         public static string GitRoot => Path.Combine(s_root, "git2");
 
         public static string DownloadsRoot => Path.Combine(s_root, "downloads2");
 
         public static string MutexRoot => Path.Combine(s_root, "mutex");
 
-        public static string CacheRoot => Path.Combine(s_root, "cache");
+        public static string CacheRoot => GetCachePath?.Invoke() ?? EnvironmentVariable.CachePath ?? Path.Combine(s_root, "cache");
 
         public static string DependencyLockRoot => Path.Combine(s_root, "lock");
 
@@ -61,9 +64,7 @@ namespace Microsoft.Docs.Build
         /// </summary>
         private static string GetGlobalConfigPath()
         {
-            var docfxGlobalConfig = EnvironmentVariable.GlobalConfigPath;
-            var configPath = PathUtility.FindYamlOrJson(Path.Combine(s_root, "docfx"));
-            return string.IsNullOrEmpty(docfxGlobalConfig) ? configPath : Path.GetFullPath(docfxGlobalConfig);
+            return Path.GetFullPath(EnvironmentVariable.GlobalConfigPath ?? PathUtility.FindYamlOrJson(Path.Combine(s_root, "docfx")));
         }
 
         /// <summary>
@@ -72,11 +73,7 @@ namespace Microsoft.Docs.Build
         /// </summary>
         private static string GetAppDataRoot()
         {
-            var docfxAppData = EnvironmentVariable.AppDataPath;
-
-            return string.IsNullOrEmpty(docfxAppData)
-                ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".docfx")
-                : Path.GetFullPath(docfxAppData);
+            return Path.GetFullPath(EnvironmentVariable.AppDataPath ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".docfx");
         }
     }
 }

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -163,6 +163,12 @@ namespace Microsoft.Docs.Build
         public readonly SourceInfo<string> DependencyLock = new SourceInfo<string>(string.Empty);
 
         /// <summary>
+        /// When enabled, updated_at for each document will be the last build time
+        /// for the latest commit that touches that document.
+        /// </summary>
+        public readonly bool UpdateTimeAsCommitBuildTime = false;
+
+        /// <summary>
         /// Gets the config file name.
         /// </summary>
         [JsonIgnore]

--- a/src/docfx/config/ContributionConfig.cs
+++ b/src/docfx/config/ContributionConfig.cs
@@ -16,12 +16,6 @@ namespace Microsoft.Docs.Build
         public readonly string Repository;
 
         /// <summary>
-        /// The address of commit time history file, which contains the time each commit being pushed.
-        /// It should be an absolute url or a relative path
-        /// </summary>
-        public readonly SourceInfo<string> GitCommitsTime = new SourceInfo<string>(string.Empty);
-
-        /// <summary>
         /// The excluded contributors which you don't want to show
         /// </summary>
         public readonly HashSet<string> ExcludedContributors = new HashSet<string>(StringComparer.OrdinalIgnoreCase);

--- a/src/docfx/config/EnvironmentVariable.cs
+++ b/src/docfx/config/EnvironmentVariable.cs
@@ -7,12 +7,20 @@ namespace Microsoft.Docs.Build
 {
     public static class EnvironmentVariable
     {
-        public static string GlobalConfigPath => Environment.GetEnvironmentVariable("DOCFX_GLOBAL_CONFIG_PATH");
+        public static string GlobalConfigPath => GetValue("DOCFX_GLOBAL_CONFIG_PATH");
 
-        public static string AppDataPath => Environment.GetEnvironmentVariable("DOCFX_APPDATA_PATH");
+        public static string AppDataPath => GetValue("DOCFX_APPDATA_PATH");
 
-        public static string RepositoryUrl => Environment.GetEnvironmentVariable("DOCFX_REPOSITORY_URL");
+        public static string CachePath => GetValue("DOCFX_CACHE_PATH");
 
-        public static string RepositoryBranch => Environment.GetEnvironmentVariable("DOCFX_REPOSITORY_BRANCH");
+        public static string RepositoryUrl => GetValue("DOCFX_REPOSITORY_URL");
+
+        public static string RepositoryBranch => GetValue("DOCFX_REPOSITORY_BRANCH");
+
+        private static string GetValue(string name)
+        {
+            var value = Environment.GetEnvironmentVariable(name);
+            return string.IsNullOrEmpty(value) ? null : value;
+        }
     }
 }

--- a/src/docfx/lib/git/CommitBuildTime.cs
+++ b/src/docfx/lib/git/CommitBuildTime.cs
@@ -7,8 +7,6 @@ namespace Microsoft.Docs.Build
 {
     internal class CommitBuildTime
     {
-        public string LastBuildCommitId { get; set; }
-
         public List<CommitBuildTimeItem> Commits { get; set; } = new List<CommitBuildTimeItem>();
     }
 }

--- a/src/docfx/lib/git/CommitBuildTime.cs
+++ b/src/docfx/lib/git/CommitBuildTime.cs
@@ -2,13 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using Newtonsoft.Json;
 
 namespace Microsoft.Docs.Build
 {
-    internal class GitCommitsTime
+    internal class CommitBuildTime
     {
-        [JsonProperty("commits")]
-        public List<CommitsTimeItem> Commits { get; set; } = new List<CommitsTimeItem>();
+        public string LastBuildCommitId { get; set; }
+
+        public List<CommitBuildTimeItem> Commits { get; set; } = new List<CommitBuildTimeItem>();
     }
 }

--- a/src/docfx/lib/git/CommitBuildTimeItem.cs
+++ b/src/docfx/lib/git/CommitBuildTimeItem.cs
@@ -3,15 +3,15 @@
 
 using System;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Docs.Build
 {
-    internal class CommitsTimeItem
+    [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
+    internal class CommitBuildTimeItem
     {
-        [JsonProperty("sha")]
         public string Sha { get; set; }
 
-        [JsonProperty("built_at")]
         public DateTime BuiltAt { get; set; }
     }
 }

--- a/src/docfx/lib/git/CommitBuildTimeProvider.cs
+++ b/src/docfx/lib/git/CommitBuildTimeProvider.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.Docs.Build
+{
+    internal class CommitBuildTimeProvider
+    {
+        private readonly Repository _repo;
+        private readonly string _commitBuildTimePath;
+        private readonly string _lastBuildCommit;
+        private readonly IReadOnlyDictionary<string, DateTime> _buildTimeByCommit;
+
+        public CommitBuildTimeProvider(Repository repo)
+        {
+            _repo = repo;
+            _commitBuildTimePath = AppData.GetCommitBuildTimePath(repo.Remote, repo.Branch);
+
+            var commitBuildTime = File.Exists(_commitBuildTimePath)
+                ? JsonUtility.Deserialize<CommitBuildTime>(ProcessUtility.ReadFile(_commitBuildTimePath))
+                : new CommitBuildTime();
+
+            _lastBuildCommit = commitBuildTime.LastBuildCommitId;
+            _buildTimeByCommit = commitBuildTime.Commits.ToDictionary(item => item.Sha, item => item.BuiltAt);
+        }
+
+        public bool TryGetCommitBuildTime(string commitId, out DateTime time)
+        {
+            return _buildTimeByCommit.TryGetValue(commitId, out time);
+        }
+
+        public void UpdateAndSaveCache()
+        {
+            // Get diff commits between last commit id and current commit id
+            // TODO: retrive git log from `FileCommitProvider` since it should already be there.
+            var diffCommits = GitUtility.GetCommits(_repo.Path, _lastBuildCommit != null ? $"{_lastBuildCommit}..{_repo.Commit}" : _repo.Commit);
+
+            var now = DateTime.UtcNow;
+            var commits = _buildTimeByCommit.Select(item => new CommitBuildTimeItem { Sha = item.Key, BuiltAt = item.Value }).ToList();
+
+            foreach (var diffCommit in diffCommits)
+            {
+                if (!_buildTimeByCommit.ContainsKey(diffCommit))
+                {
+                    commits.Add(new CommitBuildTimeItem { Sha = diffCommit, BuiltAt = now });
+                }
+            }
+
+            PathUtility.CreateDirectoryFromFilePath(_commitBuildTimePath);
+            File.WriteAllText(
+                _commitBuildTimePath,
+                JsonUtility.Serialize(new CommitBuildTime { LastBuildCommitId = _repo.Commit, Commits = commits }));
+        }
+    }
+}

--- a/src/docfx/lib/git/CommitBuildTimeProvider.cs
+++ b/src/docfx/lib/git/CommitBuildTimeProvider.cs
@@ -19,12 +19,12 @@ namespace Microsoft.Docs.Build
             _repo = repo;
             _commitBuildTimePath = AppData.GetCommitBuildTimePath(repo.Remote, repo.Branch);
 
-            var commitBuildTime = new CommitBuildTime();
-            if (File.Exists(_commitBuildTimePath))
-            {
-                Log.Write($"Using git commit build time cache file: '{_commitBuildTimePath}'");
-                commitBuildTime = JsonUtility.Deserialize<CommitBuildTime>(ProcessUtility.ReadFile(_commitBuildTimePath));
-            }
+            var exists = File.Exists(_commitBuildTimePath);
+            Log.Write($"{(exists ? "Using" : "Missing")} git commit build time cache file: '{_commitBuildTimePath}'");
+
+            var commitBuildTime = exists
+                ? JsonUtility.Deserialize<CommitBuildTime>(ProcessUtility.ReadFile(_commitBuildTimePath))
+                : new CommitBuildTime();
 
             _buildTimeByCommit = commitBuildTime.Commits.ToDictionary(item => item.Sha, item => item.BuiltAt);
         }

--- a/src/docfx/lib/git/CommitBuildTimeProvider.cs
+++ b/src/docfx/lib/git/CommitBuildTimeProvider.cs
@@ -33,6 +33,11 @@ namespace Microsoft.Docs.Build
 
         public void UpdateAndSaveCache()
         {
+            if (_buildTimeByCommit.ContainsKey(_repo.Commit))
+            {
+                return;
+            }
+
             var now = DateTime.UtcNow;
             var commits = _buildTimeByCommit.Select(item => new CommitBuildTimeItem { Sha = item.Key, BuiltAt = item.Value }).ToList();
 

--- a/src/docfx/lib/git/CommitBuildTimeProvider.cs
+++ b/src/docfx/lib/git/CommitBuildTimeProvider.cs
@@ -19,9 +19,12 @@ namespace Microsoft.Docs.Build
             _repo = repo;
             _commitBuildTimePath = AppData.GetCommitBuildTimePath(repo.Remote, repo.Branch);
 
-            var commitBuildTime = File.Exists(_commitBuildTimePath)
-                ? JsonUtility.Deserialize<CommitBuildTime>(ProcessUtility.ReadFile(_commitBuildTimePath))
-                : new CommitBuildTime();
+            var commitBuildTime = new CommitBuildTime();
+            if (File.Exists(_commitBuildTimePath))
+            {
+                Log.Write($"Using git commit build time cache file: '{_commitBuildTimePath}'");
+                commitBuildTime = JsonUtility.Deserialize<CommitBuildTime>(ProcessUtility.ReadFile(_commitBuildTimePath));
+            }
 
             _buildTimeByCommit = commitBuildTime.Commits.ToDictionary(item => item.Sha, item => item.BuiltAt);
         }

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -123,9 +123,10 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Get a list of commits using git log
         /// </summary>
-        public static string[] GetCommits(string path, string committish, int top = 1)
+        public static string[] GetCommits(string path, string committish, int top = 0)
         {
-            return Execute(path, $"--no-pager log {committish} --pretty=format:\"%H\" -{top}")
+            var topParam = top > 0 ? $"-{top}" : "";
+            return Execute(path, $"--no-pager log --pretty=format:\"%H\" {topParam} {committish}")
                     .Split('\n', StringSplitOptions.RemoveEmptyEntries);
         }
 

--- a/src/docfx/lib/log/Report.cs
+++ b/src/docfx/lib/log/Report.cs
@@ -82,6 +82,9 @@ namespace Microsoft.Docs.Build
 
         public bool Write(Error error, bool force = false)
         {
+            if (error is null)
+                return false;
+
             var level = !force && _config != null && _config.Rules.TryGetValue(error.Code, out var overrideLevel)
                 ? overrideLevel
                 : error.Level;

--- a/src/docfx/restore/RestoreFile.cs
+++ b/src/docfx/restore/RestoreFile.cs
@@ -60,7 +60,6 @@ namespace Microsoft.Docs.Build
                 yield return url;
             }
 
-            yield return config.Contribution.GitCommitsTime;
             yield return config.GitHub.UserCache;
             yield return config.MonikerDefinition;
         }

--- a/test/docfx.Test/e2e/E2ESpec.cs
+++ b/test/docfx.Test/e2e/E2ESpec.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Docs.Build
 
         public readonly bool Watch;
 
-        public readonly string[] Commands = new[] { "build" };
+        public string[] Commands = new[] { "build" };
 
         public readonly string[] Environments = Array.Empty<string>();
 
@@ -29,35 +29,11 @@ namespace Microsoft.Docs.Build
 
         public readonly Dictionary<string, string> Inputs = new Dictionary<string, string>();
 
+        public readonly Dictionary<string, string> Cache = new Dictionary<string, string>();
+
         public readonly Dictionary<string, string> Outputs = new Dictionary<string, string>();
 
         public readonly Dictionary<string, JToken> Http = new Dictionary<string, JToken>();
-
-        public E2ESpec() { }
-
-        public E2ESpec(
-            string os,
-            string repo,
-            bool watch,
-            string[] commands,
-            string[] environments,
-            string[] skippableOutputs,
-            Dictionary<string, E2ECommit[]> repos,
-            Dictionary<string, string> inputs,
-            Dictionary<string, string> outputs,
-            Dictionary<string, JToken> http)
-        {
-            OS = os;
-            Repo = repo;
-            Watch = watch;
-            Commands = commands ?? Commands;
-            Environments = environments ?? Environments;
-            SkippableOutputs = skippableOutputs ?? SkippableOutputs;
-            Repos = repos ?? Repos;
-            Inputs = inputs ?? Inputs;
-            Outputs = outputs ?? Outputs;
-            Http = http ?? Http;
-        }
 
         public class E2ECommit
         {


### PR DESCRIPTION
With this we can remove `GitCommitUpdateTimeResolver`.

- Add `updateTimeAsCommitBuildTime` config, when enabled, it'll update and save current build time and use it to populate updated at
- Add `DOCFX_CACHE_PATH`  to simplify service integration (save file copies)
- Add `cache` to e2e spec to test cache content