### PR TITLE
Remove ConfigFileName in favor of source info

### DIFF
--- a/docs/specs/casing.yml
+++ b/docs/specs/casing.yml
@@ -24,7 +24,7 @@ inputs:
   docfx.yml: |
     redirections:
       docs/redirect.md: /path
-      docs/redirect1.md: /PATH
+      docs/redirect1.md: /PATH1
   docs/a.md: |
     [redirect](REDIRECT.md)
 outputs:

--- a/docs/specs/config.yml
+++ b/docs/specs/config.yml
@@ -291,7 +291,7 @@ outputs:
   .errors.log: |
     ["error","file-not-found","Invalid file link: 'b.md'.","docs/a.md",1,1]
 ---
-# Invalid redirection file
+# Redirection file content type invalid
 inputs:
   docfx.yml: |
     redirections:
@@ -300,7 +300,7 @@ outputs:
   .errors.log: |
     ["error","redirection-invalid","File 'docs/TOC.md' is redirected to '/absolute/path'. Only content files can be redirected.","docfx.yml",2,16]
 ---
-# Conflicted redirection file
+# Redirection url conflict
 inputs:
   docfx.yml: |
     redirections:
@@ -309,9 +309,9 @@ inputs:
       docs/a.md: /absolute/path2
 outputs:
   .errors.log: |
-    ["error","redirection-conflict","The 'docs/a.md' appears twice or more in the redirection mappings","docfx.yml"]
+    ["error","redirection-conflict","The 'docs/a.md' appears twice or more in the redirection mappings","docfx.yml",4,14]
 ---
-# Out of scope redirection file
+# Redirection file out of build scope
 inputs:
   docfx.yml: |
     exclude: '*'
@@ -322,7 +322,7 @@ outputs:
   .errors.log: |
     ["info","redirection-out-of-scope","Redirection file 'b.md' will not be built because it is not included in build scope","docfx.yml",4,9]
 ---
-# Out of scope file with conflicted id
+# Redirection file out of build scope with conflicted id
 inputs:
   docfx.yml: |
     exclude: '*'
@@ -345,7 +345,7 @@ inputs:
 outputs:
   .errors.log: |
     ["error","redirection-invalid","File 'docs/TOC.md' is redirected to '/absolute/path'. Only content files can be redirected.","docfx.yml",2,16]
-    ["error","redirection-conflict","The 'docs/a.md' appears twice or more in the redirection mappings","docfx.yml"]
+    ["error","redirection-conflict","The 'docs/a.md' appears twice or more in the redirection mappings","docfx.yml",5,14]
 ---
 # Wrong locale
 os: windows
@@ -465,8 +465,8 @@ inputs:
       b.md: a
 outputs:
   .errors.log: |
-    ["warning","invalid-redirect-to","The redirect url 'https://docs.microsoft.com/docfx/a' must start with '/'","docfx.yml",2,9]
-    ["warning","invalid-redirect-to","The redirect url 'a' must start with '/'","docfx.yml",3,9]
+    ["warning","redirection-url-invalid","The redirect url 'https://docs.microsoft.com/docfx/a' must start with '/'","docfx.yml",2,9]
+    ["warning","redirection-url-invalid","The redirect url 'a' must start with '/'","docfx.yml",3,9]
 ---
 # redirect to not starting with '/' is allowed in config.redirectionWithoutIds
 inputs:

--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -765,7 +765,7 @@ inputs:
 outputs:
   docs/a.json:
   .errors.log: |
-    ["warning","link-out-of-scope","File 'localization/zh-cn/docs/a.md' referenced by link '~/localization/zh-cn/docs/a.md' will not be built because it is not included in docfx.yml","docs/a.md",1,1]
+    ["warning","link-out-of-scope","File 'localization/zh-cn/docs/a.md' referenced by link '~/localization/zh-cn/docs/a.md' will not be built because it is not included in build scope","docs/a.md",1,1]
 ---
 # loc folder should be excluded from source docset during source docset build
 inputs:

