### PR TITLE
Consolidate MetadataProvider and MonikerProvider

### DIFF
--- a/src/docfx/build/context/Cache.cs
+++ b/src/docfx/build/context/Cache.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Docs.Build
     internal class Cache
     {
         private readonly ConcurrentDictionary<string, Lazy<(List<Error>, JToken)>> _tokenCache = new ConcurrentDictionary<string, Lazy<(List<Error>, JToken)>>();
-        private readonly ConcurrentDictionary<string, Lazy<(List<Error>, JObject)>> _metadataCache = new ConcurrentDictionary<string, Lazy<(List<Error>, JObject)>>();
         private readonly ConcurrentDictionary<string, Lazy<(List<Error>, TableOfContentsModel, List<(Document doc, string herf)>, List<Document>)>> _tocModelCache = new ConcurrentDictionary<string, Lazy<(List<Error>, TableOfContentsModel, List<(Document doc, string herf)>, List<Document>)>>();
 
         public (List<Error> errors, JToken token) LoadYamlFile(Document file)
@@ -29,15 +28,6 @@ namespace Microsoft.Docs.Build
                 var content = file.ReadText();
                 GitUtility.CheckMergeConflictMarker(content, file.FilePath);
                 return JsonUtility.Parse(content, file.FilePath);
-            })).Value;
-
-        public (List<Error> errors, JObject metadata) ExtractMetadata(Document file)
-            => _metadataCache.GetOrAdd(GetKeyFromFile(file), new Lazy<(List<Error>, JObject)>(() =>
-            {
-                using (var reader = new StreamReader(file.ReadStream()))
-                {
-                    return ExtractYamlHeader.Extract(reader, file.FilePath);
-                }
             })).Value;
 
         public (List<Error>, TableOfContentsModel, List<(Document doc, string herf)>, List<Document>) LoadTocModel(Context context, Document file)

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -30,8 +30,8 @@ namespace Microsoft.Docs.Build
             ErrorLog = errorLog;
             Output = new Output(outputPath);
             Cache = new Cache();
-            MetadataProvider = new MetadataProvider(docset);
-            MonikerProvider = new MonikerProvider(docset);
+            MetadataProvider = new MetadataProvider(docset, Cache);
+            MonikerProvider = new MonikerProvider(docset, MetadataProvider);
             GitHubUserCache = GitHubUserCache.Create(docset);
             GitCommitProvider = new GitCommitProvider();
             BookmarkValidator = new BookmarkValidator();

