### PR TITLE
fix: when the sitebasepath is empty or ., the asset id should not start with /

### DIFF
--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -298,7 +298,7 @@ inputs:
 outputs:
   docs/a.json:
   .manifest.json: |
-    {"files":[{"asset_id":"/docs/a.json","original":"docs/a.yml","source_relative_path":"docs/a.yml","original_type":"Conceptual","type":"Toc"}]}
+    {"files":[{"asset_id":"docs/a.json","original":"docs/a.yml","source_relative_path":"docs/a.yml","original_type":"Conceptual","type":"Toc"}]}
 ---
 # Do not copy resource when the copyResources is false
 legacy: true
@@ -312,7 +312,7 @@ outputs:
   .publish.json: |
     {"files":[{"url":"/a.png","path":"../inputs/a.png"}]}
   .manifest.json: |
-    {"files":[{"asset_id":"/a.png","output":{"resource":{"is_raw_page":false,"relative_path":"a.png"}}}]}
+    {"files":[{"asset_id":"a.png","output":{"resource":{"is_raw_page":false,"relative_path":"a.png"}}}]}
 ---
 # Build versioning repository
 legacy: true

--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -457,17 +457,17 @@ outputs:
         "crrb/a.md": {
           "type": "Content",
           "output_relative_path": "crrb/a.html",
-          "asset_id": "/crrb/a"
+          "asset_id": "crrb/a"
         },
         "crrc/a.md": {
           "type": "Content",
           "output_relative_path": "crrc/a.html",
-          "asset_id": "/crrc/a"
+          "asset_id": "crrc/a"
         },
         "docs/a.md": {
           "type": "Content",
           "output_relative_path": "docs/a.html",
-          "asset_id": "/docs/a"
+          "asset_id": "docs/a"
         }
       }
     }

--- a/src/docfx/build/legacy/LegacyUtility.cs
+++ b/src/docfx/build/legacy/LegacyUtility.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Docs.Build
                 outputPath = doc.GetOutputPath(manifestItem.Monikers, docset.SiteBasePath, isPage: false);
             }
             var legacyOutputFilePathRelativeToSiteBasePath = Path.GetRelativePath(docset.SiteBasePath, outputPath);
-
             return PathUtility.NormalizeFile(legacyOutputFilePathRelativeToSiteBasePath);
         }
 
@@ -33,7 +32,10 @@ namespace Microsoft.Docs.Build
                 legacySiteUrlRelativeToSiteBasePath = Path.GetRelativePath(
                     docset.SiteBasePath, legacySiteUrlRelativeToSiteBasePath.Substring(1));
             }
-
+            if (legacySiteUrlRelativeToSiteBasePath.StartsWith("/"))
+            {
+                legacySiteUrlRelativeToSiteBasePath = legacySiteUrlRelativeToSiteBasePath.Substring(1);
+            }
             return PathUtility.NormalizeFile(
                 Path.GetFileNameWithoutExtension(doc.FilePath.Path).Equals("index", PathUtility.PathComparison)
                 && doc.ContentType != ContentType.Resource


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5176)