### PR TITLE
_tocRel prioritized by filepath

### DIFF
--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -1134,7 +1134,7 @@ outputs:
   docs/dir1/dir2/file-with-toc.json: |
     {"_tocRel": "../toc.json"}
 ---
-# File referenced by multiple toc, _tocRel uses relative site path first
+# File referenced by multiple toc, _tocRel uses relative file path first
 inputs:
   docfx.yml: |
     routes:
@@ -1148,11 +1148,11 @@ outputs:
   toc.json:
   dir1/toc.json:
   a.json: |
-    {"_tocRel": "toc.json"}
+    {"_tocRel": "dir1/toc.json"}
   .dependencymap.json: |
     {}
 ---
-# File referenced by multiple toc with same relative site and file path, use order alphabetical. For other tests, reference build/TocTest.
+# File referenced by multiple toc with same relative file path, use order alphabetical. For other tests, reference build/TocTest.
 inputs:
   docfx.yml: 
   docs/dir1/a/TOC.yml: |


### PR DESCRIPTION
targeting to fix: [DevOps#120662](https://dev.azure.com/ceapex/Engineering/_workitems/edit/120662)

### other into
dotnet/docs has accepted the [breadcrumb-move-pr](https://github.com/dotnet/docs/pull/14453), so we got no exception for sorting by file-path.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5105)