--- a/src/docfx/build/moniker/MonikerProvider.cs
+++ b/src/docfx/build/moniker/MonikerProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -9,13 +10,18 @@ namespace Microsoft.Docs.Build
 {
     internal class MonikerProvider
     {
-        private readonly List<(Func<string, bool> glob, (string monikerRange, IEnumerable<Moniker> monikers))> _rules = new List<(Func<string, bool>, (string, IEnumerable<Moniker>))>();
+        private readonly List<(Func<string, bool> glob, (string monikerRange, IEnumerable<string> monikers))> _rules = new List<(Func<string, bool>, (string, IEnumerable<string>))>();
         private readonly MonikerRangeParser _rangeParser;
+        private readonly MetadataProvider _metadataProvider;
+        private readonly ConcurrentDictionary<Document, (Error, List<string>)> _monikerCache
+                   = new ConcurrentDictionary<Document, (Error, List<string>)>();
 
         public MonikerComparer Comparer { get; }
 
-        public MonikerProvider(Docset docset)
+        public MonikerProvider(Docset docset, MetadataProvider metadataProvider)
         {
+            _metadataProvider = metadataProvider;
+
             var monikerDefinition = new MonikerDefinitionModel();
             if (!string.IsNullOrEmpty(docset.Config.MonikerDefinition))
             {
@@ -28,28 +34,47 @@ namespace Microsoft.Docs.Build
 
             foreach (var (key, monikerRange) in docset.Config.MonikerRange)
             {
-                _rules.Add((GlobUtility.CreateGlobMatcher(key), (monikerRange, _rangeParser.ParseWithInfo(monikerRange))));
+                _rules.Add((GlobUtility.CreateGlobMatcher(key), (monikerRange, _rangeParser.Parse(monikerRange))));
             }
             _rules.Reverse();
         }
 
-        public (List<Error> errors, List<string> monikers) GetFileLevelMonikers(Document file, MetadataProvider metadataProvider)
+        public (Error error, List<string> monikers) GetFileLevelMonikers(Document file)
         {
-            var errors = new List<Error>();
-            var (metaErrors, metadata) = metadataProvider.GetInputMetadata<InputMetadata>(file, null);
-            errors.AddRange(metaErrors);
-
-            var (monikerError, monikers) = GetFileLevelMonikers(file, metadata.MonikerRange);
-            errors.AddIfNotNull(monikerError);
-
-            return (errors, monikers);
+            return _monikerCache.GetOrAdd(file, GetFileLevelMonikersCore);
         }
 
-        public (Error, List<Moniker>) GetFileLevelMonikersWithInfo(Document file, SourceInfo<string> fileMonikerRange = null)
+        public (Error error, List<string> monikers) GetZoneLevelMonikers(Document file, SourceInfo<string> rangeString)
         {
-            Error error = null;
+            var (_, fileLevelMonikers) = GetFileLevelMonikers(file);
+
+            // Moniker range not defined in docfx.yml/docfx.json,
+            // User should not define it in moniker zone
+            if (fileLevelMonikers.Count == 0)
+            {
+                return (Errors.MonikerConfigMissing(), new List<string>());
+            }
+
+            var zoneLevelMonikers = _rangeParser.Parse(rangeString);
+            var monikers = fileLevelMonikers.Intersect(zoneLevelMonikers, StringComparer.OrdinalIgnoreCase).ToList();
+
+            if (monikers.Count == 0)
+            {
+                var error = Errors.EmptyMonikers($"No intersection between zone and file level monikers. The result of zone level range string '{rangeString}' is '{string.Join(',', zoneLevelMonikers)}', while file level monikers is '{string.Join(',', fileLevelMonikers)}'.");
+                return (error, monikers);
+            }
+            monikers.Sort(Comparer);
+            return (null, monikers);
+        }
+
+        private (Error error, List<string> monikers) GetFileLevelMonikersCore(Document file)
+        {
+            var errors = new List<Error>();
+            var (_, metadata) = _metadataProvider.GetMetadata(file);
+
             string configMonikerRange = null;
-            var configMonikers = new List<Moniker>();
+            var configMonikers = new List<string>();
+
             foreach (var (glob, (monikerRange, monikers)) in _rules)
             {
                 if (glob(file.FilePath))
@@ -60,56 +85,29 @@ namespace Microsoft.Docs.Build
                 }
             }
 
-            if (!string.IsNullOrEmpty(fileMonikerRange))
+            if (!string.IsNullOrEmpty(metadata.MonikerRange))
             {
                 // Moniker range not defined in docfx.yml/docfx.json,
                 // user should not define it in file metadata
                 if (configMonikers.Count == 0)
                 {
-                    error = Errors.MonikerConfigMissing();
-                    return (error, configMonikers);
+                    return (Errors.MonikerConfigMissing(), configMonikers);
                 }
 
-                var fileMonikers = _rangeParser.ParseWithInfo(fileMonikerRange);
+                var fileMonikers = _rangeParser.Parse(metadata.MonikerRange);
                 var intersection = configMonikers.Intersect(fileMonikers).ToList();
 
                 // With non-empty config monikers,
                 // warn if no intersection of config monikers and file monikers
                 if (intersection.Count == 0)
                 {
-                    error = Errors.EmptyMonikers($"No moniker intersection between docfx.yml/docfx.json and file metadata. Config moniker range '{configMonikerRange}' is '{string.Join(',', configMonikers.Select(x => x.MonikerName))}', while file moniker range '{fileMonikerRange}' is '{string.Join(',', fileMonikers.Select(x => x.MonikerName))}'");
+                    var error = Errors.EmptyMonikers($"No moniker intersection between docfx.yml/docfx.json and file metadata. Config moniker range '{configMonikerRange}' is '{string.Join(',', configMonikers)}', while file moniker range '{metadata.MonikerRange}' is '{string.Join(',', fileMonikers)}'");
+                    return (error, intersection);
                 }
-                return (error, intersection);
+                return (null, intersection);
             }
 
-            return (error, configMonikers);
-        }
-
-        public (Error, List<string>) GetFileLevelMonikers(Document file, SourceInfo<string> fileMonikerRange = null)
-        {
-            var (error, monikers) = GetFileLevelMonikersWithInfo(file, fileMonikerRange);
-            return (error, monikers.Select(x => x.MonikerName).ToList());
-        }
-
-        public List<string> GetZoneMonikers(SourceInfo<string> rangeString, List<string> fileLevelMonikers, List<Error> errors)
-        {
-            // Moniker range not defined in docfx.yml/docfx.json,
-            // User should not define it in moniker zone
-            if (fileLevelMonikers.Count == 0)
-            {
-                errors.Add(Errors.MonikerConfigMissing());
-                return new List<string>();
-            }
-
-            var zoneLevelMonikers = _rangeParser.Parse(rangeString);
-            var monikers = fileLevelMonikers.Intersect(zoneLevelMonikers, StringComparer.OrdinalIgnoreCase).ToList();
-
-            if (monikers.Count == 0)
-            {
-                errors.Add(Errors.EmptyMonikers($"No intersection between zone and file level monikers. The result of zone level range string '{rangeString}' is '{string.Join(',', zoneLevelMonikers)}', while file level monikers is '{string.Join(',', fileLevelMonikers)}'."));
-            }
-            monikers.Sort(Comparer);
-            return monikers;
+            return (null, configMonikers);
         }
     }
 }

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -216,6 +216,7 @@ namespace Microsoft.Docs.Build
                 pageModel.Content = content;
             }
 
