### PR TITLE
fix: error extracting metadata when VSINSTALLDIR is set

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/MsBuildEnvironmentScope.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/MsBuildEnvironmentScope.cs
@@ -14,7 +14,6 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
     public class MSBuildEnvironmentScope : IDisposable
     {
-        private const string VSInstallDirKey = "VSINSTALLDIR";
         private const string MSBuildExePathKey = "MSBUILD_EXE_PATH";
         private readonly EnvironmentScope _innerScope;
 
@@ -25,13 +24,6 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
         private EnvironmentScope GetScope()
         {
-            var vsInstallDirEnv = Environment.GetEnvironmentVariable(VSInstallDirKey);
-            if (!string.IsNullOrEmpty(vsInstallDirEnv))
-            {
-                Logger.LogInfo($"Environment variable {VSInstallDirKey} is set to {vsInstallDirEnv}, it is used as the inner compiler.");
-                return null;
-            }
-
             var msbuildExePathEnv = Environment.GetEnvironmentVariable(MSBuildExePathKey);
 
             if (!string.IsNullOrEmpty(msbuildExePathEnv))
@@ -80,7 +72,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                     MSBuildLocator.RegisterInstance(latest);
                     return new EnvironmentScope(new Dictionary<string, string>
                     {
-                        [VSInstallDirKey] = latest.VisualStudioRootPath,
+                        ["VSINSTALLDIR"] = latest.VisualStudioRootPath,
                         ["VisualStudioVersion"] = latest.Version.ToString(2),
                     });
                 }

--- a/test/docfx.Tests/MetadataCommandTest.cs
+++ b/test/docfx.Tests/MetadataCommandTest.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.DocAsCode.Tests
 {
+    using System;
     using System.Collections.Generic;
     using System.IO;
 
@@ -46,6 +47,25 @@ namespace Microsoft.DocAsCode.Tests
             }).Exec(null);
 
             CheckResult();
+        }
+
+        [Fact]
+        [Trait("Related", "docfx")]
+        [Trait("Language", "CSharp")]
+        public void TestMetadataCommandFromCSProjectWithVsinstalldirEnvSet()
+        {
+            var envName = "VSINSTALLDIR";
+            var originalValue = Environment.GetEnvironmentVariable(envName);
+            Environment.SetEnvironmentVariable(envName, "c:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise");
+
+            try
+            {
+                TestMetadataCommandFromCSProject();
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envName, originalValue);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
#4782

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5204)