### PR TITLE
remove siteBasePath from documentIdConfig and append it to BaseUrl

### DIFF
--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -82,13 +82,12 @@ repos:
         theme: https://docs.com/template1
         redirections:
           a.md: /b
-        documentId:
-          siteBasePath: rawmetadata
         routes:
           /: rawmetadata
         gitHub:
           userCache: user_profile.json
           resolveUsers: true
+        baseUrl: https://docs.com/rawmetadata
       c.md: |
         ---
         api_name:
@@ -162,7 +161,7 @@ outputs:
         },
         "updated_at": "2018-10-30 12:00 AM",
         "content_git_url": "https://github.com/a/rawmetadata/blob/master/c.md",
-        "gitcommit": "https://github.com/a/rawmetadata/blob/760e36bf5dcf238e28e1eced0c98a6e9d9e444a8/c.md",
+        "gitcommit": "https://github.com/a/rawmetadata/blob/799a3349a544536618e29e38515f68f273955151/c.md",
         "original_content_git_url": "https://github.com/a/rawmetadata/blob/master/c.md",
         "original_content_git_url_template": "{repo}/blob/{branch}/c.md",
         "!metadata": null,

--- a/docs/specs/metadata.yml
+++ b/docs/specs/metadata.yml
@@ -74,10 +74,10 @@ inputs:
   docfx.yml: |
     documentId:
       sourceBasePath: sccm
-      siteBasePath: sccm
     name: sccm
     product: Win
     files: sccm/**/*
+    baseUrl: https://docs.com/sccm
   sccm/mdt/release-notes.md:
 outputs:
   sccm/mdt/release-notes.json: |
@@ -91,10 +91,10 @@ inputs:
   docfx.yml: |
     documentId:
       sourceBasePath: sccm
-      siteBasePath: sccm
     name: sccm
     product: Win
     files: "**/*"
+    baseUrl: https://docs.com/sccm
   sccm/mdm/index.md:
   sccm/index.md:
 outputs:
@@ -109,10 +109,10 @@ inputs:
   docfx.yml: |
     documentId:
       sourceBasePath: sccm
-      siteBasePath: sccm
     name: sccm
     product: Win
     files: "**/*"
+    baseUrl: https://docs.com/sccm
     redirections:
       sccm/mdm/index.md: /sccm/mdm/understand/hybrid-mobile-device-management
   sccm/mdm/understand/hybrid-mobile-device-management.md:
@@ -126,10 +126,10 @@ inputs:
   docfx.yml: |
     documentId:
       sourceBasePath: sccm
-      siteBasePath: sccm
     name: sccm
     product: Win
     files: "sccm/mdm/understand/hybrid-mobile-device-management.md"
+    baseUrl: https://docs.com/sccm
     redirections:
       sccm/mdm/index.md: /sccm/mdm/understand/hybrid-mobile-device-management
   sccm/mdm/understand/hybrid-mobile-device-management.md:
@@ -144,10 +144,10 @@ inputs:
   docfx.yml: |
     documentId:
       sourceBasePath: sccm
-      siteBasePath: sccm
     name: sccm
     product: Win
     files: "**/*"
+    baseUrl: https://docs.com/sccm
     redirectionsWithoutId:
       sccm/mdm/index.md: /sccm/mdm/understand/hybrid-mobile-device-management
   sccm/mdm/understand/hybrid-mobile-device-management.md:
@@ -160,10 +160,10 @@ inputs:
   docfx.yml: |
     documentId:
       sourceBasePath: sccm
-      siteBasePath: sccm
     name: sccm
     product: Win
     files: "**/*"
+    baseUrl: https://docs.com/sccm
     redirections:
       sccm/mdm/index.md: /sccm/mdm/understand/hybrid-mobile-device-management
       sccm/mdm/index2.md: /sccm/mdm/understand/hybrid-mobile-device-management
@@ -191,7 +191,6 @@ outputs:
 inputs:
   docfx.yml: |
     documentId:
