### PR TITLE
🎈Add validation that same uid should have same name

### DIFF
--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -484,7 +484,7 @@ outputs:
   218c13d0/docs/a.json:
   4667fedf/docs/a.json:
   .errors.log: |
-    ["warning","uid-property-conflict","UID 'a' is defined with different names: 'netcore-1.1', 'netcore-2.0'"]
+    ["warning","xref-property-conflict","UID 'a' is defined with different names: 'netcore-1.1', 'netcore-2.0'"]
 ---
 # Define same uid with multiple moniker ranges with same name, 
 # reference to it without moniker in the same docset, anyone can be taken
@@ -581,12 +581,12 @@ inputs:
     }
 outputs:
   docs/c.json: |
-    {"conceptual":"<p>Link to @a</p>"}
+    {"conceptual":"<p>Link to <a href=\"a\" data-linktype=\"relative-path\">netcore-1.1, netcore-2.0</a></p>"}
   .errors.log: |
-    ["error","moniker-overlapping","Two or more documents have defined overlapping moniker: 'netcore-2.0'"]
+    ["warning","moniker-overlapping","Two or more documents have defined overlapping moniker: 'netcore-2.0'"]
     ["error","publish-url-conflict","Two or more files of the same version('netcore-2.0') publish to the same url '/docs/a': 'docs/v1/a.md', 'docs/v2/a.md'"]
   xrefmap.json: | 
-    {"!references":null}
+    {"references":[{"uid":"a","name":"netcore-1.1, netcore-2.0"}]}
 ---
 # Define uid with moniker range, refer to it with invalid moniker, could fall back to anyone
 inputs:

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -588,7 +588,7 @@ outputs:
   xrefmap.json: | 
     {"!references":null}
 ---
-# Define uid with moniker range, refer to it with invalid moniker, could fall back to the one with any one
+# Define uid with moniker range, refer to it with invalid moniker, could fall back to anyone
 inputs:
   docfx.yml: |
     monikerRange:

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -484,7 +484,7 @@ outputs:
   218c13d0/docs/a.json:
   4667fedf/docs/a.json:
   .errors.log: |
-    ["warning","uid-name-conflict","UID 'a' is defined with different names: 'netcore-1.1', 'netcore-2.0'"]
+    ["warning","uid-property-conflict","UID 'a' is defined with different names: 'netcore-1.1', 'netcore-2.0'"]
 ---
 # Define same uid with multiple moniker ranges with same name, 
 # reference to it without moniker in the same docset, anyone can be taken

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -484,7 +484,7 @@ outputs:
   218c13d0/docs/a.json:
   4667fedf/docs/a.json:
   .errors.log: |
-    ["error","uid-name-conflict","UID 'a' is defined with different names: 'netcore-1.1', 'netcore-2.0'"]
+    ["warning","uid-name-conflict","UID 'a' is defined with different names: 'netcore-1.1', 'netcore-2.0'"]
 ---
 # Define same uid with multiple moniker ranges with same name, 
 # reference to it without moniker in the same docset, anyone can be taken

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -400,14 +400,14 @@ inputs:
   docs/v1/a.md: |
     ---
     uid: a
-    title: netcore-1.1
+    title: netcore
     monikerRange: '> netcore-1.0'
     ---
     Moniker: netcore-1.1
   docs/v2/a.md: |
     ---
     uid: a
-    title: netcore-2.0
+    title: netcore
     monikerRange: '<= netcore-2.0'
     ---
     Moniker: netcore-2.0
@@ -427,7 +427,7 @@ inputs:
 outputs:
   docs/b.json: |
     {
-      "conceptual": "<p>Link to <a href=\"a?view=netcore-1.1\">netcore-1.1</a></p>",
+      "conceptual": "<p>Link to <a href=\"a?view=netcore-1.1\">netcore</a></p>",
       "!monikers": null
     }
   docs/a.json: |
@@ -446,8 +446,8 @@ outputs:
       "monikers": ["netcore-2.0"]
     }
 ---
-# Define same uid with multiple moniker ranges, 
-# reference to it without moniker in the same docset, shoule take the latest one
+# Define same uid with multiple moniker ranges in .md,
+# title should be the same
 inputs:
   docfx.yml: |
     monikerRange:
