### PR TITLE
Remove sas token for blob url while create short folder name

### DIFF
--- a/src/docfx/lib/PathUtility.cs
+++ b/src/docfx/lib/PathUtility.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Docs.Build
 
         private static readonly HashSet<char> s_invalidPathChars = Path.GetInvalidPathChars().Concat(Path.GetInvalidFileNameChars()).Distinct().ToHashSet();
 
-        private static readonly Regex s_blobUrl = new Regex(@"^https:\/\/\w+.blob.core.windows.net(/\w+)*\?(.*)$", RegexOptions.IgnoreCase);
+        private static readonly Regex s_blobUrl = new Regex(@"^https:\/\/.+?.blob.core.windows.net\/.*?\?(.*)$", RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Check if the file is the same as matcher or is inside the directory specified by matcher.

--- a/src/docfx/lib/PathUtility.cs
+++ b/src/docfx/lib/PathUtility.cs
@@ -26,8 +26,6 @@ namespace Microsoft.Docs.Build
 
         private static readonly HashSet<char> s_invalidPathChars = Path.GetInvalidPathChars().Concat(Path.GetInvalidFileNameChars()).Distinct().ToHashSet();
 
-        private static readonly Regex s_blobUrl = new Regex(@"^https:\/\/.+?.blob.core.windows.net\/.*?\?(.*)$", RegexOptions.IgnoreCase);
-
         /// <summary>
         /// Check if the file is the same as matcher or is inside the directory specified by matcher.
         /// Both path should be normalized
@@ -211,12 +209,7 @@ namespace Microsoft.Docs.Build
         // https://docs.microsoft.com/en-us/azure/storage/common/storage-dotnet-shared-access-signature-part-1#how-a-shared-access-signature-works
         private static string RemoveQueryForBlobUrl(string url)
         {
-            var match = s_blobUrl.Match(url);
-            if (match.Success && match.Groups.Count > 2)
-            {
-                return url.Substring(0, url.Length - match.Groups[2].Length);
-            }
-            return url;
+            return Regex.Replace(url, @"^(https:\/\/.+?.blob.core.windows.net\/)(.*)\?(.*)$", match => $"{match.Groups[1]}{match.Groups[2]}");
         }
 
         private static string Normalize(string path)

--- a/test/docfx.Test/lib/PathUtilityTest.cs
+++ b/test/docfx.Test/lib/PathUtilityTest.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Docs.Build
         [InlineData("https://github.com/1/2/3/4/5/6/7/8/9/10/11/12/13/14", "github.com+1+2+3+11+12+13+14+b5f1b5a8")]
         [InlineData("https://github.com/crazy-crazy-crazy-crazy-long-repo.zh-cn", "github.com+crazy-cr..po.zh-cn+791b3f68")]
         [InlineData("https://a.com?b=c#d", "a.com+b=c+d+2183540f")]
-        [InlineData("https://abc.blob.core.windows.net/a/b/c/d?sv=d&sr=e&sig=f&st=2019-05-07&se=2019-05-08&sp=r", "abc.blob..dows.net+a+b+c+d+84d63a4b")]
+        [InlineData("https://ab-c.blob.core.windows.net/a/b/c/d?sv=d&sr=e&sig=f&st=2019-05-07&se=2019-05-08&sp=r", "ab-c.blo..dows.net+a+b+c+d+9e69c8e7")]
         public static void UrlToFolderName(string url, string folderName)
         {
             var result = PathUtility.UrlToShortName(url);

--- a/test/docfx.Test/lib/PathUtilityTest.cs
+++ b/test/docfx.Test/lib/PathUtilityTest.cs
@@ -88,9 +88,11 @@ namespace Microsoft.Docs.Build
         [InlineData("https://github.com/1/2/3/4/5/6/7/8/9/10/11/12/13/14", "github.com+1+2+3+11+12+13+14+b5f1b5a8")]
         [InlineData("https://github.com/crazy-crazy-crazy-crazy-long-repo.zh-cn", "github.com+crazy-cr..po.zh-cn+791b3f68")]
         [InlineData("https://a.com?b=c#d", "a.com+b=c+d+2183540f")]
+        [InlineData("https://abc.blob.core.windows.net/a/b/c/d?sv=d&sr=e&sig=f&st=2019-05-07&se=2019-05-08&sp=r", "abc.blob..dows.net+a+b+c+d+84d63a4b")]
         public static void UrlToFolderName(string url, string folderName)
         {
-            Assert.Equal(folderName, PathUtility.UrlToShortName(url));
+            var result = PathUtility.UrlToShortName(url);
+            Assert.Equal(folderName, result);
         }
 
         [Fact]


### PR DESCRIPTION
For azure blob URL, remove the sas token from the URL to identify if the file has been restored locally
