### PR TITLE
update obsolete

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/DocumentBuildContext.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/DocumentBuildContext.cs
@@ -126,10 +126,8 @@ namespace Microsoft.DocAsCode.Build.Engine
 
         public string BuildOutputFolder { get; }
 
-        [Obsolete("use GroupInfo")]
         public string VersionName { get; }
 
-        [Obsolete("use GroupInfo")]
         public string VersionFolder { get; }
 
         public GroupInfo GroupInfo { get; }

--- a/src/Microsoft.DocAsCode.Common/Git/GitUtility.cs
+++ b/src/Microsoft.DocAsCode.Common/Git/GitUtility.cs
@@ -70,6 +70,7 @@ namespace Microsoft.DocAsCode.Common.Git
             return null;
         }
 
+        [Obsolete("Docfx parses repoUrl in template preprocessor. This method is never used.")]
         public static GitRepoInfo Parse(string repoUrl)
         {
             if (string.IsNullOrEmpty(repoUrl))

--- a/src/Microsoft.DocAsCode.Plugins/IDocumentBuildContext.cs
+++ b/src/Microsoft.DocAsCode.Plugins/IDocumentBuildContext.cs
@@ -79,13 +79,11 @@ namespace Microsoft.DocAsCode.Plugins
         /// <summary>
         /// Current context's version name
         /// </summary>
-        [Obsolete("use GroupInfo")]
         string VersionName { get; }
 
         /// <summary>
         /// Current context's version root output path from ~ ROOT
         /// </summary>
-        [Obsolete("use GroupInfo")]
         string VersionFolder { get; }
 
         /// <summary>

--- a/src/Microsoft.DocAsCode.Plugins/IHostService.cs
+++ b/src/Microsoft.DocAsCode.Plugins/IHostService.cs
@@ -15,13 +15,11 @@ namespace Microsoft.DocAsCode.Plugins
         /// <summary>
         /// current version's name, String.Empty for default version
         /// </summary>
-        [Obsolete("use GroupInfo")]
         string VersionName { get; }
 
         /// <summary>
         /// current version's output base folder
         /// </summary>
-        [Obsolete("use GroupInfo")]
         string VersionOutputFolder { get; }
 
         GroupInfo GroupInfo { get; }

--- a/src/Microsoft.DocAsCode.Plugins/ManifestItem.cs
+++ b/src/Microsoft.DocAsCode.Plugins/ManifestItem.cs
@@ -22,7 +22,6 @@ namespace Microsoft.DocAsCode.Plugins
         [JsonProperty("is_incremental")]
         public bool IsIncremental { get; set; }
 
-        [Obsolete("use group")]
         [JsonProperty("version")]
         public string Version { get; set; }
 

--- a/src/docfx/Models/BuildJsonConfig.cs
+++ b/src/docfx/Models/BuildJsonConfig.cs
@@ -144,7 +144,6 @@ namespace Microsoft.DocAsCode
         [JsonProperty("customLinkResolver")]
         public string CustomLinkResolver { get; set; }
 
-        [Obsolete]
         [JsonProperty("versions")]
         public Dictionary<string, GroupConfig> Versions
         {

--- a/src/docfx/Models/FileMappingItem.cs
+++ b/src/docfx/Models/FileMappingItem.cs
@@ -78,7 +78,6 @@ namespace Microsoft.DocAsCode
         public string DestinationFolder { get; set; }
 
         [JsonProperty("version")]
-        [Obsolete("use GroupName")]
         public string VersionName
         {
             get


### PR DESCRIPTION
* remove on `version`: this can be never obsoleted in v2 . However, it introduces lots of warning when building docfx/ops soruce code.
* add on `GitUtility.Parse`: this is never used and could [cause confusion](https://github.com/dotnet/docfx/issues/4493#issuecomment-518289888). I do not remove it as it is `public` that may be used by someone.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4973)