### PR TITLE
Add module init for docfx.Test

### DIFF
--- a/test/docfx.Test/DocfxTest.cs
+++ b/test/docfx.Test/DocfxTest.cs
@@ -13,7 +13,6 @@ using Microsoft.DocAsTest;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
-using Xunit.Sdk;
 
 namespace Microsoft.Docs.Build
 {
@@ -26,12 +25,6 @@ namespace Microsoft.Docs.Build
 
         static DocfxTest()
         {
-            Environment.SetEnvironmentVariable("DOCFX_APPDATA_PATH", Path.GetFullPath("appdata"));
-            Environment.SetEnvironmentVariable("DOCFX_GLOBAL_CONFIG_PATH", Path.GetFullPath("docfx.test.yml"));
-
-            Log.ForceVerbose = true;
-            TestUtility.MakeDebugAssertThrowException();
-
             AppData.GetCachePath = () => t_cachePath.Value;
             GitUtility.GitRemoteProxy = remote =>
             {

--- a/test/docfx.Test/FodyWeavers.xml
+++ b/test/docfx.Test/FodyWeavers.xml
@@ -1,0 +1,3 @@
+﻿<Weavers>
+  <ModuleInit />
+</Weavers>

--- a/test/docfx.Test/ModuleInitializer.cs
+++ b/test/docfx.Test/ModuleInitializer.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+
+namespace Microsoft.Docs.Build
+{
+    public static class ModuleInitializer
+    {
+        public static void Initialize()
+        {
+            Environment.SetEnvironmentVariable("DOCFX_APPDATA_PATH", Path.GetFullPath("appdata"));
+            Environment.SetEnvironmentVariable("DOCFX_GLOBAL_CONFIG_PATH", Path.GetFullPath("docfx.test.yml"));
+
+            Log.ForceVerbose = true;
+            TestUtility.MakeDebugAssertThrowException();
+        }
+    }
+}

--- a/test/docfx.Test/docfx.Test.csproj
+++ b/test/docfx.Test/docfx.Test.csproj
@@ -2,10 +2,13 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <FodyGenerateXsd>false</FodyGenerateXsd>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0007" />
+    <PackageReference Include="Fody" Version="6.0.0" />
+    <PackageReference Include="ModuleInit.Fody" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Before C# had a way to implement module initializes https://github.com/dotnet/csharplang/issues/2608, use Fody for now.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5041)