+            pageModel.Title = pageModel.Title ?? obj?.Value<string>("title");
             pageModel.RawTitle = file.Docset.Legacy ? $"<h1>{obj?.Value<string>("title")}</h1>" : null;
 
             return (errors, file.Schema, pageModel);

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -36,6 +36,10 @@ namespace Microsoft.Docs.Build
             model.EnableLocSxs = file.Docset.Config.Localization.Bilingual;
             model.SiteName = file.Docset.Config.SiteName;
 
+            var (monikerError, monikers) = context.MonikerProvider.GetFileLevelMonikers(file);
+            errors.AddIfNotNull(monikerError);
+            model.Monikers = monikers;
+
             (model.DocumentId, model.DocumentVersionIndependentId) = file.Docset.Redirections.TryGetDocumentId(file, out var docId) ? docId : file.Id;
             (model.ContentGitUrl, model.OriginalContentGitUrl, model.OriginalContentGitUrlTemplate, model.Gitcommit) = context.ContributionProvider.GetGitUrls(file);
 
@@ -118,22 +122,12 @@ namespace Microsoft.Docs.Build
             var content = file.ReadText();
             GitUtility.CheckMergeConflictMarker(content, file.FilePath);
 
-            var (yamlHeaderErrors, yamlHeader) = ExtractYamlHeader.Extract(file, context);
-            errors.AddRange(yamlHeaderErrors);
-
-            var (metaErrors, pageModel) = context.MetadataProvider.GetInputMetadata<OutputModel>(file, yamlHeader);
-            errors.AddRange(metaErrors);
-
-            var (error, monikers) = context.MonikerProvider.GetFileLevelMonikers(file, pageModel.MonikerRange);
-            errors.AddIfNotNull(error);
-
-            // TODO: handle blank page
             var (markupErrors, html) = MarkdownUtility.ToHtml(
                 content,
                 file,
                 context.DependencyResolver,
                 buildChild,
-                rangeString => context.MonikerProvider.GetZoneMonikers(rangeString, monikers, errors),
+                context.MonikerProvider,
                 key => context.Template?.GetToken(key),
                 MarkdownPipelineType.Markdown);
             errors.AddRange(markupErrors);
@@ -147,11 +141,13 @@ namespace Microsoft.Docs.Build
                 errors.Add(Errors.HeadingNotFound(file));
             }
 
