### PR TITLE
Fix code style violation of rule MEN002

### DIFF
--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Microsoft.Docs.Build
 {
+    [SuppressMessage("Layout", "MEN002", Justification = "Suppress MEN002 for Errors.cs")]
     internal static class Errors
     {
         /// <summary>

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -38,17 +38,25 @@ namespace Microsoft.Docs.Build
                 (Docset docset, Docset fallbackDocset) GetDocsetWithFallback()
                 {
                     var currentDocset = new Docset(errorLog, docsetPath, locale, config, options, gitMap, repository);
-                    if (!string.IsNullOrEmpty(currentDocset.Locale) && !string.Equals(currentDocset.Locale, config.Localization.DefaultLocale))
+                    if (!string.IsNullOrEmpty(currentDocset.Locale)
+                        && !string.Equals(currentDocset.Locale, config.Localization.DefaultLocale))
                     {
                         if (fallbackRepo != null)
                         {
                             return (currentDocset, new Docset(errorLog, fallbackRepo.Path, locale, config, options, gitMap, fallbackRepo));
                         }
 
-                        if (LocalizationUtility.TryGetLocalizedDocsetPath(currentDocset, gitMap, config, currentDocset.Locale, out var localizationDocsetPath, out var localizationBranch))
+                        if (LocalizationUtility.TryGetLocalizedDocsetPath(
+                            currentDocset,
+                            gitMap,
+                            config,
+                            currentDocset.Locale,
+                            out var localizationDocsetPath,
+                            out var localizationBranch))
                         {
                             var repo = Repository.Create(localizationDocsetPath, localizationBranch);
-                            return (new Docset(errorLog, localizationDocsetPath, currentDocset.Locale, config, options, gitMap, repo), currentDocset);
+                            return (new Docset(
+                                errorLog, localizationDocsetPath, currentDocset.Locale, config, options, gitMap, repo), currentDocset);
                         }
                     }
 
@@ -57,7 +65,13 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static async Task Run(Docset docset, Docset fallbackDocset, RestoreGitMap restoreGitMap, CommandLineOptions options, ErrorLog errorLog, string outputPath)
+        private static async Task Run(
+            Docset docset,
+            Docset fallbackDocset,
+            RestoreGitMap restoreGitMap,
+            CommandLineOptions options,
+            ErrorLog errorLog,
+            string outputPath)
         {
             using (var context = new Context(outputPath, errorLog, docset, fallbackDocset, restoreGitMap))
             {
@@ -154,7 +168,9 @@ namespace Microsoft.Docs.Build
                     }
 
                     // if A toc includes B toc and only B toc is localized, then A need to be included and built
-                    return file.FilePath.Origin != FileOrigin.Fallback || (context.TocMap.TryGetTocReferences(file, out var tocReferences) && tocReferences.Any(toc => toc.FilePath.Origin != FileOrigin.Fallback));
+                    return file.FilePath.Origin != FileOrigin.Fallback
+                        || (context.TocMap.TryGetTocReferences(file, out var tocReferences)
+                            && tocReferences.Any(toc => toc.FilePath.Origin != FileOrigin.Fallback));
                 }
 
                 return file.FilePath.Origin != FileOrigin.Fallback;
@@ -169,8 +185,10 @@ namespace Microsoft.Docs.Build
             Debug.Assert(!string.IsNullOrEmpty(docsetPath));
 
             var (_, config) = ConfigLoader.TryLoad(docsetPath, commandLineOptions);
+            var dependencyLockPath = string.IsNullOrEmpty(config.DependencyLock)
+                ? new SourceInfo<string>(AppData.GetDependencyLockFile(docsetPath, locale)) : config.DependencyLock;
 
-            var dependencyLock = DependencyLock.Load(docsetPath, string.IsNullOrEmpty(config.DependencyLock) ? new SourceInfo<string>(AppData.GetDependencyLockFile(docsetPath, locale)) : config.DependencyLock) ?? new DependencyLockModel();
+            var dependencyLock = DependencyLock.Load(docsetPath, dependencyLockPath) ?? new DependencyLockModel();
             return RestoreGitMap.Create(dependencyLock);
         }
 
@@ -184,7 +202,8 @@ namespace Microsoft.Docs.Build
 
             if (LocalizationUtility.TryGetFallbackRepository(repository, out var fallbackRemote, out string fallbackBranch, out _))
             {
-                if (restoreGitMap.DependencyLock.GetGitLock(fallbackRemote, fallbackBranch) == null && restoreGitMap.DependencyLock.GetGitLock(fallbackRemote, "master") != null)
+                if (restoreGitMap.DependencyLock.GetGitLock(fallbackRemote, fallbackBranch) == null
+                    && restoreGitMap.DependencyLock.GetGitLock(fallbackRemote, "master") != null)
                 {
                     // fallback to master branch
                     fallbackBranch = "master";

--- a/src/docfx/build/context/Cache.cs
+++ b/src/docfx/build/context/Cache.cs
@@ -11,8 +11,12 @@ namespace Microsoft.Docs.Build
 {
     internal class Cache
     {
-        private readonly ConcurrentDictionary<string, Lazy<(List<Error>, JToken)>> _tokenCache = new ConcurrentDictionary<string, Lazy<(List<Error>, JToken)>>();
-        private readonly ConcurrentDictionary<string, Lazy<(List<Error> errors, TableOfContentsModel tocModel, List<Document> referencedFiles, List<Document> referencedTocs)>> _tocModelCache = new ConcurrentDictionary<string, Lazy<(List<Error>, TableOfContentsModel, List<Document>, List<Document>)>>();
+        private readonly ConcurrentDictionary<string, Lazy<(List<Error>, JToken)>> _tokenCache
+            = new ConcurrentDictionary<string, Lazy<(List<Error>, JToken)>>();
+
+        private readonly ConcurrentDictionary<string,
+            Lazy<(List<Error> errors, TableOfContentsModel tocModel, List<Document> referencedFiles, List<Document> referencedTocs)>>
+            _tocModelCache = new ConcurrentDictionary<string, Lazy<(List<Error>, TableOfContentsModel, List<Document>, List<Document>)>>();
 
         public (List<Error> errors, JToken token) LoadYamlFile(Document file)
             => _tokenCache.GetOrAdd(GetKeyFromFile(file), new Lazy<(List<Error>, JToken)>(() =>
@@ -30,7 +34,8 @@ namespace Microsoft.Docs.Build
                 return JsonUtility.Parse(content, file.FilePath);
             })).Value;
 
-        public (List<Error> errors, TableOfContentsModel tocModel, List<Document> referencedFiles, List<Document> referencedTocs) LoadTocModel(Context context, Document file)
+        public (List<Error> errors, TableOfContentsModel tocModel, List<Document> referencedFiles, List<Document> referencedTocs)
+            LoadTocModel(Context context, Document file)
             => _tocModelCache.GetOrAdd(
                 file.FilePath.Path,
                 new Lazy<(List<Error>, TableOfContentsModel, List<Document>, List<Document>)>(

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -57,7 +57,14 @@ namespace Microsoft.Docs.Build
             BookmarkValidator = new BookmarkValidator(errorLog, PublishModelBuilder);
             DependencyMapBuilder = new DependencyMapBuilder();
             DependencyResolver = new DependencyResolver(
-                docset.Config, BuildScope, BuildQueue, GitCommitProvider, BookmarkValidator, DependencyMapBuilder, _xrefMap, TemplateEngine);
+                docset.Config,
+                BuildScope,
+                BuildQueue,
+                GitCommitProvider,
+                BookmarkValidator,
+                DependencyMapBuilder,
+                _xrefMap,
+                TemplateEngine);
             ContributionProvider = new ContributionProvider(docset, GitHubUserCache, GitCommitProvider);
         }
 

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -43,7 +43,8 @@ namespace Microsoft.Docs.Build
             _templateEngine = templateEngine;
         }
 
-        public (Error error, string content, Document file) ResolveContent(SourceInfo<string> path, Document declaringFile, DependencyType dependencyType = DependencyType.Inclusion)
+        public (Error error, string content, Document file) ResolveContent(
+            SourceInfo<string> path, Document declaringFile, DependencyType dependencyType = DependencyType.Inclusion)
         {
             var (error, content, child) = TryResolveContent(declaringFile, path);
 
@@ -52,7 +53,8 @@ namespace Microsoft.Docs.Build
             return (error, content, child);
         }
 
-        public (Error error, string link, Document file) ResolveRelativeLink(Document relativeToFile, SourceInfo<string> path, Document declaringFile)
+        public (Error error, string link, Document file) ResolveRelativeLink(
+            Document relativeToFile, SourceInfo<string> path, Document declaringFile)
         {
             var (error, link, file) = ResolveAbsoluteLink(path, declaringFile);
 
@@ -79,13 +81,15 @@ namespace Microsoft.Docs.Build
             if (!isCrossReference && (isSelfBookmark || file != null))
             {
                 _dependencyMapBuilder.AddDependencyItem(declaringFile, file, UrlUtility.FragmentToDependencyType(fragment));
-                _bookmarkValidator.AddBookmarkReference(declaringFile, isSelfBookmark ? relativeToFile : file, fragment, isSelfBookmark, path);
+                _bookmarkValidator.AddBookmarkReference(
+                    declaringFile, isSelfBookmark ? relativeToFile : file, fragment, isSelfBookmark, path);
             }
 
             return (error, link, file);
         }
 
-        public (Error error, string href, string display, IXrefSpec spec) ResolveRelativeXref(Document relativeToFile, SourceInfo<string> href, Document declaringFile)
+        public (Error error, string href, string display, IXrefSpec spec) ResolveRelativeXref(
+            Document relativeToFile, SourceInfo<string> href, Document declaringFile)
         {
             var (error, link, display, spec) = ResolveAbsoluteXref(href, declaringFile);
 
@@ -97,7 +101,8 @@ namespace Microsoft.Docs.Build
             return (error, link, display, spec);
         }
 
-        public (Error error, string href, string display, IXrefSpec spec) ResolveAbsoluteXref(SourceInfo<string> href, Document declaringFile)
+        public (Error error, string href, string display, IXrefSpec spec) ResolveAbsoluteXref(
+            SourceInfo<string> href, Document declaringFile)
         {
             var (uid, query, fragment) = UrlUtility.SplitUrl(href);
             string moniker = null;
@@ -158,7 +163,8 @@ namespace Microsoft.Docs.Build
 
             if (file is null)
             {
-                var (content, fileFromHistory) = TryResolveContentFromHistory(declaringFile, _gitCommitProvider, pathToDocset, _templateEngine);
+                var (content, fileFromHistory) = TryResolveContentFromHistory(
+                    declaringFile, _gitCommitProvider, pathToDocset, _templateEngine);
                 if (fileFromHistory != null)
                 {
                     return (null, content, fileFromHistory);
@@ -168,7 +174,8 @@ namespace Microsoft.Docs.Build
             return file != null ? (error, file.ReadText(), file) : default;
         }
 
-        private (Error error, string href, string fragment, LinkType linkType, Document file, bool isCrossReference) TryResolveAbsoluteLink(Document declaringFile, SourceInfo<string> href)
+        private (Error error, string href, string fragment, LinkType linkType, Document file, bool isCrossReference) TryResolveAbsoluteLink(
+            Document declaringFile, SourceInfo<string> href)
         {
             Debug.Assert(href != null);
 
@@ -238,7 +245,8 @@ namespace Microsoft.Docs.Build
             return (error, file.SiteUrl + query + fragment, fragment, linkType, file, false);
         }
 
-        private (Error error, Document file, string query, string fragment, LinkType linkType, string pathToDocset) TryResolveFile(Document declaringFile, SourceInfo<string> href)
+        private (Error error, Document file, string query, string fragment, LinkType linkType, string pathToDocset) TryResolveFile(
+            Document declaringFile, SourceInfo<string> href)
         {
             href = href.Or("");
             var (path, query, fragment) = UrlUtility.SplitUrl(href);
@@ -276,7 +284,8 @@ namespace Microsoft.Docs.Build
 
                     var file = Document.CreateFromFile(declaringFile.Docset, pathToDocset, _templateEngine, _buildScope);
 
-                    // for LandingPage should not be used, it is a hack to handle some specific logic for landing page based on the user input for now
+                    // for LandingPage should not be used,
+                    // it is a hack to handle some specific logic for landing page based on the user input for now
                     // which needs to be removed once the user input is correct
                     if (_templateEngine != null && TemplateEngine.IsLandingData(declaringFile.Mime))
                     {
@@ -293,7 +302,8 @@ namespace Microsoft.Docs.Build
 
                     if (file is null)
                     {
-                        return (Errors.FileNotFound(new SourceInfo<string>(path, href)), null, query, fragment, LinkType.RelativePath, pathToDocset);
+                        return (Errors.FileNotFound(
+                            new SourceInfo<string>(path, href)), null, query, fragment, LinkType.RelativePath, pathToDocset);
                     }
 
                     return (null, file, query, fragment, LinkType.RelativePath, pathToDocset);
@@ -319,7 +329,8 @@ namespace Microsoft.Docs.Build
             return docsetRelativePath;
         }
 
-        private Document TryResolveResourceFromHistory(Document declaringFile, GitCommitProvider gitCommitProvider, string pathToDocset, TemplateEngine templateEngine)
+        private Document TryResolveResourceFromHistory(
+            Document declaringFile, GitCommitProvider gitCommitProvider, string pathToDocset, TemplateEngine templateEngine)
         {
             if (string.IsNullOrEmpty(pathToDocset))
             {
@@ -340,7 +351,8 @@ namespace Microsoft.Docs.Build
             return default;
         }
 
-        private (string content, Document file) TryResolveContentFromHistory(Document declaringFile, GitCommitProvider gitCommitProvider, string pathToDocset, TemplateEngine templateEngine)
+        private (string content, Document file) TryResolveContentFromHistory(
+            Document declaringFile, GitCommitProvider gitCommitProvider, string pathToDocset, TemplateEngine templateEngine)
         {
             if (string.IsNullOrEmpty(pathToDocset))
             {
@@ -360,7 +372,8 @@ namespace Microsoft.Docs.Build
                         // the latest commit would be deleting it from repo
                         if (GitUtility.TryGetContentFromHistory(repoPath, pathToRepo, commits[1].Sha, out var content))
                         {
-                            return (content, Document.Create(fallbackDocset, pathToDocset, templateEngine, FileOrigin.Fallback, isFromHistory: true));
+                            return (content, Document.Create(
+                                fallbackDocset, pathToDocset, templateEngine, FileOrigin.Fallback, isFromHistory: true));
                         }
                     }
                 }

--- a/src/docfx/build/legacy/LegacyAggregatedFileMap.cs
+++ b/src/docfx/build/legacy/LegacyAggregatedFileMap.cs
@@ -12,7 +12,11 @@ namespace Microsoft.Docs.Build
 {
     internal static class LegacyAggregatedFileMap
     {
-        public static void Convert(Docset docset, Context context, IEnumerable<(string legacyFilePathRelativeToBaseFolder, LegacyFileMapItem fileMapItem)> items, Dictionary<string, List<LegacyDependencyMapItem>> dependencyMap)
+        public static void Convert(
+            Docset docset,
+            Context context,
+            IEnumerable<(string legacyFilePathRelativeToBaseFolder, LegacyFileMapItem fileMapItem)> items,
+            Dictionary<string, List<LegacyDependencyMapItem>> dependencyMap)
         {
             var aggregatedFileMapItems = new List<(string path, object item)>();
 
@@ -29,8 +33,10 @@ namespace Microsoft.Docs.Build
                                     ? dependencyMap[legacyFilePathRelativeToBaseFolder].Select(
                                         x => new DependencyItem
                                         {
-                                            FromFilePath = PathUtility.NormalizeFile(Path.Combine(docset.Config.DocumentId.SourceBasePath, x.From)),
-                                            ToFilePath = PathUtility.NormalizeFile(Path.Combine(docset.Config.DocumentId.SourceBasePath, x.To)),
+                                            FromFilePath = PathUtility.NormalizeFile(
+                                                Path.Combine(docset.Config.DocumentId.SourceBasePath, x.From)),
+                                            ToFilePath = PathUtility.NormalizeFile(
+                                                Path.Combine(docset.Config.DocumentId.SourceBasePath, x.To)),
                                             DependencyType = x.Type,
                                             Version = x.Version,
                                         })
@@ -41,13 +47,16 @@ namespace Microsoft.Docs.Build
                     type = fileMapItem.Type,
                 };
 
-                aggregatedFileMapItems.Add((PathUtility.NormalizeFile(Path.Combine(docset.Config.DocumentId.SourceBasePath, legacyFilePathRelativeToBaseFolder)), aggregatedFileMapItem));
+                aggregatedFileMapItems.Add(
+                    (PathUtility.NormalizeFile(Path.Combine(docset.Config.DocumentId.SourceBasePath, legacyFilePathRelativeToBaseFolder)),
+                    aggregatedFileMapItem));
             }
 
             context.Output.WriteJson(
                 new
                 {
-                    aggregated_file_map_items = aggregatedFileMapItems.OrderBy(item => item.path).ToDictionary(item => item.path, item => item.item),
+                    aggregated_file_map_items = aggregatedFileMapItems
+                        .OrderBy(item => item.path).ToDictionary(item => item.path, item => item.item),
                     docset_infos = new Dictionary<string, object>
                     {
                         [docset.Config.Name] = new

--- a/src/docfx/build/legacy/LegacyDependencyMap.cs
+++ b/src/docfx/build/legacy/LegacyDependencyMap.cs
@@ -77,8 +77,10 @@ namespace Microsoft.Docs.Build
                     select JsonUtility.Serialize(new
                     {
                         dependency_type = dep.Type,
-                        from_file_path = Path.GetFullPath(Path.Combine(docset.DocsetPath, docset.Config.DocumentId.SourceBasePath, dep.From.Substring(2))),
-                        to_file_path = Path.GetFullPath(Path.Combine(docset.DocsetPath, docset.Config.DocumentId.SourceBasePath, dep.To.Substring(2))),
+                        from_file_path = Path.GetFullPath(
+                            Path.Combine(docset.DocsetPath, docset.Config.DocumentId.SourceBasePath, dep.From.Substring(2))),
+                        to_file_path = Path.GetFullPath(
+                            Path.Combine(docset.DocsetPath, docset.Config.DocumentId.SourceBasePath, dep.To.Substring(2))),
                         version = dep.Version,
                     });
 

--- a/src/docfx/build/legacy/LegacyFileMap.cs
+++ b/src/docfx/build/legacy/LegacyFileMap.cs
@@ -31,11 +31,17 @@ namespace Microsoft.Docs.Build
                         {
                             return;
                         }
-                        var legacyOutputFilePathRelativeToSiteBasePath = document.ToLegacyOutputPathRelativeToSiteBasePath(docset, fileManifest.Value);
+                        var legacyOutputFilePathRelativeToSiteBasePath = document.ToLegacyOutputPathRelativeToSiteBasePath(
+                            docset, fileManifest.Value);
                         var legacySiteUrlRelativeToSiteBasePath = document.ToLegacySiteUrlRelativeToSiteBasePath(docset);
 
                         var version = legacyVersionProvider.GetLegacyVersion(document);
-                        var fileItem = LegacyFileMapItem.Instance(legacyOutputFilePathRelativeToSiteBasePath, legacySiteUrlRelativeToSiteBasePath, document.ContentType, version, fileManifest.Value.Monikers);
+                        var fileItem = LegacyFileMapItem.Instance(
+                            legacyOutputFilePathRelativeToSiteBasePath,
+                            legacySiteUrlRelativeToSiteBasePath,
+                            document.ContentType,
+                            version,
+                            fileManifest.Value.Monikers);
                         if (fileItem != null)
                         {
                             listBuilder.Add((PathUtility.NormalizeFile(document.ToLegacyPathRelativeToBasePath(docset)), fileItem));

--- a/src/docfx/build/legacy/LegacyFileMapItem.cs
+++ b/src/docfx/build/legacy/LegacyFileMapItem.cs
@@ -30,14 +30,20 @@ namespace Microsoft.Docs.Build
 
         public bool ShouldSerializeIsMonikerRange() => !string.IsNullOrEmpty(Version);
 
-        public LegacyFileMapItem(string legacyOutputFilePathRelativeToSiteBasePath, string legacySiteUrlRelativeToSiteBasePath, ContentType contentType, string version, List<string> monikers)
+        public LegacyFileMapItem(
+            string legacyOutputFilePathRelativeToSiteBasePath,
+            string legacySiteUrlRelativeToSiteBasePath,
+            ContentType contentType,
+            string version,
+            List<string> monikers)
         {
             switch (contentType)
             {
                 case ContentType.Page:
                 case ContentType.Redirection:
                     Type = "Content";
-                    OutputRelativePath = PathUtility.NormalizeFile(LegacyUtility.ChangeExtension(legacyOutputFilePathRelativeToSiteBasePath, ".html"));
+                    OutputRelativePath = PathUtility.NormalizeFile(
+                        LegacyUtility.ChangeExtension(legacyOutputFilePathRelativeToSiteBasePath, ".html"));
                     AssetId = legacySiteUrlRelativeToSiteBasePath;
                     Version = version;
                     Monikers = monikers;
@@ -55,14 +61,20 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public static LegacyFileMapItem Instance(string legacyOutputFilePathRelativeToSiteBasePath, string legacySiteUrlRelativeToSiteBasePath, ContentType contentType, string version, List<string> monikers)
+        public static LegacyFileMapItem Instance(
+            string legacyOutputFilePathRelativeToSiteBasePath,
+            string legacySiteUrlRelativeToSiteBasePath,
+            ContentType contentType,
+            string version,
+            List<string> monikers)
         {
             if (contentType == ContentType.TableOfContents || contentType == ContentType.Unknown)
             {
                 return null;
             }
 
-            return new LegacyFileMapItem(legacyOutputFilePathRelativeToSiteBasePath, legacySiteUrlRelativeToSiteBasePath, contentType, version, monikers);
+            return new LegacyFileMapItem(
+                legacyOutputFilePathRelativeToSiteBasePath, legacySiteUrlRelativeToSiteBasePath, contentType, version, monikers);
         }
 
         private static string RemoveExtension(string path)

--- a/src/docfx/build/legacy/LegacyUtility.cs
+++ b/src/docfx/build/legacy/LegacyUtility.cs
@@ -45,11 +45,13 @@ namespace Microsoft.Docs.Build
             var legacySiteUrlRelativeToSiteBasePath = doc.SiteUrl;
             if (legacySiteUrlRelativeToSiteBasePath.StartsWith($"/{docset.SiteBasePath}", PathUtility.PathComparison))
             {
-                legacySiteUrlRelativeToSiteBasePath = Path.GetRelativePath(docset.SiteBasePath, legacySiteUrlRelativeToSiteBasePath.Substring(1));
+                legacySiteUrlRelativeToSiteBasePath = Path.GetRelativePath(
+                    docset.SiteBasePath, legacySiteUrlRelativeToSiteBasePath.Substring(1));
             }
 
             return PathUtility.NormalizeFile(
-                Path.GetFileNameWithoutExtension(doc.FilePath.Path).Equals("index", PathUtility.PathComparison) && doc.ContentType != ContentType.Resource
+                Path.GetFileNameWithoutExtension(doc.FilePath.Path).Equals("index", PathUtility.PathComparison)
+                && doc.ContentType != ContentType.Resource
                 ? $"{legacySiteUrlRelativeToSiteBasePath}/index"
                 : legacySiteUrlRelativeToSiteBasePath);
         }

--- a/src/docfx/build/legacy/manifest/LegacyManifest.cs
+++ b/src/docfx/build/legacy/manifest/LegacyManifest.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Docs.Build
                 Parallel.ForEach(fileManifests, fileManifest =>
                     {
                         var document = fileManifest.Key;
-                        var legacyOutputPathRelativeToSiteBasePath = document.ToLegacyOutputPathRelativeToSiteBasePath(docset, fileManifest.Value);
+                        var legacyOutputPathRelativeToSiteBasePath = document.ToLegacyOutputPathRelativeToSiteBasePath(
+                            docset, fileManifest.Value);
                         var legacySiteUrlRelativeToSiteBasePath = document.ToLegacySiteUrlRelativeToSiteBasePath(docset);
 
                         var output = new LegacyManifestOutput

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -29,7 +29,8 @@ namespace Microsoft.Docs.Build
                 ? new CommitBuildTimeProvider(docset.Repository) : null;
         }
 
-        public async Task<(List<Error> errors, ContributionInfo contributionInfo)> GetContributionInfo(Context context, Document document, SourceInfo<string> authorName)
+        public async Task<(List<Error> errors, ContributionInfo contributionInfo)> GetContributionInfo(
+            Context context, Document document, SourceInfo<string> authorName)
         {
             Debug.Assert(document != null);
             var (repo, pathToRepo, commits) = _gitCommitProvider.GetCommitHistory(document);
@@ -52,7 +53,8 @@ namespace Microsoft.Docs.Build
                 ? new ContributionInfo
                 {
                     Contributors = contributors,
-                    UpdateAt = updatedDateTime.ToString(document.Docset.Locale == "en-us" ? "M/d/yyyy" : document.Docset.Culture.DateTimeFormat.ShortDatePattern),
+                    UpdateAt = updatedDateTime.ToString(
+                        document.Docset.Locale == "en-us" ? "M/d/yyyy" : document.Docset.Culture.DateTimeFormat.ShortDatePattern),
                     UpdatedAtDateTime = updatedDateTime,
                 }
                 : null;
@@ -104,7 +106,8 @@ namespace Microsoft.Docs.Build
             {
                 if (isGitHubRepo)
                 {
-                    var (error, githubUser) = await _gitHubUserCache.GetByCommit(commit.AuthorEmail, gitHubOwner, gitHubRepoName, commit.Sha);
+                    var (error, githubUser) = await _gitHubUserCache.GetByCommit(
+                        commit.AuthorEmail, gitHubOwner, gitHubRepoName, commit.Sha);
                     errors.AddIfNotNull(error);
                     return githubUser?.ToContributor();
                 }
@@ -130,8 +133,10 @@ namespace Microsoft.Docs.Build
             List<GitCommit> GetContributionCommits()
             {
                 var result = commits;
-                var bilingual = context.BuildScope.GetFallbackDocset(document.Docset) != null && document.Docset.Config.Localization.Bilingual;
-                var contributionBranch = bilingual && LocalizationUtility.TryGetContributionBranch(repo.Branch, out var cBranch) ? cBranch : null;
+                var bilingual = context.BuildScope.GetFallbackDocset(document.Docset) != null
+                    && document.Docset.Config.Localization.Bilingual;
+                var contributionBranch = bilingual
+                    && LocalizationUtility.TryGetContributionBranch(repo.Branch, out var cBranch) ? cBranch : null;
                 if (!string.IsNullOrEmpty(contributionBranch))
                 {
                     (_, _, result) = _gitCommitProvider.GetCommitHistory(document, contributionBranch);
@@ -145,7 +150,8 @@ namespace Microsoft.Docs.Build
         {
             if (fileCommits?.Count > 0)
             {
-                return _commitBuildTimeProvider != null && _commitBuildTimeProvider.TryGetCommitBuildTime(fileCommits[0].Sha, out var timeFromHistory)
+                return _commitBuildTimeProvider != null
+                    && _commitBuildTimeProvider.TryGetCommitBuildTime(fileCommits[0].Sha, out var timeFromHistory)
                     ? timeFromHistory
                     : fileCommits[0].Time.UtcDateTime;
             }
@@ -185,7 +191,8 @@ namespace Microsoft.Docs.Build
 
                 if (!string.IsNullOrEmpty(document.Docset.Config.Contribution.Repository))
                 {
-                    var (contributionRemote, contributionBranch, hasRefSpec) = UrlUtility.SplitGitUrl(document.Docset.Config.Contribution.Repository);
+                    var (contributionRemote, contributionBranch, hasRefSpec) = UrlUtility.SplitGitUrl(
+                        document.Docset.Config.Contribution.Repository);
                     (branchUrlTemplate, _) = GetContentGitUrlTemplate(contributionRemote, pathToRepo);
 
                     (editRemote, editBranch) = (contributionRemote, hasRefSpec ? contributionBranch : editBranch);
@@ -222,7 +229,8 @@ namespace Microsoft.Docs.Build
 
             if (UrlUtility.TryParseAzureReposUrl(remote, out _, out _))
             {
-                return ($"{{repo}}?path=/{pathToRepo}&version=GB{{branch}}&_a=contents", $"{{repo}}/commit/{{commit}}?path=/{pathToRepo}&_a=contents");
+                return ($"{{repo}}?path=/{pathToRepo}&version=GB{{branch}}&_a=contents",
+                    $"{{repo}}/commit/{{commit}}?path=/{pathToRepo}&_a=contents");
             }
 
             return default;

--- a/src/docfx/build/metadata/MetadataProvider.cs
+++ b/src/docfx/build/metadata/MetadataProvider.cs
@@ -16,7 +16,8 @@ namespace Microsoft.Docs.Build
         private readonly JsonSchemaValidator[] _schemaValidators;
         private readonly JObject _globalMetadata;
         private readonly HashSet<string> _reservedMetadata;
-        private readonly List<(Func<string, bool> glob, string key, JToken value)> _rules = new List<(Func<string, bool> glob, string key, JToken value)>();
+        private readonly List<(Func<string, bool> glob, string key, JToken value)> _rules
+            = new List<(Func<string, bool> glob, string key, JToken value)>();
 
         private readonly ConcurrentDictionary<Document, (List<Error> errors, InputMetadata metadata)> _metadataCache
                    = new ConcurrentDictionary<Document, (List<Error> errors, InputMetadata metadata)>();

--- a/src/docfx/build/moniker/MonikerProvider.cs
+++ b/src/docfx/build/moniker/MonikerProvider.cs
@@ -10,7 +10,9 @@ namespace Microsoft.Docs.Build
 {
     internal class MonikerProvider
     {
-        private readonly List<(Func<string, bool> glob, (string monikerRange, IEnumerable<string> monikers))> _rules = new List<(Func<string, bool>, (string, IEnumerable<string>))>();
+        private readonly List<(Func<string, bool> glob, (string monikerRange, IEnumerable<string> monikers))>
+            _rules = new List<(Func<string, bool>, (string, IEnumerable<string>))>();
+
         private readonly MonikerRangeParser _rangeParser;
         private readonly MetadataProvider _metadataProvider;
         private readonly ConcurrentDictionary<Document, (Error, List<string>)> _monikerCache

--- a/src/docfx/build/page/BookmarkValidator.cs
+++ b/src/docfx/build/page/BookmarkValidator.cs
@@ -13,8 +13,8 @@ namespace Microsoft.Docs.Build
         private readonly PublishModelBuilder _publishModelBuilder;
 
         private readonly DictionaryBuilder<Document, HashSet<string>> _bookmarksByFile = new DictionaryBuilder<Document, HashSet<string>>();
-        private readonly ListBuilder<(Document file, Document dependency, string bookmark, bool isSelfBookmark, SourceInfo source)> _references
-                   = new ListBuilder<(Document file, Document dependency, string bookmark, bool isSelfBookmark, SourceInfo source)>();
+        private readonly ListBuilder<(Document file, Document dependency, string bookmark, bool isSelfBookmark, SourceInfo source)>
+            _references = new ListBuilder<(Document file, Document dependency, string bookmark, bool isSelfBookmark, SourceInfo source)>();
 
         public BookmarkValidator(ErrorLog errorLog, PublishModelBuilder publishModelBuilder)
         {

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -93,7 +93,10 @@ namespace Microsoft.Docs.Build
             }
             else
             {
-                JsonUtility.Merge(outputMetadata, sourceModel.TryGetValue<JObject>("metadata", out var sourceMetadata) ? sourceMetadata : new JObject(), systemMetadataJObject);
+                JsonUtility.Merge(
+                    outputMetadata,
+                    sourceModel.TryGetValue<JObject>("metadata", out var sourceMetadata) ? sourceMetadata : new JObject(),
+                    systemMetadataJObject);
                 JsonUtility.Merge(outputModel, sourceModel, new JObject { ["metadata"] = outputMetadata });
             }
 
@@ -121,20 +124,23 @@ namespace Microsoft.Docs.Build
             return (new List<Error>(), context.TemplateEngine.RunJint($"{file.Mime}.json.js", sourceModel), null);
         }
 
-        private static async Task<(List<Error>, SystemMetadata)> CreateSystemMetadata(Context context, Document file, InputMetadata inputMetadata)
+        private static async Task<(List<Error>, SystemMetadata)> CreateSystemMetadata(
+            Context context, Document file, InputMetadata inputMetadata)
         {
             var errors = new List<Error>();
             var systemMetadata = new SystemMetadata();
 
             if (!string.IsNullOrEmpty(inputMetadata.BreadcrumbPath))
             {
-                var (breadcrumbError, breadcrumbPath, _) = context.DependencyResolver.ResolveRelativeLink(file, inputMetadata.BreadcrumbPath, file);
+                var (breadcrumbError, breadcrumbPath, _) = context.DependencyResolver.ResolveRelativeLink(
+                    file, inputMetadata.BreadcrumbPath, file);
                 errors.AddIfNotNull(breadcrumbError);
                 systemMetadata.BreadcrumbPath = breadcrumbPath;
             }
 
             systemMetadata.Locale = file.Docset.Locale;
-            systemMetadata.TocRel = !string.IsNullOrEmpty(inputMetadata.TocRel) ? inputMetadata.TocRel : context.TocMap.FindTocRelativePath(file);
+            systemMetadata.TocRel = !string.IsNullOrEmpty(inputMetadata.TocRel)
+                ? inputMetadata.TocRel : context.TocMap.FindTocRelativePath(file);
             systemMetadata.CanonicalUrl = file.CanonicalUrl;
             systemMetadata.EnableLocSxs = file.Docset.Config.Localization.Bilingual;
             systemMetadata.SiteName = file.Docset.Config.SiteName;
@@ -143,11 +149,14 @@ namespace Microsoft.Docs.Build
             errors.AddIfNotNull(monikerError);
             systemMetadata.Monikers = monikers;
 
-            (systemMetadata.DocumentId, systemMetadata.DocumentVersionIndependentId) = context.BuildScope.Redirections.TryGetDocumentId(file, out var docId) ? docId : file.Id;
-            (systemMetadata.ContentGitUrl, systemMetadata.OriginalContentGitUrl, systemMetadata.OriginalContentGitUrlTemplate, systemMetadata.Gitcommit) = context.ContributionProvider.GetGitUrls(context, file);
+            (systemMetadata.DocumentId, systemMetadata.DocumentVersionIndependentId)
+                = context.BuildScope.Redirections.TryGetDocumentId(file, out var docId) ? docId : file.Id;
+            (systemMetadata.ContentGitUrl, systemMetadata.OriginalContentGitUrl, systemMetadata.OriginalContentGitUrlTemplate,
+                systemMetadata.Gitcommit) = context.ContributionProvider.GetGitUrls(context, file);
 
             List<Error> contributorErrors;
-            (contributorErrors, systemMetadata.ContributionInfo) = await context.ContributionProvider.GetContributionInfo(context, file, inputMetadata.Author);
+            (contributorErrors, systemMetadata.ContributionInfo) = await context.ContributionProvider.GetContributionInfo(
+                context, file, inputMetadata.Author);
             systemMetadata.Author = systemMetadata.ContributionInfo?.Author?.Name;
             systemMetadata.UpdatedAt = systemMetadata.ContributionInfo?.UpdatedAtDateTime.ToString("yyyy-MM-dd hh:mm tt");
 
@@ -158,7 +167,10 @@ namespace Microsoft.Docs.Build
             systemMetadata.CanonicalUrlPrefix = $"{file.Docset.HostName}/{systemMetadata.Locale}/{file.Docset.SiteBasePath}/";
 
             if (file.Docset.Config.Output.Pdf)
-                systemMetadata.PdfUrlPrefixTemplate = $"{file.Docset.HostName}/pdfstore/{systemMetadata.Locale}/{file.Docset.Config.Product}.{file.Docset.Config.Name}/{{branchName}}";
+            {
+                systemMetadata.PdfUrlPrefixTemplate = $"{file.Docset.HostName}/pdfstore/{systemMetadata.Locale}" +
+                    $"/{file.Docset.Config.Product}.{file.Docset.Config.Name}/{{branchName}}";
+            }
 
             if (contributorErrors != null)
                 errors.AddRange(contributorErrors);
@@ -253,7 +265,8 @@ namespace Microsoft.Docs.Build
             {
                 // transform metadata via json schema
                 var (metadataErrors, inputMetadata) = context.MetadataProvider.GetMetadata(file);
-                var (metadataTransformedErrors, transformedMetadata) = schemaTemplate.JsonSchemaTransformer.TransformContent(file, context, new JObject { ["metadata"] = inputMetadata.RawJObject });
+                var (metadataTransformedErrors, transformedMetadata) = schemaTemplate.JsonSchemaTransformer.TransformContent(
+                    file, context, new JObject { ["metadata"] = inputMetadata.RawJObject });
                 errors.AddRange(metadataErrors);
                 errors.AddRange(metadataTransformedErrors);
                 pageModel["metadata"] = ((JObject)transformedMetadata)["metadata"];
@@ -264,7 +277,8 @@ namespace Microsoft.Docs.Build
                 var (deserializeErrors, landingData) = JsonUtility.ToObject<LandingData>(pageModel);
                 errors.AddRange(deserializeErrors);
 
-                var htmlDom = HtmlUtility.LoadHtml(await RazorTemplate.Render(file.Mime, landingData)).StripTags().RemoveRerunCodepenIframes();
+                var htmlDom = HtmlUtility.LoadHtml(await RazorTemplate.Render(file.Mime, landingData))
+                    .StripTags().RemoveRerunCodepenIframes();
                 ValidateBookmarks(context, file, htmlDom);
                 pageModel = JsonUtility.ToJObject(new ConceptualModel
                 {
@@ -286,7 +300,8 @@ namespace Microsoft.Docs.Build
                 content = "<div></div>";
             }
 
-            var templateMetadata = context.TemplateEngine.RunJint(string.IsNullOrEmpty(file.Mime) ? "Conceptual.mta.json.js" : $"{file.Mime}.mta.json.js", pageModel);
+            var templateMetadata = context.TemplateEngine.RunJint(
+                string.IsNullOrEmpty(file.Mime) ? "Conceptual.mta.json.js" : $"{file.Mime}.mta.json.js", pageModel);
 
             if (TemplateEngine.IsLandingData(file.Mime))
             {
@@ -299,7 +314,8 @@ namespace Microsoft.Docs.Build
                 ["is_dynamic_rendering"] = true,
             };
 
-            var pageMetadata = HtmlUtility.CreateHtmlMetaTags(metadata, context.MetadataProvider.HtmlMetaHidden, context.MetadataProvider.HtmlMetaNames);
+            var pageMetadata = HtmlUtility.CreateHtmlMetaTags(
+                metadata, context.MetadataProvider.HtmlMetaHidden, context.MetadataProvider.HtmlMetaNames);
 
             // content for *.raw.page.json
             var model = new TemplateModel

--- a/src/docfx/build/redirection/RedirectionMap.cs
+++ b/src/docfx/build/redirection/RedirectionMap.cs
@@ -39,7 +39,12 @@ namespace Microsoft.Docs.Build
             return false;
         }
 
-        public static RedirectionMap Create(ErrorLog errorLog, Docset docset, Func<string, bool> glob, TemplateEngine templateEngine, IReadOnlyCollection<Document> buildFiles)
+        public static RedirectionMap Create(
+            ErrorLog errorLog,
+            Docset docset,
+            Func<string, bool> glob,
+            TemplateEngine templateEngine,
+            IReadOnlyCollection<Document> buildFiles)
         {
             var redirections = new HashSet<Document>();
             var redirectionsWithDocumentId = new List<(SourceInfo<string> redirectUrl, Document redirect)>();
@@ -99,7 +104,8 @@ namespace Microsoft.Docs.Build
                         }
                     }
 
-                    var redirect = Document.Create(docset, pathToDocset, templateEngine, redirectionUrl: mutableRedirectUrl, combineRedirectUrl: combineRedirectUrl);
+                    var redirect = Document.Create(
+                        docset, pathToDocset, templateEngine, redirectionUrl: mutableRedirectUrl, combineRedirectUrl: combineRedirectUrl);
 
                     if (redirectDocumentId)
                     {
@@ -114,11 +120,16 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static void CheckInvalidRedrectUrl(ErrorLog errorLog, List<(SourceInfo<string> redirectUrl, Document redirect)> redirectionsWithDocumentId, HashSet<Document> redirections, IReadOnlyCollection<Document> buildFiles)
+        private static void CheckInvalidRedrectUrl(
+            ErrorLog errorLog,
+            List<(SourceInfo<string> redirectUrl, Document redirect)> redirectionsWithDocumentId,
+            HashSet<Document> redirections,
+            IReadOnlyCollection<Document> buildFiles)
         {
             var redirectUrls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            var publishUrls = buildFiles.Select(file => file.SiteUrl).Concat(redirections.Select(redirection => redirection.SiteUrl)).ToHashSet();
+            var publishUrls = buildFiles.Select(file => file.SiteUrl)
+                .Concat(redirections.Select(redirection => redirection.SiteUrl)).ToHashSet();
             foreach (var (redirectionUrl, redirect) in redirectionsWithDocumentId)
             {
                 if (!publishUrls.Contains(redirect.RedirectionUrl))

--- a/src/docfx/cli/Docfx.cs
+++ b/src/docfx/cli/Docfx.cs
@@ -127,7 +127,8 @@ namespace Microsoft.Docs.Build
                     syntax.DefineCommand("restore", ref command, "Restores dependencies before build.");
                     syntax.DefineOption("locale", ref options.Locale, "The locale of the docset to build");
                     syntax.DefineOption("o|output", ref options.Output, "Output directory in which to place restore log.");
-                    syntax.DefineOption("template", ref options.Template, "The directory or git repository that contains website template.");
+                    syntax.DefineOption(
+                        "template", ref options.Template, "The directory or git repository that contains website template.");
                     syntax.DefineOption("legacy", ref options.Legacy, "Enable legacy output for backward compatibility.");
                     syntax.DefineOption("v|verbose", ref options.Verbose, "Enable diagnostics console output.");
                     syntax.DefineParameter("docset", ref docset, "Docset directory that contains docfx.yml/docfx.json.");
@@ -135,7 +136,8 @@ namespace Microsoft.Docs.Build
                     // Build command
                     syntax.DefineCommand("build", ref command, "Builds a docset.");
                     syntax.DefineOption("o|output", ref options.Output, "Output directory in which to place built artifacts.");
-                    syntax.DefineOption("template", ref options.Template, "The directory or git repository that contains website template.");
+                    syntax.DefineOption(
+                        "template", ref options.Template, "The directory or git repository that contains website template.");
                     syntax.DefineOption("legacy", ref options.Legacy, "Enable legacy output for backward compatibility.");
                     syntax.DefineOption("locale", ref options.Locale, "The locale of the docset to build.");
                     syntax.DefineOption("v|verbose", ref options.Verbose, "Enable diagnostics console output.");
@@ -144,7 +146,8 @@ namespace Microsoft.Docs.Build
                     // Watch command
                     syntax.DefineCommand("watch", ref command, "Previews a docset and watch changes interactively.");
                     syntax.DefineOption("locale", ref options.Locale, "The locale of the docset to build.");
-                    syntax.DefineOption("template", ref options.Template, "The directory or git repository that contains website template.");
+                    syntax.DefineOption(
+                        "template", ref options.Template, "The directory or git repository that contains website template.");
                     syntax.DefineOption("port", ref options.Port, "The port of the launched website.");
                     syntax.DefineOption("v|verbose", ref options.Verbose, "Enable diagnostics console output.");
                     syntax.DefineParameter("docset", ref docset, "Docset directory that contains docfx.yml/docfx.json.");
@@ -178,7 +181,8 @@ namespace Microsoft.Docs.Build
                                             : errorLog.WarningCount > 0 ? ConsoleColor.Yellow
                                             : ConsoleColor.Magenta;
                     Console.WriteLine();
-                    Console.WriteLine($"  {errorLog.ErrorCount} Error(s), {errorLog.WarningCount} Warning(s), {errorLog.SuggestionCount} Suggestion(s)");
+                    Console.WriteLine(
+                        $"  {errorLog.ErrorCount} Error(s), {errorLog.WarningCount} Warning(s), {errorLog.SuggestionCount} Suggestion(s)");
                 }
 
                 Console.ResetColor();
@@ -221,7 +225,8 @@ Run `{Environment.CommandLine}` in `{Directory.GetCurrentDirectory()}`
 ";
             try
             {
-                var issueUrl = $"https://github.com/dotnet/docfx/issues/new?title={HttpUtility.UrlEncode(title)}&body={HttpUtility.UrlEncode(body)}";
+                var issueUrl =
+                    $"https://github.com/dotnet/docfx/issues/new?title={HttpUtility.UrlEncode(title)}&body={HttpUtility.UrlEncode(body)}";
 
                 Process.Start(new ProcessStartInfo { FileName = issueUrl, UseShellExecute = true });
             }
@@ -267,7 +272,8 @@ Run `{Environment.CommandLine}` in `{Directory.GetCurrentDirectory()}`
         {
             try
             {
-                var process = Process.Start(new ProcessStartInfo { FileName = "dotnet", Arguments = "--version", RedirectStandardOutput = true });
+                var process = Process.Start(
+                    new ProcessStartInfo { FileName = "dotnet", Arguments = "--version", RedirectStandardOutput = true });
                 process.WaitForExit(2000);
                 return process.StandardOutput.ReadToEnd().Trim();
             }
@@ -281,7 +287,8 @@ Run `{Environment.CommandLine}` in `{Directory.GetCurrentDirectory()}`
         {
             try
             {
-                var process = Process.Start(new ProcessStartInfo { FileName = "git", Arguments = "--version", RedirectStandardOutput = true });
+                var process = Process.Start(
+                    new ProcessStartInfo { FileName = "git", Arguments = "--version", RedirectStandardOutput = true });
                 process.WaitForExit(2000);
                 return process.StandardOutput.ReadToEnd().Trim();
             }

--- a/src/docfx/config/AppData.cs
+++ b/src/docfx/config/AppData.cs
@@ -43,7 +43,8 @@ namespace Microsoft.Docs.Build
 
         public static string GetDependencyLockFile(string docsetPath, string locale)
         {
-            return PathUtility.NormalizeFile(Path.Combine(DependencyLockRoot, PathUtility.UrlToShortName(docsetPath), locale ?? "", ".lock.json"));
+            return PathUtility.NormalizeFile(
+                Path.Combine(DependencyLockRoot, PathUtility.UrlToShortName(docsetPath), locale ?? "", ".lock.json"));
         }
 
         public static string GetCommitCachePath(string remote)
@@ -53,7 +54,8 @@ namespace Microsoft.Docs.Build
 
         public static string GetCommitBuildTimePath(string remote, string branch)
         {
-            return Path.Combine(CacheRoot, "history", $"build_history_{HashUtility.GetMd5Guid(remote)}_{HashUtility.GetMd5Guid(branch)}.json");
+            return Path.Combine(
+                CacheRoot, "history", $"build_history_{HashUtility.GetMd5Guid(remote)}_{HashUtility.GetMd5Guid(branch)}.json");
         }
 
         /// <summary>

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -104,14 +104,16 @@ namespace Microsoft.Docs.Build
         /// The default value is empty mappings
         /// The redirection always transfer the document id
         /// </summary>
-        public readonly Dictionary<string, SourceInfo<string>> Redirections = new Dictionary<string, SourceInfo<string>>(PathUtility.PathComparer);
+        public readonly Dictionary<string, SourceInfo<string>> Redirections
+            = new Dictionary<string, SourceInfo<string>>(PathUtility.PathComparer);
 
         /// <summary>
         /// Gets the redirection mappings without document id
         /// The default value is empty mappings
         /// The redirection doesn't transfer the document id
         /// </summary>
-        public readonly Dictionary<string, SourceInfo<string>> RedirectionsWithoutId = new Dictionary<string, SourceInfo<string>>(PathUtility.PathComparer);
+        public readonly Dictionary<string, SourceInfo<string>> RedirectionsWithoutId
+            = new Dictionary<string, SourceInfo<string>>(PathUtility.PathComparer);
 
         /// <summary>
         /// Gets the document id configuration section

--- a/src/docfx/config/ConfigLoader.cs
+++ b/src/docfx/config/ConfigLoader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -17,7 +17,8 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Load the config under <paramref name="docsetPath"/>
         /// </summary>
-        public static (List<Error> errors, Config config) Load(string docsetPath, CommandLineOptions options, string locale = null, bool extend = true)
+        public static (List<Error> errors, Config config) Load(
+            string docsetPath, CommandLineOptions options, string locale = null, bool extend = true)
         {
             if (!TryGetConfigPath(docsetPath, out _))
             {
@@ -30,7 +31,8 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Load the config if it exists under <paramref name="docsetPath"/> or return default config
         /// </summary>
-        public static (List<Error> errors, Config config) TryLoad(string docsetPath, CommandLineOptions options, string locale = null, bool extend = true)
+        public static (List<Error> errors, Config config) TryLoad(
+            string docsetPath, CommandLineOptions options, string locale = null, bool extend = true)
             => LoadCore(docsetPath, options, locale, extend);
 
         public static bool TryGetConfigPath(string docset, out string configPath)
@@ -128,7 +130,8 @@ namespace Microsoft.Docs.Build
             {
                 if (extend is JValue value && value.Value is string str)
                 {
-                    var content = RestoreFileMap.GetRestoredFileContent(docsetPath, new SourceInfo<string>(str, JsonUtility.GetSourceInfo(value)), fallbackDocset: null);
+                    var content = RestoreFileMap.GetRestoredFileContent(
+                        docsetPath, new SourceInfo<string>(str, JsonUtility.GetSourceInfo(value)), fallbackDocset: null);
                     var (extendErrors, extendConfigObject) = LoadConfigObject(str, content);
                     errors.AddRange(extendErrors);
                     JsonUtility.Merge(result, extendConfigObject);

--- a/src/docfx/config/DocumentIdConfig.cs
+++ b/src/docfx/config/DocumentIdConfig.cs
@@ -38,11 +38,13 @@ namespace Microsoft.Docs.Build
             return (depotName, mappedPathRelativeToSourceBasePath);
         }
 
-        private static (string value, string matchedDirectory) GetReversedMapping(Dictionary<string, string> mappings, string normalizedFilePathToSourceBasePath)
+        private static (string value, string matchedDirectory) GetReversedMapping(
+            Dictionary<string, string> mappings, string normalizedFilePathToSourceBasePath)
         {
             foreach (var (path, value) in mappings)
             {
-                var normalizedPath = path.EndsWith("/") || path.EndsWith("\\") ? PathUtility.NormalizeFolder(path) : PathUtility.NormalizeFile(path);
+                var normalizedPath = path.EndsWith("/")
+                    || path.EndsWith("\\") ? PathUtility.NormalizeFolder(path) : PathUtility.NormalizeFile(path);
                 var (match, isFileMatch, _) = PathUtility.Match(normalizedFilePathToSourceBasePath, normalizedPath);
                 if (match)
                 {
@@ -52,7 +54,8 @@ namespace Microsoft.Docs.Build
                     }
 
                     var lastSlashIndex = normalizedFilePathToSourceBasePath.LastIndexOf("/");
-                    var matchedDirectory = lastSlashIndex > 0 ? normalizedFilePathToSourceBasePath.Substring(0, lastSlashIndex) : string.Empty;
+                    var matchedDirectory = lastSlashIndex > 0
+                        ? normalizedFilePathToSourceBasePath.Substring(0, lastSlashIndex) : string.Empty;
                     return (value, matchedDirectory);
                 }
             }

--- a/src/docfx/config/OverwriteConfigIdentifier.cs
+++ b/src/docfx/config/OverwriteConfigIdentifier.cs
@@ -33,7 +33,8 @@ namespace Microsoft.Docs.Build
             var localeMatched = TryGetMatchedParts(s_localeRegex, out var locales);
             if (branchMatched || localeMatched)
             {
-                overwriteConfigIdentifier = new OverwriteConfigIdentifier(new HashSet<string>(branches), new HashSet<string>(locales, StringComparer.OrdinalIgnoreCase));
+                overwriteConfigIdentifier = new OverwriteConfigIdentifier(
+                    new HashSet<string>(branches), new HashSet<string>(locales, StringComparer.OrdinalIgnoreCase));
                 return true;
             }
 

--- a/src/docfx/lib/collections/ConcurrentHashSet.cs
+++ b/src/docfx/lib/collections/ConcurrentHashSet.cs
@@ -12,7 +12,8 @@ namespace System.Collections.Concurrent
 
         public ConcurrentHashSet() => _dictionary = new ConcurrentDictionary<T, object>();
 
-        public ConcurrentHashSet(IEnumerable<T> source) => _dictionary = new ConcurrentDictionary<T, object>(source.Select(item => new KeyValuePair<T, object>(item, default)));
+        public ConcurrentHashSet(IEnumerable<T> source)
+            => _dictionary = new ConcurrentDictionary<T, object>(source.Select(item => new KeyValuePair<T, object>(item, default)));
 
         public ConcurrentHashSet(IEqualityComparer<T> comparer) => _dictionary = new ConcurrentDictionary<T, object>(comparer);
 


### PR DESCRIPTION
Workitem is [here](https://dev.azure.com/ceapex/Engineering/_workitems/edit/107202?src=WorkItemMention&src-action=artifact_link)

|Rule|Fix|
|---|---|
|MEN002: Lines too long<br/>(current line limit is 140 characters)|- If it is caused by too many nested brackets, try  turn local functions into member functions or use early return<br/>- If it is long parameter, try put parameters to a new line, if it is still too long, break each parameter into its own line<br/>- If parameter is a long expression, try extract a variable<br/>- For long member variable declarations with initialization, try put the default initializer to a new line<br/>- If the return value is a tuple ant the tuple definition is long, try put the return value definition in its own line<br/>- Suppress this warning in Errors.cs|

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5020)