### PR TITLE
Documented video markdown syntax

### DIFF
--- a/Documentation/spec/docfx_flavored_markdown.md
+++ b/Documentation/spec/docfx_flavored_markdown.md
@@ -568,6 +568,27 @@ Tab content-b for 2.
 When select `tabid-1` in tab group 1, you can get content-a or content-b for 1 in group 2.\
 When select `tabid-2` in tab group 1, you can get content-a or content-b for 2 in group 2.
 
+## Video
+
+Allows you to add videos to your topics.
+
+Syntax:
+```md
+> [!Video embed_link]
+```
+
+> [!NOTE]
+> You must provide the **embed** uri of the video you wish to add to your topic.
+
+Example:
+```md
+> [!Video https://www.youtube.com/embed/TAaG0nUUy6A]
+```
+
+Result:
+
+> [!Video https://www.youtube.com/embed/TAaG0nUUy6A]
+
 ## Differences introduced by DFM syntax
 
 > [!Warning]


### PR DESCRIPTION
I have added documentation for the **Video** markdown syntax. This is currently undocumented, and there are many inquiries about this capability.

This will make it very clear to everyone on how to add videos to docfx topics.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4931)