### PR TITLE
Fix thread pool starve by adding parallel limit to workqueue

### DIFF
--- a/docs/specs/validation.yml
+++ b/docs/specs/validation.yml
@@ -88,7 +88,7 @@ outputs:
     ["warning","field-required","Missing required field 'a'","a.md",2,1]
     ["warning","unexpected-type","Expect type 'String' but got 'Array'","a.md",2,6]
 ---
-# [skip] Json schema microsoft alias rule: Metu error, when no connection with Graph API
+# Json schema microsoft alias rule: Metu error, when no connection with Graph API
 inputs:
   docfx.yml: |
     metadataSchema:
@@ -114,7 +114,7 @@ outputs:
   a.json: |
     { "ms.author": "over123" }
 ---
-# [skip] Json schema microsoft alias rule: The author is in the allow list
+# Json schema microsoft alias rule: The author is in the allow list
 inputs:
   docfx.yml: |
     metadataSchema:
@@ -144,7 +144,7 @@ outputs:
   a.json: |
     { "ms.author": "over123" }
 ---
-# [skip] Json schema microsoft alias rule: The author is in the cache
+# Json schema microsoft alias rule: The author is in the cache
 inputs:
   docfx.yml: |
     metadataSchema:
@@ -189,7 +189,7 @@ outputs:
   a.json: |
     { "ms.author": "over123" }
 ---
-# [skip] Json schema microsoft alias rule: The author information has expired 
+# Json schema microsoft alias rule: The author information has expired 
 inputs:
   docfx.yml: |
     metadataSchema:
@@ -235,7 +235,7 @@ outputs:
   .errors.log: |
     ["warning","ms-alias-invalid","Invalid value for 'ms.author', '123over123' is not a valid Microsoft alias","a.md",2,12]
 ---
-# [skip] Json schema microsoft alias rule: The author is valid with graph call 
+# Json schema microsoft alias rule: The author is valid with graph call 
 inputs:
   docfx.yml: |
     metadataSchema:
@@ -265,7 +265,7 @@ outputs:
   a.json: |
     { "ms.author": "yazhao" }
 ---
-# [skip] Json schema microsoft alias rule: The author is invalid with graph call 
+# Json schema microsoft alias rule: The author is invalid with graph call 
 inputs:
   docfx.yml: |
     metadataSchema:

--- a/src/docfx/cli/Docfx.cs
+++ b/src/docfx/cli/Docfx.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
 
