### PR TITLE
🐛 merge transformed metadata after transforming model

### DIFF
--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -12,8 +12,6 @@ namespace Microsoft.Docs.Build
 {
     internal static class BuildPage
     {
-        private static IEnumerable<Error> metadataTransformedError;
-
         public static async Task<List<Error>> Build(Context context, Document file)
         {
             Debug.Assert(file.ContentType == ContentType.Page);


### PR DESCRIPTION
fix: https://dev.azure.com/ceapex/Engineering/_workitems/edit/110547

The root cause is that we change the input model in 'BuildPage', which the input model is also shared to XrefBuilder.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4960)