### PR TITLE
Refine Circular xref detection

### DIFF
--- a/docs/specs/escape.yml
+++ b/docs/specs/escape.yml
@@ -127,13 +127,13 @@ inputs:
       "uid": "a&b",
       "name": "test",
       "fullName": "test.test",
-      "summary": "<some text &>"
+      "description": "<some text &>"
     }
   html-xref.md: |
-    Link to [text](xref:a&b?displayProperty=summary)
-    Link to <xref href="a&b?displayProperty=summary" />
-    Link to <xref:a&b?displayProperty=summary>
-    Link to @a&b?displayProperty=summary
+    Link to [text](xref:a&b?displayProperty=description)
+    Link to <xref href="a&b?displayProperty=description" />
+    Link to <xref:a&b?displayProperty=description>
+    Link to @a&b?displayProperty=description
     Link to @a&c
 outputs:
   a.json:
@@ -142,9 +142,9 @@ outputs:
       "conceptual": "
           <p>
             Link to <a href=\"a.json\">text</a>
-            Link to <a href='a.json'>&lt;p&gt;&amp;lt;some text &amp;amp;&amp;gt;&lt;/p&gt;\n</a>
-            Link to <a href=\"a.json\">&lt;p&gt;&amp;lt;some text &amp;amp;&amp;gt;&lt;/p&gt;\n</a>
-            Link to <a href=\"a.json\">&lt;p&gt;&amp;lt;some text &amp;amp;&amp;gt;&lt;/p&gt;\n</a>
+            Link to <a href='a.json'>&lt;some text &amp;&gt;\n</a>
+            Link to <a href=\"a.json\">&lt;some text &amp;&gt;\n</a>
+            Link to <a href=\"a.json\">&lt;some text &amp;&gt;\n</a>
             Link to @a&amp;c
           </p>"
     }

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -25,7 +25,7 @@ inputs:
     xref: 
       - 1.xrefmap.json
       - 2.xrefmap.json
-  docs/a.md: Link to @System.String
+  docs/a.md: Link to @System.String?displayProperty=fullName
   1.xrefmap.json: |
     {
       "references":[{
@@ -40,7 +40,7 @@ inputs:
     { "references":[{"uid": "a", "name": "a", "fullName": "a", "href": "https://docs.microsoft.com/en-us/a", "nameWithType": "a"}]}
 outputs:
   docs/a.json: |
-    { "conceptual": "<p>Link to <a href=\"https://docs.microsoft.com/en-us/dotnet/api/system.string\">String</a></p>\n"}
+    { "conceptual": "<p>Link to <a href=\"https://docs.microsoft.com/en-us/dotnet/api/system.string\">System.String</a></p>\n"}
 ---
 # Restore xref map from configured url and use the YAML file for resolving
 inputs:

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -554,7 +554,106 @@ outputs:
       }
     }
 ---
-# display property of markdown content type will be ignored
+# circular reference within SDP UID definition a -> a
+inputs:
+  docfx.yml:
+  docs/a.yml: |
+    #YamlMime:TestData
+    uid: a
+    xref: a
+  _themes/ContentTemplate/schemas/TestData.schema.json: |
+    {
+      "properties": {
+          "uid": {
+            "type": "string",
+            "contentType": "uid"
+          },
+          "xref": {
+              "type": "string",
+              "contentType": "Xref"
+          }
+      },
+      "xrefProperties": [
+          "xref"
+      ]
+    }
+outputs:
+  .errors.log: |
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/a.yml'","docs/a.yml"]
+---
+# circular reference within SDP UID definition a -> b -> a
+inputs:
+  docfx.yml:
+  docs/a.yml: |
+    #YamlMime:TestData
+    uid: a
+    xref: b
+  docs/b.yml: |
+    #YamlMime:TestData
+    uid: b
+    xref: a
+  _themes/ContentTemplate/schemas/TestData.schema.json: |
+    {
+      "properties": {
+          "uid": {
+            "type": "string",
+            "contentType": "uid"
+          },
+          "xref": {
+              "type": "string",
+              "contentType": "Xref"
+          }
+      },
+      "xrefProperties": [
+          "xref"
+      ]
+    }
+outputs:
+  .errors.log: |
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/a.yml' --> 'docs/b.yml'","docs/a.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/b.yml' --> 'docs/a.yml'","docs/b.yml"]
+---
+# circular reference within SDP UID definition a -> b -> a -> c
+inputs:
+  docfx.yml:
+  docs/a.yml: |
+    #YamlMime:TestData
+    uid: a
+    xref: b
+    anotherXref: c
+  docs/b.yml: |
+    #YamlMime:TestData
+    uid: b
+    xref: a
+  docs/c.yml: |
+    #YamlMime:TestData
+    uid: c
+  _themes/ContentTemplate/schemas/TestData.schema.json: |
+    {
+      "properties": {
+          "uid": {
+            "type": "string",
+            "contentType": "uid"
+          },
+          "xref": {
+              "type": "string",
+              "contentType": "Xref"
+          },
+          "anotherXref": {
+              "type": "string",
+              "contentType": "Xref"
+          }
+      },
+      "xrefProperties": [
+          "xref"
+      ]
+    }
+outputs:
+  .errors.log: |
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/a.yml' --> 'docs/b.yml'","docs/a.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/b.yml' --> 'docs/a.yml'","docs/b.yml"]
+---
+# display property of non-plain text content type will be ignored
 inputs:
   docfx.yml: |
     template: {APP_BASE_PATH}data/template

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -554,43 +554,6 @@ outputs:
       }
     }
 ---
-# SDP non-cyclic xref reference should be resolved
-# whose display properties are plain text
-inputs:
-  docfx.yml: |
-    template: {APP_BASE_PATH}data/template
-  docs/a.json: |
-    {
-      "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TestData.json",
-      "uid": "a",
-      "name": "name for a",
-      "inlineDescription": "description for a",
-      "summary": "Link to @b?displayProperty=inlineDescription",
-    }
-  docs/b.json: |
-    {
-      "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TestData.json",
-      "uid": "b",
-      "name": "name for b",
-      "inlineDescription": "description for b",
-      "summary": "Link to @a",
-    }
-outputs:
-  docs/a.json: |
-    {
-      "name": "name for a",
-      "summary": "<p>Link to <a href=\"b.json\">description for b</a></p>\n",
-      "inlineDescription": "description for a",
-      "uid": "a"
-    }
-  docs/b.json: |
-    {
-      "name": "name for b",
-      "summary": "<p>Link to <a href=\"a.json\">name for a</a></p>\n",
-      "inlineDescription": "description for b",
-      "uid": "b"
-    }
----
 # display property of markdown content type will be ignored
 inputs:
   docfx.yml: |
