### PR TITLE
 append version info to legacy fileMap, dependencyMap and aggregatedFileMap

### DIFF
--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -70,7 +70,6 @@ outputs:
   toc.json:
   toc.mta.json:
   .manifest.json:
-  .dependency-map.json:
   filemap.json:
   op_aggregated_file_map_info.json:
   .publish.json:
@@ -351,7 +350,7 @@ outputs:
   docs/a.raw.page.json:
   docs/9d4e15fd/a.mta.json:
   docs/9d4e15fd/a.raw.page.json:
-  docs/.dependency-map.json:
+  full-dependent-list.txt:
   docs/.manifest.json: |
     {
       "files":[
@@ -369,6 +368,7 @@ outputs:
           "output_relative_path":"9d4e15fd/a.html",
           "asset_id":"a",
           "version": "< netcore-2.0",
+          "monikers":["netcore-1.0","netcore-1.1"],
           "is_moniker_range": true
         }
       }

--- a/src/docfx/build/legacy/Legacy.cs
+++ b/src/docfx/build/legacy/Legacy.cs
@@ -18,10 +18,11 @@ namespace Microsoft.Docs.Build
             using (Progress.Start("Converting to legacy"))
             {
                 var files = fileManifests.Keys.ToList();
+                var legacyVersionProvider = new LegacyVersionProvider(docset);
 
                 LegacyManifest.Convert(docset, context, fileManifests);
-                var legacyDependencyMap = LegacyDependencyMap.Convert(docset, context, files, dependencyMap, tocMap);
-                LegacyFileMap.Convert(docset, context, files, legacyDependencyMap, fileManifests);
+                var legacyDependencyMap = LegacyDependencyMap.Convert(docset, context, files, dependencyMap, tocMap, legacyVersionProvider);
+                LegacyFileMap.Convert(docset, context, files, legacyDependencyMap, fileManifests, legacyVersionProvider);
             }
         }
     }

--- a/src/docfx/build/legacy/LegacyAggregatedFileMap.cs
+++ b/src/docfx/build/legacy/LegacyAggregatedFileMap.cs
@@ -26,11 +26,18 @@ namespace Microsoft.Docs.Build
                 var aggregatedFileMapItem = new
                 {
                     dependencies = dependencyMap.ContainsKey(legacyFilePathRelativeToBaseFolder)
-                                    ? dependencyMap[legacyFilePathRelativeToBaseFolder].Select(x => new DependencyItem { FromFilePath = PathUtility.NormalizeFile(Path.Combine(docset.Config.DocumentId.SourceBasePath, x.From)), ToFilePath = PathUtility.NormalizeFile(Path.Combine(docset.Config.DocumentId.SourceBasePath, x.To)), DependencyType = x.Type })
+                                    ? dependencyMap[legacyFilePathRelativeToBaseFolder].Select(
+                                        x => new DependencyItem
+                                        {
+                                            FromFilePath = PathUtility.NormalizeFile(Path.Combine(docset.Config.DocumentId.SourceBasePath, x.From)),
+                                            ToFilePath = PathUtility.NormalizeFile(Path.Combine(docset.Config.DocumentId.SourceBasePath, x.To)),
+                                            DependencyType = x.Type,
+                                            Version = x.Version,
+                                        })
                                     : new List<DependencyItem>(),
-                    aggregated_monikers = Array.Empty<string>(), // todo
+                    aggregated_monikers = fileMapItem.Monikers,
                     docset_names = new[] { docset.Config.Name },
-                    has_non_moniker_url = true, // todo
+                    has_non_moniker_url = fileMapItem.Monikers.Count == 0,
                     type = fileMapItem.Type,
                 };
 
@@ -58,6 +65,8 @@ namespace Microsoft.Docs.Build
             public string FromFilePath { get; set; }
 
             public string ToFilePath { get; set; }
+
+            public string Version { get; set; }
 
             public LegacyDependencyMapType DependencyType { get; set; }
         }

--- a/src/docfx/build/legacy/LegacyDependencyMap.cs
+++ b/src/docfx/build/legacy/LegacyDependencyMap.cs
@@ -90,7 +90,6 @@ namespace Microsoft.Docs.Build
 
                 context.Output.WriteText(dependencyListText, "full-dependent-list.txt");
                 context.Output.WriteText(dependencyListText, "server-side-dependent-list.txt");