-      siteBasePath: azure
       depotMappings:
         articles/iot-central/: MSDN.microsoft-iot-central
       directoryMappings:
@@ -200,6 +199,7 @@ inputs:
     name: azure-documents
     product: Azure
     files: "**/*"
+    baseUrl: https://docs.com/azure
     routes:
       articles/: "azure/"
   articles/iot-central/concepts-architecture.md:
@@ -302,11 +302,10 @@ outputs:
 # redirect to redirect
 inputs:
   docfx.yml: |
-    documentId:
-      siteBasePath: azure
     name: azure-documents
     product: Azure
     files: "**/*"
+    baseUrl: https://docs.com/azure
     routes:
       articles/: "azure/"
     redirections:
@@ -326,9 +325,8 @@ inputs:
   docfx.yml: |
     product: Azure
     name: azure-documents
-    documentId:
-      siteBasePath: articles
     files: "**/*"
+    baseUrl: https://docs.com/articles
   articles/active-directory-b2c/index.yml : |
     ### YamlMime:YamlDocument
     documentType: LandingData
@@ -346,9 +344,8 @@ inputs:
   docfx.yml: |
     product: Azure
     name: azure-documents
-    documentId:
-      siteBasePath: azure
     files: "**/*"
+    baseUrl: https://docs.com/azure
     routes:
       articles/: "azure/"
     redirections:

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -2,11 +2,10 @@
 # Apply moniker range setting in the config to markdown file's output path and output content
 inputs:
   docfx.yml: |
-    documentId:
-      siteBasePath: docs
     monikerRange:
       'docs/v1/**': '< netcore-2.0'
       'docs/v2/**': '>= netcore-2.0'
+    baseUrl: https://docs.com/docs
     routes:
       docs/v1/: docs/
       docs/v2/: docs/

--- a/src/docfx/build/legacy/LegacyDependencyMap.cs
+++ b/src/docfx/build/legacy/LegacyDependencyMap.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Docs.Build
                 var sorted = from d in legacyDependencyMap
                              orderby d.From, d.To, d.Type
                              select d;
-                context.Output.WriteJson(sorted, Path.Combine(docset.Config.DocumentId.SiteBasePath, ".dependency-map.json"));
+                context.Output.WriteJson(sorted, Path.Combine(docset.SiteBasePath, ".dependency-map.json"));
                 return sorted.Select(x => new LegacyDependencyMapItem { From = x.From.Substring(2), To = x.To.Substring(2), Type = x.Type })
                     .GroupBy(x => x.From).ToDictionary(g => g.Key, g => g.ToList());
             }

--- a/src/docfx/build/legacy/LegacyFileMap.cs
+++ b/src/docfx/build/legacy/LegacyFileMap.cs
@@ -43,15 +43,15 @@ namespace Microsoft.Docs.Build
             context.Output.WriteJson(
                 new
                 {
-                    host = docset.Config.BaseUrl,
+                    host = docset.HostName,
                     locale = docset.Locale,
-                    base_path = $"/{docset.Config.DocumentId.SiteBasePath}",
+                    base_path = $"/{docset.SiteBasePath}",
                     source_base_path = docset.Config.DocumentId.SourceBasePath,
                     version_info = new { },
                     file_mapping = items.ToDictionary(
                         key => PathUtility.NormalizeFile(key.legacyFilePathRelativeToBaseFolder), v => v.fileMapItem),
                 },
-                Path.Combine(docset.Config.DocumentId.SiteBasePath, "filemap.json"));
+                Path.Combine(docset.SiteBasePath, "filemap.json"));
         }
     }
 }