+            var (metadataErrors, pageModel) = context.MetadataProvider.GetMetadata(file);
+            errors.AddRange(metadataErrors);
+
             pageModel.Conceptual = HtmlUtility.HtmlPostProcess(htmlDom, file.Docset.Culture);
-            pageModel.Title = yamlHeader.Value<string>("title") ?? title;
+            pageModel.Title = pageModel.Title ?? title;
             pageModel.RawTitle = rawTitle;
             pageModel.WordCount = wordCount;
-            pageModel.Monikers = monikers;
 
             context.BookmarkValidator.AddBookmarks(file, bookmarks);
 
@@ -200,21 +196,15 @@ namespace Microsoft.Docs.Build
             // TODO: remove schema validation in ToObject
             var (_, content) = JsonUtility.ToObject(transformedToken, file.Schema.Type);
 
-            // TODO: add check before to avoid case failure
-            var yamlHeader = obj?.Value<JObject>("metadata") ?? new JObject();
+            var (metaErrors, pageModel) = context.MetadataProvider.GetMetadata(file);
+            errors.AddRange(metaErrors);
+
             if (file.Docset.Legacy && file.Schema.Type == typeof(LandingData))
             {
                 // merge extension data to metadata in legacy model
                 var landingData = (LandingData)content;
-                var mergedMetadata = new JObject();
-                JsonUtility.Merge(mergedMetadata, landingData.ExtensionData);
-                JsonUtility.Merge(mergedMetadata, yamlHeader);
-                yamlHeader = mergedMetadata;
+                JsonUtility.Merge(pageModel.ExtensionData, landingData.ExtensionData);
             }
-            var title = yamlHeader.Value<string>("title") ?? obj?.Value<string>("title");
-
-            var (metaErrors, pageModel) = context.MetadataProvider.GetInputMetadata<OutputModel>(file, yamlHeader);
-            errors.AddRange(metaErrors);
 
             if (file.Docset.Legacy && file.Schema.Attribute is PageSchemaAttribute)
             {
@@ -226,9 +216,7 @@ namespace Microsoft.Docs.Build
                 pageModel.Content = content;
             }
 
-            pageModel.Title = title;
             pageModel.RawTitle = file.Docset.Legacy ? $"<h1>{obj?.Value<string>("title")}</h1>" : null;
-            pageModel.Monikers = new List<string>();
 
             return (errors, file.Schema, pageModel);
         }

