### PR TITLE
Resolve dependency using entry config

### DIFF
--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -702,7 +702,11 @@ repos:
         docs/a.md:
 outputs:
   docs/a.json: |
-    {"conceptual":"<p>sxs content\n<a href=\"b\">link to b</a></p>\n<p><a href=\"a\">link to a</a></p>\n", "enable_loc_sxs": true}
+    {
+      "conceptual": "
+        <p>sxs content\n<a href=\"b\">link to b</a></p>\n<p><a href=\"a\">link to a</a></p>\n",
+      "enable_loc_sxs": true
+    }
 ---
 # bilingual build 2
 # [branch mapping]

--- a/docs/specs/resolve.yml
+++ b/docs/specs/resolve.yml
@@ -297,6 +297,41 @@ outputs:
   .errors.log: |
     ["warning","link-is-dependency","File 'logo.svg' referenced by link '../dep/logo.svg' will not be built because it is from a dependency docset","docs/a.md",1,9]
 ---
+# Show warning if link from a token in dependency repo to a file in dependency repo
+repos:
+  https://github.com/dep-token/root:
+    - files:
+        docfx.yml: |
+          dependencies:
+            dep: https://github.com/dep-token/dep
+        a.md: '[!include[dep](~/dep/b.md)]'
+  https://github.com/dep-token/dep:
+    - files:
+        b.md: '[](logo.svg)'
+        logo.svg:
+outputs:
+  a.json: |
+    {"conceptual":"<p><a href=\"logo.svg\"></a></p>"}
+  .errors.log: |
+    ["warning","link-is-dependency","File 'logo.svg' referenced by link 'logo.svg' will not be built because it is from a dependency docset","b.md",1,1,"dependency"]
+---
+# Cannot include entry docset file from dependency
+repos:
+  https://github.com/dep-token-reference-entry/root:
+    - files:
+        docfx.yml: |
+          dependencies:
+            dep: https://github.com/dep-token-reference-entry/dep
+        a.md: '[!include[dep](~/dep/b.md)]'
+  https://github.com/dep-token-reference-entry/dep:
+    - files:
+        b.md: '[](~/a.md)'
+outputs:
+  a.json: |
+    {"conceptual":"<p><a href=\"%7E/a.md\"></a></p>"}
+  .errors.log: |
+    ["warning","file-not-found","Invalid file link: '~/a.md'.","b.md",1,1,"dependency"]
+---
 # Don't show warning if include a file from dependency repo
 repos:
   https://github.com/dep-include/root:

--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -20,7 +20,7 @@ outputs:
   docs/a.json: |
     {"conceptual":"<p><a href=\"%7E/docfx-test-dependencies1/docs/a.md\">link to 1</a></p>\n<p>a1</p>\n"}
 ---
-# [Skip]Restore dependencies azure repos with their children
+# Restore dependencies azure repos with their children
 repos:
   https://docascode.visualstudio.com/project/_git/a:
     - files:
@@ -118,6 +118,7 @@ inputs:
 outputs:
   .errors.log: |
     ["error","committish-not-found","Can't find branch, tag, or commit 'bad-branch' for repo https://github.com/docascode/docfx-test-dependencies."]
+    ["error","need-restore","Cannot find dependency 'https://github.com/docascode/docfx-test-dependencies#bad-branch', did you forget to run `docfx restore`?"]
 ---
 # Show error when dependent repo can't be found
 restore: false
@@ -129,7 +130,7 @@ inputs:
     [test](dep/abc)
 outputs:
   .errors.log: |
-    ["error","need-restore","Cannot find dependency 'https://github.com/docascode/docfx-test-dependencies#bad-branch', did you forget to run `docfx restore`?","docs/a.md"]
+    ["error","need-restore","Cannot find dependency 'https://github.com/docascode/docfx-test-dependencies#bad-branch', did you forget to run `docfx restore`?"]
 ---
 # Show error when dependent URL can't be found
 restore: false
@@ -191,27 +192,10 @@ repos:
     - files:
         docfx.yml: |
           dependencies:
-            dep1: https://docs.com/lock1/b#master
             dep2: https://docs.com/lock1/c
           dependencyLock: '{CACHE_PATH}.lock.json'
         docs/a.md: |
-          [!include[](~/dep1/docs/dep1.md)]
           [!include[](~/dep2/docs/dep2.md)]
-  https://docs.com/lock1/b:
-    - files:
-        docs/dep1.md: |
-          "abc"
-          [!include[](~/dep2/docs/dep2.md)]
-        docfx.yml: |
-          dependencies:
-            dep2: https://docs.com/lock1/c
-    - files:
-        docs/dep1.md: |
-          "def"
-          [!include[](~/dep2/docs/dep2.md)]
-        docfx.yml: |
-          dependencies:
-            dep2: https://docs.com/lock1/c
   https://docs.com/lock1/c:
     - files:
         docs/dep2.md: "2333"
