### PR TITLE
exclude localization folder based on mapping type

### DIFF
--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -201,6 +201,40 @@ outputs:
   docs/a.json: |
     { "content_git_url": "*dotnet/docfx.loc/blob/live.zh-cn/docs/*"}
 ---
+# Should not exclude localization folder when it's not loc build and is not folder mapping
+# [loc build scope exclusion]
+inputs:
+  docfx.yml: 
+  localization/a.md:
+outputs:
+  localization/a.json:
+---
+# Should not exclude localization folder when it's loc build and is not folder mapping
+# [loc build scope exclusion]
+locale: ja-jp
+repos:
+  https://docs.com/localization-folder-exclude#master:
+    - files:
+        docfx.yml:
+        localization/a.md: source
+  https://docs.com/localization-folder-exclude.ja-jp#master:
+    - files:
+        localization/a.md: 日本語
+outputs:
+  localization/a.json: |
+    { "conceptual":"<p>日本語</p>\n"}
+---
+# Should exclude localization folder when it's not loc build and is folder mapping
+# [loc build scope exclusion]
+inputs:
+  docfx.yml: |
+    localization:
+      mapping: folder
+  localization/a.md:
+outputs:
+  .publish.json: |
+    {"files": undefined}
+---
 # edit url convention with source locale 3
 # all loc files are in source repo under different locale folder
 # [folder mapping]

--- a/src/docfx/build/context/BuildScope.cs
+++ b/src/docfx/build/context/BuildScope.cs
@@ -107,18 +107,21 @@ namespace Microsoft.Docs.Build
 
         private static Func<string, bool> CreateGlob(Config config)
         {
+            var defaultExclude = config.Localization.Mapping == LocalizationMapping.Folder
+                               ? Config.DefaultExclude.Append(LocalizationConfig.DefaultExclude)
+                               : Config.DefaultExclude;
             if (config.FileGroups.Length > 0)
             {
                 var globs = config.FileGroups.Select(fileGroup => GlobUtility.CreateGlobMatcher(
                     fileGroup.Files,
-                    fileGroup.Exclude.Concat(Config.DefaultExclude).ToArray()))
+                    fileGroup.Exclude.Concat(defaultExclude).ToArray()))
                    .ToArray();
                 return new Func<string, bool>((file) => globs.Any(glob => glob(file)));
             }
 
             return GlobUtility.CreateGlobMatcher(
                 config.Files,
-                config.Exclude.Concat(Config.DefaultExclude).ToArray());
+                config.Exclude.Concat(defaultExclude).ToArray());
         }
     }
 }

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Docs.Build
         public static readonly string[] DefaultExclude = new[]
         {
             "_site/**",             // Default output location
-            "localization/**",      // Localization file when using folder convention
             "_themes/**",           // Default template location
         };
 

--- a/src/docfx/config/LocalizationConfig.cs
+++ b/src/docfx/config/LocalizationConfig.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Docs.Build
     {
         public const string DefaultLocaleStr = "en-us";
 
+        public static string DefaultExclude = "localization/**"; // Localization file when using folder convention
+
         /// <summary>
         /// Gets the default locale of this docset.
         /// </summary>


### PR DESCRIPTION
Take docs-help-pr for example, the [localization folder](https://github.com/MicrosoftDocs/docs-help-pr/tree/master/help-content/localization)is meant to be built and published.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5201)