@@ -617,9 +580,21 @@ outputs:
       "uid": "a",
       "name": "name for a",
       "inlineDescription": "Link to <a href=\"b.json\">name for b</a>",
-      "summary": "<p>Link to <a href=\"b.json\">name for b</a></p>\n"
+      "summary": "
+          <p>
+            Link to <a href=\"b.json\">name for b</a>
+          </p>"
     }
-  docs/b.json:
+  docs/b.json: |
+    {
+      "name": "name for b",
+      "uid": "b",
+      "inlineDescription": "description for b",
+      "summary": "
+          <p>
+            Link to <a href=\"a.json\">name for a</a>
+          </p>"
+    }
 ---
 # input yml file is not object
 inputs:

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -554,29 +554,6 @@ outputs:
       }
     }
 ---
-# Markdown and SDP non-cyclic xref reference
-inputs:
-  docfx.yml: |
-    template: {APP_BASE_PATH}data/template
-  docs/a.md: |
-    ---
-    title: Title from yaml header a
-    uid: a
-    ---
-    Link to @b?displayProperty=summary
-  docs/b.json: | 
-    {
-      "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TestData.json",
-      "uid": "b",
-      "name": "name for b",
-      "description": "description for b",
-      "summary": "Link to @a?displayProperty=summary",
-    }
-outputs:
-  docs/a.json:
-  docs/b.json: |
-    { "name":"name for b","description":"description for b" }
----
 # SDP non-cyclic xref reference should be resolved
 # whose display properties are plain text
 inputs:
@@ -614,94 +591,7 @@ outputs:
       "uid": "b"
     }
 ---
-# SDP cyclic xref reference whose display properties referring to another uid
-# a.json -> b.json -> a.json && b.json -> a.json -> b.json
-inputs:
-  docfx.yml: |
-    template: {APP_BASE_PATH}data/template
-  docs/a.json: |
-    {
-      "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TestData.json",
-      "uid": "a",
-      "name": "name for a",
-      "inlineDescription": "description for a",
-      "summary": "Link to @b?displayProperty=summary",
-    }
-  docs/b.json: |
-    {
-      "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TestData.json",
-      "uid": "b",
-      "name": "name for b",
-      "inlineDescription": "description for b",
-      "summary": "Link to @a?displayProperty=summary",
-    }
-  docs/c.json: |
-    {
-      "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TestData.json",
-      "uid": "c",
-      "name": "name for c",
-      "inlineDescription": "description for c",
-      "summary": "Link to @a",
-    }
-outputs:
-  docs/c.json: |
-    {"name":"name for c","summary":"<p>Link to <a href=\"a.json\">name for a</a></p>\n","inlineDescription":"description for c","uid":"c"}
-  .errors.log: |
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/a.json' --> 'docs/b.json' --> 'docs/a.json'","docs/a.json"]
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/b.json' --> 'docs/a.json' --> 'docs/b.json'","docs/b.json"]
----
-# SDP cyclic xref reference whose display properties referring to another uid
-# b.json -> c.json -> b.json && b.json -> c.json -> b.json && c.json -> b.json -> c.json
-inputs:
-  docfx.yml: |
-    template: {APP_BASE_PATH}data/template
-  docs/a.json: |
-    {
-      "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TestData.json",
-      "uid": "a",
-      "name": "name for a",
-      "inlineDescription": "description for a",
-      "summary": "Link to @b?displayProperty=summary",
-    }
-  docs/b.json: |
-    {
-      "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TestData.json",
-      "uid": "b",
-      "name": "name for b",
-      "inlineDescription": "description for b",
-      "summary": "Link to @c?displayProperty=summary",
-    }
-  docs/c.json: |
-    {
-      "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TestData.json",
-      "uid": "c",
-      "name": "name for c",
-      "inlineDescription": "description for c",
-      "summary": "Link to @b?displayProperty=summary",
-    }
-outputs:
-  .errors.log: | 
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/c.json' --> 'docs/b.json' --> 'docs/c.json'","docs/c.json"]
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/b.json' --> 'docs/c.json' --> 'docs/b.json'","docs/b.json"]
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/a.json' --> 'docs/b.json' --> 'docs/c.json' --> 'docs/b.json'","docs/a.json"]
----
-# SDP cyclic xref reference to itself
-inputs:
-  docfx.yml: |
-    template: {APP_BASE_PATH}data/template
-  docs/a.json: |
-    {
-      "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TestData.json",
-      "uid": "a",
-      "name": "name for a",
-      "inlineDescription": "description for a",
-      "summary": "Link to @a?displayProperty=summary",
-    }
-outputs:
-  .errors.log: |
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/a.json' --> 'docs/a.json'","docs/a.json"]
----
-# SDP non-cyclic xref reference, whose property references can be resolved
+# display property of markdown content type will be ignored
 inputs:
   docfx.yml: |
     template: {APP_BASE_PATH}data/template
@@ -712,17 +602,23 @@ inputs:
       "name": "name for a",
       "inlineDescription": "Link to @b?displayProperty=inlineDescription",
       "summary": "Link to @b?displayProperty=summary",
-    }
+    } 
   docs/b.json: |
     {
       "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TestData.json",
-      "uid": "b",
       "name": "name for b",
-      "inlineDescription": "Link to @a?displayProperty=name",
-      "summary": "Link to @a?displayProperty=inlineDescription",
+      "uid": "b",
+      "inlineDescription": "description for b",
+      "summary": "Link to @a",
     }
 outputs:
-  docs/a.json:
+  docs/a.json: |
+    {
+      "uid": "a",
+      "name": "name for a",
+      "inlineDescription": "Link to <a href=\"b.json\">name for b</a>",
+      "summary": "<p>Link to <a href=\"b.json\">name for b</a></p>\n"
+    }
   docs/b.json:
 ---
 # input yml file is not object

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -581,7 +581,7 @@ outputs:
   .errors.log: |
     ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/a.yml' --> 'docs/a.yml'","docs/a.yml"]
 ---
