### PR TITLE
don't remove resource output when the content type is resource and copyResources is false

### DIFF
--- a/docs/specs/config.yml
+++ b/docs/specs/config.yml
@@ -490,3 +490,18 @@ inputs:
 outputs:
   .errors.log: |
     ["error","violate-schema","Expected type String, please input String or type compatible with String.","docfx.yml",4,7]
+---
+# Should not change files out of outputFolder
+inputs:
+  docfx.yml: |
+    files: '**'
+    output:
+      copyResources: false
+    routes:
+      docs/: .
+  a.png:
+  docs/a.png:
+outputs:
+  .publish.json: |
+  .errors.log: |
+      ["error","publish-url-conflict","Two or more files publish to the same url '/a.png': 'a.png', 'docs/a.png'"]

--- a/src/docfx/build/resource/BuildResource.cs
+++ b/src/docfx/build/resource/BuildResource.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Docs.Build
             var outputPath = file.GetOutputPath(monikers, file.Docset.SiteBasePath);
 
             // Output path is source file path relative to output folder when copy resource is disabled
-            var publishPash = file.Docset.Config.Output.CopyResources
+            var publishPath = file.Docset.Config.Output.CopyResources
                 ? outputPath
                 : PathUtility.NormalizeFile(
                     Path.GetRelativePath(
@@ -27,7 +27,7 @@ namespace Microsoft.Docs.Build
             var publishItem = new PublishItem
             {
                 Url = file.SiteUrl,
-                Path = publishPash,
+                Path = publishPath,
                 Hash = HashUtility.GetFileSha1Hash(Path.Combine(file.Docset.DocsetPath, file.FilePath)),
                 Locale = file.Docset.Locale,
                 Monikers = monikers,

--- a/src/docfx/publish/PublishModelBuilder.cs
+++ b/src/docfx/publish/PublishModelBuilder.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Docs.Build
 
                     foreach (var conflictingFile in files.Keys)
                     {
-                        if (_publishItems.TryRemove(conflictingFile, out var item) && item.Path != null)
+                        if (_publishItems.TryRemove(conflictingFile, out var item) && item.Path != null && (conflictingFile.ContentType != ContentType.Resource || conflictingFile.Docset.Config.Output.CopyResources))
                         {
                             context.Output.Delete(item.Path, legacy);
                         }
@@ -93,7 +93,7 @@ namespace Microsoft.Docs.Build
 
                 foreach (var conflictingFile in conflictingFiles)
                 {
-                    if (_publishItems.TryRemove(conflictingFile, out var item) && item.Path != null)
+                    if (_publishItems.TryRemove(conflictingFile, out var item) && item.Path != null && (conflictingFile.ContentType != ContentType.Resource || conflictingFile.Docset.Config.Output.CopyResources))
                     {
                         context.Output.Delete(item.Path, legacy);
                     }
@@ -105,7 +105,7 @@ namespace Microsoft.Docs.Build
             {
                 if (_filesBySiteUrl.TryRemove(file.SiteUrl, out _))
                 {
-                    if (_publishItems.TryRemove(file, out var item) && item.Path != null)
+                    if (_publishItems.TryRemove(file, out var item) && item.Path != null && (file.ContentType != ContentType.Resource || file.Docset.Config.Output.CopyResources))
                     {
                         context.Output.Delete(item.Path, legacy);
                     }

--- a/src/docfx/publish/PublishModelBuilder.cs
+++ b/src/docfx/publish/PublishModelBuilder.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Docs.Build
 
                     foreach (var conflictingFile in files.Keys)
                     {
-                        if (_publishItems.TryRemove(conflictingFile, out var item) && item.Path != null && (conflictingFile.ContentType != ContentType.Resource || conflictingFile.Docset.Config.Output.CopyResources))
+                        if (_publishItems.TryRemove(conflictingFile, out var item) && item.Path != null && IsDeletableFile(item))
                         {
                             context.Output.Delete(item.Path, legacy);
                         }
@@ -93,7 +93,7 @@ namespace Microsoft.Docs.Build
 
                 foreach (var conflictingFile in conflictingFiles)
                 {
-                    if (_publishItems.TryRemove(conflictingFile, out var item) && item.Path != null && (conflictingFile.ContentType != ContentType.Resource || conflictingFile.Docset.Config.Output.CopyResources))
+                    if (_publishItems.TryRemove(conflictingFile, out var item) && item.Path != null && IsDeletableFile(item))
                     {
                         context.Output.Delete(item.Path, legacy);
                     }
@@ -105,7 +105,7 @@ namespace Microsoft.Docs.Build
             {
                 if (_filesBySiteUrl.TryRemove(file.SiteUrl, out _))
                 {
-                    if (_publishItems.TryRemove(file, out var item) && item.Path != null && (file.ContentType != ContentType.Resource || file.Docset.Config.Output.CopyResources))
+                    if (_publishItems.TryRemove(file, out var item) && item.Path != null && IsDeletableFile(item))
                     {
                         context.Output.Delete(item.Path, legacy);
                     }
@@ -125,6 +125,11 @@ namespace Microsoft.Docs.Build
             var fileManifests = _publishItems.ToDictionary(item => item.Key, item => item.Value);
 
             return (model, fileManifests);
+        }
+
+        private bool IsDeletableFile(PublishItem item)
+        {
+            return !item.Path.StartsWith("..");
         }
     }
 }

--- a/src/docfx/publish/PublishModelBuilder.cs
+++ b/src/docfx/publish/PublishModelBuilder.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace Microsoft.Docs.Build
@@ -66,7 +67,7 @@ namespace Microsoft.Docs.Build
 
                     foreach (var conflictingFile in files.Keys)
                     {
-                        if (_publishItems.TryRemove(conflictingFile, out var item) && item.Path != null && IsDeletableFile(item))
+                        if (_publishItems.TryRemove(conflictingFile, out var item) && item.Path != null && IsInsideOutputFolder(item, conflictingFile.Docset))
                         {
                             context.Output.Delete(item.Path, legacy);
                         }
@@ -93,7 +94,7 @@ namespace Microsoft.Docs.Build
 
                 foreach (var conflictingFile in conflictingFiles)
                 {
-                    if (_publishItems.TryRemove(conflictingFile, out var item) && item.Path != null && IsDeletableFile(item))
+                    if (_publishItems.TryRemove(conflictingFile, out var item) && item.Path != null && IsInsideOutputFolder(item, conflictingFile.Docset))
                     {
                         context.Output.Delete(item.Path, legacy);
                     }
@@ -105,7 +106,7 @@ namespace Microsoft.Docs.Build
             {
                 if (_filesBySiteUrl.TryRemove(file.SiteUrl, out _))
                 {
-                    if (_publishItems.TryRemove(file, out var item) && item.Path != null && IsDeletableFile(item))
+                    if (_publishItems.TryRemove(file, out var item) && item.Path != null && IsInsideOutputFolder(item, file.Docset))
                     {
                         context.Output.Delete(item.Path, legacy);
                     }
@@ -127,9 +128,11 @@ namespace Microsoft.Docs.Build
             return (model, fileManifests);
         }
 
-        private bool IsDeletableFile(PublishItem item)
+        private bool IsInsideOutputFolder(PublishItem item, Docset docset)
         {
-            return !item.Path.StartsWith("..");
+            var outputFilePath = PathUtility.NormalizeFolder(Path.Combine(docset.DocsetPath, docset.Config.Output.Path, item.Path));
+            var outputFolderPath = PathUtility.NormalizeFolder(Path.Combine(docset.DocsetPath, docset.Config.Output.Path));
+            return outputFilePath.StartsWith(outputFolderPath);
         }
     }
 }

--- a/test/docfx.Test/e2e/E2ESpec.cs
+++ b/test/docfx.Test/e2e/E2ESpec.cs
@@ -29,6 +29,13 @@ namespace Microsoft.Docs.Build
             "server-side-dependent-list.txt", "full-dependent-list.txt"
         };
 
+        public readonly string[] SkippableInputs =
+        {
+            "user_profile.json",
+            "github-user.json",
+            ".lock.json",
+        };
+
         public readonly Dictionary<string, E2ECommit[]> Repos = new Dictionary<string, E2ECommit[]>();
 
         public readonly Dictionary<string, string> Inputs = new Dictionary<string, string>();

--- a/test/docfx.Test/e2e/E2ESpec.cs
+++ b/test/docfx.Test/e2e/E2ESpec.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Docs.Build
             "user_profile.json",
             "github-user.json",
             ".lock.json",
+            ".non-exist.json",
         };
 
         public readonly Dictionary<string, E2ECommit[]> Repos = new Dictionary<string, E2ECommit[]>();

--- a/test/docfx.Test/e2e/E2ETest.cs
+++ b/test/docfx.Test/e2e/E2ETest.cs
@@ -473,7 +473,7 @@ namespace Microsoft.Docs.Build
                 {
                     continue;
                 }
-                Assert.True(File.Exists(file), $"Input file {currentFile.Name} has been deleted");
+                Assert.True(currentFile.Exists, $"Input file {currentFile.Name} has been deleted");
                 Assert.True(lastModifyTime == currentFile.LastWriteTime, $"Input file {currentFile.Name} has been changed");
                 currentFiles.Remove(file);
             }


### PR DESCRIPTION
when there is some error happen in the resource file, and the `coprResource` config is false, we will delete the original resource file in the current build folder.