@@ -471,6 +471,46 @@ inputs:
     monikerRange: '<= netcore-2.0'
     ---
     Moniker: netcore-2.0
+  monikerDefinition.json: |
+    {
+      "monikers": [
+        { "moniker_name": "netcore-1.0", "product_name": ".NET Core" },
+        { "moniker_name": "netcore-1.1", "product_name": ".NET Core" },
+        { "moniker_name": "netcore-2.0", "product_name": ".NET Core" },
+        { "moniker_name": "netcore-2.1", "product_name": ".NET Core" }
+      ]
+    }
+outputs:
+  218c13d0/docs/a.json:
+  4667fedf/docs/a.json:
+  .errors.log: |
+    ["error","uid-name-conflict","UID 'a' is defined with different names: 'netcore-1.1', 'netcore-2.0'"]
+---
+# Define same uid with multiple moniker ranges with same name, 
+# reference to it without moniker in the same docset, anyone can be taken
+inputs:
+  docfx.yml: |
+    monikerRange:
+      'docs/v1/**': '< netcore-2.0'
+      'docs/v2/**': '>= netcore-2.0'
+    routes:
+      docs/v1/: docs/
+      docs/v2/: docs/
+    monikerDefinition: monikerDefinition.json
+  docs/v1/a.md: |
+    ---
+    uid: a
+    title: netcore
+    monikerRange: '> netcore-1.0'
+    ---
+    Moniker: netcore-1.1
+  docs/v2/a.md: |
+    ---
+    uid: a
+    title: netcore
+    monikerRange: '<= netcore-2.0'
+    ---
+    Moniker: netcore-2.0
   docs/a.md: |
     No version
   docs/b.md: |
@@ -487,7 +527,7 @@ inputs:
 outputs:
   docs/b.json: |
     {
-      "conceptual": "<p>Link to <a href=\"a\">netcore-2.0</a></p>",
+      "conceptual": "<p>Link to <a href=\"a\">netcore</a></p>",
       "!monikers": null
     }
   docs/a.json: |
@@ -548,7 +588,7 @@ outputs:
   xrefmap.json: | 
     {"!references":null}
 ---
-# Define uid with moniker range, refer to it with invalid moniker, should fall back to the one with latest moniker
+# Define uid with moniker range, refer to it with invalid moniker, could fall back to the one with any one
 inputs:
   docfx.yml: |
     monikerRange:
@@ -561,14 +601,14 @@ inputs:
   docs/v1/a.md: |
     ---
     uid: a
-    title: netcore-1.1
+    title: netcore
     monikerRange: '> netcore-1.0'
     ---
     Moniker: netcore-1.1
   docs/v2/a.md: |
     ---
     uid: a
-    title: netcore-2.0
+    title: netcore
     monikerRange: '<= netcore-2.0'
     ---
     Moniker: netcore-2.0
@@ -586,7 +626,7 @@ inputs:
 outputs:
   docs/b.json: |
     {
-      "conceptual": "<p>Link <a href=\"a?view=netcore-1.0\">netcore-2.0</a></p>",
+      "conceptual": "<p>Link <a href=\"a?view=netcore-1.0\">netcore</a></p>",
       "!monikers": null
     }
   218c13d0/docs/a.json: |

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -584,6 +584,7 @@ outputs:
     {"conceptual":"<p>Link to <a href=\"a\" data-linktype=\"relative-path\">netcore-1.1, netcore-2.0</a></p>"}
   .errors.log: |
     ["warning","moniker-overlapping","Two or more documents have defined overlapping moniker: 'netcore-2.0'"]
+    ["warning","xref-property-conflict","UID 'a' is defined with different names: 'netcore-1.1, netcore-2.0', 'netcore-2.0, netcore-2.1'"]
     ["error","publish-url-conflict","Two or more files of the same version('netcore-2.0') publish to the same url '/docs/a': 'docs/v1/a.md', 'docs/v2/a.md'"]
   xrefmap.json: | 
     {"references":[{"uid":"a","name":"netcore-1.1, netcore-2.0"}]}
@@ -779,6 +780,7 @@ outputs:
     {"references":[{"uid":"a","name":"no version"}]}
   .errors.log: |
     ["warning","uid-conflict","UID 'a' is defined in more than one file: 'docs/a.md', 'docs/b.md'"]
