### PR TITLE
refine fallback and localized docset(repository)

### DIFF
--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -154,10 +154,10 @@ namespace Microsoft.Docs.Build
                     }
 
                     // if A toc includes B toc and only B toc is localized, then A need to be included and built
-                    return !context.BuildScope.IsFallbackDocset(file.Docset) || (context.TocMap.TryGetTocReferences(file, out var tocReferences) && tocReferences.Any(toc => !context.BuildScope.IsFallbackDocset(toc.Docset)));
+                    return file.FilePath.Origin != FileOrigin.Fallback || (context.TocMap.TryGetTocReferences(file, out var tocReferences) && tocReferences.Any(toc => toc.FilePath.Origin != FileOrigin.Fallback));
                 }
 
-                return !context.BuildScope.IsFallbackDocset(file.Docset);
+                return file.FilePath.Origin != FileOrigin.Fallback;
             }
         }
 

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -29,14 +29,14 @@ namespace Microsoft.Docs.Build
                 if (errorLog.Write(configErrors))
                     return;
 
+                var outputPath = Path.Combine(docsetPath, config.Output.Path);
                 var docset = GetBuildDocset(new Docset(errorLog, docsetPath, locale, config, options, fallbackRestoreGitMap ?? restoreGitMap, repository, fallbackRepo));
-                await Run(docset, options, errorLog);
+                await Run(docset, options, errorLog, outputPath);
             }
         }
 
-        private static async Task Run(Docset docset, CommandLineOptions options, ErrorLog errorLog)
+        private static async Task Run(Docset docset, CommandLineOptions options, ErrorLog errorLog, string outputPath)
         {
-            var outputPath = Path.Combine(docset.DocsetPath, docset.Config.Output.Path);
             using (var context = new Context(outputPath, errorLog, docset, BuildFile))
             {
                 context.BuildQueue.Enqueue(context.BuildScope.Files);
@@ -202,7 +202,7 @@ namespace Microsoft.Docs.Build
         {
             Debug.Assert(sourceDocset != null);
 
-            return sourceDocset.LocalizationDocset ?? sourceDocset;
+            return sourceDocset.LocalizedDocset ?? sourceDocset;
         }
     }
 }

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Graph;
 
 namespace Microsoft.Docs.Build
 {

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -155,10 +155,10 @@ namespace Microsoft.Docs.Build
                     }
 
                     // if A toc includes B toc and only B toc is localized, then A need to be included and built
-                    return file.Docset != context.BuildScope.FallbackDocset || (context.TocMap.TryGetTocReferences(file, out var tocReferences) && tocReferences.Any(toc => toc.Docset != context.BuildScope.FallbackDocset));
+                    return !context.BuildScope.IsFallbackDocset(file.Docset) || (context.TocMap.TryGetTocReferences(file, out var tocReferences) && tocReferences.Any(toc => !context.BuildScope.IsFallbackDocset(toc.Docset)));
                 }
 
-                return file.Docset != context.BuildScope.FallbackDocset;
+                return !context.BuildScope.IsFallbackDocset(file.Docset);
             }
         }
 

--- a/src/docfx/build/context/BuildScope.cs
+++ b/src/docfx/build/context/BuildScope.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Docs.Build
         private readonly Func<string, bool> _glob;
         private readonly TemplateEngine _templateEngine;
         private readonly Docset _fallbackDocset;
+        private readonly Docset _docset;
 
         /// <summary>
         /// Gets all the files to build, including redirections and fallback files.
@@ -26,14 +27,11 @@ namespace Microsoft.Docs.Build
 
         public RedirectionMap Redirections { get; }
 
-        public Docset Docset { get; }
-
         public BuildScope(ErrorLog errorLog, Docset docset, Docset fallbackDocset, TemplateEngine templateEngine)
         {
             var config = docset.Config;
 
-            Docset = docset;
-
+            _docset = docset;
             _fallbackDocset = fallbackDocset;
             _glob = CreateGlob(config);
             _templateEngine = templateEngine;
@@ -58,8 +56,11 @@ namespace Microsoft.Docs.Build
             return _fileNames.TryGetValue(fileName, out actualFileName);
         }
 
+        public Docset GetDocset(Docset docset)
+            => docset == _fallbackDocset ? _docset : null;
+
         public Docset GetFallbackDocset(Docset docset)
-            => docset == Docset || IsFallbackDocset(docset) ? _fallbackDocset : null;
+            => docset == _docset || IsFallbackDocset(docset) ? _fallbackDocset : null;
 
         public bool IsFallbackDocset(Docset docset)
             => docset == _fallbackDocset;

--- a/src/docfx/build/context/BuildScope.cs
+++ b/src/docfx/build/context/BuildScope.cs
@@ -25,17 +25,24 @@ namespace Microsoft.Docs.Build
 
         public RedirectionMap Redirections { get; }
 
-        public BuildScope(ErrorLog errorLog, Docset docset, TemplateEngine templateEngine)
+        public Docset Docset { get; }
+
+        public Docset FallbackDocset { get; }
+
+        public BuildScope(ErrorLog errorLog, Docset docset, Docset fallbackDocset, TemplateEngine templateEngine)
         {
             var config = docset.Config;
+
+            Docset = docset;
+            FallbackDocset = fallbackDocset;
 
             _glob = CreateGlob(config);
             _templateEngine = templateEngine;
 
             var (fileNames, files) = GetFiles(docset, _glob);
 
-            var fallbackFiles = docset.FallbackDocset != null
-                ? GetFiles(docset.FallbackDocset, CreateGlob(docset.FallbackDocset.Config)).files
+            var fallbackFiles = fallbackDocset != null
+                ? GetFiles(fallbackDocset, CreateGlob(fallbackDocset.Config)).files
                 : Enumerable.Empty<Document>();
 
             _fileNames = fileNames;

--- a/src/docfx/build/context/BuildScope.cs
+++ b/src/docfx/build/context/BuildScope.cs
@@ -59,6 +59,12 @@ namespace Microsoft.Docs.Build
             return _fileNames.TryGetValue(fileName, out actualFileName);
         }
 
