### PR TITLE
lazy toc map and xref map in context, control the init order

### DIFF
--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -50,16 +50,13 @@ namespace Microsoft.Docs.Build
             var docset = GetBuildDocset(new Docset(errorLog, docsetPath, locale, config, options, restoreMap, repository, fallbackRepo));
             var outputPath = Path.Combine(docsetPath, config.Output.Path);
 
-            using (var context = new Context(outputPath, errorLog, docset, () => xrefMap))
+            using (var context = new Context(outputPath, errorLog, docset, BuildFile))
             {
-                xrefMap = XrefMapBuilder.Build(context, docset);
-                var tocMap = TableOfContentsMap.Create(context);
-
                 context.BuildQueue.Enqueue(context.BuildScope.Files);
 
                 using (Progress.Start("Building files"))
                 {
-                    await context.BuildQueue.Drain(item => BuildFile(context, item, tocMap), Progress.Update);
+                    await context.BuildQueue.Drain(Progress.Update);
                 }
 
                 context.GitCommitProvider.SaveGitCommitCache();
@@ -77,7 +74,7 @@ namespace Microsoft.Docs.Build
                     if (config.Output.Json)
                     {
                         // TODO: decouple files and dependencies from legacy.
-                        Legacy.ConvertToLegacyModel(docset, context, fileManifests, dependencyMap, tocMap);
+                        Legacy.ConvertToLegacyModel(docset, context, fileManifests, dependencyMap);
                     }
                     else
                     {
@@ -102,25 +99,30 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static async Task BuildFile(Context context, Document file, TableOfContentsMap tocMap)
+        private static async Task BuildFile(Context context, Document file)
         {
+            if (ShouldBuildFile())
+            {
+                return;
+            }
+
             try
             {
                 var errors = Enumerable.Empty<Error>();
 
                 switch (file.ContentType)
                 {
-                    case ContentType.Resource when !file.Docset.IsFallback():
+                    case ContentType.Resource:
                         errors = BuildResource.Build(context, file);
                         break;
-                    case ContentType.Page when !file.Docset.IsFallback():
-                        errors = await BuildPage.Build(context, file, tocMap);
+                    case ContentType.Page:
+                        errors = await BuildPage.Build(context, file);
                         break;
                     case ContentType.TableOfContents:
                         // TODO: improve error message for toc monikers overlap
-                        errors = BuildTableOfContents.Build(context, file, tocMap);
+                        errors = BuildTableOfContents.Build(context, file);
                         break;
-                    case ContentType.Redirection when !file.Docset.IsFallback():
+                    case ContentType.Redirection:
                         errors = BuildRedirection.Build(context, file);
                         break;
                 }
@@ -142,6 +144,22 @@ namespace Microsoft.Docs.Build
             {
                 Console.WriteLine($"Build {file.FilePath} failed");
                 throw;
+            }
+
+            bool ShouldBuildFile()
+            {
+                if (file.ContentType == ContentType.TableOfContents)
+                {
+                    if (!context.TocMap.Contains(file))
+                    {
+                        return false;
+                    }
+
+                    // if A toc includes B toc and only B toc is localized, then A need to be included and built
+                    return !file.Docset.IsFallback() || (context.TocMap.TryGetTocReferences(file, out var tocReferences) && tocReferences.Any(toc => !toc.Docset.IsFallback()));
+                }
+
+                return !file.Docset.IsFallback();
             }
         }
 

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -39,7 +39,6 @@ namespace Microsoft.Docs.Build
             RestoreMap restoreMap,
             Repository fallbackRepo = null)
         {
-            XrefMap xrefMap = null;
             var (configErrors, config) = GetBuildConfig(docsetPath, options, locale, fallbackRepo);
             errorLog.Configure(config);
 
@@ -65,7 +64,7 @@ namespace Microsoft.Docs.Build
                 var (publishModel, fileManifests) = context.PublishModelBuilder.Build(context, docset.Legacy);
                 var dependencyMap = context.DependencyMapBuilder.Build();
 
-                xrefMap.OutputXrefMap(context);
+                context.XrefMap.OutputXrefMap(context);
                 context.Output.WriteJson(publishModel, ".publish.json");
                 context.Output.WriteJson(dependencyMap.ToDependencyMapModel(), ".dependencymap.json");
 
@@ -101,7 +100,7 @@ namespace Microsoft.Docs.Build
 
         private static async Task BuildFile(Context context, Document file)
         {
-            if (ShouldBuildFile())
+            if (!ShouldBuildFile())
             {
                 return;
             }

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -34,10 +34,11 @@ namespace Microsoft.Docs.Build
         private readonly Lazy<XrefMap> _xrefMap;
         private readonly Lazy<TableOfContentsMap> _tocMap;
 
-        public Context(string outputPath, ErrorLog errorLog,  Docset docset, Func<Context, Document, Task> buildFile)
+        public Context(string outputPath, ErrorLog errorLog, Docset docset, Func<Context, Document, Task> buildFile)
         {
             _xrefMap = new Lazy<XrefMap>(() => XrefMapBuilder.Build(this, docset));
             _tocMap = new Lazy<TableOfContentsMap>(() => TableOfContentsMap.Create(this));
+            BuildQueue = new WorkQueue<Document>(doc => buildFile(this, doc));
 
             ErrorLog = errorLog;
             Output = new Output(outputPath);
@@ -54,7 +55,6 @@ namespace Microsoft.Docs.Build
                 docset.Config, BuildScope, BuildQueue, GitCommitProvider, BookmarkValidator, DependencyMapBuilder, _xrefMap);
             ContributionProvider = new ContributionProvider(docset, GitHubUserCache, GitCommitProvider);
             Template = TemplateEngine.Create(docset);
-            BuildQueue = new WorkQueue<Document>(doc => buildFile(this, doc));
         }
 
         public void Dispose()

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading.Tasks;
 
 namespace Microsoft.Docs.Build
 {
@@ -26,13 +27,22 @@ namespace Microsoft.Docs.Build
         public readonly PublishModelBuilder PublishModelBuilder;
         public readonly TemplateEngine Template;
 
-        public Context(string outputPath, ErrorLog errorLog,  Docset docset, Func<XrefMap> xrefMap)
+        public XrefMap XrefMap => _xrefMap.Value;
+
+        public TableOfContentsMap TocMap => _tocMap.Value;
+
+        private readonly Lazy<XrefMap> _xrefMap;
+        private readonly Lazy<TableOfContentsMap> _tocMap;
+
+        public Context(string outputPath, ErrorLog errorLog,  Docset docset, Func<Context, Document, Task> buildFile)
         {
+            _xrefMap = new Lazy<XrefMap>(() => XrefMapBuilder.Build(this, docset));
+            _tocMap = new Lazy<TableOfContentsMap>(() => TableOfContentsMap.Create(this));
+
             ErrorLog = errorLog;
             Output = new Output(outputPath);
             Cache = new Cache();
             BuildScope = new BuildScope(errorLog, docset);
-            BuildQueue = new WorkQueue<Document>();
             MetadataProvider = new MetadataProvider(docset, Cache);
             MonikerProvider = new MonikerProvider(docset, MetadataProvider);
             GitHubUserCache = new GitHubUserCache(docset.Config);
@@ -41,10 +51,10 @@ namespace Microsoft.Docs.Build
             BookmarkValidator = new BookmarkValidator();
             DependencyMapBuilder = new DependencyMapBuilder();
             DependencyResolver = new DependencyResolver(
-                docset.Config, BuildScope, BuildQueue, GitCommitProvider, BookmarkValidator, DependencyMapBuilder, new Lazy<XrefMap>(xrefMap));
-
+                docset.Config, BuildScope, BuildQueue, GitCommitProvider, BookmarkValidator, DependencyMapBuilder, _xrefMap);
             ContributionProvider = new ContributionProvider(docset, GitHubUserCache, GitCommitProvider);
             Template = TemplateEngine.Create(docset);
+            BuildQueue = new WorkQueue<Document>(doc => buildFile(this, doc));
         }
 
         public void Dispose()

--- a/src/docfx/build/legacy/Legacy.cs
+++ b/src/docfx/build/legacy/Legacy.cs
@@ -12,15 +12,14 @@ namespace Microsoft.Docs.Build
             Docset docset,
             Context context,
             Dictionary<Document, PublishItem> fileManifests,
-            DependencyMap dependencyMap,
-            TableOfContentsMap tocMap)
+            DependencyMap dependencyMap)
         {
             using (Progress.Start("Converting to legacy"))
             {
                 var files = fileManifests.Keys.ToList();
 
                 LegacyManifest.Convert(docset, context, fileManifests);
-                var legacyDependencyMap = LegacyDependencyMap.Convert(docset, context, files, dependencyMap, tocMap);
+                var legacyDependencyMap = LegacyDependencyMap.Convert(docset, context, files, dependencyMap);
                 LegacyFileMap.Convert(docset, context, files, legacyDependencyMap, fileManifests);
             }
         }

--- a/src/docfx/build/legacy/LegacyDependencyMap.cs
+++ b/src/docfx/build/legacy/LegacyDependencyMap.cs
@@ -12,7 +12,11 @@ namespace Microsoft.Docs.Build
 {
     internal static class LegacyDependencyMap
     {
-        public static Dictionary<string, List<LegacyDependencyMapItem>> Convert(Docset docset, Context context, List<Document> documemts, DependencyMap dependencyMap, TableOfContentsMap tocMap)
+        public static Dictionary<string, List<LegacyDependencyMapItem>> Convert(
+            Docset docset,
+            Context context,
+            List<Document> documemts,
+            DependencyMap dependencyMap)
         {
             using (Progress.Start("Convert Legacy Dependency Map"))
             {
@@ -30,7 +34,7 @@ namespace Microsoft.Docs.Build
                         {
                             return;
                         }
-                        var toc = tocMap.GetNearestToc(document);
+                        var toc = context.TocMap.GetNearestToc(document);
                         if (toc != null)
                         {
                             legacyDependencyMap.Add(new LegacyDependencyMapItem

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -12,12 +12,12 @@ namespace Microsoft.Docs.Build
 {
     internal static class BuildPage
     {
-        public static async Task<IEnumerable<Error>> Build(Context context, Document file, TableOfContentsMap tocMap)
+        public static async Task<IEnumerable<Error>> Build(Context context, Document file)
         {
             Debug.Assert(file.ContentType == ContentType.Page);
 
             var (errors, isPage, (pageMetadata, pageModel), (inputMetadata, metadataObject)) = await Load(context, file);
-            var (generateErrors, outputMetadata) = await GenerateOutputMetadata(context, file, tocMap, inputMetadata, pageMetadata);
+            var (generateErrors, outputMetadata) = await GenerateOutputMetadata(context, file, inputMetadata, pageMetadata);
             errors.AddRange(generateErrors);
 
             var outputPath = file.GetOutputPath(outputMetadata.Monikers, file.Docset.SiteBasePath, isPage);
@@ -80,7 +80,6 @@ namespace Microsoft.Docs.Build
         private static async Task<(List<Error>, OutputMetadata)> GenerateOutputMetadata(
                 Context context,
                 Document file,
-                TableOfContentsMap tocMap,
                 InputMetadata inputMetadata,
                 OutputMetadata outputMetadata)
         {
@@ -93,7 +92,7 @@ namespace Microsoft.Docs.Build
             }
 
             outputMetadata.Locale = file.Docset.Locale;
-            outputMetadata.TocRel = !string.IsNullOrEmpty(inputMetadata.TocRel) ? inputMetadata.TocRel : tocMap.FindTocRelativePath(file);
+            outputMetadata.TocRel = !string.IsNullOrEmpty(inputMetadata.TocRel) ? inputMetadata.TocRel : context.TocMap.FindTocRelativePath(file);
             outputMetadata.CanonicalUrl = file.CanonicalUrl;
             outputMetadata.EnableLocSxs = file.Docset.Config.Localization.Bilingual;
             outputMetadata.SiteName = file.Docset.Config.SiteName;

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -11,20 +11,9 @@ namespace Microsoft.Docs.Build
 {
     internal static class BuildTableOfContents
     {
-        public static IEnumerable<Error> Build(Context context, Document file, TableOfContentsMap tocMap)
+        public static IEnumerable<Error> Build(Context context, Document file)
         {
             Debug.Assert(file.ContentType == ContentType.TableOfContents);
-
-            if (!tocMap.Contains(file))
-            {
-                return Array.Empty<Error>();
-            }
-
-            // if A toc includes B toc and only B toc is localized, then A need to be included and built
-            if (file.Docset.IsFallback() && !ReferencesLocalizedToc(file, tocMap))
-            {
-                return Array.Empty<Error>();
-            }
 
             // load toc model
             var (errors, model, _, _) = context.Cache.LoadTocModel(context, file);
@@ -65,11 +54,6 @@ namespace Microsoft.Docs.Build
             }
 
             return errors;
-        }
-
-        private static bool ReferencesLocalizedToc(Document file, TableOfContentsMap tocMap)
-        {
-            return tocMap.TryGetTocReferences(file, out var tocReferences) && tocReferences.Any(toc => !toc.Docset.IsFallback());
         }
     }
 }

--- a/src/docfx/lib/collections/WorkQueue.cs
+++ b/src/docfx/lib/collections/WorkQueue.cs
@@ -11,10 +11,16 @@ namespace Microsoft.Docs.Build
 {
     internal class WorkQueue<T>
     {
+        private readonly Func<T, Task> _run;
         private readonly ConcurrentQueue<T> _queue = new ConcurrentQueue<T>();
         private readonly ConcurrentHashSet<T> _recurseDetector = new ConcurrentHashSet<T>();
 
         private readonly TaskCompletionSource<int> _drainTcs = new TaskCompletionSource<int>();
+
+        public WorkQueue(Func<T, Task> run)
+        {
+            _run = run;
+        }
 
         // For progress reporting
         private int _totalCount = 0;
@@ -44,7 +50,7 @@ namespace Microsoft.Docs.Build
             Interlocked.Increment(ref _remainingCount);
         }
 
-        public Task Drain(Func<T, Task> run, Action<int, int> progress = null)
+        public Task Drain(Action<int, int> progress = null)
         {
             if (_queue.Count == 0)
             {
@@ -66,7 +72,7 @@ namespace Microsoft.Docs.Build
             {
                 try
                 {
-                    run(item).ContinueWith(OnComplete, default, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+                    _run(item).ContinueWith(OnComplete, default, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
                 }
                 catch (Exception ex)
                 {

--- a/src/docfx/lib/collections/WorkQueue.cs
+++ b/src/docfx/lib/collections/WorkQueue.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Docs.Build
     {
         private readonly Func<T, Task> _run;
         private readonly ConcurrentQueue<T> _queue = new ConcurrentQueue<T>();
-        private readonly ConcurrentHashSet<T> _recurseDetector = new ConcurrentHashSet<T>();
+        private readonly ConcurrentHashSet<T> _duplicationDetector = new ConcurrentHashSet<T>();
 
         private readonly TaskCompletionSource<int> _drainTcs = new TaskCompletionSource<int>();
 
@@ -39,7 +39,7 @@ namespace Microsoft.Docs.Build
 
         public void Enqueue(T item)
         {
-            if (!_recurseDetector.TryAdd(item))
+            if (!_duplicationDetector.TryAdd(item))
             {
                 return;
             }

--- a/test/docfx.Test/lib/WorkQueueTest.cs
+++ b/test/docfx.Test/lib/WorkQueueTest.cs
@@ -17,10 +17,10 @@ namespace Microsoft.Docs.Build
         [InlineData(typeof(TaskCanceledException))]
         public static async Task ThrowsTheSameException(Type exceptionType)
         {
-            var queue = new WorkQueue<int>();
+            var queue = new WorkQueue<int>(Run);
             queue.Enqueue(Enumerable.Range(0, 1000));
 
-            var exception = await Assert.ThrowsAnyAsync<Exception>(() => queue.Drain(Run));
+            var exception = await Assert.ThrowsAnyAsync<Exception>(() => queue.Drain());
             Assert.Equal(exceptionType, exception.GetType());
 
             Task Run(int n) => n % 500 == 0 ? throw (Exception)Activator.CreateInstance(exceptionType) : Task.CompletedTask;
@@ -32,10 +32,10 @@ namespace Microsoft.Docs.Build
             var done = 0;
             var total = 10;
 
-            var queue = new WorkQueue<int>();
+            var queue = new WorkQueue<int>(Run);
             queue.Enqueue(Enumerable.Range(0, total));
 
-            await queue.Drain(Run);
+            await queue.Drain();
 
             Task Run(int n)
             {


### PR DESCRIPTION
- lazy toc map and xref map in context
- init build action in WorkQueue constructor instead of Drain
- One single place to control which file could be build

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4790)