### PR TITLE
remove host name for review

### DIFF
--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -153,6 +153,30 @@ outputs:
       }
     }
 ---
+# Remove host from review site
+# This can be removed when xref related repo migrated to v3
+repos:
+  https://docs.com/test-uid-conceptual#live:
+    - files:
+        docfx.yml: |
+          baseUrl: https://docs.microsoft.com/base_path
+          xref: 
+            - 1.xrefmap.json
+        docs/a.md: Link to @System.String
+        1.xrefmap.json: |
+          {
+            "references":[{
+                "uid": "System.String",
+                "name": "String",
+                "fullName": "System.String",
+                "href": "https://review.docs.microsoft.com/dotnet/api/system.string",
+                "nameWithType": "System.String"
+            }]
+          }
+outputs:
+  base_path/docs/a.json: |
+    { "conceptual": "<p>Link to <a href=\"/en-us/dotnet/api/system.string\">String</a></p>\n"}
+---
 # The same uid in internal and external
 # should resolve it from the internal one
 inputs:

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -137,6 +137,13 @@ namespace Microsoft.Docs.Build
                 return url.Substring(hostName.Length);
             }
 
+            // TODO: this workaround can be removed when all xref related repos migrated to v3
+            if (hostName.Equals("https://docs.microsoft.com", StringComparison.OrdinalIgnoreCase)
+                        && url.StartsWith($"https://review.docs.microsoft.com/", StringComparison.OrdinalIgnoreCase))
+            {
+                return url.Substring("https://review.docs.microsoft.com".Length);
+            }
+
             return url;
         }
 


### PR DESCRIPTION
Host name of `.xrefmap.json` in v3 is always `docs.microsoft.com` even for review site
Host name of `.xrefmap.json` in v2 is `review.docs.microsoft.com` for review site

Apply the workaround to remove the host name, it can be removed when all xref related repos migrated to v3

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5084)