### PR TITLE
fix bug of file map for crr content

### DIFF
--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -350,3 +350,80 @@ repos:
 outputs:
   xyz/b.json:
   crrc/c.json:
+---
+# crr files have same name but in different crr
+legacy: true
+repos:
+  https://docs.com/crrsame/a:
+    - files:
+        docfx.yml: |
+          files:
+            - "crrb/**/*"
+            - "crrc/**/*"
+            - "docs/**/*"
+          dependencies:
+            crrb:
+              url: https://docs.com/crrsame/b
+              branch: master
+              includeInBuild: true
+            crrc:
+              url: https://docs.com/crrsame/c
+              branch: test
+              includeInBuild: true
+        docs/a.md: |
+          [link to b](b.md)
+        docs/b.md:
+  https://docs.com/crrsame/b:
+    - files:
+        a.md: |
+          [link to b](b.md)
+        b.md:
+  https://docs.com/crrsame/c#test:
+    - files:
+        a.md: |
+          [link to b](b.md)
+        b.md:
+outputs:
+  filemap.json: |
+    {
+      "file_mapping": {
+        "crrb/a.md": {
+          "type": "Content",
+          "output_relative_path": "crrb/a.html",
+          "asset_id": "/crrb/a"
+        },
+        "crrc/a.md": {
+          "type": "Content",
+          "output_relative_path": "crrc/a.html",
+          "asset_id": "/crrc/a"
+        },
+        "docs/a.md": {
+          "type": "Content",
+          "output_relative_path": "docs/a.html",
+          "asset_id": "/docs/a"
+        }
+      }
+    }
+  .dependencymap.json: |
+    {
+      "dependencies": {
+        "crrb/a.md": [
+          {
+            "source": "b.md",
+            "type": "link"
+           }
+          ],
+          "crrc/a.md": [
+           {
+            "source": "b.md",
+            "type": "link"
+           }
+          ],
+          "docs/a.md": [
+           {
+            "source": "docs/b.md",
+            "type": "link"
+          }
+        ]
+      }
+    }

--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -409,13 +409,13 @@ outputs:
       "dependencies": {
         "crrb/a.md": [
           {
-            "source": "b.md",
+            "source": "crrb/b.md",
             "type": "link"
            }
           ],
           "crrc/a.md": [
            {
-            "source": "b.md",
+            "source": "crrc/b.md",
             "type": "link"
            }
           ],

--- a/src/docfx/build/dependency/DependencyMap.cs
+++ b/src/docfx/build/dependency/DependencyMap.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Docs.Build
                 .ToDictionary(
                     d => GetSourcePath(d.Key.FilePath),
                     d => (from v in d.Value
-                          orderby v.To.FilePath.Path, v.Type
+                          orderby v.To.FilePath.Path, v.To.FilePath.Origin, v.To.FilePath.DependencyName ?? "", v.Type
                           select new DependencyManifestItem { Source = GetSourcePath(v.To.FilePath), Type = v.Type }).ToArray());
 
             return new { dependencies };

--- a/src/docfx/build/dependency/DependencyMap.cs
+++ b/src/docfx/build/dependency/DependencyMap.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Docs.Build
             var dependencies = this
                 .OrderBy(d => GetSourcePath(d.Key.FilePath))
                 .ToDictionary(
-                    d => Path.Combine(d.Key.FilePath.DependencyName ?? "", d.Key.FilePath.Path).Replace("\\", "/"),
+                    d => GetSourcePath(d.Key.FilePath),
                     d => (from v in d.Value
                           orderby v.To.FilePath.Path, v.Type
                           select new DependencyManifestItem { Source = GetSourcePath(v.To.FilePath), Type = v.Type }).ToArray());

--- a/src/docfx/build/dependency/DependencyMap.cs
+++ b/src/docfx/build/dependency/DependencyMap.cs
@@ -21,16 +21,17 @@ namespace Microsoft.Docs.Build
         {
             // TODO: Make dependency map a data model once we remove legacy.
             var dependencies = this
-                .OrderBy(d => d.Key.FilePath.Path)
-                .ThenBy(d => d.Key.FilePath.Origin)
-                .ThenBy(d => d.Key.FilePath.DependencyName ?? "")
+                .OrderBy(d => GetSourcePath(d.Key.FilePath))
                 .ToDictionary(
                     d => Path.Combine(d.Key.FilePath.DependencyName ?? "", d.Key.FilePath.Path).Replace("\\", "/"),
                     d => (from v in d.Value
                           orderby v.To.FilePath.Path, v.Type
-                          select new DependencyManifestItem { Source = v.To.FilePath.Path, Type = v.Type }).ToArray());
+                          select new DependencyManifestItem { Source = GetSourcePath(v.To.FilePath), Type = v.Type }).ToArray());
 
             return new { dependencies };
+
+            string GetSourcePath(FilePath file)
+                => Path.Combine(file.DependencyName ?? "", file.Path).Replace("\\", "/");
         }
     }
 }

--- a/src/docfx/build/dependency/DependencyMap.cs
+++ b/src/docfx/build/dependency/DependencyMap.cs
@@ -21,7 +21,9 @@ namespace Microsoft.Docs.Build
         {
             // TODO: Make dependency map a data model once we remove legacy.
             var dependencies = this
-                .OrderBy(d => GetSourcePath(d.Key.FilePath))
+                .OrderBy(d => d.Key.FilePath.Path)
+                .ThenBy(d => d.Key.FilePath.Origin)
+                .ThenBy(d => d.Key.FilePath.DependencyName ?? "")
                 .ToDictionary(
                     d => GetSourcePath(d.Key.FilePath),
                     d => (from v in d.Value

--- a/src/docfx/build/dependency/DependencyMap.cs
+++ b/src/docfx/build/dependency/DependencyMap.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
 
 namespace Microsoft.Docs.Build
@@ -21,8 +22,10 @@ namespace Microsoft.Docs.Build
             // TODO: Make dependency map a data model once we remove legacy.
             var dependencies = this
                 .OrderBy(d => d.Key.FilePath.Path)
+                .ThenBy(d => d.Key.FilePath.Origin)
+                .ThenBy(d => d.Key.FilePath.DependencyName ?? "")
                 .ToDictionary(
-                    d => d.Key.FilePath.Path,
+                    d => Path.Combine(d.Key.FilePath.DependencyName ?? "", d.Key.FilePath.Path).Replace("\\", "/"),
                     d => (from v in d.Value
                           orderby v.To.FilePath.Path, v.Type
                           select new DependencyManifestItem { Source = v.To.FilePath.Path, Type = v.Type }).ToArray());

--- a/src/docfx/build/legacy/LegacyUtility.cs
+++ b/src/docfx/build/legacy/LegacyUtility.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Docs.Build
 
         public static string ToLegacyPathRelativeToBasePath(this Document doc, Docset docset)
         {
-            return PathUtility.NormalizeFile(Path.GetRelativePath(docset.Config.DocumentId.SourceBasePath, doc.FilePath.Path));
+            return PathUtility.NormalizeFile(Path.GetRelativePath(docset.Config.DocumentId.SourceBasePath, Path.Combine(doc.FilePath.DependencyName ?? "", doc.FilePath.Path)));
         }
 
         public static string ToLegacyOutputPathRelativeToSiteBasePath(this Document doc, Docset docset, PublishItem manifestItem)


### PR DESCRIPTION
docfx use `FilePath` with "path" and "origin" to represent a file localization.

https://ceapex.visualstudio.com/Engineering/_workitems/edit/124152

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5138)