### PR TITLE
change toc missing name level from error to warning

### DIFF
--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -1102,9 +1102,11 @@ inputs:
 outputs:
   docs/f1/a.json:
   docs/f1/b.json:
+  docs/toc.json:
+  docs/f1/toc.json:
   .errors.log: |
-    ["error","missing-toc-head","The toc head name is missing","docs/TOC.yml",5,8]
-    ["error","missing-toc-head","The toc head name is missing","docs/f1/TOC.md",1,1]
+    ["warning","missing-toc-head","The toc head name is missing","docs/TOC.yml",5,8]
+    ["warning","missing-toc-head","The toc head name is missing","docs/f1/TOC.md",1,1]
 ---
 # Orphan file(not explicitly referenced in toc file)'s toc, only look up parent folder toc files
 inputs:
@@ -1181,8 +1183,9 @@ inputs:
     # Title
     ##
 outputs:
+  docs/toc.json:
   .errors.log: |
-    ["error","missing-toc-head","The toc head name is missing","docs/TOC.md",2,1]
+    ["warning","missing-toc-head","The toc head name is missing","docs/TOC.md",2,1]
 ---
 # Multiple leaf inlines in toc title
 inputs:

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Docs.Build
         /// </summary>
         /// Behavior: ✔️ Message: ❌
         public static Error MissingTocHead(SourceInfo source)
-            => new Error(ErrorLevel.Error, "missing-toc-head", $"The toc head name is missing", source);
+            => new Error(ErrorLevel.Warning, "missing-toc-head", $"The toc head name is missing", source);
 
         /// <summary>
         /// In markdown-format toc, used wrong toc syntax.


### PR DESCRIPTION
keep the error level consistent with v2's

Here is v2 build report example: https://opbuildstorageprod.blob.core.windows.net/report/2019%5C7%5C4%5C9ed0861b-685f-b3bf-c3bf-3795fe4252a4%5CPullRequest%5C201907040517172028-514%5Cworkflow_report.html?sv=2016-05-31&sr=b&sig=7OI1bnKSA8KbQg6Ju%2FCwcBLTe7I4stHv6XFc2RabJME%3D&st=2019-07-04T05%3A14%3A38Z&se=2019-08-04T05%3A19%3A38Z&sp=r

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4838)