### PR TITLE
🧹 Remove GitHub user cache remote update

### DIFF
--- a/docs/specs/config.yml
+++ b/docs/specs/config.yml
@@ -240,8 +240,7 @@ inputs:
     extend:
       - docs/a.yml
       - docs/b.yml
-    gitHub:
-      userCache: docs/d.json
+    xref: docs/d.json
   docs/a.yml:
   docs/b.yml:
   docs/d.json: '{}'
@@ -275,11 +274,11 @@ inputs:
   docfx.yml: |
     rules:
       file-not-found: off
-    gitHub:
-      userCache: user_profile.json
+    xref: xref.json
+  a.md: '@System.String'
 outputs:
   .errors.log: |
-    ["error","file-not-found","Invalid file link: 'user_profile.json'.","*",4,14]
+    ["error","file-not-found","Invalid file link: 'xref.json'.","*",3,7]
 ---
 # Treat warnings as errors
 inputs:

--- a/docs/specs/git.yml
+++ b/docs/specs/git.yml
@@ -1,47 +1,3 @@
----
-# Show git contribution info when userProfile is set to URL
-repos:
-  https://github.com/testowner/testrepo#master-url-cache:
-    - author: Charlie
-      email: charlie@contoso.com
-      files:
-        docs/index.md: |
-          ---
-          author: charlie
-          ---
-          Alice creates this. Bob updates this. Charlie becomes author.
-    - author: Bob 
-      email: bob@contoso.com
-      files:
-        docs/index.md: |
-          Alice creates this. Bob updates this.
-    - author: Alice 
-      email: alice@contoso.com
-      files:
-        docs/index.md: |
-          Alice creates this.
-inputs:
-  docfx.yml: |
-    gitHub:
-      userCache: https://raw.githubusercontent.com/docascode/docfx-test-dependencies/master/user_profile.json
-      resolveUsers: true
-outputs:
-  docs/index.json: |
-    {
-      "_op_gitContributorInformation":
-      {
-        "author":
-          { "name": "charlie", "profile_url": "https://github.com/charlie", "display_name": "Charlie", "id": "3" },
-        "contributors": [
-          { "name": "bob", "profile_url": "https://github.com/bob", "display_name": "Bob", "id": "2" },
-          { "name": "alice", "profile_url": "https://github.com/alice", "display_name": "Alice", "id": "1" }
-        ],
-        "update_at": "10/30/2018",
-        "updated_at_date_time": "2018-10-30T00:00:00"
-      },
-      "updated_at": "2018-10-30 12:00 AM"
-    }
----
 # Show git contribution info when userProfile is set to relative file path
 repos:
   https://github.com/testowner/testrepo#master-file-cache:
@@ -66,9 +22,9 @@ repos:
 inputs:
   docfx.yml: |
     gitHub:
-      userCache: user_profile.json
       resolveUsers: true
