### PR TITLE
Add tags to xref map output

### DIFF
--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -63,7 +63,8 @@ outputs:
 repos:
   https://docs.com/test-uid-conceptual#live:
     - files:
-        docfx.yml:
+        docfx.yml: |
+          baseUrl: https://docs.com/base_path
         docs/a.md: |
           ---
           title: Title from yaml header a
@@ -76,22 +77,24 @@ repos:
           ---
         docs/c.md: Link to @a
 outputs:
-  docs/c.json: | 
+  base_path/docs/c.json: | 
     {"conceptual":"<p>Link to <a href=\"a\">Title from yaml header a</a></p>\n"}
-  docs/a.json:
-  docs/b.json:
+  base_path/docs/a.json:
+  base_path/docs/b.json:
   .xrefmap.json: | 
     {
       "references":[
         {
           "uid": "a",
-          "href": "https://docs.com/docs/a",
-          "name": "Title from yaml header a"
+          "href": "https://docs.com/base_path/docs/a",
+          "name": "Title from yaml header a",
+          "tags": ["/base_path", "public"]
         },
         {
           "uid": "b",
-          "href": "https://docs.com/docs/b",
-          "name": "Title from yaml header b"
+          "href": "https://docs.com/base_path/docs/b",
+          "name": "Title from yaml header b",
+          "tags": ["/base_path", "public"]
         }
       ]
     }
@@ -188,6 +191,7 @@ repos:
     - files:
         docfx.yml: |
           template: {APP_BASE_PATH}data/template
+          baseUrl: https://docs.com/base_path
         docs/a.yml: |
           #YamlMime:TestData
           uid: a
@@ -198,14 +202,14 @@ repos:
           }
         docs/c.md: Link to @a
 outputs:
-  docs/a.json:
-  docs/b.json: 
-  docs/c.json: |
+  base_path/docs/a.json:
+  base_path/docs/b.json: 
+  base_path/docs/c.json: |
     {"conceptual": "<p>Link to <a href=\"a.json\" data-linktype=\"relative-path\">a</a></p>\n"}
   .errors.log: |
     ["warning","uid-conflict","UID 'a' is defined in more than one file: 'docs/a.yml', 'docs/b.json'"]
   .xrefmap.json: | 
-    {"references":[{"uid":"a","href":"https://docs.com/docs/a.json?branch=master"}]}
+    {"references":[{"uid":"a","href":"https://docs.com/base_path/docs/a.json?branch=master","tags":["/base_path","internal"]}]}
 ---
 # Resolve xref in SDP
 repos:

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -87,16 +87,18 @@ outputs:
         {
           "uid": "a",
           "href": "https://docs.com/base_path/docs/a",
-          "name": "Title from yaml header a",
-          "tags": ["/base_path", "public"]
+          "name": "Title from yaml header a"
         },
         {
           "uid": "b",
           "href": "https://docs.com/base_path/docs/b",
-          "name": "Title from yaml header b",
-          "tags": ["/base_path", "public"]
+          "name": "Title from yaml header b"
         }
-      ]
+      ],
+      "properties":
+      {
+          "tags": ["/base_path", "public"]
+      }
     }
   .dependencymap.json: |
     {
@@ -209,7 +211,7 @@ outputs:
   .errors.log: |
     ["warning","uid-conflict","UID 'a' is defined in more than one file: 'docs/a.yml', 'docs/b.json'"]
   .xrefmap.json: | 
-    {"references":[{"uid":"a","href":"https://docs.com/base_path/docs/a.json?branch=master","tags":["/base_path","internal"]}]}
+    {"references":[{"uid":"a","href":"https://docs.com/base_path/docs/a.json?branch=master"}], "properties": {"tags":["/base_path","internal"]}}
 ---
 # Resolve xref in SDP
 repos:

--- a/src/docfx/build/xref/ExternalXrefSpec.cs
+++ b/src/docfx/build/xref/ExternalXrefSpec.cs
@@ -21,8 +21,6 @@ namespace Microsoft.Docs.Build
         [JsonExtensionData]
         public JObject ExtensionData { get; } = new JObject();
 
-        public List<string> Tags { get; set; } = new List<string>();
-
         public string GetName() => GetXrefPropertyValueAsString("name");
 
         public string GetXrefPropertyValueAsString(string propertyName)

--- a/src/docfx/build/xref/ExternalXrefSpec.cs
+++ b/src/docfx/build/xref/ExternalXrefSpec.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Docs.Build
         [JsonExtensionData]
         public JObject ExtensionData { get; } = new JObject();
 
+        public List<string> Tags { get; set; } = new List<string>();
+
         public string GetName() => GetXrefPropertyValueAsString("name");
 
         public string GetXrefPropertyValueAsString(string propertyName)

--- a/src/docfx/build/xref/XrefMap.cs
+++ b/src/docfx/build/xref/XrefMap.cs
@@ -77,13 +77,25 @@ namespace Microsoft.Docs.Build
                 .Select(xref =>
                 {
                     var xrefSpec = xref.ToExternalXrefSpec();
+                    var repositoryBranch = xref.DeclaringFile.Docset.Repository?.Branch;
 
                     // DHS appends branch infomation from cookie cache to URL, which is wrong for UID resolved URL
                     // output xref map with URL appending "?branch=master" for master branch
                     var (_, _, fragment) = UrlUtility.SplitUrl(xref.Href);
                     var path = xref.DeclaringFile.CanonicalUrlWithoutLocale;
-                    var query = xref.DeclaringFile.Docset.Repository?.Branch == "master" ? "?branch=master" : "";
+                    var query = repositoryBranch == "master" ? "?branch=master" : "";
                     xrefSpec.Href = path + query + fragment;
+
+                    // populate tags
+                    xrefSpec.Tags.Add($"/{xref.DeclaringFile.Docset.SiteBasePath}");
+                    if (repositoryBranch == "master")
+                    {
+                        xrefSpec.Tags.Add("internal");
+                    }
+                    else if (repositoryBranch == "live")
+                    {
+                        xrefSpec.Tags.Add("public");
+                    }
                     return xrefSpec;
                 })
                 .OrderBy(xref => xref.Uid).ToArray();

--- a/src/docfx/build/xref/XrefProperties.cs
+++ b/src/docfx/build/xref/XrefProperties.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
+using System.Collections.Generic;
 
 namespace Microsoft.Docs.Build
 {
-    internal class XrefMapModel
+    internal class XrefProperties
     {
-        public ExternalXrefSpec[] References { get; set; } = Array.Empty<ExternalXrefSpec>();
-
-        public XrefProperties Properties { get; set; }
+        public List<string> Tags { get; set; } = new List<string>();
     }
 }


### PR DESCRIPTION
https://dev.azure.com/ceapex/Engineering/_workitems/edit/116710

Since the v2 user defines [xref_query_tags](https://github.com/OPS-E2E-PPE/docs-help-pr/blob/400b76290a681c64337fd981fbc9d1112054cfcd/.openpublishing.publish.config.json#L20)
to query xref service with the tags, v3 needs to provide these tags for xref service to consume.

#4450 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5036)