### PR TITLE
🌐 change template token path

### DIFF
--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -266,7 +266,7 @@ repos:
         >note
   https://docs.com/template/token:
   - files:
-      LocalizedTokens/docs(en-us).html/tokens.json: |
+      ContentTemplate/token.json: |
         { "note": "<p>my note</p>" }
 outputs:
   docs/a.json: |

--- a/src/docfx/template/TemplateEngine.cs
+++ b/src/docfx/template/TemplateEngine.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Docs.Build
         private static readonly string[] s_resourceFolders = new[] { "global", "css", "fonts" };
 
         private readonly string _templateDir;
-        private readonly string _locale;
         private readonly LiquidTemplate _liquid;
         private readonly JavascriptEngine _js;
         private readonly HashSet<string> _htmlMetaHidden;
@@ -26,15 +25,14 @@ namespace Microsoft.Docs.Build
 
         public JObject Global { get; }
 
-        private TemplateEngine(string templateDir, string locale, JsonSchema metadataSchema)
+        private TemplateEngine(string templateDir, JsonSchema metadataSchema)
         {
             var contentTemplateDir = Path.Combine(templateDir, "ContentTemplate");
 
             _templateDir = templateDir;
-            _locale = locale.ToLowerInvariant();
             _liquid = new LiquidTemplate(templateDir);
             _js = new JavascriptEngine(contentTemplateDir);
-            Global = LoadGlobalTokens(templateDir, _locale);
+            Global = LoadGlobalTokens(contentTemplateDir);
 
             _htmlMetaHidden = metadataSchema.HtmlMetaHidden.ToHashSet();
             _htmlMetaNames = metadataSchema.Properties
@@ -55,7 +53,7 @@ namespace Microsoft.Docs.Build
             var (themePath, themeRestoreMap) = docset.RestoreMap.GetGitRestorePath($"{themeRemote}#{themeBranch}");
             Log.Write($"Using theme '{themeRemote}#{themeRestoreMap.DependencyLock.Commit}' at '{themePath}'");
 
-            return new TemplateEngine(themePath, docset.Locale, docset.MetadataSchema);
+            return new TemplateEngine(themePath, docset.MetadataSchema);
         }
 
         public string Render(OutputModel model, Document file, JObject rawMetadata)
@@ -142,9 +140,9 @@ namespace Microsoft.Docs.Build
                     TransformMetadata("Conceptual.mta.json.js", rawMetadata), pageModel));
         }
 
-        private JObject LoadGlobalTokens(string templateDir, string locale)
+        private JObject LoadGlobalTokens(string contentTemplateDir)
         {
-            var path = Path.Combine(templateDir, $"LocalizedTokens/docs({locale}).html/tokens.json");
+            var path = Path.Combine(contentTemplateDir, "token.json");
             return File.Exists(path) ? JObject.Parse(File.ReadAllText(path)) : new JObject();
         }
 


### PR DESCRIPTION
seems there are two token file in template:

https://github.com/microsoft/templates.docs.msft.ja-jp/blob/master/LocalizedTokens/docs(ja-jp).html/tokens.json

and 

https://github.com/microsoft/templates.docs.msft.ja-jp/tree/master/ContentTemplate/token.json

They are always same but the first one may be deleted by OL, so let's use the second.

#4506 