### PR TITLE
Make RestoreGitMap.DependencyGitLock and docsetPath private

### DIFF
--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -205,9 +205,9 @@ namespace Microsoft.Docs.Build
             {
                 foreach (var branch in new[] { fallbackBranch, "master" })
                 {
-                    var fallbackRepoPath = restoreGitMap.TryGetGitRestorePath(new PackageUrl(fallbackRemote, branch));
-                    if (fallbackRepoPath != null)
+                    if (restoreGitMap.BranchExists(fallbackRemote, branch))
                     {
+                        var fallbackRepoPath = restoreGitMap.GetGitRestorePath(new PackageUrl(fallbackRemote, branch));
                         return Repository.Create(fallbackRepoPath, branch, fallbackRemote);
                     }
                 }

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -189,10 +189,8 @@ namespace Microsoft.Docs.Build
             Debug.Assert(!string.IsNullOrEmpty(docsetPath));
 
             var (_, config) = ConfigLoader.TryLoad(docsetPath, commandLineOptions);
-            var dependencyLockPath = string.IsNullOrEmpty(config.DependencyLock)
-                ? new SourceInfo<string>(AppData.GetDependencyLockFile(docsetPath, locale)) : config.DependencyLock;
 
-            return RestoreGitMap.Create(docsetPath, dependencyLockPath);
+            return RestoreGitMap.Create(docsetPath, config, locale);
         }
 
         private static Repository GetFallbackRepository(

--- a/src/docfx/build/context/Input.cs
+++ b/src/docfx/build/context/Input.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Docs.Build
                         .ToArray();
 
                 case FileOrigin.Dependency:
-                    var dependencyPath = _restoreMap.GetGitRestorePath(_config.Dependencies[dependencyName], _docsetPath);
+                    var dependencyPath = _restoreMap.GetGitRestorePath(_config.Dependencies[dependencyName]);
                     return Directory
                         .GetFiles(dependencyPath, "*", SearchOption.AllDirectories)
                         .Select(path => new FilePath(
@@ -147,14 +147,14 @@ namespace Microsoft.Docs.Build
                     return (_docsetPath, file.Path, file.Commit);
 
                 case FileOrigin.Dependency:
-                    var dependencyPath = _restoreMap.GetGitRestorePath(_config.Dependencies[file.DependencyName], _docsetPath);
+                    var dependencyPath = _restoreMap.GetGitRestorePath(_config.Dependencies[file.DependencyName]);
                     return (dependencyPath, file.Path, file.Commit);
 
                 case FileOrigin.Fallback:
                     return (_fallbackPath, file.Path, file.Commit);
 
                 case FileOrigin.Template:
-                    var templatePath = _restoreMap.GetGitRestorePath(_config.Template, _docsetPath);
+                    var templatePath = _restoreMap.GetGitRestorePath(_config.Template);
                     return (templatePath, file.Path, file.Commit);
 
                 default:

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -338,7 +338,7 @@ namespace Microsoft.Docs.Build
 
             foreach (var (name, dependency) in config.Dependencies)
             {
-                var dir = restoreGitMap.GetGitRestorePath(dependency, docset.DocsetPath);
+                var dir = restoreGitMap.GetGitRestorePath(dependency);
 
                 result.TryAdd(name, new Docset(dir, docset.Locale, config));
             }

--- a/src/docfx/restore/RestoreGitMap.cs
+++ b/src/docfx/restore/RestoreGitMap.cs
@@ -28,11 +28,24 @@ namespace Microsoft.Docs.Build
         public string GetGitRestorePath(PackageUrl packageUrl)
         {
             var path = TryGetGitRestorePath(packageUrl);
-            if (path is null)
+            if (path != null)
             {
-                throw Errors.NeedRestore(packageUrl.ToString()).ToException();
+                return path;
             }
-            return path;
+
+            switch (packageUrl.Type)
+            {
+                case PackageType.Folder:
+                    // TODO: Intentionally don't fallback to fallbackDocset for git restore path,
+                    // TODO: populate source info
+                    throw Errors.FileNotFound(new SourceInfo<string>(packageUrl.Path)).ToException();
+
+                case PackageType.Git:
+                    throw Errors.NeedRestore(packageUrl.ToString()).ToException();
+
+                default:
+                    throw new NotSupportedException($"Unknown package url: '{packageUrl}'");
+            }
         }
 
         public string TryGetGitRestorePath(PackageUrl packageUrl)

--- a/src/docfx/restore/RestoreGitMap.cs
+++ b/src/docfx/restore/RestoreGitMap.cs
@@ -99,12 +99,14 @@ namespace Microsoft.Docs.Build
         /// Acquired all shared git based on dependency lock
         /// The dependency lock must be loaded before using this method
         /// </summary>
-        public static RestoreGitMap Create(string docsetPath, SourceInfo<string> dependencyLockPath)
+        public static RestoreGitMap Create(string docsetPath, Config config, string locale)
         {
             var acquired = new Dictionary<(PackageUrl packageUrl, string commit), (string path, DependencyGit git)>();
 
             try
             {
+                var dependencyLockPath = string.IsNullOrEmpty(config.DependencyLock)
+                    ? new SourceInfo<string>(AppData.GetDependencyLockFile(docsetPath, locale)) : config.DependencyLock;
                 var dependencyLock = DependencyLockProvider.LoadGitLock(docsetPath, dependencyLockPath)
                     ?? new Dictionary<PackageUrl, DependencyGitLock>();
 

--- a/src/docfx/restore/lock/DependencyLockProvider.cs
+++ b/src/docfx/restore/lock/DependencyLockProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Docs.Build
 {
     internal static class DependencyLockProvider
     {
-        public static DependencyGitLock GetGitLock(this Dictionary<PackageUrl, DependencyGitLock> dependencyLock, PackageUrl packageUrl)
+        public static DependencyGitLock GetGitLock(this IReadOnlyDictionary<PackageUrl, DependencyGitLock> dependencyLock, PackageUrl packageUrl)
         {
             if (dependencyLock == null)
             {
@@ -45,6 +45,8 @@ namespace Microsoft.Docs.Build
             }
 
             var content = RestoreFileMap.GetRestoredFileContent(docset, dependencyLockPath, fallbackDocset: null);
+
+            Log.Write($"DependencyLock ({dependencyLockPath}):\n{content}");
 
             var dependencyLock = JsonUtility.Deserialize<DependencyLock>(content, new FilePath(dependencyLockPath));
 

--- a/src/docfx/template/TemplateEngine.cs
+++ b/src/docfx/template/TemplateEngine.cs
@@ -149,9 +149,7 @@ namespace Microsoft.Docs.Build
             }
 
             var theme = LocalizationUtility.GetLocalizedTheme(docset.Config.Template, docset.Locale, docset.Config.Localization.DefaultLocale);
-            var themePath = restoreGitMap.GetGitRestorePath(theme, docset.DocsetPath);
-            Log.Write($"Using theme '{theme}' commit {restoreGitMap.DependencyGitLock.GetGitLock(theme)?.Commit}' at '{themePath}'");
-
+            var themePath = restoreGitMap.GetGitRestorePath(theme);
             return new TemplateEngine(themePath);
         }
 

--- a/test/docfx.Test/build/TocTest.cs
+++ b/test/docfx.Test/build/TocTest.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Docs.Build
 {
     public static class TocTest
     {
-        private static readonly RestoreGitMap s_restoreGitMap = new RestoreGitMap();
+        private static readonly RestoreGitMap s_restoreGitMap = new RestoreGitMap(Directory.GetCurrentDirectory(), null, null);
         private static readonly Config s_config = JsonUtility.Deserialize<Config>("{'output': { 'json': true } }".Replace('\'', '\"'), null);
         private static readonly Docset s_docset = new Docset(Directory.GetCurrentDirectory(), "en-us", s_config, null);
         private static readonly Input s_input = new Input(Directory.GetCurrentDirectory(), null, s_config, s_restoreGitMap);


### PR DESCRIPTION
So these internal states don't leak to other components.

Print the content of lock file to stdout

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5061)