### PR TITLE
[WIP] validate bookmarks with decoded uri

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/ValidateBookmark.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/ValidateBookmark.cs
@@ -83,8 +83,8 @@ namespace Microsoft.DocAsCode.Build.Engine
                  where !"bookmark".Equals(nocheck, StringComparison.OrdinalIgnoreCase)
                  let link = node.GetAttributeValue("href", null)
                  let bookmark = UriUtility.GetFragment(link).TrimStart('#')
-			     let decodedBookmark = HttpUtility.UrlDecode(bookmark)
-				 let decodedLink = RelativePath.TryParse(HttpUtility.UrlDecode(UriUtility.GetPath(link)))
+                 let decodedBookmark = HttpUtility.UrlDecode(bookmark)
+                 let decodedLink = RelativePath.TryParse(HttpUtility.UrlDecode(UriUtility.GetPath(link)))
                  where !string.IsNullOrEmpty(bookmark) && !WhiteList.Contains(bookmark)
                  where decodedLink != null
                  select new LinkItem
@@ -92,7 +92,7 @@ namespace Microsoft.DocAsCode.Build.Engine
                      Title = node.InnerText,
                      Href = TransformPath(outputFile, decodedLink),
                      Bookmark = bookmark,
-					 DecodedBookmark = decodedBookmark,
+                     DecodedBookmark = decodedBookmark,
                      SourceFragment = WebUtility.HtmlDecode(node.GetAttributeValue("data-raw-source", null)),
                      SourceFile = WebUtility.HtmlDecode(node.GetAttributeValue("sourceFile", null)),
                      SourceLineNumber = node.GetAttributeValue("sourceStartLineNumber", 0),
@@ -118,7 +118,7 @@ namespace Microsoft.DocAsCode.Build.Engine
                     string title = linkItem.Title;
                     string linkedToFile = linkItem.Href;
                     string bookmark = linkItem.Bookmark;
-	                string decodedBookmark = linkItem.DecodedBookmark;
+                    string decodedBookmark = linkItem.DecodedBookmark;
                     if (_registeredBookmarks.TryGetValue(linkedToFile, out HashSet<string> bookmarks) 
                         && !bookmarks.Contains(bookmark)
                         && !bookmarks.Contains(decodedBookmark))
@@ -208,7 +208,7 @@ namespace Microsoft.DocAsCode.Build.Engine
 
             public string Bookmark { get; set; }
 
-			public string DecodedBookmark { get; set; }
+            public string DecodedBookmark { get; set; }
 
             public string SourceFragment { get; set; }
 

--- a/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/ValidateBookmark.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/ValidateBookmark.cs
@@ -83,7 +83,8 @@ namespace Microsoft.DocAsCode.Build.Engine
                  where !"bookmark".Equals(nocheck, StringComparison.OrdinalIgnoreCase)
                  let link = node.GetAttributeValue("href", null)
                  let bookmark = UriUtility.GetFragment(link).TrimStart('#')
-                 let decodedLink = RelativePath.TryParse(HttpUtility.UrlDecode(UriUtility.GetPath(link)))
+			     let decodedBookmark = HttpUtility.UrlDecode(bookmark)
+				 let decodedLink = RelativePath.TryParse(HttpUtility.UrlDecode(UriUtility.GetPath(link)))
                  where !string.IsNullOrEmpty(bookmark) && !WhiteList.Contains(bookmark)
                  where decodedLink != null
                  select new LinkItem
@@ -91,6 +92,7 @@ namespace Microsoft.DocAsCode.Build.Engine
                      Title = node.InnerText,
                      Href = TransformPath(outputFile, decodedLink),
                      Bookmark = bookmark,
+					 DecodedBookmark = decodedBookmark,
                      SourceFragment = WebUtility.HtmlDecode(node.GetAttributeValue("data-raw-source", null)),
                      SourceFile = WebUtility.HtmlDecode(node.GetAttributeValue("sourceFile", null)),
                      SourceLineNumber = node.GetAttributeValue("sourceStartLineNumber", 0),
@@ -116,7 +118,10 @@ namespace Microsoft.DocAsCode.Build.Engine
                     string title = linkItem.Title;
                     string linkedToFile = linkItem.Href;
                     string bookmark = linkItem.Bookmark;
-                    if (_registeredBookmarks.TryGetValue(linkedToFile, out HashSet<string> bookmarks) && !bookmarks.Contains(bookmark))
+	                string decodedBookmark = linkItem.DecodedBookmark;
+                    if (_registeredBookmarks.TryGetValue(linkedToFile, out HashSet<string> bookmarks) 
+                        && !bookmarks.Contains(bookmark)
+                        && !bookmarks.Contains(decodedBookmark))
                     {
                         string currentFileSrc = linkItem.SourceFile ?? _fileMapping[currentFile];
                         string linkedToFileSrc = _fileMapping[linkedToFile];
@@ -202,6 +207,8 @@ namespace Microsoft.DocAsCode.Build.Engine
             public string Href { get; set; }
 
             public string Bookmark { get; set; }
+
+			public string DecodedBookmark { get; set; }
 
             public string SourceFragment { get; set; }
 


### PR DESCRIPTION
When a named anchor with chinese characters is validated, DocFX reports a warning message saying that: Illegal link:  -- missing bookmark. The file {linkedToFileSrc} doesn't contain a bookmark named {EncodedURI}.

This PR add comparison of decoded bookmark and saved bookmarks.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4906)