### PR TITLE
avoid using same restore file in different spec tests

### DIFF
--- a/docs/specs/config.yml
+++ b/docs/specs/config.yml
@@ -206,7 +206,7 @@ outputs:
 # absolute url extend
 inputs:
   docfx.yml: |
-    extend: https://raw.githubusercontent.com/docascode/docfx-test-dependencies/62b0448/extend1.yml
+    extend: https://raw.githubusercontent.com/docascode/docfx-test-dependencies/master/extend1.yml
   a.md:
 outputs:
   a.json:


### PR DESCRIPTION
since spec tests are executed paralleled, which may causing test failure using same restore files in different spec tests  

fix: https://dev.azure.com/ceapex/Engineering/_workitems/edit/103780

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4849)