### PR TITLE
fix token invalid end char

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/ExtensionsHelper.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/ExtensionsHelper.cs
@@ -111,11 +111,22 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         {
             if (MatchTitle(ref slice, ref title) && MatchPath(ref slice, ref path))
             {
-                slice.NextChar();
                 return true;
             }
 
             return false;
+        }
+
+        public static bool MatchInlcusionEnd(ref StringSlice slice)
+        {
+            if (slice.CurrentChar != ']')
+            {
+                return false;
+            }
+
+            slice.NextChar();
+
+            return true;
         }
 
         public static void SkipWhitespace(ref StringSlice slice)

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionBlock/InclusionBlockParser.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionBlock/InclusionBlockParser.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
             string title = null, path = null;
 
-            if (!ExtensionsHelper.MatchLink(ref line, ref title, ref path))
+            if (!ExtensionsHelper.MatchLink(ref line, ref title, ref path) || !ExtensionsHelper.MatchInlcusionEnd(ref line))
             {
                 return BlockState.None;
             }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionInline/InclusionInlineParser.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionInline/InclusionInlineParser.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
             string title = null, path = null;
 
-            if (!ExtensionsHelper.MatchLink(ref slice, ref title, ref path))
+            if (!ExtensionsHelper.MatchLink(ref slice, ref title, ref path) || !ExtensionsHelper.MatchInlcusionEnd(ref slice))
             {
                 return false;
             }

--- a/test/Microsoft.DocAsCode.MarkdigEngine.Tests/InclusionTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdigEngine.Tests/InclusionTest.cs
@@ -28,6 +28,8 @@ Test Include File
 
 [!include[refa](a.md)]
 
+[!include[refa](a.md) ]
+
 ";
 
             var refa = @"---
@@ -37,7 +39,7 @@ description: include file
 
 # Hello Include File A
 
-This is a file A included by another file. [!include[refb](b.md)]
+This is a file A included by another file. [!include[refb](b.md)] [!include[refb](b.md) ]
 
 ";
 
@@ -56,7 +58,9 @@ description: include file
             var expected = @"<h1 id=""hello-world"">Hello World</h1>
 <p>Test Include File</p>
 <h1 id=""hello-include-file-a"">Hello Include File A</h1>
-<p>This is a file A included by another file. # Hello Include File B</p>
+<p>This is a file A included by another file. # Hello Include File B [!include<a href=""%7E/r/b.md"">refb</a> ]</p>
+
+<p>[!include<a href=""a.md"">refa</a> ]</p>
 ";
             Assert.Equal(expected.Replace("\r\n", "\n"), result.Html);
 


### PR DESCRIPTION
Related to this bug: https://dev.azure.com/ceapex/Engineering/_workitems/edit/120257

`[!include[refa](a.md)` will be recognized as token, but the syntax should be `[!include[refa](a.md)]`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5091)