@@ -220,20 +204,15 @@ repos:
 cache:
   .lock.json: |
     {
-       "git":{
-          "https://docs.com/lock1/b":{
-             "commit":"6a7b7f142f2de52a0b488309f4257d462956f59f",
-             "git":{
-                "https://docs.com/lock1/c#master":{
-                   "commit":"8720d784fb99abcbdfa922025b8bcc060f0f622a"
-                }
-             }
-          }
-       }
+      "git":{
+         "https://docs.com/lock1/c#master":{
+            "commit":"8720d784fb99abcbdfa922025b8bcc060f0f622a"
+         }
+      }
     }
 outputs:
   docs/a.json: |
-    {"conceptual":"<p>&quot;def&quot;</p>\n<p>233333</p>\n<p>2333</p>\n"}
+    {"conceptual":"<p>233333</p>\n"}
 ---
 # [skip] restore with wrong dependency version
 repos:
@@ -266,27 +245,10 @@ repos:
     - files:
         docfx.yml: |
           dependencies:
-            dep1: https://docascode.visualstudio.com/lock/_git/b#master
             dep2: https://docascode.visualstudio.com/lock/_git/c
           dependencyLock: {CACHE_PATH}.lock.json
         docs/a.md: |
-          [!include[](~/dep1/docs/dep1.md)]
           [!include[](~/dep2/docs/dep2.md)]
-  https://docascode.visualstudio.com/lock/_git/b:
-    - files:
-        docs/dep1.md: |
-          "abc"
-          [!include[](~/dep2/docs/dep2.md)]
-        docfx.yml: |
-          dependencies:
-            dep2: https://docascode.visualstudio.com/lock/_git/c
-    - files:
-        docs/dep1.md: |
-          "def"
-          [!include[](~/dep2/docs/dep2.md)]
-        docfx.yml: |
-          dependencies:
-            dep2: https://docascode.visualstudio.com/lock/_git/c
   https://docascode.visualstudio.com/lock/_git/c:
     - files:
         docs/dep2.md: "2333"
@@ -294,121 +256,13 @@ repos:
         docs/dep2.md: "233333"
 cache:
   .lock.json: |
-    {  
-       "git":{  
-          "https://docascode.visualstudio.com/lock/_git/b":{
-             "commit":"921c49b9f8d6889d36d8aadc570922462963348d",
-             "git":{  
-                "https://docascode.visualstudio.com/lock/_git/c#master":{
-                   "commit":"8720d784fb99abcbdfa922025b8bcc060f0f622a"
-                }
-             }
-          },
-          "https://docascode.visualstudio.com/lock/_git/c#master": {
-            "commit": "c5969737496ff42854a019f982882d5fac486a56"
-          }
-       }
-    }
-outputs:
-  docs/a.json: |
-    {"conceptual":"<p>&quot;def&quot;</p>\n<p>233333</p>\n<p>2333</p>\n"}
----
-# restore with sub dependency lock only, sub dependency lock doesn't work
-repos:
-  https://docs.com/lock2/a#master:
-    - files:
-        docfx.yml: |
-          dependencies:
-            dep1: https://docs.com/lock2/b#master
-          dependencyLock: '{CACHE_PATH}.non-exist.json'
-        docs/a.md: |
-          [!include[](~/dep1/docs/dep1.md)]
-  https://docs.com/lock2/b:
-    - files:
-        docs/dep1.md: |
-          "abc"
-          [!include[](~/dep2/docs/dep2.md)]
-        docfx.yml: |
-          dependencies:
-            dep2: https://docs.com/lock2/c
-          dependencyLock: '{CACHE_PATH}.lock.json'
-    - files:
-        docs/dep1.md: |
-          "def"
-          [!include[](~/dep2/docs/dep2.md)]
-        docfx.yml: |
-          dependencies:
-            dep2: https://docs.com/lock2/c
-  https://docs.com/lock2/c:
-    - files:
-        docs/dep2.md: "2333"
-    - files:
-        docs/dep2.md: "233333"
-cache:
-  .lock.json: |
     {
-       "git":{
-          "https://docs.com/lock2/c#master":{
-             "commit":"8720d784fb99abcbdfa922025b8bcc060f0f622a"
-          }
-       }
+      "git":{  
+         "https://docascode.visualstudio.com/lock/_git/c#master":{
+            "commit":"8720d784fb99abcbdfa922025b8bcc060f0f622a"
+         }
+      }
     }
 outputs:
   docs/a.json: |
