### PR TITLE
Revert "log non-docfx exception to console (#5169)"

### DIFF
--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -69,13 +69,10 @@ namespace Microsoft.Docs.Build
                         await Run(docset, fallbackDocset, dependencyDocsets, options, errorLog, outputPath, input, repositoryProvider);
                     }
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
                 {
-                    Log.Write(ex);
-                    if (DocfxException.IsDocfxException(ex, out var dex))
-                    {
-                        errorLog.Write(dex.Error, isException: true);
-                    }
+                    Log.Write(dex);
+                    errorLog.Write(dex.Error, isException: true);
                 }
                 finally
                 {

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -87,13 +87,10 @@ namespace Microsoft.Docs.Build
 
                     DependencyLockProvider.SaveGitLock(docsetPath, locale, extendedConfig.DependencyLock, restoredGitLock);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
                 {
-                    Log.Write(ex);
-                    if (DocfxException.IsDocfxException(ex, out var dex))
-                    {
-                        errorLog.Write(dex.Error, isException: true);
-                    }
+                    Log.Write(dex);
+                    errorLog.Write(dex.Error, isException: true);
                 }
                 finally
                 {


### PR DESCRIPTION
The non-docfx exception has been handled in 
https://github.com/dotnet/docfx/blob/544e094abc1aca657009c92bfd37537b96aeaf9b/src/docfx/cli/Docfx.cs#L31

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5187)