-                context.Output.WriteJson(sorted, Path.Combine(docset.SiteBasePath, ".dependency-map.json"));
 
                 return sorted.Select(x => new LegacyDependencyMapItem {
                     From = x.From.Substring(2),

--- a/src/docfx/build/legacy/LegacyDependencyMap.cs
+++ b/src/docfx/build/legacy/LegacyDependencyMap.cs
@@ -74,16 +74,13 @@ namespace Microsoft.Docs.Build
                     select d).ToArray();
 
                 var dependencyList =
-                    from d in sorted
-                    group d by d.To into g
-                    let first = g.OrderBy(_ => _.From).FirstOrDefault()
-                    where first != null
+                    from dep in sorted
                     select JsonUtility.Serialize(new
                     {
-                        dependency_type = first.Type,
-                        from_file_path = Path.GetFullPath(Path.Combine(docset.DocsetPath, docset.Config.DocumentId.SourceBasePath, first.From.Substring(2))),
-                        to_file_path = Path.GetFullPath(Path.Combine(docset.DocsetPath, docset.Config.DocumentId.SourceBasePath, first.To.Substring(2))),
-                        version = first.Version,
+                        dependency_type = dep.Type,
+                        from_file_path = Path.GetFullPath(Path.Combine(docset.DocsetPath, docset.Config.DocumentId.SourceBasePath, dep.From.Substring(2))),
+                        to_file_path = Path.GetFullPath(Path.Combine(docset.DocsetPath, docset.Config.DocumentId.SourceBasePath, dep.To.Substring(2))),
+                        version = dep.Version,
                     });
 
                 var dependencyListText = string.Join('\n', dependencyList);
@@ -91,13 +88,13 @@ namespace Microsoft.Docs.Build
                 context.Output.WriteText(dependencyListText, "full-dependent-list.txt");
                 context.Output.WriteText(dependencyListText, "server-side-dependent-list.txt");
 
-                return sorted.Select(x => new LegacyDependencyMapItem {
+                return sorted.Select(x => new LegacyDependencyMapItem
+                {
                     From = x.From.Substring(2),
                     To = x.To.Substring(2),
                     Type = x.Type,
                     Version = x.Version,
-                })
-                    .GroupBy(x => x.From).ToDictionary(g => g.Key, g => g.ToList());
+                }).GroupBy(x => x.From).ToDictionary(g => g.Key, g => g.ToList());
             }
         }
 

--- a/src/docfx/build/legacy/LegacyDependencyMapItem.cs
+++ b/src/docfx/build/legacy/LegacyDependencyMapItem.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Docs.Build
 
         public string To { get; set; }
 
+        public string Version { get; set; }
+
         public LegacyDependencyMapType Type { get; set; }
     }
 }

--- a/src/docfx/build/legacy/LegacyFileMap.cs
+++ b/src/docfx/build/legacy/LegacyFileMap.cs
@@ -17,18 +17,12 @@ namespace Microsoft.Docs.Build
             Context context,
             List<Document> documents,
             Dictionary<string, List<LegacyDependencyMapItem>> dependencyMap,