--- a/src/docfx/build/legacy/LegacyUtility.cs
+++ b/src/docfx/build/legacy/LegacyUtility.cs
@@ -30,9 +30,9 @@ namespace Microsoft.Docs.Build
         public static string ToLegacyOutputPathRelativeToBaseSitePath(this Document doc, Docset docset)
         {
             var legacyOutputFilePathRelativeToSiteBasePath = doc.SitePath;
-            if (legacyOutputFilePathRelativeToSiteBasePath.StartsWith(docset.Config.DocumentId.SiteBasePath, PathUtility.PathComparison))
+            if (legacyOutputFilePathRelativeToSiteBasePath.StartsWith(docset.SiteBasePath, PathUtility.PathComparison))
             {
-                legacyOutputFilePathRelativeToSiteBasePath = Path.GetRelativePath(docset.Config.DocumentId.SiteBasePath, legacyOutputFilePathRelativeToSiteBasePath);
+                legacyOutputFilePathRelativeToSiteBasePath = Path.GetRelativePath(docset.SiteBasePath, legacyOutputFilePathRelativeToSiteBasePath);
             }
 
             return PathUtility.NormalizeFile(legacyOutputFilePathRelativeToSiteBasePath);
@@ -41,9 +41,9 @@ namespace Microsoft.Docs.Build
         public static string ToLegacySiteUrlRelativeToBaseSitePath(this Document doc, Docset docset)
         {
             var legacySiteUrlRelativeToSiteBasePath = doc.SiteUrl;
-            if (legacySiteUrlRelativeToSiteBasePath.StartsWith($"/{docset.Config.DocumentId.SiteBasePath}", PathUtility.PathComparison))
+            if (legacySiteUrlRelativeToSiteBasePath.StartsWith($"/{docset.SiteBasePath}", PathUtility.PathComparison))
             {
-                legacySiteUrlRelativeToSiteBasePath = Path.GetRelativePath(docset.Config.DocumentId.SiteBasePath, legacySiteUrlRelativeToSiteBasePath.Substring(1));
+                legacySiteUrlRelativeToSiteBasePath = Path.GetRelativePath(docset.SiteBasePath, legacySiteUrlRelativeToSiteBasePath.Substring(1));
             }
 
             return PathUtility.NormalizeFile(
@@ -53,7 +53,7 @@ namespace Microsoft.Docs.Build
         }
 
         public static string ToLegacyOutputPath(this LegacyManifestOutputItem legacyManifestOutputItem, Docset docset, string groupId)
-            => Path.Combine(docset.Config.DocumentId.SiteBasePath, $"{groupId}", legacyManifestOutputItem.RelativePath);
+            => Path.Combine(docset.SiteBasePath, $"{groupId}", legacyManifestOutputItem.RelativePath);
 
         public static string GetAbsoluteOutputPathFromRelativePath(this Docset docset, string relativePath)
         {

--- a/src/docfx/build/legacy/manifest/LegacyManifest.cs
+++ b/src/docfx/build/legacy/manifest/LegacyManifest.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Docs.Build
                     version_info = new { },
                     items_to_publish = itemsToPublish,
                 },
-                Path.Combine(docset.Config.DocumentId.SiteBasePath, ".manifest.json"));
+                Path.Combine(docset.SiteBasePath, ".manifest.json"));
             }
         }
 

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Docs.Build
                 errors.AddRange(contributorErrors);
 
             var isPage = schema.Attribute is PageSchemaAttribute;
-            var outputPath = file.GetOutputPath(model.Monikers, file.Docset.Config.DocumentId.SiteBasePath, isPage);
+            var outputPath = file.GetOutputPath(model.Monikers, file.Docset.SiteBasePath, isPage);
             var (output, extensionData) = ApplyTemplate(context, file, model, isPage);
 
             var publishItem = new PublishItem

