### PR TITLE
monikers of toc file should be the aggregation of monikers of children

### DIFF
--- a/docs/designs/conceptual-versioning.md
+++ b/docs/designs/conceptual-versioning.md
@@ -500,17 +500,16 @@ When build the toc file(including the toc file included in another), we have to 
 
 1. *Monikers* of every node in toc(We don't support setting monikers of node in toc file).
     1. If the node is a text node(`## Header`), the *monikers* of this node is the union of its children's monikers.
-    2. If the node is a relative link node(`## [Header](a.md)`), the *monikers* of this node is the union of its children's monikers and the monikers of this node.
-    3. If the node is a absolute link node(`## [Header](/a)` or `## [Header](http://test)`), the *monikers* of this node is the monikers of this toc file, which means this node will always be displayed.
-    4. If the node is a relative folder node(`## [Header](a/)`), the *monikers* of this node is the monikers of the union of:
+    2. If the node is a relative link node(`## [Header](a.md)`) and the referenced node is a versioning page, the *monikers* of this node is the union of its children's monikers and the monikers of referenced page.
+    3. If the node is a relative link node(`## [Header](a.md)`) and the referenced node is a non-versioning page, the *monikers* of this node is empty, which means this node will always be displayed.
+    1. If the node is a absolute link node(`## [Header](/a)` or `## [Header](http://test)`), the *monikers* of this node is empty, which means this node will always be displayed.
+    1. If the node is a relative folder node(`## [Header](a/)`), the *monikers* of this node is the monikers of the union of:
         1. Its children's monikers
         2. The monikers of the document chosen as the resolved result of the current node(specified by the topicHref or the first node of the toc file under folder `a/`).
-    5. If the node is a toc referenced node(`## [Header](a/toc.yml)`), the *monikers* of this node is the monikers of the union of:
+    1. If the node is a toc referenced node(`## [Header](a/toc.yml)`), the *monikers* of this node is the monikers of the union of:
         1. The monikers of the document chosen as the resolved result of the current node(specified by the topicHref).
         1. The union of the monikers of all the node imported by the referenced toc file.
-1. *Monikers* of toc file - Intersection of the monikerRange setting in the config and file metadata(If the intersection is empty, a warning will be logged).
-
-> For now, if the monikers of the node is out of the moniker Range of this toc, we do not report warning.
+1. *Monikers* of toc file - The union of all children's monikers
 
 In phase 1, when resolving the `toc_rel` of each file, we still take the nearest toc file.
 

--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -398,9 +398,11 @@ inputs:
       docs/v1/: .
       docs/v2/: .
     monikerDefinition: monikerDefinition.json
-  docs/v1/TOC.md:
+  docs/v1/TOC.md: |
+    # [A](f1/a.md)
   docs/v1/f1/a.md:
-  docs/v2/TOC.md:
+  docs/v2/TOC.md: |
+    # [A](f1/a.md)
   docs/v2/f1/a.md:
   monikerDefinition.json: |
     {
@@ -424,7 +426,9 @@ outputs:
   docs/filemap.json:
   full-dependent-list.txt: |
     {"dependency_type":"metadata","from_file_path":"*docs\\v1\\f1\\a.md*","to_file_path":"*docs\\v1\\TOC.md*","version":"netcore-1.0"}
+    {"dependency_type":"file","from_file_path":"*docs\\v1\\TOC.md*","to_file_path":"*docs\\v1\\f1\\a.md*","version":"netcore-1.0"}
     {"dependency_type":"metadata","from_file_path":"*docs\\v2\\f1\\a.md*","to_file_path":"*docs\\v2\\TOC.md*","version":"netcore-2.0"}
+    {"dependency_type":"file","from_file_path":"*docs\\v2\\TOC.md*","to_file_path":"*docs\\v2\\f1\\a.md*","version":"netcore-2.0"}
 ---
 # legacy errors from source repo [repo mapping]
 locale: zh-cn

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -856,7 +856,8 @@ inputs:
     ## Text
     ### [A](a.md)
     ### [B](b.md)
-    ### [Non-versioning](../x.md)
+    ## [Non-versioning](../x.md)
+    ### [A](a.md)
   docs/x.md:
   monikerDefinition.json: |
     {
@@ -887,11 +888,11 @@ outputs:
           "href": "a",
           "items": [
             { "name": "B", "href": "b", "monikers": ["netcore-1.1", "netcore-1.2"] },
-            { "name": "Absolute", "href": "/c", !"monikers": null },
+            { "name": "Absolute", "href": "/c", "monikers": undefined },
             { 
               "name": "External",
               "href": "http://test.com/test",
-              "monikers": ["netcore-1.0", "netcore-1.1" ],
+              "monikers": undefined,
               "items": [
                 { "name": "A", "href": "a", "monikers": ["netcore-1.0", "netcore-1.1"] }
               ]
@@ -901,10 +902,17 @@ outputs:
               "monikers": [ "netcore-1.0", "netcore-1.1", "netcore-1.2" ],
               "items": [
                 { "name": "A", "href": "a", "monikers": [ "netcore-1.0", "netcore-1.1" ] },
-                { "name": "B", "href": "b", "monikers": [ "netcore-1.1", "netcore-1.2"] },
-                { "name": "Non-versioning", "href": "x", !"monikers": null },
+                { "name": "B", "href": "b", "monikers": [ "netcore-1.1", "netcore-1.2"] }
               ]
-            }
+            },
+            { 
+              "name": "Non-versioning",
+              "href": "x",
+              "monikers": undefined,
+              "items": [
+                { "name": "A", "href": "a", "monikers": ["netcore-1.0", "netcore-1.1"] }
+              ]
+            },
           ],
           "monikers": ["netcore-1.0", "netcore-1.1", "netcore-1.2" ]
         }

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -850,12 +850,14 @@ inputs:
     ---
     # [A](a.md)
     ## [B](b.md)
-    ## [C](/c)
-    ## [D](http://test.com/test)
+    ## [Absolute](/c)
+    ## [External](http://test.com/test)
     ### [A](xref:a)
-    ## E
+    ## Text
     ### [A](a.md)
     ### [B](b.md)
+    ### [Non-versioning](../x.md)
+  docs/x.md:
   monikerDefinition.json: |
     {
       "monikers": [
@@ -869,14 +871,15 @@ outputs:
   9d4e15fd/docs/a.json: |
     {
       "conceptual": "<p>Moniker: netcore-1.0, netcore-1.1</p>",
-      "monikers": ["netcore-1.0", "netcore-1.1"]
+      "monikers": ["netcore-1.0", "netcore-1.1" ]
     }
   e300a7df/docs/b.json: |
     {
       "conceptual": "<p>Moniker: netcore-1.1, netcore-1.2</p>",
       "monikers": ["netcore-1.1", "netcore-1.2"]
     }
-  1dd7adba/docs/toc.json: |
+  docs/x.json:
+  2420f88b/docs/toc.json: |
     {
       "items": [
         {
@@ -884,28 +887,29 @@ outputs:
           "href": "a",
           "items": [
             { "name": "B", "href": "b", "monikers": ["netcore-1.1", "netcore-1.2"] },
-            { "name": "C", "href": "/c", "monikers": ["netcore-1.1", "netcore-1.2", "netcore-1.3"] },
+            { "name": "Absolute", "href": "/c", !"monikers": null },
             { 
-              "name": "D",
+              "name": "External",
               "href": "http://test.com/test",
-              "monikers": ["netcore-1.0", "netcore-1.1", "netcore-1.2", "netcore-1.3"],
+              "monikers": ["netcore-1.0", "netcore-1.1" ],
               "items": [
                 { "name": "A", "href": "a", "monikers": ["netcore-1.0", "netcore-1.1"] }
               ]
             },
             {
-              "name": "E",
+              "name": "Text",
               "monikers": [ "netcore-1.0", "netcore-1.1", "netcore-1.2" ],
               "items": [
                 { "name": "A", "href": "a", "monikers": [ "netcore-1.0", "netcore-1.1" ] },
                 { "name": "B", "href": "b", "monikers": [ "netcore-1.1", "netcore-1.2"] },
+                { "name": "Non-versioning", "href": "x", !"monikers": null },
               ]
             }
           ],
-          "monikers": ["netcore-1.0", "netcore-1.1", "netcore-1.2", "netcore-1.3"]
+          "monikers": ["netcore-1.0", "netcore-1.1", "netcore-1.2" ]
         }
       ],
-      "metadata": {"monikers": ["netcore-1.0", "netcore-1.1", "netcore-1.2", "netcore-1.3" ]}
+      "metadata": {"monikers": ["netcore-1.0", "netcore-1.1", "netcore-1.2" ]}
     }
 ---
 # Build toc with monikers info - multiple node with same url

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -876,7 +876,7 @@ outputs:
       "conceptual": "<p>Moniker: netcore-1.1, netcore-1.2</p>",
       "monikers": ["netcore-1.1", "netcore-1.2"]
     }
-  8169d1ea/docs/toc.json: |
+  1dd7adba/docs/toc.json: |
     {
       "items": [
         {
@@ -905,7 +905,7 @@ outputs:
           "monikers": ["netcore-1.0", "netcore-1.1", "netcore-1.2", "netcore-1.3"]
         }
       ],
-      "metadata": {"monikers": ["netcore-1.1", "netcore-1.2", "netcore-1.3" ]}
+      "metadata": {"monikers": ["netcore-1.0", "netcore-1.1", "netcore-1.2", "netcore-1.3" ]}
     }
 ---
 # Build toc with monikers info - multiple node with same url
@@ -965,7 +965,7 @@ inputs:
     Moniker: netcore-1.2
   docs/v1/e.md: |
     ---
-    monikerRange: netcore-1.3
+    monikerRange: netcore-1.3 
     ---
     Moniker: netcore-1.3
   docs/v1/TOC.yml: |
@@ -996,7 +996,7 @@ outputs:
   218c13d0/docs/c.json:
   b201e604/docs/d.json:
   8d1c2563/docs/e.json:
-  8169d1ea/docs/toc.json: |
+  3e6312f5/docs/toc.json: |
     {
       "items": [
         {
@@ -1017,7 +1017,7 @@ outputs:
           ]
         }
       ],
-      "metadata": { "monikers": ["netcore-1.1", "netcore-1.2", "netcore-1.3" ] }
+      "metadata": { "monikers": ["netcore-1.0", "netcore-1.1", "netcore-1.3" ] }
     }
 ---
 # Build folder reference toc with moniker info
@@ -1077,7 +1077,7 @@ outputs:
   218c13d0/docs/c.json:
   b201e604/docs/d.json:
   8d1c2563/docs/e.json:
-  8169d1ea/docs/toc.json: |
+  4a6b740e/docs/toc.json: |
     {
       "items": [
         {
@@ -1097,7 +1097,7 @@ outputs:
           ]
         }
       ],
-      "metadata": { "monikers": ["netcore-1.1", "netcore-1.2", "netcore-1.3" ] }
+      "metadata": { "monikers": ["netcore-1.0", "netcore-1.2", "netcore-1.3" ] }
     }
 ---
 # Build toc with duplicate monikers
