### PR TITLE
MarkdownUtility --> MarkdownEngine

### DIFF
--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -24,24 +24,23 @@ namespace Microsoft.Docs.Build
         public readonly BookmarkValidator BookmarkValidator;
         public readonly DependencyMapBuilder DependencyMapBuilder;
         public readonly DependencyResolver DependencyResolver;
+        public readonly XrefResolver XrefResolver;
         public readonly GitHubUserCache GitHubUserCache;
         public readonly MicrosoftGraphCache MicrosoftGraphCache;
         public readonly ContributionProvider ContributionProvider;
         public readonly PublishModelBuilder PublishModelBuilder;
+        public readonly MarkdownEngine MarkdownEngine;
         public readonly TemplateEngine TemplateEngine;
-
-        public XrefResolver XrefResolver => _xrefResolver.Value;
 
         public TableOfContentsMap TocMap => _tocMap.Value;
 
-        private readonly Lazy<XrefResolver> _xrefResolver;
         private readonly Lazy<TableOfContentsMap> _tocMap;
 
         public Context(string outputPath, ErrorLog errorLog, Docset docset, Docset fallbackDocset, Dictionary<string, (Docset docset, bool inScope)> dependencyDocsets, RestoreGitMap restoreGitMap)
         {
             var restoreFileMap = new RestoreFileMap(docset.DocsetPath, fallbackDocset?.DocsetPath);
             DependencyMapBuilder = new DependencyMapBuilder();
-            _xrefResolver = new Lazy<XrefResolver>(() => new XrefResolver(this, docset, restoreFileMap, DependencyMapBuilder));
+            XrefResolver = new XrefResolver(this, docset, restoreFileMap, DependencyMapBuilder);
             _tocMap = new Lazy<TableOfContentsMap>(() => TableOfContentsMap.Create(this));
             BuildQueue = new WorkQueue<Document>();
 
@@ -74,8 +73,10 @@ namespace Microsoft.Docs.Build
                 GitCommitProvider,
                 BookmarkValidator,
                 DependencyMapBuilder,
-                _xrefResolver,
+                XrefResolver,
                 TemplateEngine);
+
+            MarkdownEngine = new MarkdownEngine(DependencyResolver, XrefResolver, MonikerProvider, TemplateEngine);
         }
 
         public void Dispose()

--- a/src/docfx/build/dependency/DependencyResolver.cs
+++ b/src/docfx/build/dependency/DependencyResolver.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Docs.Build
         private readonly GitCommitProvider _gitCommitProvider;
         private readonly IReadOnlyDictionary<string, string> _resolveAlias;
         private readonly IReadOnlyDictionary<string, Docset> _dependencies;
