### PR TITLE
refine repository and config loader

### DIFF
--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Docs.Build
 
             using (var restoreGitMap = RestoreGitMap.Create(docsetPath, locale))
             {
-                // load configuration from current docset and falback docset
+                // load configuration from current docset and fallback docset
                 var input = new Input(docsetPath, repositoryProvider);
                 var configLoader = new ConfigLoader(docsetPath, input, repositoryProvider);
 

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Docs.Build
                 var configLoader = new ConfigLoader(docsetPath, input, repositoryProvider);
 
                 repositoryProvider.ConfigRestoreMap(restoreGitMap);
-                var (errors, config) = configLoader.Load(options, locale, extend: true);
+                var (errors, config) = configLoader.Load(options, extend: true);
 
                 errorLog.Configure(config);
 

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -208,10 +208,10 @@ namespace Microsoft.Docs.Build
 
             foreach (var (name, dependency) in config.Dependencies)
             {
-                var repository = repositoryProvider.GetRepository(FileOrigin.Dependency, name);
-                if (repository != null)
+                var (entry, repository) = repositoryProvider.GetRepositoryWithEntry(FileOrigin.Dependency, name);
+                if (!string.IsNullOrEmpty(entry))
                 {
-                    result.TryAdd(name, (new Docset(repository.Path, docset.Locale, config, repository), dependency.BuildFiles));
+                    result.TryAdd(name, (new Docset(entry, docset.Locale, config, repository), dependency.BuildFiles));
                 }
             }
 

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -37,9 +37,9 @@ namespace Microsoft.Docs.Build
         private readonly Lazy<XrefResolver> _xrefResolver;
         private readonly Lazy<TableOfContentsMap> _tocMap;
 
-        public Context(string outputPath, ErrorLog errorLog, Docset docset, Docset fallbackDocset, Dictionary<string, (Docset docset, bool inScope)> dependencyDocsets, RestoreGitMap restoreGitMap)
+        public Context(string outputPath, ErrorLog errorLog, Docset docset, Docset fallbackDocset, Dictionary<string, (Docset docset, bool inScope)> dependencyDocsets, Input input, RepositoryProvider repositoryProvider)
         {
-            var restoreFileMap = new RestoreFileMap(docset.DocsetPath, fallbackDocset?.DocsetPath);
+            var restoreFileMap = new RestoreFileMap(input);
             DependencyMapBuilder = new DependencyMapBuilder();
             _xrefResolver = new Lazy<XrefResolver>(() => new XrefResolver(this, docset, restoreFileMap, DependencyMapBuilder));
             _tocMap = new Lazy<TableOfContentsMap>(() => TableOfContentsMap.Create(this));
@@ -47,9 +47,9 @@ namespace Microsoft.Docs.Build
 
             ErrorLog = errorLog;
             Output = new Output(outputPath);
-            Input = new Input(docset.DocsetPath, fallbackDocset?.DocsetPath, docset.Config, restoreGitMap);
+            Input = input;
             Cache = new Cache(Input);
-            TemplateEngine = TemplateEngine.Create(docset, restoreGitMap);
+            TemplateEngine = TemplateEngine.Create(docset, repositoryProvider);
             BuildScope = new BuildScope(errorLog, Input, docset, fallbackDocset, dependencyDocsets, TemplateEngine);
             MicrosoftGraphCache = new MicrosoftGraphCache(docset.Config);
             MetadataProvider = new MetadataProvider(docset, Input, Cache, MicrosoftGraphCache, restoreFileMap);

--- a/src/docfx/build/context/Input.cs
+++ b/src/docfx/build/context/Input.cs
@@ -44,16 +44,6 @@ namespace Microsoft.Docs.Build
         }
 
         /// <summary>
-        /// Get the absolute path of current root
-        /// </summary>
-        public string GetRootPath(FileOrigin origin, string dependencyName = null)
-        {
-            var (basePath, _, _) = ResolveFilePath(dependencyName != null ? new FilePath("", dependencyName) : new FilePath("", origin));
-
-            return basePath;
-        }
-
-        /// <summary>
         /// Try get the absolute path of the specified file if it exists physically on disk.
         /// Some file path like content from a bare git repo does not exist physically
         /// on disk but we can still read its content.

--- a/src/docfx/build/context/Input.cs
+++ b/src/docfx/build/context/Input.cs
@@ -14,17 +14,13 @@ namespace Microsoft.Docs.Build
     internal class Input
     {
         private readonly string _docsetPath;
-        private readonly string _fallbackPath;
-        private readonly Config _config;
-        private readonly RestoreGitMap _restoreMap;
+        private readonly RepositoryProvider _repositoryProvider;
         private readonly ConcurrentDictionary<FilePath, byte[]> _gitBlobCache = new ConcurrentDictionary<FilePath, byte[]>();
 
-        public Input(string docsetPath, string fallbackPath, Config config, RestoreGitMap restoreMap)
+        public Input(string docsetPath, RepositoryProvider repositoryProvider)
         {
-            _config = config;
-            _restoreMap = restoreMap;
+            _repositoryProvider = repositoryProvider;
             _docsetPath = Path.GetFullPath(docsetPath);
-            _fallbackPath = fallbackPath is null ? null : Path.GetFullPath(fallbackPath);
         }
 
         /// <summary>
@@ -45,6 +41,16 @@ namespace Microsoft.Docs.Build
             }
 
             return _gitBlobCache.GetOrAdd(file, _ => GitUtility.ReadBytes(basePath, path, commit)) != null;
+        }
+
+        /// <summary>
+        /// Get the absolute path of current root
+        /// </summary>
+        public string GetRootPath(FileOrigin origin, string dependencyName = null)
+        {
+            var (basePath, _, _) = ResolveFilePath(dependencyName != null ? new FilePath("", dependencyName) : new FilePath("", origin));
+
+            return basePath;
         }
 
         /// <summary>
