### PR TITLE
Consolidate HtmlPostProcess

### DIFF
--- a/docs/specs/resolve.yml
+++ b/docs/specs/resolve.yml
@@ -129,6 +129,14 @@ outputs:
     { "conceptual": "<p><a target=\"_blank\" href=\"c\">c</a></p>" }
   docs/dir/c.json:
 ---
+# Add locale for absolute links
+inputs:
+  docfx.yml:
+  a.md: Link to [absolute path](/a)
+outputs:
+  a.json: |
+    { "conceptual": "<p>Link to <a href=\"/en-us/a\">bsolute-path</a></p>" }
+---
 # Show warning if the link is empty, missing
 inputs:
   docfx.yml: |

--- a/docs/specs/resolve.yml
+++ b/docs/specs/resolve.yml
@@ -135,7 +135,7 @@ inputs:
   a.md: Link to [absolute path](/a)
 outputs:
   a.json: |
-    { "conceptual": "<p>Link to <a href=\"/en-us/a\">absolute-path</a></p>" }
+    { "conceptual": "<p>Link to <a href=\"/en-us/a\">absolute path</a></p>" }
 ---
 # Show warning if the link is empty, missing
 inputs:

--- a/docs/specs/resolve.yml
+++ b/docs/specs/resolve.yml
@@ -135,7 +135,7 @@ inputs:
   a.md: Link to [absolute path](/a)
 outputs:
   a.json: |
-    { "conceptual": "<p>Link to <a href=\"/en-us/a\">bsolute-path</a></p>" }
+    { "conceptual": "<p>Link to <a href=\"/en-us/a\">absolute-path</a></p>" }
 ---
 # Show warning if the link is empty, missing
 inputs:

--- a/src/docfx/build/page/AttributeTransformer.cs
+++ b/src/docfx/build/page/AttributeTransformer.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Docs.Build
                     context.ErrorLog.Write(file.ToString(), error);
                     return link;
                 });
-                return HtmlUtility.StripTags(HtmlUtility.LoadHtml(html)).OuterHtml;
+                return HtmlUtility.HtmlPostProcess(html, file.Docset.Culture);
             }
 
             if (attribute is XrefAttribute)

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
-using HtmlAgilityPack;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build
@@ -147,7 +146,7 @@ namespace Microsoft.Docs.Build
                 errors.Add(Errors.HeadingNotFound(file));
             }
 
-            pageModel.Conceptual = HtmlPostProcess(file, htmlDom);
+            pageModel.Conceptual = HtmlUtility.HtmlPostProcess(htmlDom, file.Docset.Culture);
             pageModel.Title = yamlHeader.Value<string>("title") ?? title;
             pageModel.RawTitle = rawTitle;
             pageModel.WordCount = wordCount;
@@ -206,7 +205,7 @@ namespace Microsoft.Docs.Build
             if (file.Docset.Legacy && file.Schema.Attribute is PageSchemaAttribute)
             {
                 var html = await RazorTemplate.Render(file.Schema.Name, content);
-                pageModel.Conceptual = HtmlPostProcess(file, HtmlUtility.LoadHtml(html));
+                pageModel.Conceptual = HtmlUtility.HtmlPostProcess(html, file.Docset.Culture);
             }
             else
             {
@@ -218,24 +217,6 @@ namespace Microsoft.Docs.Build
             pageModel.Monikers = new List<string>();
 
             return (errors, file.Schema, pageModel);
-        }
-
-        private static string HtmlPostProcess(Document file, HtmlNode html)
-        {
-            html = html.StripTags();
-
-            if (file.Docset.Legacy)
-            {
-                html = html.AddLinkType(file.Docset.Locale)
-                           .RemoveRerunCodepenIframes();
-            }
-
-            if (string.IsNullOrWhiteSpace(html.OuterHtml))
-            {
-                return "<div></div>";
-            }
-
-            return LocalizationUtility.AddLeftToRightMarker(file.Docset, html.OuterHtml);
         }
 
         private static (object output, JObject extensionData) ApplyTemplate(Context context, Document file, OutputModel model, bool isPage)

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -204,8 +204,7 @@ namespace Microsoft.Docs.Build
 
             if (file.Docset.Legacy && file.Schema.Attribute is PageSchemaAttribute)
             {
-                var html = await RazorTemplate.Render(file.Schema.Name, content);
-                pageModel.Conceptual = HtmlUtility.HtmlPostProcess(html, file.Docset.Culture);
+                pageModel.Conceptual = await RazorTemplate.Render(file.Schema.Name, content);
             }
             else
             {

--- a/src/docfx/lib/HtmlUtility.cs
+++ b/src/docfx/lib/HtmlUtility.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Text;
 using System.Web;
 using HtmlAgilityPack;
@@ -16,25 +15,27 @@ namespace Microsoft.Docs.Build
         private static readonly Func<HtmlAgilityPack.HtmlAttribute, int> s_getValueStartIndex =
             ReflectionUtility.CreateInstanceFieldGetter<HtmlAgilityPack.HtmlAttribute, int>("_valuestartindex");
 
+        public static string HtmlPostProcess(string html, CultureInfo culture) => HtmlPostProcess(LoadHtml(html), culture);
+
+        public static string HtmlPostProcess(HtmlNode html, CultureInfo culture)
+        {
+            html = html.StripTags();
+            html = html.AddLinkType(culture.Name.ToLowerInvariant())
+                       .RemoveRerunCodepenIframes();
+
+            if (string.IsNullOrWhiteSpace(html.OuterHtml))
+            {
+                return "<div></div>";
+            }
+
+            return LocalizationUtility.AddLeftToRightMarker(culture, html.OuterHtml);
+        }
+
         public static HtmlNode LoadHtml(string html)
         {
             var doc = new HtmlDocument();
             doc.LoadHtml(html);
             return doc.DocumentNode;
-        }
-
-        public static string TransformHtml(string html, Func<HtmlNode, HtmlNode> transform)
-        {
-            HtmlDocument document = new HtmlDocument();
-            document.LoadHtml(html);
-            return transform(document.DocumentNode).OuterHtml;
-        }
-
-        public static HtmlNode AddLinkType(this HtmlNode html, string locale)
-        {
-            AddLinkType(html, "a", "href", locale);
-            AddLinkType(html, "img", "src", locale);
-            return html;
         }
 
         public static long CountWord(this HtmlNode node)
@@ -52,46 +53,6 @@ namespace Microsoft.Docs.Build
                 total += CountWord(child);
             }
             return total;
