### PR TITLE
add attribute 'jsonpath' for markdown content

### DIFF
--- a/Documentation/spec/docfx_flavored_markdown.md
+++ b/Documentation/spec/docfx_flavored_markdown.md
@@ -568,6 +568,27 @@ Tab content-b for 2.
 When select `tabid-1` in tab group 1, you can get content-a or content-b for 1 in group 2.\
 When select `tabid-2` in tab group 1, you can get content-a or content-b for 2 in group 2.
 
+## Video
+
+Allows you to add videos to your topics.
+
+Syntax:
+```md
+> [!Video embed_link]
+```
+
+> [!NOTE]
+> You must provide the **embed** uri of the video you wish to add to your topic.
+
+Example:
+```md
+> [!Video https://www.youtube.com/embed/TAaG0nUUy6A]
+```
+
+Result:
+
+> [!Video https://www.youtube.com/embed/TAaG0nUUy6A]
+
 ## Differences introduced by DFM syntax
 
 > [!Warning]

--- a/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/RemoveDebugInfo.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/RemoveDebugInfo.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DocAsCode.Build.Engine
             "sourceFile",
             "sourceStartLineNumber",
             "sourceEndLineNumber",
-            "jsonpath",
+            "jsonPath",
             "data-raw-source",
             "nocheck",
         };

--- a/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/RemoveDebugInfo.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/RemoveDebugInfo.cs
@@ -14,6 +14,7 @@ namespace Microsoft.DocAsCode.Build.Engine
             "sourceFile",
             "sourceStartLineNumber",
             "sourceEndLineNumber",
+            "jsonPath",
             "data-raw-source",
             "nocheck",
         };

--- a/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/RemoveDebugInfo.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/RemoveDebugInfo.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DocAsCode.Build.Engine
             "sourceFile",
             "sourceStartLineNumber",
             "sourceEndLineNumber",
-            "jsonPath",
+            "jsonpath",
             "data-raw-source",
             "nocheck",
         };

--- a/src/Microsoft.DocAsCode.Build.SchemaDriven/Processors/MarkdownInterpreter.cs
+++ b/src/Microsoft.DocAsCode.Build.SchemaDriven/Processors/MarkdownInterpreter.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DocAsCode.Build.SchemaDriven.Processors
                     node.SetAttributeValue("jsonPath", path);
             }
 
-            return htmlDocument.ToString();
+            return htmlDocument.DocumentNode.InnerHtml;
         }
     }
 }

--- a/src/Microsoft.DocAsCode.Build.SchemaDriven/Processors/MarkdownInterpreter.cs
+++ b/src/Microsoft.DocAsCode.Build.SchemaDriven/Processors/MarkdownInterpreter.cs
@@ -42,17 +42,11 @@ namespace Microsoft.DocAsCode.Build.SchemaDriven.Processors
 
             HtmlDocument htmlDocument = new HtmlDocument();
             htmlDocument.LoadHtml(mr.Html);
-            foreach (var node in htmlDocument.DocumentNode.Descendants())
-            {
-                if (!node.HasAttributes)
-                {
-                    continue;
-                }
-                //if the node have this attribute, it's markdown content and add new attribute
-                if (!node.GetAttributeValue("sourceStartLineNumber", false))
-                    node.SetAttributeValue("jsonPath", path);
-            }
 
+            //if the node have this attribute, it's markdown content and add new attribute
+            if (!htmlDocument.DocumentNode.FirstChild.GetAttributeValue("sourceStartLineNumber", false))
+                htmlDocument.DocumentNode.FirstChild.SetAttributeValue("jsonPath", path);
+                       
             return htmlDocument.DocumentNode.InnerHtml;
         }
     }

--- a/src/Microsoft.DocAsCode.Build.SchemaDriven/Processors/MarkdownInterpreter.cs
+++ b/src/Microsoft.DocAsCode.Build.SchemaDriven/Processors/MarkdownInterpreter.cs
@@ -43,11 +43,12 @@ namespace Microsoft.DocAsCode.Build.SchemaDriven.Processors
             HtmlDocument htmlDocument = new HtmlDocument();
             htmlDocument.LoadHtml(mr.Html);
 