-            Dictionary<Document, PublishItem> fileManifests)
+            Dictionary<Document, PublishItem> fileManifests,
+            LegacyVersionProvider legacyVersionProvider)
         {
             using (Progress.Start("Convert Legacy File Map"))
             {
                 var listBuilder = new ListBuilder<(string legacyFilePathRelativeToBaseFolder, LegacyFileMapItem fileMapItem)>();
-
-                var monikerRangeConfigs = new Dictionary<Func<string, bool>, string>();
-                foreach (var (key, monikerRange) in docset.Config.MonikerRange)
-                {
-                    monikerRangeConfigs.Add(GlobUtility.CreateGlobMatcher(key), monikerRange);
-                }
-                monikerRangeConfigs.Reverse();
 
                 Parallel.ForEach(
                     documents,
@@ -42,8 +36,8 @@ namespace Microsoft.Docs.Build
                         var legacyOutputFilePathRelativeToSiteBasePath = document.ToLegacyOutputPathRelativeToSiteBasePath(docset, publishItem);
                         var legacySiteUrlRelativeToSiteBasePath = document.ToLegacySiteUrlRelativeToSiteBasePath(docset);
 
-                        var monikerRange = GetMonikerRangeConfig(document);
-                        var fileItem = LegacyFileMapItem.Instance(legacyOutputFilePathRelativeToSiteBasePath, legacySiteUrlRelativeToSiteBasePath, document.ContentType, monikerRange);
+                        var version = legacyVersionProvider.GetLegacyVersion(document);
+                        var fileItem = LegacyFileMapItem.Instance(legacyOutputFilePathRelativeToSiteBasePath, legacySiteUrlRelativeToSiteBasePath, document.ContentType, version, publishItem.Monikers);
                         if (fileItem != null)
                         {
                             listBuilder.Add((PathUtility.NormalizeFile(document.ToLegacyPathRelativeToBasePath(docset)), fileItem));
@@ -53,18 +47,6 @@ namespace Microsoft.Docs.Build
                 var fileMapItems = listBuilder.ToList();
                 Convert(docset, context, fileMapItems);
                 LegacyAggregatedFileMap.Convert(docset, context, fileMapItems, dependencyMap);
-
-                string GetMonikerRangeConfig(Document file)
-                {
-                    foreach (var (glob, monikerRange) in monikerRangeConfigs)
-                    {
-                        if (glob(file.FilePath))
-                        {
-                            return monikerRange;
-                        }
-                    }
-                    return default;
-                }
             }
         }
 

--- a/src/docfx/build/legacy/LegacyFileMapItem.cs
+++ b/src/docfx/build/legacy/LegacyFileMapItem.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
 
@@ -24,9 +25,12 @@ namespace Microsoft.Docs.Build
         [JsonProperty(PropertyName = "is_moniker_range")]
         public bool IsMonikerRange { get; set; } = true;
 
+        [JsonProperty(PropertyName = "monikers")]
+        public List<string> Monikers { get; set; } = new List<string>();
+
         public bool ShouldSerializeIsMonikerRange() => !string.IsNullOrEmpty(Version);
 
-        public LegacyFileMapItem(string legacyOutputFilePathRelativeToSiteBasePath, string legacySiteUrlRelativeToSiteBasePath, ContentType contentType, string version)
+        public LegacyFileMapItem(string legacyOutputFilePathRelativeToSiteBasePath, string legacySiteUrlRelativeToSiteBasePath, ContentType contentType, string version, List<string> monikers)
         {
             switch (contentType)
             {
@@ -36,12 +40,14 @@ namespace Microsoft.Docs.Build
                     OutputRelativePath = PathUtility.NormalizeFile(LegacyUtility.ChangeExtension(legacyOutputFilePathRelativeToSiteBasePath, ".html"));
                     AssetId = legacySiteUrlRelativeToSiteBasePath;
                     Version = version;
+                    Monikers = monikers;
                     break;
                 case ContentType.Resource:
                     Type = "Resource";
                     OutputRelativePath = PathUtility.NormalizeFile(legacyOutputFilePathRelativeToSiteBasePath);
                     AssetId = legacySiteUrlRelativeToSiteBasePath;
                     Version = version;
+                    Monikers = monikers;
                     break;
                 case ContentType.TableOfContents:
                 default:
@@ -49,14 +55,14 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public static LegacyFileMapItem Instance(string legacyOutputFilePathRelativeToSiteBasePath, string legacySiteUrlRelativeToSiteBasePath, ContentType contentType, string version)
+        public static LegacyFileMapItem Instance(string legacyOutputFilePathRelativeToSiteBasePath, string legacySiteUrlRelativeToSiteBasePath, ContentType contentType, string version, List<string> monikers)
         {
             if (contentType == ContentType.TableOfContents || contentType == ContentType.Unknown)
             {
                 return null;
             }
 
-            return new LegacyFileMapItem(legacyOutputFilePathRelativeToSiteBasePath, legacySiteUrlRelativeToSiteBasePath, contentType, version);
+            return new LegacyFileMapItem(legacyOutputFilePathRelativeToSiteBasePath, legacySiteUrlRelativeToSiteBasePath, contentType, version, monikers);
         }
 
         private static string RemoveExtension(string path)

--- a/src/docfx/build/legacy/LegacyVersionProvider.cs
+++ b/src/docfx/build/legacy/LegacyVersionProvider.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Docs.Build
+{
+    internal class LegacyVersionProvider
+    {
+        private readonly Dictionary<Func<string, bool>, string> _versionConfigs = new Dictionary<Func<string, bool>, string>();
+
+        public LegacyVersionProvider(Docset docset)
+        {
+            foreach (var (key, monikerRange) in docset.Config.MonikerRange)
+            {
+                _versionConfigs.Add(GlobUtility.CreateGlobMatcher(key), monikerRange);
+            }
+            _versionConfigs.Reverse();
+        }
+
+        public string GetLegacyVersion(Document file)
+        {
+            foreach (var (glob, monikerRange) in _versionConfigs)
+            {
+                if (glob(file.FilePath))
+                {
+                    return monikerRange;
+                }
+            }
+            return default;
+        }
+    }
+}


### PR DESCRIPTION
- add `version` to full-dependent-list.txt
- add `version` to aggregatedFileMap
- add `monikers` to filemap
- implement `aggregated_monikers` and `has_non_moniker_url` in aggregatedFileMap
- skip generating dependencyMap
- fix the item in full-dependent-list.txt

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4794)