-    {"conceptual":"<p>&quot;abc&quot;</p>\n<p>2333</p>"}
----
-# restore with root and sub dependency lock, root lock wins
-repos:
-  https://docs.com/lock3/a#master:
-    - files:
-        docfx.yml: |
-          dependencies:
-            dep1: https://docs.com/lock3/b#master
-          dependencyLock: '{CACHE_PATH}.lock.json'
-        docs/a.md: |
-          [!include[](~/dep1/docs/dep1.md)]
-  https://docs.com/lock3/b:
-    - files:
-        docs/dep1.md: |
-          "abc"
-          [!include[](~/dep2/docs/dep2.md)]
-        docfx.yml: |
-          dependencies:
-            dep2: https://docs.com/lock3/c
-          dependencyLock: .lock.json
-        .lock.json: |
-          {
-             "git":{
-                "https://docs.com/lock3/c#master":{
-                   "commit":"8720d784fb99abcbdfa922025b8bcc060f0f622a"
-                }
-             }
-          }
-    - files:
-        docs/dep1.md: |
-          "def"
-          [!include[](~/dep2/docs/dep2.md)]
-        docfx.yml: |
-          dependencies:
-            dep2: https://docs.com/lock3/c
-  https://docs.com/lock3/c:
-    - files:
-        docs/dep2.md: "2333"
-    - files:
-        docs/dep2.md: "233333"
-cache:
-  .lock.json: |
-    {  
-       "git":{  
-          "https://docs.com/lock3/b":{  
-             "git":{  
-                "https://docs.com/lock3/c#master":{  
-                   "commit":"c5969737496ff42854a019f982882d5fac486a56"
-                }
-             }
-          }
-       }
-    }
-outputs:
-  docs/a.json: |
-    {"conceptual":"<p>&quot;abc&quot;</p>\n<p>2333</p>"}
+    {"conceptual":"<p>233333</p>"}

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Docs.Build
 
                 var gitMap = fallbackRestoreGitMap ?? restoreGitMap;
                 var (docset, fallbackDocset) = GetDocsetWithFallback(
-                    docsetPath, options, errorLog, repository, locale, fallbackRepo, config, gitMap);
+                    docsetPath, repository, locale, fallbackRepo, config, gitMap);
                 var outputPath = Path.Combine(docsetPath, config.Output.Path);
 
                 await Run(docset, fallbackDocset, gitMap, options, errorLog, outputPath);
