### PR TITLE
Define base_path as empty string or path without leading /

### DIFF
--- a/docs/designs/output.md
+++ b/docs/designs/output.md
@@ -59,7 +59,7 @@ Each input file transforms to zero or more output files depending on its content
 `{output-dir}/{siteBasePath}/{monikerListHash}?/{site-path-relative-to-base-path}`
 
 ```
-  siteBasePath monikerListHash    site-path-relative-to-base-path
+  siteBasePath monikerListHash    site-path (relative-to-base-path)
       |--^-| |--^--| |----------------^----------|
 _site/dotnet/01ddf122/api/system.string/index.html
 ```
@@ -75,8 +75,8 @@ Different files can share the same `{site-url}` or `{site-path}` due to versioni
     |------ |----|
     | `url` | https://docs.microsoft.com/en-us/dotnet/api/system.string?view=netstandard-2.0 |
     | `site-url` | /dotnet/api/system.string |
-    | `site-path` | dotnet/api/system.string.json |
-    | `site-path-relative-to-base-path` | api/system.string.json |
+    | `base-path` | dotnet |
+    | `site-path` | api/system.string.json |
     | `output-path` | dotnet/01ddf122/api/system.string.json |
 
 - Content for static rendering using pretty url
@@ -85,7 +85,8 @@ Different files can share the same `{site-url}` or `{site-path}` due to versioni
     |------ |----|
     | `url` | https://docs.microsoft.com/en-us/dotnet/api/system.string/ |
     | `site-url` | /dotnet/api/system.string/ |
-    | `site-path` | dotnet/api/system.string/index.html |
+    | `base-path` | dotnet |
+    | `site-path` | api/system.string/index.html |
     | `output-path` | dotnet/api/system.string/index.html |
 
 - Content for static rendering using ugly url
@@ -94,7 +95,8 @@ Different files can share the same `{site-url}` or `{site-path}` due to versioni
     |------ |----|
     | `url` | https://docs.microsoft.com/en-us/dotnet/api/system.string.html |
     | `site-url` | /dotnet/api/system.string.html |
-    | `site-path` | dotnet/api/system.string.html |
+    | `base-path` | dotnet |
+    | `site-path` | api/system.string.html |
     | `output-path` | dotnet/api/system.string.html |
 
 - Table of Contents
@@ -103,7 +105,8 @@ Different files can share the same `{site-url}` or `{site-path}` due to versioni
     |------ |----|
     | `url` | https://docs.microsoft.com/en-us/dotnet/api/TOC.json |
     | `site-url` | /dotnet/api/TOC.json |
-    | `site-path` | dotnet/api/TOC.json |
+    | `base-path` | dotnet |
+    | `site-path` | api/TOC.json |
     | `output-path` | dotnet/api/TOC.json |
 
 - Image

--- a/docs/designs/output.md
+++ b/docs/designs/output.md
@@ -56,10 +56,10 @@ https://docs.microsoft.com/en-us/dotnet/api/system.string.html#Instantiation
 
 Each input file transforms to zero or more output files depending on its content type. `docfx` places output files in `output-path` relative to output directory. **Regardless of static rendering or dynamic rendering, output path shares the same schema**:
 
-`{output-dir}/{siteBasePath}/{monikerListHash}?/{site-path-relative-to-base-path}`
+`{output-dir}/{base-path}/{moniker-hash}?/{site-path}`
 
 ```
-  siteBasePath monikerListHash    site-path (relative-to-base-path)
+  base-path moniker-hash    site-path (relative-to-base-path)
       |--^-| |--^--| |----------------^----------|
 _site/dotnet/01ddf122/api/system.string/index.html
 ```

--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -298,7 +298,7 @@ inputs:
 outputs:
   docs/a.json:
   .manifest.json: |