-# circular reference within SDP UID definition a -> b -> a
+# circular reference within SDP UID definition a -> b -> c -> a
 inputs:
   docfx.yml:
   docs/a.yml: |
@@ -591,6 +591,10 @@ inputs:
   docs/b.yml: |
     #YamlMime:TestData
     uid: b
+    xref: c
+  docs/c.yml: |
+    #YamlMime:TestData
+    uid: c
     xref: a
   _themes/ContentTemplate/schemas/TestData.schema.json: |
     {
@@ -610,8 +614,9 @@ inputs:
     }
 outputs:
   .errors.log: |
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/a.yml' --> 'docs/b.yml' --> 'docs/a.yml'","docs/a.yml"]
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/b.yml' --> 'docs/a.yml' --> 'docs/b.yml'","docs/b.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/a.yml' --> 'docs/b.yml' --> 'docs/c.yml' --> 'docs/a.yml'","docs/a.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/b.yml' --> 'docs/c.yml' --> 'docs/a.yml' --> 'docs/b.yml'","docs/b.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/c.yml' --> 'docs/a.yml' --> 'docs/b.yml' --> 'docs/c.yml'","docs/c.yml"]
 ---
 # circular reference within SDP UID definition a -> b -> a -> c
 inputs:

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -579,7 +579,7 @@ inputs:
     }
 outputs:
   .errors.log: |
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/a.yml'","docs/a.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/a.yml' --> 'docs/a.yml'","docs/a.yml"]
 ---
 # circular reference within SDP UID definition a -> b -> a
 inputs:
@@ -610,8 +610,8 @@ inputs:
     }
 outputs:
   .errors.log: |
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/a.yml' --> 'docs/b.yml'","docs/a.yml"]
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/b.yml' --> 'docs/a.yml'","docs/b.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/a.yml' --> 'docs/b.yml' --> 'docs/a.yml'","docs/a.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/b.yml' --> 'docs/a.yml' --> 'docs/b.yml'","docs/b.yml"]
 ---
 # circular reference within SDP UID definition a -> b -> a -> c
 inputs:
@@ -650,8 +650,8 @@ inputs:
     }
 outputs:
   .errors.log: |
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/a.yml' --> 'docs/b.yml'","docs/a.yml"]
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/b.yml' --> 'docs/a.yml'","docs/b.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/a.yml' --> 'docs/b.yml' --> 'docs/a.yml'","docs/a.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/b.yml' --> 'docs/a.yml' --> 'docs/b.yml'","docs/b.yml"]
 ---
 # display property of non-plain text content type will be ignored
 inputs:

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -579,7 +579,7 @@ inputs:
     }
 outputs:
   .errors.log: |
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/a.yml' --> 'docs/a.yml'","docs/a.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'a (docs/a.yml)' --> 'a (docs/a.yml)'","docs/a.yml"]
 ---
 # circular reference within SDP UID definition a -> b -> c -> a
 inputs:
@@ -614,9 +614,9 @@ inputs:
     }
 outputs:
   .errors.log: |
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/a.yml' --> 'docs/b.yml' --> 'docs/c.yml' --> 'docs/a.yml'","docs/a.yml"]
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/b.yml' --> 'docs/c.yml' --> 'docs/a.yml' --> 'docs/b.yml'","docs/b.yml"]
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/c.yml' --> 'docs/a.yml' --> 'docs/b.yml' --> 'docs/c.yml'","docs/c.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'a (docs/a.yml)' --> 'b (docs/b.yml)' --> 'c (docs/c.yml)' --> 'a (docs/a.yml)'","docs/a.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'b (docs/b.yml)' --> 'c (docs/c.yml)' --> 'a (docs/a.yml)' --> 'b (docs/b.yml)'","docs/b.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'c (docs/c.yml)' --> 'a (docs/a.yml)' --> 'b (docs/b.yml)' --> 'c (docs/c.yml)'","docs/c.yml"]
 ---
 # circular reference within SDP UID definition a -> b -> a -> c
 inputs:
@@ -655,8 +655,8 @@ inputs:
     }
 outputs:
   .errors.log: |
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/a.yml' --> 'docs/b.yml' --> 'docs/a.yml'","docs/a.yml"]
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/b.yml' --> 'docs/a.yml' --> 'docs/b.yml'","docs/b.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'a (docs/a.yml)' --> 'b (docs/b.yml)' --> 'a (docs/a.yml)'","docs/a.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'b (docs/b.yml)' --> 'a (docs/a.yml)' --> 'b (docs/b.yml)'","docs/b.yml"]
 ---
 # display property of non-plain text content type will be ignored
 inputs:

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Docs.Build
         /// </summary>
         /// Behavior: ✔️ Message: ✔️
         public static Error CircularReference<T>(IEnumerable<T> dependencyChain, Document declaringFile)
-            => new Error(ErrorLevel.Error, "circular-reference", $"Build has identified file(s) referencing each other: {string.Join(" --> ", dependencyChain.Select(file => $"'{file}'"))} --> '{declaringFile}'", file: declaringFile.FilePath);
+            => new Error(ErrorLevel.Error, "circular-reference", $"Build has identified file(s) referencing each other: {string.Join(" --> ", dependencyChain.Select(file => $"'{file}'"))}", file: declaringFile.FilePath);
 
         /// <summary>
         /// Didn't run `docfx restore` before running `docfx build`.

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Docs.Build
         /// </summary>
         /// Behavior: ✔️ Message: ✔️
         public static Error CircularReference<T>(IEnumerable<T> dependencyChain, Document declaringFile)
-            => new Error(ErrorLevel.Error, "circular-reference", $"Build has identified file(s) referencing each other: {string.Join(" --> ", dependencyChain.Select(file => $"'{file}'"))}", file: declaringFile.FilePath);
+            => new Error(ErrorLevel.Error, "circular-reference", $"Build has identified file(s) referencing each other: {string.Join(" --> ", dependencyChain.Select(file => $"'{file}'"))} --> '{declaringFile}'", file: declaringFile.FilePath);
 
         /// <summary>
         /// Didn't run `docfx restore` before running `docfx build`.

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -73,8 +73,8 @@ namespace Microsoft.Docs.Build
         ///   - a.md references b.json's property with xref syntax, and b.json includes a.md reversely
         /// </summary>
         /// Behavior: ✔️ Message: ✔️
