### PR TITLE
🧹 Extract build scope, scan scope, redirection map into context

### DIFF
--- a/docs/specs/casing.yml
+++ b/docs/specs/casing.yml
@@ -85,15 +85,3 @@ outputs:
   docs/A.json: |
     {"conceptual":"<p><a href=\"B\"></a></p>"}
   docs/B.json:
----
-# Use real file casing in manifest
-inputs:
-  docfx.yml: |
-    files: a.md
-  a.md: '[](B.png)'
-  b.png:
-outputs:
-  a.json: |
-    { "conceptual":"<p><a href=\"B\"></a></p>" }
-  b.png:
-

--- a/docs/specs/casing.yml
+++ b/docs/specs/casing.yml
@@ -85,3 +85,15 @@ outputs:
   docs/A.json: |
     {"conceptual":"<p><a href=\"B\"></a></p>"}
   docs/B.json:
+---
+# Use real file casing in manifest
+inputs:
+  docfx.yml: |
+    files: a.md
+  a.md: '[](B.png)'
+  b.png:
+outputs:
+  a.json: |
+    { "conceptual":"<p><a href=\"B\"></a></p>" }
+  b.png:
+

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Docs.Build
             var docset = GetBuildDocset(new Docset(errorLog, docsetPath, locale, config, options, restoreMap, repository, fallbackRepo));
             var outputPath = Path.Combine(docsetPath, config.Output.Path);
             var (buildScopeErrors, buildScope) = BuildScope.Create(docset);
-            errorLog.Write(null, buildScopeErrors);
+            errorLog.Write(buildScopeErrors);
 
             using (var context = new Context(outputPath, errorLog, buildScope, docset, () => xrefMap))
             {

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Docs.Build
         public readonly ErrorLog ErrorLog;
         public readonly Cache Cache;
         public readonly Output Output;
+        public readonly BuildScope BuildScope;
         public readonly MetadataProvider MetadataProvider;
         public readonly MonikerProvider MonikerProvider;
         public readonly GitCommitProvider GitCommitProvider;
@@ -25,9 +26,10 @@ namespace Microsoft.Docs.Build
         public readonly PublishModelBuilder PublishModelBuilder;
         public readonly TemplateEngine Template;
 
-        public Context(string outputPath, ErrorLog errorLog, Docset docset, Func<XrefMap> xrefMap)
+        public Context(string outputPath, ErrorLog errorLog, BuildScope buildScope, Docset docset, Func<XrefMap> xrefMap)
         {
             ErrorLog = errorLog;
+            BuildScope = buildScope;
             Output = new Output(outputPath);
             Cache = new Cache();
             MetadataProvider = new MetadataProvider(docset);
@@ -36,8 +38,8 @@ namespace Microsoft.Docs.Build
             GitCommitProvider = new GitCommitProvider();
             BookmarkValidator = new BookmarkValidator();
             DependencyMapBuilder = new DependencyMapBuilder();
-            DependencyResolver = new DependencyResolver(GitCommitProvider, BookmarkValidator, DependencyMapBuilder, new Lazy<XrefMap>(xrefMap));
-            LandingPageDependencyResolver = new DependencyResolver(GitCommitProvider, BookmarkValidator, DependencyMapBuilder, new Lazy<XrefMap>(xrefMap), forLandingPage: true);
+            DependencyResolver = new DependencyResolver(BuildScope, GitCommitProvider, BookmarkValidator, DependencyMapBuilder, new Lazy<XrefMap>(xrefMap));
+            LandingPageDependencyResolver = new DependencyResolver(BuildScope, GitCommitProvider, BookmarkValidator, DependencyMapBuilder, new Lazy<XrefMap>(xrefMap), forLandingPage: true);
             ContributionProvider = new ContributionProvider(docset, GitHubUserCache, GitCommitProvider);
             PublishModelBuilder = new PublishModelBuilder();
             Template = TemplateEngine.Create(docset);

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Docs.Build
             // Pages outside build scope, don't build the file, use relative href
             if (error is null
                 && (file.ContentType == ContentType.Page || file.ContentType == ContentType.TableOfContents)
-                && !_buildScope.Files.Contains(file))
+                && !_buildScope.FilesWithFallback.Contains(file))
             {
                 return (Errors.LinkOutOfScope(href, file), relativeUrl + query + fragment, fragment, linkType, null);
             }

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Docs.Build
             model.EnableLocSxs = file.Docset.Config.Localization.Bilingual;
             model.SiteName = file.Docset.Config.SiteName;
 
-            (model.DocumentId, model.DocumentVersionIndependentId) = file.Docset.Redirections.TryGetDocumentId(file, out var docId) ? docId : file.Id;
+            (model.DocumentId, model.DocumentVersionIndependentId) = context.BuildScope.Redirections.TryGetDocumentId(file, out var docId) ? docId : file.Id;
             (model.ContentGitUrl, model.OriginalContentGitUrl, model.OriginalContentGitUrlTemplate, model.Gitcommit) = context.ContributionProvider.GetGitUrls(file);
 
             List<Error> contributorErrors;

--- a/src/docfx/build/toc/TableOfContentsMap.cs
+++ b/src/docfx/build/toc/TableOfContentsMap.cs
@@ -81,12 +81,12 @@ namespace Microsoft.Docs.Build
             })?.Toc;
         }
 
