### PR TITLE
Add component abstractions

### DIFF
--- a/src/docfx/abstractions/IBookmarkValidator.cs
+++ b/src/docfx/abstractions/IBookmarkValidator.cs
@@ -8,7 +8,5 @@ namespace Microsoft.Docs.Build
         void AddLink(FilePath declaringFile, FilePath targetFile, SourceInfo<string> url);
 
         void AddBookmarks(FilePath file, string[] bookmarks);
-
-        void Validate();
     }
 }

--- a/src/docfx/abstractions/IBookmarkValidator.cs
+++ b/src/docfx/abstractions/IBookmarkValidator.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Docs.Build
+{
+    internal interface IBookmarkValidator
+    {
+        void AddLink(FilePath declaringFile, FilePath targetFile, SourceInfo<string> url);
+
+        void AddBookmarks(FilePath file, string[] bookmarks);
+
+        void Validate();
+    }
+}

--- a/src/docfx/abstractions/IBuildQueue.cs
+++ b/src/docfx/abstractions/IBuildQueue.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Docs.Build
+{
+    internal interface IBuildQueue
+    {
+        void Enqueue(FilePath file);
+
+        void Drain();
+    }
+}

--- a/src/docfx/abstractions/IBuildQueue.cs
+++ b/src/docfx/abstractions/IBuildQueue.cs
@@ -6,7 +6,5 @@ namespace Microsoft.Docs.Build
     internal interface IBuildQueue
     {
         void Enqueue(FilePath file);
-
-        void Drain();
     }
 }

--- a/src/docfx/abstractions/IBuildScope.cs
+++ b/src/docfx/abstractions/IBuildScope.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Docs.Build
+{
+    /// <summary>
+    /// Represents the initial build scope.
+    /// </summary>
+    internal interface IBuildScope
+    {
+        /// <summary>
+        /// Gets all the files to build including fallback files.
+        /// </summary>
+        FilePath[] Files { get; }
+    }
+}

--- a/src/docfx/abstractions/IDependencyTracker.cs
+++ b/src/docfx/abstractions/IDependencyTracker.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Docs.Build
+{
+    internal interface IDependencyTracker
+    {
+        void TrackDependency(FilePath from, FilePath to, DependencyType type);
+
+        DependencyMap CreateDependencyMap();
+    }
+}

--- a/src/docfx/abstractions/IDependencyTracker.cs
+++ b/src/docfx/abstractions/IDependencyTracker.cs
@@ -6,7 +6,5 @@ namespace Microsoft.Docs.Build
     internal interface IDependencyTracker
     {
         void TrackDependency(FilePath from, FilePath to, DependencyType type);
-
-        DependencyMap CreateDependencyMap();
     }
 }

--- a/src/docfx/abstractions/IDocumentInfoProvider.cs
+++ b/src/docfx/abstractions/IDocumentInfoProvider.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Docs.Build
+{
+    internal interface IDocumentInfoProvider
+    {
+        SourceInfo<string> GetSchemaName(FilePath file);
+
+        string GetSiteUrl(FilePath file);
+
+        string GetSitePath(FilePath file);
+
+        (string id, string versionIndependentId) GetDocumentId(FilePath file);
+
+        string GetOutputPath(FilePath file);
+
+        bool IsExperimental(FilePath file);
+    }
+}

--- a/src/docfx/abstractions/IErrorLog.cs
+++ b/src/docfx/abstractions/IErrorLog.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Docs.Build
+{
+    internal interface IErrorLog
+    {
+        bool Write(Error error);
+
+        bool HasError(FilePath file);
+    }
+}

--- a/src/docfx/abstractions/IGitHubClient.cs
+++ b/src/docfx/abstractions/IGitHubClient.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.Docs.Build
+{
+    internal interface IGitHubClient
+    {
+        Task<(Error error, GitHubUser user)> GetUserByLogin(SourceInfo<string> login);
+
+        Task<(Error error, GitHubUser user)> GetUserByEmail(string email);
+
+        Task<(Error error, GitHubUser user)> GetUserByCommit(string email, string owner, string name, string commit);
+    }
+}

