### PR TITLE
Refactor GitCommitCache outside CommitProvider

### DIFF
--- a/src/docfx/lib/git/FileCommitProvider.cs
+++ b/src/docfx/lib/git/FileCommitProvider.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -13,16 +12,12 @@ using System.Threading.Tasks;
 
 using static Microsoft.Docs.Build.LibGit2;
 
-#pragma warning disable CA2002 // Do not lock on objects with weak identity
-
 namespace Microsoft.Docs.Build
 {
     internal sealed class FileCommitProvider : IDisposable
     {
-        private const int MaxCommitCacheCountPerFile = 10;
-
         private readonly string _repoPath;
-        private readonly string _cacheFilePath;
+        private readonly Lazy<GitCommitCache> _commitCache;
 
         // Commit history and a lookup table from commit hash to commit.
         // Use `long` to represent SHA2 git hashes for more efficient lookup and smaller size.
@@ -35,14 +30,7 @@ namespace Microsoft.Docs.Build
         private readonly ConcurrentDictionary<long, Dictionary<int, git_oid>> _trees
                    = new ConcurrentDictionary<long, Dictionary<int, git_oid>>();
 
-        // Commit history LRU cache per file. Key is the file path relative to repository root.
-        // Value is a dictionary of git commit history for a particular commit hash and file blob hash.
-        // Only the last N = MaxCommitCacheCountPerFile commit histories are cached for a file, they are selected by least recently used order (lruOrder).
-        private readonly Lazy<ConcurrentDictionary<string, Dictionary<(long commit, long blob), (long[] commitHistory, int lruOrder)>>> _commitCache;
-
-        private int _nextLruOrder;
         private int _nextStringId;
-        private bool _cacheUpdated;
         private IntPtr _repo;
 
         public FileCommitProvider(string repoPath, string cacheFilePath)
@@ -52,19 +40,30 @@ namespace Microsoft.Docs.Build
                 throw new ArgumentException($"Invalid git repo {repoPath}");
             }
             _repoPath = repoPath;
-            _cacheFilePath = cacheFilePath;
+            _commitCache = new Lazy<GitCommitCache>(() => new GitCommitCache(cacheFilePath));
             _commits = new ConcurrentDictionary<string, Lazy<(List<Commit>, Dictionary<long, Commit>)>>();
-            _commitCache = new Lazy<ConcurrentDictionary<string, Dictionary<(long commit, long blob), (long[] commitHistory, int lruOrder)>>>(
-                () => LoadCommitCache(_cacheFilePath));
         }
 
-        public List<GitCommit> GetCommitHistory(string file, string committish)
+        public List<GitCommit> GetCommitHistory(string committish = null)
+        {
+            return GetCommitHistory("", committish);
+        }
+
+        public List<GitCommit> GetCommitHistory(string file, string committish = null)
         {
             Debug.Assert(!file.Contains('\\'));
 
-            const int MaxParentBlob = 32;
+            var commitCache = _commitCache.Value.ForFile(file);
 
-            var commitCache = _commitCache.Value.GetOrAdd(file, _ => new Dictionary<(long, long), (long[], int)>());
+            lock (commitCache)
+            {
+                return GetCommitHistory(commitCache, file, committish);
+            }
+        }
+
+        private List<GitCommit> GetCommitHistory(GitCommitCache.FileCommitCache commitCache, string file, string committish = null)
+        {
+            const int MaxParentBlob = 32;
 
             var (commits, commitsBySha) = _commits.GetOrAdd(
                 committish ?? "",
@@ -96,8 +95,15 @@ namespace Microsoft.Docs.Build
                 }
 
                 // Lookup and use cached commit history ONLY if there are no other commits to follow
-                if (commitsToFollow.Count == 0 && TryPopulateResultFromCache(commit, blob))
+                if (commitsToFollow.Count == 0 && commitCache.TryGetCommits(commit.Sha.a, blob, out var commitIds))
                 {
+                    // Only update cache when the cached result has changed.
+                    updateCache = result.Count != 0;
+
+                    for (var i = 0; i < commitIds.Length; i++)
+                    {
+                        result.Add(commitsBySha[commitIds[i]]);
+                    }
                     break;
                 }
 
@@ -136,33 +142,11 @@ namespace Microsoft.Docs.Build
             {
                 lock (commitCache)
                 {
-                    _cacheUpdated = true;
-                    commitCache[(headCommit.Sha.a, headBlob)] = (result.Select(c => c.Sha.a).ToArray(), 0);
+                    commitCache.SetCommits(headCommit.Sha.a, headBlob, result.Select(c => c.Sha.a).ToArray());
                 }
             }
 
             return result.Select(c => c.GitCommit).ToList();
-
-            bool TryPopulateResultFromCache(Commit commit, long blob)
-            {
-                lock (commitCache)
-                {
-                    if (commitCache.TryGetValue((commit.Sha.a, blob), out var cachedValue))
-                    {
-                        // Only update cache when the cached result has changed.
-                        updateCache = result.Count != 0;
-
-                        var (cachedCommitHistory, lruOrder) = cachedValue;
-                        foreach (var cachedCommit in cachedCommitHistory)
-                        {
-                            result.Add(commitsBySha[cachedCommit]);
-                        }
-                        commitCache[(commit.Sha.a, blob)] = (cachedCommitHistory, _nextLruOrder--);
-                        return true;
-                    }
-                    return false;
-                }
-            }
         }
 
         private static bool TryRemoveCommit(Commit commit, List<(Commit commit, long blob)> commitsToFollow, out long blob)
