### PR TITLE
dont parse datetime when load swagger json

### DIFF
--- a/src/Microsoft.DocAsCode.Build.RestApi/Swagger/Internals/SwaggerJsonBuilder.cs
+++ b/src/Microsoft.DocAsCode.Build.RestApi/Swagger/Internals/SwaggerJsonBuilder.cs
@@ -41,6 +41,7 @@ namespace Microsoft.DocAsCode.Build.RestApi.Swagger.Internals
         {
             using (JsonReader reader = new JsonTextReader(EnvironmentContext.FileAbstractLayer.OpenReadText(swaggerPath)))
             {
+                reader.DateParseHandling = DateParseHandling.None;
                 var token = JToken.ReadFrom(reader);
                 return LoadCore(token, swaggerPath);
             }


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4797)