--- a/src/docfx/abstractions/IInput.cs
+++ b/src/docfx/abstractions/IInput.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+
+namespace Microsoft.Docs.Build
+{
+    internal interface IInput
+    {
+        /// <summary>
+        /// Check if the specified file path exist.
+        /// </summary>
+        bool Exists(FilePath file);
+
+        /// <summary>
+        /// Try get the absolute path of the specified file if it exists physically on disk.
+        /// Some file path like content from a bare git repo does not exist physically
+        /// on disk but we can still read its content.
+        /// </summary>
+        bool TryGetPhysicalPath(FilePath file, out string physicalPath);
+
+        /// <summary>
+        /// Try get the file path in actual case.
+        /// </summary>
+        FilePath GetActualCase(FilePath file);
+
+        /// <summary>
+        /// Reads the specified file as a string.
+        /// </summary>
+        string ReadString(FilePath file);
+
+        /// <summary>
+        /// Open the specified file and read it as text.
+        /// </summary>
+        TextReader ReadText(FilePath file);
+
+        /// <summary>
+        /// List all the file path.
+        /// </summary>
+        FilePath[] ListFilesRecursive(FileOrigin origin, string dependencyName = null);
+    }
+}

--- a/src/docfx/abstractions/ILinkResolver.cs
+++ b/src/docfx/abstractions/ILinkResolver.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Docs.Build
+{
+    internal interface ILinkResolver
+    {
+        (Error error, string content, FilePath declaringFile) ResolveContent(
+            SourceInfo<string> href, FilePath referencingFile, DependencyType dependencyType = DependencyType.Inclusion);
+
+        (Error error, string url, FilePath declaringFile) ResolveLink(SourceInfo<string> href, FilePath referencingFile);
+    }
+}

--- a/src/docfx/abstractions/IMarkdownEngine.cs
+++ b/src/docfx/abstractions/IMarkdownEngine.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using HtmlAgilityPack;
+using Markdig.Syntax;
+
+namespace Microsoft.Docs.Build
+{
+    internal interface IMarkdownEngine
+    {
+        (Error[] errors, MarkdownDocument ast) Parse(string markdown, MarkdownPipelineType piplineType);
+
+        (Error[] errors, HtmlNode html) ToHtml(string markdown, FilePath file, MarkdownPipelineType pipelineType);
+    }
+}

--- a/src/docfx/abstractions/IMetadataProvider.cs
+++ b/src/docfx/abstractions/IMetadataProvider.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Docs.Build
+{
+    internal interface IMetadataProvider
+    {
+        (Error[] errors, InputMetadata metadata) GetMetadata(FilePath file);
+
+        bool TryGetHtmlMetaName(string metadataName, out string htmlMetaName);
+    }
+}

--- a/src/docfx/abstractions/IMicrosoftGraphClient.cs
+++ b/src/docfx/abstractions/IMicrosoftGraphClient.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.Docs.Build
+{
+    internal interface IMicrosoftGraphClient
+    {
+        /// <summary>
+        /// Returns null if the specified alias is a valid microsoft alias,
+        /// or the corresponding error.
+        /// </summary>
+        Task<Error> IsValidMicrosoftAlias(string alias);
+    }
+}

--- a/src/docfx/abstractions/IMonikerProvider.cs
+++ b/src/docfx/abstractions/IMonikerProvider.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Docs.Build
+{
+    internal interface IMonikerProvider
+    {
+        (Error error, string[] monikers) GetMonikers(FilePath file);
+
+        (Error error, string[] monikers) ResolveMonikerRange(SourceInfo<string> rangeString, FilePath declaringFile);
+    }
+}