@@ -1111,9 +1111,11 @@ inputs:
       docs/v2/: docs/
     monikerDefinition: monikerDefinition.json
   docs/v1/TOC.md: |
-    # Node
+    # [A](a.md)
+  docs/v1/a.md:
   docs/v2/TOC.md: |
-    # Node
+    # [A](b.md)
+  docs/v2/b.md:
   monikerDefinition.json: |
     {
       "monikers": [
@@ -1126,11 +1128,13 @@ outputs:
     {
       "files":
       [
+        { "url": "/docs/b" },
         {
           "url": "/docs/toc.json",
           "locale": "en-us",
           "has_error": true
         },
+        { "url": "/docs/a" },
         {
           "url": "/docs/toc.json",
           "locale": "en-us",
@@ -1163,8 +1167,6 @@ inputs:
     }
 outputs:
   docs/toc.json:
-  .errors.log: |
-    ["warning","empty-monikers","No moniker intersection between docfx.yml/docfx.json and file metadata. Config moniker range '>= netcore-2.0' is 'netcore-2.0', while file moniker range 'netcore-1.0' is 'netcore-1.0'","docs/v1/TOC.md"]
 ---
 # Build resource file with moniker
 inputs:

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -1373,12 +1373,12 @@ inputs:
       uid: a
 outputs:
   e300a7df/docs/a.json:
-  8169d1ea/docs/toc.json: |
+  e300a7df/docs/toc.json: |
     {
       "items": [
         { "name":"Uid Ref","href":"a","monikers": ["netcore-1.1", "netcore-1.2"] }
       ],
-      "metadata": {"monikers": ["netcore-1.1", "netcore-1.2", "netcore-1.3" ]}
+      "metadata": {"monikers": ["netcore-1.1", "netcore-1.2" ]}
     }
 ---
 # uid reference in markdown toc
@@ -1425,12 +1425,12 @@ inputs:
     # @b
 outputs:
   e300a7df/docs/a.json:
-  8169d1ea/docs/toc.json: |
+  e300a7df/docs/toc.json: |
     {
       "items": [
         { "name":"Title A","href":"a","monikers": ["netcore-1.1", "netcore-1.2"] }
       ],
-      "metadata": {"monikers": ["netcore-1.1", "netcore-1.2", "netcore-1.3" ]}
+      "metadata": {"monikers": ["netcore-1.1", "netcore-1.2" ]}
     }
 ---
 # uid reference in toc inclusion
@@ -1591,7 +1591,7 @@ inputs:
         - "4.0"
 outputs:
   336669db/docs/b.json:
-  docs/toc.json: |
+  336669db/docs/toc.json: |
     {
         "items": [
             {
@@ -1613,5 +1613,6 @@ outputs:
                     "5.0"
                 ]
             }
-        ]
+        ],
+        "metadata": {"monikers": [ "5.0" ]}
     }

--- a/src/docfx/build/moniker/MonikerProvider.cs
+++ b/src/docfx/build/moniker/MonikerProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Microsoft.Docs.Build
@@ -43,6 +44,8 @@ namespace Microsoft.Docs.Build
 
         public (Error error, List<string> monikers) GetFileLevelMonikers(Document file)
         {
+            Debug.Assert(file.ContentType != ContentType.TableOfContents);
+
             return _monikerCache.GetOrAdd(file, GetFileLevelMonikersCore);
         }
 

--- a/src/docfx/build/toc/parser/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsParser.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Docs.Build
                 }
 
                 // resolve monikers
-                newItem.Monikers = GetMonikers(context, rootPath, newItem, errors);
+                newItem.Monikers = GetMonikers(context, newItem, errors);
                 newItems.Add(newItem);
 
                 // validate
@@ -173,7 +173,7 @@ namespace Microsoft.Docs.Build
             return (errors, newItems);
         }
 
