### PR TITLE
Remove error level info

### DIFF
--- a/docs/specs/config.yml
+++ b/docs/specs/config.yml
@@ -311,7 +311,7 @@ outputs:
   .errors.log: |
     ["error","redirection-conflict","The 'docs/a.md' appears twice or more in the redirection mappings","docfx.yml",4,14]
 ---
-# Redirection file out of build scope
+# Redirection file is independent of build scope
 inputs:
   docfx.yml: |
     exclude: '*'
@@ -319,20 +319,13 @@ inputs:
       docs/a.md: /absolute/path1
       b.md: /absolute/path2
 outputs:
-  .errors.log: |
-    ["info","redirection-out-of-scope","Redirection file 'b.md' will not be built because it is not included in build scope","docfx.yml",4,9]
----
-# Redirection file out of build scope with conflicted id
-inputs:
-  docfx.yml: |
-    exclude: '*'
-    redirections:
-      a.md: /absolute/path1
-      b.md: /absolute/path1
-outputs:
-  .errors.log: |
-    ["info","redirection-out-of-scope","Redirection file 'a.md' will not be built because it is not included in build scope","docfx.yml",3,9]
-    ["info","redirection-out-of-scope","Redirection file 'b.md' will not be built because it is not included in build scope","docfx.yml",4,9]
+  .publish.json: |
+    {
+      "files": [
+        { "url": "/b", "redirect_url": "/absolute/path2" },
+        { "url": "/docs/a", "redirect_url": "/absolute/path1" }
+      ]
+    }
 ---
 # Multiple redirection errors
 inputs:

--- a/docs/specs/escape.yml
+++ b/docs/specs/escape.yml
@@ -139,5 +139,3 @@ outputs:
             Link to @a&amp;c
           </p>
         "}
-  .errors.log: |
-    ["info","at-xref-not-found","Cross reference not found: '@a&c'","html-xref.md",5,10]

--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -694,8 +694,6 @@ repos:
         docs/b.md: |
           link to @c
 outputs:
-  .errors.log: |
-    ["info","at-xref-not-found","Cross reference not found: '@c'","docs/b.md",1,10]
   docs/a.json:
   docs/b.json:
 ---
@@ -717,8 +715,6 @@ inputs:
     ---
   localization/zh-cn/docs/b.md: link to @c
 outputs:
-  .errors.log: |
-    ["info","at-xref-not-found","Cross reference not found: '@c'","docs/b.md",1,10]
   docs/a.json:
   docs/b.json:
 ---

--- a/docs/specs/manifest.yml
+++ b/docs/specs/manifest.yml
@@ -242,14 +242,14 @@ outputs:
 inputs:
   docfx.yml: |
     rules:
-      link-is-empty: error
+      file-not-found: error
   docs/a.md: |
-    a []()
+    a [](b)
 outputs:
   .publish.json: |
     { "!files": null }
   .errors.log: |
-    ["error","link-is-empty","Link is empty","docs/a.md",1,3]
+    ["error","file-not-found","Invalid file link: 'b'.","docs/a.md",1,3]
 ---
 # inclusion chain
 inputs:

--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -34,9 +34,7 @@ outputs:
 ---
 # extract rawTitle from h1 to h3
 inputs:
-  docfx.yml: |
-    rules:
-      heading-not-found: info
+  docfx.yml:
   h1.md: |
     # h1 title
   h2.md: |
@@ -67,14 +65,10 @@ outputs:
       "rawTitle": "",
       "conceptual": "<h4 id=\"h4-title\">h4 title</h4>",
     }
-  .errors.log: |
-    ["info","heading-not-found","The first visible block is not a heading block with `#`, `##` or `###`","h4.md"]
 ---
 # remove title from html
 inputs:
-  docfx.yml: |
-    rules:
-      heading-not-found: info
+  docfx.yml:
   h1ToRemove.md: |
     # h1 title
   h1ToKeep.md: |
@@ -94,9 +88,7 @@ outputs:
 ---
 # No H1
 inputs:
-  docfx.yml: |
-    rules:
-      heading-not-found: info
+  docfx.yml:
   docs/a.md: |
     ---
     title: Title from yaml header
@@ -105,14 +97,10 @@ inputs:
     hello
 outputs:
   docs/a.json:
-  .errors.log: |
-    ["info","heading-not-found","The first visible block is not a heading block with `#`, `##` or `###`","docs/a.md"]
 ---
 # Non-comments block between yaml-header and H1
 inputs:
-  docfx.yml: |
-    rules:
-      heading-not-found: info
+  docfx.yml:
   docs/a.md: |
     ---
     title: Title from yaml header
