### PR TITLE
Do not run jobs already in thread pool when WorkQueue encountered exception

### DIFF
--- a/src/docfx/lib/collections/WorkQueue.cs
+++ b/src/docfx/lib/collections/WorkQueue.cs
@@ -70,6 +70,11 @@ namespace Microsoft.Docs.Build
 
             void Run(T item)
             {
+                if (_drainTcs.Task.IsCompleted)
+                {
+                    return;
+                }
+
                 try
                 {
                     _run(item).ContinueWith(OnComplete, default, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);


### PR DESCRIPTION
When one job throws an exception during `WorkQueue` parallel execution, `Drain` returns immediately without waiting for completion of jobs already queued in the thread pool. This can leak to situations where `Run` is called after `Dispose` in the following example:

```csharp
queue.Drain(Run);
Dispose();
```

This PR mitigate the problem by checking for completion before executing jobs. It significantly reduced the likelyhood but still it is theoretically possible that some part of `Run` is called after `Dispose` during parallel execution.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4848)