-        public static TableOfContentsMap Create(Context context, Docset docset)
+        public static TableOfContentsMap Create(Context context)
         {
             using (Progress.Start("Loading TOC"))
             {
                 var builder = new TableOfContentsMapBuilder();
-                var tocFiles = docset.ScanScope.Where(f => f.ContentType == ContentType.TableOfContents);
+                var tocFiles = context.BuildScope.FilesWithFallback.Where(f => f.ContentType == ContentType.TableOfContents);
                 if (!tocFiles.Any())
                 {
                     return builder.Build();

--- a/src/docfx/build/xref/XrefMapBuilder.cs
+++ b/src/docfx/build/xref/XrefMapBuilder.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Docs.Build
                     }, content);
                 }
             });
-            var internalXrefMap = CreateInternalXrefMap(context, docset.ScanScope);
+            var internalXrefMap = CreateInternalXrefMap(context, context.BuildScope.FilesWithFallback);
             return new XrefMap(context, BuildMap(externalXrefMap.ToDictionary(), internalXrefMap), internalXrefMap);
         }
 

--- a/src/docfx/docset/BuildScope.cs
+++ b/src/docfx/docset/BuildScope.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Docs.Build
+{
+    internal class BuildScope
+    {
+        public HashSet<Document> Files { get; }
+
+        /// <summary>
+        /// Gets the scan scope used to generate toc map, xref map, xxx map before build
+        /// </summary>
+        public HashSet<Document> ScanFiles { get; }
+
+        /*
+        private HashSet<Document> CreateBuildScope(IEnumerable<Document> redirections, Func<string, bool> glob)
+        {
+            using (Progress.Start("Globbing files"))
+            {
+                var files = new ListBuilder<Document>();
+
+                ParallelUtility.ForEach(
+                    Directory.EnumerateFiles(DocsetPath, "*.*", SearchOption.AllDirectories),
+                    file =>
+                    {
+                        var relativePath = Path.GetRelativePath(DocsetPath, file);
+                        if (glob(relativePath))
+                        {
+                            files.Add(Document.CreateFromFile(this, relativePath));
+                        }
+                    });
+
+                return new HashSet<Document>(files.ToList().Concat(redirections));
+            }
+        }
+
+        private static HashSet<Document> GetScanScope(Docset docset)
+        {
+            var scanScopeFilePaths = new HashSet<string>(PathUtility.PathComparer);
+            var scanScope = new HashSet<Document>();
+
+            foreach (var buildScope in new[] { docset.LocalizationDocset?.BuildScope, docset.BuildScope, docset.FallbackDocset?.BuildScope })
+            {
+                if (buildScope is null)
+                {
+                    continue;
+                }
+
+                foreach (var document in buildScope)
+                {
+                    if (scanScopeFilePaths.Add(document.FilePath))
+                    {
+                        scanScope.Add(document);
+                    }
+                }
+            }
+
+            return scanScope;
+        }*/
+    }
+}


### PR DESCRIPTION
We need a way to detect the real file name on file system, the simplest way is to load all files names under the current docset, this also gives us the ability to enable case insensitive file resolve on linux.

This PR is a cleanup to give us a place to manage this lookup table, to address #4664 , which is currently a blocker to integration azure-docs-pr to integration test