@@ -126,9 +114,7 @@ outputs:
 ---
 # Include block before h1
 inputs:
-  docfx.yml: |
-    rules:
-      heading-not-found: info
+  docfx.yml:
   docs/a.md: |
     [!include[]()]
     # Heading
@@ -187,8 +173,6 @@ outputs:
 inputs:
   docfx.yml: |
     files: docs/a.md
-    rules:
-      heading-not-found: info
   docs/a.md: |
     [!INCLUDE[B](b.md)]
     [!INCLUDE[C](c.md)]
@@ -209,8 +193,6 @@ outputs:
 inputs:
   docfx.yml: |
     files: docs/a.md
-    rules:
-      heading-not-found: info
   docs/a.md: |
     [!INCLUDE[B](b.md)]
     [!INCLUDE[C](c.md)]

--- a/docs/specs/metadata.yml
+++ b/docs/specs/metadata.yml
@@ -122,27 +122,6 @@ outputs:
   sccm/mdm/understand/hybrid-mobile-device-management.json: |
     { "document_id": "1c42a151-6248-df0c-15e6-3b1158d7bee3", "document_version_independent_id": "beb14a44-b076-14b8-b9c5-b42f9e36b973" }
 ---
-# generate different document id and version id with 'redirection with document id' when it's out of build scope
-# A => B, A is out of build scope, B's ids should be different with A's
-inputs:
-  docfx.yml: |
-    documentId:
-      sourceBasePath: sccm
-    name: sccm
-    product: Win
-    files: "sccm/mdm/understand/hybrid-mobile-device-management.md"
-    baseUrl: https://docs.com/sccm
-    redirections:
-      sccm/mdm/index.md: /sccm/mdm/understand/hybrid-mobile-device-management
-    routes:
-      sccm/: .
-  sccm/mdm/understand/hybrid-mobile-device-management.md:
-outputs:
-  sccm/mdm/understand/hybrid-mobile-device-management.json: |
-    { "document_id": "7412621b-4920-dc7e-bed6-1f1ea774f7dd", "document_version_independent_id": "de5d1641-2c0e-1158-7611-e52a22d96a5e" }
-  .errors.log: |
-    ["info","redirection-out-of-scope","Redirection file 'sccm/mdm/index.md' will not be built because it is not included in build scope","docfx.yml",8,22]
----
 # generate different document id and version id with 'redirection without document id'
 inputs:
   docfx.yml: |

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -552,7 +552,6 @@ outputs:
     {"conceptual":"<p>Link to @a</p>"}
   .errors.log: |
     ["error","moniker-overlapping","Two or more documents have defined overlapping moniker: 'netcore-2.0'"]
-    ["info","at-xref-not-found","Cross reference not found: '@a'","docs/c.md",1,10]
     ["error","publish-url-conflict","Two or more files of the same version('netcore-2.0') publish to the same url '/docs/a': 'docs/v1/a.md', 'docs/v2/a.md'"]
   xrefmap.json: | 
     {"!references":null}
@@ -610,8 +609,6 @@ outputs:
     }
   xrefmap.json: | 
     {"references":[{"uid":"a","href":"https://docs.com/docs/a","name":"netcore-2.0"}]}
-  .errors.log: |
-    ["info","invalid-uid-moniker","Moniker 'netcore-1.0' is not defined with uid 'a'","docs/b.md",1,7]
 ---
 # [skip] Define same uid with and without moniker range
 # while refer to it without moniker range, should pick the one without moniker range
@@ -752,7 +749,6 @@ outputs:
     {"!references":null}
   .errors.log: |
     ["error","uid-conflict","UID 'a' is defined in more than one file: 'docs/a.md', 'docs/b.md'"]
-    ["info","at-xref-not-found","Cross reference not found: '@a'","docs/c.md",1,10]
 ---
 # Build toc with monikers info
 inputs:

--- a/docs/specs/resolve.yml
+++ b/docs/specs/resolve.yml
@@ -149,7 +149,6 @@ outputs:
   docs/a.json: |
     { "conceptual": "<p><a href=\"\">Empty</a><a href=\"a%3C%3Eb.md\">Invalid</a><a href=\"c.md\">Missing</a></p>" }
   .errors.log: |
-    ["info","link-is-empty","Link is empty","docs/a.md",1,1]
     ["warning","file-not-found","Invalid file link: 'a<>b.md'.","docs/a.md",1,11]
     ["warning","file-not-found","Invalid file link: 'c.md'.","b.md",1,1]
 ---

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -9,15 +9,13 @@ outputs:
   .errors.log: |
     ["warning","xref-not-found","Cross reference not found: '<xref:a>'","docs/a.md",1,9]
 ---
