### PR TITLE
fix: LandingPage missing title and cardtext section.

### DIFF
--- a/src/Microsoft.Docs.Template/Views/Template/BuildItemListPartial.cshtml
+++ b/src/Microsoft.Docs.Template/Views/Template/BuildItemListPartial.cshtml
@@ -123,7 +123,7 @@ else if (Model.Style == "cards")
                         <a class="card" href="@listItem.Href">
                             @if (listItem.Image?.Src != null)
                             {
-                                <img class="cardImage" role="presentation" src="@listItem.Image.Src">
+                            <img class="cardImage" role="presentation" src="@listItem.Image.Src">
                             }
                             <div class="cardText">
                                 <h3>@listItem.Title</h3>


### PR DESCRIPTION
1. fix LandingPage missing cardtext section when item don't have image src. https://ceapex.visualstudio.com/Engineering/_workitems/edit/132787

2. fix LandingPage <a> missing title https://ceapex.visualstudio.com/Engineering/_workitems/edit/132790