### PR TITLE
Generate dependency list

### DIFF
--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -76,6 +76,8 @@ outputs:
   op_aggregated_file_map_info.json:
   .publish.json:
   xrefmap.json:
+  server-side-dependent-list.txt:
+  full-dependent-list.txt:
 ---
 # Raw metadata generated for template
 # todo: remove this test and make raw model as our page model

--- a/test/docfx.Test/e2e/E2ESpec.cs
+++ b/test/docfx.Test/e2e/E2ESpec.cs
@@ -21,9 +21,13 @@ namespace Microsoft.Docs.Build
 
         public readonly string[] Environments = Array.Empty<string>();
 
-        public readonly string[] SkippableOutputs = new[] { "xrefmap.json", ".publish.json", ".dependencymap.json",
-                                                            // legacy
-                                                            ".manifest.json", ".dependency-map.json", "filemap.json", "op_aggregated_file_map_info.json", ".publish.json", "xrefmap.json" };
+        public readonly string[] SkippableOutputs =
+        {
+            "xrefmap.json", ".publish.json", ".dependencymap.json",
+            // legacy
+            ".manifest.json", ".dependency-map.json", "filemap.json", "op_aggregated_file_map_info.json",
+            "server-side-dependent-list.txt", "full-dependent-list.txt"
+        };
 
         public readonly Dictionary<string, E2ECommit[]> Repos = new Dictionary<string, E2ECommit[]>();
 


### PR DESCRIPTION
For v3, `full-dependent-list.txt` and `server-side-dependent-list.txt` are the same and does not depend on git change list, so with this, we can remove `ResolveDependencyConsole`.