--- a/docs/specs/metadata.yml
+++ b/docs/specs/metadata.yml
@@ -151,7 +151,7 @@ outputs:
   sccm/mdm/understand/hybrid-mobile-device-management.json: |
     { "document_id": "7412621b-4920-dc7e-bed6-1f1ea774f7dd", "document_version_independent_id": "de5d1641-2c0e-1158-7611-e52a22d96a5e" }
 ---
-# get conflicted redirection document id warning if two or more files redirect to the same file with document id
+# Show warning if two or more files redirect to the same file with document id
 inputs:
   docfx.yml: |
     documentId:
@@ -168,7 +168,7 @@ outputs:
   sccm/mdm/understand/hybrid-mobile-device-management.json: |
     { "document_id": "1c42a151-6248-df0c-15e6-3b1158d7bee3", "document_version_independent_id": "beb14a44-b076-14b8-b9c5-b42f9e36b973" }
   .errors.log: |
-    ["warning","redirected-id-conflict","Multiple documents redirected to '/sccm/mdm/understand/hybrid-mobile-device-management' with document id: 'sccm/mdm/index.md', 'sccm/mdm/index2.md'","docfx.yml"]
+    ["warning","redirection-url-conflict","The '/sccm/mdm/understand/hybrid-mobile-device-management' appears twice or more in the redirection mappings","docfx.yml",9,23]
 ---
 # redirect to empty URL
 inputs:

--- a/docs/specs/metadata.yml
+++ b/docs/specs/metadata.yml
@@ -180,7 +180,7 @@ outputs:
   sccm/mdm/understand/hybrid-mobile-device-management.json: |
     { "document_id": "1c42a151-6248-df0c-15e6-3b1158d7bee3", "document_version_independent_id": "beb14a44-b076-14b8-b9c5-b42f9e36b973" }
   .errors.log: |
-    ["warning","redirection-url-conflict","The '/sccm/mdm/understand/hybrid-mobile-device-management' appears twice or more in the redirection mappings","docfx.yml",9,23]
+    ["warning","redirection-url-conflict","The '/sccm/mdm/understand/hybrid-mobile-device-management' appears twice or more in the redirection mappings","docfx.yml",11,23]
 ---
 # redirect to empty URL
 inputs:

--- a/docs/specs/resolve.yml
+++ b/docs/specs/resolve.yml
@@ -244,7 +244,7 @@ outputs:
   docs/b.json: |
     {"conceptual":"<p><a href=\"#self\"></a></p>"}
   .errors.log: |
-    ["warning","link-out-of-scope","File 'c.md' referenced by link '../c.md' will not be built because it is not included in docfx.yml","docs/a.md",1,9]
+    ["warning","link-out-of-scope","File 'c.md' referenced by link '../c.md' will not be built because it is not included in build scope","docs/a.md",1,9]
     ["suggestion","internal-bookmark-not-found","Cannot find bookmark '#self' in 'c.md'","c.md",1,1]
 ---
 # Don't show warning if link to a resource outside build scope

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -632,7 +632,7 @@ outputs:
        ]
     }
   .errors.log: |
-    ["warning","link-out-of-scope","File 'docs/f1/n2.md' referenced by link '~/docs/f1/n2.md' will not be built because it is not included in docfx.yml","docs/f1/TOC.yml",3,14]
+    ["warning","link-out-of-scope","File 'docs/f1/n2.md' referenced by link '~/docs/f1/n2.md' will not be built because it is not included in build scope","docs/f1/TOC.yml",3,14]
 ---
 # Combine topic href and href(toc) => href + items
 # replace href finally
@@ -669,8 +669,8 @@ outputs:
        ]
     }
   .errors.log: |
