### PR TITLE
Remove unknown field check from JsonUtility

### DIFF
--- a/docs/specs/config.yml
+++ b/docs/specs/config.yml
@@ -454,8 +454,6 @@ inputs:
   a.md:
 outputs:
   a.json:
-  .errors.log: |
-    ["warning","unknown-field","Could not find member 'locales: zh-cn' on object of type 'Config'.","docfx.yml",4,1]
 ---
 # redirect to in config.redirections must start with '/'
 inputs:

--- a/src/docfx/lib/json/JsonUtility.cs
+++ b/src/docfx/lib/json/JsonUtility.cs
@@ -161,8 +161,6 @@ namespace Microsoft.Docs.Build
 
                 t_status.Value.Push(status);
 
-                token.ReportUnknownFields(errors, type);
-
                 var value = s_schemaValidationSerializer.Deserialize(status.Reader, type);
 
                 return (errors, value);
@@ -480,88 +478,6 @@ namespace Microsoft.Docs.Build
                 return "Expected type String, please input String or type compatible with String.";
             }
             return message;
-        }
-
-        private static void ReportUnknownFields(this JToken token, List<Error> errors, Type type)
-        {
-            if (token is JArray array)
-            {
-                var itemType = GetCollectionItemTypeIfArrayType(type);
-                foreach (var item in array)
-                {
-                    item.ReportUnknownFields(errors, itemType);
-                }
-            }
-            else if (token is JObject obj)
-            {
-                foreach (var prop in obj.Properties())
-                {
-                    // skip the special property
-                    if (prop.Name == "$schema")
-                        continue;
-
-                    var nestedType = GetNestedTypeAndCheckForUnknownField(type, prop, errors);
-                    if (nestedType != null)
-                    {
-                        prop.Value.ReportUnknownFields(errors, nestedType);
-                    }
-                }
-            }
-        }
-
-        private static Type GetCollectionItemTypeIfArrayType(Type type)
-        {
-            var contract = s_serializer.ContractResolver.ResolveContract(type);
-            if (contract is JsonObjectContract)
-            {
-                return type;
-            }
-            else if (contract is JsonArrayContract arrayContract)
-            {
-                var itemType = arrayContract.CollectionItemType;
-                if (itemType is null)
-                {
-                    return type;
-                }
-                else
-                {
-                    return itemType;
-                }
-            }
-            return type;
-        }
-
-        private static Type GetNestedTypeAndCheckForUnknownField(Type type, JProperty prop, List<Error> errors)
-        {
-            var contract = s_serializer.ContractResolver.ResolveContract(type);
-
-            if (contract is JsonObjectContract objectContract)
-            {
-                var matchingProperty = objectContract.Properties.GetClosestMatchProperty(prop.Name);
-                if (matchingProperty is null && type.IsSealed)
-                {
-                    errors.Add(Errors.UnknownField(GetSourceInfo(prop), prop.Name, type.Name));
-                }
-                return matchingProperty?.PropertyType;
-            }
-
-            if (contract is JsonArrayContract arrayContract)
-            {
-                var matchingProperty = GetPropertiesFromJsonArrayContract(arrayContract).GetClosestMatchProperty(prop.Name);
-                return matchingProperty?.PropertyType;
-            }
-
-            return null;
-        }
-
-        private static JsonPropertyCollection GetPropertiesFromJsonArrayContract(JsonArrayContract arrayContract)
-        {
-            var itemContract = s_serializer.ContractResolver.ResolveContract(arrayContract.CollectionItemType);
-            if (itemContract is JsonObjectContract objectContract)
-                return objectContract.Properties;
-            else if (itemContract is JsonArrayContract contract)
-                return GetPropertiesFromJsonArrayContract(contract);
-            return null;
         }
 
         internal class Status

--- a/test/docfx.Test/lib/JsonUtilityTest.cs
+++ b/test/docfx.Test/lib/JsonUtilityTest.cs
@@ -239,61 +239,6 @@ namespace Microsoft.Docs.Build
         }
 
         [Theory]