-  user_profile.json: |
+cache:
+  github-users.json: |
       { "users": [
           {"name": "Alice", "login": "alice", "id": 1, "emails": ["alice@contoso.com"]},
           {"name": "Bob", "login": "bob", "id": 2, "emails": ["bob@contoso.com"]},
@@ -99,9 +55,9 @@ inputs:
     # git-test
   docfx.yml: |
     gitHub:
-      userCache: user_profile.json
       resolveUsers: true
-  user_profile.json: |
+cache:
+  github-users.json: |
     {
       "users": [
         {"login": "invalid_user"},
@@ -131,9 +87,9 @@ repos:
 inputs:
   docfx.yml: |
     gitHub:
-      userCache: user_profile.json
       resolveUsers: true
-  user_profile.json: |
+cache:
+  github-users.json: |
       { "users": [
           {"name": "Alice", "login": "alice", "id": 1, "emails": ["alice@contoso.com"]},
           {"name": "Bob", "login": "bob", "id": 2, "emails": ["bob@contoso.com"]},
@@ -179,13 +135,13 @@ repos:
 inputs:
   docfx.yml: |
     gitHub:
-      userCache: user_profile.json
       resolveUsers: true
     contribution:
       excludedContributors:
         - AlIcE
         - BoB
-  user_profile.json: |
+cache:
+  github-users.json: |
       { "users": [
           {"name": "Alice", "login": "alice", "id": 1, "emails": ["alice@contoso.com"]},
           {"name": "Bob", "login": "bob", "id": 2, "emails": ["bob@contoso.com"]},
@@ -219,9 +175,9 @@ repos:
 inputs:
   docfx.yml: |
     gitHub:
-      userCache: user_profile.json
       resolveUsers: true
-  user_profile.json: |
+cache:
+  github-users.json: |
       { "users": [
           {"name": "Alice", "login": "alice", "id": 1, "emails": ["alice@contoso.com"]},
           {"name": "Bob", "login": "bob", "id": 2, "emails": ["bob@contoso.com"]},
@@ -261,12 +217,12 @@ repos:
 inputs:
   docfx.yml: |
     gitHub:
-      userCache: user_profile.json
       resolveUsers: true
     contribution:
       excludedContributors:
         - ChArLiE
-  user_profile.json: |
+cache:
+  github-users.json: |
       { "users": [
           {"name": "Alice", "login": "alice", "id": 1, "emails": ["alice@contoso.com"]},
           {"name": "Bob", "login": "bob", "id": 2, "emails": ["bob@contoso.com"]},
@@ -298,12 +254,12 @@ repos:
 inputs:
   docfx.yml: |
     gitHub:
-      userCache: user_profile.json
       resolveUsers: true
     contribution:
       excludedContributors:
         - alice
-  user_profile.json: |
+cache:
+  github-users.json: |
       { "users": [{"name": "Alice", "login": "alice", "id": 1, "emails": ["alice@contoso.com"]}] }
 outputs:
   docs/index.json: |
@@ -500,12 +456,12 @@ repos:
 inputs:
   docfx.yml: |
     gitHub:
-      userCache: user_profile.json
       resolveUsers: true
       authToken: {DOCS_GITHUB_TOKEN}
     contribution:
       repository: https://github.com/docascode/contribution-test
-  user_profile.json: |
+cache:
+  github-users.json: |
       { "users": [
           {"name": "Alice", "login": "alice", "id": 1, "emails": ["alice@contoso.com"]},
           {"name": "Bob", "login": "bob", "id": 2, "emails": ["bob@contoso.com"]},
@@ -554,11 +510,11 @@ repos:
 inputs:
   docfx.yml: |
     gitHub:
-      userCache: user_profile.json
       resolveUsers: true
     contribution:
       repository: https://docascode.visualstudio.com/contribution1/_git/a
-  user_profile.json: |
+cache:
+  github-users.json: |
       { "users": [
           {"name": "Alice", "login": "alice", "id": 1, "emails": ["alice@contoso.com"]},
           {"name": "Bob", "login": "bob", "id": 2, "emails": ["bob@contoso.com"]},
@@ -603,9 +559,9 @@ repos:
 inputs:
   docfx.yml: |
     gitHub:
-      userCache: user_profile.json
       resolveUsers: false
-  user_profile.json: |
+cache:
+  github-users.json: |
       { "users": [
           {"name": "Alice", "login": "alice", "id": 1, "emails": ["alice@contoso.com"]},
           {"name": "Bob", "login": "bob", "id": 2, "emails": ["bob@contoso.com"]},

--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -91,7 +91,6 @@ repos:
         redirections:
           a.md: /b
         gitHub:
-          userCache: user_profile.json
           resolveUsers: true
         baseUrl: https://docs.com/rawmetadata
       c.md: |
@@ -111,15 +110,16 @@ repos:
         documentType: LandingData
         metadata:
           document_id: abc
-      user_profile.json: |
-        { "users": [
-            {"name": "Bob", "login": "bob", "id": 2, "emails": ["bob@contoso.com"]},
-            {"name": "Charlie", "login": "charlie", "id": 3, "emails": ["charlie@contoso.com"]}
-          ]
-        }
   https://docs.com/template1:
   - files:
       readme.md:
+cache:
+  github-users.json: |
+    { "users": [
+        {"name": "Bob", "login": "bob", "id": 2, "emails": ["bob@contoso.com"]},
+        {"name": "Charlie", "login": "charlie", "id": 3, "emails": ["charlie@contoso.com"]}
+      ]
+    }
 outputs:
   rawmetadata/c.json:
   rawmetadata/d.png:

--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -166,7 +166,7 @@ outputs:
         },
         "updated_at": "2018-10-30 12:00 AM",
         "content_git_url": "https://github.com/a/rawmetadata/blob/master/c.md",
-        "gitcommit": "https://github.com/a/rawmetadata/blob/a4d4512285a54b1db9a73e567493315da3273a5f/c.md",
+        "gitcommit": "https://github.com/a/rawmetadata/blob/5cb844f400525147e40455b6f1adf54646de2693/c.md",
         "original_content_git_url": "https://github.com/a/rawmetadata/blob/master/c.md",
         "original_content_git_url_template": "{repo}/blob/{branch}/c.md",
         "!metadata": null,

--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -88,7 +88,7 @@ outputs:
   docs/dep.json: |
     {"conceptual": "<p>loc-DEP-sxs</p>"}
 ---
-# loc docset share the source docset's restore map 1
+# [only] loc docset share the source docset's restore map 1
 # [repository mapping]
 commands:
   - restore --locale zh-cn
@@ -102,17 +102,17 @@ repos:
             child1: https://docs.com/d/restore5
         xrefmap.json: |
           {
-            "references": [{ "uid": "System.String", "name": "String" }]
+            "references": [{ "uid": "System.String", "name": "String", "href": "//docs.com" }]
           }
   https://github.com/d/restore5.zh-cn#master:
     - files:
         a.md: '@System.String'
   https://docs.com/d/restore5:
     - files:
-        docs/d.md: d
+        d.md: d
 outputs:
-  docs/a.json: |
-    { "conceptual":"<p>d</p>\n" }
+  a.json: |
+    { "conceptual":"<p><a href=\"//docs.com\">String</a></p>" }
 ---
 # loc docset share the source docset's restore map 2
 # [branch mapping] & bilingual

--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -97,70 +97,22 @@ repos:
   https://github.com/d/restore5#master:
     - files:
         docfx.yml: |
-          gitHub:
-            userCache: github-user.json
-            resolveUsers: true
+          xref: xrefmap.json
           dependencies:
             child1: https://docs.com/d/restore5
-        github-user.json: |
+        xrefmap.json: |
           {
-            "users": [
-              {
-                "name": "Osmond Jiang",
-                "login": "OsmondJiang",
-                "id": 19990166,
-                "expiry":"2099-01-01T00:00:00.00000Z",
-                "emails": [
-                  "xinjiang@microsoft.com"
-                ]
-              },
-              {
-                "name": "Renze Yu",
-                "login": "superyyrrzz",
-                "id": 3831744,
-                "expiry":"2099-01-01T00:00:00.00000Z",
-                "emails": [
-                  "renzeyu@microsoft.com",
-                  "superyyrrzz@gmail.com"
-                ]
-              },
-              {
-                "name": "Yufei Huang",
-                "login": "yufeih",
-                "id": 511355,
-                "expiry":"2099-01-01T00:00:00.00000Z",
-                "emails": [
-                  "yufeih@users.noreply.github.com",
-                  "yufeih@live.com"
-                ]
-              }
-            ]
+            "references": [{ "uid": "System.String", "name": "String" }]
           }
   https://github.com/d/restore5.zh-cn#master:
     - files:
-        docs/a.md: |
-          [!include[](~/child1/docs/d.md)]
-      author: yufeih
-      email: yufeih@live.com
-    - files:
-        docs/a.md: a
-      author: OsmondJiang
-      email: xinjiang@microsoft.com
+        a.md: '@System.String'
   https://docs.com/d/restore5:
     - files:
         docs/d.md: d
 outputs:
   docs/a.json: |
-    {
-      "conceptual":"<p>d</p>\n",
-      "_op_gitContributorInformation":
-      {
-        "author":
-          {"display_name":"Osmond Jiang","id":"19990166"},
-        "contributors":
-          [{"display_name":"Yufei Huang","id":"511355"}],
-      }
-    }
+    { "conceptual":"<p>d</p>\n" }
 ---
 # loc docset share the source docset's restore map 2
 # [branch mapping] & bilingual

--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -98,17 +98,20 @@ repos:
     - files:
         docfx.yml: |
           xref: xrefmap.json
+          dependencies:
+            child1: https://docs.com/d/restore5
         xrefmap.json: |
           { "references": [{ "uid": "System.String", "name": "String", "href": "//docs.com" }] }
   https://github.com/d/restore5.zh-cn#master:
     - files:
-        a.md: '@System.String'
+        a.md: |
+          @System.String [!include[](~/child1/d.md)]
   https://docs.com/d/restore5:
     - files:
         d.md: d
 outputs:
   a.json: |
-    { "conceptual":"<p><a href=\"//docs.com\">String</a></p>" }
+    { "conceptual":"<p><a href=\"//docs.com\">String</a> d </p>" }
 ---
 # loc docset share the source docset's restore map 2
 # [branch mapping] & bilingual
@@ -129,16 +132,17 @@ repos:
           { "references": [{ "uid": "System.String", "name": "String", "href": "//docs.com" }] }
   https://github.com/d/restore6.loc#master-sxs.zh-cn:
     - files:
-        a.md: '@System.String'
+        a.md: |
+          @System.String [!include[](~/child1/d.md)]
   https://github.com/d/restore6.loc#master.zh-cn:
     - files:
         a.md: '@System.String'
   https://docs.com/d/restore6#master:
     - files:
-        docs/d.md: d
+        d.md: d
 outputs:
   a.json: |
-    { "conceptual":"<p><a href=\"//docs.com\">String</a></p>" }
+    { "conceptual":"<p><a href=\"//docs.com\">String</a> d </p>" }
 ---
 # edit url convention without source locale 1
 # [repository mapping] 

--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -88,7 +88,7 @@ outputs:
   docs/dep.json: |
     {"conceptual": "<p>loc-DEP-sxs</p>"}
 ---
-# [only] loc docset share the source docset's restore map 1
+# loc docset share the source docset's restore map 1
 # [repository mapping]
 commands:
   - restore --locale zh-cn
@@ -101,9 +101,7 @@ repos:
           dependencies:
             child1: https://docs.com/d/restore5
         xrefmap.json: |
-          {
-            "references": [{ "uid": "System.String", "name": "String", "href": "//docs.com" }]
-          }
+          { "references": [{ "uid": "System.String", "name": "String", "href": "//docs.com" }] }
   https://github.com/d/restore5.zh-cn#master:
     - files:
         a.md: '@System.String'
@@ -126,74 +124,20 @@ repos:
           localization:
             bilingual: true
             mapping: Branch
-          gitHub:
-            userCache: github-user.json
-            resolveUsers: true
+          xref: xrefmap.json
           dependencies:
             child1: https://docs.com/d/restore6
-        github-user.json: |
-          {
-            "users": [
-              {
-                "name": "Osmond Jiang",
-                "login": "OsmondJiang",
-                "id": 19990166,
-                "expiry":"2099-01-01T00:00:00.00000Z",
-                "emails": [
-                  "xinjiang@microsoft.com"
-                ]
-              },
-              {
-                "name": "Renze Yu",
-                "login": "superyyrrzz",
-                "id": 3831744,
-                "expiry":"2099-01-01T00:00:00.00000Z",
-                "emails": [
-                  "renzeyu@microsoft.com",
-                  "superyyrrzz@gmail.com"
-                ]
-              },
-              {
-                "name": "Yufei Huang",
-                "login": "yufeih",
-                "id": 511355,
-                "expiry":"2099-01-01T00:00:00.00000Z",
-                "emails": [
-                  "yufeih@users.noreply.github.com",
-                  "yufeih@live.com"
-                ]
-              }
-            ]
-          }
+        xrefmap.json: |
+          { "references": [{ "uid": "System.String", "name": "String", "href": "//docs.com" }] }
   https://github.com/d/restore6.loc#master-sxs.zh-cn:
     - files:
-        docs/a.md: |
-          [!include[](~/child1/docs/d.md)]
+        a.md: '@System.String'
   https://github.com/d/restore6.loc#master.zh-cn:
     - files:
-        docs/a.md: |
-          [!include[](~/child1/docs/d.md)]
-      author: yufeih
-      email: yufeih@live.com
-    - files:
-        docs/a.md: a
-      author: OsmondJiang
-      email: xinjiang@microsoft.com
-  https://docs.com/d/restore6:
-    - files:
-        docs/d.md: d
+        a.md: '@System.String'
 outputs:
-  docs/a.json: |
-    {
-      "conceptual":"<p>d</p>\n",
-      "_op_gitContributorInformation":
-      {
-        "author":
-          {"display_name":"Osmond Jiang","id":"19990166"},
-        "contributors":
-          [{"display_name":"Yufei Huang","id":"511355"}],
-      }
-    }
+  a.json: |
+    { "conceptual":"<p><a href=\"//docs.com\">String</a></p>" }
 ---
 # edit url convention without source locale 1
 # [repository mapping] 

--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -98,8 +98,6 @@ repos:
     - files:
         docfx.yml: |
           xref: xrefmap.json
-          dependencies:
-            child1: https://docs.com/d/restore5
         xrefmap.json: |
           { "references": [{ "uid": "System.String", "name": "String", "href": "//docs.com" }] }
   https://github.com/d/restore5.zh-cn#master:
@@ -135,6 +133,9 @@ repos:
   https://github.com/d/restore6.loc#master.zh-cn:
     - files:
         a.md: '@System.String'
+  https://docs.com/d/restore6#master:
+    - files:
+        docs/d.md: d
 outputs:
   a.json: |
     { "conceptual":"<p><a href=\"//docs.com\">String</a></p>" }
@@ -823,13 +824,6 @@ repos:
           gitHub:
             userCache: github-user.json
             resolveUsers: true
-        github-user.json: |
-          { "users": [
-              {"name": "Alice", "login": "alice", "id": 1, "emails": ["alice@contoso.com"]},
-              {"name": "Bob", "login": "bob", "id": 2, "emails": ["bob@contoso.com"]},
-              {"name": "Terry", "login": "terry", "id": 3, "emails": ["terry@contoso.com"]},
-            ]
-          }
   https://github.com/ss/b.loc#master-sxs.zh-cn:
     - files:
         docs/a.md: a
@@ -844,6 +838,14 @@ repos:
         docs/a.md: cd
       author: Terry
       email: terry@contoso.com
+cache:
+  github-users.json: |
+    { "users": [
+        {"name": "Alice", "login": "alice", "id": 1, "emails": ["alice@contoso.com"]},
+        {"name": "Bob", "login": "bob", "id": 2, "emails": ["bob@contoso.com"]},
+        {"name": "Terry", "login": "terry", "id": 3, "emails": ["terry@contoso.com"]},
+      ]
+    }
 outputs:
   docs/a.json: |
     {

--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -61,9 +61,7 @@ repos:
     - files:
         docs/a.md:
         docfx.yml: |
-          gitHub:
-            userCache: https://raw.githubusercontent.com/docascode/docfx-test-dependencies/github-user-cache-file/user_profile.json
-            resolveUsers: true
+          monikerDefinition: https://raw.githubusercontent.com/docascode/docfx-test-dependencies/github-user-cache-file/user_profile.json
       author: OsmondJiang
       email: xinjiang@microsoft.com
 outputs:

--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -56,42 +56,22 @@ outputs:
     { "conceptual": "<div class=\"NOTE\"><p>my note</p><p>note</p></div>" }
 ---
 # Restore urls
-repos:
-  https://github.com/restore/b:
-    - files:
-        docs/a.md:
-        docfx.yml: |
-          monikerDefinition: https://raw.githubusercontent.com/docascode/docfx-test-dependencies/github-user-cache-file/user_profile.json
-      author: OsmondJiang
-      email: xinjiang@microsoft.com
+inputs:
+  docfx.yml: |
+    xref: https://raw.githubusercontent.com/docascode/docfx-test-dependencies/xref/xref.json
+  a.md: '@System.String'
 outputs:
-  docs/a.json: |
-    {
-      "_op_gitContributorInformation":
-      {
-        "author":
-          {"name":"OsmondJiang","profile_url":"https://github.com/OsmondJiang","display_name":"Osmond Jiang","id":"19990166"}
-      }
-    }
+  a.json: |
+    { "content": "" }
 ---
 # Restore urls with extends
-repos:
-  https://github.com/restore/c:
-    - files:
-        docs/a.md:
-        docfx.yml: |
-          extend: https://raw.githubusercontent.com/docascode/docfx-test-dependencies/extend-test-2/extend2.yml
-      author: OsmondJiang
-      email: xinjiang@microsoft.com
+inputs:
+  docfx.yml: |
+    extend: https://raw.githubusercontent.com/docascode/docfx-test-dependencies/extend-test-2/extend2.yml
+  a.md: '@System.String'
 outputs:
-  docs/a.json: |
-    {
-      "_op_gitContributorInformation":
-      {
-        "author":
-          {"name":"OsmondJiang","profile_url":"https://github.com/OsmondJiang","display_name":"Osmond Jiang","id":"19990166"}
-      }
-    }
+  a.json: |
+    { "content": "" }
 ---
 # Restore dependencies with extends
 repos:

--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -58,20 +58,20 @@ outputs:
 # Restore urls
 inputs:
   docfx.yml: |
-    xref: https://raw.githubusercontent.com/docascode/docfx-test-dependencies/xref/xref.json
+    xref: https://raw.githubusercontent.com/docascode/docfx-test-dependencies/xref/xrefmap.json
   a.md: '@System.String'
 outputs:
   a.json: |
-    { "content": "" }
+    { "conceptual": "<p><a href=\"https://docs.microsoft.com/en-us/dotnet/api/system.string\">String</a></p>" }
 ---
 # Restore urls with extends
 inputs:
   docfx.yml: |
-    extend: https://raw.githubusercontent.com/docascode/docfx-test-dependencies/extend-test-2/extend2.yml
+    extend: https://raw.githubusercontent.com/docascode/docfx-test-dependencies/xref/extend.yml
   a.md: '@System.String'
 outputs:
   a.json: |
-    { "content": "" }
+    { "conceptual": "<p><a href=\"https://docs.microsoft.com/en-us/dotnet/api/system.string\">String</a></p>" }
 ---
 # Restore dependencies with extends
 repos:

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -58,8 +58,6 @@ namespace Microsoft.Docs.Build
 
                 var (publishManifest, fileManifests, sourceDependencies) = await BuildFiles(context, docset, tocMap);
 
-                var saveGitHubUserCache = context.GitHubUserCache.SaveChanges(config);
-
                 xrefMap.OutputXrefMap(context);
                 context.Output.WriteJson(publishManifest, ".publish.json");
                 context.Output.WriteJson(sourceDependencies.ToDependencyMapModel(), ".dependencymap.json");
@@ -77,9 +75,8 @@ namespace Microsoft.Docs.Build
                     }
                 }
 
-                context.ErrorLog.Write(await saveGitHubUserCache);
-
-                context.ContributionProvider.UpdateCommitBuildTime();
+                context.GitHubUserCache.Save();
+                context.ContributionProvider.Save();
             }
         }
 

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Docs.Build
             Cache = new Cache();
             MetadataProvider = new MetadataProvider(docset);
             MonikerProvider = new MonikerProvider(docset);
-            GitHubUserCache = GitHubUserCache.Create(docset);
+            GitHubUserCache = new GitHubUserCache(docset.Config);
             GitCommitProvider = new GitCommitProvider();
             BookmarkValidator = new BookmarkValidator();
             DependencyMapBuilder = new DependencyMapBuilder();

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -210,11 +210,11 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public void UpdateCommitBuildTime()
+        public void Save()
         {
             if (_commitBuildTimeProvider != null)
             {
-                _commitBuildTimeProvider.UpdateAndSaveCache();
+                _commitBuildTimeProvider.Save();
             }
         }
 

--- a/src/docfx/build/xref/XrefMapBuilder.cs
+++ b/src/docfx/build/xref/XrefMapBuilder.cs
@@ -94,12 +94,12 @@ namespace Microsoft.Docs.Build
                         if (json.TokenType == JsonToken.StartObject)
                         {
                             startLine = json.LineNumber;
-                            startColumn = json.LinePosition;
+                            startColumn = json.LinePosition + 1;
                         }
                         else if (json.TokenType == JsonToken.EndObject)
                         {
                             endLine = json.LineNumber;
-                            endColumn = json.LinePosition;
+                            endColumn = json.LinePosition + 1;
                             if (uid != null)
                             {
                                 populate(uid, startLine, endLine, startColumn, endColumn);

--- a/src/docfx/build/xref/XrefMapBuilder.cs
+++ b/src/docfx/build/xref/XrefMapBuilder.cs
@@ -39,7 +39,9 @@ namespace Microsoft.Docs.Build
                 else
                 {
                     // Convert to array since ref local is not allowed to be used in lambda expression
-                    var filePath = RestoreMap.GetRestoredFilePath(docset.DocsetPath, url);
+                    //
+                    // TODO: It is very easy to forget passing fallbackDocsetPath, the RestoreMap interface needs improvement
+                    var filePath = RestoreMap.GetRestoredFilePath(docset.DocsetPath, url, docset.FallbackDocset?.DocsetPath);
                     var result = XrefMapLoader.Load(filePath);
                     foreach (var (uid, spec) in result.ToList())
                     {

--- a/src/docfx/config/AppData.cs
+++ b/src/docfx/config/AppData.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Docs.Build
 
         public static string GlobalConfigPath => GetGlobalConfigPath();
 
-        public static string GitHubUserCachePath => Path.Combine(CacheRoot, "github-user-cache.json");
+        public static string GitHubUserCachePath => Path.Combine(CacheRoot, "github-users.json");
 
         public static string GetGitDir(string remote)
         {

--- a/src/docfx/config/AppData.cs
+++ b/src/docfx/config/AppData.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Docs.Build
 
         public static string GlobalConfigPath => GetGlobalConfigPath();
 
-        public static string DefaultGitHubUserCachePath => Path.Combine(CacheRoot, "github-users.json");
+        public static string GitHubUserCachePath => Path.Combine(CacheRoot, "github-user-cache.json");
 
         public static string GetGitDir(string remote)
         {
@@ -52,11 +52,6 @@ namespace Microsoft.Docs.Build
         public static string GetCommitBuildTimePath(string remote, string branch)
         {
             return Path.Combine(CacheRoot, "history", $"build_history_{HashUtility.GetMd5Guid(remote)}_{HashUtility.GetMd5Guid(branch)}.json");
-        }
-
-        public static string GetGitHubUserCachePath(string url)
-        {
-            return Path.Combine(CacheRoot, "github-users", PathUtility.UrlToShortName(url));
         }
 
         /// <summary>

--- a/src/docfx/config/GitHubConfig.cs
+++ b/src/docfx/config/GitHubConfig.cs
@@ -11,17 +11,6 @@ namespace Microsoft.Docs.Build
         public readonly string AuthToken = string.Empty;
 
         /// <summary>
-        /// The address of user profile cache, used for generating authoer and contributors.
-        /// It should be an absolute url or a relative path.
-        /// </summary>
-        public readonly SourceInfo<string> UserCache = new SourceInfo<string>(string.Empty);
-
-        /// <summary>
-        /// Whether upload the updated user cache to remote if it is set to a URL.
-        /// </summary>
-        public readonly bool UpdateRemoteUserCache = false;
-
-        /// <summary>
         /// Determines how long at most a user remains valid in cache.
         /// </summary>
         public readonly int UserCacheExpirationInHours = 30 * 24;

--- a/src/docfx/lib/HttpClientUtility.cs
+++ b/src/docfx/lib/HttpClientUtility.cs
@@ -41,18 +41,6 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public static Task<HttpResponseMessage> PutAsync(string requestUri, HttpContent content, Config config, EntityTagHeaderValue etag = null)
-        {
-            var message = CreateHttpRequestMessage(requestUri, config);
-            message.Method = HttpMethod.Put;
-            message.Content = content;
-            if (etag != null)
-            {
-                message.Headers.IfMatch.Add(etag);
-            }
-            return s_httpClient.SendAsync(message);
-        }
-
         private static HttpRequestMessage CreateHttpRequestMessage(string requestUri, Config config)
         {
             var message = new HttpRequestMessage();

--- a/src/docfx/lib/git/CommitBuildTimeProvider.cs
+++ b/src/docfx/lib/git/CommitBuildTimeProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Docs.Build
             return true;
         }
 
-        public void UpdateAndSaveCache()
+        public void Save()
         {
             if (_buildTimeByCommit.ContainsKey(_repo.Commit))
             {

--- a/src/docfx/lib/github/GitHubUserCache.cs
+++ b/src/docfx/lib/github/GitHubUserCache.cs
@@ -27,9 +27,9 @@ namespace Microsoft.Docs.Build
         private readonly Dictionary<string, GitHubUser> _usersByLogin = new Dictionary<string, GitHubUser>(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, GitHubUser> _usersByEmail = new Dictionary<string, GitHubUser>(StringComparer.OrdinalIgnoreCase);
 
-        private readonly GitHubAccessor _githubAccessor;
         private readonly SemaphoreSlim _syncRoot = new SemaphoreSlim(1, 1);
 
+        private readonly GitHubAccessor _githubAccessor;
         private readonly string _cachePath;
         private readonly double _expirationInHours;
         private bool _updated = false;

--- a/src/docfx/lib/github/GitHubUserCache.cs
+++ b/src/docfx/lib/github/GitHubUserCache.cs
@@ -6,9 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -30,15 +27,28 @@ namespace Microsoft.Docs.Build
         private readonly Dictionary<string, GitHubUser> _usersByLogin = new Dictionary<string, GitHubUser>(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, GitHubUser> _usersByEmail = new Dictionary<string, GitHubUser>(StringComparer.OrdinalIgnoreCase);
 
+        private readonly GitHubAccessor _githubAccessor;
         private readonly SemaphoreSlim _syncRoot = new SemaphoreSlim(1, 1);
 
-        private readonly GitHubAccessor _githubAccessor = null;
-        private readonly string _url = null;
-        private readonly string _content = null;
-        private readonly EntityTagHeaderValue _etag = null;
         private readonly string _cachePath;
         private readonly double _expirationInHours;
         private bool _updated = false;
+
+        public GitHubUserCache(Config config)
+        {
+            _cachePath = AppData.GitHubUserCachePath;
+            _expirationInHours = config.GitHub.UserCacheExpirationInHours;
+
+            _githubAccessor = new GitHubAccessor(config.GitHub.AuthToken);
+            _getUserByLoginFromGitHub = _githubAccessor.GetUserByLogin;
+            _getUsersByCommitFromGitHub = _githubAccessor.GetUsersByCommit;
+
+            if (File.Exists(_cachePath))
+            {
+                var cache = JsonUtility.Deserialize<GitHubUserCacheModel>(ProcessUtility.ReadFile(_cachePath), _cachePath);
+                UpdateUsers(cache.Users);
+            }
+        }
 
         /// <summary>
         /// Only for test purpose
@@ -48,53 +58,6 @@ namespace Microsoft.Docs.Build
             _cachePath = cachePath;
             _expirationInHours = expirationInHours;
             UpdateUsers(users);
-        }
-
-        private GitHubUserCache(Docset docset, string cachePath)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(cachePath));
-
-            _githubAccessor = new GitHubAccessor(docset.Config.GitHub.AuthToken);
-            _getUserByLoginFromGitHub = _githubAccessor.GetUserByLogin;
-            _getUsersByCommitFromGitHub = _githubAccessor.GetUsersByCommit;
-            _expirationInHours = docset.Config.GitHub.UserCacheExpirationInHours;
-            _cachePath = cachePath;
-        }
-
-        private GitHubUserCache(Docset docset, string url, string content, string etag, string cachePath)
-            : this(docset, cachePath)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(url));
-            Debug.Assert(!string.IsNullOrEmpty(content));
-            Debug.Assert(!string.IsNullOrEmpty(etag));
-
-            _url = url;
-            _content = content;
-            _etag = EntityTagHeaderValue.Parse(etag);
-        }
-
-        public static GitHubUserCache Create(Docset docset)
-        {
-            var result = Create();
-            result.ReadCacheFiles();
-            return result;
-
-            GitHubUserCache Create()
-            {
-                var path = docset.Config.GitHub.UserCache;
-                if (string.IsNullOrEmpty(path))
-                {
-                    return new GitHubUserCache(docset, AppData.DefaultGitHubUserCachePath);
-                }
-
-                var (localPath, content, etag) = RestoreMap.GetRestoredFileContent(docset, new SourceInfo<string>(path, docset.Config.GitHub.UserCache));
-                if (string.IsNullOrEmpty(localPath))
-                {
-                    return new GitHubUserCache(docset, path, content, etag, AppData.GetGitHubUserCachePath(path));
-                }
-
-                return new GitHubUserCache(docset, localPath);
-            }
         }
 
         public Task<(Error error, GitHubUser user)> GetByLogin(string login)
@@ -166,35 +129,24 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public Task<Error> SaveChanges(Config config)
+        public void Save()
         {
-            if (!_updated)
+            if (_updated)
             {
-                return Task.FromResult<Error>(null);
-            }
+                _syncRoot.Wait();
 
-            return Synchronized(SaveChangesCore);
-
-            async Task<Error> SaveChangesCore()
-            {
-                var remainingRetries = 3;
-                var (error, collide) = await SaveChanges(config, _etag);
-                while (collide && remainingRetries-- > 0)
+                try
                 {
-                    HttpResponseMessage response;
-                    try
-                    {
-                        response = await HttpClientUtility.GetAsync(_url, config);
-                    }
-                    catch (Exception ex)
-                    {
-                        throw Errors.DownloadFailed(_url).ToException(ex);
-                    }
-                    var content = await response.EnsureSuccessStatusCode().Content.ReadAsStringAsync();
-                    ReadCache(content);
-                    (error, collide) = await SaveChanges(config, response.Headers.ETag);
+                    var content = JsonUtility.Serialize(new GitHubUserCacheModel { Users = Users.ToArray() });
+
+                    PathUtility.CreateDirectoryFromFilePath(_cachePath);
+                    ProcessUtility.WriteFile(_cachePath, content);
+                    _updated = false;
                 }
-                return error;
+                finally
+                {
+                    _syncRoot.Release();
+                }
             }
         }
 
@@ -202,48 +154,6 @@ namespace Microsoft.Docs.Build
         {
             _githubAccessor.Dispose();
             _syncRoot.Dispose();
-        }
-
-        private async Task<(Error error, bool collide)> SaveChanges(Config config, EntityTagHeaderValue etag)
-        {
-            var file = JsonUtility.Serialize(new GitHubUserCacheFile { Users = Users.ToArray() });
-
-            SaveLocal(file);
-            if (config.GitHub.UpdateRemoteUserCache && _url != null)
-            {
-                return await SaveRemote(file);
-            }
-            return default;
-
-            void SaveLocal(string content)
-            {
-                PathUtility.CreateDirectoryFromFilePath(_cachePath);
-                ProcessUtility.WriteFile(_cachePath, content);
-            }
-
-            async Task<(Error error, bool collide)> SaveRemote(string content)
-            {
-                try
-                {
-                    var response = await HttpClientUtility.PutAsync(_url, new StringContent(file), config, etag);
-                    if (response.IsSuccessStatusCode)
-                    {
-                        return (null, false);
-                    }
-                    if (response.StatusCode == HttpStatusCode.PreconditionFailed)
-                    {
-                        return (null, true);
-                    }
-                    else
-                    {
-                        return (Errors.UploadFailed(_url, response.ReasonPhrase), false);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    return (Errors.UploadFailed(_url, ex.Message), false);
-                }
-            }
         }
 
         /// <summary>
@@ -323,40 +233,11 @@ namespace Microsoft.Docs.Build
         private DateTime NextExpiry()
             => DateTime.UtcNow.AddHours((_expirationInHours / 2) + (t_random.Value.NextDouble() * _expirationInHours / 2));
 
-        private void ReadCacheFiles()
-        {
-            ReadCacheFile(_cachePath);
-
-            if (!string.IsNullOrEmpty(_content))
-            {
-                ReadCache(_content);
-            }
-
-            void ReadCacheFile(string path)
-            {
-                if (path != null && File.Exists(path))
-                {
-                    var content = ProcessUtility.ReadFile(path);
-                    ReadCache(content);
-                }
-            }
-        }
-
-        private void ReadCache(string content)
-        {
-            // TODO: populate file to JsonUtility.Deserialize
-            var users = JsonUtility.Deserialize<GitHubUserCacheFile>(content, "").Users;
-            if (users != null)
-            {
-                UpdateUsers(users);
-            }
-        }
-
         private async Task<T> Synchronized<T>(Func<Task<T>> action)
         {
+            await _syncRoot.WaitAsync();
             try
             {
-                await _syncRoot.WaitAsync();
                 return await action();
             }
             finally

--- a/src/docfx/lib/github/GitHubUserCache.cs
+++ b/src/docfx/lib/github/GitHubUserCache.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Docs.Build
 
             if (File.Exists(_cachePath))
             {
-                var cache = JsonUtility.Deserialize<GitHubUserCacheModel>(ProcessUtility.ReadFile(_cachePath), _cachePath);
+                var cache = JsonUtility.Deserialize<GitHubUserCacheFile>(ProcessUtility.ReadFile(_cachePath), _cachePath);
                 UpdateUsers(cache.Users);
             }
         }
@@ -137,7 +137,7 @@ namespace Microsoft.Docs.Build
 
                 try
                 {
-                    var content = JsonUtility.Serialize(new GitHubUserCacheModel { Users = Users.ToArray() });
+                    var content = JsonUtility.Serialize(new GitHubUserCacheFile { Users = Users.ToArray() });
 
                     PathUtility.CreateDirectoryFromFilePath(_cachePath);
                     ProcessUtility.WriteFile(_cachePath, content);

--- a/src/docfx/lib/github/GitHubUserCache.cs
+++ b/src/docfx/lib/github/GitHubUserCache.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Docs.Build
                 // only mark the email as invalid when the user is not found
                 if (users != null)
                 {
-                    UpdateUsers(users, preferExistingName: true);
+                    UpdateUsers(users);
                 }
 
                 return (error, _usersByEmail.TryGetValue(authorEmail, out var user) && user.IsValid() ? user : null);
@@ -163,7 +163,7 @@ namespace Microsoft.Docs.Build
         /// 2. User missing with the specified login: { "login": "..." }
         /// 3. User missing with the specified email: { "emails": [ "..." ] }
         /// </summary>
-        private void UpdateUser(GitHubUser user, bool preferExistingName = false)
+        private void UpdateUser(GitHubUser user)
         {
             Debug.Assert(user != null);
 
@@ -178,7 +178,7 @@ namespace Microsoft.Docs.Build
             {
                 if (_usersByLogin.TryGetValue(user.Login, out var existingUser))
                 {
-                    MergeUser(user, existingUser, preferExistingName);
+                    MergeUser(user, existingUser);
                 }
             }
             else
@@ -188,7 +188,7 @@ namespace Microsoft.Docs.Build
                 {
                     if (_usersByEmail.TryGetValue(email, out var existingUser))
                     {
-                        MergeUser(user, existingUser, preferExistingName);
+                        MergeUser(user, existingUser);
                         break;
                     }
                 }
@@ -206,7 +206,7 @@ namespace Microsoft.Docs.Build
             _updated = true;
         }
 
-        private static void MergeUser(GitHubUser user, GitHubUser existingUser, bool preferExistingName)
+        private static void MergeUser(GitHubUser user, GitHubUser existingUser)
         {
             if (existingUser.IsValid())
             {
@@ -216,17 +216,15 @@ namespace Microsoft.Docs.Build
                     user.Login = existingUser.Login;
                 if (user.Name is null)
                     user.Name = existingUser.Name;
-                if (preferExistingName && existingUser.Name != null)
-                    user.Name = existingUser.Name;
                 user.Emails = user.Emails.Concat(existingUser.Emails).Distinct().ToArray();
             }
         }
 
-        private void UpdateUsers(IEnumerable<GitHubUser> users, bool preferExistingName = false)
+        private void UpdateUsers(IEnumerable<GitHubUser> users)
         {
             foreach (var user in users)
             {
-                UpdateUser(user, preferExistingName);
+                UpdateUser(user);
             }
         }
 

--- a/src/docfx/lib/github/GitHubUserCacheFile.cs
+++ b/src/docfx/lib/github/GitHubUserCacheFile.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Docs.Build
 {
-    internal class GitHubUserCacheModel
+    internal class GitHubUserCacheFile
     {
         public GitHubUser[] Users { get; set; } = Array.Empty<GitHubUser>();
     }

--- a/src/docfx/lib/github/GitHubUserCacheModel.cs
+++ b/src/docfx/lib/github/GitHubUserCacheModel.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace Microsoft.Docs.Build
 {
-    internal class GitHubUserCacheFile
+    internal class GitHubUserCacheModel
     {
-        public GitHubUser[] Users { get; set; }
+        public GitHubUser[] Users { get; set; } = Array.Empty<GitHubUser>();
     }
 }

--- a/src/docfx/restore/RestoreFile.cs
+++ b/src/docfx/restore/RestoreFile.cs
@@ -57,7 +57,6 @@ namespace Microsoft.Docs.Build
                 yield return url;
             }
 
-            yield return config.GitHub.UserCache;
             yield return config.MonikerDefinition;
 
             foreach (var metadataSchema in config.MetadataSchema)

--- a/test/docfx.Test/lib/GitHubUserCacheTest.cs
+++ b/test/docfx.Test/lib/GitHubUserCacheTest.cs
@@ -196,19 +196,6 @@ namespace Microsoft.Docs.Build
                 1,
                 1
             };
-            yield return new object[]
-            {
-                "Prefer existing email name",
-                (Func<GitHubUserCache, Task>)(async (cache) =>
-                    {
-                        await cache.GetByCommit("bob1@contoso.com", "owner", "name", "4");
-                        await cache.GetByCommit("bob2@contoso.com", "owner", "name", "5");
-                    }),
-                "[]",
-                "[{'id':2,'login':'bob','name':'bob1','emails':['bob1@contoso.com','bob2@contoso.com']}]",
-                0,
-                2
-            };
         }
 
         private void AssertUsersEqual(GitHubUser[] expectedUsers, GitHubUser[] actualUsers)

--- a/test/docfx.Test/restore/RestoreTest.cs
+++ b/test/docfx.Test/restore/RestoreTest.cs
@@ -132,8 +132,7 @@ dependencies:
             var restoreDir = AppData.GetFileDownloadDir(url);
 
             File.WriteAllText(Path.Combine(docsetPath, "docfx.yml"), $@"
-gitHub:
-  userCache: https://raw.githubusercontent.com/docascode/docfx-test-dependencies-clean/master/README.md");
+monikerDefinition: https://raw.githubusercontent.com/docascode/docfx-test-dependencies-clean/master/README.md");
 
             // run restore
             await Docfx.Run(new[] { "restore", docsetPath });


### PR DESCRIPTION
Since we put all GitHub user cache inside the cache folder, and you can only get GitHub with a PAT token, the explicit GitHub user location is not needed. Most of the changes are updating test cases that uses `github_user_cache` to test restore.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4725)