-    ["warning","link-out-of-scope","File 'docs/f1/f11/n1.md' referenced by link 'f11/n1.md' will not be built because it is not included in docfx.yml","docs/f1/TOC.yml",3,14]
-    ["warning","link-out-of-scope","File 'docs/f1/f11/n1.md' referenced by link 'n1.md' will not be built because it is not included in docfx.yml","docs/f1/f11/TOC.md",1,3]
+    ["warning","link-out-of-scope","File 'docs/f1/f11/n1.md' referenced by link 'f11/n1.md' will not be built because it is not included in build scope","docs/f1/TOC.yml",3,14]
+    ["warning","link-out-of-scope","File 'docs/f1/f11/n1.md' referenced by link 'n1.md' will not be built because it is not included in build scope","docs/f1/f11/TOC.md",1,3]
 ---
 # Combine topic href and toc href(folder) -> topic href > toc href(folder)
 inputs:

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Defined same redirection entry in both <see cref="Config.Redirections"/> and <see cref="Config.RedirectionsWithoutId"/>.
         /// </summary>
-        public static Error RedirectionConflict(string redirectFrom)
-            => new Error(ErrorLevel.Error, "redirection-conflict", $"The '{redirectFrom}' appears twice or more in the redirection mappings");
+        public static Error RedirectionConflict(SourceInfo source, string path)
+            => new Error(ErrorLevel.Error, "redirection-conflict", $"The '{path}' appears twice or more in the redirection mappings", source);
 
         /// <summary>
         /// Redirection entry isn't a conceptual article(*.{md,json,yml}).
@@ -30,8 +30,15 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Defined redirect dest not starting with '\' in <see cref="Config.Redirections"/>.
         /// </summary>
-        public static Error InvalidRedirectTo(SourceInfo<string> source)
-            => new Error(ErrorLevel.Warning, "invalid-redirect-to", $"The redirect url '{source}' must start with '/'", source);
+        public static Error RedirectionUrlInvalid(SourceInfo<string> source)
+            => new Error(ErrorLevel.Warning, "redirection-url-invalid", $"The redirect url '{source}' must start with '/'", source);
+
+        /// <summary>
+        /// Multiple files defined in <see cref="Config.Redirections"/> are redirected to the same url,
+        /// can't decide which entry to use when computing document id.
+        /// </summary>
+        public static Error RedirectionUrlConflict(SourceInfo<string> source)
+            => new Error(ErrorLevel.Warning, "redirection-url-conflict", $"The '{source}' appears twice or more in the redirection mappings", source);
 
         /// <summary>
         /// Used invalid glob pattern in configuration.
@@ -201,8 +208,8 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Link which's resolved to a file out of build scope.
         /// </summary>
-        public static Error LinkOutOfScope(SourceInfo<string> source, Document file, string configFile)
-            => new Error(ErrorLevel.Warning, "link-out-of-scope", $"File '{file}' referenced by link '{source}' will not be built because it is not included in {configFile}", source);
+        public static Error LinkOutOfScope(SourceInfo<string> source, Document file)
+            => new Error(ErrorLevel.Warning, "link-out-of-scope", $"File '{file}' referenced by link '{source}' will not be built because it is not included in build scope", source);
 
         /// <summary>
         /// Defined a redirection entry that's not matched by config's files glob patterns.
@@ -282,13 +289,6 @@ namespace Microsoft.Docs.Build
         /// </summary>
         public static Error OutputPathConflict(string path, IEnumerable<Document> files)
             => new Error(ErrorLevel.Error, "output-path-conflict", $"Two or more files output to the same path '{path}': {Join(files, file => file.ContentType == ContentType.Redirection ? $"{file} <redirection>" : file.ToString())}");
-
-        /// <summary>
-        /// Multiple files defined in <see cref="Config.Redirections"/> are redirected to the same url,
-        /// can't decide which entry to use when computing document id.
-        /// </summary>
-        public static Error RedirectionDocumentIdConflict(IEnumerable<Document> redirectFromDocs, string redirectTo)
-            => new Error(ErrorLevel.Warning, "redirected-id-conflict", $"Multiple documents redirected to '{redirectTo}' with document id: {Join(redirectFromDocs)}");
 
         /// <summary>
         /// Used docfx output model property which are not defined in input model.

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Docs.Build
             errorLog.Configure(config);
 
             // just return if config loading has errors
