### PR TITLE
hide dependency lock model from build and restore

### DIFF
--- a/src/docfx/lib/path/PackageUrl.cs
+++ b/src/docfx/lib/path/PackageUrl.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Docs.Build
     /// The commit-sh can be any tag, sha, or branch. The default commit-ish is master.
     /// </summary>
     [JsonConverter(typeof(ShortHandConverter))]
-    internal class PackageUrl : IEquatable<PackageUrl>
+    internal class PackageUrl
     {
         public PackageType Type { get; set; }
 
@@ -80,29 +80,6 @@ namespace Microsoft.Docs.Build
             var refspec = hasRefSpec ? fragment.Substring(1) : "master";
 
             return (path, refspec);
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Type, Path, Url, Branch);
-        }
-
-        public bool Equals(PackageUrl other)
-        {
-            if (other == null)
-            {
-                return false;
-            }
-
-            return Type == other.Type &&
-                   string.Equals(Path, other.Path, PathUtility.PathComparison) &&
-                   Url == other.Url &&
-                   Branch == other.Branch;
-        }
-
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as PackageUrl);
         }
     }
 }

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Docs.Build
                 await RestoreFile.Restore(restoreUrls, extendedConfig);
 
                 // restore git repos includes dependency repos, theme repo and loc repos
-                var restoreDependencyResults = RestoreGit.Restore(extendedConfig, localeToRestore, repository, DependencyLockProvider.LoadGitLock(docsetPath, extendedConfig.DependencyLock));
+                var restoreDependencyResults = RestoreGit.Restore(extendedConfig, localeToRestore, repository, DependencyLockProvider.Create(docsetPath, extendedConfig.DependencyLock));
 
                 // save dependency lock
                 var restoredGitLock = new List<DependencyGitLock>();
@@ -70,7 +70,7 @@ namespace Microsoft.Docs.Build
                     ? AppData.GetDependencyLockFile(docsetPath, localeToRestore)
                     : extendedConfig.DependencyLock;
 
-                DependencyLockProvider.SaveGitLock(docsetPath, dependencyLockFilePath, restoredGitLock);
+                DependencyLockProvider.Save(docsetPath, dependencyLockFilePath, restoredGitLock);
             }
         }
 

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Docs.Build
                     ? AppData.GetDependencyLockFile(docsetPath, localeToRestore)
                     : extendedConfig.DependencyLock;
 
-                DependencyLockProvider.Save(docsetPath, dependencyLockFilePath, restoredGitLock);
+                DependencyLockProvider.SaveGitLock(docsetPath, dependencyLockFilePath, restoredGitLock);
             }
         }
 

--- a/src/docfx/restore/lock/DependencyLockProvider.cs
+++ b/src/docfx/restore/lock/DependencyLockProvider.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Docs.Build
                 v => v.Value));
         }
 
-        public static void Save(string docset, string dependencyLockPath, List<DependencyGitLock> dependencyGitLock)
+        public static void SaveGitLock(string docset, string dependencyLockPath, List<DependencyGitLock> dependencyGitLock)
         {
             Debug.Assert(!string.IsNullOrEmpty(docset));
             Debug.Assert(!string.IsNullOrEmpty(dependencyLockPath));

--- a/src/docfx/restore/lock/DependencyLockProvider.cs
+++ b/src/docfx/restore/lock/DependencyLockProvider.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -9,16 +8,20 @@ using System.Linq;
 
 namespace Microsoft.Docs.Build
 {
-    internal static class DependencyLockProvider
+    internal class DependencyLockProvider
     {
-        public static DependencyGitLock GetGitLock(this IReadOnlyDictionary<PackageUrl, DependencyGitLock> dependencyLock, PackageUrl packageUrl)
-        {
-            if (dependencyLock == null)
-            {
-                return null;
-            }
+        private readonly IReadOnlyDictionary<(string url, string branch), DependencyGitLock> _dependencyGitLock;
 
-            if (dependencyLock.TryGetValue(packageUrl, out var gitLock))
+        private DependencyLockProvider(IReadOnlyDictionary<(string url, string branch), DependencyGitLock> dependencyGitLock)
+        {
+            Debug.Assert(dependencyGitLock != null);
+
+            _dependencyGitLock = dependencyGitLock;
+        }
+
+        public DependencyGitLock GetGitLock(string url, string branch)
+        {
+            if (_dependencyGitLock.TryGetValue((url, branch), out var gitLock))
             {
                 return gitLock;
             }
@@ -26,34 +29,45 @@ namespace Microsoft.Docs.Build
             return null;
         }
 
-        public static Dictionary<PackageUrl, DependencyGitLock> LoadGitLock(string docset, SourceInfo<string> dependencyLockPath)
+        public IEnumerable<(string url, string branch, DependencyGitLock)> ListAll()
         {
-            Debug.Assert(!string.IsNullOrEmpty(docset));
+            return _dependencyGitLock.Select(k => (k.Key.url, k.Key.branch, k.Value));
+        }
+
+        public static DependencyLockProvider Create(string docsetPath, SourceInfo<string> dependencyLockPath)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(docsetPath));
 
             if (string.IsNullOrEmpty(dependencyLockPath))
             {
-                return null;
+                return new DependencyLockProvider(new Dictionary<(string url, string branch), DependencyGitLock>());
             }
 
             // dependency lock path can be a place holder for saving usage
             if (!UrlUtility.IsHttp(dependencyLockPath))
             {
-                if (!File.Exists(Path.Combine(docset, dependencyLockPath)))
+                if (!File.Exists(Path.Combine(docsetPath, dependencyLockPath)))
                 {
-                    return null;
+                    return new DependencyLockProvider(new Dictionary<(string url, string branch), DependencyGitLock>());
                 }
             }
 
-            var content = RestoreFileMap.GetRestoredFileContent(docset, dependencyLockPath, fallbackDocset: null);
+            var content = RestoreFileMap.GetRestoredFileContent(docsetPath, dependencyLockPath, fallbackDocset: null);
 
             Log.Write($"DependencyLock ({dependencyLockPath}):\n{content}");
 
             var dependencyLock = JsonUtility.Deserialize<DependencyLock>(content, new FilePath(dependencyLockPath));
 
-            return dependencyLock.Git.ToDictionary(k => new PackageUrl(k.Key), v => v.Value);
+            return new DependencyLockProvider(dependencyLock.Git.ToDictionary(
+                k =>
+                {
+                    var packageUrl = new PackageUrl(k.Key);
+                    return (packageUrl.Url, packageUrl.Branch);
+                },
+                v => v.Value));
         }
 
-        public static void SaveGitLock(string docset, string dependencyLockPath, List<DependencyGitLock> dependencyGitLock)
+        public static void Save(string docset, string dependencyLockPath, List<DependencyGitLock> dependencyGitLock)
         {
             Debug.Assert(!string.IsNullOrEmpty(docset));
             Debug.Assert(!string.IsNullOrEmpty(dependencyLockPath));


### PR DESCRIPTION
use dependency lock provider instead

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5090)