-    {"files":[{"asset_id":"/docs/a.json","original":"docs/a.yml","source_relative_path":"docs/a.yml","original_type":"Conceptual","type":"Toc"}]}
+    {"files":[{"asset_id":"docs/a.json","original":"docs/a.yml","source_relative_path":"docs/a.yml","original_type":"Conceptual","type":"Toc"}]}
 ---
 # Do not copy resource when the copyResources is false
 legacy: true
@@ -312,7 +312,7 @@ outputs:
   .publish.json: |
     {"files":[{"url":"/a.png","path":"../inputs/a.png"}]}
   .manifest.json: |
-    {"files":[{"asset_id":"/a.png","output":{"resource":{"is_raw_page":false,"relative_path":"a.png"}}}]}
+    {"files":[{"asset_id":"a.png","output":{"resource":{"is_raw_page":false,"relative_path":"a.png"}}}]}
 ---
 # Build versioning repository
 legacy: true

--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -5,7 +5,7 @@ inputs:
   docs/a.md: Hello `docfx`!
 outputs:
   docs/a.json: |
-    { "conceptual": "<p>Hello <code>docfx</code>!</p>", "wordCount": 2, "_op_canonicalUrlPrefix": "https://docs.com/en-us/./", "_path": "docs/a.json"}
+    { "conceptual": "<p>Hello <code>docfx</code>!</p>", "wordCount": 2, "_op_canonicalUrlPrefix": "https://docs.com/en-us/", "_path": "docs/a.json"}
 ---
 # Basic markdown syntax
 inputs:

--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -457,17 +457,17 @@ outputs:
         "crrb/a.md": {
           "type": "Content",
           "output_relative_path": "crrb/a.html",
-          "asset_id": "/crrb/a"
+          "asset_id": "crrb/a"
         },
         "crrc/a.md": {
           "type": "Content",
           "output_relative_path": "crrc/a.html",
-          "asset_id": "/crrc/a"
+          "asset_id": "crrc/a"
         },
         "docs/a.md": {
           "type": "Content",
           "output_relative_path": "docs/a.html",
-          "asset_id": "/docs/a"
+          "asset_id": "docs/a"
         }
       }
     }

--- a/src/docfx/build/legacy/LegacyUtility.cs
+++ b/src/docfx/build/legacy/LegacyUtility.cs
@@ -18,9 +18,10 @@ namespace Microsoft.Docs.Build
             var outputPath = manifestItem.Path;
             if (doc.ContentType == ContentType.Resource && !doc.Docset.Config.Output.CopyResources)
             {
-                outputPath = doc.GetOutputPath(manifestItem.Monikers, docset.SiteBasePath, isPage: false);
+                outputPath = doc.GetOutputPath(manifestItem.Monikers, isPage: false);
             }
-            var legacyOutputFilePathRelativeToSiteBasePath = Path.GetRelativePath(docset.SiteBasePath, outputPath);
+            var legacyOutputFilePathRelativeToSiteBasePath = Path.GetRelativePath(
+                string.IsNullOrEmpty(docset.SiteBasePath) ? "." : docset.SiteBasePath, outputPath);
 
             return PathUtility.NormalizeFile(legacyOutputFilePathRelativeToSiteBasePath);
         }
