### PR TITLE
Legacy OutputRelativePath should target to logic output path instead of the physial path

### DIFF
--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -310,6 +310,21 @@ outputs:
   .manifest.json: |
     {"files":[{"asset_id":"/docs/a.json","original":"docs/a.yml","source_relative_path":"docs/a.yml","original_type":"Conceptual","type":"Toc"}]}
 ---
+# Do not copy resource when the copyResources is false
+commands:
+  - build --legacy
+inputs:
+  docfx.yml: |
+    files: a.png
+    output:
+      copyResources: false
+  a.png:
+outputs:
+  .publish.json: |
+    {"files":[{"url":"/a.png","path":"../a.png"}]}
+  .manifest.json: |
+    {"files":[{"asset_id":"/a.png","output":{"resource":{"is_raw_page":false,"relative_path":"a.png"}}}]}
+---
 # Build versioning repository
 commands:
   - build --legacy

--- a/src/docfx/build/legacy/LegacyFileMap.cs
+++ b/src/docfx/build/legacy/LegacyFileMap.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Docs.Build
                             return;
                         }
                         fileManifests.TryGetValue(document, out var publishItem);
-                        var legacyOutputFilePathRelativeToSiteBasePath = document.ToLegacyOutputPathRelativeToSiteBasePath(docset, publishItem.Path);
+                        var legacyOutputFilePathRelativeToSiteBasePath = document.ToLegacyOutputPathRelativeToSiteBasePath(docset, publishItem);
                         var legacySiteUrlRelativeToSiteBasePath = document.ToLegacySiteUrlRelativeToSiteBasePath(docset);
 
                         var fileItem = LegacyFileMapItem.Instance(legacyOutputFilePathRelativeToSiteBasePath, legacySiteUrlRelativeToSiteBasePath, document.ContentType);

--- a/src/docfx/build/legacy/LegacyUtility.cs
+++ b/src/docfx/build/legacy/LegacyUtility.cs
@@ -28,9 +28,14 @@ namespace Microsoft.Docs.Build
             return PathUtility.NormalizeFile(Path.GetRelativePath(docset.Config.DocumentId.SourceBasePath, doc.FilePath));
         }
 
-        public static string ToLegacyOutputPathRelativeToSiteBasePath(this Document doc, Docset docset, string outputFilePath)
+        public static string ToLegacyOutputPathRelativeToSiteBasePath(this Document doc, Docset docset, PublishItem manifestItem)
         {
-            var legacyOutputFilePathRelativeToSiteBasePath = Path.GetRelativePath(docset.SiteBasePath, outputFilePath);
+            var outputPath = manifestItem.Path;
+            if (doc.ContentType == ContentType.Resource && !doc.Docset.Config.Output.CopyResources)
+            {
+                outputPath = doc.GetOutputPath(manifestItem.Monikers, docset.SiteBasePath);
+            }
+            var legacyOutputFilePathRelativeToSiteBasePath = Path.GetRelativePath(docset.SiteBasePath, outputPath);
 
             return PathUtility.NormalizeFile(legacyOutputFilePathRelativeToSiteBasePath);
         }

--- a/src/docfx/build/legacy/manifest/LegacyManifest.cs
+++ b/src/docfx/build/legacy/manifest/LegacyManifest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Docs.Build
                     fileManifest =>
                     {
                         var document = fileManifest.Key;
-                        var legacyOutputPathRelativeToSiteBasePath = document.ToLegacyOutputPathRelativeToSiteBasePath(docset, fileManifest.Value.Path);
+                        var legacyOutputPathRelativeToSiteBasePath = document.ToLegacyOutputPathRelativeToSiteBasePath(docset, fileManifest.Value);
                         var legacySiteUrlRelativeToSiteBasePath = document.ToLegacySiteUrlRelativeToSiteBasePath(docset);
 
                         var output = new LegacyManifestOutput

--- a/src/docfx/build/resource/BuildResource.cs
+++ b/src/docfx/build/resource/BuildResource.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Docs.Build
             var outputPath = file.GetOutputPath(monikers, file.Docset.SiteBasePath);
 
             // Output path is source file path relative to output folder when copy resource is disabled
-            var publishPash = file.Docset.Config.Output.CopyResources
+            var publishPath = file.Docset.Config.Output.CopyResources
                 ? outputPath
                 : PathUtility.NormalizeFile(
                     Path.GetRelativePath(
@@ -27,7 +27,7 @@ namespace Microsoft.Docs.Build
             var publishItem = new PublishItem
             {
                 Url = file.SiteUrl,
-                Path = publishPash,
+                Path = publishPath,
                 Hash = HashUtility.GetFileSha1Hash(Path.Combine(file.Docset.DocsetPath, file.FilePath)),
                 Locale = file.Docset.Locale,
                 Monikers = monikers,


### PR DESCRIPTION
https://opbuildstoragesandbox2.blob.core.windows.net/report/2019%5C5%5C17%5C0c07d4eb-0562-6512-9227-12dbf89d9a0f%5CCommit%5C201905170201395186-docfx-v3-e2e-test%5Crawlog.txt?sv=2015-02-21&sr=b&sig=Lsr51PfanRXeVegKeemTOJ%2B8v%2Bu8Xkchti80cl02B6k%3D&st=2019-05-17T02%3A08%3A52Z&se=2019-06-17T02%3A13%3A52Z&sp=r

Op have a limitation:
The output Relative Path have to be the subfolder of output folder.