### PR TITLE
Remove TemplateEngine.PreprocessMetadata

### DIFF
--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -139,8 +139,6 @@ outputs:
         "search.ms_sitename": "Docs",
         "locale": "en-us",
         "site_name": "Docs",
-        "__global": {
-        },
         "_path": "c.json",
         "_tocRel": "toc.json",
         "wordCount": 2,

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -113,7 +113,9 @@ namespace Microsoft.Docs.Build
             outputMetadata.Author = outputMetadata.ContributionInfo?.Author?.Name;
             outputMetadata.UpdatedAt = outputMetadata.ContributionInfo?.UpdatedAtDateTime.ToString("yyyy-MM-dd hh:mm tt");
 
-            outputMetadata.DepotName = $"{file.Docset.Config.Product}.{file.Docset.Config.Name}";
+            outputMetadata.SearchProduct = file.Docset.Config.Product;
+            outputMetadata.SearchDocsetName = file.Docset.Config.Name;
+
             outputMetadata.Path = PathUtility.NormalizeFile(Path.GetRelativePath(file.Docset.SiteBasePath, file.SitePath));
             outputMetadata.CanonicalUrlPrefix = $"{file.Docset.HostName}/{outputMetadata.Locale}/{file.Docset.SiteBasePath}/";
 
@@ -251,7 +253,7 @@ namespace Microsoft.Docs.Build
         private static (object model, JObject metadata) ApplyPageTemplate(Context context, Document file, JObject pageMetadata, JObject pageModel, bool isConceptual)
         {
             var conceptual = isConceptual ? pageModel.Value<string>("conceptual") : string.Empty;
-            var processedMetadata = context.TemplateEngine.PreprocessMetadata(isConceptual ? pageModel : pageMetadata, file);
+            var processedMetadata = isConceptual ? pageModel : pageMetadata;
 
             if (!file.Docset.Config.Output.Json)
             {

--- a/src/docfx/build/page/OutputMetadata.cs
+++ b/src/docfx/build/page/OutputMetadata.cs
@@ -58,7 +58,16 @@ namespace Microsoft.Docs.Build
 
         public string SiteName { get; set; }
 
-        public string DepotName { get; set; }
+        public string DepotName => $"{SearchProduct}.{SearchDocsetName}";
+
+        [JsonProperty("search.ms_docsetname")]
+        public string SearchDocsetName { get; set; }
+
+        [JsonProperty("search.ms_product")]
+        public string SearchProduct { get; set; }
+
+        [JsonProperty("search.ms_sitename")]
+        public string SearchSiteName => SiteName;
 
         [JsonProperty("_path")]
         public string Path { get; set; }

--- a/src/docfx/template/TemplateEngine.cs
+++ b/src/docfx/template/TemplateEngine.cs
@@ -274,15 +274,5 @@ namespace Microsoft.Docs.Build
             }
             return rawMetadata;
         }
-
-        private static JObject ToJObject(Contributor info)
-        {
-            return new JObject
-            {
-                ["display_name"] = !string.IsNullOrEmpty(info.DisplayName) ? info.DisplayName : info.Name,
-                ["id"] = info.Id,
-                ["profile_url"] = info.ProfileUrl,
-            };
-        }
     }
 }

--- a/src/docfx/template/TemplateEngine.cs
+++ b/src/docfx/template/TemplateEngine.cs
@@ -23,24 +23,24 @@ namespace Microsoft.Docs.Build
 
         private readonly string _templateDir;
         private readonly string _schemaDir;
+        private readonly JObject _global;
         private readonly LiquidTemplate _liquid;
         private readonly JavascriptEngine _js;
         private readonly HashSet<string> _htmlMetaHidden;
         private readonly Dictionary<string, string> _htmlMetaNames;
         private readonly HashSet<string> _schemas;
 
-        public JObject Global { get; }
-
         private TemplateEngine(string templateDir, JsonSchema metadataSchema)
         {
             var contentTemplateDir = Path.Combine(templateDir, "ContentTemplate");
             var schemaDir = Path.Combine(contentTemplateDir, "schemas");
 
+            _global = LoadGlobalTokens(contentTemplateDir);
+
             _templateDir = templateDir;
             _schemaDir = schemaDir;
             _liquid = new LiquidTemplate(templateDir);
-            _js = new JavascriptEngine(contentTemplateDir);
-            Global = LoadGlobalTokens(contentTemplateDir);
+            _js = new JavascriptEngine(contentTemplateDir, _global);
             _schemas = Directory.Exists(schemaDir) ? Directory.EnumerateFiles(schemaDir, "*.schema.json", SearchOption.TopDirectoryOnly)
                                                     .Select(k => Path.GetFileNameWithoutExtension(k))
                                                     .Select(k => k.Substring(0, k.Length - ".schema".Length)).ToHashSet() : new HashSet<string>();
@@ -171,21 +171,7 @@ namespace Microsoft.Docs.Build
 
         public string GetToken(string key)
         {
-            return Global[key]?.ToString();
-        }
-
-        public JObject PreprocessMetadata(JObject outputMetadata, Document file)
-        {
-            var docset = file.Docset;
-
-            var processedMetadata = (JObject)JsonUtility.DeepClone(outputMetadata);
-            processedMetadata["search.ms_docsetname"] = docset.Config.Name;
-            processedMetadata["search.ms_product"] = docset.Config.Product;
-            processedMetadata["search.ms_sitename"] = "Docs";
-
-            processedMetadata["__global"] = Global;
-
-            return processedMetadata;
+            return _global[key]?.ToString();
         }
 
         public JObject TransformTocMetadata(object model)

--- a/test/docfx.Test/template/JavascriptEngineTest.cs
+++ b/test/docfx.Test/template/JavascriptEngineTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Docs.Build
         {
             var inputJson = JObject.Parse(input.Replace('\'', '"'));
             var outputJson = _js.Run("index.js", "main", inputJson);
-            (outputJson as JObject).Property("__global")?.Remove();
+            (outputJson as JObject)?.Property("__global")?.Remove();
             Assert.Equal(output.Replace('\'', '"'), outputJson.ToString(Formatting.None));
         }
 

--- a/test/docfx.Test/template/JavascriptEngineTest.cs
+++ b/test/docfx.Test/template/JavascriptEngineTest.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Docs.Build
         {
             var inputJson = JObject.Parse(input.Replace('\'', '"'));
             var outputJson = _js.Run("index.js", "main", inputJson);
+            (outputJson as JObject).Property("__global")?.Remove();
             Assert.Equal(output.Replace('\'', '"'), outputJson.ToString(Formatting.None));
         }
 


### PR DESCRIPTION
- Move global to `JavascriptEngine` so we don't convert it for each jint run (__global is huge)
- Remove `TemplateEngine.PreprocessMetadata`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4809)