### PR TITLE
refine build page data flow for conceptual and sdp

### DIFF
--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -62,6 +62,7 @@ outputs:
         <meta name=\"search.ms_product\" content=\"\" />
         <meta name=\"search.ms_sitename\" content=\"Docs\" />
         <meta name=\"site_name\" content=\"Docs\" />
+        <meta name=\"title\" content=\"\" />
         <meta name=\"updated_at\" content=\"2018-10-30 12:00 AM\" />
         <meta name=\"wordCount\" content=\"1\" />"
     }

--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -61,7 +61,7 @@ outputs:
     }
   h4.json: |
     {
-      "!title": null,
+      "title": null,
       "rawTitle": "",
       "conceptual": "<h4 id=\"h4-title\">h4 title</h4>",
     }

--- a/src/docfx/build/metadata/InputMetadata.cs
+++ b/src/docfx/build/metadata/InputMetadata.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Docs.Build
@@ -22,5 +23,8 @@ namespace Microsoft.Docs.Build
 
         [JsonProperty("_tocRel")]
         public string TocRel { get; set; }
+
+        [JsonIgnore]
+        public JObject RawJObject { get; set; } = new JObject();
     }
 }

--- a/src/docfx/build/metadata/MetadataProvider.cs
+++ b/src/docfx/build/metadata/MetadataProvider.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Docs.Build
         private readonly HashSet<string> _reservedMetadata;
         private readonly List<(Func<string, bool> glob, string key, JToken value)> _rules = new List<(Func<string, bool> glob, string key, JToken value)>();
 
-        private readonly ConcurrentDictionary<Document, (List<Error> errors, InputMetadata metadataModel)> _metadataCache
-                   = new ConcurrentDictionary<Document, (List<Error> errors, InputMetadata metadataModel)>();
+        private readonly ConcurrentDictionary<Document, (List<Error> errors, InputMetadata metadata)> _metadataCache
+                   = new ConcurrentDictionary<Document, (List<Error> errors, InputMetadata metadata)>();
 
         public MetadataProvider(Docset docset, Cache cache, MicrosoftGraphCache microsoftGraphCache)
         {
@@ -41,12 +41,12 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public (List<Error> errors, InputMetadata metadataModel) GetMetadata(Document file)
+        public (List<Error> errors, InputMetadata metadata) GetMetadata(Document file)
         {
             return _metadataCache.GetOrAdd(file, GetMetadataCore);
         }
 
-        private (List<Error> errors, InputMetadata metadataModel) GetMetadataCore(Document file)
+        private (List<Error> errors, InputMetadata metadata) GetMetadataCore(Document file)
         {
             if (file.ContentType != ContentType.Page && file.ContentType != ContentType.TableOfContents)
             {
@@ -88,13 +88,13 @@ namespace Microsoft.Docs.Build
 
             errors.AddRange(_schemaValidator.Validate(result));
 
-            var (validationErrors, metadataModel) = JsonUtility.ToObject<InputMetadata>(result);
+            var (validationErrors, metadata) = JsonUtility.ToObject<InputMetadata>(result);
 
-            metadataModel.RawJObject = result;
+            metadata.RawJObject = result;
 
             errors.AddRange(validationErrors);
 
-            return (errors, metadataModel);
+            return (errors, metadata);
         }
 
         private static bool IsValidMetadataType(JToken token)

--- a/src/docfx/build/moniker/MonikerProvider.cs
+++ b/src/docfx/build/moniker/MonikerProvider.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Docs.Build
         private (Error error, List<string> monikers) GetFileLevelMonikersCore(Document file)
         {
             var errors = new List<Error>();
-            var (_, _, metadata) = _metadataProvider.GetMetadata(file);
+            var (_, metadata) = _metadataProvider.GetMetadata(file);
 
             string configMonikerRange = null;
             var configMonikers = new List<string>();

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -175,8 +175,8 @@ namespace Microsoft.Docs.Build
             {
                 ["conceptual"] = HtmlUtility.HtmlPostProcess(htmlDom, file.Docset.Culture),
                 ["wordCount"] = wordCount,
-                ["raw_title"] = rawTitle,
-                ["title"] = title,
+                ["rawTitle"] = rawTitle,
+                ["title"] = inputMetadata.Title ?? title,
             };
 
             context.BookmarkValidator.AddBookmarks(file, bookmarks);
@@ -241,7 +241,7 @@ namespace Microsoft.Docs.Build
             }
 
             pageModel["title"] = inputMetadata.Title ?? obj?.Value<string>("title");
-            pageModel["raw_title"] = file.Docset.Legacy ? $"<h1>{obj?.Value<string>("title")}</h1>" : null;
+            pageModel["rawTitle"] = file.Docset.Legacy ? $"<h1>{obj?.Value<string>("title")}</h1>" : null;
 
             return (errors, pageModel as JObject, inputMetadata);
         }

--- a/src/docfx/build/page/OutputMetadata.cs
+++ b/src/docfx/build/page/OutputMetadata.cs
@@ -12,8 +12,6 @@ namespace Microsoft.Docs.Build
     {
         public string Locale { get; set; }
 
-        public string Title { get; set; }
-
         public string Author { get; set; }
 
         public string BreadcrumbPath { get; set; }
@@ -24,17 +22,11 @@ namespace Microsoft.Docs.Build
         [JsonProperty("_tocRel")]
         public string TocRel { get; set; }
 
-        [JsonProperty(PropertyName = "rawTitle")]
-        public string RawTitle { get; set; }
-
         public string CanonicalUrl { get; set; }
 
         public string RedirectUrl { get; set; }
 
         public string DocumentId { get; set; }
-
-        [JsonProperty("wordCount")]
-        public long? WordCount { get; set; }
 
         public string DocumentVersionIndependentId { get; set; }
 

--- a/src/docfx/build/page/OutputMetadata.cs
+++ b/src/docfx/build/page/OutputMetadata.cs
@@ -16,9 +16,6 @@ namespace Microsoft.Docs.Build
 
         public string BreadcrumbPath { get; set; }
 
-        [JsonIgnore]
-        public string SchemaType { get; set; }
-
         [JsonProperty("_tocRel")]
         public string TocRel { get; set; }
 

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Docs.Build
                 var callStack = new List<Document> { file };
                 if (file.FilePath.EndsWith(".md", PathUtility.PathComparison))
                 {
-                    var (fileMetaErrors, _, fileMetadata) = context.MetadataProvider.GetMetadata(file);
+                    var (fileMetaErrors, fileMetadata) = context.MetadataProvider.GetMetadata(file);
                     errors.AddRange(fileMetaErrors);
 
                     if (!string.IsNullOrEmpty(fileMetadata.Uid))


### PR DESCRIPTION
1. reduce return values of `Load`
2. reduce output metadata shared by sdp and conceptual
3. reduce return values of `getMetadata`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4816)