### PR TITLE
Optimize xrefmap load using UTF8JsonReader

### DIFF
--- a/src/docfx/build/xref/XrefMapLoader.cs
+++ b/src/docfx/build/xref/XrefMapLoader.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+
+namespace Microsoft.Docs.Build
+{
+    internal class XrefMapLoader
+    {
+        private static readonly byte[] s_uidSpan = Encoding.UTF8.GetBytes("uid");
+
+        public static Dictionary<string, List<Lazy<XrefSpec>>> LoadXrefMap(string path, Action<string, Lazy<XrefSpec>> callback)
+        {
+            var utf8Json = File.ReadAllBytes(path);
+            var result = new Dictionary<string, List<Lazy<XrefSpec>>>();
+            var uidPositions = GetUidPositions(utf8Json);
+
+            using (var stream = File.OpenRead(path))
+            {
+                foreach (var (uid, start, end) in uidPositions)
+                {
+                    if (!result.TryGetValue(uid, out var xrefspecs))
+                    {
+                        result.Add(uid, xrefspecs = new List<Lazy<XrefSpec>>(xrefspecs));
+                    }
+
+                    var json = ReadJsonFragment(stream, start, end);
+                    xrefspecs.Add(new Lazy<XrefSpec>(() => JsonUtility.Deserialize<XrefSpec>(json, path)));
+                }
+            }
+
+            return result;
+        }
+
+        private static List<(string uid, long start, long end)> GetUidPositions(ReadOnlySpan<byte> utf8Json)
+        {
+            var reader = new Utf8JsonReader(utf8Json, isFinalBlock: true, new JsonReaderState());
+            var result = new List<(string uid, long start, long end)>();
+            var stack = new Stack<(string uid, long start)>();
+
+            while (reader.Read())
+            {
+                switch (reader.TokenType)
+                {
+                    case JsonTokenType.PropertyName:
+                        if (reader.TextEquals(s_uidSpan) &&
+                            reader.Read() &&
+                            reader.TokenType == JsonTokenType.String &&
+                            stack.TryPop(out var top))
+                        {
+                            var uid = Encoding.UTF8.GetString(reader.ValueSpan);
+                            stack.Push((uid, top.start));
+                        }
+                        break;
+
+                    case JsonTokenType.StartObject:
+                        stack.Push((null, reader.TokenStartIndex));
+                        break;
+
+                    case JsonTokenType.EndObject:
+                        if (stack.TryPop(out var node))
+                        {
+                            result.Add((node.uid, node.start, reader.TokenStartIndex));
+                        }
+                        break;
+                }
+            }
+
+            return result;
+        }
+
+        private static string ReadJsonFragment(Stream stream, long start, long end)
+        {
+            var offset = 0;
+            var bytesRead = 0;
+            var bytes = new byte[end - start];
+            stream.Seek(start, SeekOrigin.Begin);
+
+            while ((bytesRead = stream.Read(bytes, offset, bytes.Length)) > 0)
+            {
+                offset += bytesRead;
+            }
+
+            return Encoding.UTF8.GetString(bytes, 0, offset);
+        }
+    }
+}

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="Stubble.Core" Version="1.2.7" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-rc.114" PrivateAssets="All" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180503-2" />
+    <PackageReference Include="System.Text.Json" Version="4.6.0-preview6.19259.10" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
     <PackageReference Include="YamlDotNet" Version="5.4.0" />
   </ItemGroup>


### PR DESCRIPTION
This is a proposal to optimize xrefmap.json load using `Utf8JsonReader`.

With `Utf8JsonReader`, we can get the exact byte position of each child `JObject`, and slice it upon use. A map of `uid --> (byte_pos_start, byte_pos_end)` can be build when _xrefmap.json_ is accessed for the first time and cached on disk. When an uid is resolved, we only need to open a portion of file to load only the JSON fragment that contains the xrefspec.

It is easy to ensure correctness then slicing from `line, column` info.

@live1206 #4674 