### PR TITLE
Treat content output as required output

### DIFF
--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -868,6 +868,7 @@ inputs:
       ]
     }
 outputs:
+  docs/x.json:
   9d4e15fd/docs/a.json: |
     {
       "conceptual": "<p>Moniker: netcore-1.0, netcore-1.1</p>",

--- a/docs/specs/output.yml
+++ b/docs/specs/output.yml
@@ -466,6 +466,7 @@ outputs:
   218c13d0/docs/a.json:
   23d205a5/docs/b.json:
   23d205a5/docs/c.json:
+  23d205a5/docs/d.json:
   docs/toc.json:
   .links.json: |
     {

--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -384,6 +384,18 @@ repos:
           [link to b](b.md)
         b.md:
 outputs:
+  docs/a.mta.json:
+  docs/a.raw.page.json:
+  docs/b.mta.json:
+  docs/b.raw.page.json:
+  crrb/a.mta.json:
+  crrb/a.raw.page.json:
+  crrb/b.mta.json:
+  crrb/b.raw.page.json:
+  crrc/a.mta.json:
+  crrc/a.raw.page.json:
+  crrc/b.mta.json:
+  crrc/b.raw.page.json:
   filemap.json: |
     {
       "file_mapping": {

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -1165,6 +1165,8 @@ inputs:
 outputs:
   dir1/a.json: |
     {"_tocRel": "dir2/toc.json"}
+  dir1/toc.json:
+  dir1/dir2/toc.json:
 ---
 # File referenced by multiple toc with same relative file path, use order alphabetical. For other tests, reference build/TocTest.
 inputs:

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -725,6 +725,7 @@ inputs:
       ]
     }
 outputs:
+  docs/c.json:
   .errors.log: |
     ["error","circular-reference","Build has identified file(s) referencing each other: 'a (docs/a.yml)' --> 'b (docs/b.yml)' --> 'a (docs/a.yml)'","docs/a.yml"]
     ["error","circular-reference","Build has identified file(s) referencing each other: 'b (docs/b.yml)' --> 'a (docs/a.yml)' --> 'b (docs/b.yml)'","docs/b.yml"]

--- a/src/Microsoft.DocAsTest/JsonDiff/JsonDiffExtensions.cs
+++ b/src/Microsoft.DocAsTest/JsonDiff/JsonDiffExtensions.cs
@@ -110,7 +110,8 @@ namespace Microsoft.DocAsTest
         /// <example>
         /// Given the expectation { "a": 1 }, { "b": 1 } pass.
         /// </example>
-        public static JsonDiffBuilder UseAdditionalProperties(this JsonDiffBuilder builder, JsonDiffPredicate predicate = null)
+        public static JsonDiffBuilder UseAdditionalProperties(
+            this JsonDiffBuilder builder, JsonDiffPredicate predicate = null, Func<string, bool> isRequiredProperty = null)
         {
             if (builder is null)
                 throw new ArgumentNullException(nameof(builder));
@@ -119,12 +120,25 @@ namespace Microsoft.DocAsTest
             {
                 if (expected is JObject expectedObj && actual is JObject actualObj)
                 {
-                    var newActual = new JObject(actualObj.Properties().Where(p => expectedObj.ContainsKey(p.Name)));
+                    var newActual = new JObject(actualObj.Properties().Where(IsRequiredProperty));
 
                     return (expected, newActual);
                 }
 
                 return (expected, actual);
+
+                bool IsRequiredProperty(JProperty property)
+                {
+                    if (expectedObj.ContainsKey(property.Name))
+                    {
+                        return true;
+                    }
+                    if (isRequiredProperty != null && isRequiredProperty(property.Name))
+                    {
+                        return true;
+                    }
+                    return false;
+                }
             });
         }
 

--- a/test/docfx.Test/DocfxTest.cs
+++ b/test/docfx.Test/DocfxTest.cs
@@ -227,6 +227,11 @@ namespace Microsoft.Docs.Build
 
         private static bool IsHtml(JToken expected, JToken actual, string name)
         {
+            if (name.EndsWith(".html", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
             if (expected is JValue value && value.Value is string str &&
                 str.Trim() is string html && html.StartsWith('<') && html.EndsWith('>'))
             {

--- a/test/docfx.Test/DocfxTest.cs
+++ b/test/docfx.Test/DocfxTest.cs
@@ -195,30 +195,38 @@ namespace Microsoft.Docs.Build
 
         private static JsonDiff CreateJsonDiff()
         {
-            return new JsonDiffBuilder()
+            var fileJsonDiff = new JsonDiffBuilder()
                 .UseAdditionalProperties()
                 .UseNegate()
                 .UseRegex()
                 .UseWildcard()
-                .UseIgnoreNull(IsOutputFile)
-                .UseJson()
                 .UseHtml(IsHtml)
                 .Use(IsHtml, RemoveDataLinkType)
-                .UseLogFile()
+                .Build();
+
+            return new JsonDiffBuilder()
+                .UseAdditionalProperties(null, IsRequiredOutput)
+                .UseIgnoreNull()
+                .UseJson(null, fileJsonDiff)
+                .UseLogFile(fileJsonDiff)
+                .UseHtml(IsHtml)
+                .Use(IsHtml, RemoveDataLinkType)
                 .Build();
         }
 
-        private static bool IsOutputFile(JToken expected, JToken actual, string name)
+        private static bool IsRequiredOutput(string name)
         {
-            // TODO: this will also match first property inside JSON file.
-            return expected.Parent?.Parent == expected.Root;
+            var fileName = Path.GetFileName(name);
+
+            return (fileName == ".errors.log" || !fileName.StartsWith("."))
+                && fileName != "filemap.json"
+                && fileName != "op_aggregated_file_map_info.json"
+                && fileName != "full-dependent-list.txt"
+                && fileName != "server-side-dependent-list.txt";
         }
 
         private static bool IsHtml(JToken expected, JToken actual, string name)
         {
-            if (name.EndsWith(".html", StringComparison.OrdinalIgnoreCase))
-                return true;
-
             if (expected is JValue value && value.Value is string str &&
                 str.Trim() is string html && html.StartsWith('<') && html.EndsWith('>'))
             {
@@ -244,11 +252,11 @@ namespace Microsoft.Docs.Build
             return (expectedHtml, actualHtml);
         }
 
-        private static JsonDiffBuilder UseLogFile(this JsonDiffBuilder builder)
+        private static JsonDiffBuilder UseLogFile(this JsonDiffBuilder builder, JsonDiff jsonDiff)
         {
             return builder.Use(
                 (expected, actual, name) => name.EndsWith(".txt") || name.EndsWith(".log"),
-                (expected, actual, name, jsonDiff) =>
+                (expected, actual, name, _) =>
                 {
                     if (expected.Type != JTokenType.String || actual.Type != JTokenType.String)
                     {
@@ -257,12 +265,12 @@ namespace Microsoft.Docs.Build
 
                     var expectedLines = expected.Value<string>()
                         .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-                        .OrderBy(_ => _)
+                        .OrderBy(item => item)
                         .ToArray();
 
                     var actualLines = actual.Value<string>()
                         .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-                        .OrderBy(_ => _)
+                        .OrderBy(item => item)
                         .ToArray();
 
                     for (var i = 0; i < Math.Min(expectedLines.Length, actualLines.Length); i++)


### PR DESCRIPTION
- Treat content output as required output, fix related tests
- Add lock to test adapter output to see if it solves vs test explorer display problems.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5139)