@@ -31,7 +32,7 @@ namespace Microsoft.Docs.Build
             if (legacySiteUrlRelativeToSiteBasePath.StartsWith($"/{docset.SiteBasePath}", PathUtility.PathComparison))
             {
                 legacySiteUrlRelativeToSiteBasePath = Path.GetRelativePath(
-                    docset.SiteBasePath, legacySiteUrlRelativeToSiteBasePath.Substring(1));
+                    string.IsNullOrEmpty(docset.SiteBasePath) ? "." : docset.SiteBasePath, legacySiteUrlRelativeToSiteBasePath.Substring(1));
             }
 
             return PathUtility.NormalizeFile(

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Docs.Build
             var (monikerError, monikers) = context.MonikerProvider.GetFileLevelMonikers(file);
             errors.AddIfNotNull(monikerError);
 
-            var outputPath = file.GetOutputPath(monikers, file.Docset.SiteBasePath, file.IsPage);
+            var outputPath = file.GetOutputPath(monikers, file.IsPage);
 
             var (outputErrors, output, metadata) = file.IsPage
                 ? await CreatePageOutput(context, file, sourceModel)
@@ -163,13 +163,13 @@ namespace Microsoft.Docs.Build
             systemMetadata.SearchProduct = file.Docset.Config.Product;
             systemMetadata.SearchDocsetName = file.Docset.Config.Name;
 
-            systemMetadata.Path = PathUtility.NormalizeFile(Path.GetRelativePath(file.Docset.SiteBasePath, file.SitePath));
-            systemMetadata.CanonicalUrlPrefix = $"{file.Docset.HostName}/{systemMetadata.Locale}/{file.Docset.SiteBasePath}/";
+            systemMetadata.Path = file.SitePath;
+            systemMetadata.CanonicalUrlPrefix = UrlUtility.Combine(file.Docset.HostName, systemMetadata.Locale, file.Docset.SiteBasePath) + "/";
 
             if (file.Docset.Config.Output.Pdf)
             {
-                systemMetadata.PdfUrlPrefixTemplate = $"{file.Docset.HostName}/pdfstore/{systemMetadata.Locale}" +
-                    $"/{file.Docset.Config.Product}.{file.Docset.Config.Name}/{{branchName}}";
+                systemMetadata.PdfUrlPrefixTemplate = UrlUtility.Combine(
+                    file.Docset.HostName, "pdfstore", systemMetadata.Locale, $"{file.Docset.Config.Product}.{file.Docset.Config.Name}", "{branchName}");
             }
 
             if (contributorErrors != null)

--- a/src/docfx/build/redirection/BuildRedirection.cs
+++ b/src/docfx/build/redirection/BuildRedirection.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Docs.Build
 
             if (file.Docset.Legacy)
             {
-                publishItem.Path = file.GetOutputPath(monikers, file.Docset.SiteBasePath);
+                publishItem.Path = file.GetOutputPath(monikers);
             }
 
             if (context.PublishModelBuilder.TryAdd(file, publishItem) && file.Docset.Legacy)

--- a/src/docfx/build/resource/BuildResource.cs
+++ b/src/docfx/build/resource/BuildResource.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Docs.Build
             var (monikerError, monikers) = context.MonikerProvider.GetFileLevelMonikers(file);
             errors.AddIfNotNull(monikerError);
 
-            var outputPath = file.GetOutputPath(monikers, file.Docset.SiteBasePath, isPage: false);
+            var outputPath = file.GetOutputPath(monikers, isPage: false);
 
             // Output path is source file path relative to output folder when copy resource is disabled
             var copy = true;

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -1,10 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 
 namespace Microsoft.Docs.Build
 {
@@ -18,13 +16,12 @@ namespace Microsoft.Docs.Build
             var (errors, model, _, _) = context.Cache.LoadTocModel(context, file);
 
             // enable pdf
-            var outputPath = file.GetOutputPath(model.Metadata.Monikers, file.Docset.SiteBasePath, isPage: false);
+            var outputPath = file.GetOutputPath(model.Metadata.Monikers, isPage: false);
 
             if (file.Docset.Config.Output.Pdf)
             {
-                var siteBasePath = file.Docset.SiteBasePath;
-                var relativePath = PathUtility.NormalizeFile(Path.GetRelativePath(siteBasePath, LegacyUtility.ChangeExtension(outputPath, ".pdf")));
-                model.Metadata.PdfAbsolutePath = $"/{siteBasePath}/opbuildpdf/{relativePath}";
+                model.Metadata.PdfAbsolutePath = UrlUtility.Combine(
+                    file.Docset.SiteBasePath, "opbuildpdf", LegacyUtility.ChangeExtension(file.SitePath, ".pdf"));
             }
 
             // TODO: Add experimental and experiment_id to publish item

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Docs.Build
 
             if (file.Docset.Config.Output.Pdf)
             {
-                model.Metadata.PdfAbsolutePath = UrlUtility.Combine(
+                model.Metadata.PdfAbsolutePath = "/" + UrlUtility.Combine(
                     file.Docset.SiteBasePath, "opbuildpdf", LegacyUtility.ChangeExtension(file.SitePath, ".pdf"));
             }
 

--- a/src/docfx/docset/Docset.cs
+++ b/src/docfx/docset/Docset.cs
@@ -51,7 +51,8 @@ namespace Microsoft.Docs.Build
         public Repository Repository { get; }
 
         /// <summary>
-        /// Gets the site base path calculated from <see cref="Config.BaseUrl"/> or an empty string, it never starts with /
+        /// Gets the site base path calculated from <see cref="Config.BaseUrl"/>.
+        /// It is either an empty string, or a path without leading /
         /// </summary>
         public string SiteBasePath { get; }
 

--- a/src/docfx/lib/UrlUtility.cs
+++ b/src/docfx/lib/UrlUtility.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Specialized;
+using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Web;
@@ -64,6 +65,36 @@ namespace Microsoft.Docs.Build
             }
 
             return (path, query, fragment);
+        }
+
+        /// <summary>
+        /// Split an absolute URL into a host name (including https://) and a base path (never starts with /)
+        /// </summary>
+        public static (string host, string basePath) SplitBaseUrl(string url)
+        {
+            url = url.Replace('\\', '/');
+
+            var i = url.IndexOf("://");
+            if (i < 0)
+            {
+                return ("", url.Trim('/'));
+            }
+
+            i = url.IndexOf('/', i + 3);
+            if (i < 0)
+            {
+                return (url, "");
+            }
+
+            return (url.Substring(0, i), url.Substring(i).Trim('/'));
+        }
+
+        /// <summary>
+        /// Combines URL segments into a single URL.
+        /// </summary>
+        public static string Combine(params string[] urlSegments)
+        {
+            return Path.Combine(urlSegments).Replace('\\', '/');
         }
 
         /// <summary>

--- a/test/docfx.Test/lib/UrlUtilityTest.cs
+++ b/test/docfx.Test/lib/UrlUtilityTest.cs
@@ -27,6 +27,22 @@ namespace Microsoft.Docs.Build
         }
 
         [Theory]