@@ -69,6 +70,8 @@ namespace Microsoft.Docs.Build
             using (var errorLog = new ErrorLog(docset, options.Legacy))
             {
                 Log.Write($"Using docfx {GetDocfxVersion()}");
+
+                ThreadPool.SetMinThreads(32, 32);
 
                 try
                 {

--- a/src/docfx/cli/Docfx.cs
+++ b/src/docfx/cli/Docfx.cs
@@ -71,7 +71,8 @@ namespace Microsoft.Docs.Build
             {
                 Log.Write($"Using docfx {GetDocfxVersion()}");
 
-                ThreadPool.SetMinThreads(32, 32);
+                var minThreads = Math.Max(32, Environment.ProcessorCount * 4);
+                ThreadPool.SetMinThreads(minThreads, minThreads);
 
                 try
                 {

--- a/src/docfx/lib/ParallelUtility.cs
+++ b/src/docfx/lib/ParallelUtility.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Docs.Build
     {
         private static readonly ExecutionDataflowBlockOptions s_dataflowOptions = new ExecutionDataflowBlockOptions
         {
-            MaxDegreeOfParallelism = DataflowBlockOptions.Unbounded,
+            MaxDegreeOfParallelism = Math.Max(8, Environment.ProcessorCount * 2),
             BoundedCapacity = DataflowBlockOptions.Unbounded,
             EnsureOrdered = false,
         };

--- a/src/docfx/lib/RandomUtility.cs
+++ b/src/docfx/lib/RandomUtility.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+
+namespace Microsoft.Docs.Build
+{
+    internal static class RandomUtility
+    {
+        private static int s_randomSeed = Environment.TickCount;
+        private static ThreadLocal<Random> t_random = new ThreadLocal<Random>(
+            () => new Random(Interlocked.Increment(ref s_randomSeed)));
+
+        public static double NextEvenDistribution(double value)
+        {
+            return (value / 2) + (t_random.Value.NextDouble() * value / 2);
+        }
+    }
+}

--- a/src/docfx/lib/log/TelemetryName.cs
+++ b/src/docfx/lib/log/TelemetryName.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Docs.Build
         GitCommitCache,
         GitRepositoryCache,
         GitHubUserCache,
+        MicrosoftGraphCache,
         LoadCommitHistory,
         BuildItems,
         BuildCommits,

--- a/src/docfx/lib/msgraph/MicrosoftGraphCache.cs
+++ b/src/docfx/lib/msgraph/MicrosoftGraphCache.cs
@@ -2,10 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Docs.Build
@@ -14,12 +13,14 @@ namespace Microsoft.Docs.Build
     {
         private readonly string _cachePath;
         private readonly double _expirationInHours;
-        private readonly SemaphoreSlim _syncRoot = new SemaphoreSlim(1, 1);
         private readonly MicrosoftGraphAccessor _microsoftGraphAccessor = null;
-        private readonly List<string> _tempInvalidAliases = new List<string>();
 
-        private Dictionary<string, MicrosoftAlias> _aliases = new Dictionary<string, MicrosoftAlias>();
+        private readonly ConcurrentDictionary<string, Task<(Error error, MicrosoftAlias alias)>> _aliases
+                   = new ConcurrentDictionary<string, Task<(Error error, MicrosoftAlias alias)>>();
+
         private bool _needUpdate = false;
+
+        public bool IsConnectedToGraphApi => _microsoftGraphAccessor != null;
 
         public MicrosoftGraphCache(Config config)
         {
@@ -38,110 +39,73 @@ namespace Microsoft.Docs.Build
 
             if (File.Exists(_cachePath))
             {
+                var now = DateTime.UtcNow;
                 var cacheFile = JsonUtility.Deserialize<MicrosoftGraphCacheFile>(ProcessUtility.ReadFile(_cachePath), _cachePath);
-                _aliases = cacheFile.Aliases.Where(msAlias => msAlias.Expiry >= DateTime.UtcNow).ToDictionary(msAlias => msAlias.Alias);
-            }
-        }
 
-        public Task<(Error error, MicrosoftAlias msAlias)> GetMicrosoftAliasAsync(string alias)
-        {
-            if (string.IsNullOrEmpty(alias))
-            {
-                return new Task<(Error error, MicrosoftAlias msAlias)>(null, null);
-            }
-
-            return Synchronized(GetAsyncCore);
-
-            async Task<(Error error, MicrosoftAlias msAlias)> GetAsyncCore()
-            {
-                if (_aliases.TryGetValue(alias, out var msAlias))
+                foreach (var msAlias in cacheFile.Aliases)
                 {
-                    return (null, msAlias);
-                }
-
-                if (_tempInvalidAliases.Contains(alias) || _microsoftGraphAccessor == null)
-                {
-                    return default;
-                }
-
-                Telemetry.TrackCacheTotalCount(TelemetryName.GitHubUserCache);
-
-                var (error, isValid) = await _microsoftGraphAccessor.ValidateAlias(alias);
-
-                Log.Write($"Calling Microsoft Graph API to validate {alias}");
-                Telemetry.TrackCacheMissCount(TelemetryName.GitHubUserCache);
-
-                if (error != null)
-                {
-                    return (error, null);
-                }
-
-                if (isValid)
-                {
-                    var newMsAlias = new MicrosoftAlias()
+                    if (msAlias.Expiry > now)
                     {
-                        Alias = alias,
-                        Expiry = NextExpiry(),
-                    };
-
-                    _aliases.Add(alias, new MicrosoftAlias() { Alias = alias, Expiry = NextExpiry() });
-                    _needUpdate = true;
-
-                    return (error, newMsAlias);
-                }
-                else
-                {
-                    _tempInvalidAliases.Add(alias);
-                    return (error, null);
+                        _aliases.TryAdd(msAlias.Alias, Task.FromResult((default(Error), msAlias)));
+                    }
                 }
             }
         }
 
-        public bool IsConnectedToGraphApi()
+        public Task<(Error error, MicrosoftAlias msAlias)> GetMicrosoftAlias(string alias)
         {
-            return _microsoftGraphAccessor != null;
+            if (string.IsNullOrEmpty(alias) || _microsoftGraphAccessor == null)
+            {
+                return Task.FromResult(default((Error, MicrosoftAlias)));
+            }
+
+            Telemetry.TrackCacheTotalCount(TelemetryName.MicrosoftGraphCache);
+
+            return _aliases.GetOrAdd(alias, GetMicrosoftAliasCore);
         }
 
         public void Save()
         {
             if (_needUpdate)
             {
-                _syncRoot.Wait();
+                var aliases = _aliases.Values
+                    .Where(item => item.IsCompletedSuccessfully && !string.IsNullOrEmpty(item.Result.alias?.Alias))
+                    .Select(item => item.Result.alias)
+                    .ToArray();
 
-                try
-                {
-                    var content = JsonUtility.Serialize(new MicrosoftGraphCacheFile { Aliases = _aliases.Values.ToArray() });
+                var content = JsonUtility.Serialize(new MicrosoftGraphCacheFile { Aliases = aliases });
 
-                    PathUtility.CreateDirectoryFromFilePath(_cachePath);
-                    ProcessUtility.WriteFile(_cachePath, content);
-                    _needUpdate = false;
-                }
-                finally
-                {
-                    _syncRoot.Release();
-                }
+                PathUtility.CreateDirectoryFromFilePath(_cachePath);
+                ProcessUtility.WriteFile(_cachePath, content);
+                _needUpdate = false;
             }
         }
 
         public void Dispose()
         {
-            _syncRoot.Dispose();
             _microsoftGraphAccessor?.Dispose();
         }
 
-        private DateTime NextExpiry() => DateTime.UtcNow.AddHours(_expirationInHours);
-
-        private async Task<T> Synchronized<T>(Func<Task<T>> action)
+        private async Task<(Error error, MicrosoftAlias msAlias)> GetMicrosoftAliasCore(string alias)
         {
-            await _syncRoot.WaitAsync();
-            try
+            Log.Write($"Calling Microsoft Graph API to validate {alias}");
+            Telemetry.TrackCacheMissCount(TelemetryName.MicrosoftGraphCache);
+
+            var (error, isValid) = await _microsoftGraphAccessor.ValidateAlias(alias);
+            if (error != null || !isValid)
             {
-                return await action();
+                return (error, null);
             }
-            finally
+
+            _needUpdate = true;
+
+            var result = new MicrosoftAlias
             {
-                _syncRoot.Release();
-            }
+                Alias = alias,
+                Expiry = DateTime.UtcNow.AddHours(RandomUtility.NextEvenDistribution(_expirationInHours)),
+            };
+
+            return (null, result);
         }
     }
 }

--- a/src/docfx/lib/schema/JsonSchemaValidator.cs
+++ b/src/docfx/lib/schema/JsonSchemaValidator.cs
@@ -176,6 +176,7 @@ namespace Microsoft.Docs.Build
         private void ValidateString(JsonSchema schema, string name, JValue scalar, string str, List<Error> errors)
         {
             ValidateDateFormat(schema, name, scalar, str, errors);
+            ValidateMicrosoftAlias(schema, name, scalar, str, errors);
 
             if (schema.MaxLength.HasValue || schema.MinLength.HasValue)
             {

--- a/src/docfx/lib/schema/JsonSchemaValidator.cs
+++ b/src/docfx/lib/schema/JsonSchemaValidator.cs
@@ -321,12 +321,12 @@ namespace Microsoft.Docs.Build
                 {
                     if (_microsoftGraphCache != null)
                     {
-                        var (error, msAlias) = _microsoftGraphCache.GetMicrosoftAliasAsync(alias).GetAwaiter().GetResult();
+                        var (error, msAlias) = _microsoftGraphCache.GetMicrosoftAlias(alias).GetAwaiter().GetResult();
 
                         errors.AddIfNotNull(error);
 
                         // Mute error, when unable to connect to Microsoft Graph API
-                        if (msAlias == null && _microsoftGraphCache.IsConnectedToGraphApi())
+                        if (msAlias == null && _microsoftGraphCache.IsConnectedToGraphApi)
                         {
                             errors.Add(Errors.MsAliasInvalid(JsonUtility.GetSourceInfo(scalar), name, alias));
                         }

--- a/src/docfx/lib/schema/JsonSchemaValidator.cs
+++ b/src/docfx/lib/schema/JsonSchemaValidator.cs
@@ -321,6 +321,9 @@ namespace Microsoft.Docs.Build
                 {
                     if (_microsoftGraphCache != null)
                     {
+                        // NOTE: this line block waits an asynchronious method to simplify code structure.
+                        // It does not have much performance impact because most of the time
+                        // the returned task is a completed task due to cache hit.
                         var (error, msAlias) = _microsoftGraphCache.GetMicrosoftAlias(alias).GetAwaiter().GetResult();
 
                         errors.AddIfNotNull(error);


### PR DESCRIPTION
WorkQueue is currently too aggressive and causes starvation.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4871)