--- a/src/docfx/build/redirection/BuildRedirection.cs
+++ b/src/docfx/build/redirection/BuildRedirection.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Docs.Build
 
             if (context.PublishModelBuilder.TryAdd(file, publishItem) && file.Docset.Legacy)
             {
-                var outputPath = file.GetOutputPath(monikers, file.Docset.Config.DocumentId.SiteBasePath, rawPage: true);
+                var outputPath = file.GetOutputPath(monikers, file.Docset.SiteBasePath, rawPage: true);
                 var metadataPath = outputPath.Substring(0, outputPath.Length - ".raw.page.json".Length) + ".mta.json";
                 var metadata = new
                 {

--- a/src/docfx/build/resource/BuildResource.cs
+++ b/src/docfx/build/resource/BuildResource.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Docs.Build
             Debug.Assert(file.ContentType == ContentType.Resource);
 
             var (errors, monikers) = context.MonikerProvider.GetFileLevelMonikers(file, context.MetadataProvider);
-            var outputPath = file.GetOutputPath(monikers, file.Docset.Config.DocumentId.SiteBasePath);
+            var outputPath = file.GetOutputPath(monikers, file.Docset.SiteBasePath);
 
             // Output path is source file path relative to output folder when copy resource is disabled
             var publishPash = file.Docset.Config.Output.CopyResources

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -37,11 +37,11 @@ namespace Microsoft.Docs.Build
             ResolveItemMonikers(model.Items);
 
             // enable pdf
-            var outputPath = file.GetOutputPath(model.Metadata.Monikers, file.Docset.Config.DocumentId.SiteBasePath);
+            var outputPath = file.GetOutputPath(model.Metadata.Monikers, file.Docset.SiteBasePath);
 
             if (file.Docset.Config.Output.Pdf)
             {
-                var siteBasePath = file.Docset.Config.DocumentId.SiteBasePath;
+                var siteBasePath = file.Docset.SiteBasePath;
                 var relativePath = PathUtility.NormalizeFile(Path.GetRelativePath(siteBasePath, Path.ChangeExtension(outputPath, ".pdf")));
                 model.Metadata.PdfAbsolutePath = $"/{siteBasePath}/opbuildpdf/{relativePath}";
             }

--- a/src/docfx/build/xref/XrefMap.cs
+++ b/src/docfx/build/xref/XrefMap.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Docs.Build
 
             string RemoveHostnameIfSharingTheSameOne(string input)
             {
-                var hostname = rootFile.Docset.Config.BaseUrl;
+                var hostname = rootFile.Docset.HostName;
                 if (input.StartsWith(hostname, StringComparison.OrdinalIgnoreCase))
                 {
                     return input.Substring(hostname.Length);

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Docs.Build
         public readonly JObject GlobalMetadata = new JObject();
 
         /// <summary>
-        /// The hostname
+        /// {Schema}://{Hostname}/{SiteBasePath}: https://docs.microsoft.com/dotnet
         /// </summary>
         public readonly string BaseUrl = string.Empty;
 

--- a/src/docfx/config/DocumentIdConfig.cs
+++ b/src/docfx/config/DocumentIdConfig.cs
@@ -15,12 +15,6 @@ namespace Microsoft.Docs.Build
         public readonly string SourceBasePath = ".";
 
         /// <summary>
-        /// For backward compatibility, the output site path prefix
-        /// Used for resolving versionIndependentId in <see cref="Document.LoadDocumentId()"/>
-        /// </summary>
-        public readonly string SiteBasePath = ".";
-
-        /// <summary>
         /// The mappings between depot and files/directory
         /// Used for backward compatibility
         /// </summary>

--- a/src/docfx/docset/Docset.cs
+++ b/src/docfx/docset/Docset.cs
@@ -82,6 +82,16 @@ namespace Microsoft.Docs.Build
         public RestoreMap RestoreMap { get; }
 
         /// <summary>
+        /// Gets the site base path
+        /// </summary>
+        public string SiteBasePath { get; }
+
+        /// <summary>
+        /// Gets the {Schema}://{HostName}
+        /// </summary>
+        public string HostName { get; }
+
+        /// <summary>
         /// Gets the dependent docsets
         /// </summary>
         public IReadOnlyDictionary<string, Docset> DependencyDocsets => _dependencyDocsets.Value;
@@ -164,6 +174,7 @@ namespace Microsoft.Docs.Build
             Culture = CreateCultureInfo(locale);
             LocalizationDocset = localizedDocset;
             FallbackDocset = fallbackDocset;
+            (HostName, SiteBasePath) = SplitBaseUrl(config.BaseUrl);
 
             MetadataSchema = LoadMetadataSchema(Config);
             ResolveAlias = LoadResolveAlias(Config);
@@ -320,6 +331,22 @@ namespace Microsoft.Docs.Build
             }
 
             return scanScope;
+        }
+
+        private static (string hostName, string siteBasePath) SplitBaseUrl(string baseUrl)
+        {
+            string hostName = string.Empty;
+            string siteBasePath = ".";
+            if (!string.IsNullOrEmpty(baseUrl)
+                && Uri.TryCreate(baseUrl, UriKind.Absolute, out var uriResult))
+            {
+                if (uriResult.AbsolutePath != "/")
+                {
+                    siteBasePath = uriResult.AbsolutePath.Substring(1);
+                }
+                hostName = $"{uriResult.Scheme}://{uriResult.Host}";
+            }
+            return (hostName, siteBasePath);
         }
     }
 }

