### PR TITLE
Validate each metadata schema individually for multiple metadata schema definitions

### DIFF
--- a/docs/specs/validation.yml
+++ b/docs/specs/validation.yml
@@ -88,6 +88,28 @@ outputs:
     ["warning","missing-attribute","Missing required attribute: 'a'","a.md",2,1]
     ["warning","unexpected-type","Expected type 'String' but got 'Array'","a.md",2,6]
 ---
+# Validate each metadata schema individually for multiple metadata schema definitions
+inputs:
+  docfx.yml: |
+    metadataSchema:
+      - schema1.json
+      - schema2.json
+  schema1.json: |
+    { "required": ["a"], "properties": { "key": { "type": "string" } } }
+  schema2.json: |
+    { "required": ["b"], "properties": { "key": { "type": "array" } } }
+  a.md: |
+    ---
+    key: 1
+    ---
+outputs:
+  a.json:
+  .errors.log: |
+    ["warning","missing-attribute","Missing required attribute: 'a'","a.md",2,1]
+    ["warning","unexpected-type","Expected type 'String' but got 'Integer'","a.md",2,6]
+    ["warning","missing-attribute","Missing required attribute: 'b'","a.md",2,1]
+    ["warning","unexpected-type","Expected type 'Array' but got 'Integer'","a.md",2,6]
+---
 # Json schema microsoft alias rule: Metu error, when no connection with Graph API
 inputs:
   docfx.yml: |

--- a/src/docfx/build/metadata/MetadataProvider.cs
+++ b/src/docfx/build/metadata/MetadataProvider.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Docs.Build
     internal class MetadataProvider
     {
         private readonly Cache _cache;
-        private readonly JsonSchemaValidator _schemaValidator;
+        private readonly JsonSchemaValidator[] _schemaValidators;
         private readonly JObject _globalMetadata;
         private readonly HashSet<string> _reservedMetadata;
         private readonly List<(Func<string, bool> glob, string key, JToken value)> _rules = new List<(Func<string, bool> glob, string key, JToken value)>();
@@ -21,17 +21,37 @@ namespace Microsoft.Docs.Build
         private readonly ConcurrentDictionary<Document, (List<Error> errors, InputMetadata metadata)> _metadataCache
                    = new ConcurrentDictionary<Document, (List<Error> errors, InputMetadata metadata)>();
 
+        public JsonSchema[] MetadataSchemas { get; }
+
+        public ICollection<string> HtmlMetaHidden { get; }
+
+        public IReadOnlyDictionary<string, string> HtmlMetaNames { get; }
+
         public MetadataProvider(Docset docset, Cache cache, MicrosoftGraphCache microsoftGraphCache)
         {
             _cache = cache;
-            _schemaValidator = new JsonSchemaValidator(docset.MetadataSchema, microsoftGraphCache);
             _globalMetadata = docset.Config.GlobalMetadata;
+
+            MetadataSchemas = Array.ConvertAll(
+                docset.Config.MetadataSchema,
+                schema => JsonUtility.Deserialize<JsonSchema>(
+                    RestoreMap.GetRestoredFileContent(docset, schema), schema.Source.File));
+
+            _schemaValidators = Array.ConvertAll(
+                MetadataSchemas,
+                schema => new JsonSchemaValidator(schema, microsoftGraphCache));
 
             _reservedMetadata = JsonUtility.GetPropertyNames(typeof(OutputMetadata))
                 .Concat(JsonUtility.GetPropertyNames(typeof(ConceptualModel)))
-                .Concat(docset.MetadataSchema.Reserved)
+                .Concat(MetadataSchemas.SelectMany(schema => schema.Reserved))
                 .Except(JsonUtility.GetPropertyNames(typeof(InputMetadata)))
                 .ToHashSet();
+
+            HtmlMetaHidden = MetadataSchemas.SelectMany(schema => schema.HtmlMetaHidden).ToHashSet();
+
+            HtmlMetaNames = MetadataSchemas.SelectMany(
+                schema => schema.Properties.Where(prop => !string.IsNullOrEmpty(prop.Value.HtmlMetaName)))
+                    .ToDictionary(prop => prop.Key, prop => prop.Value.HtmlMetaName);
 
             foreach (var (key, item) in docset.Config.FileMetadata)
             {
@@ -87,7 +107,10 @@ namespace Microsoft.Docs.Build
                 }
             }
 
-            errors.AddRange(_schemaValidator.Validate(result));
+            foreach (var schemaValidator in _schemaValidators)
+            {
+                errors.AddRange(schemaValidator.Validate(result));
+            }
 
             var (validationErrors, metadata) = JsonUtility.ToObject<InputMetadata>(result);
 

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -290,7 +290,7 @@ namespace Microsoft.Docs.Build
                 ["is_dynamic_rendering"] = true,
             };
 
-            var pageMetadata = HtmlUtility.CreateHtmlMetaTags(metadata, context.TemplateEngine.HtmlMetaConfigs);
+            var pageMetadata = HtmlUtility.CreateHtmlMetaTags(metadata, context.MetadataProvider.HtmlMetaHidden, context.MetadataProvider.HtmlMetaNames);
 
             // content for *.raw.page.json
             var model = new TemplateModel

--- a/src/docfx/docset/Docset.cs
+++ b/src/docfx/docset/Docset.cs
@@ -68,11 +68,6 @@ namespace Microsoft.Docs.Build
         public DependencyLockModel DependencyLock { get; }
 
         /// <summary>
