### PR TITLE
Update XrefMap model for JSON serialization

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/XRefMaps/XRefMap.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/XRefMaps/XRefMap.cs
@@ -12,28 +12,37 @@ namespace Microsoft.DocAsCode.Build.Engine
     using Microsoft.DocAsCode.Common;
     using Microsoft.DocAsCode.Plugins;
     using Microsoft.DocAsCode.YamlSerialization;
+    using Newtonsoft.Json.Serialization;
+    using Newtonsoft.Json;
 
     public class XRefMap : IXRefContainer
     {
         [YamlMember(Alias = "sorted")]
+        [JsonProperty("sorted")]
         public bool? Sorted { get; set; }
 
         [YamlMember(Alias = "hrefUpdated")]
+        [JsonProperty("hrefUpdated")]
         public bool? HrefUpdated { get; set; }
 
         [YamlMember(Alias = "baseUrl")]
+        [JsonProperty("baseUrl")]
         public string BaseUrl { get; set; }
 
         [YamlMember(Alias = "tags")]
+        [JsonProperty("tags")]
         public List<string> Tags { get; set; }
 
         [YamlMember(Alias = "redirections")]
+        [JsonProperty("redirections")]
         public List<XRefMapRedirection> Redirections { get; set; }
 
         [YamlMember(Alias = "references")]
+        [JsonProperty("references")]
         public List<XRefSpec> References { get; set; }
 
         [ExtensibleMember]
+        [JsonExtensionData]
         public Dictionary<string, object> Others { get; set; } = new Dictionary<string, object>();
 
         public void Sort()


### PR DESCRIPTION
xrefmap.yml:
```yml
### YamlMime:XRefMap
sorted: true
tags: []
properties:
  vendor: aspnet-core-conceptual-ppe-master
  tags:
  - /aspnet-core-conceptual-ppe
  - internal
```
xrefmap.json:
```json
{
    "Sorted": true,
    "Tags": [],
    "Others": {
        "properties": {
            "vendor": "aspnet-core-conceptual-ppe-master",
            "tags": [
                "/aspnet-core-conceptual-ppe",
                "internal"
            ]
        }
    }
}
```
Fix to let JSON serialization have the same output as YAML serialization

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4944)