-        private static List<string> GetMonikers(Context context, Document rootPath, TableOfContentsItem currentItem, List<Error> errors)
+        private static List<string> GetMonikers(Context context, TableOfContentsItem currentItem, List<Error> errors)
         {
             var monikers = new List<string>();
             if (currentItem.Monikers.Any())
@@ -183,12 +183,20 @@ namespace Microsoft.Docs.Build
             else if (!string.IsNullOrEmpty(currentItem.Href))
             {
                 var linkType = UrlUtility.GetLinkType(currentItem.Href);
-                if (linkType != LinkType.External && linkType != LinkType.AbsolutePath)
+                if (linkType == LinkType.External || linkType == LinkType.AbsolutePath)
+                {
+                    return monikers;
+                }
+                else
                 {
                     if (currentItem.Document != null)
                     {
                         var (error, referenceFileMonikers) = context.MonikerProvider.GetFileLevelMonikers(currentItem.Document);
                         errors.AddIfNotNull(error);
+                        if (referenceFileMonikers.Count == 0)
+                        {
+                            return referenceFileMonikers;
+                        }
 
                         monikers = referenceFileMonikers;
                     }

--- a/src/docfx/build/toc/parser/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsParser.cs
@@ -25,10 +25,7 @@ namespace Microsoft.Docs.Build
 
             var (errors, model) = LoadInternal(context, file, file, referencedFiles, referencedTocs);
 
-            var (error, monikers) = context.MonikerProvider.GetFileLevelMonikers(file);
-            errors.AddIfNotNull(error);
-
-            model.Metadata.Monikers = monikers;
+            model.Metadata.Monikers = model.Items.SelectMany(item => item.Monikers).Distinct(context.MonikerProvider.Comparer).ToList();
             return (errors, model, referencedFiles, referencedTocs);
         }
 

--- a/src/docfx/build/toc/parser/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsParser.cs
@@ -183,14 +183,7 @@ namespace Microsoft.Docs.Build
             else if (!string.IsNullOrEmpty(currentItem.Href))
             {
                 var linkType = UrlUtility.GetLinkType(currentItem.Href);
-                if (linkType == LinkType.External || linkType == LinkType.AbsolutePath)
-                {
-                    var (error, rootFileMonikers) = context.MonikerProvider.GetFileLevelMonikers(rootPath);
-                    errors.AddIfNotNull(error);
-
-                    monikers = rootFileMonikers;
-                }
-                else
+                if (linkType != LinkType.External && linkType != LinkType.AbsolutePath)
                 {
                     if (currentItem.Document != null)
                     {

--- a/src/docfx/lib/moniker/MonikerComparer.cs
+++ b/src/docfx/lib/moniker/MonikerComparer.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 
 namespace Microsoft.Docs.Build
 {
-    internal class MonikerComparer : IComparer<string>
+    internal class MonikerComparer : IComparer<string>, IEqualityComparer<string>
     {
         private readonly Dictionary<string, (string productName, int orderInProduct)> _monikerOrder;
 
@@ -34,6 +34,16 @@ namespace Microsoft.Docs.Build
             }
 
             return orderXInProduct.CompareTo(orderYInProduct);
+        }
+
+        public bool Equals(string x, string y)
+        {
+            return Compare(x, y) == 0;
+        }
+
+        public int GetHashCode(string obj)
+        {
+            return HashCode.Combine(obj);
         }
     }
 }


### PR DESCRIPTION
https://dev.azure.com/ceapex/Engineering/_workitems/edit/120652
1. the monikers to toc file is the aggregation of monikers of children
2. the monikers of absolute link/external link/non-versioning page node in toc file should be empty.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5101)