@@ -119,17 +125,19 @@ namespace Microsoft.Docs.Build
                         .ToArray();
 
                 case FileOrigin.Fallback:
+                    var fallbackRepository = _repositoryProvider.GetRepository(origin);
+
                     return Directory
-                        .GetFiles(_fallbackPath, "*", SearchOption.AllDirectories)
+                        .GetFiles(fallbackRepository.Path, "*", SearchOption.AllDirectories)
                         .Select(path => new FilePath(
-                            Path.GetRelativePath(_fallbackPath, path).Replace('\\', '/'), FileOrigin.Fallback))
+                            Path.GetRelativePath(fallbackRepository.Path, path).Replace('\\', '/'), FileOrigin.Fallback))
                         .ToArray();
 
                 case FileOrigin.Dependency:
-                    var (dependencyPath, commit) = _restoreMap.GetRestoreGitPath(_config.Dependencies[dependencyName], true);
+                    var dependencyRepository = _repositoryProvider.GetRepository(origin, dependencyName);
 
                     // todo: get tree list from repository
-                    return GitUtility.ListTree(dependencyPath, commit)
+                    return GitUtility.ListTree(dependencyRepository.Path, dependencyRepository.Commit)
                         .Select(path => new FilePath(
                             path.Replace('\\', '/'), dependencyName))
                         .ToArray();
@@ -147,15 +155,16 @@ namespace Microsoft.Docs.Build
                     return (_docsetPath, file.Path, file.Commit);
 
                 case FileOrigin.Dependency:
-                    var (dependencyPath, dependencyCommit) = _restoreMap.GetRestoreGitPath(_config.Dependencies[file.DependencyName], true);
-                    return (dependencyPath, file.Path, file.Commit ?? dependencyCommit);
+                    var dependencyRepository = _repositoryProvider.GetRepository(file.Origin, file.DependencyName);
+                    return (dependencyRepository.Path, file.Path, file.Commit ?? dependencyRepository.Commit);
 
                 case FileOrigin.Fallback:
-                    return (_fallbackPath, file.Path, file.Commit);
+                    var fallbackRepository = _repositoryProvider.GetRepository(file.Origin);
+                    return (fallbackRepository.Path, file.Path, file.Commit);
 
                 case FileOrigin.Template:
-                    var (templatePath, _) = _restoreMap.GetRestoreGitPath(_config.Template, false);
-                    return (templatePath, file.Path, file.Commit);
+                    var templateRepository = _repositoryProvider.GetRepository(FileOrigin.Template);
+                    return (templateRepository.Path, file.Path, file.Commit);
 
                 default:
                     return default;

--- a/src/docfx/config/AppData.cs
+++ b/src/docfx/config/AppData.cs
@@ -25,8 +25,6 @@ namespace Microsoft.Docs.Build
 
         public static string StateRoot => GetStatePath?.Invoke() ?? EnvironmentVariable.StatePath ?? Path.Combine(s_root, "state");
 
-        public static string DependencyLockRoot => Path.Combine(s_root, "lock");
-
         public static string GlobalConfigPath => GetGlobalConfigPath();
 
         public static string GitHubUserCachePath => Path.Combine(CacheRoot, "github-users.json");
@@ -47,7 +45,7 @@ namespace Microsoft.Docs.Build
         public static string GetDependencyLockFile(string docsetPath, string locale)
         {
             return PathUtility.NormalizeFile(
-                Path.Combine(DependencyLockRoot, PathUtility.UrlToShortName(docsetPath), locale ?? "", ".lock.json"));
+                    Path.Combine(s_root, "lock", PathUtility.UrlToShortName(docsetPath), locale ?? "", ".lock.json"));
         }
 
         public static string GetCommitCachePath(string remote)

--- a/src/docfx/config/ConfigLoader.cs
+++ b/src/docfx/config/ConfigLoader.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using Newtonsoft.Json.Linq;
 