-# Unknown xrefs using @ syntax are output as is with a informational message
+# Unknown xrefs using @ syntax are not included in error log
 inputs:
   docfx.yml:
   docs/a.md: Link to @a
 outputs:
   docs/a.json: |
     { "conceptual": "<p>Link to @a</p>" }
-  .errors.log: |
-    ["info","at-xref-not-found","Cross reference not found: '@a'","docs/a.md",1,10]
 ---
 # Restore xref map from configured url and use the map for resolving
 # hostname should be removed if docset sharing the same one
@@ -177,7 +175,6 @@ outputs:
     {"conceptual":"<p>Link to @a</p>\n"}
   .errors.log: |
     ["error","uid-conflict","UID 'a' is defined in more than one file: 'docs/a.yml', 'docs/b.json'"]
-    ["info","at-xref-not-found","Cross reference not found: '@a'","docs/c.md",1,10]
   xrefmap.json: | 
     {"!references":null}
 ---
@@ -697,9 +694,4 @@ outputs:
     {"conceptual" : "<p>str <a href='c'>Title from yaml header c</a>\nstr @mention\nsome text\nstr @higher\nmultiple xref @mentione some text @mentionf</p>\n<p>\n  @mentione\n  some text\n  mentionf\n</p>\n"}
   docs/c.json:
   .errors.log: |
-    ["info","at-xref-not-found","Cross reference not found: '<xref href=\"d\" data-raw-source=\"@mention\">'","docs/a.md",2,12]
-    ["info","at-xref-not-found","Cross reference not found: '<xref href=\"d\" data-raw-html=\"@higher\" data-raw-source=\"@mention\">'","docs/a.md",4,12]
-    ["info","at-xref-not-found","Cross reference not found: '<xref href=\"e\" data-raw-source=\"@mentione\">'","docs/a.md",5,12]
-    ["info","at-xref-not-found","Cross reference not found: '<xref href=\"f\" data-raw-source=\"@mentionf\">'","docs/a.md",5,12]
-    ["info","at-xref-not-found","Cross reference not found: '<p>\n  <xref href=\"e\" data-raw-source=\"@mentione\" />\n  some text\n  <xref href=\"f\" data-raw-source=\"mentionf\" />\n</p>'","docs/a.md",6,18]
     ["warning","xref-not-found","Cross reference not found: '<p>\n  <xref href=\"e\" data-raw-source=\"@mentione\" />\n  some text\n  <xref href=\"f\" data-raw-source=\"mentionf\" />\n</p>'","docs/a.md",6,78]

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -220,27 +220,11 @@ namespace Microsoft.Docs.Build
             => new Error(ErrorLevel.Error, "json-syntax-error", message, source);
 
         /// <summary>
-        /// Used empty link in article.md.
-        /// Examples:
-        ///   - [link]()
-        /// </summary>
-        /// Behavior: ✔️ Message: ❌
-        public static Error LinkIsEmpty(Document relativeTo)
-            => new Error(ErrorLevel.Off, "link-is-empty", "Link is empty", relativeTo.ToString());
-
-        /// <summary>
         /// Link which's resolved to a file out of build scope.
         /// </summary>
         /// Behavior: ✔️ Message: ❌
         public static Error LinkOutOfScope(SourceInfo<string> source, Document file)
             => new Error(ErrorLevel.Warning, "link-out-of-scope", $"File '{file}' referenced by link '{source}' will not be built because it is not included in build scope", source);
-
-        /// <summary>
-        /// Defined a redirection entry that's not matched by config's files glob patterns.
-        /// </summary>
-        /// Behavior: ✔️ Message: ❌
-        public static Error RedirectionOutOfScope(SourceInfo source, string redirection)
-            => new Error(ErrorLevel.Off, "redirection-out-of-scope", $"Redirection file '{redirection}' will not be built because it is not included in build scope", source);
 
         /// <summary>
         /// Link which's resolved to a file in dependency repo won't be built.
@@ -533,15 +517,6 @@ namespace Microsoft.Docs.Build
         /// Behavior: ✔️ Message: ❌
         public static Error EmptyMonikers(string message)
             => new Error(ErrorLevel.Warning, "empty-monikers", message);
-
-        /// <summary>
-        /// Referenced an article using uid with invalid moniker(?view=).
-        /// Examples:
-        ///   - article with uid `a` has only netcore-1.0 & netcore-1.1 version, but get referenced with @a?view=netcore-2.0
-        /// </summary>
-        /// Behavior: ✔️ Message: ❌
-        public static Error InvalidUidMoniker(SourceInfo source, string moniker, string uid)
-            => new Error(ErrorLevel.Off, "invalid-uid-moniker", $"Moniker '{moniker}' is not defined with uid '{uid}'", source);
 
         /// <summary>
         /// Custom 404 page is not supported

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Docs.Build
         /// </summary>
         /// Behavior: ✔️ Message: ❌
         public static Error LinkIsEmpty(Document relativeTo)