-        private readonly Lazy<XrefResolver> _xrefResolver;
+        private readonly XrefResolver _xrefResolver;
         private readonly TemplateEngine _templateEngine;
 
         public DependencyResolver(
@@ -35,7 +35,7 @@ namespace Microsoft.Docs.Build
             GitCommitProvider gitCommitProvider,
             BookmarkValidator bookmarkValidator,
             DependencyMapBuilder dependencyMapBuilder,
-            Lazy<XrefResolver> xrefResolver,
+            XrefResolver xrefResolver,
             TemplateEngine templateEngine)
         {
             _input = input;
@@ -117,7 +117,7 @@ namespace Microsoft.Docs.Build
             if (href.Value.StartsWith("xref:"))
             {
                 var uid = new SourceInfo<string>(href.Value.Substring("xref:".Length), href);
-                var (uidError, uidHref, _, declaringFile) = _xrefResolver.Value.ResolveAbsoluteXref(uid, referencingFile);
+                var (uidError, uidHref, _, declaringFile) = _xrefResolver.ResolveAbsoluteXref(uid, referencingFile);
                 var xrefLinkType = declaringFile != null ? LinkType.RelativePath : LinkType.External;
 
                 return (uidError, uidHref, null, xrefLinkType, declaringFile, true);

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -199,11 +199,7 @@ namespace Microsoft.Docs.Build
             var content = context.Input.ReadString(file.FilePath);
             GitUtility.CheckMergeConflictMarker(content, file.FilePath);
 
-            var (markupErrors, htmlDom) = MarkdownUtility.ToHtml(
-                context,
-                content,
-                file,
-                MarkdownPipelineType.Markdown);
+            var (markupErrors, htmlDom) = context.MarkdownEngine.ToHtml(content, file, MarkdownPipelineType.Markdown);
             errors.AddRange(markupErrors);
 
             var wordCount = HtmlUtility.CountWord(htmlDom);

--- a/src/docfx/build/toc/parser/MarkdownTocMarkup.cs
+++ b/src/docfx/build/toc/parser/MarkdownTocMarkup.cs
@@ -15,11 +15,11 @@ namespace Microsoft.Docs.Build
 {
     internal static class MarkdownTocMarkup
     {
-        public static (List<Error> errors, TableOfContentsModel model) Parse(string tocContent, Document file)
+        public static (List<Error> errors, TableOfContentsModel model) Parse(MarkdownEngine markdownEngine, string tocContent, Document file)
         {
             var errors = new List<Error>();
             var headingBlocks = new List<HeadingBlock>();
-            var (markupErrors, ast) = MarkdownUtility.Parse(tocContent, MarkdownPipelineType.TocMarkdown);
+            var (markupErrors, ast) = markdownEngine.Parse(tocContent, MarkdownPipelineType.TocMarkdown);
             errors.AddRange(markupErrors);
 
             foreach (var block in ast)

--- a/src/docfx/build/toc/parser/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsParser.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Docs.Build
             {
                 content = content ?? context.Input.ReadString(file.FilePath);
                 GitUtility.CheckMergeConflictMarker(content, file.FilePath);
-                return MarkdownTocMarkup.Parse(content, file);
+                return MarkdownTocMarkup.Parse(context.MarkdownEngine, content, file);
             }
 
             throw new NotSupportedException($"{filePath} is an unknown TOC file");

--- a/src/docfx/lib/markdown/MarkdownEngine.cs
+++ b/src/docfx/lib/markdown/MarkdownEngine.cs
@@ -12,22 +12,41 @@ using Microsoft.DocAsCode.MarkdigEngine.Extensions;
 
 namespace Microsoft.Docs.Build
 {
-    internal static class MarkdownUtility
+    internal class MarkdownEngine
     {
         // This magic string identifies if an URL was a relative URL in source,
         // URLs starting with this magic string are transformed into relative URL after markup.
         private const string RelativeUrlMarker = "//////";
 
-        private static readonly MarkdownPipeline[] s_markdownPipelines = new[]
-        {
-            CreateMarkdownPipeline(),
-            CreateInlineMarkdownPipeline(),
-            CreateTocMarkdownPipeline(),
-        };
+        private readonly DependencyResolver _dependencyResolver;
+        private readonly XrefResolver _xrefResolver;
+        private readonly MonikerProvider _monikerProvider;
+        private readonly TemplateEngine _templateEngine;
+
+        private readonly MarkdownContext _markdownContext;
+        private readonly MarkdownPipeline[] _pipelines;
 
         private static readonly ThreadLocal<Stack<Status>> t_status = new ThreadLocal<Stack<Status>>(() => new Stack<Status>());
 
-        public static (List<Error> errors, MarkdownDocument ast) Parse(string content, MarkdownPipelineType piplineType)
+        public MarkdownEngine(
+            DependencyResolver dependencyResolver, XrefResolver xrefResolver, MonikerProvider monikerProvider, TemplateEngine templateEngine)
+        {
+            _dependencyResolver = dependencyResolver;
+            _xrefResolver = xrefResolver;
+            _monikerProvider = monikerProvider;
+            _templateEngine = templateEngine;
+
+            _markdownContext = new MarkdownContext(GetToken, LogInfo, LogSuggestion, LogWarning, LogError, ReadFile);
+
+            _pipelines = new[]
+            {
+                CreateMarkdownPipeline(),
+                CreateInlineMarkdownPipeline(),
+                CreateTocMarkdownPipeline(),
+            };
+        }
+
+        public (List<Error> errors, MarkdownDocument ast) Parse(string content, MarkdownPipelineType piplineType)
         {
             try
             {
@@ -35,7 +54,7 @@ namespace Microsoft.Docs.Build
 
                 t_status.Value.Push(status);
 
-                var ast = Markdown.Parse(content, s_markdownPipelines[(int)piplineType]);
+                var ast = Markdown.Parse(content, _pipelines[(int)piplineType]);
 
                 return (status.Errors, ast);
             }
@@ -45,11 +64,7 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public static (List<Error> errors, HtmlNode html) ToHtml(
-            Context context,
-            string markdown,
-            Document file,
-            MarkdownPipelineType pipelineType)
+        public (List<Error> errors, HtmlNode html) ToHtml(string markdown, Document file, MarkdownPipelineType pipelineType)
         {
             using (InclusionContext.PushFile(file))
             {
@@ -58,12 +73,11 @@ namespace Microsoft.Docs.Build
                     var status = new Status
                     {
                         Errors = new List<Error>(),
-                        Context = context,
                     };
 
                     t_status.Value.Push(status);
 
-                    var html = Markdown.ToHtml(markdown, s_markdownPipelines[(int)pipelineType]);
+                    var html = Markdown.ToHtml(markdown, _pipelines[(int)pipelineType]);
                     var htmlNode = HtmlUtility.LoadHtml(html);
 
                     var htmlNodeWithRelativeLink = HtmlUtility.TransformLinks(htmlNode, (href, _) =>
@@ -84,38 +98,22 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static MarkdownPipeline CreateMarkdownPipeline()
+        private MarkdownPipeline CreateMarkdownPipeline()
         {
-            var markdownContext = new MarkdownContext(
-                GetToken,
-                LogInfo,
-                LogSuggestion,
-                LogWarning,
-                LogError,
-                ReadFile);
-
             return new MarkdownPipelineBuilder()
                 .UseYamlFrontMatter()
-                .UseDocfxExtensions(markdownContext)
+                .UseDocfxExtensions(_markdownContext)
                 .UseLink(GetLink)
                 .UseXref(GetXref)
                 .UseMonikerZone(GetMonikerRange)
                 .Build();
         }
 
-        private static MarkdownPipeline CreateInlineMarkdownPipeline()
+        private MarkdownPipeline CreateInlineMarkdownPipeline()
         {
-            var markdownContext = new MarkdownContext(
-                GetToken,
-                LogInfo,
-                LogSuggestion,
-                LogWarning,
-                LogError,
-                ReadFile);
-
             return new MarkdownPipelineBuilder()
                 .UseYamlFrontMatter()
-                .UseDocfxExtensions(markdownContext)
+                .UseDocfxExtensions(_markdownContext)
                 .UseLink(GetLink)
                 .UseXref(GetXref)
                 .UseMonikerZone(GetMonikerRange)
@@ -143,9 +141,9 @@ namespace Microsoft.Docs.Build
             return builder.Build();
         }
 
-        private static string GetToken(string key)
+        private string GetToken(string key)
         {
-            return t_status.Value.Peek().Context.TemplateEngine.GetToken(key);
+            return _templateEngine.GetToken(key);
         }
 
         private static void LogInfo(string code, string message, MarkdownObject origin, int? line)
@@ -168,18 +166,18 @@ namespace Microsoft.Docs.Build
             t_status.Value.Peek().Errors.Add(new Error(ErrorLevel.Suggestion, code, message, origin.ToSourceInfo(line)));
         }
 
-        private static (string content, object file) ReadFile(string path, object relativeTo, MarkdownObject origin)
+        private (string content, object file) ReadFile(string path, object relativeTo, MarkdownObject origin)
         {
             var status = t_status.Value.Peek();
-            var (error, content, file) = status.Context.DependencyResolver.ResolveContent(new SourceInfo<string>(path, origin.ToSourceInfo()), (Document)relativeTo);
+            var (error, content, file) = _dependencyResolver.ResolveContent(new SourceInfo<string>(path, origin.ToSourceInfo()), (Document)relativeTo);
             status.Errors.AddIfNotNull(error);
             return (content, file);
         }
 
-        private static string GetLink(SourceInfo<string> href)
+        private string GetLink(SourceInfo<string> href)
         {
             var status = t_status.Value.Peek();
-            var (error, link, file) = status.Context.DependencyResolver.ResolveAbsoluteLink(
+            var (error, link, file) = _dependencyResolver.ResolveAbsoluteLink(
                 href, (Document)InclusionContext.File);
 
             if (file != null)
@@ -191,10 +189,10 @@ namespace Microsoft.Docs.Build
             return link;
         }
 
-        private static (string href, string display) GetXref(SourceInfo<string> href, bool isShorthand)
+        private (string href, string display) GetXref(SourceInfo<string> href, bool isShorthand)
         {
             var status = t_status.Value.Peek();
-            var (error, link, display, declaringFile) = status.Context.XrefResolver.ResolveAbsoluteXref(
+            var (error, link, display, declaringFile) = _xrefResolver.ResolveAbsoluteXref(
                 href, (Document)InclusionContext.File);
 
             if (declaringFile != null)
@@ -209,10 +207,10 @@ namespace Microsoft.Docs.Build
             return (link, display);
         }
 
-        private static List<string> GetMonikerRange(SourceInfo<string> monikerRange)
+        private List<string> GetMonikerRange(SourceInfo<string> monikerRange)
         {
             var status = t_status.Value.Peek();
-            var (error, monikers) = status.Context.MonikerProvider.GetZoneLevelMonikers((Document)InclusionContext.RootFile, monikerRange);
+            var (error, monikers) = _monikerProvider.GetZoneLevelMonikers((Document)InclusionContext.RootFile, monikerRange);
             status.Errors.AddIfNotNull(error);
             return monikers;
         }
@@ -220,8 +218,6 @@ namespace Microsoft.Docs.Build
         private sealed class Status
         {
             public List<Error> Errors;
-
-            public Context Context;
         }
     }
 }

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -220,12 +220,7 @@ namespace Microsoft.Docs.Build
                     break;
 
                 case JsonSchemaContentType.Markdown:
-                    var (markupErrors, html) = MarkdownUtility.ToHtml(
-                        context,
-                        content,
-                        file,
-                        MarkdownPipelineType.Markdown);
-
+                    var (markupErrors, html) = context.MarkdownEngine.ToHtml(content, file, MarkdownPipelineType.Markdown);
                     errors.AddRange(markupErrors);
 
                     // todo: use BuildPage.CreateHtmlContent() when we only validate markdown properties' bookmarks
@@ -233,12 +228,7 @@ namespace Microsoft.Docs.Build
                     break;
 
                 case JsonSchemaContentType.InlineMarkdown:
-                    var (inlineMarkupErrors, inlineHtml) = MarkdownUtility.ToHtml(
-                        context,
-                        content,
-                        file,
-                        MarkdownPipelineType.InlineMarkdown);
-
+                    var (inlineMarkupErrors, inlineHtml) = context.MarkdownEngine.ToHtml(content, file, MarkdownPipelineType.InlineMarkdown);
                     errors.AddRange(inlineMarkupErrors);
 
                     // todo: use BuildPage.CreateHtmlContent() when we only validate markdown properties' bookmarks


### PR DESCRIPTION
Related to #5114 

The current `MarkdownUtility` does not have an easy way to persist (cache) per build information like `ValidationContext` in the above PR.

`MarkdownEngine`'s lifetime is bound to a build, with this change, a member variable can be used to store per build information.

@LowEntropyBody 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5120)