### PR TITLE
monikers of external link/absolute link/non-versioning page node should be null

### DIFF
--- a/docs/designs/conceptual-versioning.md
+++ b/docs/designs/conceptual-versioning.md
@@ -498,16 +498,17 @@ In current docfx v3, Toc file is build at the same time with `page` files, becau
 
 When build the toc file(including the toc file included in another), we have to cover:
 
-1. *Monikers* of every node in toc(We don't support setting monikers of node in toc file).
-    1. If the node is a text node(`## Header`), the *monikers* of this node is the union of its children's monikers.
-    2. If the node is a relative link node(`## [Header](a.md)`), the *monikers* of this node is the union of its children's monikers and the monikers of this node.
-    3. If the node is a absolute link node(`## [Header](/a)` or `## [Header](http://test)`), the *monikers* of this node is the monikers of this toc file, which means this node will always be displayed.
-    4. If the node is a relative folder node(`## [Header](a/)`), the *monikers* of this node is the monikers of the union of:
-        1. Its children's monikers
-        2. The monikers of the document chosen as the resolved result of the current node(specified by the topicHref or the first node of the toc file under folder `a/`).
-    5. If the node is a toc referenced node(`## [Header](a/toc.yml)`), the *monikers* of this node is the monikers of the union of:
-        1. The monikers of the document chosen as the resolved result of the current node(specified by the topicHref).
-        1. The union of the monikers of all the node imported by the referenced toc file.
+1. *Monikers* of every node in toc(We don't support setting monikers of node in toc file) should be the union of current node's monikers and the monikers of all children. The moniker of current node should be:
+    1. If the node is a text node(`## Header`), the *monikers* of current node is empty.
+    2. If the node is a relative link node(`## [Header](a.md)`) and the referenced node is a versioning page, the *monikers* of current node is the monikers of referenced page.
+    3. If the node is a relative link node(`## [Header](a.md)`) and the referenced node is a non-versioning page, the *monikers* of current node is null.
+    4. If the node is a absolute link node(`## [Header](/a)` or `## [Header](http://test)`), the *monikers* of this node is the monikers of current node is null.
+    5. If the node is a relative folder node(`## [Header](a/)`), the *monikers* of current node is the monikers of the monikers of the document chosen as the resolved result of the current node(specified by the topicHref or the first node of the toc file under folder `a/`).
+    6. If the node is a toc referenced node(`## [Header](a/toc.yml)`), the *monikers* of current node is the monikers of the document chosen as the resolved result of the current node(specified by the topicHref).
+> **Notes**
+> 1. When the monikers of toc node is null, this node will always display.
+> 2. When calculating the union of nodes' monikers, once there is a child whose monikers is null, the union result is null.
+
 1. *Monikers* of toc file - Intersection of the monikerRange setting in the config and file metadata(If the intersection is empty, a warning will be logged).
 
 > For now, if the monikers of the node is out of the moniker Range of this toc, we do not report warning.

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -850,12 +850,14 @@ inputs:
     ---
     # [A](a.md)
     ## [B](b.md)
-    ## [C](/c)
-    ## [D](http://test.com/test)
+    ## [Absolute](/c)
+    ## [External](http://test.com/test)
     ### [A](xref:a)
-    ## E
+    ## Text
     ### [A](a.md)
-    ### [B](b.md)
+    ## [Non-versioning](../x.md)
+    ### [A](a.md)
+  docs/x.md:
   monikerDefinition.json: |
     {
       "monikers": [
@@ -882,27 +884,34 @@ outputs:
         {
           "name": "A",
           "href": "a",
+          "monikers": undefined,
           "items": [
             { "name": "B", "href": "b", "monikers": ["netcore-1.1", "netcore-1.2"] },
-            { "name": "C", "href": "/c", "monikers": ["netcore-1.1", "netcore-1.2", "netcore-1.3"] },
-            { 
-              "name": "D",
+            { "name": "Absolute", "href": "/c", "monikers": undefined },
+            {
+              "name": "External",
               "href": "http://test.com/test",
-              "monikers": ["netcore-1.0", "netcore-1.1", "netcore-1.2", "netcore-1.3"],
+              "monikers": undefined,
               "items": [
                 { "name": "A", "href": "a", "monikers": ["netcore-1.0", "netcore-1.1"] }
               ]
             },
             {
-              "name": "E",
-              "monikers": [ "netcore-1.0", "netcore-1.1", "netcore-1.2" ],
+              "name": "Text",
+              "monikers": [ "netcore-1.0", "netcore-1.1" ],
               "items": [
-                { "name": "A", "href": "a", "monikers": [ "netcore-1.0", "netcore-1.1" ] },
-                { "name": "B", "href": "b", "monikers": [ "netcore-1.1", "netcore-1.2"] },
+                { "name": "A", "href": "a", "monikers": [ "netcore-1.0", "netcore-1.1" ] }
               ]
-            }
-          ],
-          "monikers": ["netcore-1.0", "netcore-1.1", "netcore-1.2", "netcore-1.3"]
+            },
+            { 
+              "name": "Non-versioning",
+              "href": "x",
+              "monikers": undefined,
+              "items": [
+                { "name": "A", "href": "a", "monikers": ["netcore-1.0", "netcore-1.1"] }
+              ]
+            },
+          ]
         }
       ],
       "metadata": {"monikers": ["netcore-1.1", "netcore-1.2", "netcore-1.3" ]}
@@ -983,6 +992,12 @@ inputs:
         items:
           - name: D
             href: d.md
+      - name: Toc ref with external link topicHref
+        href: folder/TOC.yml
+        topicHref: https://hostname/test
+        items:
+          - name: D
+            href: d.md
   docs/v1/folder/TOC.yml: |
     metadata:
       monikerRange: '<= netcore-1.1'
@@ -1011,6 +1026,15 @@ outputs:
           "name": "Toc ref with topicHref",
           "href": "e",
           "monikers": [ "netcore-1.0", "netcore-1.1", "netcore-1.3" ],
+          "items": [
+            { "name": "B", "href": "b", "monikers": ["netcore-1.0"] },
+            { "name": "C", "href": "c", "monikers": ["netcore-1.1"] }
+          ]
+        },
+        {
+          "name": "Toc ref with external link topicHref",
+          "href": "https://hostname/test",
+          "monikers": undefined,
           "items": [
             { "name": "B", "href": "b", "monikers": ["netcore-1.0"] },
             { "name": "C", "href": "c", "monikers": ["netcore-1.1"] }
@@ -1064,6 +1088,12 @@ inputs:
         items:
           - name: D
             href: d.md
+      - name: Folder ref with external link topicHref
+        href: folder/
+        topicHref: https://hostname/test
+        items:
+          - name: D
+            href: d.md
   docs/v1/folder/TOC.yml: |
     metadata:
       monikerRange: '<= netcore-1.1'
@@ -1092,6 +1122,14 @@ outputs:
           "name": "Folder ref with topicHref",
           "href": "e",
           "monikers": [ "netcore-1.2", "netcore-1.3" ],
+          "items": [
+            { "name": "D", "href": "d", "monikers": ["netcore-1.2"] }
+          ]
+        },
+        {
+          "name": "Folder ref with external link topicHref",
+          "href": "https://hostname/test",
+          "monikers": undefined,
           "items": [
             { "name": "D", "href": "d", "monikers": ["netcore-1.2"] }
           ]

--- a/src/docfx/build/toc/parser/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsParser.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Docs.Build
                 }
 
                 // resolve monikers
-                newItem.Monikers = GetMonikers(context, rootPath, newItem, errors);
+                newItem.Monikers = GetMonikers(context, newItem, errors);
                 newItems.Add(newItem);
 
                 // validate
@@ -174,7 +174,7 @@ namespace Microsoft.Docs.Build
             return (errors, newItems);
         }
 
-        private static List<string> GetMonikers(Context context, Document rootPath, TableOfContentsItem currentItem, List<Error> errors)
+        private static List<string> GetMonikers(Context context, TableOfContentsItem currentItem, List<Error> errors)
         {
             var monikers = new List<string>();
             if (!string.IsNullOrEmpty(currentItem.Href))

--- a/src/docfx/build/toc/parser/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsParser.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using Microsoft.Graph;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build


### PR DESCRIPTION
separated from #5101 


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5119)