### PR TITLE
Enable integration testing for forked repos

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,7 +96,8 @@ jobs:
 
       if (-Not (Test-Path -Path ../Docs.Build)) {
           # Clone Docs.Build if not exists
-          exec "git $auth clone https://dev.azure.com/ceapex/Engineering/_git/Docs.Build --depth 1 --branch develop ../Docs.Build"
+          ## !!!!!!!!!!!!!!!!!!!!!!!!
+          exec "git $auth clone https://dev.azure.com/ceapex/Engineering/_git/Docs.Build --depth 1 --branch vsts_auth_type ../Docs.Build"
       } else {
         try {
             # Update Docs.Build to latest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ jobs:
   steps:
   - bash: ./build.sh
     env:
-      SYSTEM_ACCESS_TOKEN: $(System.AccessToken)
+      AZURE_DEVOPS_TOKEN: $(AZURE_DEVOPS_TOKEN)
       DOCS_GITHUB_TOKEN: $(DOCS_GITHUB_TOKEN)
 
 - job: MacBuild
@@ -26,7 +26,7 @@ jobs:
   steps:
   - bash: ./build.sh
     env:
-      SYSTEM_ACCESS_TOKEN: $(System.AccessToken)
+      AZURE_DEVOPS_TOKEN: $(AZURE_DEVOPS_TOKEN)
       DOCS_GITHUB_TOKEN: $(DOCS_GITHUB_TOKEN)
 
 # Test and deploy on windows
@@ -39,7 +39,7 @@ jobs:
   - powershell: ./build.ps1
     displayName: Build
     env:
-      SYSTEM_ACCESS_TOKEN: $(System.AccessToken)
+      AZURE_DEVOPS_TOKEN: $(AZURE_DEVOPS_TOKEN)
       DOCS_GITHUB_TOKEN: $(DOCS_GITHUB_TOKEN)
 
   # Publish code coverage results
@@ -92,7 +92,7 @@ jobs:
           }
       }
 
-      $auth = "-c http.https://dev.azure.com.extraheader=""AUTHORIZATION: bearer $env:SYSTEM_ACCESS_TOKEN"""
+      $auth = "-c http.https://dev.azure.com.extraheader=""AUTHORIZATION: bearer $env:AZURE_DEVOPS_TOKEN"""
 
       if (-Not (Test-Path -Path ../Docs.Build)) {
           # Clone Docs.Build if not exists
@@ -111,7 +111,7 @@ jobs:
 
     displayName: Checkout Docs.Build
     env:
-      SYSTEM_ACCESS_TOKEN: $(System.AccessToken)
+      AZURE_DEVOPS_TOKEN: $(AZURE_DEVOPS_TOKEN)
 
   # Build
   - powershell: ../Docs.Build/build.ps1 -noTest
@@ -126,5 +126,5 @@ jobs:
       BUILD_REASON: $(Build.Reason)
       DOCFX_APPDATA_PATH: D:/appdata
       DOCS_GITHUB_TOKEN: $(DOCS_GITHUB_TOKEN)
-      SYSTEM_ACCESS_TOKEN: $(System.AccessToken)
+      AZURE_DEVOPS_TOKEN: $(AZURE_DEVOPS_TOKEN)
       AzureServicesAuthConnectionString: $(AzureServicesAuthConnectionString)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,8 @@ jobs:
           }
       }
 
-      $auth = "-c http.https://dev.azure.com.extraheader=""AUTHORIZATION: bearer $env:AZURE_DEVOPS_TOKEN"""
+      $basicAuth = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("user:$env:AZURE_DEVOPS_TOKEN"))
+      $auth = "-c http.https://dev.azure.com.extraheader=""AUTHORIZATION: basic $basicAuth"""
 
       if (-Not (Test-Path -Path ../Docs.Build)) {
           # Clone Docs.Build if not exists

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,8 +97,7 @@ jobs:
 
       if (-Not (Test-Path -Path ../Docs.Build)) {
           # Clone Docs.Build if not exists
-          ## !!!!!!!!!!!!!!!!!!!!!!!!
-          exec "git $auth clone https://dev.azure.com/ceapex/Engineering/_git/Docs.Build --depth 1 --branch vsts_auth_type ../Docs.Build"
+          exec "git $auth clone https://dev.azure.com/ceapex/Engineering/_git/Docs.Build --depth 1 --branch develop ../Docs.Build"
       } else {
         try {
             # Update Docs.Build to latest

--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -163,25 +163,6 @@ outputs:
       "conceptual": "<p>for long file path test.</p>"
     }
 ---
-# [Skip] Restore private azure repos with dependencies
-# VSTS recently are not really stable, so skip this test for now
-inputs:
-  docfx.yml: |
-    dependencies:
-      dep: https://ceapex.visualstudio.com/Engineering/_git/docs-host-vnext#c9c018c
-    http:
-      https://ceapex.visualstudio.com:
-        headers:
-          Authorization: Bearer {SYSTEM_ACCESS_TOKEN}
-  docs/a.md: |
-    [link to readmd](~/dep/README.md)
-environments:
-  - SYSTEM_ACCESS_TOKEN
-outputs:
-  docs/a.json:
-  .errors.log: |
-    ["warning","link-is-dependency","File 'README.md' referenced by link '~/dep/README.md' will not be built because it is from a dependency docset","docs/a.md",1,1]
----
 # Restored repo should be always retrieved
 repos:
   https://docs.com/restore/x#master1:


### PR DESCRIPTION
- Replace System.AccessToken with a custom devops token
- Removes a private repo spec test because it is covered by integration test