+    ["warning","xref-property-conflict","UID 'a' is defined with different names: 'b with no version', 'netcore-1.1', 'netcore-2.0', 'no version'"]
 ---
 # Build toc with monikers info
 inputs:

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -523,6 +523,17 @@ namespace Microsoft.Docs.Build
         }
 
         /// <summary>
+        /// Same uid defined within different versions with the different name.
+        /// Examples:
+        ///   - Same uid defined in multiple .md files with different versions have different titles.
+        /// </summary>
+        /// Behavior: ❌ Message: ❌
+        public static Error UidNameConflict(string uid, IEnumerable<string> nameConflicts)
+        {
+            return new Error(ErrorLevel.Error, "uid-name-conflict", $"UID '{uid}' is defined with different names: {Join(nameConflicts)}");
+        }
+
+        /// <summary>
         /// Multiple articles with same uid contain overlapped monikers,
         /// and can't decide which article to use when referencing that uid with this overlapped version
         /// </summary>

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -537,7 +537,7 @@ namespace Microsoft.Docs.Build
         /// Behavior: ✔️ Message: ❌
         public static Error UidPropertyConflict(string uid, string propertyName, IEnumerable<string> conflicts)
         {
-            return new Error(ErrorLevel.Warning, "uid-property-conflict", $"UID '{uid}' is defined with different {propertyName}s: {Join(conflicts)}");
+            return new Error(ErrorLevel.Warning, "xref-property-conflict", $"UID '{uid}' is defined with different {propertyName}s: {Join(conflicts)}");
         }
 
         /// <summary>
@@ -546,7 +546,7 @@ namespace Microsoft.Docs.Build
         /// </summary>
         /// Behavior: ✔️ Message: ❌
         public static Error MonikerOverlapping(IEnumerable<string> overlappingmonikers)
-            => new Error(ErrorLevel.Error, "moniker-overlapping", $"Two or more documents have defined overlapping moniker: {Join(overlappingmonikers)}");
+            => new Error(ErrorLevel.Warning, "moniker-overlapping", $"Two or more documents have defined overlapping moniker: {Join(overlappingmonikers)}");
 
         /// <summary>
         /// Failed to parse moniker string.

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -527,10 +527,10 @@ namespace Microsoft.Docs.Build
         /// Examples:
         ///   - Same uid defined in multiple .md files with different versions have different titles.
         /// </summary>
-        /// Behavior: ❌ Message: ❌
-        public static Error UidNameConflict(string uid, IEnumerable<string> nameConflicts)
+        /// Behavior: ✔️ Message: ❌
+        public static Error UidPropertyConflict(string uid, string propertyName, IEnumerable<string> conflicts)
         {
-            return new Error(ErrorLevel.Error, "uid-name-conflict", $"UID '{uid}' is defined with different names: {Join(nameConflicts)}");
+            return new Error(ErrorLevel.Warning, "uid-property-conflict", $"UID '{uid}' is defined with different {propertyName}s: {Join(conflicts)}");
         }
 
         /// <summary>

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Docs.Build
             var displayProperty = queries?["displayProperty"];
 
             // need to url decode uid from input content
