### PR TITLE
Ensures updated_at fallbacks to now when updateTimeAsCommitBuildTime is true

### DIFF
--- a/docs/specs/git.yml
+++ b/docs/specs/git.yml
@@ -375,6 +375,19 @@ outputs:
       "updated_at": "2019-04-23 12:00 AM",
     }
 ---
+# Use now as updated_at when `updateTimeAsCommitBuildTime` is true and the commit is not found
+repos:
+  https://github.com/MicrosoftDocs/edge-developer#master:
+    - files:
+        docfx.yml: |
+          updateTimeAsCommitBuildTime: true
+        docs/index.md: Alice creates this.
+outputs:
+  docs/index.json: |
+    {
+      "updated_at": "!2018-10-30 12:00 AM"
+    }
+---
 # Support git submodule
 repo: https://github.com/docascode/docfx-test-dependencies#c70a63e
 outputs:

--- a/docs/specs/git.yml
+++ b/docs/specs/git.yml
@@ -359,7 +359,7 @@ outputs:
 ---
 # Use commit build time as updated_at when `updateTimeAsCommitBuildTime` is true
 repos:
-  https://github.com/MicrosoftDocs/edge-developer#master:
+  https://docs.com/update_time_as_commit_build_time:
     - files:
         docfx.yml: |
           updateTimeAsCommitBuildTime: true
@@ -377,7 +377,7 @@ outputs:
 ---
 # Use now as updated_at when `updateTimeAsCommitBuildTime` is true and the commit is not found
 repos:
-  https://github.com/MicrosoftDocs/edge-developer#master:
+  https://docs.com/update_time_as_commit_build_time#commit-not-found:
     - files:
         docfx.yml: |
           updateTimeAsCommitBuildTime: true

--- a/src/docfx/lib/git/CommitBuildTimeProvider.cs
+++ b/src/docfx/lib/git/CommitBuildTimeProvider.cs
@@ -35,7 +35,6 @@ namespace Microsoft.Docs.Build
             if (!_buildTimeByCommit.TryGetValue(commitId, out time))
             {
                 time = _buildTime;
-                return false;
             }
             return true;
         }

