### PR TITLE
add quotes to example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Our current focus is conceptual document parity with https://docs.microsoft.com,
 - Install [.NET Core](https://www.microsoft.com/net/download)
 - Install latest `docfx` pre release using:
 ```powershell
-dotnet tool install -g docfx --version 3.0.0-* --add-source https://www.myget.org/F/docfx-v3/api/v2
+dotnet tool install -g docfx --version "3.0.0-*" --add-source https://www.myget.org/F/docfx-v3/api/v2
 ```
 - Create a directory with a `docfx.yml` config file, markdown files and other contents. See examples in our [specification](https://github.com/dotnet/docfx/tree/v3/docs/specs).
 - Run `docfx restore` to restore the dependencies of your docset.


### PR DESCRIPTION
zsh treats `*` as a glob, so the command fails without the quotes

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4885)