### PR TITLE
clean up code of netcore sdk support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,6 @@ For more information see the [.NET Foundation Code of Conduct](http://www.dotnet
 
 ### Running Status
 
-| Windows with .NET Core v2.0.3 | Windows with VS2017 | Ubuntu Linux with Mono
-| ---------- | ------------- |---------- 
-| [![.NET CORE](https://docascode.visualstudio.com/_apis/public/build/definitions/c8f1f4cb-74cb-4c89-a2db-6c3438796b0a/1/badge)](https://docascode.visualstudio.com/docfx/_build/index?context=mine&path=%5C&definitionId=1&_a=completed)|[![VS](https://docascode.visualstudio.com/_apis/public/build/definitions/c8f1f4cb-74cb-4c89-a2db-6c3438796b0a/2/badge)](https://docascode.visualstudio.com/docfx/_build/index?context=mine&path=%5C&definitionId=2&_a=completed)|[![Ubuntu](https://travis-ci.org/docascode/docfx.test.svg?branch=master)](https://travis-ci.org/docascode/docfx.test)
+| Windows with VS2017 | Ubuntu Linux with Mono
+| ------------- |----------
+| [![VS](https://docascode.visualstudio.com/_apis/public/build/definitions/c8f1f4cb-74cb-4c89-a2db-6c3438796b0a/2/badge)](https://docascode.visualstudio.com/docfx/_build/index?context=mine&path=%5C&definitionId=2&_a=completed)|[![Ubuntu](https://travis-ci.org/docascode/docfx.test.svg?branch=master)](https://travis-ci.org/docascode/docfx.test)


### PR DESCRIPTION
#4708 removed `Microsoft.Build` package reference. This is the right way to use `MSBuildLocator`, and we are no longer coupled with Visual Studio new release, but users with .NET Core SDK alone installed will no longer work.

microsoft/MSBuildLocator#21 exposes a new method for user to provide msbuild location for this issue. To use this, users usually need to install "Build Tools for Visual Studio" to prepare this, but it finally makes MSBuildLocator think Visual Studio is installed. This makes the NO-VS user fallback take no effect.

As a result, we can stop supporting users with .NET Core SDK alone to work. The minimal requirement is "Build Tools for Visual Studio".

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4827)