-            if (errorLog.Write(config.ConfigFileName, configErrors))
+            if (errorLog.Write(configErrors))
                 return;
 
             var docset = GetBuildDocset(new Docset(errorLog, docsetPath, locale, config, options, restoreMap, repository, fallbackRepo));

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Docs.Build
                 && (file.ContentType == ContentType.Page || file.ContentType == ContentType.TableOfContents)
                 && !file.Docset.BuildScope.Contains(file))
             {
-                return (Errors.LinkOutOfScope(href, file, file.Docset.Config.ConfigFileName), relativeUrl + query + fragment, fragment, linkType, null);
+                return (Errors.LinkOutOfScope(href, file), relativeUrl + query + fragment, fragment, linkType, null);
             }
 
             return (error, relativeUrl + query + fragment, fragment, linkType, file);

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -181,11 +181,5 @@ namespace Microsoft.Docs.Build
         /// for the latest commit that touches that document.
         /// </summary>
         public readonly bool UpdateTimeAsCommitBuildTime = false;
-
-        /// <summary>
-        /// Gets the config file name.
-        /// </summary>
-        [JsonIgnore]
-        public string ConfigFileName { get; set; } = "docfx.yml";
     }
 }

--- a/src/docfx/config/ConfigLoader.cs
+++ b/src/docfx/config/ConfigLoader.cs
@@ -74,7 +74,6 @@ namespace Microsoft.Docs.Build
             var (deserializeErrors, config) = JsonUtility.ToObject<Config>(configObject);
             errors.AddRange(deserializeErrors);
 
-            config.ConfigFileName = configFileName;
             return (errors, config);
 
             string GetBranch()

--- a/src/docfx/docset/Docset.cs
+++ b/src/docfx/docset/Docset.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Docs.Build
             _redirections = new Lazy<RedirectionMap>(() =>
             {
                 var (errors, map) = RedirectionMap.Create(this, glob);
-                errorLog.Write(Config.ConfigFileName, errors);
+                errorLog.Write(errors);
                 return map;
             });
             _scanScope = new Lazy<HashSet<Document>>(() => GetScanScope(this));
@@ -195,7 +195,7 @@ namespace Microsoft.Docs.Build
             _dependencyDocsets = new Lazy<IReadOnlyDictionary<string, Docset>>(() =>
             {
                 var (errors, dependencies) = LoadDependencies(_errorLog, docsetPath, Config, Locale, RestoreMap, _options);
-                _errorLog.Write(Config.ConfigFileName, errors);
+                _errorLog.Write(errors);
                 return dependencies;
             });
 

--- a/src/docfx/lib/log/ErrorLog.cs
+++ b/src/docfx/lib/log/ErrorLog.cs
@@ -56,6 +56,19 @@ namespace Microsoft.Docs.Build
             _config = config;
         }
 
+        public bool Write(IEnumerable<Error> errors)
+        {
+            var hasErrors = false;
+            foreach (var error in errors)
+            {
+                if (Write(error))
+                {
+                    hasErrors = true;
+                }
+            }
+            return hasErrors;
+        }
+
         public bool Write(string file, IEnumerable<Error> errors)
         {
             var hasErrors = false;

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Docs.Build
                         {
                             errorLog.Configure(config);
                         }
-                        errorLog.Write(config.ConfigFileName, errors);
+                        errorLog.Write(errors);
 
                         // no need to restore child docsets' loc repository
                         return await RestoreOneDocset(
@@ -66,7 +66,7 @@ namespace Microsoft.Docs.Build
 
                 // extend the config before loading
                 var (errors, extendedConfig) = ConfigLoader.TryLoad(docset, options, locale, extend: true);
-                errorLog.Write(extendedConfig.ConfigFileName, errors);
+                errorLog.Write(errors);
 
                 // restore and load dependency lock if need
                 if (UrlUtility.IsHttp(extendedConfig.DependencyLock))


### PR DESCRIPTION
Now that we have source info, `ConfigFileName` can be removed. Most of the changes are related to redirection because it is the only error that still uses that property. 