-            //if the node have this attribute, it's markdown content and add new attribute
-            if (!htmlDocument.DocumentNode.FirstChild.GetAttributeValue("sourceStartLineNumber", false))
-                htmlDocument.DocumentNode.FirstChild.SetAttributeValue("jsonPath", path);
-                       
-            return htmlDocument.DocumentNode.InnerHtml;
+            //Add attribute 'jsonPath' into debugInfo
+            if (mr.Html.StartsWith(@"<p"))
+                mr.Html = mr.Html.Insert(mr.Html.IndexOf(@">"), " jsonpath=\"" + path + "\"");
+            //htmlDocument.DocumentNode.FirstChild.SetAttributeValue("jsonPath", path);
+
+            return mr.Html;
         }
     }
 }

--- a/src/Microsoft.DocAsCode.Build.SchemaDriven/Processors/MarkdownInterpreter.cs
+++ b/src/Microsoft.DocAsCode.Build.SchemaDriven/Processors/MarkdownInterpreter.cs
@@ -8,6 +8,7 @@ namespace Microsoft.DocAsCode.Build.SchemaDriven.Processors
     using Microsoft.DocAsCode.Common;
     using Microsoft.DocAsCode.Plugins;
 
+    using HtmlAgilityPack;
     public class MarkdownInterpreter : IInterpreter
     {
         public bool CanInterpret(BaseSchema schema)
@@ -38,7 +39,21 @@ namespace Microsoft.DocAsCode.Build.SchemaDriven.Processors
             (context.FileLinkSources).Merge(mr.FileLinkSources);
             (context.UidLinkSources).Merge(mr.UidLinkSources);
             (context.Dependency).UnionWith(mr.Dependency);
-            return mr.Html;
+
+            HtmlDocument htmlDocument = new HtmlDocument();
+            htmlDocument.LoadHtml(mr.Html);
+            foreach (var node in htmlDocument.DocumentNode.Descendants())
+            {
+                if (!node.HasAttributes)
+                {
+                    continue;
+                }
+                //if the node have this attribute, it's markdown content and add new attribute
+                if (!node.GetAttributeValue("sourceStartLineNumber", false))
+                    node.SetAttributeValue("jsonPath", path);
+            }
+
+            return htmlDocument.ToString();
         }
     }
 }

--- a/src/Microsoft.DocAsCode.Build.SchemaDriven/Processors/MarkdownInterpreter.cs
+++ b/src/Microsoft.DocAsCode.Build.SchemaDriven/Processors/MarkdownInterpreter.cs
@@ -40,14 +40,8 @@ namespace Microsoft.DocAsCode.Build.SchemaDriven.Processors
             (context.UidLinkSources).Merge(mr.UidLinkSources);
             (context.Dependency).UnionWith(mr.Dependency);
 
-            HtmlDocument htmlDocument = new HtmlDocument();
-            htmlDocument.LoadHtml(mr.Html);
-
-            //Add attribute 'jsonPath' into debugInfo
             if (mr.Html.StartsWith(@"<p"))
-                mr.Html = mr.Html.Insert(mr.Html.IndexOf(@">"), " jsonpath=\"" + path + "\"");
-            //htmlDocument.DocumentNode.FirstChild.SetAttributeValue("jsonPath", path);
-
+                mr.Html = mr.Html.Insert(mr.Html.IndexOf(@">"), " jsonPath=\"" + path + "\"");
             return mr.Html;
         }
     }

--- a/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/MergeMarkdownFragmentsTest.cs
+++ b/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/MergeMarkdownFragmentsTest.cs
@@ -319,7 +319,7 @@ overwrite in contents block
             Assert.True(File.Exists(_rawModelFilePath));
             var rawModel = JsonUtility.Deserialize<JObject>(_rawModelFilePath);
             Assert.Equal("name overwrite", rawModel["name"]);