--- a/src/docfx/lib/git/CommitBuildTimeProvider.cs
+++ b/src/docfx/lib/git/CommitBuildTimeProvider.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Docs.Build
 {
     internal class CommitBuildTimeProvider
     {
+        private readonly DateTime _buildTime = DateTime.UtcNow;
         private readonly Repository _repo;
         private readonly string _commitBuildTimePath;
         private readonly IReadOnlyDictionary<string, DateTime> _buildTimeByCommit;
@@ -31,7 +32,12 @@ namespace Microsoft.Docs.Build
 
         public bool TryGetCommitBuildTime(string commitId, out DateTime time)
         {
-            return _buildTimeByCommit.TryGetValue(commitId, out time);
+            if (!_buildTimeByCommit.TryGetValue(commitId, out time))
+            {
+                time = _buildTime;
+                return false;
+            }
+            return true;
         }
 
         public void UpdateAndSaveCache()
@@ -41,7 +47,6 @@ namespace Microsoft.Docs.Build
                 return;
             }
 
-            var now = DateTime.UtcNow;
             var commits = _buildTimeByCommit.Select(item => new CommitBuildTimeItem { Sha = item.Key, BuiltAt = item.Value }).ToList();
 
             // TODO: retrive git log from `FileCommitProvider` since it should already be there.
@@ -49,7 +54,7 @@ namespace Microsoft.Docs.Build
             {
                 if (!_buildTimeByCommit.ContainsKey(diffCommit))
                 {
-                    commits.Add(new CommitBuildTimeItem { Sha = diffCommit, BuiltAt = now });
+                    commits.Add(new CommitBuildTimeItem { Sha = diffCommit, BuiltAt = _buildTime });
                 }
             }
 

--- a/src/docfx/lib/github/GitHubAccessor.cs
+++ b/src/docfx/lib/github/GitHubAccessor.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Octokit;
@@ -13,8 +13,9 @@ namespace Microsoft.Docs.Build
     internal class GitHubAccessor
     {
         private readonly GitHubClient _client;
+        private readonly ConcurrentHashSet<(string owner, string name)> _unknownRepos = new ConcurrentHashSet<(string owner, string name)>();
 
-        private static volatile Error _rateLimitError;
+        private volatile Error _rateLimitError;
 
         public GitHubAccessor(string token = null)
         {
@@ -25,8 +26,6 @@ namespace Microsoft.Docs.Build
 
         public async Task<(Error, GitHubUser)> GetUserByLogin(string login)
         {
-            Debug.Assert(!string.IsNullOrEmpty(login));
-
             if (_rateLimitError != null)
             {
                 return (_rateLimitError, null);
@@ -66,13 +65,14 @@ namespace Microsoft.Docs.Build
 
         public async Task<(Error, IEnumerable<GitHubUser>)> GetUsersByCommit(string repoOwner, string repoName, string commitSha)
         {
-            Debug.Assert(!string.IsNullOrEmpty(repoOwner));
-            Debug.Assert(!string.IsNullOrEmpty(repoName));
-            Debug.Assert(!string.IsNullOrEmpty(commitSha));
-
             if (_rateLimitError != null)
             {
                 return (_rateLimitError, null);
+            }
+
+            if (_unknownRepos.Contains((repoOwner, repoName)))
+            {
+                return default;
             }
 
             var apiDetail = $"GET /repos/{repoOwner}/{repoName}/commits/{commitSha}";
@@ -90,7 +90,8 @@ namespace Microsoft.Docs.Build
             }
             catch (NotFoundException)
             {
-                // owner/repo doesn't exist
+                // repository doesn't exist or unauthorized
+                _unknownRepos.TryAdd((repoOwner, repoName));
                 return default;
             }
             catch (ApiValidationException)

--- a/test/docfx.Test/common/TestUtility.cs
+++ b/test/docfx.Test/common/TestUtility.cs
@@ -46,28 +46,25 @@ namespace Microsoft.Docs.Build
                 var expectedValue = ((JValue)expected).Value;
                 var actualValue = ((JValue)actual).Value;
 
-                if (expectedValue is string expectedHtml && actualValue is string actualHtml && IsHtmlLike(expectedHtml))
+                if (expectedValue is string expectedString && actualValue is string actualString)
                 {
-                    // Treat `content` as html if the expected value looks like: <blablabla>
-                    Assert.Equal(NormalizeHtml(expectedHtml), NormalizeHtml(actualHtml));
-                }
-                else if (
-                    expectedValue is string expectedStr && actualValue is string actualStr &&
-                    expectedStr.StartsWith("*") && expectedStr.EndsWith("*"))
-                {
-                    expectedStr = expectedStr.Trim(new[] { '*' });
-                    Assert.True(actualStr.Contains(expectedStr), $"{expectedStr} is not part of {actual}");
+                    expectedString = expectedString.Trim();
+
+                    // Treat value as html if it looks like: <blablabla>
+                    if (expectedString.StartsWith('<') && expectedString.EndsWith('>'))
+                    {
+                        Assert.Equal(NormalizeHtml(expectedString), NormalizeHtml(actualString));
+                    }
+                    // Treat value negate if it looks like: !blablabla
+                    else if (expectedString.StartsWith('!'))
+                    {
+                        Assert.NotEqual(expectedString, actualString);
+                    }
                 }
                 else
                 {
                     Assert.Equal(expectedValue, actualValue);
                 }
-            }
-
-            bool IsHtmlLike(string content)
-            {
-                var trimedContent = content.Trim();
-                return trimedContent.StartsWith('<') && trimedContent.EndsWith('>');
             }
         }
 


### PR DESCRIPTION
Currently when `updateTimeAsCommitBuildTime` is true, the first time a repo is build, `update_at` fallbacks to commit time, it should fallback to now.