-            var (error, resolvedHref, display, xrefSpec) = _xrefMap.Value.Resolve(Uri.UnescapeDataString(uid), href, displayProperty, declaringFile, moniker);
+            var (error, resolvedHref, display, xrefSpec) = _xrefMap.Value.Resolve(Uri.UnescapeDataString(uid), href, displayProperty, declaringFile);
 
             if (xrefSpec?.DeclaringFile != null)
             {

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Docs.Build
         {
             var (error, link, display, spec) = ResolveAbsoluteXref(href, declaringFile);
 
-            if (spec?.DeclairingFile != null)
+            if (spec?.DeclaringFile != null)
             {
                 link = UrlUtility.GetRelativeUrl(relativeToFile.SiteUrl, link);
             }
@@ -112,9 +112,9 @@ namespace Microsoft.Docs.Build
             // need to url decode uid from input content
             var (error, resolvedHref, display, xrefSpec) = _xrefMap.Value.Resolve(Uri.UnescapeDataString(uid), href, displayProperty, declaringFile, moniker);
 
-            if (xrefSpec?.DeclairingFile != null)
+            if (xrefSpec?.DeclaringFile != null)
             {
-                _dependencyMapBuilder.AddDependencyItem(declaringFile, xrefSpec?.DeclairingFile, DependencyType.UidInclusion);
+                _dependencyMapBuilder.AddDependencyItem(declaringFile, xrefSpec?.DeclaringFile, DependencyType.UidInclusion);
             }
 
             if (!string.IsNullOrEmpty(resolvedHref))
@@ -155,9 +155,9 @@ namespace Microsoft.Docs.Build
             {
                 var uid = new SourceInfo<string>(href.Value.Substring("xref:".Length), href);
                 var (uidError, uidHref, _, xrefSpec) = ResolveAbsoluteXref(uid, declaringFile);
-                var xrefLinkType = xrefSpec?.DeclairingFile != null ? LinkType.RelativePath : LinkType.External;
+                var xrefLinkType = xrefSpec?.DeclaringFile != null ? LinkType.RelativePath : LinkType.External;
 
-                return (uidError, uidHref, null, xrefLinkType, xrefSpec?.DeclairingFile);
+                return (uidError, uidHref, null, xrefLinkType, xrefSpec?.DeclaringFile);
             }
 
             var decodedHref = new SourceInfo<string>(Uri.UnescapeDataString(href), href);

--- a/src/docfx/build/toc/parser/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsParser.cs
@@ -322,14 +322,14 @@ namespace Microsoft.Docs.Build
                     var (uidError, uidLink, display, xrefSpec) = context.DependencyResolver.ResolveRelativeXref(rootPath, uid, filePath);
                     errors.AddIfNotNull(uidError);
 
-                    if (xrefSpec?.DeclairingFile != null)
+                    if (xrefSpec?.DeclaringFile != null)
                     {
-                        referencedFiles.Add(xrefSpec?.DeclairingFile);
+                        referencedFiles.Add(xrefSpec?.DeclaringFile);
                     }
 
                     if (!string.IsNullOrEmpty(uidLink))
                     {
-                        return (new SourceInfo<string>(uidLink, uid), new SourceInfo<string>(display, uid), xrefSpec?.DeclairingFile);
+                        return (new SourceInfo<string>(uidLink, uid), new SourceInfo<string>(display, uid), xrefSpec?.DeclaringFile);
                     }
                 }
 

--- a/src/docfx/build/xref/ExternalXRefSpec.cs
+++ b/src/docfx/build/xref/ExternalXRefSpec.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Docs.Build
 
         public string Href { get; set; }
 
-        Document IXrefSpec.DeclairingFile => null;
+        Document IXrefSpec.DeclaringFile => null;
 
         [JsonIgnore]
         public HashSet<string> Monikers { get; set; } = new HashSet<string>();

--- a/src/docfx/build/xref/IXrefSpec.cs
+++ b/src/docfx/build/xref/IXrefSpec.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Docs.Build
     {
         string Href { get; }
 
-        Document DeclairingFile { get; }
+        Document DeclaringFile { get; }
 
         HashSet<string> Monikers { get; }
 

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Docs.Build
 {
     internal static class InternalXrefMapBuilder
     {
-        public static IReadOnlyDictionary<string, InternalXrefSpec[]> Build(Context context)
+        public static IReadOnlyDictionary<string, InternalXrefSpec> Build(Context context)
         {
             var builder = new ListBuilder<InternalXrefSpec>();
 
@@ -28,11 +28,10 @@ namespace Microsoft.Docs.Build
                 from spec in builder.ToList()
                 group spec by spec.Uid into g
                 let uid = g.Key
-                let specs = AggregateXrefSpecs(context, uid, g.ToArray())
-                where specs.Length > 0
-                select (uid, specs);
+                let spec = AggregateXrefSpecs(context, uid, g.ToArray())
+                select (uid, spec);
 
-            return result.ToDictionary(item => item.uid, item => item.specs);
+            return result.ToDictionary(item => item.uid, item => item.spec);
         }
 
         private static void Load(Context context, ListBuilder<InternalXrefSpec> xrefs, Document file)
@@ -89,7 +88,7 @@ namespace Microsoft.Docs.Build
             {
                 Uid = metadata.Uid,
                 Href = file.SiteUrl,
-                DeclairingFile = file,
+                DeclaringFile = file,
             };
             xref.ExtensionData["name"] = new Lazy<JToken>(() => new JValue(string.IsNullOrEmpty(metadata.Title) ? metadata.Uid : metadata.Title));
 
@@ -117,7 +116,7 @@ namespace Microsoft.Docs.Build
                 {
                     Uid = item.Key,
                     Href = isRoot ? file.SiteUrl : $"{file.SiteUrl}#{GetBookmarkFromUid(item.Key)}",
-                    DeclairingFile = file,
+                    DeclaringFile = file,
                 };
                 xref.ExtensionData.AddRange(properties);
                 return xref;
@@ -129,12 +128,12 @@ namespace Microsoft.Docs.Build
                 => Regex.Replace(uid, @"\W", "_");
         }
 
-        private static InternalXrefSpec[] AggregateXrefSpecs(Context context, string uid, InternalXrefSpec[] specsWithSameUid)
+        private static InternalXrefSpec AggregateXrefSpecs(Context context, string uid, InternalXrefSpec[] specsWithSameUid)
         {
             // no conflicts
             if (specsWithSameUid.Length <= 1)
             {
-                return specsWithSameUid;
+                return specsWithSameUid.FirstOrDefault();
             }
 
             // multiple uid conflicts without moniker range definition
@@ -142,9 +141,8 @@ namespace Microsoft.Docs.Build
             var conflictsWithoutMoniker = specsWithSameUid.Where(item => item.Monikers.Count == 0).ToArray();
             if (conflictsWithoutMoniker.Length > 1)
             {
-                var orderedConflict = conflictsWithoutMoniker.OrderBy(item => item.DeclairingFile);
-                context.ErrorLog.Write(Errors.UidConflict(uid, orderedConflict.Select(x => x.DeclairingFile.FilePath)));
-                return new InternalXrefSpec[] { orderedConflict.First() };
+                var orderedConflict = conflictsWithoutMoniker.OrderBy(item => item.DeclaringFile);
+                context.ErrorLog.Write(Errors.UidConflict(uid, orderedConflict.Select(x => x.DeclaringFile.FilePath)));
             }
 
             // uid conflicts with overlapping monikers
@@ -153,7 +151,6 @@ namespace Microsoft.Docs.Build
             if (CheckOverlappingMonikers(specsWithSameUid, out var overlappingMonikers))
             {
                 context.ErrorLog.Write(Errors.MonikerOverlapping(overlappingMonikers));
-                return new InternalXrefSpec[] { conflictsWithMoniker.OrderBy(item => item.DeclairingFile).First() };
             }
 
             // uid conflicts with different names
@@ -162,10 +159,9 @@ namespace Microsoft.Docs.Build
             if (conflictingNames.Count() > 1)
             {
                 context.ErrorLog.Write(Errors.UidPropertyConflict(uid, "name", conflictingNames));
-                return new InternalXrefSpec[] { specsWithSameUid.OrderBy(spec => spec.DeclairingFile).First() };
             }
 
-            return conflictsWithoutMoniker.Concat(conflictsWithMoniker).ToArray();
+            return specsWithSameUid.OrderBy(spec => spec.DeclaringFile).First();
         }
 
         private static bool CheckOverlappingMonikers(IXrefSpec[] specsWithSameUid, out HashSet<string> overlappingMonikers)

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Docs.Build
             }
 
             // multiple uid conflicts without moniker range definition
-            // log an warning and take the first one order by the declairing file
+            // log an warning and take the first one order by the declaring file
             var conflictsWithoutMoniker = specsWithSameUid.Where(item => item.Monikers.Count == 0).ToArray();
             if (conflictsWithoutMoniker.Length > 1)
             {

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -189,10 +189,15 @@ namespace Microsoft.Docs.Build
                 return Array.Empty<InternalXrefSpec>();
             }
 
-            // Sort by monikers
-            return conflictsWithoutMoniker.Concat(
-                conflictsWithMoniker.OrderByDescending(
-                    spec => spec.Monikers.First(), context.MonikerProvider.Comparer)).ToArray();
+            // uid conflicts with different names, drop the uid and log an error
+            var conflictingNames = specsWithSameUid.Select(x => x.GetName()).Distinct();
+            if (conflictingNames.Count() > 1)
+            {
+                context.ErrorLog.Write(Errors.UidNameConflict(uid, conflictingNames));
+                return Array.Empty<InternalXrefSpec>();
+            }
+
+            return conflictsWithoutMoniker.Concat(conflictsWithMoniker).ToArray();
         }
 
         private static bool CheckOverlappingMonikers(IXrefSpec[] specsWithSameUid, out HashSet<string> overlappingMonikers)

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -131,9 +131,9 @@ namespace Microsoft.Docs.Build
         private static InternalXrefSpec AggregateXrefSpecs(Context context, string uid, InternalXrefSpec[] specsWithSameUid)
         {
             // no conflicts
-            if (specsWithSameUid.Length <= 1)
+            if (specsWithSameUid.Length == 1)
             {
-                return specsWithSameUid.FirstOrDefault();
+                return specsWithSameUid.First();
             }
 
             // multiple uid conflicts without moniker range definition

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -131,8 +131,6 @@ namespace Microsoft.Docs.Build
 
         private static InternalXrefSpec[] AggregateXrefSpecs(Context context, string uid, InternalXrefSpec[] specsWithSameUid)
         {
-            var orderedSpecs = specsWithSameUid.OrderBy(spec => spec.DeclairingFile);
-
             // no conflicts
             if (specsWithSameUid.Length <= 1)
             {
@@ -149,21 +147,21 @@ namespace Microsoft.Docs.Build
                 return new InternalXrefSpec[] { orderedConflict.First() };
             }
 
-            // uid conflicts with different names
-            // log an warning and take the first one order by the declaring file
-            var conflictingNames = specsWithSameUid.Select(x => x.GetName()).Distinct();
-            if (conflictingNames.Count() > 1)
-            {
-                context.ErrorLog.Write(Errors.UidPropertyConflict(uid, "name", conflictingNames));
-                return new InternalXrefSpec[] { orderedSpecs.First() };
-            }
-
             // uid conflicts with overlapping monikers, drop the uid and log an error
             var conflictsWithMoniker = specsWithSameUid.Where(x => x.Monikers.Count > 0).ToArray();
             if (CheckOverlappingMonikers(specsWithSameUid, out var overlappingMonikers))
             {
                 context.ErrorLog.Write(Errors.MonikerOverlapping(overlappingMonikers));
                 return Array.Empty<InternalXrefSpec>();
+            }
+
+            // uid conflicts with different names
+            // log an warning and take the first one order by the declaring file
+            var conflictingNames = specsWithSameUid.Select(x => x.GetName()).Distinct();
+            if (conflictingNames.Count() > 1)
+            {
+                context.ErrorLog.Write(Errors.UidPropertyConflict(uid, "name", conflictingNames));
+                return new InternalXrefSpec[] { specsWithSameUid.OrderBy(spec => spec.DeclairingFile).First() };
             }
 
             return conflictsWithoutMoniker.Concat(conflictsWithMoniker).ToArray();

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Docs.Build
             }
 
             // multiple uid conflicts without moniker range definition
-            // order by the declairing file, take the first one
+            // log an warning and take the first one order by the declairing file
             var conflictsWithoutMoniker = specsWithSameUid.Where(item => item.Monikers.Count == 0).ToArray();
             if (conflictsWithoutMoniker.Length > 1)
             {
@@ -147,12 +147,13 @@ namespace Microsoft.Docs.Build
                 return new InternalXrefSpec[] { orderedConflict.First() };
             }
 
-            // uid conflicts with overlapping monikers, drop the uid and log an error
+            // uid conflicts with overlapping monikers
+            // log an warning and take the first one order by the declaring file
             var conflictsWithMoniker = specsWithSameUid.Where(x => x.Monikers.Count > 0).ToArray();
             if (CheckOverlappingMonikers(specsWithSameUid, out var overlappingMonikers))
             {
                 context.ErrorLog.Write(Errors.MonikerOverlapping(overlappingMonikers));
-                return Array.Empty<InternalXrefSpec>();
+                return new InternalXrefSpec[] { conflictsWithMoniker.OrderBy(item => item.DeclairingFile).First() };
             }
 
             // uid conflicts with different names

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Docs.Build
 
         public string Href { get; set; }
 
-        public Document DeclairingFile { get; set; }
+        public Document DeclaringFile { get; set; }
 
         public HashSet<string> Monikers { get; set; } = new HashSet<string>();
 
@@ -40,17 +40,17 @@ namespace Microsoft.Docs.Build
             if (forXrefMapOutput)
             {
                 var (_, _, fragment) = UrlUtility.SplitUrl(Href);
-                var path = DeclairingFile.CanonicalUrlWithoutLocale;
+                var path = DeclaringFile.CanonicalUrlWithoutLocale;
 
                 // DHS appends branch infomation from cookie cache to URL, which is wrong for UID resolved URL
                 // output xref map with URL appending "?branch=master" for master branch
-                var query = DeclairingFile.Docset.Repository?.Branch == "master" ? "?branch=master" : "";
+                var query = DeclaringFile.Docset.Repository?.Branch == "master" ? "?branch=master" : "";
                 spec.Href = path + query + fragment;
             }
             else
             {
                 // relative path for internal UID resolving
-                spec.Href = PathUtility.GetRelativePathToFile(DeclairingFile.SiteUrl, Href);
+                spec.Href = PathUtility.GetRelativePathToFile(DeclaringFile.SiteUrl, Href);
             }
 
             foreach (var (key, value) in ExtensionData)
@@ -61,7 +61,7 @@ namespace Microsoft.Docs.Build
                 }
                 catch (DocfxException ex)
                 {
-                    context.ErrorLog.Write(DeclairingFile.FilePath, ex.Error);
+                    context.ErrorLog.Write(DeclaringFile.FilePath, ex.Error);
                 }
             }
             return spec;