+        public Docset GetFallbackDocset(Docset docset)
+            => docset == Docset || IsFallbackDocset(docset) ? FallbackDocset : null;
+
+        public bool IsFallbackDocset(Docset docset)
+            => docset == FallbackDocset;
+
         private (HashSet<string> fileNames, IReadOnlyList<Document> files) GetFiles(Docset docset, Func<string, bool> glob)
         {
             using (Progress.Start("Globbing files"))

--- a/src/docfx/build/context/BuildScope.cs
+++ b/src/docfx/build/context/BuildScope.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Docs.Build
                 {
                     if (glob(file))
                     {
-                        files.Add(Document.CreateFromFile(docset, file, _templateEngine));
+                        files.Add(Document.Create(docset, file, _templateEngine, isFallback: docset == FallbackDocset));
                     }
                 });
 

--- a/src/docfx/build/context/BuildScope.cs
+++ b/src/docfx/build/context/BuildScope.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Docs.Build
         private readonly HashSet<string> _fileNames;
         private readonly Func<string, bool> _glob;
         private readonly TemplateEngine _templateEngine;
+        private readonly Docset _fallbackDocset;
 
         /// <summary>
         /// Gets all the files to build, including redirections and fallback files.
@@ -27,15 +28,13 @@ namespace Microsoft.Docs.Build
 
         public Docset Docset { get; }
 
-        public Docset FallbackDocset { get; }
-
         public BuildScope(ErrorLog errorLog, Docset docset, Docset fallbackDocset, TemplateEngine templateEngine)
         {
             var config = docset.Config;
 
             Docset = docset;
-            FallbackDocset = fallbackDocset;
 
+            _fallbackDocset = fallbackDocset;
             _glob = CreateGlob(config);
             _templateEngine = templateEngine;
 
@@ -60,10 +59,10 @@ namespace Microsoft.Docs.Build
         }
 
         public Docset GetFallbackDocset(Docset docset)
-            => docset == Docset || IsFallbackDocset(docset) ? FallbackDocset : null;
+            => docset == Docset || IsFallbackDocset(docset) ? _fallbackDocset : null;
 
         public bool IsFallbackDocset(Docset docset)
-            => docset == FallbackDocset;
+            => docset == _fallbackDocset;
 
         private (HashSet<string> fileNames, IReadOnlyList<Document> files) GetFiles(Docset docset, Func<string, bool> glob)
         {
@@ -80,7 +79,7 @@ namespace Microsoft.Docs.Build
                 {
                     if (glob(file))
                     {
-                        files.Add(Document.Create(docset, file, _templateEngine, isFallback: docset == FallbackDocset));
+                        files.Add(Document.Create(docset, file, _templateEngine, isFallback: docset == _fallbackDocset));
                     }
                 });
 

--- a/src/docfx/build/dependency/DependencyMapBuilder.cs
+++ b/src/docfx/build/dependency/DependencyMapBuilder.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Docs.Build
     {
         private readonly ConcurrentHashSet<DependencyItem> _dependencyItems = new ConcurrentHashSet<DependencyItem>();
 
-        public void AddDependencyItem(Document from, Document to, DependencyType type)
+        public void AddDependencyItem(Document from, Document to, DependencyType type, Docset fallbackDocset)
         {
             Debug.Assert(from != null);
 
@@ -24,7 +24,7 @@ namespace Microsoft.Docs.Build
                 return;
             }
 
-            if (from.Docset.IsFallback())
+            if (from.Docset == fallbackDocset)
             {
                 return;
             }

--- a/src/docfx/build/dependency/DependencyMapBuilder.cs
+++ b/src/docfx/build/dependency/DependencyMapBuilder.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Docs.Build
     {
         private readonly ConcurrentHashSet<DependencyItem> _dependencyItems = new ConcurrentHashSet<DependencyItem>();
 
-        public void AddDependencyItem(Document from, Document to, DependencyType type, BuildScope buildScope)
+        public void AddDependencyItem(Document from, Document to, DependencyType type)
         {
             Debug.Assert(from != null);
 
@@ -24,7 +24,7 @@ namespace Microsoft.Docs.Build
                 return;
             }
 
-            if (buildScope.IsFallbackDocset(from.Docset))
+            if (from.FilePath.Origin == FileOrigin.Fallback)
             {
                 return;
             }

--- a/src/docfx/build/dependency/DependencyMapBuilder.cs
+++ b/src/docfx/build/dependency/DependencyMapBuilder.cs
@@ -24,8 +24,7 @@ namespace Microsoft.Docs.Build
                 return;
             }
 
-            var isLocalizedBuild = from.Docset.IsLocalizedBuild() || to.Docset.IsLocalizedBuild();
-            if (isLocalizedBuild && !from.Docset.IsLocalized())
+            if (from.Docset.IsFallback())
             {
                 return;
             }

--- a/src/docfx/build/dependency/DependencyMapBuilder.cs
+++ b/src/docfx/build/dependency/DependencyMapBuilder.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Docs.Build
     {
         private readonly ConcurrentHashSet<DependencyItem> _dependencyItems = new ConcurrentHashSet<DependencyItem>();
 
-        public void AddDependencyItem(Document from, Document to, DependencyType type, Docset fallbackDocset)
+        public void AddDependencyItem(Document from, Document to, DependencyType type, BuildScope buildScope)
         {
             Debug.Assert(from != null);
 
@@ -24,7 +24,7 @@ namespace Microsoft.Docs.Build
                 return;
             }
 
-            if (from.Docset == fallbackDocset)
+            if (buildScope.IsFallbackDocset(from.Docset))
             {
                 return;
             }

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Docs.Build
                         return (null, redirectFile, query, fragment, LinkType.RelativePath, pathToDocset);
                     }
 
-                    var file = Document.CreateFromFile(_buildScope.Docset, pathToDocset, _templateEngine, _buildScope.FallbackDocset);
+                    var file = Document.CreateFromFile(GetDocset(declaringFile), pathToDocset, _templateEngine, GetFallbackDocset(declaringFile));
 
                     // for LandingPage should not be used, it is a hack to handle some specific logic for landing page based on the user input for now
                     // which needs to be removed once the user input is correct
@@ -266,7 +266,7 @@ namespace Microsoft.Docs.Build
                         {
                             // try to resolve with .md for landing page
                             pathToDocset = ResolveToDocsetRelativePath($"{path}.md", declaringFile);
-                            file = Document.CreateFromFile(_buildScope.Docset, pathToDocset, _templateEngine, _buildScope.FallbackDocset);
+                            file = Document.CreateFromFile(GetDocset(declaringFile), pathToDocset, _templateEngine, GetFallbackDocset(declaringFile));
                         }
 
                         // Do not report error for landing page
@@ -283,6 +283,26 @@ namespace Microsoft.Docs.Build
                 default:
                     return default;
             }
