### PR TITLE
Revert "zip file loading order (#5072)"

### DIFF
--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -87,8 +87,6 @@ inputs:
       - xrefmap.zip
   docs/a.md: Link to @System.String
   xrefmap.zip: |
-    a.json: |
-      { "references":[{"uid": "System.String", "name": "a", "fullName": "a", "href": "https://docs.microsoft.com/en-us/a", "nameWithType": "a"}]}
     xrefmap.yml: |
       references:
         - uid: System.String
@@ -96,6 +94,8 @@ inputs:
           fullName: System.String
           href: https://docs.microsoft.com/en-us/dotnet/api/system.string
           nameWithType: System.String
+    a.json: |
+      { "references":[{"uid": "a", "name": "a", "fullName": "a", "href": "https://docs.microsoft.com/en-us/a", "nameWithType": "a"}]}
 outputs:
   docs/a.json: |
     { "conceptual": "<p>Link to <a href=\"https://docs.microsoft.com/en-us/dotnet/api/system.string\">String</a></p>\n"}

--- a/src/docfx/build/xref/ExternalXrefMapLoader.cs
+++ b/src/docfx/build/xref/ExternalXrefMapLoader.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Docs.Build
                             var xrefMap = YamlUtility.Deserialize<XrefMapModel>(sr.ReadToEnd(), new FilePath(url));
                             foreach (var spec in xrefMap.References)
                             {
-                                result[spec.Uid] = new Lazy<ExternalXrefSpec>(() => spec);
+                                result.TryAdd(spec.Uid, new Lazy<ExternalXrefSpec>(() => spec));
                             }
                         }
                         else if (entry.FullName.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
@@ -90,7 +90,7 @@ namespace Microsoft.Docs.Build
                             var xrefMap = JsonUtility.Deserialize<XrefMapModel>(sr.ReadToEnd(), new FilePath(url));
                             foreach (var spec in xrefMap.References)
                             {
-                                result[spec.Uid] = new Lazy<ExternalXrefSpec>(() => spec);
+                                result.TryAdd(spec.Uid, new Lazy<ExternalXrefSpec>(() => spec));
                             }
                         }
                     }


### PR DESCRIPTION
This reverts commit 0a2897bb94861602f420efd9dc420af5c5f70a36.

https://dev.azure.com/ceapex/Engineering/_workitems/edit/118436?src=WorkItemMention&src-action=artifact_link
The root cause is xref resolving in v2 is not stable, fixed in #5086 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5087)