@@ -47,11 +46,11 @@ namespace Microsoft.Docs.Build
 
         public bool TryGetConfigPath(out FilePath configPath)
         {
-            configPath = PathUtility.FindYamlOrJson(_input, FileOrigin.Default, "docfx");
+            configPath = _input.FindYamlOrJson(FileOrigin.Default, "docfx");
 
             if (configPath == null)
             {
-                configPath = PathUtility.FindYamlOrJson(_input, FileOrigin.Fallback, "docfx");
+                configPath = _input.FindYamlOrJson(FileOrigin.Fallback, "docfx");
             }
 
             return configPath != null;

--- a/src/docfx/config/ConfigLoader.cs
+++ b/src/docfx/config/ConfigLoader.cs
@@ -28,21 +28,21 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Load the config under <paramref name="docsetPath"/>
         /// </summary>
-        public (List<Error> errors, Config config) Load(CommandLineOptions options, string locale = null, bool extend = true)
+        public (List<Error> errors, Config config) Load(CommandLineOptions options, bool extend = true)
         {
             if (!TryGetConfigPath(out _))
             {
                 throw Errors.ConfigNotFound(_docsetPath).ToException();
             }
 
-            return TryLoad(options, locale, extend);
+            return TryLoad(options, extend);
         }
 
         /// <summary>
         /// Load the config if it exists under <paramref name="docsetPath"/> or return default config
         /// </summary>
-        public (List<Error> errors, Config config) TryLoad(CommandLineOptions options, string locale = null, bool extend = true)
-            => LoadCore(options, locale, extend);
+        public (List<Error> errors, Config config) TryLoad(CommandLineOptions options, bool extend = true)
+            => LoadCore(options, extend);
 
         public bool TryGetConfigPath(out FilePath configPath)
         {
@@ -56,7 +56,7 @@ namespace Microsoft.Docs.Build
             return configPath != null;
         }
 
-        private (List<Error>, Config) LoadCore(CommandLineOptions options, string locale, bool extend)
+        private (List<Error>, Config) LoadCore(CommandLineOptions options, bool extend)
         {
             var errors = new List<Error>();
             var configObject = new JObject();
@@ -85,7 +85,8 @@ namespace Microsoft.Docs.Build
             }
 
             // apply overwrite
-            OverwriteConfig(configObject, locale ?? options.Locale, _repositoryProvider.GetRepository(FileOrigin.Default)?.Branch);
+            var repository = _repositoryProvider.GetRepository(configPath?.Origin ?? FileOrigin.Default);
+            OverwriteConfig(configObject, LocalizationUtility.GetLocale(repository, options), repository?.Branch);
 
             var (deserializeErrors, config) = JsonUtility.ToObject<Config>(configObject);
             errors.AddRange(deserializeErrors);

--- a/src/docfx/config/ConfigLoader.cs
+++ b/src/docfx/config/ConfigLoader.cs
@@ -3,53 +3,68 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build
 {
-    internal static class ConfigLoader
+    internal class ConfigLoader
     {
         private const string Extend = "extend";
         private const string DefaultLocale = "defaultLocale";
         private const string Localization = "localization";
 
+        private readonly string _docsetPath;
+        private readonly Input _input;
+        private readonly RepositoryProvider _repositoryProvider;
+
+        public ConfigLoader(string docsetPath, Input input, RepositoryProvider repositoryProvider)
+        {
+            _docsetPath = docsetPath;
+            _input = input;
+            _repositoryProvider = repositoryProvider;
+        }
+
         /// <summary>
         /// Load the config under <paramref name="docsetPath"/>
         /// </summary>
-        public static (List<Error> errors, Config config) Load(
-            string docsetPath, CommandLineOptions options, string locale = null, bool extend = true)
+        public (List<Error> errors, Config config) Load(CommandLineOptions options, string locale = null, bool extend = true)
         {
-            if (!TryGetConfigPath(docsetPath, out _))
+            if (!TryGetConfigPath(out _))
             {
-                throw Errors.ConfigNotFound(docsetPath).ToException();
+                throw Errors.ConfigNotFound(_docsetPath).ToException();
             }
 
-            return TryLoad(docsetPath, options, locale, extend);
+            return TryLoad(options, locale, extend);
         }
 
         /// <summary>
         /// Load the config if it exists under <paramref name="docsetPath"/> or return default config
         /// </summary>
-        public static (List<Error> errors, Config config) TryLoad(
-            string docsetPath, CommandLineOptions options, string locale = null, bool extend = true)
-            => LoadCore(docsetPath, options, locale, extend);
+        public (List<Error> errors, Config config) TryLoad(CommandLineOptions options, string locale = null, bool extend = true)
+            => LoadCore(options, locale, extend);
 
-        public static bool TryGetConfigPath(string docset, out string configPath)
+        public bool TryGetConfigPath(out FilePath configPath)
         {
-            configPath = PathUtility.FindYamlOrJson(Path.Combine(docset, "docfx"));
+            configPath = PathUtility.FindYamlOrJson(_input, FileOrigin.Default, "docfx");
 
-            return !string.IsNullOrEmpty(configPath);
+            if (configPath == null)
+            {
+                configPath = PathUtility.FindYamlOrJson(_input, FileOrigin.Fallback, "docfx");
+            }
+
+            return configPath != null;
         }
 
-        private static (List<Error>, Config) LoadCore(string docsetPath, CommandLineOptions options, string locale, bool extend)
+        private (List<Error>, Config) LoadCore(CommandLineOptions options, string locale, bool extend)
         {
             var errors = new List<Error>();
             var configObject = new JObject();
-            if (TryGetConfigPath(docsetPath, out var configPath))
+            if (TryGetConfigPath(out var configPath))
             {
-                var configFileName = PathUtility.NormalizeFile(Path.GetRelativePath(docsetPath, configPath));
-                (errors, configObject) = LoadConfigObject(configFileName, File.ReadAllText(configPath));
+                var configFileName = configPath.Path;
+                (errors, configObject) = LoadConfigObject(configFileName, _input.ReadString(configPath));
             }
 
             // apply options
@@ -66,24 +81,39 @@ namespace Microsoft.Docs.Build
             if (extend)
             {
                 var extendErrors = new List<Error>();
-                (extendErrors, configObject) = ExtendConfigs(configObject, docsetPath);
+                (extendErrors, configObject) = ExtendConfigs(configObject);
                 errors.AddRange(extendErrors);
             }
 
             // apply overwrite
-            OverwriteConfig(configObject, locale ?? options.Locale, GetBranch());
+            OverwriteConfig(configObject, locale ?? options.Locale, _repositoryProvider.GetRepository(FileOrigin.Default)?.Branch);
 
             var (deserializeErrors, config) = JsonUtility.ToObject<Config>(configObject);
             errors.AddRange(deserializeErrors);
 
             return (errors, config);
+        }
 
-            string GetBranch()
+        private (List<Error>, JObject) ExtendConfigs(JObject config)
+        {
+            var result = new JObject();
+            var errors = new List<Error>();
+            var extends = config[Extend] is JArray arr ? arr : new JArray(config[Extend]);
+
+            foreach (var extend in extends)
             {
-                var repoPath = GitUtility.FindRepo(docsetPath);
-
-                return repoPath is null ? null : GitUtility.GetRepoInfo(repoPath).branch;
+                if (extend is JValue value && value.Value is string str)
+                {
+                    var content = RestoreFileMap.GetRestoredFileContent(
+                        _input, new SourceInfo<string>(str, JsonUtility.GetSourceInfo(value)));
+                    var (extendErrors, extendConfigObject) = LoadConfigObject(str, content);
+                    errors.AddRange(extendErrors);
+                    JsonUtility.Merge(result, extendConfigObject);
+                }
             }
+
+            JsonUtility.Merge(result, config);
+            return (errors, result);
         }
 
         private static (List<Error>, JObject) LoadConfigObject(string fileName, string content)
@@ -114,28 +144,6 @@ namespace Microsoft.Docs.Build
             if (File.Exists(globalConfigPath))
             {
                 (errors, result) = LoadConfigObject(globalConfigPath, File.ReadAllText(globalConfigPath));
-            }
-
-            JsonUtility.Merge(result, config);
-            return (errors, result);
-        }
-
-        private static (List<Error>, JObject) ExtendConfigs(JObject config, string docsetPath)
-        {
-            var result = new JObject();
-            var errors = new List<Error>();
-            var extends = config[Extend] is JArray arr ? arr : new JArray(config[Extend]);
-
-            foreach (var extend in extends)
-            {
-                if (extend is JValue value && value.Value is string str)
-                {
-                    var content = RestoreFileMap.GetRestoredFileContent(
-                        docsetPath, new SourceInfo<string>(str, JsonUtility.GetSourceInfo(value)), fallbackDocset: null);
-                    var (extendErrors, extendConfigObject) = LoadConfigObject(str, content);
-                    errors.AddRange(extendErrors);
-                    JsonUtility.Merge(result, extendConfigObject);
-                }
             }
 
             JsonUtility.Merge(result, config);

--- a/src/docfx/config/ConfigLoader.cs
+++ b/src/docfx/config/ConfigLoader.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Docs.Build
         public (List<Error> errors, Config config) TryLoad(CommandLineOptions options, bool extend = true)
             => LoadCore(options, extend);
 
-        public bool TryGetConfigPath(out FilePath configPath)
+        private bool TryGetConfigPath(out FilePath configPath)
         {
             configPath = _input.FindYamlOrJson(FileOrigin.Default, "docfx");
 

--- a/src/docfx/docset/Docset.cs
+++ b/src/docfx/docset/Docset.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Docs.Build
             Culture = CreateCultureInfo(Locale);
             (HostName, SiteBasePath) = SplitBaseUrl(config.BaseUrl);
 
-            Repository = repository ?? Repository.Create(DocsetPath, branch: null);
+            Repository = repository;
 
             _repositories = new ConcurrentDictionary<string, Lazy<Repository>>();
         }

--- a/src/docfx/docset/Docset.cs
+++ b/src/docfx/docset/Docset.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Docs.Build
             _repositories = new ConcurrentDictionary<string, Lazy<Repository>>();
         }
 
+        // todo: use repository provider instead
         public Repository GetRepository(string filePath)
         {
             return GetRepositoryInternal(Path.Combine(DocsetPath, filePath));

--- a/src/docfx/docset/RepositoryProvider.cs
+++ b/src/docfx/docset/RepositoryProvider.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+
+namespace Microsoft.Docs.Build
+{
+    internal class RepositoryProvider
+    {
+        private readonly ConcurrentDictionary<string, Lazy<Repository>> _repositories = new ConcurrentDictionary<string, Lazy<Repository>>();
+        private readonly Repository _docsetRepository;
+        private readonly Repository _fallbackRepository;
+        private readonly RestoreGitMap _restoreGitMap;
+        private readonly Config _config;
+
+        public RepositoryProvider(string docsetPath)
+            : this(Repository.Create(docsetPath), null, null, null)
+        {
+        }
+
+        public RepositoryProvider WithConfig(Config config)
+        {
+            return new RepositoryProvider(_docsetRepository, _fallbackRepository, _restoreGitMap, config);
+        }
+
+        public RepositoryProvider WithRestoreMap(RestoreGitMap restoreGitMap)
+        {
+            return new RepositoryProvider(_docsetRepository, GetFallbackRepository(_docsetRepository, restoreGitMap), restoreGitMap, _config);
+        }
+
+        private RepositoryProvider(Repository docsetRepository, Repository fallbackRepository, RestoreGitMap restoreGitMap, Config config)
+        {
+            _docsetRepository = docsetRepository;
+            _fallbackRepository = fallbackRepository;
+            _restoreGitMap = restoreGitMap;
+            _config = config;
+        }
+
+        public Repository GetRepository(FileOrigin origin, string dependencyName = null)
+        {
+            switch (origin)
+            {
+                case FileOrigin.Redirection:
+                case FileOrigin.Default:
+                    return _docsetRepository;
+
+                case FileOrigin.Fallback:
+                    return _fallbackRepository;
+
+                case FileOrigin.Template when _config != null && _restoreGitMap != null:
+                    return _repositories.GetOrAdd(origin.ToString(), _ =>
+                    new Lazy<Repository>(() =>
+                    {
+                        if (_config.Template.Type != PackageType.Git)
+                            return null;
+
+                        var (templatePath, templateCommit) = _restoreGitMap.GetRestoreGitPath(_config.Template, false);
+                        return Repository.Create(templatePath, _config.Template.Branch, _config.Template.Url, templateCommit);
+                    })).Value;
+
+                case FileOrigin.Dependency when _config != null && _restoreGitMap != null && dependencyName != null:
+                    return _repositories.GetOrAdd(origin.ToString(), _ =>
+                    new Lazy<Repository>(() =>
+                    {
+                        if (_config.Dependencies[dependencyName].Type != PackageType.Git)
+                            return null;
+
+                        var (dependencyPath, dependencyCommit) = _restoreGitMap.GetRestoreGitPath(_config.Dependencies[dependencyName], false);
+                        return Repository.Create(dependencyPath, _config.Template.Branch, _config.Template.Url, dependencyCommit);
+                    })).Value;
+            }
+
+            return null;
+        }
+
+        private static Repository GetFallbackRepository(
+            Repository repository,
+            RestoreGitMap restoreGitMap)
+        {
+            Debug.Assert(restoreGitMap != null);
+
+            if (LocalizationUtility.TryGetFallbackRepository(repository, out var fallbackRemote, out string fallbackBranch, out _))
+            {
+                foreach (var branch in new[] { fallbackBranch, "master" })
+                {
+                    if (restoreGitMap.IsBranchRestored(fallbackRemote, branch))
+                    {
+                        var (fallbackRepoPath, fallbackRepoCommit) = restoreGitMap.GetRestoreGitPath(new PackageUrl(fallbackRemote, branch), bare: false);
+                        return Repository.Create(fallbackRepoPath, branch, fallbackRemote, fallbackRepoCommit);
+                    }
+                }
+            }
+
+            return default;
+        }
+    }
+}

--- a/src/docfx/docset/RepositoryProvider.cs
+++ b/src/docfx/docset/RepositoryProvider.cs
@@ -96,22 +96,23 @@ namespace Microsoft.Docs.Build
                             return (templatePath, null);
                         }
 
-                        return (templatePath, Repository.Create(templatePath, _config.Template.Branch, _config.Template.Url, templateCommit));
+                        return (templatePath, Repository.Create(templatePath, theme.Branch, theme.Url, templateCommit));
                     })).Value;
 
                 case FileOrigin.Dependency when _config != null && _restoreGitMap != null && dependencyName != null:
                     return _repositories.GetOrAdd(origin.ToString() + dependencyName, _ =>
                     new Lazy<(string docset, Repository repository)>(() =>
                     {
-                        var (dependencyPath, dependencyCommit) = _restoreGitMap.GetRestoreGitPath(_config.Dependencies[dependencyName], bare: true);
+                        var dependency = _config.Dependencies[dependencyName];
+                        var (dependencyPath, dependencyCommit) = _restoreGitMap.GetRestoreGitPath(dependency, bare: true);
 
-                        if (_config.Dependencies[dependencyName].Type != PackageType.Git)
+                        if (dependency.Type != PackageType.Git)
                         {
                             // point to a folder
                             return (dependencyPath, null);
                         }
 
-                        return (dependencyPath, Repository.Create(dependencyPath, _config.Template.Branch, _config.Template.Url, dependencyCommit));
+                        return (dependencyPath, Repository.Create(dependencyPath, dependency.Branch, dependency.Url, dependencyCommit));
                     })).Value;
             }
 

