### PR TITLE
Expand of system enviromentVariables in metadata src

### DIFF
--- a/Documentation/tutorial/docfx.exe_user_manual.md
+++ b/Documentation/tutorial/docfx.exe_user_manual.md
@@ -560,7 +560,7 @@ files              | **REQUIRED**. The file or file array, `glob` pattern is sup
 ~~name~~           | **Obsoleted**, please use `dest`.
 exclude            | The files to be excluded, `glob` pattern is supported.
 ~~cwd~~            | **Obsoleted**, please use `src`.
-src                | Specifies the source directory. If omitted, the directory of the config file will be used. Use this option when you want to refer to files in relative folders while want to keep folder structure. e.g. set `src` to `..`.
+src                | Specifies the source directory. If omitted, the directory of the config file will be used. It is possible to set this path relative or absolute. Use the relative path defintion when you want to refer to files in relative folders while want to keep folder structure. e.g. set `src` to `..`. When you prefere absolut path, maybe it is more meaningful to use System Enviroment variables.
 dest               | The folder name for the generated files.
 version            | Version name for the current file mapping. If not set, treat the current file-mapping item as in default version. Mappings with the same version name will be built together. Cross reference doesn't support cross different versions.
 caseSensitive      | **TOBEIMPLEMENTED**. Default value is `false`. If set to `true`, the glob pattern is case sensitive. e.g. `*.txt` will not match `1.TXT`. For OS Windows, file path is case insensitive while for Linux/Unix, file path is case sensitive. This option offers user the flexibility to determine how to search files.

--- a/src/docfx/Glob/GlobUtility.cs
+++ b/src/docfx/Glob/GlobUtility.cs
@@ -28,13 +28,12 @@ namespace Microsoft.DocAsCode
             var expandedFileMapping = new FileMapping();
             foreach (var item in fileMapping.Items)
             {
-                string expandedSourceFolder = Environment.ExpandEnvironmentVariables(item.SourceFolder ?? string.Empty);
-                var src =  Path.IsPathRooted(expandedSourceFolder) ? expandedSourceFolder : Path.Combine(baseDirectory, expandedSourceFolder);
+                string expandedSourceFolder = Path.Combine(baseDirectory, Environment.ExpandEnvironmentVariables(item.SourceFolder ?? string.Empty));
                 var options = GetMatchOptionsFromItem(item);
-                var fileItems = new FileItems(FileGlob.GetFiles(src, item.Files, item.Exclude, options));
+                var fileItems = new FileItems(FileGlob.GetFiles(expandedSourceFolder, item.Files, item.Exclude, options));
                 if (fileItems.Count == 0)
                 {
-                    var currentSrcFullPath = string.IsNullOrEmpty(src) ? Directory.GetCurrentDirectory() : Path.GetFullPath(src);
+                    var currentSrcFullPath = string.IsNullOrEmpty(expandedSourceFolder) ? Directory.GetCurrentDirectory() : Path.GetFullPath(expandedSourceFolder);
                     Logger.LogInfo($"No files are found with glob pattern {StringExtension.ToDelimitedString(item.Files) ?? "<none>"}, excluding {StringExtension.ToDelimitedString(item.Exclude) ?? "<none>"}, under directory \"{currentSrcFullPath}\"");
                     CheckPatterns(item.Files);
                 }
@@ -45,7 +44,7 @@ namespace Microsoft.DocAsCode
                 expandedFileMapping.Add(
                     new FileMappingItem
                     {
-                        SourceFolder = src,
+                        SourceFolder = expandedSourceFolder,
                         Files = fileItems,
                         DestinationFolder = item.DestinationFolder
                     });

--- a/src/docfx/Glob/GlobUtility.cs
+++ b/src/docfx/Glob/GlobUtility.cs
@@ -28,7 +28,8 @@ namespace Microsoft.DocAsCode
             var expandedFileMapping = new FileMapping();
             foreach (var item in fileMapping.Items)
             {
-                var src = Path.Combine(baseDirectory, item.SourceFolder ?? string.Empty);
+                string expandedSourceFolder = Environment.ExpandEnvironmentVariables(item.SourceFolder ?? string.Empty);
+                var src =  Path.IsPathRooted(expandedSourceFolder) ? expandedSourceFolder : Path.Combine(baseDirectory, expandedSourceFolder);
                 var options = GetMatchOptionsFromItem(item);
                 var fileItems = new FileItems(FileGlob.GetFiles(src, item.Files, item.Exclude, options));
                 if (fileItems.Count == 0)


### PR DESCRIPTION
This is the code change for #4983 

It is now possible to use environment variables in `src` like:

```json
"metadata": [
    {
      "src": [
        {
          "src": "%userprofile%\\.nuget\\packages",
          "files": [
            "nugetpackage/2.0.0/src/ProjectX/ProjectX.csproj"
          ]
        }
      ],
      "dest": "api", 
      "properties": {
        "TargetFramework": "net471"
      }
    }
  ]
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/4994)