### PR TITLE
fix: add back removed public method TocHelper.Resolve

### DIFF
--- a/src/Microsoft.DocAsCode.Build.TableOfContents/BuildTocDocument.cs
+++ b/src/Microsoft.DocAsCode.Build.TableOfContents/BuildTocDocument.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DocAsCode.Build.TableOfContents
         /// </summary>
         public override IEnumerable<FileModel> Prebuild(ImmutableList<FileModel> models, IHostService host)
         {
-            var (resolvedTocModels, includedTocs) = TocHelper.Resolve(models, host);
+            var (resolvedTocModels, includedTocs) = TocHelper.ResolveToc(models, host);
 
             ReportPreBuildDependency(resolvedTocModels, host, 8, includedTocs);
 

--- a/src/Microsoft.DocAsCode.Build.TableOfContents/TocHelper.cs
+++ b/src/Microsoft.DocAsCode.Build.TableOfContents/TocHelper.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DocAsCode.Build.TableOfContents
             YamlDeserializerWithFallback.Create<TocViewModel>()
             .WithFallback<TocRootViewModel>();
 
-        public static (List<FileModel> tocModels, HashSet<string> includedTocs) Resolve(ImmutableList<FileModel> models, IHostService host)
+        public static (List<FileModel> tocModels, HashSet<string> includedTocs) ResolveToc(ImmutableList<FileModel> models, IHostService host)
         {
             var tocCache = new Dictionary<string, TocItemInfo>(FilePathComparer.OSPlatformSensitiveStringComparer);
             var nonReferencedTocModels = new List<FileModel>();
@@ -53,7 +53,13 @@ namespace Microsoft.DocAsCode.Build.TableOfContents
             return (nonReferencedTocModels, referencedToc);
         }
 
-        // TODO: refactor the return value to TocRootViewModel
+        [Obsolete("Use ResolveToc")]
+        public static IEnumerable<FileModel> Resolve(ImmutableList<FileModel> models, IHostService host)
+        {
+            var (result, _) = ResolveToc(models, host);
+            return result;
+        }
+
         public static TocItemViewModel LoadSingleToc(string file)
         {
             if (string.IsNullOrEmpty(file))


### PR DESCRIPTION
#5149 removed it, but OPS is using it.
https://github.com/dotnet/docfx/pull/5149/files#diff-9c03f77416c653f546c03c5afc06abe9R22

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5200)