+        }
+
+        private Docset GetDocset(Document declaringFile)
+        {
+            if (declaringFile.Docset == _buildScope.FallbackDocset)
+            {
+                return _buildScope.Docset;
+            }
+
+            return declaringFile.Docset;
+        }
+
+        private Docset GetFallbackDocset(Document declaringFile)
+        {
+            if (declaringFile.Docset == _buildScope.Docset)
+            {
+                return _buildScope.FallbackDocset;
+            }
+
+            return null;
         }
 
         private string ResolveToDocsetRelativePath(string path, Document declaringFile)

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -353,13 +353,13 @@ namespace Microsoft.Docs.Build
 
         private static Docset GetFallbackDocset(Docset docset)
         {
-            if (docset.LocalizedDocset != null)
+            if (docset.IsLocalized())
             {
                 // source docset in loc build
                 return docset;
             }
 
-            if (docset.FallbackDocset != null)
+            if (docset.IsLocalized())
             {
                 // localized docset in loc build
                 return docset.FallbackDocset;

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Docs.Build
         {
             var (error, content, child) = TryResolveContent(declaringFile, path);
 
-            _dependencyMapBuilder.AddDependencyItem(declaringFile, child, dependencyType);
+            _dependencyMapBuilder.AddDependencyItem(declaringFile, child, dependencyType, _buildScope.FallbackDocset);
 
             return (error, content, child);
         }
@@ -78,7 +78,7 @@ namespace Microsoft.Docs.Build
             var isSelfBookmark = linkType == LinkType.SelfBookmark || relativeToFile == file;
             if (!isCrossReference && (isSelfBookmark || file != null))
             {
-                _dependencyMapBuilder.AddDependencyItem(declaringFile, file, UrlUtility.FragmentToDependencyType(fragment));
+                _dependencyMapBuilder.AddDependencyItem(declaringFile, file, UrlUtility.FragmentToDependencyType(fragment), _buildScope.FallbackDocset);
                 _bookmarkValidator.AddBookmarkReference(declaringFile, isSelfBookmark ? relativeToFile : file, fragment, isSelfBookmark, path);
             }
 
@@ -116,7 +116,7 @@ namespace Microsoft.Docs.Build
 
             if (xrefSpec?.DeclaringFile != null)
             {
-                _dependencyMapBuilder.AddDependencyItem(declaringFile, xrefSpec?.DeclaringFile, DependencyType.UidInclusion);
+                _dependencyMapBuilder.AddDependencyItem(declaringFile, xrefSpec?.DeclaringFile, DependencyType.UidInclusion, _buildScope.FallbackDocset);
             }
 
             if (!string.IsNullOrEmpty(resolvedHref))
@@ -145,7 +145,7 @@ namespace Microsoft.Docs.Build
 
             if (file is null)
             {
-                var (content, fileFromHistory) = TryResolveContentFromHistory(_gitCommitProvider, declaringFile.Docset, pathToDocset, _templateEngine);
+                var (content, fileFromHistory) = TryResolveContentFromHistory(_gitCommitProvider, pathToDocset, _templateEngine);
                 if (fileFromHistory != null)
                 {
                     return (null, content, fileFromHistory);
@@ -179,7 +179,7 @@ namespace Microsoft.Docs.Build
             // Cannot resolve the file, leave href as is
             if (file is null)
             {
-                file = TryResolveResourceFromHistory(_gitCommitProvider, declaringFile.Docset, pathToDocset, _templateEngine);
+                file = TryResolveResourceFromHistory(_gitCommitProvider, pathToDocset, _templateEngine);
                 if (file is null)
                 {
                     return (error, href, fragment, linkType, null, false);
@@ -301,7 +301,7 @@ namespace Microsoft.Docs.Build
             return docsetRelativePath;
         }
 
-        private Document TryResolveResourceFromHistory(GitCommitProvider gitCommitProvider, Docset docset, string pathToDocset, TemplateEngine templateEngine)
+        private Document TryResolveResourceFromHistory(GitCommitProvider gitCommitProvider, string pathToDocset, TemplateEngine templateEngine)
         {
             if (string.IsNullOrEmpty(pathToDocset))
             {
@@ -322,7 +322,7 @@ namespace Microsoft.Docs.Build
             return default;
         }
 
-        private (string content, Document file) TryResolveContentFromHistory(GitCommitProvider gitCommitProvider, Docset docset, string pathToDocset, TemplateEngine templateEngine)
+        private (string content, Document file) TryResolveContentFromHistory(GitCommitProvider gitCommitProvider, string pathToDocset, TemplateEngine templateEngine)
         {
             if (string.IsNullOrEmpty(pathToDocset))
             {

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Docs.Build
         {
             var (error, content, child) = TryResolveContent(declaringFile, path);
 
-            _dependencyMapBuilder.AddDependencyItem(declaringFile, child, dependencyType, _buildScope);
+            _dependencyMapBuilder.AddDependencyItem(declaringFile, child, dependencyType);
 
             return (error, content, child);
         }
@@ -78,7 +78,7 @@ namespace Microsoft.Docs.Build
             var isSelfBookmark = linkType == LinkType.SelfBookmark || relativeToFile == file;
             if (!isCrossReference && (isSelfBookmark || file != null))
             {
-                _dependencyMapBuilder.AddDependencyItem(declaringFile, file, UrlUtility.FragmentToDependencyType(fragment), _buildScope);
+                _dependencyMapBuilder.AddDependencyItem(declaringFile, file, UrlUtility.FragmentToDependencyType(fragment));
                 _bookmarkValidator.AddBookmarkReference(declaringFile, isSelfBookmark ? relativeToFile : file, fragment, isSelfBookmark, path);
             }
 
@@ -116,7 +116,7 @@ namespace Microsoft.Docs.Build
 
             if (xrefSpec?.DeclaringFile != null)
             {
-                _dependencyMapBuilder.AddDependencyItem(declaringFile, xrefSpec?.DeclaringFile, DependencyType.UidInclusion, _buildScope);
+                _dependencyMapBuilder.AddDependencyItem(declaringFile, xrefSpec?.DeclaringFile, DependencyType.UidInclusion);
             }
 
             if (!string.IsNullOrEmpty(resolvedHref))
@@ -315,7 +315,7 @@ namespace Microsoft.Docs.Build
                 var (repo, _, commits) = gitCommitProvider.GetCommitHistory(fallbackDocset, pathToDocset);
                 if (repo != null && commits.Count > 0)
                 {
-                    return Document.Create(fallbackDocset, pathToDocset, templateEngine, isFromHistory: true);
+                    return Document.Create(fallbackDocset, pathToDocset, templateEngine, FileOrigin.Fallback, isFromHistory: true);
                 }
             }
 
@@ -342,7 +342,7 @@ namespace Microsoft.Docs.Build
                         // the latest commit would be deleting it from repo
                         if (GitUtility.TryGetContentFromHistory(repoPath, pathToRepo, commits[1].Sha, out var content))
                         {
-                            return (content, Document.Create(fallbackDocset, pathToDocset, templateEngine, isFromHistory: true));
+                            return (content, Document.Create(fallbackDocset, pathToDocset, templateEngine, FileOrigin.Fallback, isFromHistory: true));
                         }
                     }
                 }

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -353,7 +353,7 @@ namespace Microsoft.Docs.Build
 
         private static Docset GetFallbackDocset(Docset docset)
         {
-            if (docset.LocalizationDocset != null)
+            if (docset.LocalizedDocset != null)
             {
                 // source docset in loc build
                 return docset;

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Docs.Build
                 ? new CommitBuildTimeProvider(docset.Repository) : null;
         }
 
-        public async Task<(List<Error> errors, ContributionInfo contributionInfo)> GetContributionInfo(Document document, SourceInfo<string> authorName)
+        public async Task<(List<Error> errors, ContributionInfo contributionInfo)> GetContributionInfo(Context context, Document document, SourceInfo<string> authorName)
         {
             Debug.Assert(document != null);
             var (repo, pathToRepo, commits) = _gitCommitProvider.GetCommitHistory(document);
@@ -130,7 +130,7 @@ namespace Microsoft.Docs.Build
             List<GitCommit> GetContributionCommits()
             {
                 var result = commits;
-                var bilingual = document.Docset.IsLocalized() && document.Docset.Config.Localization.Bilingual;
+                var bilingual = document.Docset == context.BuildScope.Docset && context.BuildScope.FallbackDocset != null && document.Docset.Config.Localization.Bilingual;
                 var contributionBranch = bilingual && LocalizationUtility.TryGetContributionBranch(repo.Branch, out var cBranch) ? cBranch : null;
                 if (!string.IsNullOrEmpty(contributionBranch))
                 {
@@ -153,7 +153,7 @@ namespace Microsoft.Docs.Build
         }
 
         public (string contentGitUrl, string originalContentGitUrl, string originalContentGitUrlTemplate, string gitCommit)
-            GetGitUrls(Document document)
+            GetGitUrls(Context context, Document document)
         {
             Debug.Assert(document != null);
 
@@ -189,7 +189,7 @@ namespace Microsoft.Docs.Build
                     (branchUrlTemplate, _) = GetContentGitUrlTemplate(contributionRemote, pathToRepo);
 
                     (editRemote, editBranch) = (contributionRemote, hasRefSpec ? contributionBranch : editBranch);
-                    if (document.Docset.IsLocalized())
+                    if (document.Docset == context.BuildScope.Docset && context.BuildScope.FallbackDocset != null)
                     {
                         (editRemote, editBranch) = LocalizationUtility.GetLocalizedRepo(
                                                     document.Docset.Config.Localization.Mapping,

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Docs.Build
             List<GitCommit> GetContributionCommits()
             {
                 var result = commits;
-                var bilingual = document.Docset == context.BuildScope.Docset && context.BuildScope.FallbackDocset != null && document.Docset.Config.Localization.Bilingual;
+                var bilingual = context.BuildScope.GetFallbackDocset(document.Docset) != null && document.Docset.Config.Localization.Bilingual;
                 var contributionBranch = bilingual && LocalizationUtility.TryGetContributionBranch(repo.Branch, out var cBranch) ? cBranch : null;
                 if (!string.IsNullOrEmpty(contributionBranch))
                 {
@@ -189,7 +189,7 @@ namespace Microsoft.Docs.Build
                     (branchUrlTemplate, _) = GetContentGitUrlTemplate(contributionRemote, pathToRepo);
 
                     (editRemote, editBranch) = (contributionRemote, hasRefSpec ? contributionBranch : editBranch);
-                    if (document.Docset == context.BuildScope.Docset && context.BuildScope.FallbackDocset != null)
+                    if (context.BuildScope.GetFallbackDocset(document.Docset) != null)
                     {
                         (editRemote, editBranch) = LocalizationUtility.GetLocalizedRepo(
                                                     document.Docset.Config.Localization.Mapping,

--- a/src/docfx/build/metadata/MetadataProvider.cs
+++ b/src/docfx/build/metadata/MetadataProvider.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Docs.Build
 
         public IReadOnlyDictionary<string, string> HtmlMetaNames { get; }
 
-        public MetadataProvider(Docset docset, Cache cache, MicrosoftGraphCache microsoftGraphCache)
+        public MetadataProvider(Docset docset, Cache cache, MicrosoftGraphCache microsoftGraphCache, RestoreFileMap restoreFileMap)
         {
             _cache = cache;
             _globalMetadata = docset.Config.GlobalMetadata;
@@ -35,7 +35,7 @@ namespace Microsoft.Docs.Build
             MetadataSchemas = Array.ConvertAll(
                 docset.Config.MetadataSchema,
                 schema => JsonUtility.Deserialize<JsonSchema>(
-                    docset.RestoreFileMap.GetRestoredFileContent(schema), schema.Source.File));
+                    restoreFileMap.GetRestoredFileContent(schema), schema.Source.File));
 
             _schemaValidators = Array.ConvertAll(
                 MetadataSchemas,

--- a/src/docfx/build/moniker/MonikerProvider.cs
+++ b/src/docfx/build/moniker/MonikerProvider.cs
@@ -18,14 +18,14 @@ namespace Microsoft.Docs.Build
 
         public MonikerComparer Comparer { get; }
 
-        public MonikerProvider(Docset docset, MetadataProvider metadataProvider)
+        public MonikerProvider(Docset docset, MetadataProvider metadataProvider, RestoreFileMap restoreFileMap)
         {
             _metadataProvider = metadataProvider;
 
             var monikerDefinition = new MonikerDefinitionModel();
             if (!string.IsNullOrEmpty(docset.Config.MonikerDefinition))
             {
-                var content = docset.RestoreFileMap.GetRestoredFileContent(docset.Config.MonikerDefinition);
+                var content = restoreFileMap.GetRestoredFileContent(docset.Config.MonikerDefinition);
                 monikerDefinition = JsonUtility.Deserialize<MonikerDefinitionModel>(content, new FilePath(docset.Config.MonikerDefinition));
             }
             var monikersEvaluator = new EvaluatorWithMonikersVisitor(monikerDefinition);

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -142,10 +142,10 @@ namespace Microsoft.Docs.Build
             outputMetadata.Monikers = monikers;
 
             (outputMetadata.DocumentId, outputMetadata.DocumentVersionIndependentId) = context.BuildScope.Redirections.TryGetDocumentId(file, out var docId) ? docId : file.Id;
-            (outputMetadata.ContentGitUrl, outputMetadata.OriginalContentGitUrl, outputMetadata.OriginalContentGitUrlTemplate, outputMetadata.Gitcommit) = context.ContributionProvider.GetGitUrls(file);
+            (outputMetadata.ContentGitUrl, outputMetadata.OriginalContentGitUrl, outputMetadata.OriginalContentGitUrlTemplate, outputMetadata.Gitcommit) = context.ContributionProvider.GetGitUrls(context, file);
 
             List<Error> contributorErrors;
-            (contributorErrors, outputMetadata.ContributionInfo) = await context.ContributionProvider.GetContributionInfo(file, inputMetadata.Author);
+            (contributorErrors, outputMetadata.ContributionInfo) = await context.ContributionProvider.GetContributionInfo(context, file, inputMetadata.Author);
             outputMetadata.Author = outputMetadata.ContributionInfo?.Author?.Name;
             outputMetadata.UpdatedAt = outputMetadata.ContributionInfo?.UpdatedAtDateTime.ToString("yyyy-MM-dd hh:mm tt");
 

--- a/src/docfx/build/redirection/RedirectionMap.cs
+++ b/src/docfx/build/redirection/RedirectionMap.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Docs.Build
                         }
                     }
 
-                    Document redirect = Document.Create(docset, pathToDocset, templateEngine, mutableRedirectUrl, combineRedirectUrl: combineRedirectUrl);
+                    var redirect = Document.Create(docset, pathToDocset, templateEngine, redirectionUrl: mutableRedirectUrl, combineRedirectUrl: combineRedirectUrl);
                     if (redirectDocumentId && !redirectUrls.Add(redirect.RedirectionUrl))
                     {
                         errorLog.Write(Errors.RedirectionUrlConflict(redirectUrl));

--- a/src/docfx/build/toc/parser/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsParser.cs
@@ -275,7 +275,7 @@ namespace Microsoft.Docs.Build
                     if (tocHrefType == TocHrefType.RelativeFolder)
                     {
                         var nestedTocFirstItem = GetFirstItem(nestedToc.Items);
-                        context.DependencyMapBuilder.AddDependencyItem(filePath, nestedTocFirstItem?.Document, DependencyType.Link, context.BuildScope);
+                        context.DependencyMapBuilder.AddDependencyItem(filePath, nestedTocFirstItem?.Document, DependencyType.Link);
                         return (default, default, nestedTocFirstItem);
                     }
 

--- a/src/docfx/build/toc/parser/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsParser.cs
@@ -275,7 +275,7 @@ namespace Microsoft.Docs.Build
                     if (tocHrefType == TocHrefType.RelativeFolder)
                     {
                         var nestedTocFirstItem = GetFirstItem(nestedToc.Items);
-                        context.DependencyMapBuilder.AddDependencyItem(filePath, nestedTocFirstItem?.Document, DependencyType.Link, context.BuildScope.FallbackDocset);
+                        context.DependencyMapBuilder.AddDependencyItem(filePath, nestedTocFirstItem?.Document, DependencyType.Link, context.BuildScope);
                         return (default, default, nestedTocFirstItem);
                     }
 

--- a/src/docfx/build/toc/parser/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsParser.cs
@@ -275,7 +275,7 @@ namespace Microsoft.Docs.Build
                     if (tocHrefType == TocHrefType.RelativeFolder)
                     {
                         var nestedTocFirstItem = GetFirstItem(nestedToc.Items);
-                        context.DependencyMapBuilder.AddDependencyItem(filePath, nestedTocFirstItem?.Document, DependencyType.Link);
+                        context.DependencyMapBuilder.AddDependencyItem(filePath, nestedTocFirstItem?.Document, DependencyType.Link, context.BuildScope.FallbackDocset);
                         return (default, default, nestedTocFirstItem);
                     }
 

--- a/src/docfx/build/xref/ExternalXrefMapLoader.cs
+++ b/src/docfx/build/xref/ExternalXrefMapLoader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -13,7 +13,7 @@ namespace Microsoft.Docs.Build
     {
         private static byte[] s_uidBytes = Encoding.UTF8.GetBytes("uid");
 
-        public static IReadOnlyDictionary<string, Lazy<ExternalXrefSpec>> Load(Docset docset)
+        public static IReadOnlyDictionary<string, Lazy<ExternalXrefSpec>> Load(Docset docset, RestoreFileMap restoreFileMap)
         {
             var result = new Dictionary<string, Lazy<ExternalXrefSpec>>();
 
@@ -21,7 +21,7 @@ namespace Microsoft.Docs.Build
             {
                 if (url.Value.EndsWith(".yml", StringComparison.OrdinalIgnoreCase))
                 {
-                    var content = docset.RestoreFileMap.GetRestoredFileContent(url);
+                    var content = restoreFileMap.GetRestoredFileContent(url);
                     var xrefMap = YamlUtility.Deserialize<XrefMapModel>(content, new FilePath(url));
                     foreach (var spec in xrefMap.References)
                     {
@@ -30,7 +30,7 @@ namespace Microsoft.Docs.Build
                 }
                 else
                 {
-                    var filePath = docset.RestoreFileMap.GetRestoredFilePath(url);
+                    var filePath = restoreFileMap.GetRestoredFilePath(url);
                     foreach (var (uid, spec) in Load(filePath))
                     {
                         // for same uid with multiple specs, we should respect the order of the list

--- a/src/docfx/build/xref/XrefMap.cs
+++ b/src/docfx/build/xref/XrefMap.cs
@@ -17,10 +17,10 @@ namespace Microsoft.Docs.Build
 
         private static ThreadLocal<Stack<(string uid, string propertyName, Document parent)>> t_recursionDetector = new ThreadLocal<Stack<(string, string, Document)>>(() => new Stack<(string, string, Document)>());
 
-        public XrefMap(Context context, Docset docset)
+        public XrefMap(Context context, Docset docset, RestoreFileMap restoreFileMap)
         {
             _internalXrefMap = InternalXrefMapBuilder.Build(context);
-            _externalXrefMap = ExternalXrefMapLoader.Load(docset, context.RestoreFileMap);
+            _externalXrefMap = ExternalXrefMapLoader.Load(docset, restoreFileMap);
         }
 
         public (Error error, string href, string display, IXrefSpec xrefSpec) Resolve(string uid, SourceInfo<string> href, string displayPropertyName, Document relativeTo)

--- a/src/docfx/build/xref/XrefMap.cs
+++ b/src/docfx/build/xref/XrefMap.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Docs.Build
         public XrefMap(Context context, Docset docset)
         {
             _internalXrefMap = InternalXrefMapBuilder.Build(context);
-            _externalXrefMap = ExternalXrefMapLoader.Load(docset);
+            _externalXrefMap = ExternalXrefMapLoader.Load(docset, context.RestoreFileMap);
         }
 
         public (Error error, string href, string display, IXrefSpec xrefSpec) Resolve(string uid, SourceInfo<string> href, string displayPropertyName, Document relativeTo)

--- a/src/docfx/docset/Docset.cs
+++ b/src/docfx/docset/Docset.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Gets the localization docset, it will be set when the current build locale is different with default locale
         /// </summary>
-        public Docset LocalizationDocset { get; private set; }
+        public Docset LocalizedDocset { get; private set; }
 
         /// <summary>
         /// Gets the fallback docset, usually is English docset. It will be set when the current docset is localization docset.
@@ -130,7 +130,7 @@ namespace Microsoft.Docs.Build
                 else if (LocalizationUtility.TryGetLocalizedDocsetPath(this, restoreGitMap, Config, Locale, out var localizationDocsetPath, out var localizationBranch))
                 {
                     var repo = Repository.Create(localizationDocsetPath, localizationBranch);
-                    LocalizationDocset = new Docset(_errorLog, localizationDocsetPath, Locale, Config, _options, RestoreGitMap, repo, fallbackDocset: this);
+                    LocalizedDocset = new Docset(_errorLog, localizationDocsetPath, Locale, Config, _options, RestoreGitMap, repo, fallbackDocset: this);
                 }
             }
         }
@@ -155,7 +155,7 @@ namespace Microsoft.Docs.Build
             Locale = locale.ToLowerInvariant();
             Routes = NormalizeRoutes(config.Routes);
             Culture = CreateCultureInfo(locale);
-            LocalizationDocset = localizedDocset;
+            LocalizedDocset = localizedDocset;
             FallbackDocset = fallbackDocset;
             (HostName, SiteBasePath) = SplitBaseUrl(config.BaseUrl);
 

--- a/src/docfx/docset/Docset.cs
+++ b/src/docfx/docset/Docset.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Docs.Build
             DocsetPath = PathUtility.NormalizeFolder(Path.GetFullPath(docsetPath));
             Locale = !string.IsNullOrEmpty(locale) ? locale.ToLowerInvariant() : config.Localization.DefaultLocale;
             Routes = NormalizeRoutes(config.Routes);
-            Culture = CreateCultureInfo(locale);
+            Culture = CreateCultureInfo(Locale);
             (HostName, SiteBasePath) = SplitBaseUrl(config.BaseUrl);
 
             Repository = repository ?? Repository.Create(DocsetPath, branch: null);

--- a/src/docfx/docset/Docset.cs
+++ b/src/docfx/docset/Docset.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -105,26 +105,32 @@ namespace Microsoft.Docs.Build
             CommandLineOptions options,
             RestoreGitMap restoreGitMap,
             Repository repository = null,
-            Repository fallbackRepo = default,
-            Docset localizedDocset = null,
-            Docset fallbackDocset = null,
-            bool isDependency = false)
-            : this(errorLog, docsetPath, !string.IsNullOrEmpty(locale) ? locale : config.Localization.DefaultLocale, config, options, restoreGitMap, repository, fallbackDocset, localizedDocset)
+            Repository fallbackRepo = default)
+            : this(
+                  errorLog,
+                  docsetPath,
+                  !string.IsNullOrEmpty(locale) ? locale : config.Localization.DefaultLocale,
+                  config,
+                  options,
+                  restoreGitMap,
+                  repository,
+                  fallbackDocset: null,
+                  localizedDocset: null)
         {
             Debug.Assert(restoreGitMap != null);
 
-            if (!isDependency && !string.Equals(Locale, Config.Localization.DefaultLocale, StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(Locale, Config.Localization.DefaultLocale, StringComparison.OrdinalIgnoreCase))
             {
                 // localization/fallback docset will share the same context, config, build locale and options with source docset
                 // source docset configuration will be overwritten by build locale overwrite configuration
                 if (fallbackRepo != default)
                 {
-                    FallbackDocset = new Docset(_errorLog, fallbackRepo.Path, Locale, Config, _options, RestoreGitMap, fallbackRepo, localizedDocset: this, isDependency: true);
+                    FallbackDocset = new Docset(_errorLog, fallbackRepo.Path, Locale, Config, _options, RestoreGitMap, fallbackRepo, localizedDocset: this);
                 }
                 else if (LocalizationUtility.TryGetLocalizedDocsetPath(this, restoreGitMap, Config, Locale, out var localizationDocsetPath, out var localizationBranch))
                 {
                     var repo = Repository.Create(localizationDocsetPath, localizationBranch);
-                    LocalizationDocset = new Docset(_errorLog, localizationDocsetPath, Locale, Config, _options, RestoreGitMap, repo, fallbackDocset: this, isDependency: true);
+                    LocalizationDocset = new Docset(_errorLog, localizationDocsetPath, Locale, Config, _options, RestoreGitMap, repo, fallbackDocset: this);
                 }
             }
         }
@@ -230,7 +236,7 @@ namespace Microsoft.Docs.Build
                 var (loadErrors, subConfig) = ConfigLoader.TryLoad(dir, options, locale);
                 errors.AddRange(loadErrors);
 
-                result.TryAdd(PathUtility.NormalizeFolder(name), new Docset(errorLog, dir, locale, subConfig, options, subRestoreMap, isDependency: true));
+                result.TryAdd(PathUtility.NormalizeFolder(name), new Docset(errorLog, dir, locale, subConfig, options, subRestoreMap, fallbackDocset: null));
             }
             return (errors, result);
         }

--- a/src/docfx/docset/Docset.cs
+++ b/src/docfx/docset/Docset.cs
@@ -51,11 +51,6 @@ namespace Microsoft.Docs.Build
         public Repository Repository { get; }
 
         /// <summary>
-        /// Gets the dependency repos/files locked version
-        /// </summary>
-        public DependencyLockModel DependencyLock { get; }
-
-        /// <summary>
         /// Gets the site base path
         /// </summary>
         public string SiteBasePath { get; }
@@ -153,14 +148,14 @@ namespace Microsoft.Docs.Build
         }
 
         private static (List<Error>, Dictionary<string, Docset>) LoadDependencies(
-            ErrorLog errorLog, string docsetPath, Config config, string locale, RestoreGitMap restoreMap, CommandLineOptions options)
+            ErrorLog errorLog, string docsetPath, Config config, string locale, RestoreGitMap restoreGitMap, CommandLineOptions options)
         {
             var errors = new List<Error>();
             var result = new Dictionary<string, Docset>(config.Dependencies.Count, PathUtility.PathComparer);
             foreach (var (name, url) in config.Dependencies)
             {
                 var (remote, branch, _) = UrlUtility.SplitGitUrl(url);
-                var (dir, subRestoreMap) = restoreMap.GetGitRestorePath(remote, branch, docsetPath);
+                var (dir, subRestoreMap) = restoreGitMap.GetGitRestorePath(remote, branch, docsetPath);
 
                 // get dependent docset config or default config
                 // todo: what parent config should be pass on its children

--- a/src/docfx/docset/Document.cs
+++ b/src/docfx/docset/Document.cs
@@ -494,9 +494,9 @@ namespace Microsoft.Docs.Build
         private static bool TryResolveDocset(Docset docset, string file, out Docset resolvedDocset)
         {
             // resolve from localization docset
-            if (docset.LocalizationDocset != null && File.Exists(Path.Combine(docset.LocalizationDocset.DocsetPath, file)))
+            if (docset.LocalizedDocset != null && File.Exists(Path.Combine(docset.LocalizedDocset.DocsetPath, file)))
             {
-                resolvedDocset = docset.LocalizationDocset;
+                resolvedDocset = docset.LocalizedDocset;
                 return true;
             }
 

--- a/src/docfx/docset/Document.cs
+++ b/src/docfx/docset/Document.cs
@@ -248,7 +248,7 @@ namespace Microsoft.Docs.Build
             var filePath = PathUtility.NormalizeFile(path);
             var isConfigReference = docset.Config.Extend.Concat(docset.Config.GetFileReferences()).Contains(filePath, PathUtility.PathComparer);
             var type = isConfigReference ? ContentType.Unknown : GetContentType(filePath);
-            var mime = type == ContentType.Page ? ReadMimeFromFile(docset, filePath, Path.Combine(docset.DocsetPath, filePath), isFallback) : default;
+            var mime = type == ContentType.Page ? ReadMimeFromFile(filePath, Path.Combine(docset.DocsetPath, filePath), isFallback) : default;
             var isPage = templateEngine.IsPage(mime);
             var isExperimental = Path.GetFileNameWithoutExtension(filePath).EndsWith(".experimental", PathUtility.PathComparison);
             var routedFilePath = ApplyRoutes(filePath, docset.Routes, docset.SiteBasePath);
@@ -511,7 +511,7 @@ namespace Microsoft.Docs.Build
             return false;
         }
 
-        private static SourceInfo<string> ReadMimeFromFile(Docset docset, string pathToDocset, string filePath, bool isFallback)
+        private static SourceInfo<string> ReadMimeFromFile(string pathToDocset, string filePath, bool isFallback)
         {
             SourceInfo<string> mime = default;
 

--- a/src/docfx/docset/Document.cs
+++ b/src/docfx/docset/Document.cs
@@ -279,7 +279,7 @@ namespace Microsoft.Docs.Build
         /// <param name="docset">The current docset</param>
         /// <param name="pathToDocset">The path relative to docset root</param>
         /// <returns>A new document, or null if not found</returns>
-        public static Document CreateFromFile(Docset docset, string pathToDocset, TemplateEngine templateEngine, Docset fallbackDocset = null)
+        public static Document CreateFromFile(Docset docset, string pathToDocset, TemplateEngine templateEngine, Docset fallbackDocset)
         {
             Debug.Assert(docset != null);
             Debug.Assert(!string.IsNullOrEmpty(pathToDocset));
@@ -289,7 +289,7 @@ namespace Microsoft.Docs.Build
 
             if (TryResolveDocset(docset, fallbackDocset, pathToDocset, out var resolvedDocset))
             {
-                return Create(resolvedDocset, pathToDocset, templateEngine);
+                return Create(resolvedDocset, pathToDocset, templateEngine, isFallback: resolvedDocset == fallbackDocset);
             }
 
             // resolve from dependent docsets
@@ -303,7 +303,7 @@ namespace Microsoft.Docs.Build
                     continue;
                 }
 
-                var dependencyFile = CreateFromFile(dependentDocset, pathToDocset.Substring(dependencyName.Length), templateEngine);
+                var dependencyFile = CreateFromFile(dependentDocset, pathToDocset.Substring(dependencyName.Length), templateEngine, fallbackDocset: null);
                 if (dependencyFile != null)
                 {
                     return dependencyFile;

--- a/src/docfx/docset/Document.cs
+++ b/src/docfx/docset/Document.cs
@@ -493,7 +493,7 @@ namespace Microsoft.Docs.Build
 
         private static bool TryResolveDocset(Docset docset, BuildScope buildScope, string file, out Docset resolvedDocset)
         {
-            docset = buildScope?.IsFallbackDocset(docset) ?? false ? buildScope?.Docset : docset;
+            docset = buildScope?.GetDocset(docset) ?? docset;
             var fallbackDocset = buildScope?.GetFallbackDocset(docset);
 
             // resolve from current docset

--- a/src/docfx/localization/LocalizationUtility.cs
+++ b/src/docfx/localization/LocalizationUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -154,11 +154,9 @@ namespace Microsoft.Docs.Build
             return false;
         }
 
-        public static bool IsFallback(this Docset docset) => docset.LocalizationDocset != null;
+        public static bool IsFallback(this Docset docset) => docset.LocalizedDocset != null;
 
         public static bool IsLocalized(this Docset docset) => docset.FallbackDocset != null;
-
-        public static bool IsLocalizedBuild(this Docset docset) => docset.FallbackDocset != null || docset.LocalizationDocset != null;
 
         public static (string remote, string branch) GetLocalizedTheme(string theme, string locale, string defaultLocale)
         {

--- a/src/docfx/localization/LocalizationUtility.cs
+++ b/src/docfx/localization/LocalizationUtility.cs
@@ -154,10 +154,6 @@ namespace Microsoft.Docs.Build
             return false;
         }
 
-        public static bool IsFallback(this Docset docset) => docset.LocalizedDocset != null;
-
-        public static bool IsLocalized(this Docset docset) => docset.FallbackDocset != null;
-
         public static (string remote, string branch) GetLocalizedTheme(string theme, string locale, string defaultLocale)
         {
             Debug.Assert(!string.IsNullOrEmpty(theme));

--- a/src/docfx/restore/RestoreFileMap.cs
+++ b/src/docfx/restore/RestoreFileMap.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;

--- a/src/docfx/restore/RestoreFileMap.cs
+++ b/src/docfx/restore/RestoreFileMap.cs
@@ -8,17 +8,19 @@ namespace Microsoft.Docs.Build
 {
     internal class RestoreFileMap
     {
-        private readonly Docset _docset;
+        private readonly string _docsetPath;
+        private readonly string _fallbackDocsetPath;
 
-        public RestoreFileMap(Docset docset)
+        public RestoreFileMap(string docsetPath, string fallbackDocsetPath = null)
         {
-            Debug.Assert(docset != null);
-            _docset = docset;
+            Debug.Assert(docsetPath != null);
+            _docsetPath = docsetPath;
+            _fallbackDocsetPath = fallbackDocsetPath;
         }
 
         public string GetRestoredFileContent(SourceInfo<string> url)
         {
-            return GetRestoredFileContent(_docset.DocsetPath, url, _docset.FallbackDocset?.DocsetPath);
+            return GetRestoredFileContent(_docsetPath, url, _fallbackDocsetPath);
         }
 
         public string GetRestoredFilePath(SourceInfo<string> url)
@@ -27,15 +29,15 @@ namespace Microsoft.Docs.Build
             if (!fromUrl)
             {
                 // directly return the relative path
-                var fullPath = Path.Combine(_docset.DocsetPath, url);
+                var fullPath = Path.Combine(_docsetPath, url);
                 if (File.Exists(fullPath))
                 {
                     return fullPath;
                 }
 
-                if (!string.IsNullOrEmpty(_docset.FallbackDocset?.DocsetPath))
+                if (!string.IsNullOrEmpty(_fallbackDocsetPath))
                 {
-                    fullPath = Path.Combine(_docset.FallbackDocset?.DocsetPath, url);
+                    fullPath = Path.Combine(_fallbackDocsetPath, url);
                     if (File.Exists(fullPath))
                     {
                         return fullPath;

--- a/src/docfx/template/TemplateEngine.cs
+++ b/src/docfx/template/TemplateEngine.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -131,7 +131,7 @@ namespace Microsoft.Docs.Build
             return _global[key]?.ToString();
         }
 
-        public static TemplateEngine Create(Docset docset)
+        public static TemplateEngine Create(Docset docset, RestoreGitMap restoreGitMap)
         {
             Debug.Assert(docset != null);
 
@@ -141,7 +141,7 @@ namespace Microsoft.Docs.Build
             }
 
             var (themeRemote, themeBranch) = LocalizationUtility.GetLocalizedTheme(docset.Config.Template, docset.Locale, docset.Config.Localization.DefaultLocale);
-            var (themePath, themeRestoreMap) = docset.RestoreGitMap.GetGitRestorePath(themeRemote, themeBranch, docset.DocsetPath);
+            var (themePath, themeRestoreMap) = restoreGitMap.GetGitRestorePath(themeRemote, themeBranch, docset.DocsetPath);
             Log.Write($"Using theme '{themeRemote}#{themeRestoreMap.DependencyLock?.Commit}' at '{themePath}'");
 
             return new TemplateEngine(themePath);

--- a/test/docfx.Test/build/TocTest.cs
+++ b/test/docfx.Test/build/TocTest.cs
@@ -10,13 +10,15 @@ namespace Microsoft.Docs.Build
 {
     public static class TocTest
     {
+        private static readonly RestoreGitMap s_restoreGitMap = new RestoreGitMap();
+
         private static readonly Docset s_docset = new Docset(
             new ErrorLog(),
             Directory.GetCurrentDirectory(),
             "en-us",
             JsonUtility.Deserialize<Config>("{'output': { 'json': true } }".Replace('\'', '\"'), null),
             new CommandLineOptions(),
-            new RestoreGitMap());
+            s_restoreGitMap);
 
         [Theory]
         // same level
@@ -52,7 +54,7 @@ namespace Microsoft.Docs.Build
         public static void FindTocRelativePath(string[] tocFiles, string file, string expectedTocPath, string expectedOrphanTocPath)
         {
             var builder = new TableOfContentsMapBuilder();
-            var templateEngine = TemplateEngine.Create(s_docset);
+            var templateEngine = TemplateEngine.Create(s_docset, s_restoreGitMap);
             var document = Document.Create(s_docset, file, templateEngine);
 
             // test multiple reference case


### PR DESCRIPTION
currently fallback/localized docset and fallback/localized repository repository is not really clear. sometime we are using repository, sometimes we are using docset.

And also the fallback/localized docset make the code hard to read and maintain, restore file map and restore git map are used anywhere.

this pr is try to use 
1. localized/fallback docset as much as possible
2. reduce the complexity of current docset and fallback/localized docset.
3. hide fallback docset in the pipeline
4. hide restore file map and restore git map, use it in the init of context

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4946)