--- a/src/docfx/abstractions/IOutput.cs
+++ b/src/docfx/abstractions/IOutput.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Docs.Build
+{
+    internal interface IOutput
+    {
+        /// <summary>
+        /// Writes the input object as json to an output file.
+        /// Throws if multiple threads trying to write to the same destination concurrently.
+        /// </summary>
+        void WriteJson(object graph, string destRelativePath);
+
+        /// <summary>
+        /// Writes the input text to an output file.
+        /// Throws if multiple threads trying to write to the same destination concurrently.
+        /// </summary>
+        void WriteString(string value, string destRelativePath);
+
+        /// <summary>
+        /// Copies a file from source to destination, throws if source does not exists.
+        /// Throws if multiple threads trying to write to the same destination concurrently.
+        /// </summary>
+        void Copy(string sourceRelativePath, string destRelativePath);
+
+        void Delete(string destRelativePath);
+    }
+}

--- a/src/docfx/abstractions/IPublishManifestBuilder.cs
+++ b/src/docfx/abstractions/IPublishManifestBuilder.cs
@@ -6,7 +6,5 @@ namespace Microsoft.Docs.Build
     internal interface IPublishManifestBuilder
     {
         bool TryAdd(FilePath file, PublishItem item);
-
-        PublishModel CreatePublishManifest();
     }
 }

--- a/src/docfx/abstractions/IPublishManifestBuilder.cs
+++ b/src/docfx/abstractions/IPublishManifestBuilder.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Docs.Build
+{
+    internal interface IPublishManifestBuilder
+    {
+        bool TryAdd(FilePath file, PublishItem item);
+
+        PublishModel CreatePublishManifest();
+    }
+}

--- a/src/docfx/abstractions/IRedirectionProvider.cs
+++ b/src/docfx/abstractions/IRedirectionProvider.cs
@@ -7,6 +7,6 @@ namespace Microsoft.Docs.Build
     {
         bool TryGetRedirection(string sourcePath, out string redirectUrl);
 
-        bool TryGetRename(string sourcePath, out string renamedPath);
+        bool TryGetRename(string sourcePath, out string originalPath);
     }
 }

--- a/src/docfx/abstractions/IRedirectionProvider.cs
+++ b/src/docfx/abstractions/IRedirectionProvider.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Docs.Build
+{
+    internal interface IRedirectionProvider
+    {
+        bool TryGetRedirection(string sourcePath, out string redirectUrl);
+
+        bool TryGetRename(string sourcePath, out string renamedPath);
+    }
+}

--- a/src/docfx/abstractions/IRepository.cs
+++ b/src/docfx/abstractions/IRepository.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Docs.Build
+{
+    internal interface IRepository
+    {
+        byte[] ReadBytes(string path, string committish = null);
+
+        string[] ListFilesRecursive(string committish = null);
+
+        GitCommit[] GetCommitHistory(string committish = null);
+
+        GitCommit[] GetFileCommitHistory(string path, string committish = null);
+    }
+}

--- a/src/docfx/abstractions/IRepositoryProvider.cs
+++ b/src/docfx/abstractions/IRepositoryProvider.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Docs.Build
+{
+    internal interface IRepositoryProvider
+    {
+        bool TryGetRepositoryInfo(FilePath file, out string url, out string branch, out string commit);
+
+        bool TryGetRepositoryInfo(FileOrigin origin, out string url, out string branch, out string commit);
+
+        bool TryGetRepository(FilePath file, out IRepository repository);
+
+        (string contentGitUrl, string originalContentGitUrl, string originalContentGitUrlTemplate, string gitCommit)
+            GetGitUrls(FilePath file);
+    }
+}

--- a/src/docfx/abstractions/IRestoreMap.cs
+++ b/src/docfx/abstractions/IRestoreMap.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Docs.Build
 
         string GetFilePath(SourceInfo<string> url);
 
-        (string path, string commit) GetGitRepository(string url, string branch);
+        (string path, string commit) GetGitRepositoryPath(string url, string branch);
 
         bool TryGetGitRepositoryPath(string url, string branch, out string path, out string commit);
     }

--- a/src/docfx/abstractions/IRestoreMap.cs
+++ b/src/docfx/abstractions/IRestoreMap.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Docs.Build
+{
+    internal interface IRestoreMap
+    {
+        string ReadFile(SourceInfo<string> url);
+
+        string GetFilePath(SourceInfo<string> url);
+
+        (string path, string commit) GetGitRepository(string url, string branch);
+
+        bool TryGetGitRepositoryPath(string url, string branch, out string path, out string commit);
+    }
+}

