### PR TITLE
UID resolving should respect the order of xref list config.

### DIFF
--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -728,14 +728,11 @@ inputs:
     {
       "references":[{
           "uid": "System.String",
-          "name": "String.1",
-          "fullName": "System.String.1",
-          "href": "https://docs.microsoft.com/en-us/dotnet/api/system.string",
-          "nameWithType": "System.String"
+          "href": "https://docs.microsoft.com/en-us/dotnet/api/system.string"
       }]
     }
   2.xrefmap.json: |
-    { "references":[{"uid": "System.String", "name": "String.2", "fullName": "System.String.2", "href": "https://2.docs.microsoft.com/en-us/a", "nameWithType": "System.String"}]}
+    { "references":[{"uid": "System.String", "href": "https://2.docs.microsoft.com/en-us/system.string"}]}
 outputs:
   docs/a.json: |
-    { "conceptual": "<p>Link to <a href=\"/en-us/dotnet/api/system.string\">String.1</a></p>\n"}
+    { "conceptual": "<p>Link to <a href=\"/en-us/dotnet/api/system.string\">System.String</a></p>\n"}

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -715,3 +715,27 @@ outputs:
     ["info","at-xref-not-found","Cross reference not found: '<xref href=\"f\" data-raw-source=\"@mentionf\">'","docs/a.md",5,12]
     ["info","at-xref-not-found","Cross reference not found: '<p>\n  <xref href=\"e\" data-raw-source=\"@mentione\" />\n  some text\n  <xref href=\"f\" data-raw-source=\"mentionf\" />\n</p>'","docs/a.md",6,18]
     ["warning","xref-not-found","Cross reference not found: '<p>\n  <xref href=\"e\" data-raw-source=\"@mentione\" />\n  some text\n  <xref href=\"f\" data-raw-source=\"mentionf\" />\n</p>'","docs/a.md",6,78]
+---
+# uid resolving should respect the order of xref settings
+inputs:
+  docfx.yml: |
+    baseUrl: https://docs.microsoft.com
+    xref: 
+      - 1.xrefmap.json
+      - 2.xrefmap.json
+  docs/a.md: Link to @System.String
+  1.xrefmap.json: |
+    {
+      "references":[{
+          "uid": "System.String",
+          "name": "String.1",
+          "fullName": "System.String.1",
+          "href": "https://docs.microsoft.com/en-us/dotnet/api/system.string",
+          "nameWithType": "System.String"
+      }]
+    }
+  2.xrefmap.json: |
+    { "references":[{"uid": "System.String", "name": "String.2", "fullName": "System.String.2", "href": "https://2.docs.microsoft.com/en-us/a", "nameWithType": "System.String"}]}
+outputs:
+  docs/a.json: |
+    { "conceptual": "<p>Link to <a href=\"/en-us/dotnet/api/system.string\">String.1</a></p>\n"}

--- a/src/docfx/build/xref/XrefMapBuilder.cs
+++ b/src/docfx/build/xref/XrefMapBuilder.cs
@@ -5,13 +5,8 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Text.Json;
 using System.Text.RegularExpressions;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build
@@ -24,7 +19,7 @@ namespace Microsoft.Docs.Build
             // https://github.com/dotnet/corefx/issues/12067
             // Prefer Dictionary with manual lock to ConcurrentDictionary while only adding
             var externalXrefMap = new DictionaryBuilder<string, Lazy<IXrefSpec>>();
-            ParallelUtility.ForEach(docset.Config.Xref, url =>
+            foreach (var url in docset.Config.Xref)
             {
                 XrefMapModel xrefMap = new XrefMapModel();
                 if (url?.Value.EndsWith(".yml", StringComparison.OrdinalIgnoreCase) != false)
@@ -46,7 +41,7 @@ namespace Microsoft.Docs.Build
                         externalXrefMap.TryAdd(uid, spec);
                     }
                 }
-            });
+            }
             var internalXrefMap = CreateInternalXrefMap(context, docset.ScanScope);
             return new XrefMap(context, BuildMap(externalXrefMap.ToDictionary(), internalXrefMap), internalXrefMap);
         }

--- a/src/docfx/build/xref/XrefMapBuilder.cs
+++ b/src/docfx/build/xref/XrefMapBuilder.cs
@@ -15,10 +15,7 @@ namespace Microsoft.Docs.Build
     {
         public static XrefMap Build(Context context, Docset docset)
         {
-            // TODO: not considering same uid with multiple specs, it will be Dictionary<string, List<T>>
-            // https://github.com/dotnet/corefx/issues/12067
-            // Prefer Dictionary with manual lock to ConcurrentDictionary while only adding
-            var externalXrefMap = new DictionaryBuilder<string, Lazy<IXrefSpec>>();
+            var externalXrefMap = new Dictionary<string, Lazy<IXrefSpec>>();
             foreach (var url in docset.Config.Xref)
             {
                 XrefMapModel xrefMap = new XrefMapModel();
@@ -38,12 +35,13 @@ namespace Microsoft.Docs.Build
                     var result = XrefMapLoader.Load(filePath);
                     foreach (var (uid, spec) in result.ToList())
                     {
+                        // for same uid with multiple specs, we should respect the order of the list
                         externalXrefMap.TryAdd(uid, spec);
                     }
                 }
             }
             var internalXrefMap = CreateInternalXrefMap(context, docset.ScanScope);
-            return new XrefMap(context, BuildMap(externalXrefMap.ToDictionary(), internalXrefMap), internalXrefMap);
+            return new XrefMap(context, BuildMap(externalXrefMap, internalXrefMap), internalXrefMap);
         }
 
         private static Dictionary<string, List<Lazy<IXrefSpec>>> BuildMap(IReadOnlyDictionary<string, Lazy<IXrefSpec>> externalXrefMap, Dictionary<string, List<Lazy<IXrefSpec>>> internalXrefMap)


### PR DESCRIPTION
fix https://dev.azure.com/ceapex/Engineering/_workitems/edit/98868

This change does not affect the build performance.
Tested with dotnet/docs locally:
Build done in 00:02:13.0870000

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4736)