### PR TITLE
Add back workqueue assertions

### DIFF
--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -59,13 +59,13 @@ namespace Microsoft.Docs.Build
 
         private static async Task Run(Docset docset, Docset fallbackDocset, RestoreGitMap restoreGitMap, CommandLineOptions options, ErrorLog errorLog, string outputPath)
         {
-            using (var context = new Context(outputPath, errorLog, docset, fallbackDocset, restoreGitMap, BuildFile))
+            using (var context = new Context(outputPath, errorLog, docset, fallbackDocset, restoreGitMap))
             {
                 context.BuildQueue.Enqueue(context.BuildScope.Files);
 
                 using (Progress.Start("Building files"))
                 {
-                    await context.BuildQueue.Drain(Progress.Update);
+                    await context.BuildQueue.Drain(file => BuildFile(context, file), Progress.Update);
                 }
 
                 context.BookmarkValidator.Validate();

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -35,13 +35,13 @@ namespace Microsoft.Docs.Build
         private readonly Lazy<XrefMap> _xrefMap;
         private readonly Lazy<TableOfContentsMap> _tocMap;
 
-        public Context(string outputPath, ErrorLog errorLog, Docset docset, Docset fallbackDocset, RestoreGitMap restoreGitMap, Func<Context, Document, Task> buildFile)
+        public Context(string outputPath, ErrorLog errorLog, Docset docset, Docset fallbackDocset, RestoreGitMap restoreGitMap)
         {
             var restoreFileMap = new RestoreFileMap(docset.DocsetPath, fallbackDocset?.DocsetPath);
 
             _xrefMap = new Lazy<XrefMap>(() => new XrefMap(this, docset, restoreFileMap));
             _tocMap = new Lazy<TableOfContentsMap>(() => TableOfContentsMap.Create(this));
-            BuildQueue = new WorkQueue<Document>(doc => buildFile(this, doc));
+            BuildQueue = new WorkQueue<Document>();
 
             ErrorLog = errorLog;
             Output = new Output(outputPath);

--- a/src/docfx/lib/collections/WorkQueue.cs
+++ b/src/docfx/lib/collections/WorkQueue.cs
@@ -13,16 +13,10 @@ namespace Microsoft.Docs.Build
     {
         private static readonly int s_maxParallelism = Math.Max(8, Environment.ProcessorCount * 2);
 
-        private readonly Func<T, Task> _run;
         private readonly ConcurrentQueue<T> _queue = new ConcurrentQueue<T>();
         private readonly ConcurrentHashSet<T> _duplicationDetector = new ConcurrentHashSet<T>();
 
         private readonly TaskCompletionSource<int> _drainTcs = new TaskCompletionSource<int>();
-
-        public WorkQueue(Func<T, Task> run)
-        {
-            _run = run;
-        }
 
         // For progress reporting
         private int _totalCount = 0;
@@ -54,13 +48,18 @@ namespace Microsoft.Docs.Build
                 return;
             }
 
+            if (_drainTcs.Task.IsCompleted)
+            {
+                throw new InvalidOperationException("Cannot enqueue new items after the queue is drained");
+            }
+
             _queue.Enqueue(item);
 
             Interlocked.Increment(ref _totalCount);
             Interlocked.Increment(ref _remainingCount);
         }
 
-        public Task Drain(Action<int, int> progress = null)
+        public Task Drain(Func<T, Task> run, Action<int, int> progress = null)
         {
             if (_queue.Count == 0)
             {
@@ -107,7 +106,7 @@ namespace Microsoft.Docs.Build
 
                 try
                 {
-                    task = _run(item);
+                    task = run(item);
                 }
                 catch (Exception ex)
                 {

--- a/src/docfx/lib/collections/WorkQueue.cs
+++ b/src/docfx/lib/collections/WorkQueue.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Docs.Build
         {
             if (Interlocked.CompareExchange(ref _drained, 1, 0) == 1)
             {
-                throw new InvalidOperationException("Cannot drain twice");
+                throw new InvalidOperationException("Can only drain once");
             }
 
             DrainCore();

--- a/src/docfx/lib/collections/WorkQueue.cs
+++ b/src/docfx/lib/collections/WorkQueue.cs
@@ -63,9 +63,14 @@ namespace Microsoft.Docs.Build
 
         public Task Drain(Func<T, Task> run, Action<int, int> progress = null)
         {
-            if (Interlocked.CompareExchange(ref _drained, 1, 0) == 1)
+            if (Interlocked.Exchange(ref _drained, 1) == 1)
             {
                 throw new InvalidOperationException("Can only drain once");
+            }
+
+            if (_queue.Count == 0)
+            {
+                return Task.CompletedTask;
             }
 
             DrainCore();

--- a/test/docfx.Test/lib/WorkQueueTest.cs
+++ b/test/docfx.Test/lib/WorkQueueTest.cs
@@ -17,10 +17,10 @@ namespace Microsoft.Docs.Build
         [InlineData(typeof(TaskCanceledException))]
         public static async Task ThrowsTheSameException(Type exceptionType)
         {
-            var queue = new WorkQueue<int>(Run);
+            var queue = new WorkQueue<int>();
             queue.Enqueue(Enumerable.Range(0, 1000));
 
-            var exception = await Assert.ThrowsAnyAsync<Exception>(() => queue.Drain());
+            var exception = await Assert.ThrowsAnyAsync<Exception>(() => queue.Drain(Run));
             Assert.Equal(exceptionType, exception.GetType());
 
             Task Run(int n) => n % 500 == 0 ? throw (Exception)Activator.CreateInstance(exceptionType) : Task.CompletedTask;
@@ -32,10 +32,10 @@ namespace Microsoft.Docs.Build
             var done = 0;
             var total = 10;
 
-            var queue = new WorkQueue<int>(Run);
+            var queue = new WorkQueue<int>();
             queue.Enqueue(Enumerable.Range(0, total));
 
-            await queue.Drain();
+            await queue.Drain(Run);
 
             Task Run(int n)
             {


### PR DESCRIPTION
The assertion now take place after duplication detection #4764 

Make `run` a parameter of `Drain` to express the intent that we only execute and item when calling `Drain`, it is not executed upon `Enqueue`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4978)