### PR TITLE
contine fix deploy scripts

### DIFF
--- a/tools/Deployment/gulpfile.js
+++ b/tools/Deployment/gulpfile.js
@@ -232,9 +232,9 @@ gulp.task("syncBranchCore", () => {
 });
 gulp.task("test", gulp.series("clean", "build", "e2eTest", "publish:myget-test"));
 gulp.task("dev", gulp.series("clean", "build", "e2eTest"));
+gulp.task("dev:release", gulp.series("clean", "build", "e2eTest", "publish:myget-dev"));
 
 gulp.task("master:build", gulp.series("clean", "build:release", "e2eTest", "updateGhPage"));
 gulp.task("master:release", gulp.series("packAssetZip", "publish:myget-master", "publish:gh-release", "publish:gh-asset", "publish:chocolatey"));
-gulp.task("master:releaseAssetAndChocolatey", gulp.series("packAssetZip", "publish:gh-asset", "publish:chocolatey"));
 
 gulp.task("default", gulp.series("dev"));

--- a/tools/Deployment/lib/chocolatey.ts
+++ b/tools/Deployment/lib/chocolatey.ts
@@ -22,6 +22,7 @@ export class Chocolatey {
         Guard.argumentNotNullOrEmpty(chocoToken, "chocoToken");
 
         // Ignore to publish chocolatey package if RELEASENOTE.md hasn't been modified.
+        // TODO: check is this packaged published instead of RELEASENOTE.md
         let isUpdated = await Common.isReleaseNoteVersionChangedAsync(releaseNotePath);
         if (!isUpdated) {
             console.log(`${releaseNotePath} hasn't been changed. Ignore to publish package to chocolatey.`);

--- a/tools/Deployment/lib/github.ts
+++ b/tools/Deployment/lib/github.ts
@@ -37,6 +37,7 @@ export class Github {
         Guard.argumentNotNullOrEmpty(repoUrl, "repoUrl");
         Guard.argumentNotNullOrEmpty(assetZipPath, "assetZipPath");
         Guard.argumentNotNullOrEmpty(githubToken, "githubToken");
+        // TODO: add check: if this zip has been publish, skip this step
 
         let githubApi = new GithubApi(repoUrl, githubToken);
         let assetInfo = this.getAssetZipInfo(assetZipPath);

--- a/tools/Deployment/package.json
+++ b/tools/Deployment/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@types/axios": "^0.9.36",
     "@types/node": "^7.0.12",
-    "axios": ">=0.19.0",
+    "axios": "0.16.2",
     "child-process-promise": "^2.2.0",
     "colors": "^1.1.2",
     "commander": "^2.9.0",


### PR DESCRIPTION
* Revert axios: I reverted this change as it will meet `Error: Request body larger than maxBodyLength limit`. This upgrade originally aims to fix a DoS vulnerability. However, this is not the case when we use it as deployment script, instead of handling user inputs.
    * Note: I have not tried `maxContentLength` as it does not seem to work: https://github.com/axios/axios/issues/1362#issuecomment-386239009
* Add back `dev:release`: nightlly build need it
* Add some TODOs: current check for release not cannot work properly if steps after gh-release failed.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4758)