### PR TITLE
refine git contribution for CRR content

### DIFF
--- a/docs/specs/git.yml
+++ b/docs/specs/git.yml
@@ -635,7 +635,7 @@ outputs:
       },
       "content_git_url": "https://github.com/testowner/crr-content/blob/master/b.md",
       "original_content_git_url": "https://github.com/testowner/crr-content/blob/master/b.md",
-      "original_content_git_url_template": undefined,
+      "original_content_git_url_template": "https://github.com/testowner/crr-content/blob/master/b.md",
       "gitcommit": "https://github.com/testowner/crr-content/blob/44e7dd472e06b95898986635feccbcefde3c42f0/b.md",
       "updated_at": "2018-10-30 12:00 AM"
     }

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Docs.Build
         {
             Debug.Assert(document != null);
 
-            var isDependency = document.FilePath.Origin == FileOrigin.Dependency;
+            var isWhitelisted = document.FilePath.Origin == FileOrigin.Default || document.FilePath.Origin == FileOrigin.Fallback;
             var (repo, pathToRepo, commits) = _gitCommitProvider.GetCommitHistory(document);
             if (repo is null)
                 return default;
@@ -185,7 +185,7 @@ namespace Microsoft.Docs.Build
 
             return (GetContentGitUrl(contentBranchUrlTemplate),
                 originalContentGitUrl,
-                isDependency ? null : originalContentGitUrlTemplate,
+                !isWhitelisted ? originalContentGitUrl : originalContentGitUrlTemplate,
                 contentGitCommitUrl);
 
             string GetContentGitUrl(string branchUrlTemplate)
@@ -197,7 +197,7 @@ namespace Microsoft.Docs.Build
                     editBranch = repoContributionBranch;
                 }
 
-                if (!string.IsNullOrEmpty(document.Docset.Config.Contribution.Repository) && !isDependency)
+                if (!string.IsNullOrEmpty(document.Docset.Config.Contribution.Repository) && isWhitelisted)
                 {
                     var contributionPackageUrl = new PackageUrl(document.Docset.Config.Contribution.Repository);
                     (branchUrlTemplate, _) = GetContentGitUrlTemplate(contributionPackageUrl.Url, pathToRepo);


### PR DESCRIPTION
refine #5092 
Set `original_content_git_url_template` the same value as `original_content_git_url` to avoid the fallback
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5104)