### PR TITLE
fix adding post processor twice issue

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/HtmlPostProcessor.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/HtmlPostProcessor.cs
@@ -25,12 +25,18 @@ namespace Microsoft.DocAsCode.Build.Engine
 
         public List<IHtmlDocumentHandler> Handlers { get; } = new List<IHtmlDocumentHandler>();
 
+        private bool _handlerInitialized;
+
         public ImmutableDictionary<string, object> PrepareMetadata(ImmutableDictionary<string, object> metadata)
         {
-            Handlers.Add(new ValidateBookmark());
-            if (!metadata.ContainsKey("_keepDebugInfo") || ((bool)metadata["_keepDebugInfo"]) == false)
+            if (!_handlerInitialized)
             {
-                Handlers.Add(new RemoveDebugInfo());
+                Handlers.Add(new ValidateBookmark());
+                if (!metadata.ContainsKey("_keepDebugInfo") || ((bool)metadata["_keepDebugInfo"]) == false)
+                {
+                    Handlers.Add(new RemoveDebugInfo());
+                }
+                _handlerInitialized = true;
             }
 
             return metadata;


### PR DESCRIPTION
fix bug introduced in #4774. When `PrepareMetadata` is called multiple times, docfx will validate bookmark multiple times and log duplicate warnings.

https://ceapex.visualstudio.com/Engineering/_workitems/edit/104360/

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4863)