### PR TITLE
Expose main method

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -43,7 +43,6 @@ function publish() {
 
     Remove-Item ./drop -Force -Recurse -ErrorAction Ignore
     exec "dotnet pack src\docfx -c Release -o $PSScriptRoot\drop /p:Version=$version /p:InformationalVersion=$version"
-    exec "dotnet publish src\docfx -c Release -o $PSScriptRoot\drop\docfx /p:Version=$version /p:InformationalVersion=$version"
     exec "dotnet drop\docfx\docfx.dll --version"
 }
 

--- a/build.ps1
+++ b/build.ps1
@@ -43,6 +43,7 @@ function publish() {
 
     Remove-Item ./drop -Force -Recurse -ErrorAction Ignore
     exec "dotnet pack src\docfx -c Release -o $PSScriptRoot\drop /p:Version=$version /p:InformationalVersion=$version"
+    exec "dotnet publish src\docfx -c Release -o $PSScriptRoot\drop\docfx /p:Version=$version /p:InformationalVersion=$version"
     exec "dotnet drop\docfx\docfx.dll --version"
 }
 

--- a/src/docfx/cli/Docfx.cs
+++ b/src/docfx/cli/Docfx.cs
@@ -13,9 +13,9 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Docs.Build
 {
-    internal static class Program
+    public static class Docfx
     {
-        internal static async Task<int> Main(string[] args)
+        public static async Task<int> Main(params string[] args)
         {
             try
             {
@@ -234,7 +234,7 @@ git: `{GetGitVersion()}`
         {
             try
             {
-                return typeof(Program).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+                return typeof(Docfx).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
             }
             catch (Exception ex)
             {

--- a/test/docfx.Test/e2e/E2ETest.cs
+++ b/test/docfx.Test/e2e/E2ETest.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Docs.Build
             bool failed = false;
             foreach (var command in spec.Commands)
             {
-                if (await Program.Run(command.Split(" ").Concat(new[] { docsetPath }).ToArray()) != 0)
+                if (await Docfx.Run(command.Split(" ").Concat(new[] { docsetPath }).ToArray()) != 0)
                 {
                     failed = true;
                     break;

--- a/test/docfx.Test/restore/RestoreTest.cs
+++ b/test/docfx.Test/restore/RestoreTest.cs
@@ -50,7 +50,7 @@ dependencies:
             ProcessUtility.AcquireExclusiveLock($"{gitUrl}/1", true);
 
             // run restore and check the work trees
-            await Program.Run(new[] { "restore", docsetPath });
+            await Docfx.Run(new[] { "restore", docsetPath });
             Assert.Equal(1, GetWorkTreeFolderCount(restoreDir));
         }
 
@@ -71,7 +71,7 @@ dependencies:
   dep6: {gitUrl}#chi");
 
             // run restore and check the work trees
-            await Program.Run(new[] { "restore", docsetPath });
+            await Docfx.Run(new[] { "restore", docsetPath });
             Assert.Equal(2, GetWorkTreeFolderCount(restoreDir));
 
             File.WriteAllText(Path.Combine(docsetPath, "docfx.yml"), $@"
@@ -79,7 +79,7 @@ dependencies:
   dep1: {gitUrl}#test-1-clean");
 
             // run restore again
-            await Program.Run(new[] { "restore", docsetPath });
+            await Docfx.Run(new[] { "restore", docsetPath });
 
             // since the lockdown time works, new slot will be created
             Assert.Equal(3, GetWorkTreeFolderCount(restoreDir));
@@ -98,11 +98,11 @@ dependencies:
 
             // run restore again
             // will create a new slot and find an available slot
-            await Program.Run(new[] { "restore", docsetPath });
+            await Docfx.Run(new[] { "restore", docsetPath });
             Assert.Equal(4, GetWorkTreeFolderCount(restoreDir));
 
             // restore again to use existing worktree
-            await Program.Run(new[] { "restore", docsetPath });
+            await Docfx.Run(new[] { "restore", docsetPath });
             Assert.Equal(4, GetWorkTreeFolderCount(restoreDir));
 
             // make worktree not synced with slots
@@ -113,7 +113,7 @@ dependencies:
 
             // run restore again
             // will create a new slot and find an available slot
-            await Program.Run(new[] { "restore", docsetPath });
+            await Docfx.Run(new[] { "restore", docsetPath });
             Assert.Equal(5, GetWorkTreeFolderCount(restoreDir));
         }
 
@@ -135,12 +135,12 @@ gitHub:
   userCache: https://raw.githubusercontent.com/docascode/docfx-test-dependencies-clean/master/README.md");
 
             // run restore
-            await Program.Run(new[] { "restore", docsetPath });
+            await Docfx.Run(new[] { "restore", docsetPath });
 
             Assert.Equal(2, Directory.EnumerateFiles(restoreDir, "*").Count());
 
             // run restore again
-            await Program.Run(new[] { "restore", docsetPath });
+            await Docfx.Run(new[] { "restore", docsetPath });
 
             Assert.Equal(2, Directory.EnumerateFiles(restoreDir, "*").Count());
         }


### PR DESCRIPTION
Due to https://github.com/dotnet/cli/issues/10387, there is no easy way to _reference_ another project as a standalone executable in .NET core, thus we are calling `docfx` using in process call for the time being, so expose the `Main` method