### PR TITLE
improve quote float in yaml serializer

### DIFF
--- a/src/Microsoft.DocAsCode.YamlSerialization/Helpers/Regexes.cs
+++ b/src/Microsoft.DocAsCode.YamlSerialization/Helpers/Regexes.cs
@@ -13,8 +13,12 @@ namespace Microsoft.DocAsCode.YamlSerialization.Helpers
         // |null|Null|NULL|~
         // |on|On|ON|off|Off|OFF
         public static readonly Regex BooleanLike = new Regex(@"^(true|True|TRUE|false|False|FALSE)$", RegexOptions.Compiled);
+
         public static readonly Regex NullLike = new Regex(@"^(null|Null|NULL|~)$", RegexOptions.Compiled);
+
         public static readonly Regex IntegerLike = new Regex(@"^-?(0|[1-9][0-9]*)$", RegexOptions.Compiled);
-        public static readonly Regex DoubleLike = new Regex(@"^-?(0|[1-9][0-9]*)(\.[0-9]*)?([eE][-+]?[0-9]+)?$", RegexOptions.Compiled);
+
+        // https://yaml.org/spec/1.2/spec.html#id2805071
+        public static readonly Regex FloatLike = new Regex(@"^[-+]?(\.[0-9]+|[0-9]+(\.[0-9]*)?)([eE][-+]?[0-9]+)?$", RegexOptions.Compiled);
     }
 }

--- a/src/Microsoft.DocAsCode.YamlSerialization/NodeTypeResolvers/ScalarYamlNodeTypeResolver.cs
+++ b/src/Microsoft.DocAsCode.YamlSerialization/NodeTypeResolvers/ScalarYamlNodeTypeResolver.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DocAsCode.YamlSerialization.NodeTypeResolvers
                         }
                     }
 
-                    if (Regexes.DoubleLike.IsMatch(scalar.Value))
+                    if (Regexes.FloatLike.IsMatch(scalar.Value))
                     {
                         currentType = typeof(double);
                         return true;

--- a/src/Microsoft.DocAsCode.YamlSerialization/ObjectDescriptors/BetterObjectDescriptor.cs
+++ b/src/Microsoft.DocAsCode.YamlSerialization/ObjectDescriptors/BetterObjectDescriptor.cs
@@ -22,41 +22,21 @@ namespace Microsoft.DocAsCode.YamlSerialization.ObjectDescriptors
             Value = value;
             Type = type;
             StaticType = staticType;
-            if (scalarStyle == ScalarStyle.Any)
+            ScalarStyle = scalarStyle == ScalarStyle.Any && NeedQuote(value) ? ScalarStyle.DoubleQuoted : scalarStyle;
+
+            bool NeedQuote(object val)
             {
-                if (value is string s)
-                {
-                    if (Regexes.BooleanLike.IsMatch(s))
-                    {
-                        scalarStyle = ScalarStyle.DoubleQuoted;
-                    }
-                    else if (Regexes.NullLike.IsMatch(s))
-                    {
-                        scalarStyle = ScalarStyle.DoubleQuoted;
-                    }
-                    else if (Regexes.IntegerLike.IsMatch(s))
-                    {
-                        scalarStyle = ScalarStyle.DoubleQuoted;
-                    }
-                    else if (Regexes.DoubleLike.IsMatch(s))
-                    {
-                        scalarStyle = ScalarStyle.DoubleQuoted;
-                    }
-                    else if (s.StartsWith("'", StringComparison.Ordinal))
-                    {
-                        scalarStyle = ScalarStyle.DoubleQuoted;
-                    }
-                    else if (s.StartsWith("\"", StringComparison.Ordinal))
-                    {
-                        scalarStyle = ScalarStyle.DoubleQuoted;
-                    }
-                    else if (s.Length > 0 && char.IsWhiteSpace(s[0]))
-                    {
-                        scalarStyle = ScalarStyle.DoubleQuoted;
-                    }
-                }
+                if (!(val is string s))
+                    return false;
+
+                return Regexes.BooleanLike.IsMatch(s)
+                    || Regexes.NullLike.IsMatch(s)
+                    || Regexes.IntegerLike.IsMatch(s)
+                    || Regexes.FloatLike.IsMatch(s)
+                    || s.StartsWith("'", StringComparison.Ordinal)
+                    || s.StartsWith("\"", StringComparison.Ordinal)
+                    || s.Length > 0 && char.IsWhiteSpace(s[0]);
             }
-            ScalarStyle = scalarStyle;
         }
 
         public ScalarStyle ScalarStyle { get; }

--- a/test/Microsoft.DocAsCode.Common.Tests/YamlSerializationTest.cs
+++ b/test/Microsoft.DocAsCode.Common.Tests/YamlSerializationTest.cs
@@ -41,6 +41,24 @@ namespace Microsoft.DocAsCode.Common.Tests
             Assert.Equal(input, value.C);
         }
 
+        [Theory]
+        [InlineData("123")]
+        [InlineData("1.23")]
+        [InlineData("0.123")]
+        [InlineData(".123")]
+        [InlineData("0.")]
+        [InlineData("-0.0")]
+        [InlineData(".5")]
+        [InlineData("+12e03")]
+        [InlineData("-2E+05")]
+        public void TestScalarLikeStringValueNeedDoubleQuoted(string input)
+        {
+            var sw = new StringWriter();
+            YamlUtility.Serialize(sw, input);
+            var yaml = sw.ToString();
+            Assert.Equal($"\"{input}\"", yaml.Trim());
+        }
+
         [Fact]
         public void TestNotWorkInYamlDotNet39()
         {


### PR DESCRIPTION
Before, string `".123"` is serialized to `.123`, which will be resolved to float type according to YAML spec.

After this change, string `".123"` will be serialized to `".123"`.