### PR TITLE
Move Error log inside build and restore

### DIFF
--- a/src/docfx/lib/log/Log.cs
+++ b/src/docfx/lib/log/Log.cs
@@ -2,10 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace Microsoft.Docs.Build
 {
+    [SuppressMessage("Reliability", "CA2002", Justification = "Lock Console.Out")]
     internal static class Log
     {
         internal static bool ForceVerbose;
@@ -20,6 +22,16 @@ namespace Microsoft.Docs.Build
             return new LogScope(() => t_verbose.Value = false);
         }
 
+        public static void Important(string message, ConsoleColor color)
+        {
+            lock (Console.Out)
+            {
+                Console.ForegroundColor = color;
+                Console.WriteLine(message);
+                Console.ResetColor();
+            }
+        }
+
         public static void Write(Exception exception)
         {
             Write(exception.ToString(), ConsoleColor.DarkRed);
@@ -29,9 +41,7 @@ namespace Microsoft.Docs.Build
         {
             if (Verbose)
             {
-#pragma warning disable CA2002
                 lock (Console.Out)
-#pragma warning restore CA2002
                 {
                     Console.ForegroundColor = color;
                     Console.WriteLine(message);

--- a/src/docfx/lib/process/InterProcessMutex.cs
+++ b/src/docfx/lib/process/InterProcessMutex.cs
@@ -30,14 +30,7 @@ namespace Microsoft.Docs.Build
             {
                 while (!mutex.WaitOne(TimeSpan.FromSeconds(30)))
                 {
-#pragma warning disable CA2002 // Do not lock on objects with weak identity
-                    lock (Console.Out)
-#pragma warning restore CA2002
-                    {
-                        Console.ForegroundColor = ConsoleColor.Yellow;
-                        Console.WriteLine($"Waiting for another process to access '{mutexName}'");
-                        Console.ResetColor();
-                    }
+                    Log.Important($"Waiting for another process to access '{mutexName}'", ConsoleColor.Yellow);
                 }
             }
             catch (AbandonedMutexException)

--- a/src/docfx/lib/process/InterProcessReaderWriterLock.cs
+++ b/src/docfx/lib/process/InterProcessReaderWriterLock.cs
@@ -58,14 +58,7 @@ namespace Microsoft.Docs.Build
                 {
                     if (DateTime.UtcNow - start > TimeSpan.FromSeconds(30))
                     {
-#pragma warning disable CA2002 // Do not lock on objects with weak identity
-                        lock (Console.Out)
-#pragma warning restore CA2002
-                        {
-                            Console.ForegroundColor = ConsoleColor.Yellow;
-                            Console.WriteLine($"Waiting for another process to access '{name}'");
-                            Console.ResetColor();
-                        }
+                        Log.Important($"Waiting for another process to access '{name}'", ConsoleColor.Yellow);
                     }
 
                     Thread.Sleep(200);

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -67,8 +67,11 @@ namespace Microsoft.Docs.Build
                     var restoredGitLock = new List<DependencyGitLock>();
                     foreach (var restoreResult in restoreDependencyResults.Concat(new[] { restoreFallbackResult }))
                     {
-                        DependencyLockProvider.SaveGitLock(docsetPath, locale, extendedConfig.DependencyLock, restoredGitLock);
+                        if (restoreResult != null)
+                            restoredGitLock.Add(new DependencyGitLock { Url = restoreResult.Remote, Branch = restoreResult.Branch, Commit = restoreResult.Commit });
                     }
+
+                    DependencyLockProvider.SaveGitLock(docsetPath, locale, extendedConfig.DependencyLock, restoredGitLock);
                 }
                 catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
                 {

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -18,9 +18,11 @@ namespace Microsoft.Docs.Build
 
             // Restore has to use Config directly, it cannot depend on Docset,
             // because Docset assumes the repo to physically exist on disk.
-            using (var errorLog = new ErrorLog("restore", docsetPath, options.Output, () => config, options.Legacy))
+            using (var errorLog = new ErrorLog(docsetPath, options.Output, () => config, options.Legacy))
             using (Progress.Start("Restore dependencies"))
             {
+                var stopwatch = Stopwatch.StartNew();
+
                 try
                 {
                     // load and trace entry repository
@@ -77,6 +79,12 @@ namespace Microsoft.Docs.Build
                 {
                     Log.Write(dex);
                     errorLog.Write(dex.Error, isException: true);
+                }
+                finally
+                {
+                    Telemetry.TrackOperationTime("restore", stopwatch.Elapsed);
+                    Log.Important($"Restore '{config?.Name}' done in {Progress.FormatTimeSpan(stopwatch.Elapsed)}", ConsoleColor.Green);
+                    errorLog.PrintSummary();
                 }
             }
         }

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -10,66 +11,76 @@ namespace Microsoft.Docs.Build
 {
     internal static class Restore
     {
-        public static async Task Run(string docsetPath, CommandLineOptions options, ErrorLog errorLog)
+        public static async Task Run(string docsetPath, CommandLineOptions options)
         {
+            List<Error> errors;
+            Config config = null;
+
             // Restore has to use Config directly, it cannot depend on Docset,
             // because Docset assumes the repo to physically exist on disk.
+            using (var errorLog = new ErrorLog("restore", docsetPath, options.Output, () => config, options.Legacy))
             using (Progress.Start("Restore dependencies"))
             {
-                var repository = Repository.Create(docsetPath);
-                Telemetry.SetRepository(repository?.Remote, repository?.Branch);
-
-                var localeToRestore = LocalizationUtility.GetLocale(repository?.Remote, repository?.Branch, options);
-
-                var configPath = docsetPath;
-                var (errors, config) = ConfigLoader.TryLoad(configPath, options, localeToRestore, extend: false);
-
-                var restoreFallbackResult = RestoreFallbackRepo(config, repository);
-                if (!ConfigLoader.TryGetConfigPath(docsetPath, out _))
+                try
                 {
-                    // build from loc directly with overwrite config
-                    // use the fallback config
-                    Log.Write("Use config from fallback repository");
-                    List<Error> fallbackConfigErrors;
-                    configPath = restoreFallbackResult.Path;
-                    (fallbackConfigErrors, config) = ConfigLoader.Load(configPath, options, localeToRestore, extend: false);
-                    errors.AddRange(fallbackConfigErrors);
+                    var repository = Repository.Create(docsetPath);
+                    Telemetry.SetRepository(repository?.Remote, repository?.Branch);
+
+                    var localeToRestore = LocalizationUtility.GetLocale(repository?.Remote, repository?.Branch, options);
+
+                    var configPath = docsetPath;
+                    (errors, config) = ConfigLoader.TryLoad(configPath, options, localeToRestore, extend: false);
+
+                    var restoreFallbackResult = RestoreFallbackRepo(config, repository);
+                    if (!ConfigLoader.TryGetConfigPath(docsetPath, out _))
+                    {
+                        // build from loc directly with overwrite config
+                        // use the fallback config
+                        Log.Write("Use config from fallback repository");
+                        List<Error> fallbackConfigErrors;
+                        configPath = restoreFallbackResult.Path;
+                        (fallbackConfigErrors, config) = ConfigLoader.Load(configPath, options, localeToRestore, extend: false);
+                        errors.AddRange(fallbackConfigErrors);
+                    }
+
+                    if (errorLog.Write(errors))
+                        return;
+
+                    // restore extend url firstly
+                    await ParallelUtility.ForEach(
+                        config.Extend.Where(UrlUtility.IsHttp),
+                        restoreUrl => RestoreFile.Restore(restoreUrl, config));
+
+                    // extend the config after the extend url being restored
+                    var (extendConfigErrors, extendedConfig) = ConfigLoader.Load(configPath, options, localeToRestore, extend: true);
+                    errorLog.Write(extendConfigErrors);
+
+                    // restore urls except extend url
+                    var restoreUrls = extendedConfig.GetFileReferences().Where(UrlUtility.IsHttp).ToList();
+                    await RestoreFile.Restore(restoreUrls, extendedConfig);
+
+                    // restore git repos includes dependency repos, theme repo and loc repos
+                    var restoreDependencyResults = RestoreGit.Restore(extendedConfig, localeToRestore, repository, DependencyLockProvider.Create(docsetPath, extendedConfig.DependencyLock));
+
+                    // save dependency lock
+                    var restoredGitLock = new List<DependencyGitLock>();
+                    foreach (var restoreResult in restoreDependencyResults.Concat(new[] { restoreFallbackResult }))
+                    {
+                        if (restoreResult != null)
+                            restoredGitLock.Add(new DependencyGitLock { Url = restoreResult.Remote, Branch = restoreResult.Branch, Commit = restoreResult.Commit });
+                    }
+
+                    var dependencyLockFilePath = string.IsNullOrEmpty(extendedConfig.DependencyLock)
+                        ? AppData.GetDependencyLockFile(docsetPath, localeToRestore)
+                        : extendedConfig.DependencyLock;
+
+                    DependencyLockProvider.SaveGitLock(docsetPath, dependencyLockFilePath, restoredGitLock);
                 }
-
-                // config error log, and return if config has errors
-                errorLog.Configure(config);
-                if (errorLog.Write(errors))
-                    return;
-
-                // restore extend url firstly
-                await ParallelUtility.ForEach(
-                    config.Extend.Where(UrlUtility.IsHttp),
-                    restoreUrl => RestoreFile.Restore(restoreUrl, config));
-
-                // extend the config after the extend url being restored
-                var (extendConfigErrors, extendedConfig) = ConfigLoader.Load(configPath, options, localeToRestore, extend: true);
-                errorLog.Write(extendConfigErrors);
-
-                // restore urls except extend url
-                var restoreUrls = extendedConfig.GetFileReferences().Where(UrlUtility.IsHttp).ToList();
-                await RestoreFile.Restore(restoreUrls, extendedConfig);
-
-                // restore git repos includes dependency repos, theme repo and loc repos
-                var restoreDependencyResults = RestoreGit.Restore(extendedConfig, localeToRestore, repository, DependencyLockProvider.Create(docsetPath, extendedConfig.DependencyLock));
-
-                // save dependency lock
-                var restoredGitLock = new List<DependencyGitLock>();
-                foreach (var restoreResult in restoreDependencyResults.Concat(new[] { restoreFallbackResult }))
+                catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
                 {
-                    if (restoreResult != null)
-                        restoredGitLock.Add(new DependencyGitLock { Url = restoreResult.Remote, Branch = restoreResult.Branch, Commit = restoreResult.Commit });
+                    Log.Write(dex);
+                    errorLog.Write(dex.Error, isException: true);
                 }
-
-                var dependencyLockFilePath = string.IsNullOrEmpty(extendedConfig.DependencyLock)
-                    ? AppData.GetDependencyLockFile(docsetPath, localeToRestore)
-                    : extendedConfig.DependencyLock;
-
-                DependencyLockProvider.SaveGitLock(docsetPath, dependencyLockFilePath, restoredGitLock);
             }
         }
 

--- a/test/docfx.Test/lib/ErrorLogTest.cs
+++ b/test/docfx.Test/lib/ErrorLogTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Docs.Build
         public void MaxErrors()
         {
             var maxErrors = 1000;
-            using (var errorLog = new ErrorLog(".", "DedupErrors", () => new Config()))
+            using (var errorLog = new ErrorLog(".", "MaxErrors", () => new Config()))
             {
                 for (var i = 0; i < maxErrors; i++)
                 {

--- a/test/docfx.Test/lib/ErrorLogTest.cs
+++ b/test/docfx.Test/lib/ErrorLogTest.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Docs.Build
         [Fact]
         public void DedupErrors()
         {
-            using (var errorLog = new ErrorLog("DedupErrors"))
+            using (var errorLog = new ErrorLog("test", ".", "DedupErrors", () => new Config()))
             {
                 errorLog.Write(new Error(ErrorLevel.Error, "an-error-code", "message 1"));
                 errorLog.Write(new Error(ErrorLevel.Error, "an-error-code", "message 1"));
@@ -25,7 +25,7 @@ namespace Microsoft.Docs.Build
         public void MaxErrors()
         {
             var maxErrors = 1000;
-            using (var errorLog = new ErrorLog("MaxErrors"))
+            using (var errorLog = new ErrorLog("test", ".", "DedupErrors", () => new Config()))
             {
                 for (var i = 0; i < maxErrors; i++)
                 {

--- a/test/docfx.Test/lib/ErrorLogTest.cs
+++ b/test/docfx.Test/lib/ErrorLogTest.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Docs.Build
         [Fact]
         public void DedupErrors()
         {
-            using (var errorLog = new ErrorLog("test", ".", "DedupErrors", () => new Config()))
+            using (var errorLog = new ErrorLog(".", "DedupErrors", () => new Config()))
             {
                 errorLog.Write(new Error(ErrorLevel.Error, "an-error-code", "message 1"));
                 errorLog.Write(new Error(ErrorLevel.Error, "an-error-code", "message 1"));
@@ -25,7 +25,7 @@ namespace Microsoft.Docs.Build
         public void MaxErrors()
         {
             var maxErrors = 1000;
-            using (var errorLog = new ErrorLog("test", ".", "DedupErrors", () => new Config()))
+            using (var errorLog = new ErrorLog(".", "DedupErrors", () => new Config()))
             {
                 for (var i = 0; i < maxErrors; i++)
                 {


### PR DESCRIPTION
For multiple docset build, each build/restore manages it's own ErrorLog instance

Enject ErrorLog --> Config dependency from constructor

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5143)