--- a/src/docfx/docset/Document.cs
+++ b/src/docfx/docset/Document.cs
@@ -394,7 +394,7 @@ namespace Microsoft.Docs.Build
                 siteUrl = Document.PathToAbsoluteUrl(sitePath, contentType, schema, config.Output.Json);
             }
 
-            return withLocale ? $"{config.BaseUrl}/{docset.Locale}{siteUrl}" : $"{config.BaseUrl}{siteUrl}";
+            return withLocale ? $"{docset.HostName}/{docset.Locale}{siteUrl}" : $"{config.BaseUrl}{siteUrl}";
 
             string ReplaceLast(string source, string find, string replace)
             {
@@ -468,7 +468,7 @@ namespace Microsoft.Docs.Build
             // get set path from site path
             // site path doesn't contain version info according to the output spec
             var sitePathWithoutExtension = Path.Combine(Path.GetDirectoryName(SitePath), Path.GetFileNameWithoutExtension(SitePath));
-            var sitePath = PathUtility.NormalizeFile(Path.GetRelativePath(Docset.Config.DocumentId.SiteBasePath, sitePathWithoutExtension));
+            var sitePath = PathUtility.NormalizeFile(Path.GetRelativePath(Docset.SiteBasePath, sitePathWithoutExtension));
 
             return (
                 HashUtility.GetMd5Guid($"{depotName}|{sourcePath.ToLowerInvariant()}").ToString(),

--- a/src/docfx/template/TemplateEngine.cs
+++ b/src/docfx/template/TemplateEngine.cs
@@ -178,16 +178,16 @@ namespace Microsoft.Docs.Build
             rawMetadata["__global"] = Global;
             rawMetadata.Remove("content");
 
-            var path = PathUtility.NormalizeFile(Path.GetRelativePath(file.Docset.Config.DocumentId.SiteBasePath, file.SitePath));
+            var path = PathUtility.NormalizeFile(Path.GetRelativePath(file.Docset.SiteBasePath, file.SitePath));
 
             rawMetadata["_path"] = path;
             rawMetadata["wordCount"] = pageModel.WordCount;
 
-            rawMetadata["_op_canonicalUrlPrefix"] = $"{docset.Config.BaseUrl}/{docset.Locale}/{docset.Config.DocumentId.SiteBasePath}/";
+            rawMetadata["_op_canonicalUrlPrefix"] = $"{docset.HostName}/{docset.Locale}/{docset.SiteBasePath}/";
 
             if (docset.Config.Output.Pdf)
             {
-                rawMetadata["_op_pdfUrlPrefixTemplate"] = $"{docset.Config.BaseUrl}/pdfstore/{pageModel.Locale}/{docset.Config.Product}.{docset.Config.Name}/{{branchName}}";
+                rawMetadata["_op_pdfUrlPrefixTemplate"] = $"{docset.HostName}/pdfstore/{pageModel.Locale}/{docset.Config.Product}.{docset.Config.Name}/{{branchName}}";
             }
 
             rawMetadata.Remove("schema_type");


### PR DESCRIPTION
#4222 

Requires change on config migration tool: @mingwli 
1. remove `siteBasePath` from `documentIdConfig`
2. append `siteBasePath` to `baseUrl`