--- a/src/docfx/build/xref/XrefMap.cs
+++ b/src/docfx/build/xref/XrefMap.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Docs.Build
             _externalXrefMap = ExternalXrefMapLoader.Load(docset);
         }
 
-        public (Error error, string href, string display, IXrefSpec xrefSpec) Resolve(string uid, SourceInfo<string> href, string displayPropertyName, Document relativeTo, string moniker = null)
+        public (Error error, string href, string display, IXrefSpec xrefSpec) Resolve(string uid, SourceInfo<string> href, string displayPropertyName, Document relativeTo)
         {
             if (t_recursionDetector.Value.Contains((uid, displayPropertyName, relativeTo)))
             {
@@ -36,7 +36,7 @@ namespace Microsoft.Docs.Build
             try
             {
                 t_recursionDetector.Value.Push((uid, displayPropertyName, relativeTo));
-                return ResolveCore(uid, href, displayPropertyName, moniker);
+                return ResolveCore(uid, href, displayPropertyName);
             }
             finally
             {
@@ -55,9 +55,9 @@ namespace Microsoft.Docs.Build
         }
 
         private (Error error, string href, string display, IXrefSpec xrefSpec) ResolveCore(
-            string uid, SourceInfo<string> href, string displayPropertyName, string moniker = null)
+            string uid, SourceInfo<string> href, string displayPropertyName)
         {
-            var spec = ResolveXrefSpec(uid, moniker);
+            var spec = ResolveXrefSpec(uid);
             if (spec is null)
             {
                 return (Errors.XrefNotFound(href), null, null, null);
@@ -75,9 +75,9 @@ namespace Microsoft.Docs.Build
             return (null, resolvedHref, display, spec);
         }
 
-        private IXrefSpec ResolveXrefSpec(string uid, string moniker)
+        private IXrefSpec ResolveXrefSpec(string uid)
         {
-            return ResolveInternalXrefSpec(uid, moniker) ?? ResolveExternalXrefSpec(uid);
+            return ResolveInternalXrefSpec(uid) ?? ResolveExternalXrefSpec(uid);
         }
 
         private IXrefSpec ResolveExternalXrefSpec(string uid)
@@ -85,14 +85,9 @@ namespace Microsoft.Docs.Build
             return _externalXrefMap.TryGetValue(uid, out var result) ? result.Value : null;
         }
 
-        private IXrefSpec ResolveInternalXrefSpec(string uid, string moniker)
+        private IXrefSpec ResolveInternalXrefSpec(string uid)
         {
-            if (!_internalXrefMap.TryGetValue(uid, out var spec))
-            {
-                return null;
-            }
-
-            return spec;
+            return _internalXrefMap.TryGetValue(uid, out var spec) ? spec : null;
         }
     }
 }