-            => new Error(ErrorLevel.Info, "link-is-empty", "Link is empty", relativeTo.ToString());
+            => new Error(ErrorLevel.Off, "link-is-empty", "Link is empty", relativeTo.ToString());
 
         /// <summary>
         /// Link which's resolved to a file out of build scope.
@@ -240,7 +240,7 @@ namespace Microsoft.Docs.Build
         /// </summary>
         /// Behavior: ✔️ Message: ❌
         public static Error RedirectionOutOfScope(SourceInfo source, string redirection)
-            => new Error(ErrorLevel.Info, "redirection-out-of-scope", $"Redirection file '{redirection}' will not be built because it is not included in build scope", source);
+            => new Error(ErrorLevel.Off, "redirection-out-of-scope", $"Redirection file '{redirection}' will not be built because it is not included in build scope", source);
 
         /// <summary>
         /// Link which's resolved to a file in dependency repo won't be built.
@@ -259,11 +259,11 @@ namespace Microsoft.Docs.Build
             => new Error(ErrorLevel.Warning, "local-file-path", $"Link '{path}' points to a local file. Use a relative path instead", relativeTo.ToString());
 
         /// <summary>
-        /// The fisrt tag in an article.md isn't h1 tag.
+        /// The first tag in an article.md isn't h1 tag.
         /// </summary>
         /// Behavior: ✔️ Message: ❌
         public static Error HeadingNotFound(Document file)
-            => new Error(ErrorLevel.Info, "heading-not-found", $"The first visible block is not a heading block with `#`, `##` or `###`", file.ToString());
+            => new Error(ErrorLevel.Off, "heading-not-found", $"The first visible block is not a heading block with `#`, `##` or `###`", file.ToString());
 
         /// <summary>
         /// Can't find a file referenced by configuration, or user writes a non-existing link.
@@ -295,7 +295,7 @@ namespace Microsoft.Docs.Build
         /// </summary>
         /// Behavior: ❌ Message: ✔️
         public static Error AtXrefNotFound(SourceInfo<string> source)
-            => new Error(ErrorLevel.Info, "at-xref-not-found", $"Cross reference not found: '{source}'", source);
+            => new Error(ErrorLevel.Off, "at-xref-not-found", $"Cross reference not found: '{source}'", source);
 
         /// <summary>
         /// Failed to resolve uid defined by [link](xref:uid) or <xref:uid> syntax.
@@ -541,7 +541,7 @@ namespace Microsoft.Docs.Build
         /// </summary>
         /// Behavior: ✔️ Message: ❌
         public static Error InvalidUidMoniker(SourceInfo source, string moniker, string uid)
-            => new Error(ErrorLevel.Info, "invalid-uid-moniker", $"Moniker '{moniker}' is not defined with uid '{uid}'", source);
+            => new Error(ErrorLevel.Off, "invalid-uid-moniker", $"Moniker '{moniker}' is not defined with uid '{uid}'", source);
 
         /// <summary>
         /// Custom 404 page is not supported

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Docs.Build
         {
             if (string.IsNullOrEmpty(href))
             {
-                return (Errors.LinkIsEmpty(relativeTo), null, null, null, null, null);
+                return default;
             }
 
             var (path, query, fragment) = UrlUtility.SplitUrl(href);

--- a/src/docfx/build/redirection/RedirectionMap.cs
+++ b/src/docfx/build/redirection/RedirectionMap.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Docs.Build
             return false;
         }
 