-            Assert.Equal($"<p sourcefile=\"{_inputFolder}/Suppressions.yml.md\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonpath=\"/definitions/0/properties/0/description\">overwrite in yaml block</p>\n", rawModel["definitions"][0]["properties"][0]["description"].ToString());
+            Assert.Equal($"<p sourcefile=\"{_inputFolder}/Suppressions.yml.md\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonPath=\"/definitions/0/properties/0/description\">overwrite in yaml block</p>\n", rawModel["definitions"][0]["properties"][0]["description"].ToString());
             Assert.Equal($"<p sourceFile=\"{_inputFolder}/Suppressions.yml.md\" sourceStartLineNumber=\"14\">overwrite in contents block</p>\n", rawModel["definitions"][0]["properties"][1]["description"].ToString());
         }
 

--- a/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/MergeMarkdownFragmentsTest.cs
+++ b/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/MergeMarkdownFragmentsTest.cs
@@ -319,7 +319,7 @@ overwrite in contents block
             Assert.True(File.Exists(_rawModelFilePath));
             var rawModel = JsonUtility.Deserialize<JObject>(_rawModelFilePath);
             Assert.Equal("name overwrite", rawModel["name"]);
-            Assert.Equal($"<p sourcefile=\"{_inputFolder}/Suppressions.yml.md\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\">overwrite in yaml block</p>\n", rawModel["definitions"][0]["properties"][0]["description"].ToString());
+            Assert.Equal($"<p sourcefile=\"{_inputFolder}/Suppressions.yml.md\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonpath=\"/definitions/0/properties/0/description\">overwrite in yaml block</p>\n", rawModel["definitions"][0]["properties"][0]["description"].ToString());
             Assert.Equal($"<p sourceFile=\"{_inputFolder}/Suppressions.yml.md\" sourceStartLineNumber=\"14\">overwrite in contents block</p>\n", rawModel["definitions"][0]["properties"][1]["description"].ToString());
         }
 

--- a/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/SchemaDrivenProcessorTest.cs
+++ b/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/SchemaDrivenProcessorTest.cs
@@ -83,7 +83,7 @@ namespace Microsoft.DocAsCode.Build.SchemaDriven.Tests
                 Assert.Equal("world", rawModel["metadata"]["hello"].ToString());
                 Assert.Equal("Hello world!", rawModel["meta"].ToString());
                 Assert.Equal("/metadata", rawModel["metadata"]["path"].ToString());
-                Assert.Equal($"<p sourcefile=\"{_inputFolder}/landingPage1.yml\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonpath=\"/sections/1/children/0/content\">Create an application using <a href=\"app-service-web-tutorial-dotnet-sqldatabase.md\" data-raw-source=\"[.NET with Azure SQL DB](app-service-web-tutorial-dotnet-sqldatabase.md)\" sourcefile=\"{_inputFolder}/landingPage1.yml\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\">.NET with Azure SQL DB</a> or <a href=\"app-service-web-tutorial-nodejs-mongodb-app.md\" data-raw-source=\"[Node.js with MongoDB](app-service-web-tutorial-nodejs-mongodb-app.md)\" sourcefile=\"{_inputFolder}/landingPage1.yml\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\">Node.js with MongoDB</a></p>\n"
+                Assert.Equal($"<p sourcefile=\"{_inputFolder}/landingPage1.yml\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonPath=\"/sections/1/children/0/content\">Create an application using <a href=\"app-service-web-tutorial-dotnet-sqldatabase.md\" data-raw-source=\"[.NET with Azure SQL DB](app-service-web-tutorial-dotnet-sqldatabase.md)\" sourcefile=\"{_inputFolder}/landingPage1.yml\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\">.NET with Azure SQL DB</a> or <a href=\"app-service-web-tutorial-nodejs-mongodb-app.md\" data-raw-source=\"[Node.js with MongoDB](app-service-web-tutorial-nodejs-mongodb-app.md)\" sourcefile=\"{_inputFolder}/landingPage1.yml\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\">Node.js with MongoDB</a></p>\n"
                                 , rawModel["sections"][1]["children"][0]["content"].ToString());
             }
         }
