### PR TITLE
Make error immutable

### DIFF
--- a/docs/specs/config.yml
+++ b/docs/specs/config.yml
@@ -278,7 +278,7 @@ inputs:
   a.md: '@System.String'
 outputs:
   .errors.log: |
-    ["error","file-not-found","Invalid file link: 'xref.json'.","*",3,7]
+    ["error","file-not-found","Invalid file link: 'xref.json'.","docfx.yml",3,7]
 ---
 # Treat warnings as errors
 inputs:

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Docs.Build
             }
             catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
             {
-                context.ErrorLog.Write(file.ToString(), dex.Error, true);
+                context.ErrorLog.Write(file.ToString(), dex.Error, isException: true);
                 context.PublishModelBuilder.MarkError(file);
             }
             catch

--- a/src/docfx/build/toc/TableOfContentsMap.cs
+++ b/src/docfx/build/toc/TableOfContentsMap.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Docs.Build
                 }
                 catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
                 {
-                    context.ErrorLog.Write(fileToBuild.ToString(), dex.Error, true);
+                    context.ErrorLog.Write(fileToBuild.ToString(), dex.Error, isException: true);
                 }
             }
         }

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Docs.Build
             }
             catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
             {
-                context.ErrorLog.Write(file.ToString(), dex.Error, true);
+                context.ErrorLog.Write(file.ToString(), dex.Error, isException: true);
             }
             catch
             {

--- a/src/docfx/cli/Docfx.cs
+++ b/src/docfx/cli/Docfx.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Docs.Build
                 catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
                 {
                     Log.Write(dex);
-                    errorLog.Write(dex.Error, true);
+                    errorLog.Write(dex.Error, isException: true);
                     return 1;
                 }
             }

--- a/src/docfx/lib/log/Error.cs
+++ b/src/docfx/lib/log/Error.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Docs.Build
     {
         public static readonly IEqualityComparer<Error> Comparer = new EqualityComparer();
 
-        public ErrorLevel Level { get; private set; }
+        public ErrorLevel Level { get; set; }
 
         public string Code { get; }
 
@@ -66,7 +66,6 @@ namespace Microsoft.Docs.Build
 
         public DocfxException ToException(Exception innerException = null)
         {
-            Level = ErrorLevel.Error;
             return new DocfxException(this, innerException);
         }
 

--- a/src/docfx/lib/log/ErrorLog.cs
+++ b/src/docfx/lib/log/ErrorLog.cs
@@ -90,7 +90,8 @@ namespace Microsoft.Docs.Build
             return Write(
                 file == error.File || !string.IsNullOrEmpty(error.File)
                     ? error
-                    : new Error(error.Level, error.Code, error.Message, file, error.Line, error.Column));
+                    : new Error(error.Level, error.Code, error.Message, file, error.Line, error.Column),
+                isException);
         }
 
         public bool Write(Error error, bool isException = false)

--- a/src/docfx/lib/log/ErrorLog.cs
+++ b/src/docfx/lib/log/ErrorLog.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Docs.Build
             return hasErrors;
         }
 
-        public bool Write(string file, Error error, bool force = false)
+        public bool Write(string file, Error error, bool isException = false)
         {
             if (error is null)
                 return false;
@@ -90,18 +90,17 @@ namespace Microsoft.Docs.Build
             return Write(
                 file == error.File || !string.IsNullOrEmpty(error.File)
                     ? error
-                    : new Error(error.Level, error.Code, error.Message, file, error.Line, error.Column),
-                force);
+                    : new Error(error.Level, error.Code, error.Message, file, error.Line, error.Column));
         }
 
-        public bool Write(Error error, bool force = false)
+        public bool Write(Error error, bool isException = false)
         {
-            if (error is null)
-                return false;
+            var level = isException ? ErrorLevel.Error : error.Level;
 
-            var level = !force && _config != null && _config.Rules.TryGetValue(error.Code, out var overrideLevel)
-                ? overrideLevel
-                : error.Level;
+            if (_config != null && _config.Rules.TryGetValue(error.Code, out var overrideLevel))
+            {
+                level = overrideLevel;
+            }
 
             if (level == ErrorLevel.Off)
             {

--- a/src/docfx/lib/log/ErrorLog.cs
+++ b/src/docfx/lib/log/ErrorLog.cs
@@ -84,9 +84,6 @@ namespace Microsoft.Docs.Build
 
         public bool Write(string file, Error error, bool isException = false)
         {
-            if (error is null)
-                return false;
-
             return Write(
                 file == error.File || !string.IsNullOrEmpty(error.File)
                     ? error

--- a/src/docfx/lib/log/ErrorLog.cs
+++ b/src/docfx/lib/log/ErrorLog.cs
@@ -93,9 +93,13 @@ namespace Microsoft.Docs.Build
 
         public bool Write(Error error, bool isException = false)
         {
-            var level = isException ? ErrorLevel.Error : error.Level;
+            var level = error.Level;
 
-            if (_config != null && _config.Rules.TryGetValue(error.Code, out var overrideLevel))
+            if (isException)
+            {
+                level = ErrorLevel.Error;
+            }
+            else if (_config != null && _config.Rules.TryGetValue(error.Code, out var overrideLevel))
             {
                 level = overrideLevel;
             }


### PR DESCRIPTION
Set level to error in `ErrorLog.Write` instead of `ToException`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4807)