@@ -181,9 +165,12 @@ namespace Microsoft.Docs.Build
             return false;
         }
 
-        public void SaveCache()
+        public void Save()
         {
-            SaveCacheCore();
+            if (_commitCache.IsValueCreated)
+            {
+                _commitCache.Value.Save();
+            }
         }
 
         public void Dispose()
@@ -332,94 +319,6 @@ namespace Microsoft.Docs.Build
         private int GetStringId(string value)
         {
             return _stringPool.GetOrAdd(value, _ => Interlocked.Increment(ref _nextStringId));
-        }
-
-        private static ConcurrentDictionary<string, Dictionary<(long commit, long blob), (long[] commitHistory, int lruOrder)>>
-            LoadCommitCache(string cacheFilePath)
-        {
-            Telemetry.TrackCacheTotalCount(TelemetryName.GitCommitCache);
-            if (!File.Exists(cacheFilePath))
-            {
-                Telemetry.TrackCacheMissCount(TelemetryName.GitCommitCache);
-                return new ConcurrentDictionary<string, Dictionary<(long commit, long blob), (long[] commitHistory, int lruOrder)>>();
-            }
-
-            Log.Write($"Using git commit history cache file: '{cacheFilePath}'");
-            return ProcessUtility.ReadFile(cacheFilePath, stream =>
-            {
-                var result = new ConcurrentDictionary<string, Dictionary<(long commit, long blob), (long[] commitHistory, int lruOrder)>>();
-                using (var reader = new BinaryReader(stream))
-                {
-                    var fileCount = reader.ReadInt32();
-                    for (var fileIndex = 0; fileIndex < fileCount; fileIndex++)
-                    {
-                        var file = reader.ReadString();
-                        var cacheCount = reader.ReadInt32();
-                        var cachedCommits = result.GetOrAdd(file, _ => new Dictionary<(long, long), (long[], int)>());
-
-                        for (var cacheIndex = 0; cacheIndex < cacheCount; cacheIndex++)
-                        {
-                            var commit = reader.ReadInt64();
-                            var blob = reader.ReadInt64();
-                            var commitCount = reader.ReadInt32();
-                            var commitHistory = new long[commitCount];
-
-                            for (var commitIndex = 0; commitIndex < commitCount; commitIndex++)
-                            {
-                                commitHistory[commitIndex] = reader.ReadInt64();
-                            }
-                            cachedCommits.Add((commit, blob), (commitHistory, cacheIndex + 1));
-                        }
-                    }
-                }
-                return result;
-            });
-        }
-
-        private void SaveCacheCore()
-        {
-            if (!_cacheUpdated || string.IsNullOrEmpty(_cacheFilePath) || !_commitCache.IsValueCreated)
-            {
-                return;
-            }
-
-            PathUtility.CreateDirectoryFromFilePath(_cacheFilePath);
-
-            ProcessUtility.WriteFile(_cacheFilePath, stream =>
-            {
-                using (var writer = new BinaryWriter(stream))
-                {
-                    // Create a snapshot of commit cache to ensure count and items matches.
-                    //
-                    // There is a race condition in Linq ToList() method, use ConcurrentDictionary.ToArray() to create a snapshot
-                    // https://stackoverflow.com/questions/11692389/getting-argument-exception-in-concurrent-dictionary-when-sorting-and-displaying
-                    var commitCache = _commitCache.Value.ToArray();
-
-                    writer.Write(commitCache.Length);
-                    foreach (var (file, value) in commitCache)
-                    {
-                        lock (value)
-                        {
-                            writer.Write(file);
-                            writer.Write(Math.Min(value.Count, MaxCommitCacheCountPerFile));
-
-                            var lruValues = value.OrderBy(pair => pair.Value.lruOrder).Take(MaxCommitCacheCountPerFile);
-
-                            foreach (var ((commit, blob), (commitHistory, _)) in lruValues)
-                            {
-                                writer.Write(commit);
-                                writer.Write(blob);
-                                writer.Write(commitHistory.Length);
-
-                                foreach (var sha in commitHistory)
-                                {
-                                    writer.Write(sha);
-                                }
-                            }
-                        }
-                    }
-                }
-            });
         }
 
         private class Commit