@@ -126,7 +126,7 @@ searchScope:
                 Assert.Equal("Hello world!", rawModel["meta"].Value<string>());
                 Assert.Equal("/absolute/toc.json", rawModel["breadcrumb_path"].Value<string>());
                 Assert.Equal("../a b/toc.md", rawModel["toc_rel"].Value<string>());
-                Assert.Equal($"<p sourcefile=\"{includeFile}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonpath=\"/file_include\"><a href=\"~/{inputFile}\" data-raw-source=\"[root](../co/active.yml)\" sourcefile=\"{includeFile}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\">root</a></p>\n",
+                Assert.Equal($"<p sourcefile=\"{includeFile}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonPath=\"/file_include\"><a href=\"~/{inputFile}\" data-raw-source=\"[root](../co/active.yml)\" sourcefile=\"{includeFile}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\">root</a></p>\n",
                     rawModel["file_include"].Value<string>());
                 Assert.Equal("../../a b/toc.md", rawModel["file_include2"].Value<string>());
                 Assert.Equal("MSDocsHeader-DotNet", rawModel["uhfHeaderId"].Value<string>());

--- a/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/SchemaDrivenProcessorTest.cs
+++ b/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/SchemaDrivenProcessorTest.cs
@@ -83,7 +83,7 @@ namespace Microsoft.DocAsCode.Build.SchemaDriven.Tests
                 Assert.Equal("world", rawModel["metadata"]["hello"].ToString());
                 Assert.Equal("Hello world!", rawModel["meta"].ToString());
                 Assert.Equal("/metadata", rawModel["metadata"]["path"].ToString());
-                Assert.Equal($"<p sourcefile=\"{_inputFolder}/landingPage1.yml\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\">Create an application using <a href=\"app-service-web-tutorial-dotnet-sqldatabase.md\" data-raw-source=\"[.NET with Azure SQL DB](app-service-web-tutorial-dotnet-sqldatabase.md)\" sourcefile=\"{_inputFolder}/landingPage1.yml\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\">.NET with Azure SQL DB</a> or <a href=\"app-service-web-tutorial-nodejs-mongodb-app.md\" data-raw-source=\"[Node.js with MongoDB](app-service-web-tutorial-nodejs-mongodb-app.md)\" sourcefile=\"{_inputFolder}/landingPage1.yml\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\">Node.js with MongoDB</a></p>\n"
+                Assert.Equal($"<p sourcefile=\"{_inputFolder}/landingPage1.yml\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonpath=\"/sections/1/children/0/content\">Create an application using <a href=\"app-service-web-tutorial-dotnet-sqldatabase.md\" data-raw-source=\"[.NET with Azure SQL DB](app-service-web-tutorial-dotnet-sqldatabase.md)\" sourcefile=\"{_inputFolder}/landingPage1.yml\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonpath=\"/sections/1/children/0/content\">.NET with Azure SQL DB</a> or <a href=\"app-service-web-tutorial-nodejs-mongodb-app.md\" data-raw-source=\"[Node.js with MongoDB](app-service-web-tutorial-nodejs-mongodb-app.md)\" sourcefile=\"{_inputFolder}/landingPage1.yml\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonpath=\"/sections/1/children/0/content\">Node.js with MongoDB</a></p>\n"
                                 , rawModel["sections"][1]["children"][0]["content"].ToString());
             }
         }
@@ -126,7 +126,7 @@ searchScope:
                 Assert.Equal("Hello world!", rawModel["meta"].Value<string>());
                 Assert.Equal("/absolute/toc.json", rawModel["breadcrumb_path"].Value<string>());
                 Assert.Equal("../a b/toc.md", rawModel["toc_rel"].Value<string>());