-        }
-
-        public static HtmlNode RemoveRerunCodepenIframes(this HtmlNode html)
-        {
-            // the rerun button on codepen iframes isn't accessibile.
-            // rather than get acc bugs or ban codepen, we're just hiding the rerun button using their iframe api
-            foreach (var node in html.Descendants("iframe"))
-            {
-                var src = node.GetAttributeValue("src", null);
-                if (src != null && src.Contains("codepen.io", StringComparison.OrdinalIgnoreCase))
-                {
-                    node.SetAttributeValue("src", src + "&rerun-position=hidden&");
-                }
-            }
-            return html;
-        }
-
-        public static HtmlNode StripTags(this HtmlNode html)
-        {
-            var nodesToRemove = new List<HtmlNode>();
-
-            foreach (var node in html.DescendantsAndSelf())
-            {
-                if (node.Name.Equals("script", StringComparison.OrdinalIgnoreCase) ||
-                    node.Name.Equals("link", StringComparison.OrdinalIgnoreCase) ||
-                    node.Name.Equals("style", StringComparison.OrdinalIgnoreCase))
-                {
-                    nodesToRemove.Add(node);
-                }
-                else
-                {
-                    node.Attributes.Remove("style");
-                }
-            }
-
-            foreach (var node in nodesToRemove)
-            {
-                node.Remove();
-            }
-            return html;
         }
 
         public static HashSet<string> GetBookmarks(this HtmlNode html)
@@ -268,6 +229,53 @@ namespace Microsoft.Docs.Build
             }
         }
 
