### PR TITLE
Update schema-not-found and empty-monikers message

### DIFF
--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -359,7 +359,7 @@ inputs:
 outputs:
   docs/a.json:
   .errors.log: |
-    ["warning","empty-monikers","No moniker intersection between docfx.yml/docfx.json and file metadata. Config moniker range '< netcore-2.0' is 'netcore-1.0,netcore-1.1', while file moniker range '> netcore-2.0' is 'netcore-2.1'","docs/v1/a.md"]
+    ["warning","empty-monikers","No moniker intersection between docfx.yml/docfx.json and file metadata. Config moniker range '< netcore-2.0' is 'netcore-1.0', 'netcore-1.1', while file moniker range '> netcore-2.0' is 'netcore-2.1'","docs/v1/a.md"]
 ---
 # No intersection of file level monikers and zone monikers
 inputs:
@@ -385,7 +385,7 @@ inputs:
 outputs:
   9d4e15fd/docs/a.json:
   .errors.log: |
-    ["warning","empty-monikers","No intersection between zone and file level monikers. The result of zone level range string 'netcore-1.2' is 'netcore-1.2', while file level monikers is 'netcore-1.0,netcore-1.1'.","docs/v1/a.md"]
+    ["warning","empty-monikers","No intersection between zone and file level monikers. The result of zone level range string 'netcore-1.2' is 'netcore-1.2', while file level monikers is 'netcore-1.0', 'netcore-1.1'.","docs/v1/a.md"]
 ---
 # Define uid with moniker range, refer to it with valid moniker in the same docset
 inputs:

--- a/docs/specs/schema.yml
+++ b/docs/specs/schema.yml
@@ -72,9 +72,9 @@ inputs:
     { "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/SchemaNotExisting.json"}
 outputs:
   .errors.log: |
-   ["error","schema-not-found","Schema 'SchemaNotExisting' not found.","docs/a.yml",1,1]
-   ["error","schema-not-found","Schema 'SchemaNotExisting' not found.","docs/b.json",2,95]
-   ["error","schema-not-found","Schema 'SchemaNotExisting' not found.","docs/c.json",1,95]
+   ["error","schema-not-found","Unknown schema 'SchemaNotExisting'","docs/a.yml",1,1]
+   ["error","schema-not-found","Unknown schema 'SchemaNotExisting'","docs/b.json",2,95]
+   ["error","schema-not-found","Unknown schema 'SchemaNotExisting'","docs/c.json",1,95]
 ---
 # Support schema documents with Href content
 inputs:

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -559,10 +559,10 @@ namespace Microsoft.Docs.Build
         /// </summary>
         /// Behavior: ✔️ Message: ❌
         public static Error EmptyMonikers(SourceInfo<string> rangeString, IReadOnlyList<string> zoneLevelMonikers, List<string> fileLevelMonikers)
-            => new Error(ErrorLevel.Warning, "empty-monikers", $"No intersection between zone and file level monikers. The result of zone level range string '{rangeString}' is '{string.Join(',', zoneLevelMonikers)}', while file level monikers is '{string.Join(',', fileLevelMonikers)}'.");
+            => new Error(ErrorLevel.Warning, "empty-monikers", $"No intersection between zone and file level monikers. The result of zone level range string '{rangeString}' is {Join(zoneLevelMonikers)}, while file level monikers is {Join(fileLevelMonikers)}.");
 
         public static Error EmptyMonikers(string configMonikerRange, List<string> configMonikers, SourceInfo<string> monikerRange, IReadOnlyList<string> fileMonikers)
-            => new Error(ErrorLevel.Warning, "empty-monikers", $"No moniker intersection between docfx.yml/docfx.json and file metadata. Config moniker range '{configMonikerRange}' is '{string.Join(',', configMonikers)}', while file moniker range '{monikerRange}' is '{string.Join(',', fileMonikers)}'");
+            => new Error(ErrorLevel.Warning, "empty-monikers", $"No moniker intersection between docfx.yml/docfx.json and file metadata. Config moniker range '{configMonikerRange}' is {Join(configMonikers)}, while file moniker range '{monikerRange}' is {Join(fileMonikers)}");
 
         /// <summary>
         /// Custom 404 page is not supported

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -163,16 +163,6 @@ namespace Microsoft.Docs.Build
             => new Error(ErrorLevel.Error, "download-failed", $"Download failed for file '{url}'. Try closing and reopening the PR. If you get this Error again, file an issue.");
 
         /// <summary>
-        /// Failed to update user profile cache file.
-        /// Examples:
-        ///   - when <see cref="GitHubConfig.UpdateRemoteUserCache"/> is turned on, and docfx fails to
-        ///     update the file cache with put request
-        /// </summary>
-        /// Behavior: ❌ Message: ✔️
-        public static Error UploadFailed(string url, string message)
-            => new Error(ErrorLevel.Warning, "upload-failed", $"Upload failed for '{url}': {message} Try closing and reopening the PR. If you get this Error again, file an issue.");
-
-        /// <summary>
         /// Failed to run `git fetch` or `git worktree add`.
         /// Examples:
         ///   - restore a repo with bad url