--- a/src/docfx/lib/git/GitCommitCache.cs
+++ b/src/docfx/lib/git/GitCommitCache.cs
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.Docs.Build
+{
+    internal class GitCommitCache
+    {
+        private const int MaxCommitCacheCountPerFile = 10;
+
+        private readonly string _cacheFilePath;
+
+        // Commit history LRU cache per file (or empty for whole repo). Key is the file path relative to repository root.
+        // Value is a dictionary of git commit history for a particular commit hash and file blob hash.
+        // Only the last N = MaxCommitCacheCountPerFile commit histories are cached for a file, they are selected by least recently used order (lruOrder).
+        private readonly ConcurrentDictionary<string, FileCommitCache> _commitCache = new ConcurrentDictionary<string, FileCommitCache>();
+
+        private bool _cacheUpdated;
+
+        public GitCommitCache(string cacheFilePath)
+        {
+            _cacheFilePath = cacheFilePath;
+            Load();
+        }
+
+        public FileCommitCache ForFile(string file)
+        {
+            return _commitCache.GetOrAdd(file, _ => new FileCommitCache(this));
+        }
+
+        public void Save()
+        {
+            if (!_cacheUpdated)
+            {
+                return;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(_cacheFilePath)));
+
+            ProcessUtility.WriteFile(_cacheFilePath, stream =>
+            {
+                using (var writer = new BinaryWriter(stream))
+                {
+                    // Create a snapshot of commit cache to ensure count and items matches.
+                    //
+                    // There is a race condition in Linq ToList() method, use ConcurrentDictionary.ToArray() to create a snapshot
+                    // https://stackoverflow.com/questions/11692389/getting-argument-exception-in-concurrent-dictionary-when-sorting-and-displaying
+                    var commitCache = _commitCache.ToArray();
+
+                    writer.Write(commitCache.Length);
+                    foreach (var (file, cache) in commitCache)
+                    {
+                        writer.Write(file);
+                        lock (cache)
+                        {
+                            cache.Save(writer);
+                        }
+                    }
+                }
+            });
+        }
+
+        private void Load()
+        {
+            Telemetry.TrackCacheTotalCount(TelemetryName.GitCommitCache);
+            if (!File.Exists(_cacheFilePath))
+            {
+                Telemetry.TrackCacheMissCount(TelemetryName.GitCommitCache);
+                return;
+            }
+
+            Log.Write($"Using git commit history cache file: '{_cacheFilePath}'");
+            ProcessUtility.ReadFile(_cacheFilePath, stream =>
+            {
+                using (var reader = new BinaryReader(stream))
+                {
+                    var count = reader.ReadInt32();
+                    for (var i = 0; i < count; i++)
+                    {
+                        var file = reader.ReadString();
+                        var cache = _commitCache.GetOrAdd(file, _ => new FileCommitCache(this));
+
+                        lock (cache)
+                        {
+                            cache.Load(reader);
+                        }
+                    }
+                }
+            });
+        }
+
+        public class FileCommitCache
+        {
+            private readonly GitCommitCache _parent;
+            private readonly Dictionary<(long commit, long blob), (long[] commitHistory, int lruOrder)> _commits
+                       = new Dictionary<(long commit, long blob), (long[] commitHistory, int lruOrder)>();
+
+            private int _nextLruOrder;
+
+            internal FileCommitCache(GitCommitCache parent) => _parent = parent;
+
+            public bool TryGetCommits(long sha, long blob, out long[] commits)
+            {
+                if (_commits.TryGetValue((sha, blob), out var value))
+                {
+                    (commits, _) = value;
+                    _commits[(sha, blob)] = (commits, _nextLruOrder--);
+                    return true;
+                }
+                commits = null;
+                return false;
+            }
+
+            public void SetCommits(long sha, long blob, long[] commits)
+            {
+                _parent._cacheUpdated = true;
+                _commits[(sha, blob)] = (commits, 0);
+            }
+
+            public void Load(BinaryReader reader)
+            {
+                var count = reader.ReadInt32();
+                for (var i = 0; i < count; i++)
+                {
+                    var commit = reader.ReadInt64();
+                    var blob = reader.ReadInt64();
+                    var commitCount = reader.ReadInt32();
+                    var commitHistory = new long[commitCount];
+
+                    for (var commitIndex = 0; commitIndex < commitCount; commitIndex++)
+                    {
+                        commitHistory[commitIndex] = reader.ReadInt64();
+                    }
+                    _commits.Add((commit, blob), (commitHistory, i + 1));
+                }
+            }
+
+            public void Save(BinaryWriter writer)
+            {
+                writer.Write(Math.Min(_commits.Count, MaxCommitCacheCountPerFile));
+
+                var lruValues = _commits.OrderBy(pair => pair.Value.lruOrder).Take(MaxCommitCacheCountPerFile);
+
+                foreach (var ((commit, blob), (commitHistory, _)) in lruValues)
+                {
+                    writer.Write(commit);
+                    writer.Write(blob);
+                    writer.Write(commitHistory.Length);
+
+                    foreach (var sha in commitHistory)
+                    {
+                        writer.Write(sha);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/docfx/lib/git/GitCommitProvider.cs
+++ b/src/docfx/lib/git/GitCommitProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Docs.Build
         {
             foreach (var p in _fileCommitProvidersByRepoPath.Values)
             {
-                p.SaveCache();
+                p.Save();
             }
         }
 

--- a/src/docfx/lib/process/ProcessUtility.cs
+++ b/src/docfx/lib/process/ProcessUtility.cs
@@ -262,6 +262,15 @@ namespace Microsoft.Docs.Build
             }
         }
 
+        public static void ReadFile(string path, Action<Stream> read)
+        {
+            using (InterProcessMutex.Create(path))
+            using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 1024, FileOptions.SequentialScan))
+            {
+                read(fs);
+            }
+        }
+
         /// <summary>
         /// Reads the content of a file.
         /// When used together with <see cref="ReadFile(string)"/>, provides inter-process synchronized access to the file.


### PR DESCRIPTION
Profile shows `LoadCommit` takes a lot of time and we aren't executing other stuff while calling `LoadCommit`. We could optimize `LoadCommit` to also leverage cache, this is a refactor only PR that extract GitCommitCache to a separate class, I'll merge the logic of `LoadCommit` and `GetFileCommitHistory` into one.

https://dev.azure.com/ceapex/Engineering/_workitems/edit/113226/

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5021)