### PR TITLE
📝Increase column for line info of link within HTML block

### DIFF
--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -537,4 +537,18 @@ inputs:
 outputs:
   docs/a.json:
   docs/b.json:
-
+---
+# resolve link in html block
+inputs:
+  docfx.yml:
+  docs/a.md: |
+    some text
+    <div>
+      <p>Link to <a href="#bookmark">text</a></p>
+      <p>Link to <a href="#bookmark">some other text</a></p>
+    </div>
+outputs:
+  docs/a.json:
+  build.log: |
+    ["suggestion","internal-bookmark-not-found","Cannot find bookmark '#bookmark' in 'docs/a.md'","docs/a.md",2,1]
+    ["suggestion","internal-bookmark-not-found","Cannot find bookmark '#bookmark' in 'docs/a.md'","docs/a.md",2,2]

--- a/src/docfx/build/page/AttributeTransformer.cs
+++ b/src/docfx/build/page/AttributeTransformer.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Docs.Build
 
             if (attribute is HtmlAttribute)
             {
-                var html = HtmlUtility.TransformLinks((string)value, href =>
+                var html = HtmlUtility.TransformLinks((string)value, (href, _) =>
                 {
                     var (error, link, _) = dependencyResolver.ResolveLink(new SourceInfo<string>(href, value), file, file, buildChild);
 

--- a/src/docfx/lib/HtmlUtility.cs
+++ b/src/docfx/lib/HtmlUtility.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Docs.Build
             return result;
         }
 
-        public static string TransformLinks(string html, Func<string, string> transform)
+        public static string TransformLinks(string html, Func<string, int, string> transform)
         {
             // Fast pass it does not have <a> tag or <img> tag
             if (!((html.Contains("<a", StringComparison.OrdinalIgnoreCase) && html.Contains("href", StringComparison.OrdinalIgnoreCase)) ||
@@ -133,6 +133,8 @@ namespace Microsoft.Docs.Build
             var pos = 0;
             var result = new StringBuilder(html.Length + 64);
 
+            // TODO: remove this column offset hack while we have accurate line info for link in HTML block
+            var columnOffset = 0;
             foreach (var node in doc.DocumentNode.Descendants())
             {
                 var link = node.Name == "a" ? node.Attributes["href"]
@@ -149,12 +151,13 @@ namespace Microsoft.Docs.Build
                 {
                     result.Append(html, pos, valueStartIndex - pos);
                 }
-                var transformed = transform(HttpUtility.HtmlDecode(link.Value));
+                var transformed = transform(HttpUtility.HtmlDecode(link.Value), columnOffset);
                 if (!string.IsNullOrEmpty(transformed))
                 {
                     result.Append(HttpUtility.HtmlEncode(transformed));
                 }
                 pos = valueStartIndex + link.Value.Length;
+                columnOffset += 1;
             }
 
             if (html.Length > pos)

--- a/src/docfx/lib/markdown/MarkdigUtility.cs
+++ b/src/docfx/lib/markdown/MarkdigUtility.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Concurrent;
 using Markdig;
 using Markdig.Parsers;
 using Markdig.Renderers;
@@ -14,28 +13,11 @@ namespace Microsoft.Docs.Build
 {
     internal static class MarkdigUtility
     {
-        private static readonly ConcurrentDictionary<MarkdownObject, int> s_htmlBlockSources = new ConcurrentDictionary<MarkdownObject, int>();
-
-        public static SourceInfo ToSourceInfo(this MarkdownObject obj, int? line = null, string file = null)
+        public static SourceInfo ToSourceInfo(this MarkdownObject obj, int? line = null, string file = null, int columnOffset = 0)
         {
-            var column = obj.Column;
-
-            // TODO: remove this hack while we have accurate line info for link in HTML block
-            if (obj is HtmlBlock)
-            {
-                if (s_htmlBlockSources.TryGetValue(obj, out var value))
-                {
-                    column = value + 1;
-                }
-                else
-                {
-                    s_htmlBlockSources.TryAdd(obj, obj.Column);
-                }
-            }
-
             // Line info in markdown object is zero based, turn it into one based.
             if (obj != null)
-                return new SourceInfo(file ?? InclusionContext.File?.ToString(), obj.Line + 1, column + 1);
+                return new SourceInfo(file ?? InclusionContext.File?.ToString(), obj.Line + 1, obj.Column + columnOffset + 1);
 
             if (line != null)
                 return new SourceInfo(file ?? InclusionContext.File?.ToString(), line.Value + 1, 0);

--- a/src/docfx/lib/markdown/MarkdigUtility.cs
+++ b/src/docfx/lib/markdown/MarkdigUtility.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 using Markdig;
 using Markdig.Parsers;
 using Markdig.Renderers;
@@ -13,11 +14,28 @@ namespace Microsoft.Docs.Build
 {
     internal static class MarkdigUtility
     {
+        private static readonly ConcurrentDictionary<MarkdownObject, int> s_htmlBlockSources = new ConcurrentDictionary<MarkdownObject, int>();
+
         public static SourceInfo ToSourceInfo(this MarkdownObject obj, int? line = null, string file = null)
         {
+            var column = obj.Column;
+
+            // TODO: remove this hack while we have accurate line info for link in HTML block
+            if (obj is HtmlBlock)
+            {
+                if (s_htmlBlockSources.TryGetValue(obj, out var value))
+                {
+                    column = value + 1;
+                }
+                else
+                {
+                    s_htmlBlockSources.TryAdd(obj, obj.Column);
+                }
+            }
+
             // Line info in markdown object is zero based, turn it into one based.
             if (obj != null)
-                return new SourceInfo(file ?? InclusionContext.File?.ToString(), obj.Line + 1, obj.Column + 1);
+                return new SourceInfo(file ?? InclusionContext.File?.ToString(), obj.Line + 1, column + 1);
 
             if (line != null)
                 return new SourceInfo(file ?? InclusionContext.File?.ToString(), line.Value + 1, 0);

--- a/src/docfx/lib/markdown/MarkdownUtility.cs
+++ b/src/docfx/lib/markdown/MarkdownUtility.cs
@@ -81,10 +81,10 @@ namespace Microsoft.Docs.Build
             t_status.Value.Peek().Errors.Add(error);
         }
 
-        internal static string GetLink(string path, object relativeTo, object resultRelativeTo, MarkdownObject origin)
+        internal static string GetLink(string path, object relativeTo, object resultRelativeTo, MarkdownObject origin, int columnOffset = 0)
         {
             var status = t_status.Value.Peek();
-            var (error, link, _) = status.DependencyResolver.ResolveLink(new SourceInfo<string>(path, origin.ToSourceInfo()), (Document)relativeTo, (Document)resultRelativeTo, status.BuildChild);
+            var (error, link, _) = status.DependencyResolver.ResolveLink(new SourceInfo<string>(path, origin.ToSourceInfo(columnOffset: columnOffset)), (Document)relativeTo, (Document)resultRelativeTo, status.BuildChild);
             status.Errors.AddIfNotNull(error?.WithSourceInfo(origin.ToSourceInfo()));
             return link;
         }

--- a/src/docfx/lib/markdown/ResolveLinkExtension.cs
+++ b/src/docfx/lib/markdown/ResolveLinkExtension.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Docs.Build
             {
                 return HtmlUtility.TransformLinks(
                     html,
-                    href => MarkdownUtility.GetLink(href, InclusionContext.File, InclusionContext.RootFile, block));
+                    (href, columnOffset) => MarkdownUtility.GetLink(href, InclusionContext.File, InclusionContext.RootFile, block, columnOffset));
             }
         }
     }

--- a/test/docfx.Test/lib/HtmlUtilityTest.cs
+++ b/test/docfx.Test/lib/HtmlUtilityTest.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Docs.Build
         [InlineData("<div><img src='a/b.png' /><a href='hello'></div>", "666", "<div><img src='666' /><a href='666'></div>")]
         public void TransformLinks(string input, string link, string output)
         {
-            Assert.Equal(output, HtmlUtility.TransformLinks(input, _ => link));
+            Assert.Equal(output, HtmlUtility.TransformLinks(input, (href, _) => link));
         }
 
         [Theory]


### PR DESCRIPTION
- Workaround to distinguish errors of links within the same HTML block in `.md`

- Add TODO to remove this while accurate line info is in place

https://ceapex.visualstudio.com/Engineering/_workitems/edit/90580