### PR TITLE
upgrade msbuild locator to support msbuild 16

### DIFF
--- a/Documentation/tutorial/docfx_getting_started.md
+++ b/Documentation/tutorial/docfx_getting_started.md
@@ -19,7 +19,7 @@ If you are interested in creating your own website with your own styles, you can
 For detailed description about DFM, please refer to [DFM](../spec/docfx_flavored_markdown.md).
 
 > [!Warning]
-> **Prerequisites** [Visual Studio 2017](https://www.visualstudio.com/downloads/) is needed for `docfx metadata` msbuild projects. It's not required when generating metadata directly from source code (`.cs`, `.vb`) or assemblies (`.dll`)
+> **Prerequisites** [Visual Studio 2019](https://www.visualstudio.com/downloads/) is needed for `docfx metadata` msbuild projects. It's not required when generating metadata directly from source code (`.cs`, `.vb`) or assemblies (`.dll`)
 
 ## 2. Use *DocFX* as a command-line tool
 

--- a/Documentation/tutorial/howto_build_your_own_type_of_documentation_with_custom_plug-in.md
+++ b/Documentation/tutorial/howto_build_your_own_type_of_documentation_with_custom_plug-in.md
@@ -15,7 +15,7 @@ Goal and limitation
 
 Preparation
 -----------
-1.  Create a new C# class library project in `Visual Studio`, targets .NET Framework 4.6.1.
+1.  Create a new C# class library project in `Visual Studio`, targets .NET Framework 4.7.2.
 
 2.  Add nuget packages:  
     * `System.Collections.Immutable` with version 1.3.1
@@ -26,7 +26,7 @@ Preparation
     otherwise add the nuget packages with the same version as DocFX.
 
 4.  Add framework assembly references:
-    `PresentationCore`, `PresentationFramework`, `WindowsBase`. (This step is optional in Visual Studio 2017)
+    `PresentationCore`, `PresentationFramework`, `WindowsBase`. (This step is optional in Visual Studio 2017 or above)
 
 5.  Add a project for converting rtf to html:  
     Clone project [MarkupConverter](https://github.com/mmanela/MarkupConverter), and reference it.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 pool:
-  name: Hosted VS2017
+  name: Hosted Windows 2019 with VS2019
 steps:
 - task: NodeTool@0
   displayName: 'Use Node 8.x'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,6 @@
 pool:
   name: Hosted Windows 2019 with VS2019
+  vmImage: 'windows-2019'
 steps:
 - task: NodeTool@0
   displayName: 'Use Node 8.x'

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn.csproj
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn.csproj
@@ -31,8 +31,8 @@
     <PackageReference Include="Microsoft.Composition" Version="1.0.31" />
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.5.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
-    <PackageReference Include="Microsoft.Build" Version="15.8.166" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.8.166" />
+    <PackageReference Include="Microsoft.Build" Version="16.1.76" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.1.76" />
     <PackageReference Include="NuGet.ProjectModel" Version="4.5.0" />
     <PackageReference Include="NuGet.Packaging.Core" Version="4.5.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.5.24" />

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Microsoft.DocAsCode.Metadata.ManagedReference.csproj
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Microsoft.DocAsCode.Metadata.ManagedReference.csproj
@@ -21,6 +21,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.0.13" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.2" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/MsBuildEnvironmentScope.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/MsBuildEnvironmentScope.cs
@@ -91,7 +91,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 {
                     // workaround for https://github.com/dotnet/docfx/issues/1969
                     // FYI https://github.com/dotnet/roslyn/issues/21799#issuecomment-343695700
-                    var latest = instances.FirstOrDefault(a => a.Version.Major == 15);
+                    var latest = instances.FirstOrDefault(a => a.Version.Major >= 15);
                     if (latest != null)
                     {
                         Logger.LogInfo($"Using msbuild {latest.MSBuildPath} as inner compiler.");
@@ -99,7 +99,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                         return new EnvironmentScope(new Dictionary<string, string>
                         {
                             [VSInstallDirKey] = latest.VisualStudioRootPath,
-                            ["VisualStudioVersion"] = "15.0"
+                            ["VisualStudioVersion"] = latest.Version.ToString(2),
                         });
                     }
                 }

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/MsBuildEnvironmentScope.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/MsBuildEnvironmentScope.cs
@@ -104,7 +104,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                     }
                     else
                     {
-                        Logger.LogWarning("Fail to find MSBuild >= 16.0 on machine. Please install Visual Studio 2019 with MSBuild >= 16.0 first.");
+                        Logger.LogWarning("Fail to find MSBuild >= 16.0 on machine. Please install Visual Studio 2019 with MSBuild >= 16.0: https://visualstudio.microsoft.com/vs/");
                     }
                 }
             }

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/MsBuildEnvironmentScope.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/MsBuildEnvironmentScope.cs
@@ -91,7 +91,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 {
                     // workaround for https://github.com/dotnet/docfx/issues/1969
                     // FYI https://github.com/dotnet/roslyn/issues/21799#issuecomment-343695700
-                    var latest = instances.FirstOrDefault(a => a.Version.Major >= 15);
+                    var latest = instances.FirstOrDefault(a => a.Version.Major >= 16);
                     if (latest != null)
                     {
                         Logger.LogInfo($"Using msbuild {latest.MSBuildPath} as inner compiler.");
@@ -101,6 +101,10 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                             [VSInstallDirKey] = latest.VisualStudioRootPath,
                             ["VisualStudioVersion"] = latest.Version.ToString(2),
                         });
+                    }
+                    else
+                    {
+                        Logger.LogWarning("Fail to find MSBuild >= 16.0 on machine. Please install Visual Studio 2019 with MSBuild >= 16.0 first.");
                     }
                 }
             }


### PR DESCRIPTION
resolve #4437
depend on #4616

Note that the PR check is expected to fail, unless it uses `vmImage: 'windows-2019'` specified in this PR.