### PR TITLE
moniker-config-missing shouldn't report on the toc file which have reference the file contains this error

### DIFF
--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -320,6 +320,9 @@ inputs:
     monikerRange: '> netcore-1.0'
     ---
     Moniker: netcore-1.1
+  docs/v1/toc.yml: |
+    - name: A
+      href: a.md
   monikerDefinition.json: |
     {
       "monikers": [
@@ -331,6 +334,7 @@ inputs:
     }
 outputs:
   docs/v1/a.json:
+  docs/v1/toc.json:
   .errors.log: |
     ["warning","moniker-config-missing","Moniker range missing in docfx.yml/docfx.json, user should not define it in file metadata or moniker zone.","docs/v1/a.md"]
 ---

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -320,7 +320,7 @@ inputs:
     monikerRange: '> netcore-1.0'
     ---
     Moniker: netcore-1.1
-  docs/v1/toc.yml: |
+  docs/v1/TOC.yml: |
     - name: A
       href: a.md
   monikerDefinition.json: |

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -577,8 +577,8 @@ namespace Microsoft.Docs.Build
         /// which used monikerRange in its yaml header or used moniker-zone syntax.
         /// </summary>
         /// Behavior: ✔️ Message: ❌
-        public static Error MonikerConfigMissing()
-            => new Error(ErrorLevel.Warning, "moniker-config-missing", "Moniker range missing in docfx.yml/docfx.json, user should not define it in file metadata or moniker zone.");
+        public static Error MonikerConfigMissing(Document file)
+            => new Error(ErrorLevel.Warning, "moniker-config-missing", "Moniker range missing in docfx.yml/docfx.json, user should not define it in file metadata or moniker zone.", file.FilePath);
 
         /// <summary>
         /// Config's monikerRange and monikerRange defined in yaml header has no intersection,

--- a/src/docfx/build/moniker/MonikerProvider.cs
+++ b/src/docfx/build/moniker/MonikerProvider.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Docs.Build
             // User should not define it in moniker zone
             if (fileLevelMonikers.Count == 0)
             {
-                return (Errors.MonikerConfigMissing(), new List<string>());
+                return (Errors.MonikerConfigMissing(file), new List<string>());
             }
 
             var zoneLevelMonikers = _rangeParser.Parse(rangeString);
@@ -91,7 +91,7 @@ namespace Microsoft.Docs.Build
                 // user should not define it in file metadata
                 if (configMonikers.Count == 0)
                 {
-                    return (Errors.MonikerConfigMissing(), configMonikers);
+                    return (Errors.MonikerConfigMissing(file), configMonikers);
                 }
 
                 var fileMonikers = _rangeParser.Parse(metadata.MonikerRange);


### PR DESCRIPTION
https://ceapex.visualstudio.com/Engineering/_workitems/edit/111494

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4968)