### PR TITLE
remove siteBasePath from routes and always prepend to sitePath

### DIFF
--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -90,8 +90,6 @@ repos:
         theme: https://docs.com/template1
         redirections:
           a.md: /b
-        routes:
-          /: rawmetadata
         gitHub:
           userCache: user_profile.json
           resolveUsers: true
@@ -334,8 +332,9 @@ inputs:
       'docs/v1/**': '< netcore-2.0'
     baseUrl: https://docs.com/docs
     routes:
-      docs/v1/: docs/
-      docs/v2/: docs/
+      docs/: .
+      docs/v1/: .
+      docs/v2/: .
     monikerDefinition: monikerDefinition.json
   docs/v1/a.md: |
   docs/a.md: |

--- a/docs/specs/metadata.yml
+++ b/docs/specs/metadata.yml
@@ -74,6 +74,8 @@ inputs:
     product: Win
     files: sccm/**/*
     baseUrl: https://docs.com/sccm
+    routes:
+      sccm/: .
   sccm/mdt/release-notes.md:
 outputs:
   sccm/mdt/release-notes.json: |
@@ -91,6 +93,8 @@ inputs:
     product: Win
     files: "**/*"
     baseUrl: https://docs.com/sccm
+    routes:
+      sccm/: .
   sccm/mdm/index.md:
   sccm/index.md:
 outputs:
@@ -109,6 +113,8 @@ inputs:
     product: Win
     files: "**/*"
     baseUrl: https://docs.com/sccm
+    routes:
+      sccm/: .
     redirections:
       sccm/mdm/index.md: /sccm/mdm/understand/hybrid-mobile-device-management
   sccm/mdm/understand/hybrid-mobile-device-management.md:
@@ -128,6 +134,8 @@ inputs:
     baseUrl: https://docs.com/sccm
     redirections:
       sccm/mdm/index.md: /sccm/mdm/understand/hybrid-mobile-device-management
+    routes:
+      sccm/: .
   sccm/mdm/understand/hybrid-mobile-device-management.md:
 outputs:
   sccm/mdm/understand/hybrid-mobile-device-management.json: |
@@ -144,6 +152,8 @@ inputs:
     product: Win
     files: "**/*"
     baseUrl: https://docs.com/sccm
+    routes:
+      sccm/: .
     redirectionsWithoutId:
       sccm/mdm/index.md: /sccm/mdm/understand/hybrid-mobile-device-management
   sccm/mdm/understand/hybrid-mobile-device-management.md:
@@ -160,6 +170,8 @@ inputs:
     product: Win
     files: "**/*"
     baseUrl: https://docs.com/sccm
+    routes:
+      sccm/: .
     redirections:
       sccm/mdm/index.md: /sccm/mdm/understand/hybrid-mobile-device-management
       sccm/mdm/index2.md: /sccm/mdm/understand/hybrid-mobile-device-management
@@ -197,7 +209,7 @@ inputs:
     files: "**/*"
     baseUrl: https://docs.com/azure
     routes:
-      articles/: "azure/"
+      articles/: .
   articles/iot-central/concepts-architecture.md:
   articles/billing/billing-add-change-azure-subscription-administrator.md:
 outputs:
@@ -303,7 +315,7 @@ inputs:
     files: "**/*"
     baseUrl: https://docs.com/azure
     routes:
-      articles/: "azure/"
+      articles/: .
     redirections:
       articles/active-directory/active-directory-saas-splunkenterpriseandsplunkcloud-tutorial.md: /azure/active-directory/saas-apps/splunkenterpriseandsplunkcloud-tutorial
       articles/active-directory/active-directory-saas-splunk-enterprise-and-splunk-cloud-tutorial.md: /azure/active-directory/active-directory-saas-splunkenterpriseandsplunkcloud-tutorial
@@ -323,6 +335,8 @@ inputs:
     name: azure-documents
     files: "**/*"
     baseUrl: https://docs.com/articles
+    routes:
+      articles/: .
   articles/active-directory-b2c/index.yml : |
     ### YamlMime:YamlDocument
     documentType: LandingData
@@ -343,7 +357,7 @@ inputs:
     files: "**/*"
     baseUrl: https://docs.com/azure
     routes:
-      articles/: "azure/"
+      articles/: .
     redirections:
       articles/virtual-machines/windows/classic/web-app-visual-studio.md: /azure/app-service/
   articles/app-service/index.yml : |
@@ -359,7 +373,7 @@ inputs:
     files: "**/*"
     baseUrl: "https://docs.microsoft.com"
     routes:
-      articles/: "azure/"
+      articles/: .
   articles/app-service/index.md:
   articles/app-service/index.experimental.md:
 outputs:

--- a/docs/specs/metadata.yml
+++ b/docs/specs/metadata.yml
@@ -373,7 +373,7 @@ inputs:
     files: "**/*"
     baseUrl: "https://docs.microsoft.com"
     routes:
-      articles/: .
+      articles/: azure/
   articles/app-service/index.md:
   articles/app-service/index.experimental.md:
 outputs:

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -7,8 +7,9 @@ inputs:
       'docs/v2/**': '>= netcore-2.0'
     baseUrl: https://docs.com/docs
     routes:
-      docs/v1/: docs/
-      docs/v2/: docs/
+      docs/: .
+      docs/v1/: .
+      docs/v2/: .
     monikerDefinition: monikerDefinition.json
   docs/v1/a.md: |
     Moniker: netcore-1.0, netcore-1.1

--- a/src/docfx/docset/Document.cs
+++ b/src/docfx/docset/Document.cs
@@ -242,7 +242,7 @@ namespace Microsoft.Docs.Build
             var type = isConfigReference ? ContentType.Unknown : GetContentType(filePath);
             var (mime, schema) = type == ContentType.Page ? Schema.ReadFromFile(filePath, Path.Combine(docset.DocsetPath, filePath)) : default;
             var isExperimental = Path.GetFileNameWithoutExtension(filePath).EndsWith(".experimental", PathUtility.PathComparison);
-            var routedFilePath = ApplyRoutes(filePath, docset.Routes);
+            var routedFilePath = ApplyRoutes(filePath, docset.Routes, docset.SiteBasePath);
 
             var sitePath = FilePathToSitePath(routedFilePath, type, schema, docset.Config.Output.Json, docset.Config.Output.UglifyUrl);
             if (docset.Config.Output.LowerCaseUrl)
@@ -403,7 +403,7 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static string ApplyRoutes(string path, IReadOnlyDictionary<string, string> routes)
+        private static string ApplyRoutes(string path, IReadOnlyDictionary<string, string> routes, string siteBasePath)
         {
             // the latter rule takes precedence of the former rule
             foreach (var (source, dest) in routes)
@@ -411,10 +411,11 @@ namespace Microsoft.Docs.Build
                 var result = ApplyRoutes(path, source, dest);
                 if (result != null)
                 {
-                    return result.Replace('\\', '/');
+                    path = result;
+                    break;
                 }
             }
-            return path;
+            return PathUtility.NormalizeFile(Path.Combine(siteBasePath, path));
         }
 
         private static string ApplyRoutes(string path, string source, string dest)


### PR DESCRIPTION
#4222 

require changes of config migration tool @mingwli :
1. remove `siteBasePath` from routes