### PR TITLE
work around error under azpipeline vs2019

### DIFF
--- a/UpdateTemplate.ps1
+++ b/UpdateTemplate.ps1
@@ -6,6 +6,9 @@ if (-not (Get-Command "node" -ErrorAction SilentlyContinue)) {
     exit 1
 }
 
+# https://github.com/PowerShell/Phosphor/issues/26#issuecomment-299702987
+$logLevelParam = if ($env:TF_BUILD -eq "True") { "--loglevel=error" } else { "" }
+
 Push-Location $PSScriptRoot
 
 $TemplateHome="$PSScriptRoot/src/docfx.website.themes/"
@@ -13,12 +16,12 @@ $DefaultTemplate="${TemplateHome}default/"
 $GulpCommand="${DefaultTemplate}node_modules/gulp/bin/gulp"
 
 Set-Location "$DefaultTemplate"
-npm install
-node ./node_modules/bower/bin/bower install
+npm install $logLevelParam
+node ./node_modules/bower/bin/bower install $logLevelParam
 node "$GulpCommand"
 
 Set-Location "$TemplateHome"
-npm install
+npm install $logLevelParam
 node "$GulpCommand"
 
 Pop-Location

--- a/build.ps1
+++ b/build.ps1
@@ -16,7 +16,6 @@ param(
 
 $ErrorActionPreference = 'Stop'
 $releaseBranch = "master"
-$dotnetCommand = "dotnet"
 $gitCommand = "git"
 $framework = "net472"
 $packageVersion = "1.0.0"


### PR DESCRIPTION
When use new agent `Hosted Windows 2019 with VS2019`, warnings from `npm install` was treated as error by powershell. Add parameters to remove warning.

Related: https://github.com/PowerShell/Phosphor/issues/26#issuecomment-299702987