+        [InlineData("", "", "")]
+        [InlineData("/", "", "")]
+        [InlineData("/a", "", "a")]
+        [InlineData("https://github.com", "https://github.com", "")]
+        [InlineData("https://github.com/", "https://github.com", "")]
+        [InlineData("https://github.com/a", "https://github.com", "a")]
+        [InlineData("https://github.com/a/b", "https://github.com", "a/b")]
+        public static void SplitBaseUrl(string url, string host, string basePath)
+        {
+            var (ahost, abasePath) = UrlUtility.SplitBaseUrl(url);
+
+            Assert.Equal(host, ahost);
+            Assert.Equal(basePath, abasePath);
+        }
+
+        [Theory]
         [InlineData("", "", "", "")]
         [InlineData("", "?b", "#c", "?b#c")]
         [InlineData("a", "?b=1", "#c", "a?b=1#c")]


### PR DESCRIPTION
#5185 #5176 

To avoid doing reverse operations (`GetRelativePath`):

- Define `base_path` as an empty string or path without leading `/`
- Define `site_path` as path without `base_path`

https://ceapex.visualstudio.com/Engineering/_workitems/edit/124478
https://ceapex.visualstudio.com/Engineering/_workitems/edit/124477
https://ceapex.visualstudio.com/Engineering/_workitems/edit/124481

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5191)