-                Assert.Equal($"<p sourcefile=\"{includeFile}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\"><a href=\"~/{inputFile}\" data-raw-source=\"[root](../co/active.yml)\" sourcefile=\"{includeFile}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\">root</a></p>\n",
+                Assert.Equal($"<p sourcefile=\"{includeFile}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonpath=\"/file_include\"><a href=\"~/{inputFile}\" data-raw-source=\"[root](../co/active.yml)\" sourcefile=\"{includeFile}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonpath=\"/file_include\">root</a></p>\n",
                     rawModel["file_include"].Value<string>());
                 Assert.Equal("../../a b/toc.md", rawModel["file_include2"].Value<string>());
                 Assert.Equal("MSDocsHeader-DotNet", rawModel["uhfHeaderId"].Value<string>());

--- a/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/SchemaDrivenProcessorTest.cs
+++ b/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/SchemaDrivenProcessorTest.cs
@@ -83,7 +83,7 @@ namespace Microsoft.DocAsCode.Build.SchemaDriven.Tests
                 Assert.Equal("world", rawModel["metadata"]["hello"].ToString());
                 Assert.Equal("Hello world!", rawModel["meta"].ToString());
                 Assert.Equal("/metadata", rawModel["metadata"]["path"].ToString());
-                Assert.Equal($"<p sourcefile=\"{_inputFolder}/landingPage1.yml\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonpath=\"/sections/1/children/0/content\">Create an application using <a href=\"app-service-web-tutorial-dotnet-sqldatabase.md\" data-raw-source=\"[.NET with Azure SQL DB](app-service-web-tutorial-dotnet-sqldatabase.md)\" sourcefile=\"{_inputFolder}/landingPage1.yml\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonpath=\"/sections/1/children/0/content\">.NET with Azure SQL DB</a> or <a href=\"app-service-web-tutorial-nodejs-mongodb-app.md\" data-raw-source=\"[Node.js with MongoDB](app-service-web-tutorial-nodejs-mongodb-app.md)\" sourcefile=\"{_inputFolder}/landingPage1.yml\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonpath=\"/sections/1/children/0/content\">Node.js with MongoDB</a></p>\n"
+                Assert.Equal($"<p sourcefile=\"{_inputFolder}/landingPage1.yml\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonpath=\"/sections/1/children/0/content\">Create an application using <a href=\"app-service-web-tutorial-dotnet-sqldatabase.md\" data-raw-source=\"[.NET with Azure SQL DB](app-service-web-tutorial-dotnet-sqldatabase.md)\" sourcefile=\"{_inputFolder}/landingPage1.yml\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\">.NET with Azure SQL DB</a> or <a href=\"app-service-web-tutorial-nodejs-mongodb-app.md\" data-raw-source=\"[Node.js with MongoDB](app-service-web-tutorial-nodejs-mongodb-app.md)\" sourcefile=\"{_inputFolder}/landingPage1.yml\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\">Node.js with MongoDB</a></p>\n"
                                 , rawModel["sections"][1]["children"][0]["content"].ToString());
             }
         }
@@ -126,7 +126,7 @@ searchScope:
                 Assert.Equal("Hello world!", rawModel["meta"].Value<string>());
                 Assert.Equal("/absolute/toc.json", rawModel["breadcrumb_path"].Value<string>());
                 Assert.Equal("../a b/toc.md", rawModel["toc_rel"].Value<string>());
