### PR TITLE
remove bilingual type from output metadata, just use enable_loc_sxs

### DIFF
--- a/src/docfx/build/page/OutputMetadata.cs
+++ b/src/docfx/build/page/OutputMetadata.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Docs.Build
@@ -66,8 +65,5 @@ namespace Microsoft.Docs.Build
 
         [JsonProperty("_op_pdfUrlPrefixTemplate")]
         public string PdfUrlPrefixTemplate { get; set; }
-
-        // todo: remove this if `enable_loc_sxs` works well
-        public string BilingualType => EnableLocSxs ? "hover over" : null;
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19990166/60068547-d09b0700-9741-11e9-9ea7-fdb3fc004737.png)

![image](https://user-images.githubusercontent.com/19990166/60068567-e1e41380-9741-11e9-81dd-f95d98d824a8.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4795)