### PR TITLE
nearest toc calculation

### DIFF
--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -1152,6 +1152,20 @@ outputs:
   .dependencymap.json: |
     {}
 ---
+# Parent toc including child toc by relative path won't participate in child toc calculation
+inputs:
+  docfx.yml:
+  dir1/a.md:
+  dir1/TOC.yml: |
+    - name: Include dir2 toc
+      href: dir2/
+  dir1/dir2/TOC.yml: |
+    - name: reference a.md
+      href: ../a.md
+outputs:
+  dir1/a.json: |
+    {"_tocRel": "dir2/toc.json"}
+---
 # File referenced by multiple toc with same relative file path, use order alphabetical. For other tests, reference build/TocTest.
 inputs:
   docfx.yml: 

--- a/src/docfx/build/toc/parser/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsParser.cs
@@ -291,8 +291,9 @@ namespace Microsoft.Docs.Build
                 context, filePath, referencedTocs, tocHrefType, new SourceInfo<string>(hrefPath, tocHref), errors);
             if (referencedTocContent != null)
             {
-                var (subErrors, nestedToc) = LoadInternal(
-                    context, referenceTocFilePath, rootPath, referencedFiles, referencedTocs, referencedTocContent);
+                var (subErrors, nestedToc) = tocHrefType == TocHrefType.RelativeFolder
+                    ? LoadInternal(context, referenceTocFilePath, rootPath, new List<Document>(), referencedTocs, referencedTocContent)
+                    : LoadInternal(context, referenceTocFilePath, rootPath, referencedFiles, referencedTocs, referencedTocContent);
                 errors.AddRange(subErrors);
 
                 if (tocHrefType == TocHrefType.RelativeFolder)

--- a/src/docfx/build/toc/parser/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/parser/TableOfContentsParser.cs
@@ -291,9 +291,13 @@ namespace Microsoft.Docs.Build
                 context, filePath, referencedTocs, tocHrefType, new SourceInfo<string>(hrefPath, tocHref), errors);
             if (referencedTocContent != null)
             {
-                var (subErrors, nestedToc) = tocHrefType == TocHrefType.RelativeFolder
-                    ? LoadInternal(context, referenceTocFilePath, rootPath, new List<Document>(), referencedTocs, referencedTocContent)
-                    : LoadInternal(context, referenceTocFilePath, rootPath, referencedFiles, referencedTocs, referencedTocContent);
+                var (subErrors, nestedToc) = LoadInternal(
+                    context,
+                    referenceTocFilePath,
+                    rootPath,
+                    tocHrefType == TocHrefType.RelativeFolder ? new List<Document>() : referencedFiles,
+                    referencedTocs,
+                    referencedTocContent);
                 errors.AddRange(subErrors);
 
                 if (tocHrefType == TocHrefType.RelativeFolder)


### PR DESCRIPTION
Parent toc including child toc by relative path won't participate in child toc calculation

Fixing: 
- [DevOps#122690](https://dev.azure.com/ceapex/Engineering/_workitems/edit/122690)
- [DevOps#122689](https://dev.azure.com/ceapex/Engineering/_workitems/edit/122689)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5130)