### PR TITLE
remove bookmark for uid resoved href

### DIFF
--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -302,7 +302,7 @@ inputs:
 outputs:
   docs/a.json:
   docs/b.json: |
-    {"conceptual": "<p>Link to <a href=\"a.json#a_b\">a.b</a></p>\n"}
+    {"conceptual": "<p>Link to <a href=\"a.json\">a.b</a></p>\n"}
   xrefmap.json: |
     {
       "references": [{
@@ -818,21 +818,21 @@ outputs:
     {
       "conceptual":
         "<p>
-        Link to <a href=\"a.json\" data-linktype=\"relative-path\">description for a</a>
-        Link to <a href=\"a.json\" data-linktype=\"relative-path\">a</a>
-        Link to <a href=\"a.json\" data-linktype=\"relative-path\">a</a>
-        Link to <a href=\"a.json#child\" data-linktype=\"relative-path\">child aaaaa</a>
-        Link to <a href=\"a.json#child\" data-linktype=\"relative-path\">child</a>
-        Link to <a href=\"a.json#child\" data-linktype=\"relative-path\">child.c cccccc</a>
-        Link to <a href=\"a.json#child\" data-linktype=\"relative-path\">child</a>
-        Link to <a href=\"a.json#children_a\" data-linktype=\"relative-path\">children.a</a>
-        Link to <a href=\"a.json#children_a\" data-linktype=\"relative-path\">children.a</a>
-        Link to <a href=\"a.json#children_a\" data-linktype=\"relative-path\">children.a</a>
-        Link to <a href=\"a.json#children_b\" data-linktype=\"relative-path\">children.b aaaaa</a>
-        Link to <a href=\"a.json#children_b\" data-linktype=\"relative-path\">children.b</a>
-        Link to <a href=\"a.json#children_b\" data-linktype=\"relative-path\">children.b</a>
-        Link to <a href=\"a.json#children_c\" data-linktype=\"relative-path\">children.c cccccc</a>
-        </p>"
+         Link to <a href=\"a.json\" data-linktype=\"relative-path\">description for a</a>
+         Link to <a href=\"a.json\" data-linktype=\"relative-path\">a</a>
+         Link to <a href=\"a.json\" data-linktype=\"relative-path\">a</a>
+         Link to <a href=\"a.json\" data-linktype=\"relative-path\">child aaaaa</a>
+         Link to <a href=\"a.json\" data-linktype=\"relative-path\">child</a>
+         Link to <a href=\"a.json\" data-linktype=\"relative-path\">child.c cccccc</a>
+         Link to <a href=\"a.json\" data-linktype=\"relative-path\">child</a>
+         Link to <a href=\"a.json\" data-linktype=\"relative-path\">children.a</a>
+         Link to <a href=\"a.json\" data-linktype=\"relative-path\">children.a</a>
+         Link to <a href=\"a.json\" data-linktype=\"relative-path\">children.a</a>
+         Link to <a href=\"a.json\" data-linktype=\"relative-path\">children.b aaaaa</a>
+         Link to <a href=\"a.json\" data-linktype=\"relative-path\">children.b</a>
+         Link to <a href=\"a.json\" data-linktype=\"relative-path\">children.b</a>
+         Link to <a href=\"a.json\" data-linktype=\"relative-path\">children.c cccccc</a>
+         </p>"
     }
   xrefmap.json: |
     {
@@ -928,7 +928,7 @@ outputs:
             },
             {
                 "uid": "child",
-                "href": "https://docs.com/docs/a.json#child",
+                "href": "https://docs.com/docs/a.json",
                 "list": [
                     "2.0",
                     "3.0"
@@ -936,14 +936,14 @@ outputs:
             },
             {
                 "uid": "children.a",
-                "href": "https://docs.com/docs/a.json#children_a",
+                "href": "https://docs.com/docs/a.json",
                 "list": [
                     "1.0"
                 ]
             },
             {
                 "uid": "children.b",
-                "href": "https://docs.com/docs/a.json#children_b",
+                "href": "https://docs.com/docs/a.json",
                 "list": [
                     "2.0",
                     "3.0"
@@ -1047,7 +1047,7 @@ outputs:
              "uid":"child2",
              "xref":{
                 "uid":"child1",
-                "href":"a.json#child1"
+                "href":"a.json"
              }
           }
        ]

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -844,22 +844,22 @@ outputs:
             },
             {
                 "uid": "child",
-                "href": "https://docs.com/docs/a.json#child",
+                "href": "https://docs.com/docs/a.json",
                 "a": "child aaaaa",
                 "child.c": "child.c cccccc"
             },
             {
                 "uid": "children.a",
-                "href": "https://docs.com/docs/a.json#children_a"
+                "href": "https://docs.com/docs/a.json"
             },
             {
                 "uid": "children.b",
-                "href": "https://docs.com/docs/a.json#children_b",
+                "href": "https://docs.com/docs/a.json",
                 "a": "children.b aaaaa"
             },
             {
                 "uid": "children.c",
-                "href": "https://docs.com/docs/a.json#children_c",
+                "href": "https://docs.com/docs/a.json",
                 "child.c": "children.c cccccc"
             }
         ]

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -100,15 +100,12 @@ namespace Microsoft.Docs.Build
                     {
                         Uid = uid,
                         Source = JsonUtility.GetSourceInfo(obj),
-                        Href = obj.Parent is null ? file.SiteUrl : $"{file.SiteUrl}#{GetBookmarkFromUid(uid)}",
+                        Href = obj.Parent is null ? file.SiteUrl : $"{file.SiteUrl}",
                         DeclaringFile = file,
                     };
                     xref.ExtensionData.AddRange(xrefProperties);
                     return xref;
                 }
-
-                string GetBookmarkFromUid(string uid)
-                    => Regex.Replace(uid, @"\W", "_");
 
                 void TraverseObjectXref(JObject obj, Func<JsonSchema, string, JToken, bool> action = null)
                 {


### PR DESCRIPTION
before we implement Reference SDP, we don't need generate bookmark for resolved href of UID. Current implementation is not consistent with v2 template.

fix: https://dev.azure.com/ceapex/Engineering/_workitems/edit/112063

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4985)