@@ -552,8 +542,8 @@ namespace Microsoft.Docs.Build
         /// Failed to parse moniker string.
         /// </summary>
         /// Behavior: ✔️ Message: ❌
-        public static Error MonikerRangeInvalid(SourceInfo<string> source, string message)
-            => new Error(ErrorLevel.Error, "moniker-range-invalid", $"Invalid moniker range: '{source}': {message}", source);
+        public static Error MonikerRangeInvalid(SourceInfo<string> source, Exception ex)
+            => new Error(ErrorLevel.Error, "moniker-range-invalid", $"Invalid moniker range: '{source}': {ex.Message}", source);
 
         /// <summary>
         /// MonikerRange is not defined in docfx.yml or doesn't match an article.md,
@@ -568,8 +558,11 @@ namespace Microsoft.Docs.Build
         /// or moniker-zone defined in article.md has no intersection with file-level monikers.
         /// </summary>
         /// Behavior: ✔️ Message: ❌
-        public static Error EmptyMonikers(string message)
-            => new Error(ErrorLevel.Warning, "empty-monikers", message);
+        public static Error EmptyMonikers(SourceInfo<string> rangeString, IReadOnlyList<string> zoneLevelMonikers, List<string> fileLevelMonikers)
+            => new Error(ErrorLevel.Warning, "empty-monikers", $"No intersection between zone and file level monikers. The result of zone level range string '{rangeString}' is '{string.Join(',', zoneLevelMonikers)}', while file level monikers is '{string.Join(',', fileLevelMonikers)}'.");
+
+        public static Error EmptyMonikers(string configMonikerRange, List<string> configMonikers, SourceInfo<string> monikerRange, IReadOnlyList<string> fileMonikers)
+            => new Error(ErrorLevel.Warning, "empty-monikers", $"No moniker intersection between docfx.yml/docfx.json and file metadata. Config moniker range '{configMonikerRange}' is '{string.Join(',', configMonikers)}', while file moniker range '{monikerRange}' is '{string.Join(',', fileMonikers)}'");
 
         /// <summary>
         /// Custom 404 page is not supported

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -504,7 +504,7 @@ namespace Microsoft.Docs.Build
         /// </summary>
         /// Behavior: ❌ Message: ✔️
         public static Error SchemaNotFound(SourceInfo<string> source)
-            => new Error(ErrorLevel.Error, "schema-not-found", !string.IsNullOrEmpty(source) ? $"Schema '{source}' not found." : $"Unknown schema '{source}'", source);
+            => new Error(ErrorLevel.Error, "schema-not-found", $"Unknown schema '{source}'", source);
 
         /// <summary>
         /// Build errors is larger than <see cref="OutputConfig.MaxErrors"/>.

--- a/src/docfx/build/moniker/MonikerProvider.cs
+++ b/src/docfx/build/moniker/MonikerProvider.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Docs.Build
 
             if (monikers.Count == 0)
             {
-                var error = Errors.EmptyMonikers($"No intersection between zone and file level monikers. The result of zone level range string '{rangeString}' is '{string.Join(',', zoneLevelMonikers)}', while file level monikers is '{string.Join(',', fileLevelMonikers)}'.");
+                var error = Errors.EmptyMonikers(rangeString, zoneLevelMonikers, fileLevelMonikers);
                 return (error, monikers);
             }
             monikers.Sort(Comparer);
@@ -101,7 +101,7 @@ namespace Microsoft.Docs.Build
                 // warn if no intersection of config monikers and file monikers
                 if (intersection.Count == 0)
                 {
-                    var error = Errors.EmptyMonikers($"No moniker intersection between docfx.yml/docfx.json and file metadata. Config moniker range '{configMonikerRange}' is '{string.Join(',', configMonikers)}', while file moniker range '{metadata.MonikerRange}' is '{string.Join(',', fileMonikers)}'");
+                    var error = Errors.EmptyMonikers(configMonikerRange, configMonikers, metadata.MonikerRange, fileMonikers);
                     return (error, intersection);
                 }
                 return (null, intersection);

--- a/src/docfx/lib/moniker/MonikerRangeParser.cs
+++ b/src/docfx/lib/moniker/MonikerRangeParser.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Docs.Build
                     }
                     catch (MonikerRangeException ex)
                     {
-                        throw Errors.MonikerRangeInvalid(rangeString, ex.Message).ToException();
+                        throw Errors.MonikerRangeInvalid(rangeString, ex).ToException();
                     }
 
                     return monikers;


### PR DESCRIPTION
- put empty-monikers message template to Errors.cs
- remove switch in schema-not-found

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4853)