### PR TITLE
Fix crash building against a file

### DIFF
--- a/src/docfx/config/ConfigLoader.cs
+++ b/src/docfx/config/ConfigLoader.cs
@@ -39,6 +39,11 @@ namespace Microsoft.Docs.Build
                 return new[] { (workingDirectory, options.Output) };
             }
 
+            if (!Directory.Exists(workingDirectory))
+            {
+                return Array.Empty<(string, string)>();
+            }
+
             return Directory.GetFiles(workingDirectory, "docfx.yml", SearchOption.AllDirectories)
 
                 // TODO: look for docfx.json after config migration tool has been merged info docfx

--- a/test/docfx.Test/restore/RestoreTest.cs
+++ b/test/docfx.Test/restore/RestoreTest.cs
@@ -71,5 +71,11 @@ monikerDefinition: {url}");
             Assert.Equal(2, Directory.EnumerateFiles(restoreDir, "*").Count());
             Assert.NotEqual("1", File.ReadAllText(filePath));
         }
+
+        [Fact]
+        public static async Task RestoreAgainstFileShouldNotCrash()
+        {
+            await Docfx.Run(new [] { "restore", "docfx.Test.dll" });
+        }
     }
 }


### PR DESCRIPTION
#5208 

Building against a file throws on `Directory.GetFiles`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5209)