-        public static Error CircularReference<T>(IEnumerable<T> dependencyChain)
-            => new Error(ErrorLevel.Error, "circular-reference", $"Build has identified file(s) referencing each other: {string.Join(" --> ", dependencyChain.Select(file => $"'{file}'"))}");
+        public static Error CircularReference<T>(IEnumerable<T> dependencyChain, Document declaringFile)
+            => new Error(ErrorLevel.Error, "circular-reference", $"Build has identified file(s) referencing each other: {string.Join(" --> ", dependencyChain.Select(file => $"'{file}'"))}", file: declaringFile.FilePath);
 
         /// <summary>
         /// Didn't run `docfx restore` before running `docfx build`.

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Docs.Build
 
                 var (publishModel, fileManifests) = context.PublishModelBuilder.Build(context, docset.Legacy);
                 var dependencyMap = context.DependencyMapBuilder.Build();
-                var xrefMapModel = context.XrefMap.ToXrefMapModel(context);
+                var xrefMapModel = context.XrefMap.ToXrefMapModel();
 
                 context.Output.WriteJson(xrefMapModel, "xrefmap.json");
                 context.Output.WriteJson(publishModel, ".publish.json");

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -115,7 +115,22 @@ namespace Microsoft.Docs.Build
             queries.Remove("displayProperty");
 
             // need to url decode uid from input content
-            var (error, resolvedHref, display, xrefSpec) = _xrefMap.Value.Resolve(Uri.UnescapeDataString(uid), href, displayProperty, text, declaringFile);
+            var (error, resolvedHref, xrefSpec) = _xrefMap.Value.Resolve(Uri.UnescapeDataString(uid), href);
+
+            var name = xrefSpec?.GetXrefPropertyValue("name");
+            if (xrefSpec is InternalXrefSpec internalSpec && internalSpec?.ContentTypeMapping.TryGetValue(displayProperty, out var contentType) == true)
+            {
+                if (contentType != default && new JsonSchemaContentType[] { JsonSchemaContentType.InlineMarkdown, JsonSchemaContentType.Markdown }.Contains(contentType))
+                {
+                }
+            }
+            var displayPropertyValue =  xrefSpec?.GetXrefPropertyValue(displayProperty);
+
+            // fallback order:
+            // text -> xrefSpec.displayPropertyName -> xrefSpec.name -> uid
+            var display = !string.IsNullOrEmpty(text)
+                ? text
+                : (!string.IsNullOrEmpty(displayPropertyValue) ? displayPropertyValue : (!string.IsNullOrEmpty(name) ? name : uid));
 
             if (xrefSpec?.DeclaringFile != null)
             {

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -115,25 +115,14 @@ namespace Microsoft.Docs.Build
             queries.Remove("displayProperty");
 
             // need to url decode uid from input content
-            var (error, resolvedHref, xrefSpec) = _xrefMap.Value.Resolve(Uri.UnescapeDataString(uid), href);
-
-            var name = xrefSpec?.GetXrefPropertyValueAsString("name");
-
-            // for internal UID, the display property can not be markdown or inline markdown
-            // because the display text should be plain text
-            string displayPropertyValue = null;
-            if (xrefSpec is InternalXrefSpec internalSpec)
+            var xrefSpec = _xrefMap.Value.Resolve(new SourceInfo<string>(Uri.UnescapeDataString(uid), href.Source));
+            if (xrefSpec is null)
             {
-                var contentType = internalSpec.GetXrefPropertyContentType(displayProperty);
-                if (contentType != JsonSchemaContentType.Markdown && contentType != JsonSchemaContentType.InlineMarkdown)
-                {
-                    displayPropertyValue = xrefSpec?.GetXrefPropertyValueAsString(displayProperty);
-                }
+                return (Errors.XrefNotFound(href), null, null, null);
             }
-            else
-            {
-                displayPropertyValue = xrefSpec?.GetXrefPropertyValueAsString(displayProperty);
-            }
+
+            var name = xrefSpec.GetXrefPropertyValueAsString("name");
+            var displayPropertyValue = xrefSpec.GetXrefPropertyValueAsString(displayProperty);
 
             // fallback order:
             // text -> xrefSpec.displayPropertyName -> xrefSpec.name -> uid
@@ -143,22 +132,19 @@ namespace Microsoft.Docs.Build
 
             if (xrefSpec?.DeclaringFile != null)
             {
-                _dependencyMapBuilder.AddDependencyItem(declaringFile, xrefSpec?.DeclaringFile, DependencyType.UidInclusion);
+                _dependencyMapBuilder.AddDependencyItem(declaringFile, xrefSpec.DeclaringFile, DependencyType.UidInclusion);
             }
 
-            if (!string.IsNullOrEmpty(resolvedHref))
+            if (!string.IsNullOrEmpty(moniker))
             {
-                if (!string.IsNullOrEmpty(moniker))
-                {
-                    queries["view"] = moniker;
-                }
-                resolvedHref = UrlUtility.MergeUrl(
-                    resolvedHref,
-                    queries.AllKeys.Length == 0 ? "" : "?" + string.Join('&', queries),
-                    fragment.Length == 0 ? "" : fragment.Substring(1));
+                queries["view"] = moniker;
             }
+            var resolvedHref = UrlUtility.MergeUrl(
+                xrefSpec.Href,
+                queries.AllKeys.Length == 0 ? "" : "?" + string.Join('&', queries),
+                fragment.Length == 0 ? "" : fragment.Substring(1));
 
-            return (error, resolvedHref, display, xrefSpec);
+            return (null, resolvedHref, display, xrefSpec);
         }
 
         private (Error error, string content, Document file) TryResolveContent(Document declaringFile, SourceInfo<string> href)

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -118,13 +118,16 @@ namespace Microsoft.Docs.Build
             var (error, resolvedHref, xrefSpec) = _xrefMap.Value.Resolve(Uri.UnescapeDataString(uid), href);
 
             var name = xrefSpec?.GetXrefPropertyValue("name");
