### PR TITLE
fix: get token from resource to avoid duplicate warnings

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/DocumentBuilder.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/DocumentBuilder.cs
@@ -420,7 +420,7 @@ namespace Microsoft.DocAsCode.Build.Engine
 
         private MarkdigMarkdownService CreateMarkdigMarkdownService(DocumentBuildParameters parameters)
         {
-            var templateProcessor = parameters.TemplateManager?.GetTemplateProcessor(new DocumentBuildContext(parameters), parameters.MaxParallelism);
+            var resourceProvider = parameters.TemplateManager?.CreateTemplateResource();
 
             return new MarkdigMarkdownService(
                 new MarkdownServiceParameters
@@ -428,7 +428,7 @@ namespace Microsoft.DocAsCode.Build.Engine
                     BasePath = parameters.Files.DefaultBaseDir,
                     TemplateDir = parameters.TemplateDir,
                     Extensions = parameters.MarkdownEngineParameters,
-                    Tokens = templateProcessor?.Tokens?.ToImmutableDictionary(),
+                    Tokens = TemplateProcessorUtility.LoadTokens(resourceProvider)?.ToImmutableDictionary(),
                 },
                 new CompositionContainer(CompositionContainer.DefaultContainer));
         }

--- a/src/Microsoft.DocAsCode.Build.Engine/TemplateProcessors/TemplateProcessor.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/TemplateProcessors/TemplateProcessor.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DocAsCode.Build.Engine
             _resourceProvider = resourceProvider;
             _maxParallelism = maxParallelism;
             _templateCollection = new TemplateCollection(resourceProvider, context, maxParallelism);
-            Tokens = LoadTokenJson(resourceProvider) ?? new Dictionary<string, string>();
+            Tokens = TemplateProcessorUtility.LoadTokens(resourceProvider) ?? new Dictionary<string, string>();
         }
 
         public TemplateBundle GetTemplateBundle(string documentType)
@@ -158,23 +158,6 @@ namespace Microsoft.DocAsCode.Build.Engine
                 _maxParallelism);
             return manifest.ToList();
 
-        }
-
-        private static IDictionary<string, string> LoadTokenJson(ResourceFileReader resource)
-        {
-            var tokenJson = resource.GetResource("token.json");
-            if (string.IsNullOrEmpty(tokenJson))
-            {
-                // also load `global.json` for backward compatibility
-                // TODO: remove this
-                tokenJson = resource.GetResource("global.json");
-                if (string.IsNullOrEmpty(tokenJson))
-                {
-                    return null;
-                }
-            }
-
-            return JsonUtility.FromJsonString<Dictionary<string, string>>(tokenJson);
         }
 
         public void Dispose()

--- a/src/Microsoft.DocAsCode.Build.Engine/TemplateProcessors/TemplateProcessorUtility.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/TemplateProcessors/TemplateProcessorUtility.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode.Build.Engine
+{
+    using System.Collections.Generic;
+    using Microsoft.DocAsCode.Common;
+
+    public static class TemplateProcessorUtility
+    {
+        public static IDictionary<string, string> LoadTokens(ResourceFileReader resource)
+        {
+            if (resource == null)
+            {
+                return null;
+            }
+
+            var tokenJson = resource.GetResource("token.json");
+            if (string.IsNullOrEmpty(tokenJson))
+            {
+                // also load `global.json` for backward compatibility
+                // TODO: remove this
+                tokenJson = resource.GetResource("global.json");
+                if (string.IsNullOrEmpty(tokenJson))
+                {
+                    return null;
+                }
+            }
+
+            return JsonUtility.FromJsonString<Dictionary<string, string>>(tokenJson);
+        }
+    }
+}


### PR DESCRIPTION
https://dev.azure.com/ceapex/Engineering/_workitems/edit/115652?src=WorkItemMention&src-action=artifact_link

When constructing `DocumentBuildContext`, it will check duplicate files. Before, it is constructed 2 times in `DocumentBuilder.CreateMarkdigMarkdownService` and `SingleDocumentBuilder.BuildCore`. This PR removes the former one to avoid duplicate warnings.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5093)