### PR TITLE
Create error logs using with append

### DIFF
--- a/src/docfx/lib/log/Report.cs
+++ b/src/docfx/lib/log/Report.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Docs.Build
 
                 PathUtility.CreateDirectoryFromFilePath(outputFilePath);
 
-                return File.CreateText(outputFilePath);
+                return File.AppendText(outputFilePath);
             });
         }
 


### PR DESCRIPTION
With this, we can get rid of all `try { } finally { copy-report file }` in `docsbuild`.
