### PR TITLE
🐞 Fixes weak etag parsing error

### DIFF
--- a/src/docfx/restore/RestoreFile.cs
+++ b/src/docfx/restore/RestoreFile.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Docs.Build
             if (!string.IsNullOrEmpty(existingContent) && @implicit)
                 return;
 
-            var existingEtag = !string.IsNullOrEmpty(existingEtagContent) ? new EntityTagHeaderValue(existingEtagContent) : null;
+            var existingEtag = !string.IsNullOrEmpty(existingEtagContent) ? EntityTagHeaderValue.Parse(existingEtagContent) : null;
 
             var (tempFile, etag) = await DownloadToTempFile(url, config, existingEtag);
             if (tempFile is null)


### PR DESCRIPTION
When the service returns a weak etag that looks like `W/"99a5dbb8d73da1ec452d74c0ab45b11ebe8615a0"`, restore throws `Message: System.FormatException : The specified value is not a valid quoted string.`

This PR fix this bug.