### PR TITLE
docfx changes need for `Docs.Build` regression test

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,3 +1,5 @@
+param ([switch]$noTest = $false)
+
 function exec([string] $cmd) {
     Write-Host $cmd -ForegroundColor Green
     & ([scriptblock]::Create($cmd))
@@ -7,6 +9,10 @@ function exec([string] $cmd) {
 }
 
 function test() {
+    if ($noTest) {
+        return
+    }
+
     try {
         pushd test/docfx.Test
 

--- a/src/docfx/build/legacy/manifest/LegacyManifest.cs
+++ b/src/docfx/build/legacy/manifest/LegacyManifest.cs
@@ -95,9 +95,9 @@ namespace Microsoft.Docs.Build
                         }
                         var file = new LegacyManifestItem
                         {
-                            SiteUrlRelativeToSiteBasePath = legacySiteUrlRelativeToBaseSitePath,
-                            FilePath = document.FilePath,
-                            FilePathRelativeToSourceBasePath = document.ToLegacyPathRelativeToBasePath(docset),
+                            AssetId = legacySiteUrlRelativeToBaseSitePath,
+                            Original = document.FilePath,
+                            SourceRelativePath = document.ToLegacyPathRelativeToBasePath(docset),
                             OriginalType = GetOriginalType(document.ContentType),
                             Type = GetType(document.ContentType, document.Schema),
                             Output = output,
@@ -127,7 +127,7 @@ namespace Microsoft.Docs.Build
                         version_folder = string.Empty,
                         xref_map = "xrefmap.yml",
                     },
-                    files = convertedItems.Select(f => f.manifestItem),
+                    files = convertedItems.OrderBy(f => f.manifestItem.AssetId).Select(f => f.manifestItem),
                     is_already_processed = true,
                     source_base_path = docset.Config.DocumentId.SourceBasePath,
                     version_info = new { },

--- a/src/docfx/build/legacy/manifest/LegacyManifestItem.cs
+++ b/src/docfx/build/legacy/manifest/LegacyManifestItem.cs
@@ -2,40 +2,33 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Docs.Build
 {
+    [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
     internal class LegacyManifestItem
     {
         // published url relative to site base path
-        [JsonProperty("asset_id")]
-        public string SiteUrlRelativeToSiteBasePath { get; set; }
+        public string AssetId { get; set; }
 
         // rource path relative to source repo root
-        [JsonProperty("original")]
-        public string FilePath { get; set; }
+        public string Original { get; set; }
 
         // source path relative to source base path
-        [JsonProperty("source_relative_path")]
-        public string FilePathRelativeToSourceBasePath { get; set; }
+        public string SourceRelativePath { get; set; }
 
-        [JsonProperty("original_type")]
         public string OriginalType { get; set; }
 
-        [JsonProperty("type")]
         public string Type { get; set; }
 
-        [JsonProperty("output")]
         public LegacyManifestOutput Output { get; set; }
 
         // tell ops to use plugin for normalization
-        [JsonProperty("skip_normalization")]
         public bool SkipNormalization { get; set; }
 
-        [JsonProperty("skip_schema_check")]
         public bool SkipSchemaCheck { get; set; }
 
-        [JsonProperty("group")]
         public string Group { get; set; }
     }
 }


### PR DESCRIPTION
- Add `noTest` to `build.ps1` for faster build
- Stablize legacy manifest
- Rename legacy manifest item to match output