@@ -40,20 +40,18 @@ namespace Microsoft.Docs.Build
 
         private static (Docset docset, Docset fallbackDocset) GetDocsetWithFallback(
             string docsetPath,
-            CommandLineOptions options,
-            ErrorLog errorLog,
             Repository repository,
             string locale,
             Repository fallbackRepo,
             Config config,
             RestoreGitMap gitMap)
         {
-            var currentDocset = new Docset(errorLog, docsetPath, locale, config, options, gitMap, repository);
+            var currentDocset = new Docset(docsetPath, locale, config, repository);
             if (!string.IsNullOrEmpty(currentDocset.Locale) && !string.Equals(currentDocset.Locale, config.Localization.DefaultLocale))
             {
                 if (fallbackRepo != null)
                 {
-                    return (currentDocset, new Docset(errorLog, fallbackRepo.Path, locale, config, options, gitMap, fallbackRepo));
+                    return (currentDocset, new Docset(fallbackRepo.Path, locale, config, fallbackRepo));
                 }
 
                 if (LocalizationUtility.TryGetLocalizedDocsetPath(
@@ -65,8 +63,7 @@ namespace Microsoft.Docs.Build
                     out var localizationBranch))
                 {
                     var repo = Repository.Create(localizationDocsetPath, localizationBranch);
-                    return (new Docset(
-                        errorLog, localizationDocsetPath, currentDocset.Locale, config, options, gitMap, repo), currentDocset);
+                    return (new Docset(localizationDocsetPath, currentDocset.Locale, config, repo), currentDocset);
                 }
             }
 

--- a/src/docfx/build/context/BuildScope.cs
+++ b/src/docfx/build/context/BuildScope.cs
@@ -25,16 +25,10 @@ namespace Microsoft.Docs.Build
 
         public RedirectionMap Redirections { get; }
 
-        public Docset Docset { get; }
-
-        public Docset FallbackDocset { get; }
-
         public BuildScope(ErrorLog errorLog, Docset docset, Docset fallbackDocset, TemplateEngine templateEngine)
         {
             var config = docset.Config;
 
-            Docset = docset;
-            FallbackDocset = fallbackDocset;
             _glob = CreateGlob(config);
             _templateEngine = templateEngine;
 

--- a/src/docfx/build/context/BuildScope.cs
+++ b/src/docfx/build/context/BuildScope.cs
@@ -17,8 +17,6 @@ namespace Microsoft.Docs.Build
         private readonly HashSet<string> _fileNames;
         private readonly Func<string, bool> _glob;
         private readonly TemplateEngine _templateEngine;
-        private readonly Docset _fallbackDocset;
-        private readonly Docset _docset;
 
         /// <summary>
         /// Gets all the files to build, including redirections and fallback files.
@@ -27,19 +25,23 @@ namespace Microsoft.Docs.Build
 
         public RedirectionMap Redirections { get; }
 
+        public Docset Docset { get; }
+
+        public Docset FallbackDocset { get; }
+
         public BuildScope(ErrorLog errorLog, Docset docset, Docset fallbackDocset, TemplateEngine templateEngine)
         {
             var config = docset.Config;
 
-            _docset = docset;
-            _fallbackDocset = fallbackDocset;
+            Docset = docset;
+            FallbackDocset = fallbackDocset;
             _glob = CreateGlob(config);
             _templateEngine = templateEngine;
 
-            var (fileNames, files) = GetFiles(docset, _glob);
+            var (fileNames, files) = GetFiles(FileOrigin.Default, docset, _glob);
 
             var fallbackFiles = fallbackDocset != null
-                ? GetFiles(fallbackDocset, CreateGlob(fallbackDocset.Config)).files
+                ? GetFiles(FileOrigin.Fallback, fallbackDocset, CreateGlob(fallbackDocset.Config)).files
                 : Enumerable.Empty<Document>();
 
             _fileNames = fileNames;
@@ -56,35 +58,8 @@ namespace Microsoft.Docs.Build
             return _fileNames.TryGetValue(fileName, out actualFileName);
         }
 
-        public Docset GetFallbackDocset(Docset docset)
-            => docset == _docset || docset == _fallbackDocset ? _fallbackDocset : null;
-
-        public bool TryResolveDocset(Docset docset, string file, out (Docset resolvedDocset, FileOrigin fileOrigin) resolved)
-        {
-            docset = docset == _fallbackDocset ? _docset : docset;
-            var fallbackDocset = GetFallbackDocset(docset);
-            resolved = default;
-
-            // resolve from current docset
-            if (File.Exists(Path.Combine(docset.DocsetPath, file)))
-            {
-                resolved.resolvedDocset = docset;
-                resolved.fileOrigin = FileOrigin.Current;
-                return true;
-            }
-
-            // resolve from fallback docset
-            if (fallbackDocset != null && File.Exists(Path.Combine(fallbackDocset.DocsetPath, file)))
-            {
-                resolved.resolvedDocset = fallbackDocset;
-                resolved.fileOrigin = FileOrigin.Fallback;
-                return true;
-            }
-
-            return false;
-        }
-
-        private (HashSet<string> fileNames, IReadOnlyList<Document> files) GetFiles(Docset docset, Func<string, bool> glob)
+        private (HashSet<string> fileNames, IReadOnlyList<Document> files) GetFiles(
+            FileOrigin origin, Docset docset, Func<string, bool> glob)
         {
             using (Progress.Start("Globbing files"))
             {
@@ -99,16 +74,13 @@ namespace Microsoft.Docs.Build
                 {
                     if (glob(file))
                     {
-                        files.Add(Document.Create(docset, file, _templateEngine, GetOrigin(docset)));
+                        files.Add(Document.Create(docset, new FilePath(file, origin), _templateEngine));
                     }
                 });
 
                 return (fileNames, files.ToList());
             }
         }
-
-        private FileOrigin GetOrigin(Docset docset)
-            => docset == _fallbackDocset ? FileOrigin.Fallback : FileOrigin.Current;
 
         private static Func<string, bool> CreateGlob(Config config)
         {

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -56,11 +56,12 @@ namespace Microsoft.Docs.Build
             PublishModelBuilder = new PublishModelBuilder();
             BookmarkValidator = new BookmarkValidator(errorLog, PublishModelBuilder);
             DependencyResolver = new DependencyResolver(
-                docset.Config,
+                docset,
                 BuildScope,
                 BuildQueue,
                 GitCommitProvider,
                 BookmarkValidator,
+                restoreGitMap,
                 DependencyMapBuilder,
                 _xrefMap,
                 TemplateEngine);

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -55,8 +55,11 @@ namespace Microsoft.Docs.Build
             GitCommitProvider = new GitCommitProvider();
             PublishModelBuilder = new PublishModelBuilder();
             BookmarkValidator = new BookmarkValidator(errorLog, PublishModelBuilder);
+            ContributionProvider = new ContributionProvider(docset, fallbackDocset, GitHubUserCache, GitCommitProvider);
+
             DependencyResolver = new DependencyResolver(
                 docset,
+                fallbackDocset,
                 BuildScope,
                 BuildQueue,
                 GitCommitProvider,
@@ -65,7 +68,6 @@ namespace Microsoft.Docs.Build
                 DependencyMapBuilder,
                 _xrefMap,
                 TemplateEngine);
-            ContributionProvider = new ContributionProvider(docset, GitHubUserCache, GitCommitProvider);
         }
 
         public void Dispose()

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -283,15 +283,15 @@ namespace Microsoft.Docs.Build
             return docsetRelativePath;
         }
 