+        private static HtmlNode AddLinkType(this HtmlNode html, string locale)
+        {
+            AddLinkType(html, "a", "href", locale);
+            AddLinkType(html, "img", "src", locale);
+            return html;
+        }
+
+        private static HtmlNode RemoveRerunCodepenIframes(this HtmlNode html)
+        {
+            // the rerun button on codepen iframes isn't accessibile.
+            // rather than get acc bugs or ban codepen, we're just hiding the rerun button using their iframe api
+            foreach (var node in html.Descendants("iframe"))
+            {
+                var src = node.GetAttributeValue("src", null);
+                if (src != null && src.Contains("codepen.io", StringComparison.OrdinalIgnoreCase))
+                {
+                    node.SetAttributeValue("src", src + "&rerun-position=hidden&");
+                }
+            }
+            return html;
+        }
+
+        private static HtmlNode StripTags(this HtmlNode html)
+        {
+            var nodesToRemove = new List<HtmlNode>();
+
+            foreach (var node in html.DescendantsAndSelf())
+            {
+                if (node.Name.Equals("script", StringComparison.OrdinalIgnoreCase) ||
+                    node.Name.Equals("link", StringComparison.OrdinalIgnoreCase) ||
+                    node.Name.Equals("style", StringComparison.OrdinalIgnoreCase))
+                {
+                    nodesToRemove.Add(node);
+                }
+                else
+                {
+                    node.Attributes.Remove("style");
+                }
+            }
+
+            foreach (var node in nodesToRemove)
+            {
+                node.Remove();
+            }
+            return html;
+        }
+
         private static void AddLinkType(this HtmlNode html, string tag, string attribute, string locale)
         {
             foreach (var node in html.Descendants(tag))
@@ -285,7 +293,6 @@ namespace Microsoft.Docs.Build
                         node.SetAttributeValue("data-linktype", "self-bookmark");
                         break;
                     case LinkType.AbsolutePath:
-                    case LinkType.WindowsAbsolutePath:
                         node.SetAttributeValue("data-linktype", "absolute-path");
                         node.SetAttributeValue(attribute, AddLocaleIfMissing(href, locale));
                         break;

--- a/src/docfx/localization/LocalizationUtility.cs
+++ b/src/docfx/localization/LocalizationUtility.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
 
@@ -13,9 +14,9 @@ namespace Microsoft.Docs.Build
         private static readonly Regex s_nameWithLocale = new Regex(@"^.+?(\.[a-z]{2,4}-[a-z]{2,4}(-[a-z]{2,4})?|\.loc)?$", RegexOptions.IgnoreCase);
         private static readonly Regex s_lrmAdjustment = new Regex(@"(^|\s|\>)(C#|F#|C\+\+)(\s*|[.!?;:]*)(\<|[\n\r]|$)", RegexOptions.IgnoreCase);
 
-        public static string AddLeftToRightMarker(Docset docset, string text)
+        public static string AddLeftToRightMarker(CultureInfo culture, string text)
         {
-            if (!docset.Culture.TextInfo.IsRightToLeft)
+            if (!culture.TextInfo.IsRightToLeft)
             {
                 return text;
             }

--- a/test/docfx.Test/common/TestUtility.cs
+++ b/test/docfx.Test/common/TestUtility.cs
@@ -104,7 +104,10 @@ namespace Microsoft.Docs.Build
                         sb.Append(node.Name);
                         foreach (var attr in node.Attributes.OrderBy(a => a.Name))
                         {
-                            sb.Append($" {attr.Name}=\"{TrimWhiteSpace(attr.Value)}\"");
+                            if (attr.Name != "data-linktype")
+                            {
+                                sb.Append($" {attr.Name}=\"{TrimWhiteSpace(attr.Value)}\"");
+                            }
                         }
                         sb.Append(">\n");
 

--- a/test/docfx.Test/lib/HtmlUtilityTest.cs
+++ b/test/docfx.Test/lib/HtmlUtilityTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Globalization;
 using Xunit;
 
 namespace Microsoft.Docs.Build
@@ -8,6 +9,8 @@ namespace Microsoft.Docs.Build
     public class HtmlUtilityTest
     {
         [Theory]
+
+        // Add link type
         [InlineData("<a href='a.md' />", "<a href='a.md' data-linktype='relative-path' />")]
         [InlineData("<a href='(https://a)' />", "<a href='(https://a)' data-linktype='relative-path' />")]
         [InlineData("<a href='#aA' />", "<a href='#aA' data-linktype='self-bookmark' />")]
@@ -20,33 +23,21 @@ namespace Microsoft.Docs.Build
         [InlineData("<a href='http://abc' />", "<a href='http://abc' data-linktype='external' />")]
         [InlineData("<a href='https://abc' />", "<a href='https://abc' data-linktype='external' />")]
         [InlineData("<a href='https://[abc]' />", "<a href='https://[abc]' data-linktype='external' />")]
-        public void AddLinkType(string input, string output)
-        {
-            var actual = HtmlUtility.TransformHtml(input, node => node.AddLinkType("zh-cn"));
 
-            Assert.Equal(TestUtility.NormalizeHtml(output), TestUtility.NormalizeHtml(actual));
-        }
-
-        [Theory]
+        // Rerun codepen iframes
         [InlineData("<div></div>", "<div></div>")]
         [InlineData("<iframe></iframe>", "<iframe></iframe>")]
         [InlineData("<iframe src='//codepen.io/a' />", "<iframe src='//codepen.io/a&rerun-position=hidden&' />")]
-        public void RemoveRerunCodepenIframes(string input, string output)
-        {
-            var actual = HtmlUtility.TransformHtml(input, node => node.RemoveRerunCodepenIframes());
 
-            Assert.Equal(TestUtility.NormalizeHtml(output), TestUtility.NormalizeHtml(actual));
-        }
-
-        [Theory]
-        [InlineData("<style href='a'>", "")]
+        // Strip tags
+        [InlineData("<style href='a'>", "<div></div>")]
         [InlineData("<div style='a'></div>", "<div></div>")]
         [InlineData("<div><style href='a'></div>", "<div></div>")]
         [InlineData("<div><link href='a'></div>", "<div></div>")]
         [InlineData("<div><script></script></div>", "<div></div>")]
-        public void StripTags(string input, string output)
+        public void HtmlPostProcess(string input, string output)
         {
-            var actual = HtmlUtility.TransformHtml(input, node => node.StripTags());
+            var actual = HtmlUtility.HtmlPostProcess(input, new CultureInfo("zh-CN"));
 
             Assert.Equal(TestUtility.NormalizeHtml(output), TestUtility.NormalizeHtml(actual));
         }


### PR DESCRIPTION
- Let SDP use HtmlPostProcess for `[html]`, make details of `HtmlPostProcess` private
- Always add locale for absolute path (removed a legacy switch)
- Adjust tests

#4078 #4450 