-        public static (List<Error> errors, RedirectionMap map) Create(Docset docset, Func<string, bool> glob)
+        public static (List<Error> errors, RedirectionMap map) Create(Docset docset)
         {
             var errors = new List<Error>();
             var redirections = new HashSet<Document>();
@@ -76,10 +76,6 @@ namespace Microsoft.Docs.Build
                     if (type != ContentType.Page)
                     {
                         errors.Add(Errors.RedirectionInvalid(redirectUrl, path));
-                    }
-                    else if (!glob(pathToDocset))
-                    {
-                        errors.Add(Errors.RedirectionOutOfScope(redirectUrl, pathToDocset));
                     }
                     else if (checkRedirectUrl && !redirectUrl.Value.StartsWith('/'))
                     {

--- a/src/docfx/build/xref/XrefMap.cs
+++ b/src/docfx/build/xref/XrefMap.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Docs.Build
             string resolvedHref;
             string displayPropertyValue;
             string name;
-            if (TryResolve(uid, href, moniker, out var spec))
+            if (TryResolve(uid, moniker, out var spec))
             {
                 var (_, query, fragment) = UrlUtility.SplitUrl(spec.Href);
                 resolvedHref = UrlUtility.MergeUrl(spec.DeclairingFile != null ? RebaseResolvedHref(rootFile, spec.DeclairingFile) : RemoveHostnameIfSharingTheSameOne(spec.Href), query, fragment.Length == 0 ? "" : fragment.Substring(1));
@@ -90,12 +90,12 @@ namespace Microsoft.Docs.Build
         private string RebaseResolvedHref(Document rootFile, Document referencedFile)
             => _context.DependencyResolver.GetRelativeUrl(rootFile, referencedFile);
 
-        private bool TryResolve(string uid, SourceInfo<string> href, string moniker, out IXrefSpec spec)
+        private bool TryResolve(string uid, string moniker, out IXrefSpec spec)
         {
             spec = null;
             if (_map.TryGetValue(uid, out var specs))
             {
-                spec = GetXrefSpec(uid, href, moniker, specs.Select(x => x.Value).ToList());
+                spec = GetXrefSpec(uid, moniker, specs.Select(x => x.Value).ToList());
 
                 if (spec is null)
                 {
@@ -106,7 +106,7 @@ namespace Microsoft.Docs.Build
             return false;
         }
 
-        private IXrefSpec GetXrefSpec(string uid, SourceInfo<string> href, string moniker, List<IXrefSpec> specs)
+        private IXrefSpec GetXrefSpec(string uid, string moniker, List<IXrefSpec> specs)
         {
             if (!TryGetValidXrefSpecs(uid, specs, out var validSpecs))
                 return default;
@@ -121,9 +121,6 @@ namespace Microsoft.Docs.Build
                     }
                 }
 
-                // if the moniker is not defined with the uid
-                // log a warning and take the one with latest version
-                _context.ErrorLog.Write(Errors.InvalidUidMoniker(href, moniker, uid));
                 return GetLatestInternalXrefMap(validSpecs);
             }
 

--- a/src/docfx/docset/Docset.cs
+++ b/src/docfx/docset/Docset.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Docs.Build
             _buildScope = new Lazy<HashSet<Document>>(() => CreateBuildScope(Redirections.Files, glob));
             _redirections = new Lazy<RedirectionMap>(() =>
             {
-                var (errors, map) = RedirectionMap.Create(this, glob);
+                var (errors, map) = RedirectionMap.Create(this);
                 errorLog.Write(errors);
                 return map;
             });

--- a/src/docfx/lib/log/ErrorLevel.cs
+++ b/src/docfx/lib/log/ErrorLevel.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Docs.Build
     internal enum ErrorLevel
     {
         Off,
-        Info,
         Suggestion,
         Warning,
         Error,

--- a/test/docfx.Test/docfx.test.yml
+++ b/test/docfx.Test/docfx.test.yml
@@ -1,10 +1,5 @@
 # default config for specs in docfx
 baseUrl: https://docs.com
-rules:
-  link-is-empty: info
-  redirection-out-of-scope: info
-  at-xref-not-found: info
-  invalid-uid-moniker: info
 output:
   json: true
 gitHub:

--- a/test/docfx.Test/docfx.test.yml
+++ b/test/docfx.Test/docfx.test.yml
@@ -1,9 +1,10 @@
 # default config for specs in docfx
 baseUrl: https://docs.com
 rules:
-  heading-not-found: off
-  resolve-author-failed: off
-  resolve-commit-failed: off
+  link-is-empty: info
+  redirection-out-of-scope: info
+  at-xref-not-found: info
+  invalid-uid-moniker: info
 output:
   json: true
 gitHub:

--- a/test/docfx.Test/lib/ErrorLogTest.cs
+++ b/test/docfx.Test/lib/ErrorLogTest.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Microsoft.Docs.Build
 {
-    public class ReportTest
+    public class ErrorLogTest
     {
         [Fact]
         public void DedupErrors()


### PR DESCRIPTION
Fixes https://dev.azure.com/ceapex/Engineering/_git/Docs.Build.TestData/commit/be67d9a7ac58a8c2f29918ee78422e2514372a8d?refName=refs%2Fheads%2Fmaster

azure-docs-pr test is unstable because there are too much info messages in `.errors.log`, this PR turns all info to off, so they do not appear in `.errors.log`. To keep existing tests intact, they remain info during tests.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4723)