### PR TITLE
consume order property in monikerDefinition file

### DIFF
--- a/docs/designs/conceptual-versioning.md
+++ b/docs/designs/conceptual-versioning.md
@@ -252,7 +252,7 @@ There are several scenarios:
 
 In **Restore** step, moniker definition file will be restored to local storage, which will be used to evaluate monikerRange expression.
 
-An **ordered** moniker list is provided by moniker definition file restored from `monikerDefinition`, the file structure should be:
+An moniker list is provided by moniker definition file restored from `monikerDefinition`, the file structure should be:
 
 ```json
 {
@@ -260,6 +260,7 @@ An **ordered** moniker list is provided by moniker definition file restored from
         {
             "moniker": "{monikerName}",
             "product": "{productName}",
+            "order": "{order}",
             "product_family": "{productFamilyName}",
             "platform": "{platform}",
             "display_name": "{displayName}"
@@ -272,6 +273,8 @@ An **ordered** moniker list is provided by moniker definition file restored from
 1. `moniker` is an unique identifier of this moniker. If two moniker define the same `monikerName`, an error throws.
 
 2. `product` defines the product this moniker belongs to, and the operators in monikerRange will be interpreted inside the product it belongs to.
+
+3. `order` defines the moniker order inside the current product, higher number takes the precedence, default value is 0.
 
 3. `product_family` and `platform` is the attributes of this product, which is used by portal to manage the monikers.
 

--- a/src/docfx/build/moniker/MonikerProvider.cs
+++ b/src/docfx/build/moniker/MonikerProvider.cs
@@ -29,8 +29,9 @@ namespace Microsoft.Docs.Build
             }
             _rules.Reverse();
 
-            _rangeParser = new MonikerRangeParser(monikerDefinition);
-            Comparer = new MonikerComparer(monikerDefinition);
+            var monikersEvaluator = new EvaluatorWithMonikersVisitor(monikerDefinition);
+            _rangeParser = new MonikerRangeParser(monikersEvaluator);
+            Comparer = new MonikerComparer(monikersEvaluator.GetSortedMonikerNameList());
         }
 
         public (List<Error> errors, List<string> monikers) GetFileLevelMonikers(Document file, MetadataProvider metadataProvider)

--- a/src/docfx/lib/moniker/Moniker.cs
+++ b/src/docfx/lib/moniker/Moniker.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Docs.Build
 
         public string ProductName { get; set; } = string.Empty;
 
+        public int Order { get; set; } = 0;
+
         [JsonExtensionData]
         public JObject ExtensionData { get; } = new JObject();
     }

--- a/src/docfx/lib/moniker/MonikerComparer.cs
+++ b/src/docfx/lib/moniker/MonikerComparer.cs
@@ -10,9 +10,9 @@ namespace Microsoft.Docs.Build
     {
         private readonly Dictionary<string, int> _monikerOrder;
 
-        public MonikerComparer(MonikerDefinitionModel monikerDefinition)
+        public MonikerComparer(List<string> monikers)
         {
-            _monikerOrder = GetMoninkerOrder(monikerDefinition.Monikers);
+            _monikerOrder = GetMoninkerOrder(monikers);
         }
 
         public int Compare(string x, string y)
@@ -46,12 +46,12 @@ namespace Microsoft.Docs.Build
         private bool TryGetMonikerOrderFromDefinition(string moniker, out int order)
             => _monikerOrder.TryGetValue(moniker, out order);
 
-        private Dictionary<string, int> GetMoninkerOrder(List<Moniker> monikers)
+        private Dictionary<string, int> GetMoninkerOrder(List<string> monikers)
         {
             var result = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             for (int i = 0; i < monikers.Count; i++)
             {
-                result[monikers[i].MonikerName] = i;
+                result[monikers[i]] = i;
             }
             return result;
         }

--- a/src/docfx/lib/moniker/MonikerRangeParser.cs
+++ b/src/docfx/lib/moniker/MonikerRangeParser.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Docs.Build
         private readonly ConcurrentDictionary<string, Lazy<IReadOnlyList<string>>> _cache = new ConcurrentDictionary<string, Lazy<IReadOnlyList<string>>>();
         private readonly EvaluatorWithMonikersVisitor _monikersEvaluator;
 
-        public MonikerRangeParser(MonikerDefinitionModel monikerDefinition)
+        public MonikerRangeParser(EvaluatorWithMonikersVisitor monikersEvaluator)
         {
-            _monikersEvaluator = new EvaluatorWithMonikersVisitor(monikerDefinition);
+            _monikersEvaluator = monikersEvaluator;
         }
 
         public IReadOnlyList<string> Parse(string rangeString)

--- a/test/docfx.Test/lib/MonikerRangeParserTest.cs
+++ b/test/docfx.Test/lib/MonikerRangeParserTest.cs
@@ -14,18 +14,9 @@ namespace Microsoft.Docs.Build
             {
                 new Moniker
                 {
-                    MonikerName = "netcore-1.0",
-                    ProductName = ".NET Core",
-                },
-                new Moniker
-                {
-                    MonikerName = "netcore-2.0",
-                    ProductName = ".NET Core",
-                },
-                new Moniker
-                {
-                    MonikerName = "netcore-3.0",
-                    ProductName = ".NET Core",
+                    MonikerName = "dotnet-3.0",
+                    ProductName = ".NET Framework",
+                    Order = 1,
                 },
                 new Moniker
                 {
@@ -39,8 +30,21 @@ namespace Microsoft.Docs.Build
                 },
                 new Moniker
                 {
-                    MonikerName = "dotnet-3.0",
-                    ProductName = ".NET Framework",
+                    MonikerName = "netcore-1.0",
+                    ProductName = ".NET Core",
+                    Order = 1,
+                },
+                new Moniker
+                {
+                    MonikerName = "netcore-3.0",
+                    ProductName = ".NET Core",
+                    Order = 3
+                },
+                new Moniker
+                {
+                    MonikerName = "netcore-2.0",
+                    ProductName = ".NET Core",
+                    Order = 2
                 },
             }
         };
@@ -50,8 +54,9 @@ namespace Microsoft.Docs.Build
 
         public MonikerRangeParserTest()
         {
-            _monikerRangeParser = new MonikerRangeParser(_monikerDefinition);
-            _monikerComparer = new MonikerComparer(_monikerDefinition);
+            var monikersEvaluator = new EvaluatorWithMonikersVisitor(_monikerDefinition);
+            _monikerRangeParser = new MonikerRangeParser(monikersEvaluator);
+            _monikerComparer = new MonikerComparer(monikersEvaluator.GetSortedMonikerNameList());
         }
 
         [Theory]
@@ -133,7 +138,7 @@ namespace Microsoft.Docs.Build
                 }
             };
 
-            var exception = Assert.Throws<DocfxException>(() => new MonikerRangeParser(monikerDefinition));
+            var exception = Assert.Throws<DocfxException>(() => new MonikerRangeParser(new EvaluatorWithMonikersVisitor(monikerDefinition)));
             Assert.Equal("moniker-name-conflict", exception.Error.Code);
             Assert.Equal("Two or more moniker definitions have the same monikerName `netcore-1.0`", exception.Error.Message);
         }
@@ -141,7 +146,7 @@ namespace Microsoft.Docs.Build
         [Fact]
         public void TestNullDefinitionShouldFail()
         {
-            var monikerRangeParser = new MonikerRangeParser(new MonikerDefinitionModel());
+            var monikerRangeParser = new MonikerRangeParser(new EvaluatorWithMonikersVisitor(new MonikerDefinitionModel()));
             var exception = Assert.Throws<DocfxException>(() => monikerRangeParser.Parse("netcore-1.0"));
             Assert.Equal("moniker-range-invalid", exception.Error.Code);
             Assert.Equal("Invalid moniker range: 'netcore-1.0': Moniker `netcore-1.0` is not defined", exception.Error.Message);


### PR DESCRIPTION
The moniker definition list return by API `/v2/monikertrees/allfamiliesproductsmonikers` are not sorted