### PR TITLE
🐛add retry for intermittent http request io exception

### DIFF
--- a/src/docfx/lib/github/GitHubAccessor.cs
+++ b/src/docfx/lib/github/GitHubAccessor.cs
@@ -278,7 +278,7 @@ query ($owner: String!, $name: String!, $commit: String!) {
                            Content = new StringContent(JsonUtility.Serialize(request), System.Text.Encoding.UTF8, "application/json"),
                            Method = HttpMethod.Post,
                        }),
-                   ex => ex is OperationCanceledException);
+                   ex => ex is OperationCanceledException || ex is System.IO.IOException/*https://4lowtherabbit.github.io/blogs/2018/11/CaseStudy*/);
 
             if (!response.IsSuccessStatusCode)
             {

--- a/src/docfx/lib/github/GitHubAccessor.cs
+++ b/src/docfx/lib/github/GitHubAccessor.cs
@@ -278,7 +278,9 @@ query ($owner: String!, $name: String!, $commit: String!) {
                            Content = new StringContent(JsonUtility.Serialize(request), System.Text.Encoding.UTF8, "application/json"),
                            Method = HttpMethod.Post,
                        }),
-                   ex => ex is OperationCanceledException || ex is System.IO.IOException/*https://4lowtherabbit.github.io/blogs/2018/11/CaseStudy*/);
+                   ex =>
+                    (ex.InnerException ?? ex) is OperationCanceledException ||
+                    (ex.InnerException ?? ex) is System.IO.IOException);
 
             if (!response.IsSuccessStatusCode)
             {


### PR DESCRIPTION
```
System.Net.Http.HttpRequestException: An error occurred while sending the request. ---> System.IO.IOException: The server returned an invalid or unrecognized response.
   at System.Net.Http.HttpConnection.FillAsync()
   at System.Net.Http.HttpConnection.ReadNextResponseHeaderLineAsync(Boolean foldedHeadersAllowed)
   at System.Net.Http.HttpConnection.SendAsyncCore(HttpRequestMessage request, CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at System.Net.Http.HttpConnection.SendAsyncCore(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.SendWithNtConnectionAuthAsync(HttpConnection connection, HttpRequestMessage request, Boolean doRequestAuth, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.SendWithRetryAsync(HttpRequestMessage request, Boolean doRequestAuth, CancellationToken cancellationToken)
   at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.FinishSendAsyncBuffered(Task`1 sendTask, HttpRequestMessage request, CancellationTokenSource cts, Boolean disposeCts)
   at Microsoft.Docs.Build.RetryUtility.Retry[T](Func`1 action, Func`2 isExpectedException)
   at Microsoft.Docs.Build.GitHubAccessor.Query(String query, Object variables)
   at Microsoft.Docs.Build.GitHubAccessor.GetUsersByCommit(String owner, String name, String commit)
```

https://4lowtherabbit.github.io/blogs/2018/11/CaseStudy'

This issue only happens on Linux platform.