### PR TITLE
🦄Json schema validation support union type

### DIFF
--- a/src/docfx/lib/schema/JsonSchema.cs
+++ b/src/docfx/lib/schema/JsonSchema.cs
@@ -3,19 +3,21 @@
 
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build
 {
     internal class JsonSchema
     {
-        public JsonSchemaType Type { get; set; }
+        [JsonConverter(typeof(OneOrManyConverter))]
+        public JsonSchemaType[] Type { get; set; }
 
         public Dictionary<string, JsonSchema> Properties { get; } = new Dictionary<string, JsonSchema>();
 
         public JsonSchema Items { get; set; }
 
-        public List<JValue> Enum { get; set; } = new List<JValue>();
+        public JValue[] Enum { get; set; }
 
         public string[] Required { get; set; } = Array.Empty<string>();
     }

--- a/src/docfx/lib/schema/OneOrManyConverter.cs
+++ b/src/docfx/lib/schema/OneOrManyConverter.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Newtonsoft.Json;
+
+namespace Microsoft.Docs.Build
+{
+    internal class OneOrManyConverter : JsonConverter
+    {
+        public override bool CanWrite => false;
+
+        public override bool CanConvert(Type objectType) => objectType.IsArray;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) => throw new InvalidOperationException();
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType != JsonToken.StartArray)
+            {
+                var elementType = objectType.GetElementType();
+                var result = Array.CreateInstance(elementType, 1);
+                result.SetValue(serializer.Deserialize(reader, elementType), 0);
+                return result;
+            }
+            return serializer.Deserialize(reader, objectType);
+        }
+    }
+}

--- a/test/docfx.Test/lib/JsonSchemaTest.cs
+++ b/test/docfx.Test/lib/JsonSchemaTest.cs
@@ -52,10 +52,6 @@ namespace Microsoft.Docs.Build
             "items and subitems",
             "with boolean schema",
             "patternProperties",
-            "multiple types can be specified in an array",
-            "type as array",
-            "type: array or object",
-            "type: array, object or null"
         };
 
         public static TheoryData<string, string, string> GetJsonSchemaTestSuite()
@@ -94,7 +90,7 @@ namespace Microsoft.Docs.Build
             var test = JObject.Parse(testText);
             var errors = JsonSchemaValidation.Validate(schema, test["data"]);
 
-            Assert.Equal(test.Value<bool>("valid"), errors.Count == 0);
+            Assert.True(test.Value<bool>("valid") == (errors.Count == 0), description);
         }
 
         [Theory]
@@ -114,8 +110,16 @@ namespace Microsoft.Docs.Build
         [InlineData("{'type': 'string'}", "1",
             "['error','unexpected-type','Expect type 'String' but got 'Integer'','file',1,1]")]
 
+        // union type validation
+        [InlineData("{'type': ['string', 'null']}", "'a'", "")]
+        [InlineData("{'properties': {'a': {'type': ['string', 'null']}}}", "{'a': null}", "")]
+        [InlineData("{'type': ['string', 'null']}", "1",
+            "['error','unexpected-type','Expect type 'String, Null' but got 'Integer'','file',1,1]")]
+
         // enum validation
         [InlineData("{'type': 'string', 'enum': ['a', 'b']}", "'a'", "")]
+        [InlineData("{'type': 'string', 'enum': []}", "'unknown'",
+            "['error','undefined-value','Value 'unknown' is not accepted. Valid values: ','file',1,9]")]
         [InlineData("{'type': 'string', 'enum': ['a', 'b']}", "'unknown'",
             "['error','undefined-value','Value 'unknown' is not accepted. Valid values: 'a', 'b'','file',1,9]")]
 


### PR DESCRIPTION
Otherwise we cannot express `string` or `null`, see https://github.com/dotnet/docfx/pull/4429#issuecomment-487493146