### PR TITLE
🐛Fix bug of restoring latest file content

### DIFF
--- a/src/docfx/restore/RestoreFile.cs
+++ b/src/docfx/restore/RestoreFile.cs
@@ -44,15 +44,10 @@ namespace Microsoft.Docs.Build
 
             using (InterProcessMutex.Create(filePath))
             {
-                if (!File.Exists(filePath))
-                {
-                    PathUtility.CreateDirectoryFromFilePath(filePath);
-                    File.Move(tempFile, filePath);
-                }
-                else
-                {
-                    File.Delete(tempFile);
-                }
+                PathUtility.CreateDirectoryFromFilePath(filePath);
+
+                File.Copy(tempFile, filePath, true);
+                File.Delete(tempFile);
 
                 if (etag != null)
                 {

--- a/test/docfx.Test/restore/RestoreTest.cs
+++ b/test/docfx.Test/restore/RestoreTest.cs
@@ -132,7 +132,7 @@ dependencies:
             var restoreDir = AppData.GetFileDownloadDir(url);
 
             File.WriteAllText(Path.Combine(docsetPath, "docfx.yml"), $@"
-monikerDefinition: https://raw.githubusercontent.com/docascode/docfx-test-dependencies-clean/master/README.md");
+monikerDefinition: {url}");
 
             // run restore
             await Docfx.Run(new[] { "restore", docsetPath });
@@ -140,9 +140,15 @@ monikerDefinition: https://raw.githubusercontent.com/docascode/docfx-test-depend
             Assert.Equal(2, Directory.EnumerateFiles(restoreDir, "*").Count());
 
             // run restore again
+            var filePath = RestoreFile.GetRestoreContentPath(url);
+            var etagPath = RestoreFile.GetRestoreEtagPath(url);
+
+            File.Delete(etagPath);
+            File.WriteAllText(filePath, "1");
             await Docfx.Run(new[] { "restore", docsetPath });
 
             Assert.Equal(2, Directory.EnumerateFiles(restoreDir, "*").Count());
+            Assert.NotEqual("1", File.ReadAllText(filePath));
         }
 
         private static int GetWorkTreeFolderCount(string path)


### PR DESCRIPTION
since we changed the logic of restoring file to one places calculated by url, we should always overwrite existing file using latest version of restored file. v

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4829)