### PR TITLE
Fix a ChakraCore source context thread bug

### DIFF
--- a/src/docfx/lib/js/ChakraCoreJsEngine.cs
+++ b/src/docfx/lib/js/ChakraCoreJsEngine.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Docs.Build
 
         private static readonly ThreadLocal<Dictionary<string, JavaScriptValue>> t_modules = new ThreadLocal<Dictionary<string, JavaScriptValue>>();
 
-        private static JavaScriptSourceContext s_currentSourceContext = JavaScriptSourceContext.FromIntPtr(IntPtr.Zero);
+        private static int s_currentSourceContext;
 
         private readonly ConcurrentDictionary<JavaScriptContext, JavaScriptValue> _globals = new ConcurrentDictionary<JavaScriptContext, JavaScriptValue>();
 
@@ -155,7 +155,9 @@ namespace Microsoft.Docs.Build
 
             try
             {
-                JavaScriptContext.RunScript(script, s_currentSourceContext++, scriptPath).CallFunction(
+                var sourceContext = JavaScriptSourceContext.FromIntPtr((IntPtr)Interlocked.Increment(ref s_currentSourceContext));
+
+                JavaScriptContext.RunScript(script, sourceContext, scriptPath).CallFunction(
                     JavaScriptValue.Undefined, // this pointer
                     JavaScriptValue.CreateObject(),
                     exports,


### PR DESCRIPTION
`JavaScriptSourceContext++` is not thread safe, this can lead to random crashes in very rare case.

https://dev.azure.com/ceapex/Engineering/_build/results?buildId=79335&view=logs&jobId=133bd042-0fac-58b5-e6e7-01018e6dc4d4

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5028)