-        /// Gets the metadata JSON schema
-        /// </summary>
-        public JsonSchema MetadataSchema { get; }
-
-        /// <summary>
         /// Gets the dependency repos/file mappings
         /// </summary>
         public RestoreMap RestoreMap { get; }
@@ -154,7 +149,6 @@ namespace Microsoft.Docs.Build
             FallbackDocset = fallbackDocset;
             (HostName, SiteBasePath) = SplitBaseUrl(config.BaseUrl);
 
-            MetadataSchema = LoadMetadataSchema(Config);
             Repository = repository ?? Repository.Create(DocsetPath, branch: null);
 
             _dependencyDocsets = new Lazy<IReadOnlyDictionary<string, Docset>>(() =>
@@ -212,17 +206,6 @@ namespace Microsoft.Docs.Build
             {
                 throw Errors.LocaleInvalid(locale).ToException();
             }
-        }
-
-        private JsonSchema LoadMetadataSchema(Config config)
-        {
-            var token = new JObject();
-            foreach (var metadataSchema in config.MetadataSchema)
-            {
-                var content = RestoreMap.GetRestoredFileContent(this, metadataSchema);
-                JsonUtility.Merge(token, JsonUtility.Parse(content, new FilePath(metadataSchema)).value as JObject);
-            }
-            return JsonUtility.ToObject<JsonSchema>(token).value;
         }
 
         private static (List<Error>, Dictionary<string, Docset>) LoadDependencies(

--- a/src/docfx/lib/HtmlUtility.cs
+++ b/src/docfx/lib/HtmlUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -212,7 +212,7 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public static string CreateHtmlMetaTags(JObject metadata, (HashSet<string> htmlMetaHidden, Dictionary<string, string> htmlMetaNames) htmlMetaConfigs)
+        public static string CreateHtmlMetaTags(JObject metadata, ICollection<string> htmlMetaHidden, IReadOnlyDictionary<string, string> htmlMetaNames)
         {
             var result = new StringBuilder();
 
@@ -220,13 +220,13 @@ namespace Microsoft.Docs.Build
             {
                 var key = property.Name;
                 var value = property.Value;
-                if (value is JObject || htmlMetaConfigs.htmlMetaHidden.Contains(key))
+                if (value is JObject || htmlMetaHidden.Contains(key))
                 {
                     continue;
                 }
 
                 var content = "";
-                var name = htmlMetaConfigs.htmlMetaNames.TryGetValue(key, out var diplayName) ? diplayName : key;
+                var name = htmlMetaNames.TryGetValue(key, out var diplayName) ? diplayName : key;
 
                 if (value is JArray arr)
                 {

--- a/src/docfx/template/TemplateEngine.cs
+++ b/src/docfx/template/TemplateEngine.cs
@@ -13,8 +13,6 @@ namespace Microsoft.Docs.Build
 {
     internal class TemplateEngine
     {
-        public (HashSet<string> htmlMetaHidden, Dictionary<string, string> htmlMetaNames) HtmlMetaConfigs { get; }
-
         private const string DefaultTemplateDir = "_themes";
         private static readonly string[] s_resourceFolders = new[] { "global", "css", "fonts" };
 
@@ -26,7 +24,7 @@ namespace Microsoft.Docs.Build
         private readonly IReadOnlyDictionary<string, Lazy<TemplateSchema>> _schemas;
         private readonly MustacheTemplate _mustacheTemplate;
 
-        private TemplateEngine(string templateDir, JsonSchema metadataSchema)
+        private TemplateEngine(string templateDir)
         {
             _templateDir = templateDir;
             _contentTemplateDir = Path.Combine(templateDir, "ContentTemplate");
@@ -37,12 +35,6 @@ namespace Microsoft.Docs.Build
             _liquid = new LiquidTemplate(_contentTemplateDir);
             _js = new JavascriptEngine(_contentTemplateDir, _global);
             _mustacheTemplate = new MustacheTemplate(_contentTemplateDir);
-
-            HtmlMetaConfigs = (
-                metadataSchema.HtmlMetaHidden.ToHashSet(),
-                metadataSchema.Properties
-                .Where(prop => !string.IsNullOrEmpty(prop.Value.HtmlMetaName))
-                .ToDictionary(prop => prop.Key, prop => prop.Value.HtmlMetaName));
         }
 
         public bool IsPage(string mime)
@@ -145,14 +137,14 @@ namespace Microsoft.Docs.Build
 
             if (string.IsNullOrEmpty(docset.Config.Template))
             {
-                return new TemplateEngine(Path.Combine(docset.DocsetPath, DefaultTemplateDir), new JsonSchema());
+                return new TemplateEngine(Path.Combine(docset.DocsetPath, DefaultTemplateDir));
             }
 
             var (themeRemote, themeBranch) = LocalizationUtility.GetLocalizedTheme(docset.Config.Template, docset.Locale, docset.Config.Localization.DefaultLocale);
             var (themePath, themeRestoreMap) = docset.RestoreMap.GetGitRestorePath(themeRemote, themeBranch, docset.DocsetPath);
             Log.Write($"Using theme '{themeRemote}#{themeRestoreMap.DependencyLock?.Commit}' at '{themePath}'");
 
-            return new TemplateEngine(themePath, docset.MetadataSchema);
+            return new TemplateEngine(themePath);
         }
 
         private JObject LoadGlobalTokens()


### PR DESCRIPTION
When multiple metadata schemas are defined, do not merge them into one and the JSON schema may specify different rules for the same property. So validate each metadata schema individually.

Related #4920 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4924)