### PR TITLE
change toc transform from replace to return new model

### DIFF
--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -1526,3 +1526,61 @@ outputs:
             }
         ]
     }
+---
+# don't respect monikers of input toc model
+inputs:
+  docfx.yml: |
+    monikerRange:
+      'docs/**/*.md': '>= 5.0'
+    monikerDefinition: monikerDefinition.json
+  monikerDefinition.json: |
+    {
+      "monikers": [
+        { "moniker_name": "1.0", "product_name": ".NET Core" },
+        { "moniker_name": "2.0", "product_name": ".NET Core" },
+        { "moniker_name": "3.0", "product_name": ".NET Core" },
+        { "moniker_name": "4.0", "product_name": ".NET Core" },
+        { "moniker_name": "5.0", "product_name": ".NET Core" },
+      ]
+    }
+  docs/b.md:
+  docs/TOC.yml: |
+    - name: item with children
+      href: /a
+      items:
+        - name: item with monikers
+          href: /b
+          monikers:
+            - "1.0"
+            - "2.0"
+    - name: item with monikers references a file with monikers
+      href: b.md
+      monikers:
+        - "3.0"
+        - "4.0"
+outputs:
+  336669db/docs/b.json:
+  docs/toc.json: |
+    {
+        "items": [
+            {
+                "name": "item with children",
+                "href": "/a",
+                "!monikers": null,
+                "items": [
+                    {
+                        "name": "item with monikers",
+                        "href": "/b",
+                        "!monikers": null
+                    }
+                ]
+            },
+            {
+                "name": "item with monikers references a file with monikers",
+                "href": "b",
+                "monikers": [
+                    "5.0"
+                ]
+            }
+        ]
+    }

--- a/src/docfx/build/toc/TableOfContentsItem.cs
+++ b/src/docfx/build/toc/TableOfContentsItem.cs
@@ -52,7 +52,6 @@ namespace Microsoft.Docs.Build
             MaintainContext = item.MaintainContext;
             ExtensionData = item.ExtensionData;
             Items = item.Items;
-            Monikers = item.Monikers;
             Document = item.Document;
         }
 

--- a/src/docfx/build/toc/TableOfContentsItem.cs
+++ b/src/docfx/build/toc/TableOfContentsItem.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build
 {
-    public class TableOfContentsItem
+    internal class TableOfContentsItem
     {
         public SourceInfo<string> Name { get; set; }
 
@@ -35,5 +35,27 @@ namespace Microsoft.Docs.Build
 
         [JsonExtensionData]
         public JObject ExtensionData { get; set; }
+
+        [JsonIgnore]
+        public Document Document { get; set; }
+
+        public TableOfContentsItem(TableOfContentsItem item)
+        {
+            Name = item.Name;
+            DisplayName = item.DisplayName;
+            Href = item.Href;
+            TopicHref = item.TopicHref;
+            TocHref = item.TocHref;
+            Homepage = item.Homepage;
+            Uid = item.Uid;
+            Expanded = item.Expanded;
+            MaintainContext = item.MaintainContext;
+            ExtensionData = item.ExtensionData;
+            Items = item.Items;
+            Monikers = item.Monikers;
+            Document = item.Document;
+        }
+
+        public TableOfContentsItem() { }
     }
 }

--- a/src/docfx/build/toc/TableOfContentsModel.cs
+++ b/src/docfx/build/toc/TableOfContentsModel.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build
 {
-    public class TableOfContentsModel
+    internal class TableOfContentsModel
     {
         public TableOfContentsMetadata Metadata { get; set; } = new TableOfContentsMetadata();
 

--- a/src/docfx/build/toc/parser/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsParser.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Docs.Build
                     Name = tocModelItem.Name.Or(resolvedTopicName),
                     Document = document ?? subChildrenFirstItem?.Document,
                     Items = subChildren?.Items ?? tocModelItem.Items,
-                    Monikers = string.IsNullOrEmpty(resolvedTocHref) && string.IsNullOrEmpty(resolvedTopicHref) ? subChildrenFirstItem?.Monikers ?? new List<string>() : tocModelItem.Monikers,
+                    Monikers = string.IsNullOrEmpty(resolvedTocHref) && string.IsNullOrEmpty(resolvedTopicHref) ? subChildrenFirstItem?.Monikers ?? new List<string>() : new List<string>(),
                 };
 
                 // resolve children

--- a/src/docfx/build/toc/parser/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsParser.cs
@@ -249,7 +249,7 @@ namespace Microsoft.Docs.Build
                 return default;
             }
 
-            (SourceInfo<string> resolvedTocHref, TableOfContentsModel subChildren, TableOfContentsItem firstItem) ProcessTocHref(SourceInfo<string> tocHref)
+            (SourceInfo<string> resolvedTocHref, TableOfContentsModel subChildren, TableOfContentsItem subChildrenFirstItem) ProcessTocHref(SourceInfo<string> tocHref)
             {
                 if (string.IsNullOrEmpty(tocHref))
                 {
@@ -272,11 +272,11 @@ namespace Microsoft.Docs.Build
                     var (subErrors, nestedToc) = LoadInternal(context, referenceTocFilePath, rootPath, referencedFiles, referencedTocs, parents, referencedTocContent);
                     errors.AddRange(subErrors);
 
-                    var firstItem = GetFirstItem(nestedToc.Items);
                     if (tocHrefType == TocHrefType.RelativeFolder)
                     {
-                        context.DependencyMapBuilder.AddDependencyItem(filePath, firstItem?.Document, DependencyType.Link);
-                        return (default, default, firstItem);
+                        var nestedTocFirstItem = GetFirstItem(nestedToc.Items);
+                        context.DependencyMapBuilder.AddDependencyItem(filePath, nestedTocFirstItem?.Document, DependencyType.Link);
+                        return (default, default, nestedTocFirstItem);
                     }
 
                     return (default, nestedToc, default);


### PR DESCRIPTION
1. reduce the complexity of code to calculate first child
2. return new model instead of change inputting model
3. reduce the complexity of code to calculate monikers 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4851)