-        [InlineData(@"{""mismatchField"": ""name""}", 1, 17, ErrorLevel.Warning, "unknown-field", typeof(ClassWithMoreMembers))]
-        [InlineData(@"{
-""anotherItems"":
-  [{ ""f"": 1,
-    ""g"": ""c"",
-    ""e"": ""e""}]}", 5, 8, ErrorLevel.Warning, "unknown-field", typeof(ClassWithMoreMembers))]
-        [InlineData(@"{
-""nestedItems"":
-  [[{ ""f"": 1,
-    ""g"": ""c"",
-    ""e"": ""e""}]]}", 5, 8, ErrorLevel.Warning, "unknown-field", typeof(ClassWithMoreMembers))]
-        [InlineData(@"[{
-""b"": 1,
-""c"": ""c"",
-""e"": ""e"",
-""nestedSealedMember"": {""unknown"": 1}}]", 5, 33, ErrorLevel.Warning, "unknown-field", typeof(List<NotSealedClass>))]
-        internal void TestUnknownFieldType(string json, int expectedLine, int expectedColumn, ErrorLevel expectedErrorLevel, string expectedErrorCode, Type type)
-        {
-            var (_, token) = JsonUtility.Parse(json, null);
-            var (errors, result) = JsonUtility.ToObject(token, type);
-            Assert.Collection(errors, error =>
-            {
-                Assert.Equal(expectedErrorLevel, error.Level);
-                Assert.Equal(expectedErrorCode, error.Code);
-                Assert.Equal(expectedLine, error.Line);
-                Assert.Equal(expectedColumn, error.Column);
-            });
-        }
-
-        [Fact]
-        public void TestMultipleUnknownFieldType()
-        {
-            var json = @"{""mismatchField1"": ""name"",
-""mismatchField2"": ""name""}";
-            var (errors, result) = DeserializeWithValidation<ClassWithMoreMembers>(json);
-            Assert.Collection(errors,
-            error =>
-            {
-                Assert.Equal(ErrorLevel.Warning, error.Level);
-                Assert.Equal("unknown-field", error.Code);
-                Assert.Equal(1, error.Line);
-                Assert.Equal(18, error.Column);
-                Assert.Equal("Could not find member 'mismatchField1' on object of type 'ClassWithMoreMembers'.", error.Message);
-            },
-            error =>
-            {
-                Assert.Equal(ErrorLevel.Warning, error.Level);
-                Assert.Equal("unknown-field", error.Code);
-                Assert.Equal(2, error.Line);
-                Assert.Equal(17, error.Column);
-                Assert.Equal("Could not find member 'mismatchField2' on object of type 'ClassWithMoreMembers'.", error.Message);
-            });
-        }
-
-        [Theory]
         [InlineData(@"{
 'numberList':
   [1, 'a']}", ErrorLevel.Error, "violate-schema", 3, 9)]
@@ -336,24 +281,6 @@ namespace Microsoft.Docs.Build
             var (_, token) = JsonUtility.Parse(json, null);
             var (errors, value) = JsonUtility.ToObject(token, type);
             Assert.Empty(errors);
-        }
-
-        [Fact]
-        public void TestNestedObjectTypeWithNotSealedType()
-        {
-            var json = @"[{
-""b"": 1,
-""c"": ""c"",
-""e"": ""e"",
-""nestedSealedMember"": {""unknown"": 1}}]";
-            var (errors, value) = DeserializeWithValidation<List<NotSealedClass>>(json);
-            Assert.Collection(errors, error =>
-            {
-                Assert.Equal(ErrorLevel.Warning, error.Level);
-                Assert.Equal("unknown-field", error.Code);
-                Assert.Equal(5, error.Line);
-                Assert.Equal(33, error.Column);
-            });
         }
 
         [Fact]


### PR DESCRIPTION
Right now we don't need this check for `config` and `toc`, even we need it, we can do it using JSON schema validation.