### PR TITLE
disable sorucelink for f# proj to fix build error

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp/Directory.Build.props
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp/Directory.Build.props
@@ -1,0 +1,2 @@
+<Project>
+</Project>


### PR DESCRIPTION
to fix error like `--sourcelink switch only supported when emitting a Portable PDB (--debug:portable or --debug:embedded)`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4981)