-            if (xrefSpec is InternalXrefSpec internalSpec && internalSpec?.ContentTypeMapping.TryGetValue(displayProperty, out var contentType) == true)
+
+            // for internal UID, the display property can not be markdown or inline markdown
+            // because the display text should be plain text
+            string displayPropertyValue = null;
+            if (xrefSpec is InternalXrefSpec internalSpec
+                && !new JsonSchemaContentType[] { JsonSchemaContentType.Markdown, JsonSchemaContentType.InlineMarkdown }
+                .Contains(internalSpec.GetXrefPropertyContentType(displayProperty)))
             {
-                if (contentType != default && new JsonSchemaContentType[] { JsonSchemaContentType.InlineMarkdown, JsonSchemaContentType.Markdown }.Contains(contentType))
-                {
-                }
+                displayPropertyValue = xrefSpec.GetXrefPropertyValue(displayProperty);
             }
-            var displayPropertyValue =  xrefSpec?.GetXrefPropertyValue(displayProperty);
 
             // fallback order:
             // text -> xrefSpec.displayPropertyName -> xrefSpec.name -> uid

--- a/src/docfx/build/toc/parser/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsParser.cs
@@ -95,7 +95,8 @@ namespace Microsoft.Docs.Build
             // add to parent path
             if (t_recursionDetector.Value.Contains(file))
             {
-                var dependencyChain = t_recursionDetector.Value.Reverse();
+                var dependencyChain = t_recursionDetector.Value.Reverse().ToList();
+                dependencyChain.Add(file);
                 throw Errors.CircularReference(dependencyChain, file).ToException();
             }
 

