### PR TITLE
Merge code InvalidInternalBookmark and InvalidExternalBookmark to InvalidBookmark

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/ValidateBookmark.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/ValidateBookmark.cs
@@ -131,12 +131,11 @@ namespace Microsoft.DocAsCode.Build.Engine
                             content = $"<a href=\"{link}\">{title}</a>";
                         }
 
-                        string errorCode = internalBookmark ? WarningCodes.Build.InvalidInternalBookmark : WarningCodes.Build.InvalidExternalBookmark;
                         Logger.LogWarning($"Invalid link: '{content}'. The file {linkedToFileSrc} doesn't contain a bookmark named '{bookmark}'.",
                             null,
                             currentFileSrc,
                             linkItem.SourceLineNumber != 0 ? linkItem.SourceLineNumber.ToString() : null,
-                            code: errorCode);
+                            code: WarningCodes.Build.InvalidBookmark);
                     }
                 }
             }

--- a/src/Microsoft.DocAsCode.Common/Loggers/WarningCodes.cs
+++ b/src/Microsoft.DocAsCode.Common/Loggers/WarningCodes.cs
@@ -13,8 +13,7 @@ namespace Microsoft.DocAsCode.Common
         public static class Build
         {
             public const string TooManyWarnings = "TooManyWarnings";
-            public const string InvalidInternalBookmark = "InvalidInternalBookmark";
-            public const string InvalidExternalBookmark = "InvalidExternalBookmark";
+            public const string InvalidBookmark = "InvalidBookmark";
             public const string InvalidFileLink = "InvalidFileLink";
             public const string DuplicateUids = "DuplicateUids";
             public const string DuplicateOutputFiles = "DuplicateOutputFiles";

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/ValidateBookmarkTest.cs
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/ValidateBookmarkTest.cs
@@ -79,8 +79,7 @@ namespace Microsoft.DocAsCode.Build.Engine.Tests
             }
             var logs = _listener.Items;
             Assert.Equal(5, logs.Count);
-            Assert.Equal(3, logs.Where(l => l.Code == WarningCodes.Build.InvalidExternalBookmark).Count());
-            Assert.Equal(2, logs.Where(l => l.Code == WarningCodes.Build.InvalidInternalBookmark).Count());
+            Assert.True(logs.All(log => log.Code == WarningCodes.Build.InvalidBookmark));
             var expected = new[]
             {
                 Tuple.Create(@"Invalid link: '[link with source info](a.md#b2)'. The file a.md doesn't contain a bookmark named 'b2'.", "b.md"),

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/ValidateBookmarkTest.cs
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/ValidateBookmarkTest.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DocAsCode.Build.Engine.Tests
             }
             var logs = _listener.Items;
             Assert.Equal(5, logs.Count);
-            Assert.True(logs.All(log => log.Code == WarningCodes.Build.InvalidBookmark));
+            Assert.True(logs.All(l => l.Code == WarningCodes.Build.InvalidBookmark));
             var expected = new[]
             {
                 Tuple.Create(@"Invalid link: '[link with source info](a.md#b2)'. The file a.md doesn't contain a bookmark named 'b2'.", "b.md"),

--- a/test/Microsoft.DocAsCode.Common.Tests/LogCodesLogListenerTest.cs
+++ b/test/Microsoft.DocAsCode.Common.Tests/LogCodesLogListenerTest.cs
@@ -19,13 +19,13 @@ namespace Microsoft.DocAsCode.Common.Tests
             var logCodesLogListener = new LogCodesLogListener();
             Logger.RegisterListener(logCodesLogListener);
             Logger.LogWarning("message1", file: "file.md", code: WarningCodes.Build.InvalidFileLink);
-            Logger.LogWarning("message2", file: "file.md", code: WarningCodes.Build.InvalidExternalBookmark);
+            Logger.LogWarning("message2", file: "file.md", code: WarningCodes.Build.InvalidBookmark);
             Logger.LogWarning("message3", file: "anotherFile.md", code: WarningCodes.Build.InvalidFileLink);
 
 
             Assert.True(logCodesLogListener.Codes.TryGetValue("file.md", out var fileCodes));
             Assert.True(fileCodes.Contains(WarningCodes.Build.InvalidFileLink));
-            Assert.True(fileCodes.Contains(WarningCodes.Build.InvalidExternalBookmark));
+            Assert.True(fileCodes.Contains(WarningCodes.Build.InvalidBookmark));
             Assert.True(logCodesLogListener.Codes.TryGetValue("anotherFile.md", out var anotherFileCodes));
             Assert.True(anotherFileCodes.Contains(WarningCodes.Build.InvalidFileLink));
 


### PR DESCRIPTION
Merge code `InvalidInternalBookmark` and `InvalidExternalBookmark` to `InvalidBookmark`.

Related workitem is [here](https://ceapex.visualstudio.com/Engineering/_workitems/edit/108157/)

Merge pending V3 change and migration tool change
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4987)