### PR TITLE
fix check to reuse build entry repo

### DIFF
--- a/src/docfx/docset/Docset.cs
+++ b/src/docfx/docset/Docset.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Docs.Build
             {
                 if (GitUtility.IsRepo(fullPath))
                 {
-                    if (string.Equals(fullPath, Repository.Path.Substring(0, DocsetPath.Length - 1), PathUtility.PathComparison))
+                    if (Repository != null && string.Equals(fullPath, Repository.Path.Substring(0, Repository.Path.Length - 1), PathUtility.PathComparison))
                     {
                         return Repository;
                     }

--- a/src/docfx/docset/Docset.cs
+++ b/src/docfx/docset/Docset.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Docs.Build
             {
                 if (GitUtility.IsRepo(fullPath))
                 {
-                    if (string.Equals(fullPath, DocsetPath.Substring(0, DocsetPath.Length - 1), PathUtility.PathComparison))
+                    if (string.Equals(fullPath, Repository.Path.Substring(0, DocsetPath.Length - 1), PathUtility.PathComparison))
                     {
                         return Repository;
                     }


### PR DESCRIPTION
Since we support multiple docset now, `DocsetPath` is not always the repo root.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5196)