--- a/src/docfx/lib/InputUtility.cs
+++ b/src/docfx/lib/InputUtility.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Docs.Build
+{
+    internal static class InputUtility
+    {
+        /// <summary>
+        /// Finds a yaml or json file under the specified location
+        /// </summary>
+        public static FilePath FindYamlOrJson(this Input input, FileOrigin origin, string pathWithoutExtension)
+        {
+            var fullPath = PathUtility.NormalizeFile(pathWithoutExtension + ".yml");
+            var filePath = new FilePath(fullPath, origin);
+            if (input.Exists(filePath))
+            {
+                return filePath;
+            }
+
+            fullPath = PathUtility.NormalizeFile(pathWithoutExtension + ".json");
+            filePath = new FilePath(fullPath, origin);
+            if (input.Exists(filePath))
+            {
+                return filePath;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/docfx/lib/git/Repository.cs
+++ b/src/docfx/lib/git/Repository.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Docs.Build
 
             if (repoPath is null)
                 return null;
+
             if (string.IsNullOrEmpty(branch) || string.IsNullOrEmpty(commit) || string.IsNullOrEmpty(repoUrl))
             {
                 var (remote, repoBranch, repoCommit) = GitUtility.GetRepoInfo(repoPath);

--- a/src/docfx/lib/path/FileOrigin.cs
+++ b/src/docfx/lib/path/FileOrigin.cs
@@ -1,36 +1,33 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-
 namespace Microsoft.Docs.Build
 {
-    [Flags]
     public enum FileOrigin
     {
         /// <summary>
         /// This file is coming from the main docset folder.
         /// </summary>
-        Default = 0,
+        Default,
 
         /// <summary>
         /// This file is coming from a dependency repository.
         /// </summary>
-        Dependency = 1,
+        Dependency,
 
         /// <summary>
         /// This file is coming from the fallback repository of a localized build.
         /// </summary>
-        Fallback = 1 << 1,
+        Fallback,
 
         /// <summary>
         /// This file is a redirection file.
         /// </summary>
-        Redirection = 1 << 2,
+        Redirection,
 
         /// <summary>
         /// This file is coming from template.
         /// </summary>
-        Template = 1 << 3,
+        Template,
     }
 }

--- a/src/docfx/lib/path/FileOrigin.cs
+++ b/src/docfx/lib/path/FileOrigin.cs
@@ -1,33 +1,36 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace Microsoft.Docs.Build
 {
+    [Flags]
     public enum FileOrigin
     {
         /// <summary>
         /// This file is coming from the main docset folder.
         /// </summary>
-        Default,
+        Default = 0,
 
         /// <summary>
         /// This file is coming from a dependency repository.
         /// </summary>
-        Dependency,
+        Dependency = 1,
 
         /// <summary>
         /// This file is coming from the fallback repository of a localized build.
         /// </summary>
-        Fallback,
+        Fallback = 1 << 1,
 
         /// <summary>
         /// This file is a redirection file.
         /// </summary>
-        Redirection,
+        Redirection = 1 << 2,
 
         /// <summary>
         /// This file is coming from template.
         /// </summary>
-        Template,
+        Template = 1 << 3,
     }
 }

--- a/src/docfx/lib/path/PathUtility.cs
+++ b/src/docfx/lib/path/PathUtility.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks.Dataflow;
 
 namespace Microsoft.Docs.Build
 {

--- a/src/docfx/lib/path/PathUtility.cs
+++ b/src/docfx/lib/path/PathUtility.cs
@@ -59,20 +59,18 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Finds a yaml or json file under the specified location
         /// </summary>
-        public static FilePath FindYamlOrJson(Input input, FileOrigin origin, string pathWithoutExtension)
+        public static string FindYamlOrJson(string pathWithoutExtension)
         {
             var fullPath = NormalizeFile(pathWithoutExtension + ".yml");
-            var filePath = new FilePath(fullPath, origin);
-            if (input.Exists(filePath))
+            if (File.Exists(fullPath))
             {
-                return filePath;
+                return fullPath;
             }
 
             fullPath = NormalizeFile(pathWithoutExtension + ".json");
-            filePath = new FilePath(fullPath, origin)
-            if (input.Exists(filePath))
+            if (File.Exists(fullPath))
             {
-                return filePath;
+                return fullPath;
             }
 
             return null;

--- a/src/docfx/lib/path/PathUtility.cs
+++ b/src/docfx/lib/path/PathUtility.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks.Dataflow;
 
 namespace Microsoft.Docs.Build
 {
@@ -58,18 +59,20 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Finds a yaml or json file under the specified location
         /// </summary>
-        public static string FindYamlOrJson(string pathWithoutExtension)
+        public static FilePath FindYamlOrJson(Input input, FileOrigin origin, string pathWithoutExtension)
         {
-            var fullPath = PathUtility.NormalizeFile(pathWithoutExtension + ".yml");
-            if (File.Exists(fullPath))
+            var fullPath = NormalizeFile(pathWithoutExtension + ".yml");
+            var filePath = new FilePath(fullPath, origin);
+            if (input.Exists(filePath))
             {
-                return fullPath;
+                return filePath;
             }
 
-            fullPath = PathUtility.NormalizeFile(pathWithoutExtension + ".json");
-            if (File.Exists(fullPath))
+            fullPath = NormalizeFile(pathWithoutExtension + ".json");
+            filePath = new FilePath(fullPath, origin)
+            if (input.Exists(filePath))
             {
-                return fullPath;
+                return filePath;
             }
 
             return null;

--- a/src/docfx/localization/LocalizationUtility.cs
+++ b/src/docfx/localization/LocalizationUtility.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Docs.Build
                             throw new NotSupportedException($"{config.Localization.Mapping} is not supporting bilingual build");
                         }
                         localizationDocsetPath = Path.Combine(docset.DocsetPath, "localization", locale);
-                        localizationRepository = Repository.Create(localizationDocsetPath, branch: null, repoUrl: null, commit: null);
+                        localizationRepository = docset.Repository;
                         break;
                     }
                 default:
@@ -109,10 +109,10 @@ namespace Microsoft.Docs.Build
             return TryGetFallbackRepository(repository.Remote, repository.Branch, out fallbackRemote, out fallbackBranch, out locale);
         }
 
-        public static string GetLocale(string remote, string branch, CommandLineOptions options)
+        public static string GetLocale(Repository repository, CommandLineOptions options)
         {
-            return options.Locale ?? (TryRemoveLocale(branch, out _, out var branchLocale)
-                ? branchLocale : TryRemoveLocale(remote, out _, out var remoteLocale)
+            return options.Locale ?? (TryRemoveLocale(repository?.Branch, out _, out var branchLocale)
+                ? branchLocale : TryRemoveLocale(repository?.Remote, out _, out var remoteLocale)
                 ? remoteLocale : default);
         }
 

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -27,13 +27,13 @@ namespace Microsoft.Docs.Build
                 var configLoader = new ConfigLoader(docsetPath, input, repositoryProvider);
 
                 var configPath = docsetPath;
-                var (errors, config) = configLoader.TryLoad(options, locale, extend: false);
+                var (errors, config) = configLoader.TryLoad(options, extend: false);
                 var restoreFallbackResult = RestoreFallbackRepo(config, repository);
                 if (restoreFallbackResult != null)
                     repositoryProvider.ConfigFallbackRepository(Repository.Create(restoreFallbackResult.Path, restoreFallbackResult.Branch, restoreFallbackResult.Remote, restoreFallbackResult.Commit));
 
                 List<Error> fallbackConfigErrors;
-                (fallbackConfigErrors, config) = configLoader.Load(options, locale, extend: false);
+                (fallbackConfigErrors, config) = configLoader.Load(options, extend: false);
                 errors.AddRange(fallbackConfigErrors);
 
                 // config error log, and return if config has errors
@@ -47,7 +47,7 @@ namespace Microsoft.Docs.Build
                     restoreUrl => RestoreFile.Restore(restoreUrl, config));
 
                 // extend the config after the extend url being restored
-                var (extendConfigErrors, extendedConfig) = configLoader.Load(options, locale, extend: true);
+                var (extendConfigErrors, extendedConfig) = configLoader.Load(options, extend: true);
                 errorLog.Write(extendConfigErrors);
 
                 // restore urls except extend url

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -16,25 +16,25 @@ namespace Microsoft.Docs.Build
             // because Docset assumes the repo to physically exist on disk.
             using (Progress.Start("Restore dependencies"))
             {
-                var repository = Repository.Create(docsetPath);
+                // load and trace entry repository
+                var repositoryProvider = new RepositoryProvider(docsetPath, options);
+                var repository = repositoryProvider.GetRepository(FileOrigin.Default);
                 Telemetry.SetRepository(repository?.Remote, repository?.Branch);
+                var locale = LocalizationUtility.GetLocale(repository, options);
 
-                var localeToRestore = LocalizationUtility.GetLocale(repository?.Remote, repository?.Branch, options);
+                // load configuration from current entry or fallback repository
+                var input = new Input(docsetPath, repositoryProvider);
+                var configLoader = new ConfigLoader(docsetPath, input, repositoryProvider);
 
                 var configPath = docsetPath;
-                var (errors, config) = ConfigLoader.TryLoad(configPath, options, localeToRestore, extend: false);
-
+                var (errors, config) = configLoader.TryLoad(options, locale, extend: false);
                 var restoreFallbackResult = RestoreFallbackRepo(config, repository);
-                if (!ConfigLoader.TryGetConfigPath(docsetPath, out _))
-                {
-                    // build from loc directly with overwrite config
-                    // use the fallback config
-                    Log.Write("Use config from fallback repository");
-                    List<Error> fallbackConfigErrors;
-                    configPath = restoreFallbackResult.Path;
-                    (fallbackConfigErrors, config) = ConfigLoader.Load(configPath, options, localeToRestore, extend: false);
-                    errors.AddRange(fallbackConfigErrors);
-                }
+                if (restoreFallbackResult != null)
+                    repositoryProvider.ConfigFallbackRepository(Repository.Create(restoreFallbackResult.Path, restoreFallbackResult.Branch, restoreFallbackResult.Remote, restoreFallbackResult.Commit));
+
+                List<Error> fallbackConfigErrors;
+                (fallbackConfigErrors, config) = configLoader.Load(options, locale, extend: false);
+                errors.AddRange(fallbackConfigErrors);
 
                 // config error log, and return if config has errors
                 errorLog.Configure(config);
@@ -47,7 +47,7 @@ namespace Microsoft.Docs.Build
                     restoreUrl => RestoreFile.Restore(restoreUrl, config));
 
                 // extend the config after the extend url being restored
-                var (extendConfigErrors, extendedConfig) = ConfigLoader.Load(configPath, options, localeToRestore, extend: true);
+                var (extendConfigErrors, extendedConfig) = configLoader.Load(options, locale, extend: true);
                 errorLog.Write(extendConfigErrors);
 
                 // restore urls except extend url
@@ -55,7 +55,7 @@ namespace Microsoft.Docs.Build
                 await RestoreFile.Restore(restoreUrls, extendedConfig);
 
                 // restore git repos includes dependency repos, theme repo and loc repos
-                var restoreDependencyResults = RestoreGit.Restore(extendedConfig, localeToRestore, repository, DependencyLockProvider.Create(docsetPath, extendedConfig.DependencyLock));
+                var restoreDependencyResults = RestoreGit.Restore(extendedConfig, locale, repository, DependencyLockProvider.CreateFromConfig(input, extendedConfig));
 
                 // save dependency lock
                 var restoredGitLock = new List<DependencyGitLock>();
@@ -65,11 +65,7 @@ namespace Microsoft.Docs.Build
                         restoredGitLock.Add(new DependencyGitLock { Url = restoreResult.Remote, Branch = restoreResult.Branch, Commit = restoreResult.Commit });
                 }
 
-                var dependencyLockFilePath = string.IsNullOrEmpty(extendedConfig.DependencyLock)
-                    ? AppData.GetDependencyLockFile(docsetPath, localeToRestore)
-                    : extendedConfig.DependencyLock;
-
-                DependencyLockProvider.SaveGitLock(docsetPath, dependencyLockFilePath, restoredGitLock);
+                DependencyLockProvider.SaveGitLock(docsetPath, locale, extendedConfig.DependencyLock, restoredGitLock);
             }
         }
 

--- a/src/docfx/restore/RestoreFileMap.cs
+++ b/src/docfx/restore/RestoreFileMap.cs
@@ -56,25 +56,22 @@ namespace Microsoft.Docs.Build
             return filePath;
         }
 
-        public static string GetRestoredFileContent(string docsetPath, SourceInfo<string> url, string fallbackDocset)
+        public static string GetRestoredFileContent(Input input, SourceInfo<string> url)
         {
             var fromUrl = UrlUtility.IsHttp(url);
             if (!fromUrl)
             {
                 // directly return the relative path
-                var fullPath = Path.Combine(docsetPath, url);
-                if (File.Exists(fullPath))
+                var localFilePath = new FilePath(url, FileOrigin.Default);
+                if (input.Exists(localFilePath))
                 {
-                    return File.ReadAllText(fullPath);
+                    return input.ReadString(localFilePath);
                 }
 
-                if (!string.IsNullOrEmpty(fallbackDocset))
+                localFilePath = new FilePath(url, FileOrigin.Fallback);
+                if (input.Exists(localFilePath))
                 {
-                    fullPath = Path.Combine(fallbackDocset, url);
-                    if (File.Exists(fullPath))
-                    {
-                        return File.ReadAllText(fullPath);
-                    }
+                    return input.ReadString(localFilePath);
                 }
 
                 throw Errors.FileNotFound(url).ToException();

--- a/src/docfx/restore/RestoreFileMap.cs
+++ b/src/docfx/restore/RestoreFileMap.cs
@@ -8,19 +8,13 @@ namespace Microsoft.Docs.Build
 {
     internal class RestoreFileMap
     {
-        private readonly string _docsetPath;
-        private readonly string _fallbackDocsetPath;
+        private readonly Input _input;
 
-        public RestoreFileMap(string docsetPath, string fallbackDocsetPath = null)
+        public RestoreFileMap(Input input)
         {
-            Debug.Assert(docsetPath != null);
-            _docsetPath = docsetPath;
-            _fallbackDocsetPath = fallbackDocsetPath;
-        }
+            Debug.Assert(input != null);
 
-        public string GetRestoredFileContent(SourceInfo<string> url)
-        {
-            return GetRestoredFileContent(_docsetPath, url, _fallbackDocsetPath);
+            _input = input;
         }
 
         public string GetRestoredFilePath(SourceInfo<string> url)
@@ -29,19 +23,16 @@ namespace Microsoft.Docs.Build
             if (!fromUrl)
             {
                 // directly return the relative path
-                var fullPath = Path.Combine(_docsetPath, url);
-                if (File.Exists(fullPath))
+                var localFilePath = new FilePath(url, FileOrigin.Default);
+                if (_input.Exists(localFilePath))
                 {
-                    return fullPath;
+                    return _input.TryGetPhysicalPath(localFilePath, out var fullPath) ? fullPath : default;
                 }
 
-                if (!string.IsNullOrEmpty(_fallbackDocsetPath))
+                localFilePath = new FilePath(url, FileOrigin.Fallback);
+                if (_input.Exists(localFilePath))
                 {
-                    fullPath = Path.Combine(_fallbackDocsetPath, url);
-                    if (File.Exists(fullPath))
-                    {
-                        return fullPath;
-                    }
+                    return _input.TryGetPhysicalPath(localFilePath, out var fullPath) ? fullPath : default;
                 }
 
                 throw Errors.FileNotFound(url).ToException();
@@ -56,12 +47,16 @@ namespace Microsoft.Docs.Build
             return filePath;
         }
 
+        public string GetRestoredFileContent(SourceInfo<string> url)
+        {
+            return GetRestoredFileContent(_input, url);
+        }
+
         public static string GetRestoredFileContent(Input input, SourceInfo<string> url)
         {
             var fromUrl = UrlUtility.IsHttp(url);
             if (!fromUrl)
             {
-                // directly return the relative path
                 var localFilePath = new FilePath(url, FileOrigin.Default);
                 if (input.Exists(localFilePath))
                 {

--- a/src/docfx/restore/RestoreGit.cs
+++ b/src/docfx/restore/RestoreGit.cs
@@ -24,7 +24,6 @@ namespace Microsoft.Docs.Build
                 by git.remote;
 
             var results = new ListBuilder<RestoreGitResult>();
-
             ParallelUtility.ForEach(
                 gitDependencies,
                 group =>

--- a/src/docfx/restore/RestoreGitMap.cs
+++ b/src/docfx/restore/RestoreGitMap.cs
@@ -95,11 +95,9 @@ namespace Microsoft.Docs.Build
         /// Acquired all shared git based on dependency lock
         /// The dependency lock must be loaded before using this method
         /// </summary>
-        public static RestoreGitMap Create(string docsetPath, Config config, string locale)
+        public static RestoreGitMap Create(string docsetPath, string locale)
         {
-            var dependencyLockPath = string.IsNullOrEmpty(config.DependencyLock)
-                    ? new SourceInfo<string>(AppData.GetDependencyLockFile(docsetPath, locale)) : config.DependencyLock;
-            var dependencyLockProvider = DependencyLockProvider.Create(docsetPath, dependencyLockPath);
+            var dependencyLockProvider = DependencyLockProvider.CreateFromAppData(docsetPath, locale);
 
             return new RestoreGitMap(dependencyLockProvider, docsetPath);
         }

--- a/src/docfx/template/TemplateEngine.cs
+++ b/src/docfx/template/TemplateEngine.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Docs.Build
             return _global[key]?.ToString();
         }
 
-        public static TemplateEngine Create(Docset docset, RestoreGitMap restoreGitMap)
+        public static TemplateEngine Create(Docset docset, RepositoryProvider repositoryProvider)
         {
             Debug.Assert(docset != null);
 
@@ -148,9 +148,8 @@ namespace Microsoft.Docs.Build
                 return new TemplateEngine(Path.Combine(docset.DocsetPath, DefaultTemplateDir));
             }
 
-            var theme = LocalizationUtility.GetLocalizedTheme(docset.Config.Template, docset.Locale, docset.Config.Localization.DefaultLocale);
-            var (themePath, _) = restoreGitMap.GetRestoreGitPath(theme, bare: false);
-            return new TemplateEngine(themePath);
+            var (templateEntry, _) = repositoryProvider.GetRepositoryWithEntry(FileOrigin.Template);
+            return new TemplateEngine(templateEntry);
         }
 
         private JObject LoadGlobalTokens()

--- a/test/docfx.Test/build/TocTest.cs
+++ b/test/docfx.Test/build/TocTest.cs
@@ -9,10 +9,11 @@ namespace Microsoft.Docs.Build
 {
     public static class TocTest
     {
+        private static readonly string s_docsetPath = Directory.GetCurrentDirectory();
+        private static readonly RepositoryProvider s_repositoryProvider = new RepositoryProvider(s_docsetPath, new CommandLineOptions());
+        private static readonly Input s_input = new Input(s_docsetPath, s_repositoryProvider);
         private static readonly Config s_config = JsonUtility.Deserialize<Config>("{'output': { 'json': true } }".Replace('\'', '\"'), null);
-        private static readonly RestoreGitMap s_restoreGitMap = RestoreGitMap.Create(Directory.GetCurrentDirectory(), s_config, null);
         private static readonly Docset s_docset = new Docset(Directory.GetCurrentDirectory(), "en-us", s_config, null);
-        private static readonly Input s_input = new Input(Directory.GetCurrentDirectory(), null, s_config, s_restoreGitMap);
 
         [Theory]
         // same level
@@ -49,7 +50,7 @@ namespace Microsoft.Docs.Build
         {
             // TODO: This test depend too much on the details of our implementation and it needs some refactoring.
             var builder = new TableOfContentsMapBuilder();
-            var templateEngine = TemplateEngine.Create(s_docset, s_restoreGitMap);
+            var templateEngine = TemplateEngine.Create(s_docset, s_repositoryProvider);
             var document = Document.Create(s_docset, new FilePath(file), s_input, templateEngine);
 
             // test multiple reference case


### PR DESCRIPTION
1. use repository provider to get repository, it's a wrapper of RestoreGitMap
2. config loader to use Input to load config
3. Repository provider is part of Input
4. hide current/fallback docset to some of the components


The component dependencies:

`->` means `Depends`

1. RepositoryProvider -> Docset Path/Config/RestoreGitMap/LocalizationRepository
2. Input -> RepositoryProvider
3. ConfigLoader -> Input
4. Config -> ConfigLoader

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5118)