--- a/src/docfx/build/xref/XrefMap.cs
+++ b/src/docfx/build/xref/XrefMap.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Docs.Build
     {
         // TODO: key could be uid+moniker+locale
         private readonly IReadOnlyDictionary<string, Lazy<ExternalXrefSpec>> _externalXrefMap;
-        private readonly IReadOnlyDictionary<string, InternalXrefSpec[]> _internalXrefMap;
+        private readonly IReadOnlyDictionary<string, InternalXrefSpec> _internalXrefMap;
 
         private static ThreadLocal<Stack<(string uid, string propertyName, Document parent)>> t_recursionDetector = new ThreadLocal<Stack<(string, string, Document)>>(() => new Stack<(string, string, Document)>());
 
@@ -48,7 +48,7 @@ namespace Microsoft.Docs.Build
         public XrefMapModel ToXrefMapModel(Context context)
         {
             var references = _internalXrefMap.Values
-                .Select(xref => xref[0].ToExternalXrefSpec(context, forXrefMapOutput: true))
+                .Select(xref => xref.ToExternalXrefSpec(context, forXrefMapOutput: true))
                 .OrderBy(xref => xref.Uid).ToArray();
 
             return new XrefMapModel { References = references };
@@ -87,23 +87,12 @@ namespace Microsoft.Docs.Build
 
         private IXrefSpec ResolveInternalXrefSpec(string uid, string moniker)
         {
-            if (!_internalXrefMap.TryGetValue(uid, out var specs))
+            if (!_internalXrefMap.TryGetValue(uid, out var spec))
             {
                 return null;
             }
 
-            if (!string.IsNullOrEmpty(moniker))
-            {
-                foreach (var spec in specs)
-                {
-                    if (spec.Monikers.Contains(moniker))
-                    {
-                        return spec;
-                    }
-                }
-            }
-
-            return specs[0];
+            return spec;
         }
     }
 }