--- a/src/docfx/abstractions/ISchemaDocumentProvider.cs
+++ b/src/docfx/abstractions/ISchemaDocumentProvider.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Docs.Build
+{
+    internal interface ISchemaDocumentProvider
+    {
+        (Error[] errors, IXrefSpec[] xrefSpecs) LoadXrefSpecs(FilePath file);
+
+        (Error[] errors, JToken model) LoadSchemaDocument(FilePath file);
+    }
+}

--- a/src/docfx/abstractions/ITableOfContentsResolver.cs
+++ b/src/docfx/abstractions/ITableOfContentsResolver.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Docs.Build
+{
+    internal interface ITableOfContentsResolver
+    {
+        FilePath ResolveTableOfContents(FilePath file);
+
+        bool IsIncluded(FilePath file);
+
+        FilePath[] GetIncludes(FilePath file);
+    }
+}

--- a/src/docfx/abstractions/ITemplateEngine.cs
+++ b/src/docfx/abstractions/ITemplateEngine.cs
@@ -17,6 +17,6 @@ namespace Microsoft.Docs.Build
 
         string RunMustache(string fileName, JToken model);
 
-        JObject RunJint(string fileName, JObject model);
+        JToken RunJint(string fileName, JToken model);
     }
 }

--- a/src/docfx/abstractions/ITemplateEngine.cs
+++ b/src/docfx/abstractions/ITemplateEngine.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Docs.Build
+{
+    internal interface ITemplateEngine
+    {
+        bool IsPage(string schemaName);
+
+        bool TryGetLocalizedToken(string token, string localizedToken);
+
+        JsonSchema GetJsonSchema(SourceInfo<string> schemaName);
+
+        string RunLiquid(string fileName, TemplateModel model);
+
+        string RunMustache(string fileName, JToken model);
+
+        JObject RunJint(string fileName, JObject model);
+    }
+}

--- a/src/docfx/abstractions/IXrefResolver.cs
+++ b/src/docfx/abstractions/IXrefResolver.cs
@@ -9,7 +9,5 @@ namespace Microsoft.Docs.Build
             SourceInfo<string> href, FilePath referencingFile);
 
         (Error error, IXrefSpec xrefSpec) ResolveXrefSpec(SourceInfo<string> uid, FilePath referencingFile);
-
-        XrefMapModel CreateXrefMap();
     }
 }

--- a/src/docfx/abstractions/IXrefResolver.cs
+++ b/src/docfx/abstractions/IXrefResolver.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Docs.Build
+{
+    internal interface IXrefResolver
+    {
+        (Error error, string href, string displayName, FilePath declaringFile) ResolveXref(
+            SourceInfo<string> href, FilePath referencingFile);
+
+        (Error error, IXrefSpec xrefSpec) ResolveXrefSpec(SourceInfo<string> uid, FilePath referencingFile);
+
+        XrefMapModel CreateXrefMap();
+    }
+}

--- a/src/docfx/abstractions/README.md
+++ b/src/docfx/abstractions/README.md
@@ -1,3 +1,0 @@
-Contains component level abstractions used internally in docfx.
-
-These abstractions are registered as singleton upon startup and are shared across multiple components.

--- a/src/docfx/abstractions/README.md
+++ b/src/docfx/abstractions/README.md
@@ -1,0 +1,3 @@
+Contains component level abstractions used internally in docfx.
+
+These abstractions are registered as singleton upon startup and are shared across multiple components.


### PR DESCRIPTION
This is a draft abstraction of internal components used inside docfx. There are a couple of reasons to add this layer today:

- Clarify internal components, their boundary, responsibility and dependency.
- Ensures each functionality is implemented in one component to avoid bugs.
- Changes to one component does not affect other components
- Highlight cross component changes as they require changes to these interfaces and respective data contract.

This is a draft proposal, some of the abstractions match closely to what is already implemented in docfx, some other abstractions don't. We don't need to implement these interfaces immediately, it gives us a guidance to gradually morph into a better componentized codebase.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5074)