### PR TITLE
rename localization folder for folder mapping 

### DIFF
--- a/docs/designs/conceptual-localization.md
+++ b/docs/designs/conceptual-localization.md
@@ -33,8 +33,8 @@ Below kinds of mappings are considered to be supported and there is a **strong c
   - **Folder**, localization files are stored in the **same repository** with source files but under different **locale folder**
     ```txt
     source file         -->         localization files
-    /readme.md          -->         /localization/zh-cn/readme.md
-    /files/a.md         -->         /localization/de-de/files/a.md
+    /readme.md          -->         /_localization/zh-cn/readme.md
+    /files/a.md         -->         /_localization/de-de/files/a.md
     ```
   - **Repository**, localization files are stored in an **independent repository** per locale but keep the **same folder structure**
       

--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -267,7 +267,11 @@ repos:
         _localization/zh-cn/docs/a.md:
 outputs:
   docs/a.json: |
-    { "content_git_url":"https://github.com/contribution/a/blob/master3/localization/zh-cn/docs/a.md","original_content_git_url":"https://github.com/contribution/a/blob/master3/localization/zh-cn/docs/a.md", "gitcommit":"https://github.com/contribution/a/blob/ffb8cfa5f33566a83770b90d647577a58e1d662d/localization/zh-cn/docs/a.md"}
+    { 
+      "content_git_url":"https://github.com/contribution/a/blob/master3/_localization/zh-cn/docs/a.md",
+      "original_content_git_url":"https://github.com/contribution/a/blob/master3/_localization/zh-cn/docs/a.md",
+      "gitcommit": "https://github.com/contribution/a/blob/661dc2d3c446f976291d34241c0ebd85bf326dd5/_localization/zh-cn/docs/a.md"
+    }
 ---
 # loc file contributor info 3
 # [branch mapping]
@@ -595,12 +599,12 @@ inputs:
     localization:
       mapping: Folder
   _localization/zh-cn/docs/a.md: |
-    [link to a](~/localization/zh-cn/docs/a.md)
+    [link to a](~/_localization/zh-cn/docs/a.md)
     [link to a](~/docs/a.md)
 outputs:
   docs/a.json:
   .errors.log: |
-    ["warning","link-out-of-scope","File 'localization/zh-cn/docs/a.md [fallback]' referenced by link '~/localization/zh-cn/docs/a.md' will not be built because it is not included in build scope","docs/a.md",1,1]
+    ["warning","link-out-of-scope","File '_localization/zh-cn/docs/a.md [fallback]' referenced by link '~/_localization/zh-cn/docs/a.md' will not be built because it is not included in build scope","docs/a.md",1,1]
 ---
 # loc folder should be excluded from source docset during source docset build
 inputs:

--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -213,7 +213,7 @@ repos:
           repository: https://github.com/dotnet/docfx.en-us
         localization:
           mapping: Folder
-      localization/zh-cn/docs/a.md:
+      _localization/zh-cn/docs/a.md:
       docs/a.md:
 outputs:
   docs/a.json: |
@@ -264,7 +264,7 @@ repos:
         docfx.yml: |
           localization:
             mapping: Folder
-        localization/zh-cn/docs/a.md:
+        _localization/zh-cn/docs/a.md:
 outputs:
   docs/a.json: |
     { "content_git_url":"https://github.com/contribution/a/blob/master3/localization/zh-cn/docs/a.md","original_content_git_url":"https://github.com/contribution/a/blob/master3/localization/zh-cn/docs/a.md", "gitcommit":"https://github.com/contribution/a/blob/ffb8cfa5f33566a83770b90d647577a58e1d662d/localization/zh-cn/docs/a.md"}
@@ -450,7 +450,7 @@ inputs:
   docs/b.md: |
     [link to a](a.md)
   docs/a.md: a
-  localization/zh-cn/docs/a.md: |
+  _localization/zh-cn/docs/a.md: |
     [link to b](b.md)
     [!include[include b](b.md)]
 outputs:
@@ -511,8 +511,8 @@ inputs:
   docs/b/TOC.md: |
     # [reference b](b.md)
   docs/a/a.md:
-  localization/zh-cn/docs/b/b.md:
-  localization/zh-cn/docs/a/TOC.md: |
+  _localization/zh-cn/docs/b/b.md:
+  _localization/zh-cn/docs/a/TOC.md: |
     # [reference a](a.md)
 outputs:
   docs/b/b.json: |
@@ -552,11 +552,11 @@ inputs:
     ---
     uid: c
     ---
-  localization/zh-cn/docs/a.md: |
+  _localization/zh-cn/docs/a.md: |
     ---
     uid: a
     ---
-  localization/zh-cn/docs/b.md: link to @c
+  _localization/zh-cn/docs/b.md: link to @c
 outputs:
   docs/a.json:
   docs/b.json:
@@ -594,7 +594,7 @@ inputs:
     files: '**/*.md'
     localization:
       mapping: Folder
-  localization/zh-cn/docs/a.md: |
+  _localization/zh-cn/docs/a.md: |
     [link to a](~/localization/zh-cn/docs/a.md)
     [link to a](~/docs/a.md)
 outputs:
@@ -608,7 +608,7 @@ inputs:
     files: '**/*.md'
     localization:
       mapping: Folder
-  localization/zh-cn/docs/a.md:
+  _localization/zh-cn/docs/a.md:
   docs/b.md:
 outputs:
   docs/b.json:
@@ -652,7 +652,7 @@ inputs:
     baseUrl: https://docs.microsoft.com
     localization:
       mapping: Folder
-  localization/zh-cn/docs/a.md:
+  _localization/zh-cn/docs/a.md:
 outputs:
   docs/a.json: |
     {"locale": "zh-cn", "canonical_url": "https://docs.microsoft.com/zh-cn/docs/a", "document_id": "fa697b4e-3e52-77f6-2219-39040f6070da", "document_version_independent_id": "7c88e748-ed5e-a29a-c057-6f89857c3591"}
@@ -991,7 +991,7 @@ repos:
         docfx.yml: |
           localization:
             mapping: Folder
-        localization/zh-cn/docs/a/a.md:
+        _localization/zh-cn/docs/a/a.md:
 outputs:
   .errors.log: |
     ["error","config-not-found","Can't find config file 'docfx.yml/docfx.json' at *"]
@@ -1204,7 +1204,7 @@ repos:
             mapping: Folder
         docs/b.md: |
           [link in a](a.md)
-        localization/zh-cn/docs/a.md: |
+        _localization/zh-cn/docs/a.md: |
           [link in b](b.md)
           [!include[](b.md)]
 outputs:

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Docs.Build
         public static readonly string[] DefaultExclude = new[]
         {
             "_site/**",             // Default output location
-            "localization/**",      // Localization file when using folder convention
+            "_localization/**",     // Localization file when using folder convention
             "_themes/**",           // Default template location
         };
 

--- a/src/docfx/localization/LocalizationUtility.cs
+++ b/src/docfx/localization/LocalizationUtility.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Docs.Build
                         {
                             throw new NotSupportedException($"{config.Localization.Mapping} is not supporting bilingual build");
                         }
-                        localizationDocsetPath = Path.Combine(docset.DocsetPath, "localization", locale);
+                        localizationDocsetPath = Path.Combine(docset.DocsetPath, "_localization", locale);
                         localizationRepository = docset.Repository;
                         break;
                     }


### PR DESCRIPTION
Take docs-help-pr for example, the [localization folder](https://github.com/MicrosoftDocs/docs-help-pr/tree/master/help-content/localization)is meant to be built and published.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5202)