-        private Document TryResolveFile(Document declaringFile, string pathToDocset)
+        private Document TryResolveFile(Document referencingFile, string pathToDocset)
         {
             // resolve from the current docset for files in dependencies
-            if (declaringFile.FilePath.Origin == FileOrigin.Dependency)
+            if (referencingFile.FilePath.Origin == FileOrigin.Dependency)
             {
-                if (File.Exists(Path.Combine(declaringFile.Docset.DocsetPath, pathToDocset)))
+                if (File.Exists(Path.Combine(referencingFile.Docset.DocsetPath, pathToDocset)))
                 {
-                    var path = new FilePath(pathToDocset, declaringFile.FilePath.DependencyName);
-                    return Document.Create(declaringFile.Docset, path, _templateEngine);
+                    var path = new FilePath(pathToDocset, referencingFile.FilePath.DependencyName);
+                    return Document.Create(referencingFile.Docset, path, _templateEngine);
                 }
                 return null;
             }

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -133,10 +133,8 @@ namespace Microsoft.Docs.Build
             List<GitCommit> GetContributionCommits()
             {
                 var result = commits;
-                var bilingual = context.BuildScope.GetFallbackDocset(document.Docset) != null
-                    && document.Docset.Config.Localization.Bilingual;
-                var contributionBranch = bilingual
-                    && LocalizationUtility.TryGetContributionBranch(repo.Branch, out var cBranch) ? cBranch : null;
+                var bilingual = context.BuildScope.FallbackDocset != null && document.Docset.Config.Localization.Bilingual;
+                var contributionBranch = bilingual && LocalizationUtility.TryGetContributionBranch(repo.Branch, out var cBranch) ? cBranch : null;
                 if (!string.IsNullOrEmpty(contributionBranch))
                 {
                     (_, _, result) = _gitCommitProvider.GetCommitHistory(document, contributionBranch);
@@ -196,7 +194,7 @@ namespace Microsoft.Docs.Build
                     (branchUrlTemplate, _) = GetContentGitUrlTemplate(contributionRemote, pathToRepo);
 
                     (editRemote, editBranch) = (contributionRemote, hasRefSpec ? contributionBranch : editBranch);
-                    if (context.BuildScope.GetFallbackDocset(document.Docset) != null)
+                    if (context.BuildScope.FallbackDocset != null)
                     {
                         (editRemote, editBranch) = LocalizationUtility.GetLocalizedRepo(
                                                     document.Docset.Config.Localization.Mapping,

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Docs.Build
 {
     internal class ContributionProvider
     {
+        private readonly Docset _fallbackDocset;
         private readonly GitHubUserCache _gitHubUserCache;
 
         // TODO: support CRR and multiple repositories
@@ -19,18 +20,20 @@ namespace Microsoft.Docs.Build
 
         private readonly GitCommitProvider _gitCommitProvider;
 
-        public ContributionProvider(Docset docset, GitHubUserCache gitHubUserCache, GitCommitProvider gitCommitProvider)
+        public ContributionProvider(
+            Docset docset, Docset fallbackDocset, GitHubUserCache gitHubUserCache, GitCommitProvider gitCommitProvider)
         {
             Debug.Assert(gitCommitProvider != null);
 
             _gitHubUserCache = gitHubUserCache;
             _gitCommitProvider = gitCommitProvider;
+            _fallbackDocset = fallbackDocset;
             _commitBuildTimeProvider = docset.Repository != null && docset.Config.UpdateTimeAsCommitBuildTime
                 ? new CommitBuildTimeProvider(docset.Repository) : null;
         }
 
         public async Task<(List<Error> errors, ContributionInfo contributionInfo)> GetContributionInfo(
-            Context context, Document document, SourceInfo<string> authorName)
+            Document document, SourceInfo<string> authorName)
         {
             Debug.Assert(document != null);
             var (repo, pathToRepo, commits) = _gitCommitProvider.GetCommitHistory(document);
@@ -133,7 +136,7 @@ namespace Microsoft.Docs.Build
             List<GitCommit> GetContributionCommits()
             {
                 var result = commits;
-                var bilingual = context.BuildScope.FallbackDocset != null && document.Docset.Config.Localization.Bilingual;
+                var bilingual = _fallbackDocset != null && document.Docset.Config.Localization.Bilingual;
                 var contributionBranch = bilingual && LocalizationUtility.TryGetContributionBranch(repo.Branch, out var cBranch) ? cBranch : null;
                 if (!string.IsNullOrEmpty(contributionBranch))
                 {
@@ -157,7 +160,7 @@ namespace Microsoft.Docs.Build
         }
 
         public (string contentGitUrl, string originalContentGitUrl, string originalContentGitUrlTemplate, string gitCommit)
-            GetGitUrls(Context context, Document document)
+            GetGitUrls(Document document)
         {
             Debug.Assert(document != null);
 
@@ -194,7 +197,7 @@ namespace Microsoft.Docs.Build
                     (branchUrlTemplate, _) = GetContentGitUrlTemplate(contributionRemote, pathToRepo);
 
                     (editRemote, editBranch) = (contributionRemote, hasRefSpec ? contributionBranch : editBranch);
-                    if (context.BuildScope.FallbackDocset != null)
+                    if (_fallbackDocset != null)
                     {
                         (editRemote, editBranch) = LocalizationUtility.GetLocalizedRepo(
                                                     document.Docset.Config.Localization.Mapping,

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -152,11 +152,11 @@ namespace Microsoft.Docs.Build
             (systemMetadata.DocumentId, systemMetadata.DocumentVersionIndependentId)
                 = context.BuildScope.Redirections.TryGetDocumentId(file, out var docId) ? docId : file.Id;
             (systemMetadata.ContentGitUrl, systemMetadata.OriginalContentGitUrl, systemMetadata.OriginalContentGitUrlTemplate,
-                systemMetadata.Gitcommit) = context.ContributionProvider.GetGitUrls(context, file);
+                systemMetadata.Gitcommit) = context.ContributionProvider.GetGitUrls(file);
 
             List<Error> contributorErrors;
             (contributorErrors, systemMetadata.ContributionInfo) = await context.ContributionProvider.GetContributionInfo(
-                context, file, inputMetadata.Author);
+                file, inputMetadata.Author);
             systemMetadata.Author = systemMetadata.ContributionInfo?.Author?.Name;
             systemMetadata.UpdatedAt = systemMetadata.ContributionInfo?.UpdatedAtDateTime.ToString("yyyy-MM-dd hh:mm tt");
 

--- a/src/docfx/build/redirection/RedirectionMap.cs
+++ b/src/docfx/build/redirection/RedirectionMap.cs
@@ -104,9 +104,7 @@ namespace Microsoft.Docs.Build
                         }
                     }
 
-                    var redirect = Document.Create(
-                        docset, pathToDocset, templateEngine, redirectionUrl: mutableRedirectUrl, combineRedirectUrl: combineRedirectUrl);
-
+                    var redirect = Document.Create(docset, new FilePath(pathToDocset, FileOrigin.Redirection), templateEngine, redirectionUrl: mutableRedirectUrl, combineRedirectUrl: combineRedirectUrl);
                     if (redirectDocumentId)
                     {
                         redirectionsWithDocumentId.Add((redirectUrl, redirect));

--- a/src/docfx/build/redirection/RedirectionMap.cs
+++ b/src/docfx/build/redirection/RedirectionMap.cs
@@ -104,7 +104,9 @@ namespace Microsoft.Docs.Build
                         }
                     }
 
-                    var redirect = Document.Create(docset, new FilePath(pathToDocset, FileOrigin.Redirection), templateEngine, redirectionUrl: mutableRedirectUrl, combineRedirectUrl: combineRedirectUrl);
+                    var filePath = new FilePath(pathToDocset, FileOrigin.Redirection);
+                    var redirect = Document.Create(
+                        docset, filePath, templateEngine, mutableRedirectUrl, isFromHistory: false, combineRedirectUrl);
                     if (redirectDocumentId)
                     {
                         redirectionsWithDocumentId.Add((redirectUrl, redirect));

--- a/src/docfx/cli/CommandLineOptions.cs
+++ b/src/docfx/cli/CommandLineOptions.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Docs.Build
 
             var result = new JObject();
             result["output"] = output;
+            result["legacy"] = Legacy;
 
             if (Template != null)
                 result["template"] = Template;

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -70,6 +70,11 @@ namespace Microsoft.Docs.Build
         public readonly string[] Extend = Array.Empty<string>();
 
         /// <summary>
+        /// Gets whether we are running in legacy mode
+        /// </summary>
+        public readonly bool Legacy;
+
+        /// <summary>
         /// Gets the file metadata added to each document.
         /// It is a map of `{metadata-name} -> {glob} -> {metadata-value}`
         /// </summary>

--- a/src/docfx/docset/Docset.cs
+++ b/src/docfx/docset/Docset.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Gets a value indicating whether enable legacy output.
         /// </summary>
-        public bool Legacy => _options.Legacy;
+        public bool Legacy => Config.Legacy;
 
         /// <summary>
         /// Gets the reversed <see cref="Config.Routes"/> for faster lookup.
@@ -60,27 +60,10 @@ namespace Microsoft.Docs.Build
         /// </summary>
         public string HostName { get; }
 
-        /// <summary>
-        /// Gets the dependent docsets
-        /// </summary>
-        public IReadOnlyDictionary<string, Docset> DependencyDocsets => _dependencyDocsets.Value;
-
-        private readonly CommandLineOptions _options;
-        private readonly ErrorLog _errorLog;
         private readonly ConcurrentDictionary<string, Lazy<Repository>> _repositories;
-        private readonly Lazy<IReadOnlyDictionary<string, Docset>> _dependencyDocsets;
 
-        public Docset(
-            ErrorLog errorLog,
-            string docsetPath,
-            string locale,
-            Config config,
-            CommandLineOptions options,
-            RestoreGitMap restoreGitMap,
-            Repository repository = null)
+        public Docset(string docsetPath, string locale, Config config, Repository repository = null)
         {
-            _options = options;
-            _errorLog = errorLog;
             Config = config;
             DocsetPath = PathUtility.NormalizeFolder(Path.GetFullPath(docsetPath));
             Locale = !string.IsNullOrEmpty(locale) ? locale.ToLowerInvariant() : config.Localization.DefaultLocale;
@@ -89,13 +72,6 @@ namespace Microsoft.Docs.Build
             (HostName, SiteBasePath) = SplitBaseUrl(config.BaseUrl);
 
             Repository = repository ?? Repository.Create(DocsetPath, branch: null);
-
-            _dependencyDocsets = new Lazy<IReadOnlyDictionary<string, Docset>>(() =>
-            {
-                var (errors, dependencies) = LoadDependencies(_errorLog, docsetPath, Config, Locale, restoreGitMap, _options);
-                _errorLog.Write(errors);
-                return dependencies;
-            });
 
             _repositories = new ConcurrentDictionary<string, Lazy<Repository>>();
         }
@@ -145,25 +121,6 @@ namespace Microsoft.Docs.Build
             {
                 throw Errors.LocaleInvalid(locale).ToException();
             }
-        }
-
-        private static (List<Error>, Dictionary<string, Docset>) LoadDependencies(
-            ErrorLog errorLog, string docsetPath, Config config, string locale, RestoreGitMap restoreGitMap, CommandLineOptions options)
-        {
-            var errors = new List<Error>();
-            var result = new Dictionary<string, Docset>(config.Dependencies.Count, PathUtility.PathComparer);
-            foreach (var (name, dependency) in config.Dependencies)
-            {
-                var (dir, subRestoreMap) = restoreGitMap.GetGitRestorePath(dependency, docsetPath);
-
-                // get dependent docset config or default config
-                // todo: what parent config should be pass on its children
-                var (loadErrors, subConfig) = ConfigLoader.TryLoad(dir, options, locale);
-                errors.AddRange(loadErrors);
-
-                result.TryAdd(PathUtility.NormalizeFolder(name), new Docset(errorLog, dir, locale, subConfig, options, subRestoreMap));
-            }
-            return (errors, result);
         }
 
         private static (string hostName, string siteBasePath) SplitBaseUrl(string baseUrl)

--- a/src/docfx/lib/log/Error.cs
+++ b/src/docfx/lib/log/Error.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Docs.Build
             object[] payload = { level, Code, Message, FilePath?.Path, Line, Column, FilePath?.Origin };
 
             var i = payload.Length - 1;
-            while (i >= 0 && (Equals(payload[i], null) || Equals(payload[i], "") || Equals(payload[i], 0) || Equals(payload[i], FileOrigin.Current)))
+            while (i >= 0 && (Equals(payload[i], null) || Equals(payload[i], "") || Equals(payload[i], 0) || Equals(payload[i], FileOrigin.Default)))
             {
                 i--;
             }

--- a/src/docfx/lib/path/FileOrigin.cs
+++ b/src/docfx/lib/path/FileOrigin.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Docs.Build
     public enum FileOrigin
     {
         /// <summary>
-        /// This file is coming from the default docset folder.
+        /// This file is coming from the main docset folder.
         /// </summary>
         Default,
 

--- a/src/docfx/lib/path/FileOrigin.cs
+++ b/src/docfx/lib/path/FileOrigin.cs
@@ -6,13 +6,23 @@ namespace Microsoft.Docs.Build
     public enum FileOrigin
     {
         /// <summary>
-        /// Current repository
+        /// This file is coming from the default docset folder.
         /// </summary>
-        Current,
+        Default,
 
         /// <summary>
-        /// Fallback repository
+        /// This file is coming from a dependency repository
+        /// </summary>
+        Dependency,
+
+        /// <summary>
+        /// This file is coming from the fallback repository of a localized build
         /// </summary>
         Fallback,
+
+        /// <summary>
+        /// This file is a redirection file
+        /// </summary>
+        Redirection,
     }
 }

--- a/src/docfx/lib/path/FilePath.cs
+++ b/src/docfx/lib/path/FilePath.cs
@@ -2,25 +2,40 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 
 namespace Microsoft.Docs.Build
 {
     internal class FilePath : IEquatable<FilePath>, IComparable<FilePath>
     {
         /// <summary>
-        /// The file relative path
+        /// Gets the file path relative to the owning repository or docset.
         /// </summary>
         public string Path { get; }
+
+        /// <summary>
+        /// Gets the name of the dependency if it is from dependency repo.
+        /// </summary>
+        public string DependencyName { get; }
 
         /// <summary>
         /// Gets the value to indicate where is this file from
         /// </summary>
         public FileOrigin Origin { get; }
 
-        public FilePath(string path, FileOrigin from = FileOrigin.Current)
+        public FilePath(string path, FileOrigin from = FileOrigin.Default)
         {
-            Path = path;
+            Debug.Assert(from != FileOrigin.Dependency);
+
+            Path = PathUtility.NormalizeFile(path);
             Origin = from;
+        }
+
+        public FilePath(string path, string dependencyName)
+        {
+            Path = PathUtility.NormalizeFile(path);
+            DependencyName = dependencyName;
+            Origin = FileOrigin.Dependency;
         }
 
         public static bool operator ==(FilePath a, FilePath b) => Equals(a, b);
@@ -36,7 +51,7 @@ namespace Microsoft.Docs.Build
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(PathUtility.PathComparer.GetHashCode(Path), Origin);
+            return HashCode.Combine(PathUtility.PathComparer.GetHashCode(Path), Origin, DependencyName);
         }
 
         public bool Equals(FilePath other)
@@ -46,7 +61,9 @@ namespace Microsoft.Docs.Build
                 return false;
             }
 
-            return string.Equals(Path, other.Path, PathUtility.PathComparison) && other.Origin == Origin;
+            return string.Equals(Path, other.Path, PathUtility.PathComparison) &&
+                   other.Origin == Origin &&
+                   DependencyName == other.DependencyName;
         }
 
         public int CompareTo(FilePath other)
@@ -54,6 +71,8 @@ namespace Microsoft.Docs.Build
             var result = string.Compare(Path, other.Path, PathUtility.PathComparison);
             if (result == 0)
                 result = Origin.CompareTo(other.Origin);
+            if (result == 0)
+                result = DependencyName.CompareTo(other.DependencyName);
 
             return result;
         }

--- a/src/docfx/lib/path/FilePath.cs
+++ b/src/docfx/lib/path/FilePath.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Docs.Build
     internal class FilePath : IEquatable<FilePath>, IComparable<FilePath>
     {
         /// <summary>
-        /// Gets the file path relative to the owning repository or docset.
+        /// Gets the file path relative to the main docset.
         /// </summary>
         public string Path { get; }
 

--- a/test/docfx.Test/build/TocTest.cs
+++ b/test/docfx.Test/build/TocTest.cs
@@ -13,12 +13,9 @@ namespace Microsoft.Docs.Build
         private static readonly RestoreGitMap s_restoreGitMap = new RestoreGitMap();
 
         private static readonly Docset s_docset = new Docset(
-            new ErrorLog(),
             Directory.GetCurrentDirectory(),
             "en-us",
-            JsonUtility.Deserialize<Config>("{'output': { 'json': true } }".Replace('\'', '\"'), null),
-            new CommandLineOptions(),
-            s_restoreGitMap);
+            JsonUtility.Deserialize<Config>("{'output': { 'json': true } }".Replace('\'', '\"'), null));
 
         [Theory]
         // same level
@@ -55,12 +52,12 @@ namespace Microsoft.Docs.Build
         {
             var builder = new TableOfContentsMapBuilder();
             var templateEngine = TemplateEngine.Create(s_docset, s_restoreGitMap);
-            var document = Document.Create(s_docset, file, templateEngine);
+            var document = Document.Create(s_docset, new FilePath(file), templateEngine);
 
             // test multiple reference case
             foreach (var tocFile in tocFiles)
             {
-                var toc = Document.Create(s_docset, tocFile, templateEngine);
+                var toc = Document.Create(s_docset, new FilePath(tocFile), templateEngine);
                 builder.Add(toc, new List<Document> { document }, new List<Document>());
             }
 
@@ -71,7 +68,7 @@ namespace Microsoft.Docs.Build
             builder = new TableOfContentsMapBuilder();
             foreach (var tocFile in tocFiles)
             {
-                var toc = Document.Create(s_docset, tocFile, templateEngine);
+                var toc = Document.Create(s_docset, new FilePath(tocFile), templateEngine);
                 builder.Add(toc, new List<Document>(), new List<Document>());
             }
             tocMap = builder.Build();


### PR DESCRIPTION
Fixes https://dev.azure.com/ceapex/Engineering/_workitems/edit/113864

The root cause is we use `Docset.DependencyDocsets` to lookup dependencies, which is empty when `Docset` itself is a dependency docset. This PR moves `Docset.DependencyDocsets` to dependency resolver and uses the same `_dependencies` dictionary to resolve everything.

Due to this change, we always use entry docset config for everything including dependencies, so some restore tests are marked as skip because they specify a config in dependency docset which is currently a not supported scenario in the docs world. We'll revisit these scenarios when doing `dotnet-docs` which uses _content from CRR_.

Dependency resolve and fallback resolve is consolidated into the same place at `DependencyResolver.TryResolveFile` to clarify the logic.

Simplified unnecessary Docset constructor parameters.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5003)