### PR TITLE
🧪Test against JSON schema test suite

### DIFF
--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -353,7 +353,7 @@ namespace Microsoft.Docs.Build
             => new Error(ErrorLevel.Error, "violate-schema", message, source);
 
         /// <summary>
-        /// Schema document with violate content type/value against predefined models(not syntax error).
+        /// The input value type does not match expected value type.
         /// </summary>
         public static Error UnexpectedType(SourceInfo source, string expectedType, string actualType)
             => new Error(ErrorLevel.Error, "unexpected-type", $"Expect type '{expectedType}' but got '{actualType}'", source);
@@ -363,6 +363,12 @@ namespace Microsoft.Docs.Build
         /// </summary>
         public static Error UndefinedValue(SourceInfo source, object value, IEnumerable<object> validValues)
             => new Error(ErrorLevel.Error, "undefined-value", $"Value '{value}' is not accepted. Valid values: {Join(validValues)}", source);
+
+        /// <summary>
+        /// A required field is missing.
+        /// </summary>
+        public static Error FieldRequired(SourceInfo source, string name)
+            => new Error(ErrorLevel.Error, "field-required", $"Missing required field '{name}'", source);
 
         /// <summary>
         /// Used unknown YamlMime.

--- a/src/docfx/lib/schema/JsonSchema.cs
+++ b/src/docfx/lib/schema/JsonSchema.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
@@ -15,5 +16,7 @@ namespace Microsoft.Docs.Build
         public JsonSchema Items { get; set; }
 
         public List<JValue> Enum { get; set; } = new List<JValue>();
+
+        public string[] Required { get; set; } = Array.Empty<string>();
     }
 }

--- a/src/docfx/lib/schema/JsonSchemaValidation.cs
+++ b/src/docfx/lib/schema/JsonSchemaValidation.cs
@@ -43,6 +43,14 @@ namespace Microsoft.Docs.Build
                     break;
 
                 case JObject map:
+                    foreach (var key in schema.Required)
+                    {
+                        if (!map.ContainsKey(key))
+                        {
+                            errors.Add(Errors.GitNotFound());
+                        }
+                    }
+
                     foreach (var (key, value) in map)
                     {
                         if (schema.Properties.TryGetValue(key, out var propertySchema))

--- a/src/docfx/lib/schema/JsonSchemaValidation.cs
+++ b/src/docfx/lib/schema/JsonSchemaValidation.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Docs.Build
                     {
                         if (!map.ContainsKey(key))
                         {
-                            errors.Add(Errors.GitNotFound());
+                            errors.Add(Errors.FieldRequired(JsonUtility.GetSourceInfo(token), key));
                         }
                     }
 

--- a/test/docfx.Test/data/jschema/draft7/additionalItems.json
+++ b/test/docfx.Test/data/jschema/draft7/additionalItems.json
@@ -1,0 +1,87 @@
+[
+    {
+        "description": "additionalItems as schema",
+        "schema": {
+            "items": [{}],
+            "additionalItems": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "additional items match schema",
+                "data": [ null, 2, 3, 4 ],
+                "valid": true
+            },
+            {
+                "description": "additional items do not match schema",
+                "data": [ null, 2, 3, "foo" ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "items is schema, no additionalItems",
+        "schema": {
+            "items": {},
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "all items match schema",
+                "data": [ 1, 2, 3, 4, 5 ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "array of items with no additionalItems",
+        "schema": {
+            "items": [{}, {}, {}],
+            "additionalItems": false
+        },
+        "tests": [
+            {
+                "description": "fewer number of items present",
+                "data": [ 1, 2 ],
+                "valid": true
+            },
+            {
+                "description": "equal number of items present",
+                "data": [ 1, 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "additional items are not permitted",
+                "data": [ 1, 2, 3, 4 ],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalItems as false without items",
+        "schema": {"additionalItems": false},
+        "tests": [
+            {
+                "description":
+                    "items defaults to empty schema so everything is valid",
+                "data": [ 1, 2, 3, 4, 5 ],
+                "valid": true
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": {"foo" : "bar"},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalItems are allowed by default",
+        "schema": {"items": [{"type": "integer"}]},
+        "tests": [
+            {
+                "description": "only the first item is validated",
+                "data": [1, "foo", false],
+                "valid": true
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/additionalProperties.json
+++ b/test/docfx.Test/data/jschema/draft7/additionalProperties.json
@@ -1,0 +1,133 @@
+[
+    {
+        "description":
+            "additionalProperties being false does not allow other properties",
+        "schema": {
+            "properties": {"foo": {}, "bar": {}},
+            "patternProperties": { "^v": {} },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "no additional properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "an additional property is invalid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : "boom"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobarbaz",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            },
+            {
+                "description": "patternProperties are not additional properties",
+                "data": {"foo":1, "vroom": 2},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "non-ASCII pattern with additionalProperties",
+        "schema": {
+            "patternProperties": {"^á": {}},
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "matching the pattern is valid",
+                "data": {"ármányos": 2},
+                "valid": true
+            },
+            {
+                "description": "not matching the pattern is invalid",
+                "data": {"élmény": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description":
+            "additionalProperties allows a schema which should validate",
+        "schema": {
+            "properties": {"foo": {}, "bar": {}},
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "no additional properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "an additional valid property is valid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : true},
+                "valid": true
+            },
+            {
+                "description": "an additional invalid property is invalid",
+                "data": {"foo" : 1, "bar" : 2, "quux" : 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description":
+            "additionalProperties can exist by itself",
+        "schema": {
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "an additional valid property is valid",
+                "data": {"foo" : true},
+                "valid": true
+            },
+            {
+                "description": "an additional invalid property is invalid",
+                "data": {"foo" : 1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties are allowed by default",
+        "schema": {"properties": {"foo": {}, "bar": {}}},
+        "tests": [
+            {
+                "description": "additional properties are allowed",
+                "data": {"foo": 1, "bar": 2, "quux": true},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "additionalProperties should not look in applicators",
+        "schema": {
+            "allOf": [
+                {"properties": {"foo": {}}}
+            ],
+            "additionalProperties": {"type": "boolean"}
+        },
+        "tests": [
+            {
+                "description": "properties defined in allOf are not allowed",
+                "data": {"foo": 1, "bar": true},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/allOf.json
+++ b/test/docfx.Test/data/jschema/draft7/allOf.json
@@ -1,0 +1,218 @@
+[
+    {
+        "description": "allOf",
+        "schema": {
+            "allOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "allOf",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "mismatch second",
+                "data": {"foo": "baz"},
+                "valid": false
+            },
+            {
+                "description": "mismatch first",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "wrong type",
+                "data": {"foo": "baz", "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with base schema",
+        "schema": {
+            "properties": {"bar": {"type": "integer"}},
+            "required": ["bar"],
+            "allOf" : [
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                },
+                {
+                    "properties": {
+                        "baz": {"type": "null"}
+                    },
+                    "required": ["baz"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": {"foo": "quux", "bar": 2, "baz": null},
+                "valid": true
+            },
+            {
+                "description": "mismatch base schema",
+                "data": {"foo": "quux", "baz": null},
+                "valid": false
+            },
+            {
+                "description": "mismatch first allOf",
+                "data": {"bar": 2, "baz": null},
+                "valid": false
+            },
+            {
+                "description": "mismatch second allOf",
+                "data": {"foo": "quux", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "mismatch both",
+                "data": {"bar": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf simple types",
+        "schema": {
+            "allOf": [
+                {"maximum": 30},
+                {"minimum": 20}
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": 25,
+                "valid": true
+            },
+            {
+                "description": "mismatch one",
+                "data": 35,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with boolean schemas, all true",
+        "schema": {"allOf": [true, true]},
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with boolean schemas, some false",
+        "schema": {"allOf": [true, false]},
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with boolean schemas, all false",
+        "schema": {"allOf": [false, false]},
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with one empty schema",
+        "schema": {
+            "allOf": [
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "any data is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with two empty schemas",
+        "schema": {
+            "allOf": [
+                {},
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "any data is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "allOf with the first empty schema",
+        "schema": {
+            "allOf": [
+                {},
+                { "type": "number" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "allOf with the last empty schema",
+        "schema": {
+            "allOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/anyOf.json
+++ b/test/docfx.Test/data/jschema/draft7/anyOf.json
@@ -1,0 +1,163 @@
+[
+    {
+        "description": "anyOf",
+        "schema": {
+            "anyOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "minimum": 2
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first anyOf valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "second anyOf valid",
+                "data": 2.5,
+                "valid": true
+            },
+            {
+                "description": "both anyOf valid",
+                "data": 3,
+                "valid": true
+            },
+            {
+                "description": "neither anyOf valid",
+                "data": 1.5,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf with base schema",
+        "schema": {
+            "type": "string",
+            "anyOf" : [
+                {
+                    "maxLength": 2
+                },
+                {
+                    "minLength": 4
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "mismatch base schema",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "one anyOf valid",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "both anyOf invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf with boolean schemas, all true",
+        "schema": {"anyOf": [true, true]},
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "anyOf with boolean schemas, some true",
+        "schema": {"anyOf": [true, false]},
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "anyOf with boolean schemas, all false",
+        "schema": {"anyOf": [false, false]},
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf complex types",
+        "schema": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first anyOf valid (complex)",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second anyOf valid (complex)",
+                "data": {"foo": "baz"},
+                "valid": true
+            },
+            {
+                "description": "both anyOf valid (complex)",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "neither anyOf valid (complex)",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "anyOf with one empty schema",
+        "schema": {
+            "anyOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "number is valid",
+                "data": 123,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/boolean_schema.json
+++ b/test/docfx.Test/data/jschema/draft7/boolean_schema.json
@@ -1,0 +1,104 @@
+[
+    {
+        "description": "boolean schema 'true'",
+        "schema": true,
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "boolean true is valid",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "boolean false is valid",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "array is valid",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "boolean schema 'false'",
+        "schema": false,
+        "tests": [
+            {
+                "description": "number is invalid",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "boolean true is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "boolean false is invalid",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "object is invalid",
+                "data": {"foo": "bar"},
+                "valid": false
+            },
+            {
+                "description": "empty object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "array is invalid",
+                "data": ["foo"],
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/const.json
+++ b/test/docfx.Test/data/jschema/draft7/const.json
@@ -1,0 +1,86 @@
+[
+    {
+        "description": "const validation",
+        "schema": {"const": 2},
+        "tests": [
+            {
+                "description": "same value is valid",
+                "data": 2,
+                "valid": true
+            },
+            {
+                "description": "another value is invalid",
+                "data": 5,
+                "valid": false
+            },
+            {
+                "description": "another type is invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with object",
+        "schema": {"const": {"foo": "bar", "baz": "bax"}},
+        "tests": [
+            {
+                "description": "same object is valid",
+                "data": {"foo": "bar", "baz": "bax"},
+                "valid": true
+            },
+            {
+                "description": "same object with different property order is valid",
+                "data": {"baz": "bax", "foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "another object is invalid",
+                "data": {"foo": "bar"},
+                "valid": false
+            },
+            {
+                "description": "another type is invalid",
+                "data": [1, 2],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with array",
+        "schema": {"const": [{ "foo": "bar" }]},
+        "tests": [
+            {
+                "description": "same array is valid",
+                "data": [{"foo": "bar"}],
+                "valid": true
+            },
+            {
+                "description": "another array item is invalid",
+                "data": [2],
+                "valid": false
+            },
+            {
+                "description": "array with additional items is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "const with null",
+        "schema": {"const": null},
+        "tests": [
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "not null is invalid",
+                "data": 0,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/contains.json
+++ b/test/docfx.Test/data/jschema/draft7/contains.json
@@ -1,0 +1,95 @@
+[
+    {
+        "description": "contains keyword validation",
+        "schema": {
+            "contains": {"minimum": 5}
+        },
+        "tests": [
+            {
+                "description": "array with item matching schema (5) is valid",
+                "data": [3, 4, 5],
+                "valid": true
+            },
+            {
+                "description": "array with item matching schema (6) is valid",
+                "data": [3, 4, 6],
+                "valid": true
+            },
+            {
+                "description": "array with two items matching schema (5, 6) is valid",
+                "data": [3, 4, 5, 6],
+                "valid": true
+            },
+            {
+                "description": "array without items matching schema is invalid",
+                "data": [2, 3, 4],
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "not array is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "contains keyword with const keyword",
+        "schema": {
+            "contains": { "const": 5 }
+        },
+        "tests": [
+            {
+                "description": "array with item 5 is valid",
+                "data": [3, 4, 5],
+                "valid": true
+            },
+            {
+                "description": "array with two items 5 is valid",
+                "data": [3, 4, 5, 5],
+                "valid": true
+            },
+            {
+                "description": "array without item 5 is invalid",
+                "data": [1, 2, 3, 4],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains keyword with boolean schema true",
+        "schema": {"contains": true},
+        "tests": [
+            {
+                "description": "any non-empty array is valid",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "contains keyword with boolean schema false",
+        "schema": {"contains": false},
+        "tests": [
+            {
+                "description": "any non-empty array is invalid",
+                "data": ["foo"],
+                "valid": false
+            },
+            {
+                "description": "empty array is invalid",
+                "data": [],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/default.json
+++ b/test/docfx.Test/data/jschema/draft7/default.json
@@ -1,0 +1,49 @@
+[
+    {
+        "description": "invalid type for default",
+        "schema": {
+            "properties": {
+                "foo": {
+                    "type": "integer",
+                    "default": []
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when property is specified",
+                "data": {"foo": 13},
+                "valid": true
+            },
+            {
+                "description": "still valid when the invalid default is used",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "invalid string value for default",
+        "schema": {
+            "properties": {
+                "bar": {
+                    "type": "string",
+                    "minLength": 4,
+                    "default": "bad"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when property is specified",
+                "data": {"bar": "good"},
+                "valid": true
+            },
+            {
+                "description": "still valid when the invalid default is used",
+                "data": {},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/definitions.json
+++ b/test/docfx.Test/data/jschema/draft7/definitions.json
@@ -1,0 +1,32 @@
+[
+    {
+        "description": "valid definition",
+        "schema": {"$ref": "http://json-schema.org/draft-07/schema#"},
+        "tests": [
+            {
+                "description": "valid definition schema",
+                "data": {
+                    "definitions": {
+                        "foo": {"type": "integer"}
+                    }
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "invalid definition",
+        "schema": {"$ref": "http://json-schema.org/draft-07/schema#"},
+        "tests": [
+            {
+                "description": "invalid definition schema",
+                "data": {
+                    "definitions": {
+                        "foo": {"type": 1}
+                    }
+                },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/dependencies.json
+++ b/test/docfx.Test/data/jschema/draft7/dependencies.json
@@ -1,0 +1,268 @@
+[
+    {
+        "description": "dependencies",
+        "schema": {
+            "dependencies": {"bar": ["foo"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependant",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "with dependency",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["bar"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "dependencies with empty array",
+        "schema": {
+            "dependencies": {"bar": []}
+        },
+        "tests": [
+            {
+                "description": "empty object",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "object with one property",
+                "data": {"bar": 2},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple dependencies",
+        "schema": {
+            "dependencies": {"quux": ["foo", "bar"]}
+        },
+        "tests": [
+            {
+                "description": "neither",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "nondependants",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "with dependencies",
+                "data": {"foo": 1, "bar": 2, "quux": 3},
+                "valid": true
+            },
+            {
+                "description": "missing dependency",
+                "data": {"foo": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing other dependency",
+                "data": {"bar": 1, "quux": 2},
+                "valid": false
+            },
+            {
+                "description": "missing both dependencies",
+                "data": {"quux": 1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "multiple dependencies subschema",
+        "schema": {
+            "dependencies": {
+                "bar": {
+                    "properties": {
+                        "foo": {"type": "integer"},
+                        "bar": {"type": "integer"}
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "no dependency",
+                "data": {"foo": "quux"},
+                "valid": true
+            },
+            {
+                "description": "wrong type",
+                "data": {"foo": "quux", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "wrong type other",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            },
+            {
+                "description": "wrong type both",
+                "data": {"foo": "quux", "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "dependencies with boolean subschemas",
+        "schema": {
+            "dependencies": {
+                "foo": true,
+                "bar": false
+            }
+        },
+        "tests": [
+            {
+                "description": "object with property having schema true is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with property having schema false is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with both properties is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "empty array of dependencies",
+        "schema": {
+            "dependencies": {
+                "foo": []
+            }
+        },
+        "tests": [
+            {
+                "description": "object with property is valid",
+                "data": { "foo": 1 },
+                "valid": true
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "non-object is valid",
+                "data": 1,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "dependencies with escaped characters",
+        "schema": {
+            "dependencies": {
+                "foo\nbar": ["foo\rbar"],
+                "foo\tbar": {
+                    "minProperties": 4
+                },
+                "foo'bar": {"required": ["foo\"bar"]},
+                "foo\"bar": ["foo'bar"]
+            }
+        },
+        "tests": [
+            {
+                "description": "valid object 1",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\rbar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "valid object 2",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2,
+                    "b": 3,
+                    "c": 4
+                },
+                "valid": true
+            },
+            {
+                "description": "valid object 3",
+                "data": {
+                    "foo'bar": 1,
+                    "foo\"bar": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "invalid object 1",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid object 2",
+                "data": {
+                    "foo\tbar": 1,
+                    "a": 2
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid object 3",
+                "data": {
+                    "foo'bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid object 4",
+                "data": {
+                    "foo\"bar": 2
+                },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/enum.json
+++ b/test/docfx.Test/data/jschema/draft7/enum.json
@@ -1,0 +1,95 @@
+[
+    {
+        "description": "simple enum validation",
+        "schema": {"enum": [1, 2, 3]},
+        "tests": [
+            {
+                "description": "one of the enum is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": 4,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "heterogeneous enum validation",
+        "schema": {"enum": [6, "foo", [], true, {"foo": 12}]},
+        "tests": [
+            {
+                "description": "one of the enum is valid",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "something else is invalid",
+                "data": null,
+                "valid": false
+            },
+            {
+                "description": "objects are deep compared",
+                "data": {"foo": false},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enums in properties",
+        "schema": {
+            "type":"object",
+            "properties": {
+                "foo": {"enum":["foo"]},
+                "bar": {"enum":["bar"]}
+            },
+            "required": ["bar"]
+        },
+        "tests": [
+            {
+                "description": "both properties are valid",
+                "data": {"foo":"foo", "bar":"bar"},
+                "valid": true
+            },
+            {
+                "description": "missing optional property is valid",
+                "data": {"bar":"bar"},
+                "valid": true
+            },
+            {
+                "description": "missing required property is invalid",
+                "data": {"foo":"foo"},
+                "valid": false
+            },
+            {
+                "description": "missing all properties is invalid",
+                "data": {},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "enum with escaped characters",
+        "schema": {
+            "enum": ["foo\nbar", "foo\rbar"]
+        },
+        "tests": [
+            {
+                "description": "member 1 is valid",
+                "data": "foo\nbar",
+                "valid": true
+            },
+            {
+                "description": "member 2 is valid",
+                "data": "foo\rbar",
+                "valid": true
+            },
+            {
+                "description": "another string is invalid",
+                "data": "abc",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/exclusiveMaximum.json
+++ b/test/docfx.Test/data/jschema/draft7/exclusiveMaximum.json
@@ -1,0 +1,30 @@
+[
+    {
+        "description": "exclusiveMaximum validation",
+        "schema": {
+            "exclusiveMaximum": 3.0
+        },
+        "tests": [
+            {
+                "description": "below the exclusiveMaximum is valid",
+                "data": 2.2,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": 3.0,
+                "valid": false
+            },
+            {
+                "description": "above the exclusiveMaximum is invalid",
+                "data": 3.5,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/exclusiveMinimum.json
+++ b/test/docfx.Test/data/jschema/draft7/exclusiveMinimum.json
@@ -1,0 +1,30 @@
+[
+    {
+        "description": "exclusiveMinimum validation",
+        "schema": {
+            "exclusiveMinimum": 1.1
+        },
+        "tests": [
+            {
+                "description": "above the exclusiveMinimum is valid",
+                "data": 1.2,
+                "valid": true
+            },
+            {
+                "description": "boundary point is invalid",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "below the exclusiveMinimum is invalid",
+                "data": 0.6,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/if-then-else.json
+++ b/test/docfx.Test/data/jschema/draft7/if-then-else.json
@@ -1,0 +1,188 @@
+[
+    {
+        "description": "ignore if without then or else",
+        "schema": {
+            "if": {
+                "const": 0
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when valid against lone if",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "valid when invalid against lone if",
+                "data": "hello",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ignore then without if",
+        "schema": {
+            "then": {
+                "const": 0
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when valid against lone then",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "valid when invalid against lone then",
+                "data": "hello",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "ignore else without if",
+        "schema": {
+            "else": {
+                "const": 0
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when valid against lone else",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "valid when invalid against lone else",
+                "data": "hello",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "if and then without else",
+        "schema": {
+            "if": {
+                "exclusiveMaximum": 0
+            },
+            "then": {
+                "minimum": -10
+            }
+        },
+        "tests": [
+            {
+                "description": "valid through then",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "invalid through then",
+                "data": -100,
+                "valid": false
+            },
+            {
+                "description": "valid when if test fails",
+                "data": 3,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "if and else without then",
+        "schema": {
+            "if": {
+                "exclusiveMaximum": 0
+            },
+            "else": {
+                "multipleOf": 2
+            }
+        },
+        "tests": [
+            {
+                "description": "valid when if test passes",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "valid through else",
+                "data": 4,
+                "valid": true
+            },
+            {
+                "description": "invalid through else",
+                "data": 3,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "validate against correct branch, then vs else",
+        "schema": {
+            "if": {
+                "exclusiveMaximum": 0
+            },
+            "then": {
+                "minimum": -10
+            },
+            "else": {
+                "multipleOf": 2
+            }
+        },
+        "tests": [
+            {
+                "description": "valid through then",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "invalid through then",
+                "data": -100,
+                "valid": false
+            },
+            {
+                "description": "valid through else",
+                "data": 4,
+                "valid": true
+            },
+            {
+                "description": "invalid through else",
+                "data": 3,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "non-interference across combined schemas",
+        "schema": {
+            "allOf": [
+                {
+                    "if": {
+                        "exclusiveMaximum": 0
+                    }
+                },
+                {
+                    "then": {
+                        "minimum": -10
+                    }
+                },
+                {
+                    "else": {
+                        "multipleOf": 2
+                    }
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid, but woud have been invalid through then",
+                "data": -100,
+                "valid": true
+            },
+            {
+                "description": "valid, but would have been invalid through else",
+                "data": 3,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/items.json
+++ b/test/docfx.Test/data/jschema/draft7/items.json
@@ -1,0 +1,250 @@
+[
+    {
+        "description": "a schema given for items",
+        "schema": {
+            "items": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [ 1, 2, 3 ],
+                "valid": true
+            },
+            {
+                "description": "wrong type of items",
+                "data": [1, "x"],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": {"foo" : "bar"},
+                "valid": true
+            },
+            {
+                "description": "JavaScript pseudo-array is valid",
+                "data": {
+                    "0": "invalid",
+                    "length": 1
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "an array of schemas for items",
+        "schema": {
+            "items": [
+                {"type": "integer"},
+                {"type": "string"}
+            ]
+        },
+        "tests": [
+            {
+                "description": "correct types",
+                "data": [ 1, "foo" ],
+                "valid": true
+            },
+            {
+                "description": "wrong types",
+                "data": [ "foo", 1 ],
+                "valid": false
+            },
+            {
+                "description": "incomplete array of items",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "array with additional items",
+                "data": [ 1, "foo", true ],
+                "valid": true
+            },
+            {
+                "description": "empty array",
+                "data": [ ],
+                "valid": true
+            },
+            {
+                "description": "JavaScript pseudo-array is valid",
+                "data": {
+                    "0": "invalid",
+                    "1": "valid",
+                    "length": 2
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items with boolean schema (true)",
+        "schema": {"items": true},
+        "tests": [
+            {
+                "description": "any array is valid",
+                "data": [ 1, "foo", true ],
+                "valid": true
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items with boolean schema (false)",
+        "schema": {"items": false},
+        "tests": [
+            {
+                "description": "any non-empty array is invalid",
+                "data": [ 1, "foo", true ],
+                "valid": false
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items with boolean schemas",
+        "schema": {
+            "items": [true, false]
+        },
+        "tests": [
+            {
+                "description": "array with one item is valid",
+                "data": [ 1 ],
+                "valid": true
+            },
+            {
+                "description": "array with two items is invalid",
+                "data": [ 1, "foo" ],
+                "valid": false
+            },
+            {
+                "description": "empty array is valid",
+                "data": [],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "items and subitems",
+        "schema": {
+            "definitions": {
+                "item": {
+                    "type": "array",
+                    "additionalItems": false,
+                    "items": [
+                        { "$ref": "#/definitions/sub-item" },
+                        { "$ref": "#/definitions/sub-item" }
+                    ]
+                },
+                "sub-item": {
+                    "type": "object",
+                    "required": ["foo"]
+                }
+            },
+            "type": "array",
+            "additionalItems": false,
+            "items": [
+                { "$ref": "#/definitions/item" },
+                { "$ref": "#/definitions/item" },
+                { "$ref": "#/definitions/item" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "valid items",
+                "data": [
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": true
+            },
+            {
+                "description": "too many items",
+                "data": [
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "too many sub-items",
+                "data": [
+                    [ {"foo": null}, {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "wrong item",
+                "data": [
+                    {"foo": null},
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "wrong sub-item",
+                "data": [
+                    [ {}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ],
+                    [ {"foo": null}, {"foo": null} ]
+                ],
+                "valid": false
+            },
+            {
+                "description": "fewer items is valid",
+                "data": [
+                    [ {"foo": null} ],
+                    [ {"foo": null} ]
+                ],
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested items",
+        "schema": {
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "number"
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid nested array",
+                "data": [[[[1]], [[2],[3]]], [[[4], [5], [6]]]],
+                "valid": true
+            },
+            {
+                "description": "nested array with invalid type",
+                "data": [[[["1"]], [[2],[3]]], [[[4], [5], [6]]]],
+                "valid": false
+            },
+            {
+                "description": "not deep enough",
+                "data": [[[1], [2],[3]], [[4], [5], [6]]],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/maxItems.json
+++ b/test/docfx.Test/data/jschema/draft7/maxItems.json
@@ -1,0 +1,28 @@
+[
+    {
+        "description": "maxItems validation",
+        "schema": {"maxItems": 2},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": "foobar",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/maxLength.json
+++ b/test/docfx.Test/data/jschema/draft7/maxLength.json
@@ -1,0 +1,33 @@
+[
+    {
+        "description": "maxLength validation",
+        "schema": {"maxLength": 2},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": "f",
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": "fo",
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 100,
+                "valid": true
+            },
+            {
+                "description": "two supplementary Unicode code points is long enough",
+                "data": "\uD83D\uDCA9\uD83D\uDCA9",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/maxProperties.json
+++ b/test/docfx.Test/data/jschema/draft7/maxProperties.json
@@ -1,0 +1,38 @@
+[
+    {
+        "description": "maxProperties validation",
+        "schema": {"maxProperties": 2},
+        "tests": [
+            {
+                "description": "shorter is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "too long is invalid",
+                "data": {"foo": 1, "bar": 2, "baz": 3},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/maximum.json
+++ b/test/docfx.Test/data/jschema/draft7/maximum.json
@@ -1,0 +1,28 @@
+[
+    {
+        "description": "maximum validation",
+        "schema": {"maximum": 3.0},
+        "tests": [
+            {
+                "description": "below the maximum is valid",
+                "data": 2.6,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": 3.0,
+                "valid": true
+            },
+            {
+                "description": "above the maximum is invalid",
+                "data": 3.5,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/minItems.json
+++ b/test/docfx.Test/data/jschema/draft7/minItems.json
@@ -1,0 +1,28 @@
+[
+    {
+        "description": "minItems validation",
+        "schema": {"minItems": 1},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": [1],
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "ignores non-arrays",
+                "data": "",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/minLength.json
+++ b/test/docfx.Test/data/jschema/draft7/minLength.json
@@ -1,0 +1,33 @@
+[
+    {
+        "description": "minLength validation",
+        "schema": {"minLength": 2},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": "fo",
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": "f",
+                "valid": false
+            },
+            {
+                "description": "ignores non-strings",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "one supplementary Unicode code point is not long enough",
+                "data": "\uD83D\uDCA9",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/minProperties.json
+++ b/test/docfx.Test/data/jschema/draft7/minProperties.json
@@ -1,0 +1,38 @@
+[
+    {
+        "description": "minProperties validation",
+        "schema": {"minProperties": 1},
+        "tests": [
+            {
+                "description": "longer is valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "exact length is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "too short is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/minimum.json
+++ b/test/docfx.Test/data/jschema/draft7/minimum.json
@@ -1,0 +1,59 @@
+[
+    {
+        "description": "minimum validation",
+        "schema": {"minimum": 1.1},
+        "tests": [
+            {
+                "description": "above the minimum is valid",
+                "data": 2.6,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": 1.1,
+                "valid": true
+            },
+            {
+                "description": "below the minimum is invalid",
+                "data": 0.6,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "minimum validation with signed integer",
+        "schema": {"minimum": -2},
+        "tests": [
+            {
+                "description": "negative above the minimum is valid",
+                "data": -1,
+                "valid": true
+            },
+            {
+                "description": "positive above the minimum is valid",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "boundary point is valid",
+                "data": -2,
+                "valid": true
+            },
+            {
+                "description": "below the minimum is invalid",
+                "data": -3,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "x",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/multipleOf.json
+++ b/test/docfx.Test/data/jschema/draft7/multipleOf.json
@@ -1,0 +1,60 @@
+[
+    {
+        "description": "by int",
+        "schema": {"multipleOf": 2},
+        "tests": [
+            {
+                "description": "int by int",
+                "data": 10,
+                "valid": true
+            },
+            {
+                "description": "int by int fail",
+                "data": 7,
+                "valid": false
+            },
+            {
+                "description": "ignores non-numbers",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "by number",
+        "schema": {"multipleOf": 1.5},
+        "tests": [
+            {
+                "description": "zero is multiple of anything",
+                "data": 0,
+                "valid": true
+            },
+            {
+                "description": "4.5 is multiple of 1.5",
+                "data": 4.5,
+                "valid": true
+            },
+            {
+                "description": "35 is not multiple of 1.5",
+                "data": 35,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "by small number",
+        "schema": {"multipleOf": 0.0001},
+        "tests": [
+            {
+                "description": "0.0075 is multiple of 0.0001",
+                "data": 0.0075,
+                "valid": true
+            },
+            {
+                "description": "0.00751 is not multiple of 0.0001",
+                "data": 0.00751,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/not.json
+++ b/test/docfx.Test/data/jschema/draft7/not.json
@@ -1,0 +1,117 @@
+[
+    {
+        "description": "not",
+        "schema": {
+            "not": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "allowed",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "disallowed",
+                "data": 1,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "not multiple types",
+        "schema": {
+            "not": {"type": ["integer", "boolean"]}
+        },
+        "tests": [
+            {
+                "description": "valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "other mismatch",
+                "data": true,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "not more complex schema",
+        "schema": {
+            "not": {
+                "type": "object",
+                "properties": {
+                    "foo": {
+                        "type": "string"
+                    }
+                }
+             }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "other match",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"foo": "bar"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "forbidden property",
+        "schema": {
+            "properties": {
+                "foo": { 
+                    "not": {}
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "property present",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "property absent",
+                "data": {"bar": 1, "baz": 2},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "not with boolean schema true",
+        "schema": {"not": true},
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "not with boolean schema false",
+        "schema": {"not": false},
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/oneOf.json
+++ b/test/docfx.Test/data/jschema/draft7/oneOf.json
@@ -1,0 +1,206 @@
+[
+    {
+        "description": "oneOf",
+        "schema": {
+            "oneOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "minimum": 2
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid",
+                "data": 2.5,
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid",
+                "data": 1.5,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with base schema",
+        "schema": {
+            "type": "string",
+            "oneOf" : [
+                {
+                    "minLength": 2
+                },
+                {
+                    "maxLength": 4
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "mismatch base schema",
+                "data": 3,
+                "valid": false
+            },
+            {
+                "description": "one oneOf valid",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, all true",
+        "schema": {"oneOf": [true, true, true]},
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, one true",
+        "schema": {"oneOf": [true, false, false]},
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, more than one true",
+        "schema": {"oneOf": [true, true, false]},
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with boolean schemas, all false",
+        "schema": {"oneOf": [false, false, false]},
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf complex types",
+        "schema": {
+            "oneOf": [
+                {
+                    "properties": {
+                        "bar": {"type": "integer"}
+                    },
+                    "required": ["bar"]
+                },
+                {
+                    "properties": {
+                        "foo": {"type": "string"}
+                    },
+                    "required": ["foo"]
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "first oneOf valid (complex)",
+                "data": {"bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second oneOf valid (complex)",
+                "data": {"foo": "baz"},
+                "valid": true
+            },
+            {
+                "description": "both oneOf valid (complex)",
+                "data": {"foo": "baz", "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "neither oneOf valid (complex)",
+                "data": {"foo": 2, "bar": "quux"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with empty schema",
+        "schema": {
+            "oneOf": [
+                { "type": "number" },
+                {}
+            ]
+        },
+        "tests": [
+            {
+                "description": "one valid - valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "both valid - invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "oneOf with required",
+        "schema": {
+            "type": "object",
+            "oneOf": [
+                { "required": ["foo", "bar"] },
+                { "required": ["foo", "baz"] }
+            ]
+        },
+        "tests": [
+            {
+                "description": "both invalid - invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "first valid - valid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": true
+            },
+            {
+                "description": "second valid - valid",
+                "data": {"foo": 1, "baz": 3},
+                "valid": true
+            },
+            {
+                "description": "both valid - invalid",
+                "data": {"foo": 1, "bar": 2, "baz" : 3},
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/pattern.json
+++ b/test/docfx.Test/data/jschema/draft7/pattern.json
@@ -1,0 +1,34 @@
+[
+    {
+        "description": "pattern validation",
+        "schema": {"pattern": "^a*$"},
+        "tests": [
+            {
+                "description": "a matching pattern is valid",
+                "data": "aaa",
+                "valid": true
+            },
+            {
+                "description": "a non-matching pattern is invalid",
+                "data": "abc",
+                "valid": false
+            },
+            {
+                "description": "ignores non-strings",
+                "data": true,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "pattern is not anchored",
+        "schema": {"pattern": "a+"},
+        "tests": [
+            {
+                "description": "matches a substring",
+                "data": "xxaayy",
+                "valid": true
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/patternProperties.json
+++ b/test/docfx.Test/data/jschema/draft7/patternProperties.json
@@ -1,0 +1,151 @@
+[
+    {
+        "description":
+            "patternProperties validates properties matching a regex",
+        "schema": {
+            "patternProperties": {
+                "f.*o": {"type": "integer"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a single valid match is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "multiple valid matches is valid",
+                "data": {"foo": 1, "foooooo" : 2},
+                "valid": true
+            },
+            {
+                "description": "a single invalid match is invalid",
+                "data": {"foo": "bar", "fooooo": 2},
+                "valid": false
+            },
+            {
+                "description": "multiple invalid matches is invalid",
+                "data": {"foo": "bar", "foooooo" : "baz"},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": ["foo"],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple simultaneous patternProperties are validated",
+        "schema": {
+            "patternProperties": {
+                "a*": {"type": "integer"},
+                "aaa*": {"maximum": 20}
+            }
+        },
+        "tests": [
+            {
+                "description": "a single valid match is valid",
+                "data": {"a": 21},
+                "valid": true
+            },
+            {
+                "description": "a simultaneous match is valid",
+                "data": {"aaaa": 18},
+                "valid": true
+            },
+            {
+                "description": "multiple matches is valid",
+                "data": {"a": 21, "aaaa": 18},
+                "valid": true
+            },
+            {
+                "description": "an invalid due to one is invalid",
+                "data": {"a": "bar"},
+                "valid": false
+            },
+            {
+                "description": "an invalid due to the other is invalid",
+                "data": {"aaaa": 31},
+                "valid": false
+            },
+            {
+                "description": "an invalid due to both is invalid",
+                "data": {"aaa": "foo", "aaaa": 31},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "regexes are not anchored by default and are case sensitive",
+        "schema": {
+            "patternProperties": {
+                "[0-9]{2,}": { "type": "boolean" },
+                "X_": { "type": "string" }
+            }
+        },
+        "tests": [
+            {
+                "description": "non recognized members are ignored",
+                "data": { "answer 1": "42" },
+                "valid": true
+            },
+            {
+                "description": "recognized members are accounted for",
+                "data": { "a31b": null },
+                "valid": false
+            },
+            {
+                "description": "regexes are case sensitive",
+                "data": { "a_x_3": 3 },
+                "valid": true
+            },
+            {
+                "description": "regexes are case sensitive, 2",
+                "data": { "a_X_3": 3 },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "patternProperties with boolean schemas",
+        "schema": {
+            "patternProperties": {
+                "f.*": true,
+                "b.*": false
+            }
+        },
+        "tests": [
+            {
+                "description": "object with property matching schema true is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "object with property matching schema false is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "object with both properties is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/properties.json
+++ b/test/docfx.Test/data/jschema/draft7/properties.json
@@ -1,0 +1,167 @@
+[
+    {
+        "description": "object properties validation",
+        "schema": {
+            "properties": {
+                "foo": {"type": "integer"},
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "both properties present and valid is valid",
+                "data": {"foo": 1, "bar": "baz"},
+                "valid": true
+            },
+            {
+                "description": "one property invalid is invalid",
+                "data": {"foo": 1, "bar": {}},
+                "valid": false
+            },
+            {
+                "description": "both properties invalid is invalid",
+                "data": {"foo": [], "bar": {}},
+                "valid": false
+            },
+            {
+                "description": "doesn't invalidate other properties",
+                "data": {"quux": []},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description":
+            "properties, patternProperties, additionalProperties interaction",
+        "schema": {
+            "properties": {
+                "foo": {"type": "array", "maxItems": 3},
+                "bar": {"type": "array"}
+            },
+            "patternProperties": {"f.o": {"minItems": 2}},
+            "additionalProperties": {"type": "integer"}
+        },
+        "tests": [
+            {
+                "description": "property validates property",
+                "data": {"foo": [1, 2]},
+                "valid": true
+            },
+            {
+                "description": "property invalidates property",
+                "data": {"foo": [1, 2, 3, 4]},
+                "valid": false
+            },
+            {
+                "description": "patternProperty invalidates property",
+                "data": {"foo": []},
+                "valid": false
+            },
+            {
+                "description": "patternProperty validates nonproperty",
+                "data": {"fxo": [1, 2]},
+                "valid": true
+            },
+            {
+                "description": "patternProperty invalidates nonproperty",
+                "data": {"fxo": []},
+                "valid": false
+            },
+            {
+                "description": "additionalProperty ignores property",
+                "data": {"bar": []},
+                "valid": true
+            },
+            {
+                "description": "additionalProperty validates others",
+                "data": {"quux": 3},
+                "valid": true
+            },
+            {
+                "description": "additionalProperty invalidates others",
+                "data": {"quux": "foo"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "properties with boolean schema",
+        "schema": {
+            "properties": {
+                "foo": true,
+                "bar": false
+            }
+        },
+        "tests": [
+            {
+                "description": "no property present is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "only 'true' property present is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "only 'false' property present is invalid",
+                "data": {"bar": 2},
+                "valid": false
+            },
+            {
+                "description": "both properties present is invalid",
+                "data": {"foo": 1, "bar": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "properties with escaped characters",
+        "schema": {
+            "properties": {
+                "foo\nbar": {"type": "number"},
+                "foo\"bar": {"type": "number"},
+                "foo\\bar": {"type": "number"},
+                "foo\rbar": {"type": "number"},
+                "foo\tbar": {"type": "number"},
+                "foo\fbar": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "object with all numbers is valid",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\"bar": 1,
+                    "foo\\bar": 1,
+                    "foo\rbar": 1,
+                    "foo\tbar": 1,
+                    "foo\fbar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with strings is invalid",
+                "data": {
+                    "foo\nbar": "1",
+                    "foo\"bar": "1",
+                    "foo\\bar": "1",
+                    "foo\rbar": "1",
+                    "foo\tbar": "1",
+                    "foo\fbar": "1"
+                },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/propertyNames.json
+++ b/test/docfx.Test/data/jschema/draft7/propertyNames.json
@@ -1,0 +1,78 @@
+[
+    {
+        "description": "propertyNames validation",
+        "schema": {
+            "propertyNames": {"maxLength": 3}
+        },
+        "tests": [
+            {
+                "description": "all property names valid",
+                "data": {
+                    "f": {},
+                    "foo": {}
+                },
+                "valid": true
+            },
+            {
+                "description": "some property names invalid",
+                "data": {
+                    "foo": {},
+                    "foobar": {}
+                },
+                "valid": false
+            },
+            {
+                "description": "object without properties is valid",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "ignores arrays",
+                "data": [1, 2, 3, 4],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "foobar",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "propertyNames with boolean schema true",
+        "schema": {"propertyNames": true},
+        "tests": [
+            {
+                "description": "object with any properties is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "propertyNames with boolean schema false",
+        "schema": {"propertyNames": false},
+        "tests": [
+            {
+                "description": "object with any properties is invalid",
+                "data": {"foo": 1},
+                "valid": false
+            },
+            {
+                "description": "empty object is valid",
+                "data": {},
+                "valid": true
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/ref.json
+++ b/test/docfx.Test/data/jschema/draft7/ref.json
@@ -1,0 +1,359 @@
+[
+    {
+        "description": "root pointer ref",
+        "schema": {
+            "properties": {
+                "foo": {"$ref": "#"}
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"foo": false},
+                "valid": true
+            },
+            {
+                "description": "recursive match",
+                "data": {"foo": {"foo": false}},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": false},
+                "valid": false
+            },
+            {
+                "description": "recursive mismatch",
+                "data": {"foo": {"bar": false}},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "relative pointer ref to object",
+        "schema": {
+            "properties": {
+                "foo": {"type": "integer"},
+                "bar": {"$ref": "#/properties/foo"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "relative pointer ref to array",
+        "schema": {
+            "items": [
+                {"type": "integer"},
+                {"$ref": "#/items/0"}
+            ]
+        },
+        "tests": [
+            {
+                "description": "match array",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "mismatch array",
+                "data": [1, "foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "escaped pointer ref",
+        "schema": {
+            "tilda~field": {"type": "integer"},
+            "slash/field": {"type": "integer"},
+            "percent%field": {"type": "integer"},
+            "properties": {
+                "tilda": {"$ref": "#/tilda~0field"},
+                "slash": {"$ref": "#/slash~1field"},
+                "percent": {"$ref": "#/percent%25field"}
+            }
+        },
+        "tests": [
+            {
+                "description": "slash invalid",
+                "data": {"slash": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "tilda invalid",
+                "data": {"tilda": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "percent invalid",
+                "data": {"percent": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "slash valid",
+                "data": {"slash": 123},
+                "valid": true
+            },
+            {
+                "description": "tilda valid",
+                "data": {"tilda": 123},
+                "valid": true
+            },
+            {
+                "description": "percent valid",
+                "data": {"percent": 123},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested refs",
+        "schema": {
+            "definitions": {
+                "a": {"type": "integer"},
+                "b": {"$ref": "#/definitions/a"},
+                "c": {"$ref": "#/definitions/b"}
+            },
+            "$ref": "#/definitions/c"
+        },
+        "tests": [
+            {
+                "description": "nested ref valid",
+                "data": 5,
+                "valid": true
+            },
+            {
+                "description": "nested ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref overrides any sibling keywords",
+        "schema": {
+            "definitions": {
+                "reffed": {
+                    "type": "array"
+                }
+            },
+            "properties": {
+                "foo": {
+                    "$ref": "#/definitions/reffed",
+                    "maxItems": 2
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "ref valid",
+                "data": { "foo": [] },
+                "valid": true
+            },
+            {
+                "description": "ref valid, maxItems ignored",
+                "data": { "foo": [ 1, 2, 3] },
+                "valid": true
+            },
+            {
+                "description": "ref invalid",
+                "data": { "foo": "string" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "remote ref, containing refs itself",
+        "schema": {"$ref": "http://json-schema.org/draft-07/schema#"},
+        "tests": [
+            {
+                "description": "remote ref valid",
+                "data": {"minLength": 1},
+                "valid": true
+            },
+            {
+                "description": "remote ref invalid",
+                "data": {"minLength": -1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property named $ref that is not a reference",
+        "schema": {
+            "properties": {
+                "$ref": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "property named $ref valid",
+                "data": {"$ref": "a"},
+                "valid": true
+            },
+            {
+                "description": "property named $ref invalid",
+                "data": {"$ref": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "$ref to boolean schema true",
+        "schema": {
+            "$ref": "#/definitions/bool",
+            "definitions": {
+                "bool": true
+            }
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$ref to boolean schema false",
+        "schema": {
+            "$ref": "#/definitions/bool",
+            "definitions": {
+                "bool": false
+            }
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Recursive references between schemas",
+        "schema": {
+            "$id": "http://localhost:1234/tree",
+            "description": "tree of nodes",
+            "type": "object",
+            "properties": {
+                "meta": {"type": "string"},
+                "nodes": {
+                    "type": "array",
+                    "items": {"$ref": "node"}
+                }
+            },
+            "required": ["meta", "nodes"],
+            "definitions": {
+                "node": {
+                    "$id": "http://localhost:1234/node",
+                    "description": "node",
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "number"},
+                        "subtree": {"$ref": "tree"}
+                    },
+                    "required": ["value"]
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid tree",
+                "data": { 
+                    "meta": "root",
+                    "nodes": [
+                        {
+                            "value": 1,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 1.1},
+                                    {"value": 1.2}
+                                ]
+                            }
+                        },
+                        {
+                            "value": 2,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 2.1},
+                                    {"value": 2.2}
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "valid": true
+            },
+            {
+                "description": "invalid tree",
+                "data": { 
+                    "meta": "root",
+                    "nodes": [
+                        {
+                            "value": 1,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": "string is invalid"},
+                                    {"value": 1.2}
+                                ]
+                            }
+                        },
+                        {
+                            "value": 2,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 2.1},
+                                    {"value": 2.2}
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "refs with quote",
+        "schema": {
+            "properties": {
+                "foo\"bar": {"$ref": "#/definitions/foo%22bar"}
+            },
+            "definitions": {
+                "foo\"bar": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "object with numbers is valid",
+                "data": {
+                    "foo\"bar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with strings is invalid",
+                "data": {
+                    "foo\"bar": "1"
+                },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/refRemote.json
+++ b/test/docfx.Test/data/jschema/draft7/refRemote.json
@@ -1,0 +1,171 @@
+[
+    {
+        "description": "remote ref",
+        "schema": {"$ref": "http://localhost:1234/integer.json"},
+        "tests": [
+            {
+                "description": "remote ref valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "remote ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "fragment within remote ref",
+        "schema": {"$ref": "http://localhost:1234/subSchemas.json#/integer"},
+        "tests": [
+            {
+                "description": "remote fragment valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "remote fragment invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref within remote ref",
+        "schema": {
+            "$ref": "http://localhost:1234/subSchemas.json#/refToInteger"
+        },
+        "tests": [
+            {
+                "description": "ref within ref valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "ref within ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change",
+        "schema": {
+            "$id": "http://localhost:1234/",
+            "items": {
+                "$id": "folder/",
+                "items": {"$ref": "folderInteger.json"}
+            }
+        },
+        "tests": [
+            {
+                "description": "base URI change ref valid",
+                "data": [[1]],
+                "valid": true
+            },
+            {
+                "description": "base URI change ref invalid",
+                "data": [["a"]],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change - change folder",
+        "schema": {
+            "$id": "http://localhost:1234/scope_change_defs1.json",
+            "type" : "object",
+            "properties": {
+                "list": {"$ref": "#/definitions/baz"}
+            },
+            "definitions": {
+                "baz": {
+                    "$id": "folder/",
+                    "type": "array",
+                    "items": {"$ref": "folderInteger.json"}
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "base URI change - change folder in subschema",
+        "schema": {
+            "$id": "http://localhost:1234/scope_change_defs2.json",
+            "type" : "object",
+            "properties": {
+                "list": {"$ref": "#/definitions/baz/definitions/bar"}
+            },
+            "definitions": {
+                "baz": {
+                    "$id": "folder/",
+                    "definitions": {
+                        "bar": {
+                            "type": "array",
+                            "items": {"$ref": "folderInteger.json"}
+                        }
+                    }
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": {"list": [1]},
+                "valid": true
+            },
+            {
+                "description": "string is invalid",
+                "data": {"list": ["a"]},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "root ref in remote ref",
+        "schema": {
+            "$id": "http://localhost:1234/object",
+            "type": "object",
+            "properties": {
+                "name": {"$ref": "name.json#/definitions/orNull"}
+            }
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": {
+                    "name": "foo"
+                },
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": {
+                    "name": null
+                },
+                "valid": true
+            },
+            {
+                "description": "object is invalid",
+                "data": {
+                    "name": {
+                        "name": null
+                    }
+                },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/required.json
+++ b/test/docfx.Test/data/jschema/draft7/required.json
@@ -1,0 +1,105 @@
+[
+    {
+        "description": "required validation",
+        "schema": {
+            "properties": {
+                "foo": {},
+                "bar": {}
+            },
+            "required": ["foo"]
+        },
+        "tests": [
+            {
+                "description": "present required property is valid",
+                "data": {"foo": 1},
+                "valid": true
+            },
+            {
+                "description": "non-present required property is invalid",
+                "data": {"bar": 1},
+                "valid": false
+            },
+            {
+                "description": "ignores arrays",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "ignores strings",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "ignores other non-objects",
+                "data": 12,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required default validation",
+        "schema": {
+            "properties": {
+                "foo": {}
+            }
+        },
+        "tests": [
+            {
+                "description": "not required by default",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required with empty array",
+        "schema": {
+            "properties": {
+                "foo": {}
+            },
+            "required": []
+        },
+        "tests": [
+            {
+                "description": "property not required",
+                "data": {},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "required with escaped characters",
+        "schema": {
+            "required": [
+                "foo\nbar",
+                "foo\"bar",
+                "foo\\bar",
+                "foo\rbar",
+                "foo\tbar",
+                "foo\fbar"
+            ]
+        },
+        "tests": [
+            {
+                "description": "object with all properties present is valid",
+                "data": {
+                    "foo\nbar": 1,
+                    "foo\"bar": 1,
+                    "foo\\bar": 1,
+                    "foo\rbar": 1,
+                    "foo\tbar": 1,
+                    "foo\fbar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with some properties missing is invalid",
+                "data": {
+                    "foo\nbar": "1",
+                    "foo\"bar": "1"
+                },
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/type.json
+++ b/test/docfx.Test/data/jschema/draft7/type.json
@@ -1,0 +1,464 @@
+[
+    {
+        "description": "integer type matches integers",
+        "schema": {"type": "integer"},
+        "tests": [
+            {
+                "description": "an integer is an integer",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a float is not an integer",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an integer",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "a string is still not an integer, even if it looks like one",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "an object is not an integer",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not an integer",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not an integer",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an integer",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "number type matches numbers",
+        "schema": {"type": "number"},
+        "tests": [
+            {
+                "description": "an integer is a number",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a float is a number",
+                "data": 1.1,
+                "valid": true
+            },
+            {
+                "description": "a string is not a number",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "a string is still not a number, even if it looks like one",
+                "data": "1",
+                "valid": false
+            },
+            {
+                "description": "an object is not a number",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a number",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not a number",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not a number",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "string type matches strings",
+        "schema": {"type": "string"},
+        "tests": [
+            {
+                "description": "1 is not a string",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not a string",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is a string",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "a string is still a string, even if it looks like a number",
+                "data": "1",
+                "valid": true
+            },
+            {
+                "description": "an empty string is still a string",
+                "data": "",
+                "valid": true
+            },
+            {
+                "description": "an object is not a string",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a string",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not a string",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not a string",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "object type matches objects",
+        "schema": {"type": "object"},
+        "tests": [
+            {
+                "description": "an integer is not an object",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not an object",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an object",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an object is an object",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "an array is not an object",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is not an object",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an object",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "array type matches arrays",
+        "schema": {"type": "array"},
+        "tests": [
+            {
+                "description": "an integer is not an array",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not an array",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not an array",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an object is not an array",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is an array",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "a boolean is not an array",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is not an array",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "boolean type matches booleans",
+        "schema": {"type": "boolean"},
+        "tests": [
+            {
+                "description": "an integer is not a boolean",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "zero is not a boolean",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "a float is not a boolean",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "a string is not a boolean",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not a boolean",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "an object is not a boolean",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not a boolean",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "true is a boolean",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "false is a boolean",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "null is not a boolean",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "null type matches only the null object",
+        "schema": {"type": "null"},
+        "tests": [
+            {
+                "description": "an integer is not null",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "a float is not null",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "zero is not null",
+                "data": 0,
+                "valid": false
+            },
+            {
+                "description": "a string is not null",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "an empty string is not null",
+                "data": "",
+                "valid": false
+            },
+            {
+                "description": "an object is not null",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is not null",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "true is not null",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "false is not null",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "null is null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "multiple types can be specified in an array",
+        "schema": {"type": ["integer", "string"]},
+        "tests": [
+            {
+                "description": "an integer is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "a string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "a float is invalid",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "an object is invalid",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "an array is invalid",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "a boolean is invalid",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type as array with one item",
+        "schema": {
+            "type": ["string"]
+        },
+        "tests": [
+            {
+                "description": "string is valid",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type: array or object",
+        "schema": {
+            "type": ["array", "object"]
+        },
+        "tests": [
+            {
+                "description": "array is valid",
+                "data": [1,2,3],
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": 123},
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "null is invalid",
+                "data": null,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "type: array, object or null",
+        "schema": {
+            "type": ["array", "object", "null"]
+        },
+        "tests": [
+            {
+                "description": "array is valid",
+                "data": [1,2,3],
+                "valid": true
+            },
+            {
+                "description": "object is valid",
+                "data": {"foo": 123},
+                "valid": true
+            },
+            {
+                "description": "null is valid",
+                "data": null,
+                "valid": true
+            },
+            {
+                "description": "number is invalid",
+                "data": 123,
+                "valid": false
+            },
+            {
+                "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/data/jschema/draft7/uniqueItems.json
+++ b/test/docfx.Test/data/jschema/draft7/uniqueItems.json
@@ -1,0 +1,79 @@
+[
+    {
+        "description": "uniqueItems validation",
+        "schema": {"uniqueItems": true},
+        "tests": [
+            {
+                "description": "unique array of integers is valid",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of integers is invalid",
+                "data": [1, 1],
+                "valid": false
+            },
+            {
+                "description": "numbers are unique if mathematically unequal",
+                "data": [1.0, 1.00, 1],
+                "valid": false
+            },
+            {
+                "description": "unique array of objects is valid",
+                "data": [{"foo": "bar"}, {"foo": "baz"}],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of objects is invalid",
+                "data": [{"foo": "bar"}, {"foo": "bar"}],
+                "valid": false
+            },
+            {
+                "description": "unique array of nested objects is valid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : false}}}
+                ],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of nested objects is invalid",
+                "data": [
+                    {"foo": {"bar" : {"baz" : true}}},
+                    {"foo": {"bar" : {"baz" : true}}}
+                ],
+                "valid": false
+            },
+            {
+                "description": "unique array of arrays is valid",
+                "data": [["foo"], ["bar"]],
+                "valid": true
+            },
+            {
+                "description": "non-unique array of arrays is invalid",
+                "data": [["foo"], ["foo"]],
+                "valid": false
+            },
+            {
+                "description": "1 and true are unique",
+                "data": [1, true],
+                "valid": true
+            },
+            {
+                "description": "0 and false are unique",
+                "data": [0, false],
+                "valid": true
+            },
+            {
+                "description": "unique heterogeneous types are valid",
+                "data": [{}, [1], true, null, 1],
+                "valid": true
+            },
+            {
+                "description": "non-unique heterogeneous types are invalid",
+                "data": [{}, [1], true, null, {}, 1],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/docfx.Test/lib/JsonSchemaTest.cs
+++ b/test/docfx.Test/lib/JsonSchemaTest.cs
@@ -133,6 +133,12 @@ namespace Microsoft.Docs.Build
         [InlineData("{'items': {'type': 'boolean'}}", "['a','b']",
             @"['error','unexpected-type','Expect type 'Boolean' but got 'String'','file',1,4]
               ['error','unexpected-type','Expect type 'Boolean' but got 'String'','file',1,8]")]
+
+        // required validation
+        [InlineData("{'required': []}", "{}", "")]
+        [InlineData("{'required': ['a']}", "{'a': 1}", "")]
+        [InlineData("{'required': ['a']}", "{'b': 1}",
+            "['error','field-required','Missing required field 'a'','file',1,1]")]
         public void TestJsonSchemaValidation(string schema, string json, string expectedErrors)
         {
             var errors = JsonSchemaValidation.Validate(


### PR DESCRIPTION
- Added JSON schema test suite
- Exclude not supported test cases
- Add `required` validation because most of the JSON schema test suite needs `required`

cc @LowEntropyBody 