--- a/src/docfx/build/redirection/BuildRedirection.cs
+++ b/src/docfx/build/redirection/BuildRedirection.cs
@@ -12,7 +12,9 @@ namespace Microsoft.Docs.Build
         {
             Debug.Assert(file.ContentType == ContentType.Redirection);
 
-            var (errors, monikers) = context.MonikerProvider.GetFileLevelMonikers(file, context.MetadataProvider);
+            var errors = new List<Error>();
+            var (monikerError, monikers) = context.MonikerProvider.GetFileLevelMonikers(file);
+            errors.AddIfNotNull(monikerError);
 
             var publishItem = new PublishItem
             {

--- a/src/docfx/build/resource/BuildResource.cs
+++ b/src/docfx/build/resource/BuildResource.cs
@@ -13,7 +13,10 @@ namespace Microsoft.Docs.Build
         {
             Debug.Assert(file.ContentType == ContentType.Resource);
 
-            var (errors, monikers) = context.MonikerProvider.GetFileLevelMonikers(file, context.MetadataProvider);
+            var errors = new List<Error>();
+            var (monikerError, monikers) = context.MonikerProvider.GetFileLevelMonikers(file);
+            errors.AddIfNotNull(monikerError);
+
             var outputPath = file.GetOutputPath(monikers, file.Docset.SiteBasePath);
 
             // Output path is source file path relative to output folder when copy resource is disabled

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Docs.Build
             }
 
             // resolve monikers
-            var (monikerError, fileMonikers) = context.MonikerProvider.GetFileLevelMonikers(file, model.Metadata.MonikerRange);
+            var (monikerError, fileMonikers) = context.MonikerProvider.GetFileLevelMonikers(file);
             errors.AddIfNotNull(monikerError);
 
             model.Metadata.Monikers = fileMonikers;

--- a/src/docfx/build/toc/parser/MarkdownTocMarkup.cs
+++ b/src/docfx/build/toc/parser/MarkdownTocMarkup.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Text;
 using Markdig.Extensions.Yaml;
@@ -15,7 +16,7 @@ namespace Microsoft.Docs.Build
 {
     internal static class MarkdownTocMarkup
     {
-        public static (List<Error> errors, TableOfContentsModel model) LoadMdTocModel(string tocContent, Document file, Context context)
+        public static (List<Error> errors, TableOfContentsModel model) LoadMdTocModel(string tocContent, Document file)
         {
             var errors = new List<Error>();
             var headingBlocks = new List<HeadingBlock>();
@@ -38,7 +39,7 @@ namespace Microsoft.Docs.Build
                 }
             }
 
-            var (metaErrors, metadata) = ExtractYamlHeader.Extract(file, context);
+            var (metaErrors, metadata) = ExtractYamlHeader.Extract(new StringReader(tocContent), file.FilePath);
             errors.AddRange(metaErrors);
 
             var (validationErrors, tocMetadata) = JsonUtility.ToObject<TableOfContentsMetadata>(metadata);

--- a/src/docfx/build/toc/parser/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsParser.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Docs.Build
             {
                 content = content ?? file.ReadText();
                 GitUtility.CheckMergeConflictMarker(content, file.FilePath);
-                return MarkdownTocMarkup.LoadMdTocModel(content, file, context);
+                return MarkdownTocMarkup.LoadMdTocModel(content, file);
             }
 
             throw new NotSupportedException($"{filePath} is an unknown TOC file");

--- a/src/docfx/build/xref/ExternalXRefSpec.cs
+++ b/src/docfx/build/xref/ExternalXRefSpec.cs
@@ -15,10 +15,8 @@ namespace Microsoft.Docs.Build
 
         Document IXrefSpec.DeclairingFile => null;
 
-        // TODO: need a lookup table of moniker definition to get Moniker from moniker name
-        // not into output for now
         [JsonIgnore]
-        public HashSet<Moniker> Monikers { get; set; } = new HashSet<Moniker>();
+        public HashSet<string> Monikers { get; set; } = new HashSet<string>();
 
         [JsonExtensionData]
         public JObject ExtensionData { get; } = new JObject();

--- a/src/docfx/build/xref/IXrefSpec.cs
+++ b/src/docfx/build/xref/IXrefSpec.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Docs.Build
 
         Document DeclairingFile { get; }
 
-        HashSet<Moniker> Monikers { get; }
+        HashSet<string> Monikers { get; }
 
         string GetXrefPropertyValue(string propertyName);
     }

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Docs.Build
 
         public Document DeclairingFile { get; set; }
 
-        public HashSet<Moniker> Monikers { get; set; } = new HashSet<Moniker>();
+        public HashSet<string> Monikers { get; set; } = new HashSet<string>();
 
         public Dictionary<string, Lazy<JValue>> ExtensionData { get; } = new Dictionary<string, Lazy<JValue>>();
 

--- a/src/docfx/build/xref/XrefMap.cs
+++ b/src/docfx/build/xref/XrefMap.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Docs.Build
             {
                 foreach (var spec in validSpecs)
                 {
-                    if (spec.Monikers.Select(x => x.MonikerName).Contains(moniker))
+                    if (spec.Monikers.Contains(moniker))
                     {
                         return spec;
                     }
@@ -161,7 +161,7 @@ namespace Microsoft.Docs.Build
 
         private IXrefSpec GetLatestInternalXrefMap(List<IXrefSpec> specs)
             => specs.SingleOrDefault(x => x.Monikers?.Any() != true)
-               ?? specs.Where(x => x.Monikers?.Any() != false).OrderByDescending(item => item.Monikers.FirstOrDefault().MonikerName, _context.MonikerProvider.Comparer).FirstOrDefault();
+               ?? specs.Where(x => x.Monikers?.Any() != false).OrderByDescending(item => item.Monikers.FirstOrDefault(), _context.MonikerProvider.Comparer).FirstOrDefault();
 
         private bool TryGetValidXrefSpecs(string uid, List<IXrefSpec> specsWithSameUid, out List<IXrefSpec> validSpecs)
         {
@@ -191,7 +191,7 @@ namespace Microsoft.Docs.Build
             var conflictsWithMoniker = specsWithSameUid.Where(x => x.Monikers.Count > 0);
             if (CheckOverlappingMonikers(specsWithSameUid, out var overlappingMonikers))
             {
-                _context.ErrorLog.Write(Errors.MonikerOverlapping(overlappingMonikers.Select(x => x.MonikerName).ToList()));
+                _context.ErrorLog.Write(Errors.MonikerOverlapping(overlappingMonikers));
                 return false;
             }
 
@@ -203,11 +203,11 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private bool CheckOverlappingMonikers(IEnumerable<IXrefSpec> specsWithSameUid, out HashSet<Moniker> overlappingMonikers)
+        private bool CheckOverlappingMonikers(IEnumerable<IXrefSpec> specsWithSameUid, out HashSet<string> overlappingMonikers)
         {
             bool isOverlapping = false;
-            overlappingMonikers = new HashSet<Moniker>();
-            var monikerHashSet = new HashSet<Moniker>();
+            overlappingMonikers = new HashSet<string>();
+            var monikerHashSet = new HashSet<string>();
             foreach (var spec in specsWithSameUid)
             {
                 foreach (var moniker in spec.Monikers)

--- a/src/docfx/build/xref/XrefMapBuilder.cs
+++ b/src/docfx/build/xref/XrefMapBuilder.cs
@@ -180,10 +180,7 @@ namespace Microsoft.Docs.Build
                 var callStack = new List<Document> { file };
                 if (file.FilePath.EndsWith(".md", PathUtility.PathComparison))
                 {
-                    var (yamlHeaderErrors, yamlHeader) = ExtractYamlHeader.Extract(file, context);
-                    errors.AddRange(yamlHeaderErrors);
-
-                    var (fileMetaErrors, fileMetadata) = context.MetadataProvider.GetInputMetadata<InputMetadata>(file, yamlHeader);
+                    var (fileMetaErrors, fileMetadata) = context.MetadataProvider.GetMetadata(file);
                     errors.AddRange(fileMetaErrors);
 
                     if (!string.IsNullOrEmpty(fileMetadata.Uid))
@@ -238,7 +235,7 @@ namespace Microsoft.Docs.Build
             };
             xref.ExtensionData["name"] = new Lazy<JValue>(() => new JValue(string.IsNullOrEmpty(metadata.Title) ? metadata.Uid : metadata.Title));
 
-            var (error, monikers) = context.MonikerProvider.GetFileLevelMonikersWithInfo(file, metadata.MonikerRange);
+            var (error, monikers) = context.MonikerProvider.GetFileLevelMonikers(file);
             foreach (var moniker in monikers)
             {
                 xref.Monikers.Add(moniker);

--- a/src/docfx/lib/markdown/ExtractYamlHeader.cs
+++ b/src/docfx/lib/markdown/ExtractYamlHeader.cs
@@ -47,8 +47,5 @@ namespace Microsoft.Docs.Build
             }
             return (errors, new JObject());
         }
-
-        public static (List<Error> errors, JObject metadata) Extract(Document file, Context context)
-            => context.Cache.ExtractMetadata(file);
     }
 }

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Docs.Build
                         file,
                         dependencyResolver,
                         buildChild,
-                        null,
+                        context.MonikerProvider,
                         key => context.Template?.GetToken(key),
                         MarkdownPipelineType.Markdown);
 
@@ -112,7 +112,7 @@ namespace Microsoft.Docs.Build
                         file,
                         dependencyResolver,
                         buildChild,
-                        null,
+                        context.MonikerProvider,
                         key => context.Template?.GetToken(key),
                         MarkdownPipelineType.InlineMarkdown);
 


### PR DESCRIPTION
#4702, #4605 , https://ceapex.visualstudio.com/Engineering/_workitems/edit/96568/

- Cache metadata in `MetadataProvider`.
- Simplify `MonikerProvider` interface to only expose one `GetFileLevelMonikers` method, cache monikers internally.
- Fix places where `Markup` is called without passing `MonikerProvider`