--- a/src/docfx/lib/markdown/MarkdownUtility.cs
+++ b/src/docfx/lib/markdown/MarkdownUtility.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Docs.Build
             var (error, link, display, spec) = status.Context.DependencyResolver.ResolveAbsoluteXref(
                 href, (Document)InclusionContext.File);
 
-            if (spec?.DeclairingFile != null)
+            if (spec?.DeclaringFile != null)
             {
                 link = RelativeUrlMarker + link;
             }

--- a/test/docfx.Test/e2e/E2ETest.cs
+++ b/test/docfx.Test/e2e/E2ETest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Docs.Build
             "download-failed", "locale-invalid",
 
             // show multiple errors with line info
-            "publish-url-conflict", "output-path-conflict", "uid-conflict", "uid-name-conflict", "redirection-conflict",
+            "publish-url-conflict", "output-path-conflict", "uid-conflict", "uid-property-conflict", "redirection-conflict",
             "redirected-id-conflict", "circular-reference", "moniker-overlapping", "empty-monikers"
         };
 

--- a/test/docfx.Test/e2e/E2ETest.cs
+++ b/test/docfx.Test/e2e/E2ETest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Docs.Build
             "download-failed", "locale-invalid",
 
             // show multiple errors with line info
-            "publish-url-conflict", "output-path-conflict", "uid-conflict", "uid-property-conflict", "redirection-conflict",
+            "publish-url-conflict", "output-path-conflict", "uid-conflict", "xref-property-conflict", "redirection-conflict",
             "redirected-id-conflict", "circular-reference", "moniker-overlapping", "empty-monikers"
         };
 

--- a/test/docfx.Test/e2e/E2ETest.cs
+++ b/test/docfx.Test/e2e/E2ETest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Docs.Build
             "download-failed", "locale-invalid",
 
             // show multiple errors with line info
-            "publish-url-conflict", "output-path-conflict", "uid-conflict", "redirection-conflict",
+            "publish-url-conflict", "output-path-conflict", "uid-conflict", "uid-name-conflict", "redirection-conflict",
             "redirected-id-conflict", "circular-reference", "moniker-overlapping", "empty-monikers"
         };
 


### PR DESCRIPTION
- Add `xref-property-conflict` as a warning and take the first UID order by the declaring file
- Change `moniker-overlapping` to warning and take the first UID order by the declaring file
- remove ordering based on monikers

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4824)