-                Assert.Equal($"<p sourcefile=\"{includeFile}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonpath=\"/file_include\"><a href=\"~/{inputFile}\" data-raw-source=\"[root](../co/active.yml)\" sourcefile=\"{includeFile}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonpath=\"/file_include\">root</a></p>\n",
+                Assert.Equal($"<p sourcefile=\"{includeFile}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonpath=\"/file_include\"><a href=\"~/{inputFile}\" data-raw-source=\"[root](../co/active.yml)\" sourcefile=\"{includeFile}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\">root</a></p>\n",
                     rawModel["file_include"].Value<string>());
                 Assert.Equal("../../a b/toc.md", rawModel["file_include2"].Value<string>());
                 Assert.Equal("MSDocsHeader-DotNet", rawModel["uhfHeaderId"].Value<string>());

--- a/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/SchemaMergerTest.cs
+++ b/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/SchemaMergerTest.cs
@@ -373,7 +373,7 @@ Nice
                 Assert.Equal($"<p sourcefile=\"{overwriteFile}\" sourcestartlinenumber=\"8\" sourceendlinenumber=\"8\">Nice</p>\n", rawModel["summary"].Value<string>());
                 Assert.Equal("src.html", rawModel["href"].Value<string>());
                 Assert.Equal("uid1", rawModel["xref"].Value<string>());
-                Assert.Equal($"<p sourcefile=\"{includeFile2}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonpath=\"/reference\"><a href=\"~/{inputFile}\" data-raw-source=\"[overwrite](../src/src.yml)\" sourcefile=\"{includeFile2}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\">overwrite</a></p>\n", rawModel["reference"].Value<string>());
+                Assert.Equal($"<p sourcefile=\"{includeFile2}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonPath=\"/reference\"><a href=\"~/{inputFile}\" data-raw-source=\"[overwrite](../src/src.yml)\" sourcefile=\"{includeFile2}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\">overwrite</a></p>\n", rawModel["reference"].Value<string>());
 
                 var outputFile = GetOutputFilePath(inputFileName);
                 Assert.Equal("<a class=\"xref\" href=\"src.html\">uid1</a>", File.ReadAllText(outputFile));

--- a/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/SchemaMergerTest.cs
+++ b/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/SchemaMergerTest.cs
@@ -373,7 +373,7 @@ Nice
                 Assert.Equal($"<p sourcefile=\"{overwriteFile}\" sourcestartlinenumber=\"8\" sourceendlinenumber=\"8\">Nice</p>\n", rawModel["summary"].Value<string>());
                 Assert.Equal("src.html", rawModel["href"].Value<string>());
                 Assert.Equal("uid1", rawModel["xref"].Value<string>());
-                Assert.Equal($"<p sourcefile=\"{includeFile2}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonpath=\"/reference\"><a href=\"~/{inputFile}\" data-raw-source=\"[overwrite](../src/src.yml)\" sourcefile=\"{includeFile2}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonpath=\"/reference\">overwrite</a></p>\n", rawModel["reference"].Value<string>());
+                Assert.Equal($"<p sourcefile=\"{includeFile2}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonpath=\"/reference\"><a href=\"~/{inputFile}\" data-raw-source=\"[overwrite](../src/src.yml)\" sourcefile=\"{includeFile2}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\">overwrite</a></p>\n", rawModel["reference"].Value<string>());
 
                 var outputFile = GetOutputFilePath(inputFileName);
                 Assert.Equal("<a class=\"xref\" href=\"src.html\">uid1</a>", File.ReadAllText(outputFile));

--- a/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/SchemaMergerTest.cs
+++ b/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/SchemaMergerTest.cs
@@ -373,7 +373,7 @@ Nice
                 Assert.Equal($"<p sourcefile=\"{overwriteFile}\" sourcestartlinenumber=\"8\" sourceendlinenumber=\"8\">Nice</p>\n", rawModel["summary"].Value<string>());
                 Assert.Equal("src.html", rawModel["href"].Value<string>());
                 Assert.Equal("uid1", rawModel["xref"].Value<string>());
-                Assert.Equal($"<p sourcefile=\"{includeFile2}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\"><a href=\"~/{inputFile}\" data-raw-source=\"[overwrite](../src/src.yml)\" sourcefile=\"{includeFile2}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\">overwrite</a></p>\n", rawModel["reference"].Value<string>());
+                Assert.Equal($"<p sourcefile=\"{includeFile2}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonpath=\"/reference\"><a href=\"~/{inputFile}\" data-raw-source=\"[overwrite](../src/src.yml)\" sourcefile=\"{includeFile2}\" sourcestartlinenumber=\"1\" sourceendlinenumber=\"1\" jsonpath=\"/reference\">overwrite</a></p>\n", rawModel["reference"].Value<string>());
 
                 var outputFile = GetOutputFilePath(inputFileName);
                 Assert.Equal("<a class=\"xref\" href=\"src.html\">uid1</a>", File.ReadAllText(outputFile));


### PR DESCRIPTION

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4940)
In order to add location information into html content. Thereby I can locate the edited part in yml file.(For inline edit feature.)