--- a/src/docfx/build/toc/parser/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsParser.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build
@@ -14,6 +15,7 @@ namespace Microsoft.Docs.Build
     {
         private static readonly string[] s_tocFileNames = new[] { "TOC.md", "TOC.json", "TOC.yml" };
         private static readonly string[] s_experimentalTocFileNames = new[] { "TOC.experimental.md", "TOC.experimental.json", "TOC.experimental.yml" };
+        private static ThreadLocal<Stack<Document>> t_recursionDetector = new ThreadLocal<Stack<Document>>(() => new Stack<Document>());
 
         public static (List<Error> errors, TableOfContentsModel model, List<Document> referencedFiles, List<Document> referencedTocs)
             Load(Context context, Document file)
@@ -21,7 +23,7 @@ namespace Microsoft.Docs.Build
             var referencedFiles = new List<Document>();
             var referencedTocs = new List<Document>();
 
-            var (errors, model) = LoadInternal(context, file, file, referencedFiles, referencedTocs, new List<Document>());
+            var (errors, model) = LoadInternal(context, file, file, referencedFiles, referencedTocs);
 
             var (error, monikers) = context.MonikerProvider.GetFileLevelMonikers(file);
             errors.AddIfNotNull(error);
@@ -88,25 +90,31 @@ namespace Microsoft.Docs.Build
             Document rootPath,
             List<Document> referencedFiles,
             List<Document> referencedTocs,
-            List<Document> parents,
             string content = null)
         {
             // add to parent path
-            if (parents.Contains(file))
+            if (t_recursionDetector.Value.Contains(file))
             {
-                parents.Add(file);
-                throw Errors.CircularReference(parents, file).ToException();
+                var dependencyChain = t_recursionDetector.Value.Reverse();
+                throw Errors.CircularReference(dependencyChain, file).ToException();
             }
 
             var (errors, model) = LoadTocModel(context, file, content);
 
             if (model.Items.Count > 0)
             {
-                parents.Add(file);
-                var (resolveErros, newItems) = ResolveTocModelItems(context, model.Items, parents, file, rootPath, referencedFiles, referencedTocs);
-                errors.AddRange(resolveErros);
-                model.Items = newItems;
-                parents.RemoveAt(parents.Count - 1);
+                try
+                {
+                    t_recursionDetector.Value.Push(file);
+                    var (resolveErros, newItems) = ResolveTocModelItems(context, model.Items, file, rootPath, referencedFiles, referencedTocs);
+                    errors.AddRange(resolveErros);
+                    model.Items = newItems;
+                }
+                finally
+                {
+                    Debug.Assert(t_recursionDetector.Value.Count > 0);
+                    t_recursionDetector.Value.Pop();
+                }
             }
 
             return (errors, model);
@@ -115,7 +123,6 @@ namespace Microsoft.Docs.Build
         private static (List<Error> errors, List<TableOfContentsItem> items) ResolveTocModelItems(
             Context context,
             List<TableOfContentsItem> tocModelItems,
-            List<Document> parents,
             Document filePath,
             Document rootPath,
             List<Document> referencedFiles,
@@ -148,7 +155,7 @@ namespace Microsoft.Docs.Build
                 // resolve children
                 if (subChildren == null && tocModelItem.Items != null)
                 {
-                    var (subErrors, subItems) = ResolveTocModelItems(context, tocModelItem.Items, parents, filePath, rootPath, referencedFiles, referencedTocs);
+                    var (subErrors, subItems) = ResolveTocModelItems(context, tocModelItem.Items, filePath, rootPath, referencedFiles, referencedTocs);
                     newItem.Items = subItems;
                     errors.AddRange(subErrors);
                 }
@@ -269,7 +276,7 @@ namespace Microsoft.Docs.Build
                 var (referencedTocContent, referenceTocFilePath) = ResolveTocHrefContent(tocHrefType, new SourceInfo<string>(hrefPath, tocHref));
                 if (referencedTocContent != null)
                 {
-                    var (subErrors, nestedToc) = LoadInternal(context, referenceTocFilePath, rootPath, referencedFiles, referencedTocs, parents, referencedTocContent);
+                    var (subErrors, nestedToc) = LoadInternal(context, referenceTocFilePath, rootPath, referencedFiles, referencedTocs, referencedTocContent);
                     errors.AddRange(subErrors);
 
                     if (tocHrefType == TocHrefType.RelativeFolder)

--- a/src/docfx/build/toc/parser/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsParser.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Docs.Build
             if (parents.Contains(file))
             {
                 parents.Add(file);
-                throw Errors.CircularReference(parents).ToException();
+                throw Errors.CircularReference(parents, file).ToException();
             }
 
             var (errors, model) = LoadTocModel(context, file, content);

--- a/src/docfx/build/xref/ExternalXRefSpec.cs
+++ b/src/docfx/build/xref/ExternalXRefSpec.cs
@@ -21,9 +21,9 @@ namespace Microsoft.Docs.Build
         [JsonExtensionData]
         public JObject ExtensionData { get; } = new JObject();
 
-        public string GetName() => GetXrefPropertyValue("name");
+        public string GetName() => GetXrefPropertyValueAsString("name");
 
-        public string GetXrefPropertyValue(string propertyName)
+        public string GetXrefPropertyValueAsString(string propertyName)
         {
             if (propertyName != null && ExtensionData.TryGetValue<JValue>(propertyName, out var v))
             {

--- a/src/docfx/build/xref/IXrefSpec.cs
+++ b/src/docfx/build/xref/IXrefSpec.cs
@@ -13,6 +13,6 @@ namespace Microsoft.Docs.Build
 
         HashSet<string> Monikers { get; }
 
-        string GetXrefPropertyValue(string propertyName);
+        string GetXrefPropertyValueAsString(string propertyName);
     }
 }

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -66,7 +66,16 @@ namespace Microsoft.Docs.Build
 
             foreach (var (key, value) in ExtensionData)
             {
-                spec.ExtensionData[key] = value.Value;
+                try
+                {
+                    spec.ExtensionData[key] = value.Value;
+                }
+
+                // circular-reference is handled in JsonSchemaTransformer
+                // no need to throw it again for xref map output
+                catch (DocfxException ex) when (forXrefMapOutput && ex.Error.Code == "circular-reference")
+                {
+                }
             }
             return spec;
         }

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -65,16 +65,7 @@ namespace Microsoft.Docs.Build
 
             foreach (var (key, value) in ExtensionData)
             {
-                try
-                {
-                    spec.ExtensionData[key] = value.Value;
-                }
-
-                // circular-reference is handled in JsonSchemaTransformer
-                // no need to throw it again for xref map output
-                catch (DocfxException ex) when (forXrefMapOutput && ex.Error.Code == "circular-reference")
-                {
-                }
+                spec.ExtensionData[key] = value.Value;
             }
             return spec;
         }

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Docs.Build
 
         public Dictionary<string, JsonSchemaContentType> PropertyContentTypeMapping { get; } = new Dictionary<string, JsonSchemaContentType>();
 
-        public string GetXrefPropertyValue(string propertyName)
+        public string GetXrefPropertyValueAsString(string propertyName)
         {
             if (propertyName is null)
                 return null;
@@ -39,7 +39,7 @@ namespace Microsoft.Docs.Build
             return PropertyContentTypeMapping.TryGetValue(propertyName, out var value) ? value : default;
         }
 
-        public string GetName() => GetXrefPropertyValue("name");
+        public string GetName() => GetXrefPropertyValueAsString("name");
 
         public ExternalXrefSpec ToExternalXrefSpec(Context context, bool forXrefMapOutput)
         {

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Docs.Build
 
         public Dictionary<string, Lazy<JToken>> ExtensionData { get; } = new Dictionary<string, Lazy<JToken>>();
 
+        public Dictionary<string, JsonSchemaContentType> ContentTypeMapping { get; } = new Dictionary<string, JsonSchemaContentType>();
+
         public string GetXrefPropertyValue(string propertyName)
         {
             if (propertyName is null)

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -3,12 +3,18 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build
 {
     internal class InternalXrefSpec : IXrefSpec
     {
+        private static ThreadLocal<Stack<(string uid, Document parent)>> t_recursionDetector
+            = new ThreadLocal<Stack<(string, Document)>>(() => new Stack<(string, Document)>());
+
         public SourceInfo Source { get; set; }
 
         public string Uid { get; set; }
@@ -28,10 +34,10 @@ namespace Microsoft.Docs.Build
             if (propertyName is null)
                 return null;
 
-            // for internal UID, the display property can not be markdown or inline markdown
+            // for internal UID, the display property should only be plain text
             // because the display text should be plain text
             var contentType = GetXrefPropertyContentType(propertyName);
-            if (contentType != JsonSchemaContentType.Markdown && contentType != JsonSchemaContentType.InlineMarkdown)
+            if (contentType == JsonSchemaContentType.None)
             {
                 return ExtensionData.TryGetValue(propertyName, out var property) && property.Value is JValue propertyValue && propertyValue.Value is string internalStr ? internalStr : null;
             }
@@ -42,40 +48,55 @@ namespace Microsoft.Docs.Build
 
         public ExternalXrefSpec ToExternalXrefSpec(Context context, bool forXrefMapOutput)
         {
-            var spec = new ExternalXrefSpec
+            if (t_recursionDetector.Value.Contains((Uid, DeclaringFile)))
             {
-                Uid = Uid,
-                Monikers = Monikers,
-            };
-
-            if (forXrefMapOutput)
-            {
-                var (_, _, fragment) = UrlUtility.SplitUrl(Href);
-                var path = DeclaringFile.CanonicalUrlWithoutLocale;
-
-                // DHS appends branch infomation from cookie cache to URL, which is wrong for UID resolved URL
-                // output xref map with URL appending "?branch=master" for master branch
-                var query = DeclaringFile.Docset.Repository?.Branch == "master" ? "?branch=master" : "";
-                spec.Href = path + query + fragment;
-            }
-            else
-            {
-                // relative path for internal UID resolving
-                spec.Href = PathUtility.GetRelativePathToFile(DeclaringFile.SiteUrl, Href);
+                var referenceMap = t_recursionDetector.Value.Select(x => x.parent).ToList();
+                throw Errors.CircularReference(referenceMap).ToException();
             }
 
-            foreach (var (key, value) in ExtensionData)
+            try
             {
-                try
+                t_recursionDetector.Value.Push((Uid, DeclaringFile));
+                var spec = new ExternalXrefSpec
                 {
-                    spec.ExtensionData[key] = value.Value;
-                }
-                catch (DocfxException ex)
+                    Uid = Uid,
+                    Monikers = Monikers,
+                };
+
+                if (forXrefMapOutput)
                 {
-                    context.ErrorLog.Write(DeclaringFile, ex.Error);
+                    var (_, _, fragment) = UrlUtility.SplitUrl(Href);
+                    var path = DeclaringFile.CanonicalUrlWithoutLocale;
+
+                    // DHS appends branch infomation from cookie cache to URL, which is wrong for UID resolved URL
+                    // output xref map with URL appending "?branch=master" for master branch
+                    var query = DeclaringFile.Docset.Repository?.Branch == "master" ? "?branch=master" : "";
+                    spec.Href = path + query + fragment;
                 }
+                else
+                {
+                    // relative path for internal UID resolving
+                    spec.Href = PathUtility.GetRelativePathToFile(DeclaringFile.SiteUrl, Href);
+                }
+
+                foreach (var (key, value) in ExtensionData)
+                {
+                    try
+                    {
+                        spec.ExtensionData[key] = value.Value;
+                    }
+                    catch (DocfxException ex)
+                    {
+                        context.ErrorLog.Write(DeclaringFile, ex.Error);
+                    }
+                }
+                return spec;
             }
-            return spec;
+            finally
+            {
+                Debug.Assert(t_recursionDetector.Value.Count > 0);
+                t_recursionDetector.Value.Pop();
+            }
         }
 
         private JsonSchemaContentType GetXrefPropertyContentType(string propertyName)

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -28,15 +28,14 @@ namespace Microsoft.Docs.Build
             if (propertyName is null)
                 return null;
 
-            return ExtensionData.TryGetValue(propertyName, out var property) && property.Value is JValue propertyValue && propertyValue.Value is string internalStr ? internalStr : null;
-        }
-
-        public JsonSchemaContentType GetXrefPropertyContentType(string propertyName)
-        {
-            if (propertyName is null)
-                return default;
-
-            return PropertyContentTypeMapping.TryGetValue(propertyName, out var value) ? value : default;
+            // for internal UID, the display property can not be markdown or inline markdown
+            // because the display text should be plain text
+            var contentType = GetXrefPropertyContentType(propertyName);
+            if (contentType != JsonSchemaContentType.Markdown && contentType != JsonSchemaContentType.InlineMarkdown)
+            {
+                return ExtensionData.TryGetValue(propertyName, out var property) && property.Value is JValue propertyValue && propertyValue.Value is string internalStr ? internalStr : null;
+            }
+            return null;
         }
 
         public string GetName() => GetXrefPropertyValueAsString("name");
@@ -77,6 +76,14 @@ namespace Microsoft.Docs.Build
                 }
             }
             return spec;
+        }
+
+        private JsonSchemaContentType GetXrefPropertyContentType(string propertyName)
+        {
+            if (propertyName is null)
+                return default;
+
+            return PropertyContentTypeMapping.TryGetValue(propertyName, out var value) ? value : default;
         }
     }
 }

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Docs.Build
 {
     internal class InternalXrefSpec : IXrefSpec
     {
-
         public SourceInfo Source { get; set; }
 
         public string Uid { get; set; }
@@ -40,7 +39,7 @@ namespace Microsoft.Docs.Build
 
         public string GetName() => GetXrefPropertyValueAsString("name");
 
-        public ExternalXrefSpec ToExternalXrefSpec(Context context, bool forXrefMapOutput)
+        public ExternalXrefSpec ToExternalXrefSpec(bool forXrefMapOutput)
         {
             var spec = new ExternalXrefSpec
             {

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Docs.Build
 
         public Dictionary<string, Lazy<JToken>> ExtensionData { get; } = new Dictionary<string, Lazy<JToken>>();
 
-        public Dictionary<string, JsonSchemaContentType> ContentTypeMapping { get; } = new Dictionary<string, JsonSchemaContentType>();
+        public Dictionary<string, JsonSchemaContentType> PropertyContentTypeMapping { get; } = new Dictionary<string, JsonSchemaContentType>();
 
         public string GetXrefPropertyValue(string propertyName)
         {
@@ -29,6 +29,14 @@ namespace Microsoft.Docs.Build
                 return null;
 
             return ExtensionData.TryGetValue(propertyName, out var property) && property.Value is JValue propertyValue && propertyValue.Value is string internalStr ? internalStr : null;
+        }
+
+        public JsonSchemaContentType GetXrefPropertyContentType(string propertyName)
+        {
+            if (propertyName is null)
+                return default;
+
+            return PropertyContentTypeMapping.TryGetValue(propertyName, out var value) ? value : default;
         }
 
         public string GetName() => GetXrefPropertyValue("name");

--- a/src/docfx/build/xref/XrefMap.cs
+++ b/src/docfx/build/xref/XrefMap.cs
@@ -23,10 +23,10 @@ namespace Microsoft.Docs.Build
             return ResolveInternalXrefSpec(uid) ?? ResolveExternalXrefSpec(uid);
         }
 
-        public XrefMapModel ToXrefMapModel(Context context)
+        public XrefMapModel ToXrefMapModel()
         {
             var references = _internalXrefMap.Values
-                .Select(xref => xref.ToExternalXrefSpec(context, forXrefMapOutput: true))
+                .Select(xref => xref.ToExternalXrefSpec(forXrefMapOutput: true))
                 .OrderBy(xref => xref.Uid).ToArray();
 
             return new XrefMapModel { References = references };

--- a/src/docfx/build/xref/XrefMap.cs
+++ b/src/docfx/build/xref/XrefMap.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Docs.Build
 {
     internal class XrefMap
     {
-        // TODO: key could be uid+moniker+locale
         private readonly IReadOnlyDictionary<string, Lazy<ExternalXrefSpec>> _externalXrefMap;
         private readonly IReadOnlyDictionary<string, InternalXrefSpec> _internalXrefMap;
 
@@ -19,18 +18,9 @@ namespace Microsoft.Docs.Build
             _externalXrefMap = ExternalXrefMapLoader.Load(docset, restoreFileMap);
         }
 
-        public (Error error, string href, IXrefSpec xrefSpec) Resolve(string uid, SourceInfo<string> href)
+        public IXrefSpec Resolve(SourceInfo<string> uid)
         {
-            var spec = ResolveXrefSpec(uid);
-            if (spec is null)
-            {
-                return (Errors.XrefNotFound(href), null, null);
-            }
-
-            var (_, query, fragment) = UrlUtility.SplitUrl(spec.Href);
-            var resolvedHref = UrlUtility.MergeUrl(spec.Href, query, fragment.Length == 0 ? "" : fragment.Substring(1));
-
-            return (null, resolvedHref, spec);
+            return ResolveInternalXrefSpec(uid) ?? ResolveExternalXrefSpec(uid);
         }
 
         public XrefMapModel ToXrefMapModel(Context context)
@@ -40,11 +30,6 @@ namespace Microsoft.Docs.Build
                 .OrderBy(xref => xref.Uid).ToArray();
 
             return new XrefMapModel { References = references };
-        }
-
-        private IXrefSpec ResolveXrefSpec(string uid)
-        {
-            return ResolveInternalXrefSpec(uid) ?? ResolveExternalXrefSpec(uid);
         }
 
         private IXrefSpec ResolveExternalXrefSpec(string uid)

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Docs.Build
                                 {
                                     if (t_recursionDetector.Value.Contains((uid, file)))
                                     {
-                                        var referenceMap = t_recursionDetector.Value.Select(x => x.declaringFile).Reverse();
+                                        var referenceMap = t_recursionDetector.Value.Select(x => $"{uid} ({x.declaringFile})").Reverse();
                                         throw Errors.CircularReference(referenceMap, file).ToException();
                                     }
 

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -93,7 +93,8 @@ namespace Microsoft.Docs.Build
                                 {
                                     if (t_recursionDetector.Value.Contains((uid, file)))
                                     {
-                                        var referenceMap = t_recursionDetector.Value.Select(x => $"{uid} ({x.declaringFile})").Reverse();
+                                        var referenceMap = t_recursionDetector.Value.Select(x => $"{x.uid} ({x.declaringFile})").Reverse().ToList();
+                                        referenceMap.Add($"{uid} ({file})");
                                         throw Errors.CircularReference(referenceMap, file).ToException();
                                     }
 

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -236,8 +236,7 @@ namespace Microsoft.Docs.Build
                     break;
 
                 case JsonSchemaContentType.Xref:
-                    // the content must be an UID here
-                    var (xrefError, _, xrefSpec) = context.XrefMap.Resolve(content.Value, content);
+                    var (xrefError, _, _, xrefSpec) = context.DependencyResolver.ResolveAbsoluteXref(content, file);
 
                     if (xrefSpec is InternalXrefSpec internalSpec)
                     {

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Docs.Build
                         DeclaringFile = file,
                     };
                     xref.ExtensionData.AddRange(xrefProperties);
-                    xref.ContentTypeMapping.AddRange(contentTypeProperties);
+                    xref.PropertyContentTypeMapping.AddRange(contentTypeProperties);
                     return xref;
                 }
 

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -254,7 +254,7 @@ namespace Microsoft.Docs.Build
                         try
                         {
                             t_recursionDetector.Value.Push((content, file));
-                            xrefSpec = internalSpec.ToExternalXrefSpec(context, forXrefMapOutput: false);
+                            xrefSpec = internalSpec.ToExternalXrefSpec(forXrefMapOutput: false);
                         }
                         finally
                         {

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -93,8 +93,7 @@ namespace Microsoft.Docs.Build
                                 {
                                     if (t_recursionDetector.Value.Contains((uid, file)))
                                     {
-                                        var referenceMap = t_recursionDetector.Value.Select(x => x.declaringFile).ToList();
-                                        referenceMap.Insert(0, file);
+                                        var referenceMap = t_recursionDetector.Value.Select(x => x.declaringFile).Reverse();
                                         throw Errors.CircularReference(referenceMap, file).ToException();
                                     }
 

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -236,6 +236,7 @@ namespace Microsoft.Docs.Build
                     break;
 
                 case JsonSchemaContentType.Xref:
+                    // TODO: the content here must be an UID, not href
                     var (xrefError, _, _, xrefSpec) = context.DependencyResolver.ResolveAbsoluteXref(content, file);
 
                     if (xrefSpec is InternalXrefSpec internalSpec)

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -78,11 +78,13 @@ namespace Microsoft.Docs.Build
 
                 InternalXrefSpec GetXrefSpec(string uid, JObject obj)
                 {
+                    var contentTypeProperties = new Dictionary<string, JsonSchemaContentType>();
                     var xrefProperties = new Dictionary<string, Lazy<JToken>>();
                     TraverseObjectXref(obj, (propertySchema, key, value) =>
                     {
                         if (schema.XrefProperties.Contains(key))
                         {
+                            contentTypeProperties[key] = propertySchema.ContentType;
                             xrefProperties[key] = new Lazy<JToken>(
                                 () =>
                                 {
@@ -104,6 +106,7 @@ namespace Microsoft.Docs.Build
                         DeclaringFile = file,
                     };
                     xref.ExtensionData.AddRange(xrefProperties);
+                    xref.ContentTypeMapping.AddRange(contentTypeProperties);
                     return xref;
                 }
 

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -236,7 +236,8 @@ namespace Microsoft.Docs.Build
                     break;
 
                 case JsonSchemaContentType.Xref:
-                    var (xrefError, _, _, xrefSpec) = context.DependencyResolver.ResolveAbsoluteXref(content, file);
+                    // the content must be an UID here
+                    var (xrefError, _, xrefSpec) = context.XrefMap.Resolve(content.Value, content);
 
                     if (xrefSpec is InternalXrefSpec internalSpec)
                     {

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -236,7 +236,7 @@ namespace Microsoft.Docs.Build
                     break;
 
                 case JsonSchemaContentType.Xref:
-                    var (xrefError, xrefLink, _, xrefSpec) = context.DependencyResolver.ResolveAbsoluteXref(content, file);
+                    var (xrefError, _, _, xrefSpec) = context.DependencyResolver.ResolveAbsoluteXref(content, file);
 
                     if (xrefSpec is InternalXrefSpec internalSpec)
                     {


### PR DESCRIPTION
#3916 
- The content type of `displayProperty` is should be plain text with syntax `@uid?displayProperty` since the title of URL should be plain text
- We can not remove `Lazy` from xref spec property, because if multiple xref spec properties needs uid resolving, each of them would require xref map to be loaded, which is single instance for build. And it will cause 
`(ValueFactory attempted to access the Value property of this instance.)`
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5002)
- Handle circular reference caused by JsonSchemaTransformer for SDP reference