### PR TITLE
Update to Microsoft.CodeAnalysis 3.3.1

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/Microsoft.DocAsCode.Metadata.ManagedReference.Common.csproj
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/Microsoft.DocAsCode.Metadata.ManagedReference.Common.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.8.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.31" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn.csproj
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn.csproj
@@ -18,15 +18,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.8.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.8.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.8.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="2.8.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Features" Version="2.8.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.8.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.8.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="2.8.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="2.8.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Features" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.31" />
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.5.0" />

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromAssemblyTest.cs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromAssemblyTest.cs
@@ -81,8 +81,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference.Tests
                 Assert.Equal("XmlTasks.ToNamespace(String, String)", method.DisplayNamesWithType[SyntaxLanguage.CSharp]);
                 Assert.Equal("TupleLibrary.XmlTasks.ToNamespace(System.String, System.String)", method.DisplayQualifiedNames[SyntaxLanguage.CSharp]);
 
-                // TODO: add whitespace after fix: https://github.com/dotnet/roslyn/issues/29390
-                Assert.Equal("public (string prefix, string uri)ToNamespace(string prefix, string uri)", method.Syntax.Content[SyntaxLanguage.CSharp]);
+                Assert.Equal("public (string prefix, string uri) ToNamespace(string prefix, string uri)", method.Syntax.Content[SyntaxLanguage.CSharp]);
             }
 
             {

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromCSUnitTest.cs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromCSUnitTest.cs
@@ -2685,7 +2685,7 @@ namespace Test1
             Assert.Equal(1, foo.Items.Count);
             var bar = foo.Items[0];
             Assert.Equal("Test1.Foo.Bar(System.Int32)", bar.Name);
-            Assert.Equal("public int Bar(int x = default(int))", bar.Syntax.Content[SyntaxLanguage.CSharp]);
+            Assert.Equal("public int Bar(int x = 0)", bar.Syntax.Content[SyntaxLanguage.CSharp]);
         }
 
         [Fact]

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromCSUnitTest.cs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromCSUnitTest.cs
@@ -2711,8 +2711,7 @@ namespace Test1
             Assert.Single(foo.Items);
             var bar = foo.Items[0];
             Assert.Equal("Test1.Foo.Bar(System.ValueTuple{System.String,System.String})", bar.Name);
-            // TODO: when https://github.com/dotnet/roslyn/issues/29390 will be fixed add space before namespace
-            Assert.Equal("public int Bar((string prefix, string uri)namespace)", bar.Syntax.Content[SyntaxLanguage.CSharp]);
+            Assert.Equal("public int Bar((string prefix, string uri) namespace)", bar.Syntax.Content[SyntaxLanguage.CSharp]);
         }
 
         [Fact]
@@ -2738,8 +2737,7 @@ namespace Test1
             Assert.Single(foo.Items);
             var bar = foo.Items[0];
             Assert.Equal("Test1.Foo.Bar(System.ValueTuple{System.String,System.String})", bar.Name);
-            // TODO: when https://github.com/dotnet/roslyn/issues/29390 will be fixed add space before namespace
-            Assert.Equal("public int Bar((string, string)namespace)", bar.Syntax.Content[SyntaxLanguage.CSharp]);
+            Assert.Equal("public int Bar((string, string) namespace)", bar.Syntax.Content[SyntaxLanguage.CSharp]);
         }
 
         [Fact]
@@ -2765,8 +2763,7 @@ namespace Test1
             Assert.Single(foo.Items);
             var bar = foo.Items[0];
             Assert.Equal("Test1.Foo.Bar(System.ValueTuple{System.String,System.String})", bar.Name);
-            // TODO: when https://github.com/dotnet/roslyn/issues/29390 will be fixed add space before namespace
-            Assert.Equal("public int Bar((string, string uri)namespace)", bar.Syntax.Content[SyntaxLanguage.CSharp]);
+            Assert.Equal("public int Bar((string, string uri) namespace)", bar.Syntax.Content[SyntaxLanguage.CSharp]);
         }
 
         [Fact]
@@ -2846,8 +2843,7 @@ namespace Test1
             Assert.Single(foo.Items);
             var bar = foo.Items[0];
             Assert.Equal("Test1.Foo.Bar", bar.Name);
-            // TODO: when https://github.com/dotnet/roslyn/issues/29390 will be fixed add space before Bar
-            Assert.Equal("public (string prefix, string uri)Bar()", bar.Syntax.Content[SyntaxLanguage.CSharp]);
+            Assert.Equal("public (string prefix, string uri) Bar()", bar.Syntax.Content[SyntaxLanguage.CSharp]);
         }
 
         [Fact]
@@ -2873,8 +2869,7 @@ namespace Test1
             Assert.Single(foo.Items);
             var bar = foo.Items[0];
             Assert.Equal("Test1.Foo.Bar", bar.Name);
-            // TODO: when https://github.com/dotnet/roslyn/issues/29390 will be fixed add space before Bar
-            Assert.Equal("public (string, string)Bar()", bar.Syntax.Content[SyntaxLanguage.CSharp]);
+            Assert.Equal("public (string, string) Bar()", bar.Syntax.Content[SyntaxLanguage.CSharp]);
         }
 
         [Fact]
@@ -2900,8 +2895,7 @@ namespace Test1
             Assert.Single(foo.Items);
             var bar = foo.Items[0];
             Assert.Equal("Test1.Foo.Bar", bar.Name);
-            // TODO: when https://github.com/dotnet/roslyn/issues/29390 will be fixed add space before Bar
-            Assert.Equal("public (string, string uri)Bar()", bar.Syntax.Content[SyntaxLanguage.CSharp]);
+            Assert.Equal("public (string, string uri) Bar()", bar.Syntax.Content[SyntaxLanguage.CSharp]);
         }
 
         [Fact]


### PR DESCRIPTION
This updates to the latest Microsoft.CodeAnalysis packages for C#8 support.

Fixes the following error on a project that uses nullable reference types:

```
Microsoft.DocAsCode.Exceptions.DocfxException: Unable to generate spec reference for !: ---> System.IO.InvalidDataException: Fail to parse id for symbol  in namespace .
  at Microsoft.DocAsCode.Metadata.ManagedReference.YamlModelGenerator.AddSpecReference (Microsoft.CodeAnalysis.ISymbol symbol, System.Collections.Generic.IReadOnlyList`1[T] typeGenericParameters, System.Collections.Generic.IReadOnlyList`1[T] methodGenericParameters, System.Collections.Generic.Dictionary`2[TKey,TValue] references, Microsoft.DocAsCode.Metadata.ManagedReference.SymbolVisitorAdapter adapter) [0x0005e] in <27b606b838ab45b788854d5e45efa610>:0
  at Microsoft.DocAsCode.Metadata.ManagedReference.SymbolVisitorAdapter.AddSpecReference (Microsoft.CodeAnalysis.ISymbol symbol, System.Collections.Generic.IReadOnlyList`1[T] typeGenericParameters, System.Collections.Generic.IReadOnlyList`1[T] methodGenericParameters) [0x00000] in <27b606b838ab45b788854d5e45efa610>:0
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5163)