### PR TITLE
Fix monikers of toc node

### DIFF
--- a/docs/designs/conceptual-versioning.md
+++ b/docs/designs/conceptual-versioning.md
@@ -501,7 +501,7 @@ When build the toc file(including the toc file included in another), we have to 
 1. *Monikers* of every node in toc(We don't support setting monikers of node in toc file).
     1. If the node is a text node(`## Header`), the *monikers* of this node is the collection of its children's monikers.
     2. If the node is a relative link node(`## [Header](a.md)`), the *monikers* of this node is the collection of its children's monikers and the monikers of this node.
-    3. If the node is a absolute link node(`## [Header](/a)` or `## [Header](http://test)`), the *monikers* of this node is the collection of its children's monikers and the monikers of this toc file.
+    3. If the node is a absolute link node(`## [Header](/a)` or `## [Header](http://test)`), the *monikers* of this node is the monikers of this toc file, which means this node will always be displayed.
 1. *Monikers* of toc file - Intersection of the monikerRange setting in the config and file metadata(If the intersection is empty, a warning will be logged).
 
 > For now, if the monikers of the node is out of the moniker Range of this toc, we do not report warning.

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -782,6 +782,9 @@ inputs:
     ## [C](/c)
     ## [D](http://test.com/test)
     ### [A](xref:a)
+    ## E
+    ### [A](a.md)
+    ### [B](b.md)
   monikerDefinition.json: |
     {
       "monikers": [
@@ -813,10 +816,18 @@ outputs:
             { "name": "C", "href": "/c", "monikers": ["netcore-1.1", "netcore-1.2", "netcore-1.3"] },
             { 
               "name": "D",
-              "href": "http://test.com/test", 
-              "monikers": ["netcore-1.0", "netcore-1.1", "netcore-1.2", "netcore-1.3"],
+              "href": "http://test.com/test",
+              "monikers": ["netcore-1.1", "netcore-1.2", "netcore-1.3"],
               "items": [
                 { "name": "A", "href": "a", "monikers": ["netcore-1.0", "netcore-1.1"] }
+              ]
+            },
+            {
+              "name": "E",
+              "monikers": [ "netcore-1.0", "netcore-1.1", "netcore-1.2" ],
+              "items": [
+                { "name": "A", "href": "a", "monikers": [ "netcore-1.0", "netcore-1.1" ] },
+                { "name": "B", "href": "b", "monikers": [ "netcore-1.1", "netcore-1.2"] },
               ]
             }
           ],

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -82,11 +82,19 @@ namespace Microsoft.Docs.Build
                     }
 
                     List<string> monikers = null;
+
+                    var linkType = UrlUtility.GetLinkType(item.Href?.Value);
+                    if (linkType == LinkType.External || linkType == LinkType.AbsolutePath)
+                    {
+                        item.Monikers = fileMonikers;
+                        continue;
+                    }
+
                     if (item.Href?.Value is null || !hrefMap.TryGetValue(item.Href, out monikers))
                     {
                         if (item.TopicHref is null || !hrefMap.TryGetValue(item.TopicHref, out monikers))
                         {
-                            monikers = fileMonikers;
+                            monikers = new List<string>();
                         }
                     }
 


### PR DESCRIPTION
- If the node is a text node(`## Header`), the *monikers* of this node is the collection of its children's monikers.
- If the node is an absolute link node(`## [Header](/a)` or `## [Header](http://test)`), the *monikers* of this node is the monikers of this toc file, which means this node will always be displayed.