### PR TITLE
Move get repository from Docset to RepositoryProvider

### DIFF
--- a/docs/specs/config.yml
+++ b/docs/specs/config.yml
@@ -437,90 +437,6 @@ repos:
       a.md:
 outputs:
 ---
-# locale overwrite config
-locale: zh-cn
-inputs:
-  docfx.yml: |
-    files: a.md
-    "locales: [zh-cn,de-de]":
-      files: b.md
-      name: test
-    localization:
-      defaultLocale: "zh-cn"
-  a.md:
-outputs:
----
-# branch | locale overwrite config
-locale: zh-cn
-repos:
-  https://docs.com/branch-or-locale-overwrite:
-  - files:
-      docfx.yml: |
-        localization:
-          defaultLocale: "zh-cn"
-        files: a.md
-        "locales: [zh-cn]":
-          files:
-            - b.md
-            - c.md
-        "branches: [master,live]":
-          exclude:
-            - b.md
-      a.md:
-      b.md:
-      c.md:
-outputs:
-  c.json:
----
-# branch & locale overwrite config
-locale: zh-cn
-repos:
-  https://docs.com/branch-and-locale-overwrite:
-  - files:
-      docfx.yml: |
-        localization:
-          defaultLocale: "zh-cn"
-        files: a.md
-        "locales: [zh-cn, de-de] branches: [live]":
-          files: b.md
-      a.md:
-outputs:
-  a.json:
----
-# branch & locale overwrite with null
-locale: zh-cn
-repo: https://github.com/docascode/docfx-test-dependencies#master
-inputs:
-  docfx.yml: |
-    files:
-      - a.md
-      - b.png
-    output:
-      copyResources: false
-    localization:
-      defaultLocale: "zh-cn"
-    "locales: [zh-cn]":
-      output:
-        copyResources:
-  a.md:
-  b.png:
-outputs:
-  a.json:
-  b.png:
----
-# invalid overwrite config
-locale: zh-cn
-inputs:
-  docfx.yml: |
-    localization:
-      defaultLocale: "zh-cn"
-    files: a.md
-    "locales: zh-cn":
-      files: b.md
-  a.md:
-outputs:
-  a.json:
----
 # redirect to not starting with '/' is allowed in config.redirectionWithoutIds
 inputs:
   docfx.yml: |
@@ -641,4 +557,4 @@ repos:
       b.md:
 outputs:
   .errors.log: |
-    ["error","need-restore","Cannot find dependency 'https://docs.com/crr-url-using-path/2', did you forget to run `docfx restore`?"]
+    ["error","directory-not-found","Invalid directory: 'https://docs.com/crr-url-using-path/2'."]

--- a/docs/specs/git.yml
+++ b/docs/specs/git.yml
@@ -361,14 +361,8 @@ outputs:
       "updated_at": "2018-07-18 05:03 AM"
     }
 ---
-# [from loc] Throw committish-not-found when try to resolve commit id by none-existing branch name
-locale: zh-cn
+# Throw committish-not-found when try to resolve commit id by none-existing branch name
 repos: 
-  https://github.com/git/repo#live:
-    - files:
-        docfx.yml: |
-          localization:
-            bilingual: true
   https://github.com/git/repo.zh-cn#live-sxs:
     - files:
         docfx.yml: |
@@ -378,6 +372,8 @@ repos:
   https://github.com/git/repo.zh-cn#live-none-existing:
     - files:
         a.md:
+  https://github.com/git/repo#live:
+    - files:
 outputs:
   .errors.log: |
     ["error","committish-not-found","Can't find branch, tag, or commit 'live' for repo *","a.md"]

--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -421,21 +421,19 @@ outputs:
     {"dependency_type":"metadata","from_file_path":"*docs\\v2\\f1\\a.md*","to_file_path":"*docs\\v2\\TOC.md*","version":"netcore-2.0"}
 ---
 # legacy errors from source repo [repo mapping]
-locale: zh-cn
 legacy: true
 repos:
-  https://docs.com/error-from-source-legacy#test:
-    - files:
-        docfx.yml:
-        docs/b.md: |
-          ---
-          title: []
-          ---
   https://docs.com/error-from-source-legacy.zh-cn#test:
     - files:
         docfx.yml:
         docs/a.md: |
           @a
+  https://docs.com/error-from-source-legacy#test:
+    - files:
+        docs/b.md: |
+          ---
+          title: []
+          ---
 outputs:
   docs/a.mta.json:
   docs/a.raw.page.json:

--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -1,15 +1,6 @@
 # restore loc repo with dependencies 1
 # [repository mapping] 
-locale: zh-cn
 repos:
-  https://docs.com/restore1#master:
-    - files:
-        docfx.yml: |
-          dependencies:
-            restore-child: https://docs.com/restore-child1#child
-  https://docs.com/restore-child1#child:
-    - files:
-        docs/child.md:
   https://docs.com/restore1.zh-cn#master:
     - files:
         docfx.yml: |
@@ -17,6 +8,11 @@ repos:
             restore-child: https://docs.com/restore-child1#child
         docs/loc.md: |
           [link to restore-child](~/restore-child/docs/child.md)
+  https://docs.com/restore1#master:
+    - files:
+  https://docs.com/restore-child1#child:
+    - files:
+        docs/child.md:
 outputs:
   docs/loc.json:
   .errors.log: |
@@ -24,22 +20,18 @@ outputs:
 ---
 # restore loc repo with dependencies 2
 # [repository mapping & bilingual]
-locale: zh-cn
 repos:
-  https://docs.com/restore2#master:
+  https://docs.com/restore2.zh-cn#master-sxs:
     - files:
+        docs/loc.md: |
+          [link to restore-child](~/restore-child/docs/child.md)
         docfx.yml: |
           localization:
             bilingual: true
           dependencies:
             restore-child: https://docs.com/restore-child2#child
-  https://docs.com/restore2.zh-cn#master-sxs:
+  https://docs.com/restore2#master:
     - files:
-        docfx.yml: |
-          dependencies:
-            restore-child: https://docs.com/restore-child2#child
-        docs/loc.md: |
-          [link to restore-child](~/restore-child/docs/child.md)
   https://docs.com/restore2.zh-cn#master:
     - files:
         docs/loc.md:
@@ -53,53 +45,40 @@ outputs:
 ---
 # restore loc repo without dependencies 1
 # [branch mapping]
-locale: zh-cn
 repos:
-  https://docs.com/restore3#master:
+  https://docs.com/restore3.loc#master.zh-cn:
     - files:
         docfx.yml: |
           localization:
             mapping: Branch
-  https://docs.com/restore3.loc#master.zh-cn:
-    - files:
-        docfx.yml:
         docs/dep.md: loc-DEP
+  https://docs.com/restore3#master:
+    - files:
 outputs:
   docs/dep.json:
 ---
 # restore loc repo  without dependencies 2
 # [branch mapping & bilingual]
-locale: zh-cn
 repos:
-  https://docs.com/restore4#master:
+  https://docs.com/restore4.loc#master-sxs.zh-cn:
     - files:
         docfx.yml: |
           localization:
             mapping: Branch
             bilingual: true
-  https://docs.com/restore4.loc#master-sxs.zh-cn:
-    - files:
-        docfx.yml:
         docs/dep.md: loc-DEP-sxs
   https://docs.com/restore4.loc#master.zh-cn:
     - files:
         docs/dep.md: loc-DEP
+  https://docs.com/restore4#master:
+    - files:
 outputs:
   docs/dep.json: |
     {"conceptual": "<p>loc-DEP-sxs</p>"}
 ---
 # loc docset share the source docset's restore map 1
 # [repository mapping]
-locale: zh-cn
 repos:
-  https://github.com/d/restore5#master:
-    - files:
-        docfx.yml: |
-          xref: xrefmap.json
-          dependencies:
-            child1: https://docs.com/d/restore5
-        xrefmap.json: |
-          { "references": [{ "uid": "System.String", "name": "String", "href": "//docs.com" }] }
   https://github.com/d/restore5.zh-cn#master:
     - files:
         docfx.yml: |
@@ -108,6 +87,10 @@ repos:
             child1: https://docs.com/d/restore5
         a.md: |
           @System.String [!include[](~/child1/d.md)]
+  https://github.com/d/restore5#master:
+    - files:
+        xrefmap.json: |
+          { "references": [{ "uid": "System.String", "name": "String", "href": "//docs.com" }] }
   https://docs.com/d/restore5:
     - files:
         d.md: d
@@ -117,9 +100,8 @@ outputs:
 ---
 # loc docset share the source docset's restore map 2
 # [branch mapping] & bilingual
-locale: zh-cn
 repos:
-  https://github.com/d/restore6#master:
+  https://github.com/d/restore6.loc#master-sxs.zh-cn:
     - files:
         docfx.yml: |
           localization:
@@ -128,16 +110,12 @@ repos:
           xref: xrefmap.json
           dependencies:
             child1: https://docs.com/d/restore6
-        xrefmap.json: |
-          { "references": [{ "uid": "System.String", "name": "String", "href": "//docs.com" }] }
-  https://github.com/d/restore6.loc#master-sxs.zh-cn:
-    - files:
-        docfx.yml: |
-          xref: xrefmap.json
-          dependencies:
-            child1: https://docs.com/d/restore6
         a.md: |
           @System.String [!include[](~/child1/d.md)]
+  https://github.com/d/restore6#master:
+    - files:
+        xrefmap.json: |
+          { "references": [{ "uid": "System.String", "name": "String", "href": "//docs.com" }] }
   https://github.com/d/restore6.loc#master.zh-cn:
     - files:
         a.md: '@System.String'
@@ -150,34 +128,22 @@ outputs:
 ---
 # edit url convention without source locale 1
 # [repository mapping] 
-locale: zh-cn
 repos: 
-  https://docfx.com/edit-url1#live:
-    - files:
-        docfx.yml: |
-          contribution:
-            repository: https://github.com/dotnet/docfx
   https://docfx.com/edit-url1.zh-cn#live:
     - files:
         docfx.yml: |
           contribution:
             repository: https://github.com/dotnet/docfx
         docs/a.md:
+  https://docfx.com/edit-url1#live:
+    - files:
 outputs:
   docs/a.json: |
     { "content_git_url": "*dotnet/docfx.zh-cn/blob/live/*"}
 ---
 # edit url convention without source locale 2
 # [branch mapping]
-locale: zh-cn
 repos: 
-  https://docfx.com/edit-url2#live:
-    - files:
-        docfx.yml: |
-          localization:
-            mapping: Branch
-          contribution:
-            repository: https://github.com/dotnet/docfx
   https://docfx.com/edit-url2.loc#live.zh-cn:
     - files:
         docfx.yml: |
@@ -186,25 +152,23 @@ repos:
           contribution:
             repository: https://github.com/dotnet/docfx
         docs/a.md:
+  https://docfx.com/edit-url2#live:
+    - files:
 outputs:
   docs/a.json: |
     { "content_git_url": "*dotnet/docfx.loc/blob/live.zh-cn*"}
 ---
 # edit url convention with source locale 1
 # [repository mapping]
-locale: zh-cn
 repos: 
-  https://docfx.com/edit-url3#live:
-    - files:
-        docfx.yml: |
-          contribution:
-            repository: https://github.com/dotnet/docfx.en-us
   https://docfx.com/edit-url3.zh-cn#live:
     - files:
         docfx.yml: |
           contribution:
             repository: https://github.com/dotnet/docfx.en-us
         docs/a.md:
+  https://docfx.com/edit-url3#live:
+    - files:
 outputs:
   docs/a.json: |
     { "content_git_url": "*dotnet/docfx.en-us.zh-cn/blob/live/*"}
@@ -212,15 +176,7 @@ outputs:
 # edit url convention with source locale 2
 # all loc files are in one repo under different branch
 # [branch mapping]
-locale: zh-cn
 repos: 
-  https://docfx.com/edit-url4#live:
-    - files:
-        docfx.yml: |
-          contribution:
-            repository: https://github.com/dotnet/docfx
-          localization:
-            mapping: Branch
   https://docfx.com/edit-url4.loc#live.zh-cn:
     - files:
         docfx.yml: |
@@ -229,40 +185,16 @@ repos:
           localization:
             mapping: Branch
         docs/a.md:
+  https://docfx.com/edit-url4#live:
+    - files:
 outputs:
   docs/a.json: |
     { "content_git_url": "*dotnet/docfx.loc/blob/live.zh-cn/docs/*"}
 ---
-# edit url convention with source locale 3
-# all loc files are in source repo under different locale folder
-# [folder mapping]
-locale: zh-cn
-repos:
-  https://github.com/folder-maping/a:
-  - files:
-      docfx.yml: |
-        contribution:
-          repository: https://github.com/dotnet/docfx.en-us
-        localization:
-          mapping: Folder
-      _localization/zh-cn/docs/a.md:
-      docs/a.md:
-outputs:
-  docs/a.json: |
-    { "content_git_url": "*dotnet/docfx.en-us/blob/master/*"}
----
 # edit url convention with branch
 # all loc files are in one repo under different branch
 # [branch mapping] & bilingual
-locale: zh-cn
 repos:
-  https://docfx.com/edit-url5#live:
-    - files:
-        docfx.yml: |
-          contribution:
-            repository: https://github.com/dotnet/docfx#master
-          localization:
-            mapping: Branch
   https://docfx.com/edit-url5.loc#live-sxs.zh-cn:
     - files:
         docfx.yml: |
@@ -274,266 +206,194 @@ repos:
   https://docfx.com/edit-url5.loc#live.zh-cn:
     - files:
         docs/a.md:
+  https://docfx.com/edit-url5#live:
+    - files:
 outputs:
   docs/a.json: |
     { "content_git_url": "*dotnet/docfx.loc/blob/master.zh-cn/docs/*"}
 ---
 # loc file contributor info 1
 # [repository mapping]
-locale: zh-cn
 repos: 
-  https://github.com/c/contribution1#master:
-    - files:
-        docfx.yml:
   https://github.com/c/contribution1.zh-cn#master:
     - files:
         docfx.yml:
         docs/a.md:
-outputs:
-  docs/a.json: |
-    {
-      "content_git_url": "https://github.com/c/contribution1.zh-cn/blob/master/docs/a.md",
-      "original_content_git_url": "https://github.com/c/contribution1.zh-cn/blob/master/docs/a.md",
-      "gitcommit": "https://github.com/c/contribution1.zh-cn/blob/81c533a0b7cc78260c82fb4e3b878f66158a9aca/docs/a.md"
-    }
----
-# loc file contributor info 2
-# [folder mapping]
-locale: zh-cn
-repos:
-  https://github.com/contribution/a#master3:
+  https://github.com/c/contribution1#master:
     - files:
-        docfx.yml: |
-          localization:
-            mapping: Folder
-        _localization/zh-cn/docs/a.md:
 outputs:
   docs/a.json: |
     { 
-      "content_git_url":"https://github.com/contribution/a/blob/master3/_localization/zh-cn/docs/a.md",
-      "original_content_git_url":"https://github.com/contribution/a/blob/master3/_localization/zh-cn/docs/a.md",
-      "gitcommit": "https://github.com/contribution/a/blob/661dc2d3c446f976291d34241c0ebd85bf326dd5/_localization/zh-cn/docs/a.md"
+      "content_git_url":"https://github.com/c/contribution1.zh-cn/blob/master/docs/a.md",
+      "original_content_git_url":"https://github.com/c/contribution1.zh-cn/blob/master/docs/a.md",
+      "gitcommit": "https://github.com/c/contribution1.zh-cn/blob/81c533a0b7cc78260c82fb4e3b878f66158a9aca/docs/a.md"
     }
 ---
 # loc file contributor info 3
 # [branch mapping]
-locale: zh-cn
 repos: 
-  https://github.com/c/contribution3#master:
+  https://github.com/c/contribution3.loc#master.zh-cn:
     - files:
         docfx.yml: |
           localization:
             mapping: Branch
-  https://github.com/c/contribution3.loc#master.zh-cn:
-    - files:
-        docfx.yml:
         docs/a.md:
+  https://github.com/c/contribution3#master:
+    - files:
 outputs:
   docs/a.json: |
-    {
-      "content_git_url":"https://github.com/c/contribution3.loc/blob/master.zh-cn/docs/a.md",
-      "original_content_git_url":"https://github.com/c/contribution3.loc/blob/master.zh-cn/docs/a.md",
-      "gitcommit":"https://github.com/c/contribution3.loc/blob/81c533a0b7cc78260c82fb4e3b878f66158a9aca/docs/a.md"
-    }
+    { "content_git_url":"https://github.com/c/contribution3.loc/blob/master.zh-cn/docs/a.md","original_content_git_url":"https://github.com/c/contribution3.loc/blob/master.zh-cn/docs/a.md", "gitcommit":"https://github.com/c/contribution3.loc/blob/920e86f61c36833c2bde899880f15329a5ecdfaf/docs/a.md"}
 ---
 # loc file contributor info 4
 # [repository mapping] & bilingual
-locale: zh-cn
 repos: 
-  https://github.com/c/contribution4#master:
+  https://github.com/c/contribution4.zh-cn#master-sxs:
     - files:
         docfx.yml: |
           localization:
             bilingual: true
-  https://github.com/c/contribution4.zh-cn#master-sxs:
-    - files:
-        docfx.yml:
         docs/a.md:
+  https://github.com/c/contribution4#master:
+    - files:
   https://github.com/c/contribution4.zh-cn#master:
     - files:
         docs/a.md:
 outputs:
   docs/a.json: |
-    {
-      "content_git_url":"https://github.com/c/contribution4.zh-cn/blob/master/docs/a.md",
-      "original_content_git_url":"https://github.com/c/contribution4.zh-cn/blob/master-sxs/docs/a.md",
-      "gitcommit":"https://github.com/c/contribution4.zh-cn/blob/81c533a0b7cc78260c82fb4e3b878f66158a9aca/docs/a.md"
-    }
+    { "content_git_url":"https://github.com/c/contribution4.zh-cn/blob/master/docs/a.md","original_content_git_url":"https://github.com/c/contribution4.zh-cn/blob/master-sxs/docs/a.md", "gitcommit":"https://github.com/c/contribution4.zh-cn/blob/812100656057e8d5916a844565a7a9ef79462152/docs/a.md"}
 ---
 # loc file contributor info 5
 # [branch mapping] & bilingual
-locale: zh-cn
 repos: 
-  https://github.com/c/contribution5#master:
+  https://github.com/c/contribution5.loc#master-sxs.zh-cn:
     - files:
         docfx.yml: |
           localization:
             bilingual: true
             mapping: Branch
-  https://github.com/c/contribution5.loc#master-sxs.zh-cn:
-    - files:
-        docfx.yml:
         docs/a.md:
   https://github.com/c/contribution5.loc#master.zh-cn:
     - files:
         docs/a.md:
+  https://github.com/c/contribution5#master:
+    - files:
 outputs:
   docs/a.json: |
-    {
-      "content_git_url":"https://github.com/c/contribution5.loc/blob/master.zh-cn/docs/a.md",
-      "original_content_git_url":"https://github.com/c/contribution5.loc/blob/master-sxs.zh-cn/docs/a.md",
-      "gitcommit":"https://github.com/c/contribution5.loc/blob/81c533a0b7cc78260c82fb4e3b878f66158a9aca/docs/a.md"
-    }
+    { "content_git_url":"https://github.com/c/contribution5.loc/blob/master.zh-cn/docs/a.md","original_content_git_url":"https://github.com/c/contribution5.loc/blob/master-sxs.zh-cn/docs/a.md", "gitcommit":"https://github.com/c/contribution5.loc/blob/16537a7ca422b81ba2e1a97b6f58bf3a6c5890cf/docs/a.md"}
 ---
 # loc page link and content fallback 1
 # [repository mapping]
-locale: zh-cn
 repos:
-  https://docs.com/page-fallback1#master:
-    - files:
-        docfx.yml:
-        docs/b.md: |
-          [link in a](a.md)
   https://docs.com/page-fallback1.zh-cn#master:
     - files:
         docfx.yml:
         docs/a.md: |
           [link in b](b.md)
           [!include[](b.md)]
+  https://docs.com/page-fallback1#master:
+    - files:
+        docs/b.md: |
+          [link in a](a.md)
 outputs:
   docs/a.json: |
     { "conceptual":"<p><a href=\"b\">link in b</a></p>\n<p><a href=\"a\">link in a</a></p>\n"}
 ---
 # loc page link and content fallback 2
 # [branch mapping]
-locale: zh-cn
 repos:
-  https://docs.com/page-fallback2#master:
+  https://docs.com/page-fallback2.loc#master.zh-cn:
     - files:
         docfx.yml: |
           localization:
             mapping: Branch
-        docs/b.md: |
-          [link in a](a.md)
-  https://docs.com/page-fallback2.loc#master.zh-cn:
-    - files:
-        docfx.yml:
         docs/a.md: |
           [link in b](b.md)
           [!include[](b.md)]
+  https://docs.com/page-fallback2#master:
+    - files:
+        docs/b.md: |
+          [link in a](a.md)
 outputs:
   docs/a.json: |
     { "conceptual":"<p><a href=\"b\">link in b</a></p>\n<p><a href=\"a\">link in a</a></p>\n"}
 ---
 # loc page link and content fallback 3
 # [branch mapping] & bilingual
-locale: zh-cn
 repos:
-  https://docs.com/page-fallback3#master:
+  https://docs.com/page-fallback3.loc#master-sxs.zh-cn:
     - files:
         docfx.yml: |
           localization:
             mapping: Branch
             bilingual: true
-        docs/b.md: |
-          [link in a](a.md)
-  https://docs.com/page-fallback3.loc#master-sxs.zh-cn:
-    - files:
-        docfx.yml:
         docs/a.md: |
           [link in b](b.md)
           [!include[](b.md)]
   https://docs.com/page-fallback3.loc#master.zh-cn:
     - files:
         docs/a.md:
+  https://docs.com/page-fallback3#master:
+    - files:
+        docs/b.md: |
+          [link in a](a.md)
 outputs:
   docs/a.json: |
     { "conceptual":"<p><a href=\"b\">link in b</a></p>\n<p><a href=\"a\">link in a</a></p>\n"}
 ---
 # loc resource fallback 1
 # [repository mapping]
-locale: zh-cn
 repos:
-  https://docs.com/resource-fallback1#master:
-    - files:
-        docs/b.png:
-        docfx.yml:
   https://docs.com/resource-fallback1.zh-cn#master:
     - files:
         docfx.yml:
         docs/a.md: |
           [link to b](b.png)
+  https://docs.com/resource-fallback1#master:
+    - files:
+        docs/b.png:
 outputs:
   docs/a.json: |
     { "conceptual":"<p><a href=\"b.png\">link to b</a></p>"}
 ---
 # loc resource fallback 2
 # [branch mapping]
-locale: zh-cn
 repos:
-  https://docs.com/resource-fallback2#live:
+  https://docs.com/resource-fallback2.loc#live.zh-cn:
     - files:
-        docs/b.png:
         docfx.yml: |
           localization:
             mapping: Branch
-  https://docs.com/resource-fallback2.loc#live.zh-cn:
-    - files:
-        docfx.yml:
         docs/a.md: |
           [link to b](b.png)
+  https://docs.com/resource-fallback2#live:
+    - files:
+        docs/b.png:
 outputs:
   docs/a.json: |
     { "conceptual":"<p><a href=\"b.png\">link to b</a></p>"}
 ---
 # loc resource fallback 3
 # [repository mapping] & bilingual
-locale: zh-cn
 repos:
-  https://docs.com/resource-fallback3#master:
+  https://docs.com/resource-fallback3.zh-cn#master-sxs:
     - files:
-        docs/b.png:
         docfx.yml: |
           localization:
             bilingual: true
-  https://docs.com/resource-fallback3.zh-cn#master-sxs:
-    - files:
-        docfx.yml:
         docs/a.md: |
           [link to b](b.png)
   https://docs.com/resource-fallback3.zh-cn#master:
     - files:
         docs/a.md:
+  https://docs.com/resource-fallback3#master:
+    - files:
+        docs/b.png:
 outputs:
   docs/a.json: |
     { "conceptual":"<p><a href=\"b.png\">link to b</a></p>"}
 ---
-# loc token fallback, all loc files are in source repo under different locale folder
-locale: zh-cn
-inputs:
-  docfx.yml: |
-    localization:
-      mapping: Folder
-  docs/b.md: |
-    [link to a](a.md)
-  docs/a.md: a
-  _localization/zh-cn/docs/a.md: |
-    [link to b](b.md)
-    [!include[include b](b.md)]
-outputs:
-  docs/a.json: |
-    { "conceptual":"<p><a href=\"b\">link to b</a></p>\n<p><a href=\"a\">link to a</a></p>\n"}
----
 # loc build with TOC map, loc TOC has higher priority
-locale: zh-cn
 repos:
-  https://docs.com/toc1#master:
-    - files:
-        docs/TOC.md: |
-          # [reference a](a.md)
-        docs/b/TOC.md: |
-          # [reference b](../b.md)
-        docfx.yml:
   https://docs.com/toc1.zh-cn#master:
     - files:
         docfx.yml:
@@ -542,6 +402,12 @@ repos:
         docs/TOC.md: |
           # [reference a](a.md)
           # [reference b](b.md)
+  https://docs.com/toc1#master:
+    - files:
+        docs/TOC.md: |
+          # [reference a](a.md)
+        docs/b/TOC.md: |
+          # [reference b](../b.md)
 outputs:
   docs/a.json: |
     {"_tocRel": "toc.json"}
@@ -551,38 +417,18 @@ outputs:
     {"items": [{"name": "reference a", "href": "a"},{"name": "reference b", "href": "b"}]}
 ---
 # loc build with mixed toc map
-locale: zh-cn
 repos:
-  https://docs.com/toc2#master:
-    - files:
-        docs/a/a.md:
-        docs/b/TOC.md: |
-          # [reference b](b.md)
-        docfx.yml:
   https://docs.com/toc2.zh-cn#master:
     - files:
         docfx.yml:
         docs/a/TOC.md: |
           # [reference a](a.md)
         docs/b/b.md:
-outputs:
-  docs/b/b.json: |
-    {"_tocRel": "toc.json"}
-  docs/a/toc.json: |
-    {"items": [{"name": "reference a", "href": "a"}]}
----
-# loc build with mixed toc map, all loc files are in source repo under different locale folder
-locale: zh-cn
-inputs:
-  docfx.yml: |
-    localization:
-      mapping: Folder
-  docs/b/TOC.md: |
-    # [reference b](b.md)
-  docs/a/a.md:
-  _localization/zh-cn/docs/b/b.md:
-  _localization/zh-cn/docs/a/TOC.md: |
-    # [reference a](a.md)
+  https://docs.com/toc2#master:
+    - files:
+        docs/a/a.md:
+        docs/b/TOC.md: |
+          # [reference b](b.md)
 outputs:
   docs/b/b.json: |
     {"_tocRel": "toc.json"}
@@ -590,15 +436,7 @@ outputs:
     {"items": [{"name": "reference a", "href": "a"}]}
 ---
 # loc build with xref map, loc file has higher priority
-locale: zh-cn
 repos:
-  https://docs.com/xref1#master:
-    - files:
-        docs/a.md: |
-          ---
-          uid: c
-          ---
-        docfx.yml:
   https://docs.com/xref1.zh-cn#master:
     - files:
         docfx.yml:
@@ -608,39 +446,18 @@ repos:
           ---
         docs/b.md: |
           link to @c
-outputs:
-  docs/a.json:
-  docs/b.json:
----
-# loc build with xref map, all locale files are in source repo under different locale folder, loc file has higher priority
-locale: zh-cn
-inputs:
-  docfx.yml: |
-    localization:
-      mapping: Folder
-  docs/a.md: |
-    ---
-    uid: c
-    ---
-  _localization/zh-cn/docs/a.md: |
-    ---
-    uid: a
-    ---
-  _localization/zh-cn/docs/b.md: link to @c
+  https://docs.com/xref1#master:
+    - files:
+        docs/a.md: |
+          ---
+          uid: c
+          ---
 outputs:
   docs/a.json:
   docs/b.json:
 ---
 # loc build with mixed xref map
-locale: zh-cn
 repos:
-  https://docs.com/xref2#master:
-    - files:
-        docs/c.md: |
-          ---
-          uid: c
-          ---
-        docfx.yml:
   https://docs.com/xref2.zh-cn#master:
     - files:
         docfx.yml:
@@ -651,6 +468,12 @@ repos:
         docs/b.md: |
           link to @a
           link to @c
+  https://docs.com/xref2#master:
+    - files:
+        docs/c.md: |
+          ---
+          uid: c
+          ---
 outputs:
   docs/a.json:
   docs/b.json: |
@@ -658,76 +481,31 @@ outputs:
   .xrefmap.json: |
     {"references":[{"uid":"a","href":"https://docs.com/docs/a?branch=master","name":"a"},{"uid":"c","href":"https://docs.com/docs/c?branch=master","name":"c"}]}
 ---
-# loc folder should be excluded from source docset during loc docset build
-locale: zh-cn
-inputs:
-  docfx.yml: |
-    files: '**/*.md'
-    localization:
-      mapping: Folder
-  _localization/zh-cn/docs/a.md: |
-    [link to a](~/_localization/zh-cn/docs/a.md)
-    [link to a](~/docs/a.md)
-outputs:
-  docs/a.json:
-  .errors.log: |
-    ["warning","link-out-of-scope","File '_localization/zh-cn/docs/a.md [fallback]' referenced by link '~/_localization/zh-cn/docs/a.md' will not be built because it is not included in build scope","docs/a.md",1,1]
----
-# loc folder should be excluded from source docset during source docset build
-inputs:
-  docfx.yml: |
-    files: '**/*.md'
-    localization:
-      mapping: Folder
-  _localization/zh-cn/docs/a.md:
-  docs/b.md:
-outputs:
-  docs/b.json:
----
 # built metadata for loc files 1
-locale: zh-cn
 repos:
-  https://docs.com/metadata1#master:
-    - files:
-        docfx.yml: |
-          baseUrl: https://docs.microsoft.com
   https://docs.com/metadata1.zh-cn#master:
     - files:
         docfx.yml: |
           baseUrl: https://docs.microsoft.com
         docs/a.md:
+  https://docs.com/metadata1#master:
+    - files:
 outputs:
   docs/a.json: |
     {"locale": "zh-cn", "canonical_url": "https://docs.microsoft.com/zh-cn/docs/a", "document_id": "fa697b4e-3e52-77f6-2219-39040f6070da", "document_version_independent_id": "7c88e748-ed5e-a29a-c057-6f89857c3591",}
 ---
 # built metadata for loc files 2
 # all loc files are in same repo under different branch
-locale: zh-cn
 repos:
-  https://docs.com/metadata2#live:
+  https://docs.com/metadata2.loc#live.zh-cn:
     - files:
         docfx.yml: |
           baseUrl: https://docs.microsoft.com
           localization:
             mapping: Branch
-  https://docs.com/metadata2.loc#live.zh-cn:
-    - files:
-        docfx.yml: |
-          baseUrl: https://docs.microsoft.com
         docs/a.md:
-outputs:
-  docs/a.json: |
-    {"locale": "zh-cn", "canonical_url": "https://docs.microsoft.com/zh-cn/docs/a", "document_id": "fa697b4e-3e52-77f6-2219-39040f6070da", "document_version_independent_id": "7c88e748-ed5e-a29a-c057-6f89857c3591"}
----
-# built metadata for loc files 3
-# all loc files are in source repo under different locale folder
-locale: zh-cn
-inputs:
-  docfx.yml: |
-    baseUrl: https://docs.microsoft.com
-    localization:
-      mapping: Folder
-  _localization/zh-cn/docs/a.md:
+  https://docs.com/metadata2#live:
+    - files:
 outputs:
   docs/a.json: |
     {"locale": "zh-cn", "canonical_url": "https://docs.microsoft.com/zh-cn/docs/a", "document_id": "fa697b4e-3e52-77f6-2219-39040f6070da", "document_version_independent_id": "7c88e748-ed5e-a29a-c057-6f89857c3591"}
@@ -735,43 +513,30 @@ outputs:
 # built metadata for loc files 4
 # all loc files are in same repo under different branch
 # bilingual
-locale: zh-cn
 repos:
-  https://docs.com/metadata4#master:
+  https://docs.com/metadata4.loc#master.zh-cn:
     - files:
         docfx.yml: |
           baseUrl: https://docs.microsoft.com
           localization:
             mapping: Branch
             bilingual: true
-  https://docs.com/metadata4.loc#master.zh-cn:
-    - files:
-        docfx.yml: |
-          baseUrl: https://docs.microsoft.com
         docs/a.md:
   https://docs.com/metadata4.loc#master-sxs.zh-cn:
     - files:
         docs/a.md:
+  https://docs.com/metadata4#master:
+    - files:
 outputs:
   docs/a.json: |
     {"locale": "zh-cn", "canonical_url": "https://docs.microsoft.com/zh-cn/docs/a", "document_id": "fa697b4e-3e52-77f6-2219-39040f6070da", "document_version_independent_id": "7c88e748-ed5e-a29a-c057-6f89857c3591"}
 ---
 # bilingual build 1
 # [repository mapping]
-locale: zh-cn
 repos:
-  https://github.com/ss/c:
-    - files:
-        docs/b.md: |
-          [link to a](a.md)
-        docs/a.md: a
-        docfx.yml: |
-          localization:
-            bilingual: true
   https://github.com/ss/c.zh-cn#master-sxs:
     - files:
         docfx.yml: |
-          # TODO: should be able to figure out bilingual automatically using convention
           localization:
             bilingual: true
         docs/a.md: |
@@ -781,6 +546,11 @@ repos:
   https://github.com/ss/c.zh-cn#master:
     - files:
         docs/a.md:
+  https://github.com/ss/c:
+    - files:
+        docs/b.md: |
+          [link to a](a.md)
+        docs/a.md: a
 outputs:
   docs/a.json: |
     {
@@ -791,23 +561,13 @@ outputs:
 ---
 # bilingual build 2
 # [branch mapping]
-locale: zh-cn
 repos:
-  https://github.com/ss/a:
-     - files:
-         docfx.yml: |
-           localization:
-             mapping: Branch
-             bilingual: true
-         docs/b.md: |
-           [link to a](a.md)
-         docs/a.md: abc
   https://github.com/ss/a.loc#master-sxs.zh-cn:
     - files:
         docfx.yml: |
-           localization:
-             mapping: Branch
-             bilingual: true
+          localization:
+            mapping: Branch
+            bilingual: true
         docs/a.md: |
           sxs content
           [link to b](b.md)
@@ -815,6 +575,11 @@ repos:
   https://github.com/ss/a.loc#master.zh-cn:
     - files:
         docs/a.md: a
+  https://github.com/ss/a:
+     - files:
+         docs/b.md: |
+           [link to a](a.md)
+         docs/a.md: abc
 outputs:
   docs/a.json: |
     {"conceptual":"<p>sxs content\n<a href=\"b\">link to b</a></p>\n<p><a href=\"a\">link to a</a></p>\n", "enable_loc_sxs": true}
@@ -826,14 +591,7 @@ outputs:
 #   loc-bilingual-sxs branch(non-sxs branch):
 #     zh-cn/docs/a.md(modified by B and C)
 # for above case, the a.md's contributors are A and B
-locale: zh-cn
 repos:
-  https://github.com/ss/b:
-    - files:
-        docfx.yml: |
-          localization:
-            mapping: Branch
-            bilingual: true
   https://github.com/ss/b.loc#master-sxs.zh-cn:
     - files:
         docfx.yml: |
@@ -852,6 +610,8 @@ repos:
         docs/a.md: cd
       author: Terry
       email: terry@contoso.com
+  https://github.com/ss/b:
+    - files:
 cache:
   github-users.json: |
     { "users": [
@@ -871,14 +631,7 @@ outputs:
       "enable_loc_sxs": true}
 ---
 # bilingual page's `gitcommit` url follows sxs content's commit history
-locale: zh-cn
 repos:
-  https://github.com/bilingual/a:
-    - files:
-        docs/a.md: a
-        docfx.yml: |
-          localization:
-            bilingual: true
   https://github.com/bilingual/a.zh-cn#master-sxs:
     - files:
         docfx.yml: |
@@ -890,6 +643,9 @@ repos:
     - files:
         docs/a.md: |
           loc content
+  https://github.com/bilingual/a:
+    - files:
+        docs/a.md: a
 outputs:
   docs/a.json: |
     {"gitcommit":"https://github.com/bilingual/a.zh-cn/blob/427086f2a28561ea018e74d0d95e99ab63399cc7/docs/a.md"}
@@ -897,13 +653,7 @@ outputs:
 # conflicted toc files(source and loc)
 # 1. should not report warning
 # 2. `_tocRel` should be resolved to loc toc
-locale: zh-cn
 repos:
-  https://github.com/conflictedtoc/a:
-    - files:
-        docs/a/TOC.md: |
-          # [md reference a](a.md)
-        docfx.yml:
   https://github.com/conflictedtoc/a.zh-cn:
     - files:
         docfx.yml:
@@ -911,6 +661,10 @@ repos:
           - href: a.md
             name: yml reference a
         docs/a/a.md:
+  https://github.com/conflictedtoc/a:
+    - files:
+        docs/a/TOC.md: |
+          # [md reference a](a.md)
 outputs:
   docs/a/a.json: |
     {"_tocRel": "toc.json"}
@@ -918,25 +672,22 @@ outputs:
     {"items":[{"name": "yml reference a"}]}
 ---
 # fallback to deleted token/codesnippet
-locale: zh-cn
 repos:
+  https://github.com/deletedtoken/a.zh-cn:
+    - files:
+        docfx.yml:
+        docs/a.md: |
+          [!include[include deleted tokena](tokena.md)]
   https://github.com/deletedtoken/a:
     - files:
-        docfx.yml:
       author: a
     - files:
-        docfx.yml:
         docs/tokena.md: |
           [!include[include deleted tokenb](tokenb.md)]
           [!code-csharp[Main](program.cs)]
         docs/tokenb.md: b
         docs/program.cs:
       author: b
-  https://github.com/deletedtoken/a.zh-cn:
-    - files:
-        docfx.yml:
-        docs/a.md: |
-          [!include[include deleted tokena](tokena.md)]
 outputs:
   docs/a.json: |
     {"conceptual":"<p>b</p>\n<pre><code class=\"lang-csharp\" name=\"Main\"></code></pre>"}
@@ -944,23 +695,20 @@ outputs:
     {"dependencies": {"docs/tokena.md": undefined}}
 ---
 # fallback to deleted resource
-locale: zh-cn
 repos:
-  https://github.com/deletedres/a:
-    - files:
-        docfx.yml:
-      author: a
-    - files:
-        docfx.yml:
-        docs/resource.png:
-        docs/b.md:
-      author: b
   https://github.com/deletedres/a.zh-cn:
     - files:
         docfx.yml:
         docs/a.md: |
           [link to deleted resource](resource.png)
           [link to deleted markdown doesnt work](b.md)
+  https://github.com/deletedres/a:
+    - files:
+      author: a
+    - files:
+        docs/resource.png:
+        docs/b.md:
+      author: b
 outputs:
   docs/a.json: |
     {"conceptual":"<p><a href=\"resource.png\">link to deleted resource</a>\n<a href=\"b.md\">link to deleted markdown doesnt work</a></p>\n"}
@@ -970,18 +718,7 @@ outputs:
     {"dependencies":{"docs/a.md":[{"source":"docs/resource.png","type":"link"}]}}
 ---
 # fallback to deleted toc
-locale: zh-cn
 repos:
-  https://github.com/deletedtoc/a:
-    - files:
-        docfx.yml:
-      author: a
-    - files:
-        docfx.yml:
-        docs/a/TOC.yml: |
-          - href: a.md
-            name: reference markdown a
-      author: b
   https://github.com/deletedtoc/a.zh-cn:
     - files:
         docfx.yml:
@@ -989,6 +726,14 @@ repos:
           - href: ../a/TOC.yml
             name: reference toc a
         docs/a/a.md:
+  https://github.com/deletedtoc/a:
+    - files:
+      author: a
+    - files:
+        docs/a/TOC.yml: |
+          - href: a.md
+            name: reference markdown a
+      author: b
 outputs:
   docs/a/a.json:
   docs/b/toc.json: |
@@ -1038,17 +783,7 @@ outputs:
     ["warning","include-not-found","Cannot resolve 'tokena.md' relative to 'docs/a.md'.","docs/a.md",1,1]
 ---
 # fallback to inclusion parent toc
-locale: zh-cn
 repos:
-  https://github.com/inclusiontoc/a:
-    - files:
-        docfx.yml:
-        docs/b/TOC.yml: |
-          - href: ../a/TOC.yml
-            name: reference toc a
-        docs/a/TOC.yml: |
-          - href: b.md
-            name: reference markdown b
   https://github.com/inclusiontoc/a.zh-cn:
     - files:
         docfx.yml:
@@ -1057,6 +792,14 @@ repos:
             name: reference markdown a
         docs/a/a.md:
         docs/a/b.md:
+  https://github.com/inclusiontoc/a:
+    - files:
+        docs/b/TOC.yml: |
+          - href: ../a/TOC.yml
+            name: reference toc a
+        docs/a/TOC.yml: |
+          - href: b.md
+            name: reference markdown b
 outputs:
   docs/a/a.json:
   docs/a/b.json:
@@ -1065,8 +808,12 @@ outputs:
 ---
 # loc build gets restored files
 # from current docset firestly, then from fallback docset if has
-locale: zh-cn
 repos:
+  https://github.com/buildhistory/a.zh-cn:
+    - files:
+        docfx.yml: |
+          monikerDefinition: monikers.json
+        docs/a.md:
   https://github.com/buildhistory/a:
     - files:
         docfx.yml: |
@@ -1074,44 +821,25 @@ repos:
         docs/a.md:
         monikers.json: |
           {}
-  https://github.com/buildhistory/a.zh-cn:
-    - files:
-        docfx.yml: |
-          monikerDefinition: monikers.json
-        docs/a.md:
 outputs:
   docs/a.json:
----
-# [skip] build from loc folder for folder mapping is not supported
-cwd: localization/zh-cn/
-repos:
-  https://github.com/buildfromlocfolder/a:
-    - files:
-        docfx.yml: |
-          localization:
-            mapping: Folder
-        _localization/zh-cn/docs/a/a.md:
-outputs:
-  .errors.log: |
-    ["error","config-not-found","Can't find config file 'docfx.yml/docfx.json' at *"]
 ---
 # loc build gets docfx config 1
 # from current docset firstly, then from fallback docset
 # [repo mapping]
-locale: zh-cn
 repos:
-  https://github.com/locconfig/a:
-    - files:
-        docfx.yml: |
-          contribution:
-            repository: https://github.com/dotnet/docfx
-        docs/a.md:
   https://github.com/locconfig/a.zh-cn:
     - files:
         docs/a.md:
         docfx.yml: |
           contribution:
             repository: https://github.com/dotnet/docfx.zh-cn
+  https://github.com/locconfig/a:
+    - files:
+        docfx.yml: |
+          contribution:
+            repository: https://github.com/dotnet/docfx
+        docs/a.md:
 outputs:
   docs/a.json: |
     { "content_git_url": "*dotnet/docfx.zh-cn/blob/master/*"}
@@ -1119,16 +847,7 @@ outputs:
 # loc build gets docfx config 2
 # from current docset firstly, then from fallback docset
 # [branch mapping]
-locale: zh-cn
 repos:
-  https://github.com/locconfig/b:
-    - files:
-        docfx.yml: |
-          contribution:
-            repository: https://github.com/dotnet/docfx#live
-          localization:
-            mapping: Branch
-        docs/a.md:
   https://github.com/locconfig/b.loc#master.zh-cn:
     - files:
         docs/a.md:
@@ -1137,6 +856,14 @@ repos:
             repository: https://github.com/dotnet/docfx.loc#live
           localization:
             mapping: Branch
+  https://github.com/locconfig/b:
+    - files:
+        docfx.yml: |
+          contribution:
+            repository: https://github.com/dotnet/docfx#live
+          localization:
+            mapping: Branch
+        docs/a.md:
 outputs:
   docs/a.json: |
     { "content_git_url": "*dotnet/docfx.loc/blob/live.zh-cn/*"}
@@ -1144,16 +871,7 @@ outputs:
 # loc build gets docfx config 3
 # from current docset firstly, then from fallback docset
 # [repo mapping] & bilingual
-locale: zh-cn
 repos:
-  https://github.com/locconfig/c:
-    - files:
-        docfx.yml: |
-          contribution:
-            repository: https://github.com/dotnet/docfx
-          localization:
-            bilingual: true
-        docs/a.md:
   https://github.com/locconfig/c.zh-cn#master-sxs:
     - files:
         docs/a.md:
@@ -1162,6 +880,14 @@ repos:
             repository: https://github.com/dotnet/docfx.zh-cn
           localization:
             bilingual: true
+  https://github.com/locconfig/c:
+    - files:
+        docfx.yml: |
+          contribution:
+            repository: https://github.com/dotnet/docfx
+          localization:
+            bilingual: true
+        docs/a.md:
   https://github.com/locconfig/c.zh-cn:
     - files:
         docs/a.md:
@@ -1172,17 +898,7 @@ outputs:
 # loc build gets docfx config 4
 # from current docset firstly, then from fallback docset
 # [branch mapping] & bilingual
-locale: zh-cn
 repos:
-  https://github.com/locconfig/d:
-    - files:
-        docfx.yml: |
-          contribution:
-            repository: https://github.com/dotnet/docfx#live
-          localization:
-            mapping: Branch
-            bilingual: true
-        docs/a.md:
   https://github.com/locconfig/d.loc#master-sxs.zh-cn:
     - files:
         docs/a.md:
@@ -1192,6 +908,15 @@ repos:
           localization:
             mapping: Branch
             bilingual: true
+  https://github.com/locconfig/d:
+    - files:
+        docfx.yml: |
+          contribution:
+            repository: https://github.com/dotnet/docfx#live
+          localization:
+            mapping: Branch
+            bilingual: true
+        docs/a.md:
   https://github.com/locconfig/d.loc#master.zh-cn:
     - files:
         docs/a.md:
@@ -1201,8 +926,16 @@ outputs:
 ---
 # loc build with different dependency git repository 1
 # [repo mapping] & bilingual
-locale: zh-cn
 repos:
+  https://github.com/locconfig2/c.zh-cn#master-sxs:
+    - files:
+        docs/a.md: |
+          [!include[include child](~/child1/token.md)]
+        docfx.yml: |
+          dependencies:
+            child1: https://github.com/locconfig2/d#live
+          localization:
+            bilingual: true
   https://github.com/locconfig2/c:
     - files:
         docfx.yml: |
@@ -1214,15 +947,6 @@ repos:
             dependencies:
               child1: https://github.com/locconfig2/d#live
         docs/a.md:
-  https://github.com/locconfig2/c.zh-cn#master-sxs:
-    - files:
-        docs/a.md: |
-          [!include[include child](~/child1/token.md)]
-        docfx.yml: |
-          dependencies:
-            child1: https://github.com/locconfig2/d#live
-          localization:
-            bilingual: true
   https://github.com/locconfig2/c.zh-cn:
     - files:
         docs/a.md:
@@ -1240,8 +964,17 @@ outputs:
 ---
 # loc build with different dependency git repository 2
 # [branch mapping] & bilingual
-locale: zh-cn
 repos:
+  https://github.com/locconfig3/c.loc#master-sxs.zh-cn:
+    - files:
+        docs/a.md: |
+          [!include[include child](~/child1/token.md)]
+        docfx.yml: |
+          dependencies:
+            child1: https://github.com/locconfig3/f#live
+          localization:
+            bilingual: true
+            mapping: Branch
   https://github.com/locconfig3/c:
     - files:
         docfx.yml: |
@@ -1254,16 +987,6 @@ repos:
             dependencies:
               child1: https://github.com/locconfig3/f#live
         docs/a.md:
-  https://github.com/locconfig3/c.loc#master-sxs.zh-cn:
-    - files:
-        docs/a.md: |
-          [!include[include child](~/child1/token.md)]
-        docfx.yml: |
-          dependencies:
-            child1: https://github.com/locconfig3/f#live
-          localization:
-            bilingual: true
-            mapping: Branch
   https://github.com/locconfig3/c.loc#master.zh-cn:
     - files:
         docs/a.md:
@@ -1280,129 +1003,97 @@ outputs:
     { "conceptual": "<p>live branch</p>\n" }
 ---
 # Apply &lrm; for right to left languages
-locale: ar-sa
 repos:
-  https://docs.com/lrm#master:
-    - files:
-        docfx.yml:
   https://docs.com/lrm.ar-sa#master:
     - files:
         docfx.yml:
         docs/a.md: |
           Learn c#.
+  https://docs.com/lrm#master:
+    - files:
 outputs:
   docs/a.json: |
     { "conceptual": "<p>Learn c#&lrm;.</p>" }
 ---
-# VSTS localized repo with folder mapping
-locale: zh-cn
-repos:
-  https://docascode.visualstudio.com/folder/_git/a:
-    - files:
-        docfx.yml: |
-          localization:
-            mapping: Folder
-        docs/b.md: |
-          [link in a](a.md)
-        _localization/zh-cn/docs/a.md: |
-          [link in b](b.md)
-          [!include[](b.md)]
-outputs:
-  docs/a.json: |
-    { "conceptual":"<p><a href=\"b\">link in b</a></p>\n<p><a href=\"a\">link in a</a></p>\n"}
----
 # VSTS localized repo with branch mapping
-locale: zh-cn
 repos:
-  https://docascode.visualstudio.com/branch/_git/a#live:
+  https://docascode.visualstudio.com/branch/_git/a.loc#live.zh-cn:
     - files:
         docfx.yml: |
           localization:
             mapping: Branch
-        docs/b.md: |
-          [link in a](a.md)
-  https://docascode.visualstudio.com/branch/_git/a.loc#live.zh-cn:
-    - files:
-        docfx.yml:
         docs/a.md: |
           [link in b](b.md)
           [!include[](b.md)]
+  https://docascode.visualstudio.com/branch/_git/a#live:
+    - files:
+        docs/b.md: |
+          [link in a](a.md)
 outputs:
   docs/a.json: |
     { "conceptual":"<p><a href=\"b\">link in b</a></p>\n<p><a href=\"a\">link in a</a></p>\n"}
 ---
 # VSTS localized repo with branch mapping & bilingual
-locale: zh-cn
 repos:
-  https://docascode.visualstudio.com/branch/_git/b#live:
+  https://docascode.visualstudio.com/branch/_git/b.loc#live-sxs.zh-cn:
     - files:
         docfx.yml: |
           localization:
             mapping: Branch
             bilingual: true
-        docs/b.md: |
-          [link in a](a.md)
-  https://docascode.visualstudio.com/branch/_git/b.loc#live-sxs.zh-cn:
-    - files:
-        docfx.yml:
         docs/a.md: |
           [link in b](b.md)
           [!include[](b.md)]
   https://docascode.visualstudio.com/branch/_git/b.loc#live.zh-cn:
     - files:
         docs/a.md: "not used"
+  https://docascode.visualstudio.com/branch/_git/b#live:
+    - files:
+        docs/b.md: |
+          [link in a](a.md)
 outputs:
   docs/a.json: |
     { "conceptual":"<p><a href=\"b\">link in b</a></p>\n<p><a href=\"a\">link in a</a></p>\n"}
 ---
 # VSTS localized repo with repo mapping
-locale: zh-cn
 repos:
-  https://docascode.visualstudio.com/repo/_git/a#live:
-    - files:
-        docfx.yml:
-        docs/b.md: |
-          [link in a](a.md)
   https://docascode.visualstudio.com/repo/_git/a.zh-cn#live:
     - files:
         docfx.yml:
         docs/a.md: |
           [link in b](b.md)
           [!include[](b.md)]
+  https://docascode.visualstudio.com/repo/_git/a#live:
+    - files:
+        docs/b.md: |
+          [link in a](a.md)
 outputs:
   docs/a.json: |
     { "conceptual":"<p><a href=\"b\">link in b</a></p>\n<p><a href=\"a\">link in a</a></p>\n"}
 ---
 # VSTS localized repo with repo mapping & bilingual
-locale: zh-cn
 repos:
-  https://docascode.visualstudio.com/repo/_git/b#live:
+  https://docascode.visualstudio.com/repo/_git/b.zh-cn#live-sxs:
     - files:
         docfx.yml: |
           localization:
             bilingual: true
-        docs/b.md: |
-          [link in a](a.md)
-  https://docascode.visualstudio.com/repo/_git/b.zh-cn#live-sxs:
-    - files:
-        docfx.yml:
         docs/a.md: |
           [link in b](b.md)
           [!include[](b.md)]
   https://docascode.visualstudio.com/repo/_git/b.zh-cn#live:
     - files:
         docs/a.md: "not used"
+  https://docascode.visualstudio.com/repo/_git/b#live:
+    - files:
+        docs/b.md: |
+          [link in a](a.md)
 outputs:
   docs/a.json: |
     { "conceptual":"<p><a href=\"b\">link in b</a></p>\n<p><a href=\"a\">link in a</a></p>\n"}
 ---
 # fallback to never existing token in multiple files
-locale: zh-cn
 repos:
-  https://github.com/neverexist/a:
-    - files:
-        docfx.yml:
-      author: a
   https://github.com/neverexist/a.zh-cn:
     - files:
         docfx.yml:
@@ -1412,6 +1103,9 @@ repos:
           [!include[include deleted tokena](tokenx.md)]
         docs/3.md: |
           [!include[include deleted tokena](tokenx.md)]
+  https://github.com/neverexist/a:
+    - files:
+      author: a
 outputs:
   docs/1.json:
   docs/2.json:
@@ -1420,36 +1114,36 @@ outputs:
 ---
 # fallback to corresponding source branch 1
 # [repo mapping]
-locale: zh-cn
 repos:
-  https://docs.com/branch-fallback1#test:
-    - files:
-        docfx.yml:
-        docs/b.md: |
-          test
-  https://docs.com/branch-fallback1#master:
-    - files:
-        docfx.yml:
-        docs/b.md: |
-          master
   https://docs.com/branch-fallback1.zh-cn#test:
     - files:
         docfx.yml:
         docs/a.md: |
           [!include[](b.md)]
+  https://docs.com/branch-fallback1#test:
+    - files:
+        docs/b.md: |
+          test
+  https://docs.com/branch-fallback1#master:
+    - files:
+        docs/b.md: |
+          master
 outputs:
   docs/a.json: |
     { "conceptual":"<p>test</p>"}
 ---
 # fallback to corresponding source branch 2
 # [repo mapping & bilingual]
-locale: zh-cn
 repos:
-  https://docs.com/branch-fallback2#test:
+  https://docs.com/branch-fallback2.zh-cn#test-sxs:
     - files:
         docfx.yml: |
           localization:
             bilingual: true
+        docs/a.md: |
+          [!include[](b.md)]
+  https://docs.com/branch-fallback2#test:
+    - files:
         docs/b.md: |
           test
   https://docs.com/branch-fallback2#master:
@@ -1457,11 +1151,6 @@ repos:
         docfx.yml:
         docs/b.md: |
           master
-  https://docs.com/branch-fallback2.zh-cn#test-sxs:
-    - files:
-        docfx.yml:
-        docs/a.md: |
-          [!include[](b.md)]
   https://docs.com/branch-fallback2.zh-cn#test:
     - files:
         docs/a.md:
@@ -1486,37 +1175,31 @@ outputs:
     { "conceptual":"<p>master</p>"}
 ---
 # Do not validate bookmark for fallback content
-locale: zh-cn
 repos:
-  https://docs.com/fallback-content-bookmark-validation#master:
-    - files:
-        docfx.yml:
-        a.md:
   https://docs.com/fallback-content-bookmark-validation.zh-cn#master:
     - files:
         docfx.yml:
         b.md: '[](a.md#invalid-bookmark)'
+  https://docs.com/fallback-content-bookmark-validation#master:
+    - files:
+        a.md:
 outputs:
   b.json:
 ---
 # Loc with not repo root config
 locale: zh-cn
 repos:
-  https://docs.com/config-not-root#test:
-    - files:
-        docs/docfx.yml:
-        docs/c/b.md: |
-          test
-  https://docs.com/config-not-root#master:
-    - files:
-        docs/docfx.yml:
-        docs/c/b.md: |
-          master
   https://docs.com/config-not-root.zh-cn#test:
     - files:
         docs/docfx.yml:
         docs/a.md: |
           [!include[](./c/b.md)]
+  https://docs.com/config-not-root#test:
+    - files:
+        docs/c/b.md: test
+  https://docs.com/config-not-root#master:
+    - files:
+        docs/c/b.md: master
 outputs:
   docs/a.json: |
     { "conceptual":"<p>test</p>"}

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -256,6 +255,14 @@ namespace Microsoft.Docs.Build
         /// Behavior: ✔️ Message: ✔️
         public static Error FileNotFound(SourceInfo<string> source)
             => new Error(ErrorLevel.Warning, "file-not-found", $"Invalid file link: '{source}'.", source);
+
+        /// <summary>
+        /// Can't find a folder.
+        /// Examples: pointing template to a local folder that does not exist
+        /// </summary>
+        /// Behavior: ✔️ Message: ❌
+        public static Error DirectoryNotFound(SourceInfo<string> source)
+            => new Error(ErrorLevel.Error, "directory-not-found", $"Invalid directory: '{source}'.", source);
 
         /// <summary>
         /// File contains git merge conflict.

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Docs.Build
         {
             List<Error> errors;
             Config config = null;
+            RestoreGitMap restoreGitMap = null;
 
             using (var errorLog = new ErrorLog(docsetPath, outputPath, () => config, options.Legacy))
             {
@@ -36,44 +37,28 @@ namespace Microsoft.Docs.Build
                 try
                 {
                     // load and trace entry repository
-                    var repositoryProvider = new RepositoryProvider(docsetPath, options);
+                    var repositoryProvider = new RepositoryProvider(docsetPath, () => config, () => restoreGitMap);
                     var repository = repositoryProvider.GetRepository(FileOrigin.Default);
                     Telemetry.SetRepository(repository?.Remote, repository?.Branch);
                     var locale = LocalizationUtility.GetLocale(repository, options);
 
-                    using (var restoreGitMap = RestoreGitMap.Create(docsetPath, locale))
+                    using (restoreGitMap = RestoreGitMap.Create(docsetPath, locale))
                     {
                         // load configuration from current docset and fallback docset
-                        var input = new Input(docsetPath, repositoryProvider);
+                        var input = new Input(docsetPath, () => config, repositoryProvider);
                         var configLoader = new ConfigLoader(docsetPath, input, repositoryProvider);
 
-                        repositoryProvider.ConfigRestoreMap(restoreGitMap);
                         (errors, config) = configLoader.Load(options, extend: true);
 
                         // just return if config loading has errors
                         if (errorLog.Write(errors))
                             return;
 
-                        // get docsets(build docset, fallback docset and dependency docsets)
-                        repositoryProvider.Config(config);
                         var (docset, fallbackDocset) = GetDocsetWithFallback(docsetPath, locale, config, repositoryProvider, restoreGitMap);
-
-                        // TODO: clean up all the RepositoryProvider config methods
-                        if (fallbackDocset != null)
-                        {
-                            repositoryProvider.ConfigFallbackDocsetPath(fallbackDocset.DocsetPath);
-                        }
-
-                        if (!string.Equals(docset.DocsetPath, PathUtility.NormalizeFolder(docsetPath), PathUtility.PathComparison))
-                        {
-                            // entry docset is not the docset to build
-                            input = new Input(docset.DocsetPath, repositoryProvider);
-                        }
-                        var dependencyDocsets = LoadDependencies(docset, repositoryProvider);
 
                         // run build based on docsets
                         outputPath = outputPath ?? Path.Combine(docsetPath, docset.Config.Output.Path);
-                        await Run(docset, fallbackDocset, dependencyDocsets, options, errorLog, outputPath, input, repositoryProvider);
+                        await Run(docset, fallbackDocset, options, errorLog, outputPath, input, repositoryProvider);
                     }
                 }
                 catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
@@ -112,12 +97,10 @@ namespace Microsoft.Docs.Build
                     restoreGitMap,
                     currentDocset,
                     config,
-                    docsetSourceFolder,
                     currentDocset.Locale,
                     out var localizationDocset,
                     out var localizationRepository))
                 {
-                    repositoryProvider.ConfigLocalizationRepo(localizationDocset, localizationRepository);
                     return (new Docset(
                         localizationDocset,
                         currentDocset.Locale,
@@ -133,14 +116,13 @@ namespace Microsoft.Docs.Build
         private static async Task Run(
             Docset docset,
             Docset fallbackDocset,
-            Dictionary<string, (Docset, bool)> dependencyDocsets,
             CommandLineOptions options,
             ErrorLog errorLog,
             string outputPath,
             Input input,
             RepositoryProvider repositoryProvider)
         {
-            using (var context = new Context(outputPath, errorLog, docset, fallbackDocset, dependencyDocsets, input, repositoryProvider))
+            using (var context = new Context(outputPath, errorLog, docset, fallbackDocset, input, repositoryProvider))
             {
                 context.BuildQueue.Enqueue(context.BuildScope.Files);
 
@@ -244,23 +226,6 @@ namespace Microsoft.Docs.Build
             }
 
             return file.FilePath.Origin != FileOrigin.Fallback;
-        }
-
-        private static Dictionary<string, (Docset docset, bool inScope)> LoadDependencies(Docset docset, RepositoryProvider repositoryProvider)
-        {
-            var config = docset.Config;
-            var result = new Dictionary<string, (Docset docset, bool inScope)>(config.Dependencies.Count, PathUtility.PathComparer);
-
-            foreach (var (name, dependency) in config.Dependencies)
-            {
-                var (entry, repository) = repositoryProvider.GetRepositoryWithEntry(FileOrigin.Dependency, name);
-                if (!string.IsNullOrEmpty(entry))
-                {
-                    result.TryAdd(name, (new Docset(entry, docset.Locale, config, repository), dependency.IncludeInBuild));
-                }
-            }
-
-            return result;
         }
     }
 }

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Docs.Build
 
         private readonly Lazy<TableOfContentsMap> _tocMap;
 
-        public Context(string outputPath, ErrorLog errorLog, Docset docset, Docset fallbackDocset, Dictionary<string, (Docset docset, bool inScope)> dependencyDocsets, Input input, RepositoryProvider repositoryProvider)
+        public Context(string outputPath, ErrorLog errorLog, Docset docset, Docset fallbackDocset, Input input, RepositoryProvider repositoryProvider)
         {
             var restoreFileMap = new RestoreFileMap(input);
             DependencyMapBuilder = new DependencyMapBuilder();
@@ -55,9 +55,9 @@ namespace Microsoft.Docs.Build
             MicrosoftGraphCache = new MicrosoftGraphCache(docset.Config);
             MetadataProvider = new MetadataProvider(docset, Input, MicrosoftGraphCache, restoreFileMap);
             MonikerProvider = new MonikerProvider(docset, MetadataProvider, restoreFileMap);
-            BuildScope = new BuildScope(errorLog, Input, docset, fallbackDocset, dependencyDocsets, TemplateEngine, MonikerProvider);
+            BuildScope = new BuildScope(errorLog, Input, docset, fallbackDocset, TemplateEngine, MonikerProvider);
             GitHubUserCache = new GitHubUserCache(docset.Config);
-            GitCommitProvider = new GitCommitProvider();
+            GitCommitProvider = new GitCommitProvider(repositoryProvider);
             PublishModelBuilder = new PublishModelBuilder(outputPath, docset.Config);
             BookmarkValidator = new BookmarkValidator(errorLog, PublishModelBuilder);
             ContributionProvider = new ContributionProvider(Input, docset, fallbackDocset, GitHubUserCache, GitCommitProvider);
@@ -67,11 +67,6 @@ namespace Microsoft.Docs.Build
             LinkResolver = new LinkResolver(
                 docset,
                 fallbackDocset,
-                dependencyDocsets.
-                    ToDictionary(
-                        k => k.Key,
-                        v => v.Value.docset,
-                        PathUtility.PathComparer),
                 Input,
                 BuildScope,
                 BuildQueue,

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Docs.Build
             Document document, SourceInfo<string> authorName)
         {
             Debug.Assert(document != null);
-            var (repo, pathToRepo, commits) = _gitCommitProvider.GetCommitHistory(document);
+            var (repo, pathToRepo, commits) = _gitCommitProvider.GetCommitHistory(document.FilePath);
             if (repo is null)
             {
                 return default;
@@ -140,7 +140,7 @@ namespace Microsoft.Docs.Build
                 var contributionBranch = bilingual && LocalizationUtility.TryGetContributionBranch(repo.Branch, out var cBranch) ? cBranch : null;
                 if (!string.IsNullOrEmpty(contributionBranch))
                 {
-                    (_, _, result) = _gitCommitProvider.GetCommitHistory(document, contributionBranch);
+                    (_, _, result) = _gitCommitProvider.GetCommitHistory(document.FilePath, contributionBranch);
                 }
 
                 return result;
@@ -168,7 +168,7 @@ namespace Microsoft.Docs.Build
             Debug.Assert(document != null);
 
             var isWhitelisted = document.FilePath.Origin == FileOrigin.Default || document.FilePath.Origin == FileOrigin.Fallback;
-            var (repo, pathToRepo, commits) = _gitCommitProvider.GetCommitHistory(document);
+            var (repo, pathToRepo, commits) = _gitCommitProvider.GetCommitHistory(document.FilePath);
             if (repo is null)
                 return default;
 

--- a/src/docfx/cli/Docfx.cs
+++ b/src/docfx/cli/Docfx.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Docs.Build
                 });
 
                 options.Locale = options.Locale?.ToLowerInvariant();
-                return (command, workingDirectory, options);
+                return (command, Path.GetFullPath(workingDirectory), options);
             }
             catch (ArgumentSyntaxException ex)
             {

--- a/src/docfx/docset/Document.cs
+++ b/src/docfx/docset/Document.cs
@@ -94,13 +94,7 @@ namespace Microsoft.Docs.Build
         /// </summary>
         public bool IsPage { get; }
 
-        /// <summary>
-        /// Gets the repository
-        /// </summary>
-        public Repository Repository => _repository.Value;
-
         private readonly Lazy<(string docId, string versionIndependentId)> _id;
-        private readonly Lazy<Repository> _repository;
 
         /// <summary>
         /// Intentionally left as private. Use <see cref="Document.CreateFromFile(Docset, string)"/> instead.
@@ -134,7 +128,6 @@ namespace Microsoft.Docs.Build
             IsPage = isPage;
 
             _id = new Lazy<(string docId, string versionId)>(() => LoadDocumentId());
-            _repository = new Lazy<Repository>(() => Docset.GetRepository(FilePath.Path));
 
             Debug.Assert(IsValidRelativePath(FilePath.Path));
             Debug.Assert(IsValidRelativePath(SitePath));

--- a/src/docfx/docset/RepositoryProvider.cs
+++ b/src/docfx/docset/RepositoryProvider.cs
@@ -3,146 +3,128 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Diagnostics;
+using System.IO;
 
 namespace Microsoft.Docs.Build
 {
     internal class RepositoryProvider
     {
-        private readonly ConcurrentDictionary<(FileOrigin origin, string dependencyName), Lazy<(string docset, Repository repository)>> _dependencyRepositories
-            = new ConcurrentDictionary<(FileOrigin origin, string dependencyName), Lazy<(string docset, Repository repository)>>();
+        private readonly string _docsetPath;
+        private readonly Func<RestoreGitMap> _restoreMap;
+        private readonly Func<Config> _config;
+        private readonly Repository _docsetRepository;
+        private readonly Lazy<Repository> _fallbackRepository;
 
-        private string _locale;
-        private string _docset;
-        private string _fallbackDocsetPath;
-        private Repository _docsetRepository;
-        private Repository _fallbackRepository;
-        private RestoreGitMap _restoreGitMap;
-        private Config _config;
+        private readonly ConcurrentDictionary<string, Repository> _repositories = new ConcurrentDictionary<string, Repository>(PathUtility.PathComparer);
+        private readonly ConcurrentDictionary<string, Repository> _dependencyRepositories = new ConcurrentDictionary<string, Repository>(PathUtility.PathComparer);
 
-        public RepositoryProvider(string docsetPath, CommandLineOptions options)
+        public RepositoryProvider(string docsetPath, Func<Config> config, Func<RestoreGitMap> restoreMap)
         {
-            _docset = docsetPath;
-            _docsetRepository = Repository.Create(docsetPath);
-            _locale = LocalizationUtility.GetLocale(_docsetRepository, options);
-
-            _fallbackDocsetPath = default;
-            _fallbackRepository = default;
-            _restoreGitMap = default;
-            _config = default;
-        }
-
-        public void ConfigFallbackRepository(Repository fallbackRepository)
-        {
-            Debug.Assert(_fallbackRepository is null);
-
-            _fallbackDocsetPath = fallbackRepository.Path;
-            _fallbackRepository = fallbackRepository;
-        }
-
-        public void Config(Config config)
-        {
-            Debug.Assert(_config is null);
-
+            _restoreMap = restoreMap;
             _config = config;
+            _docsetPath = docsetPath;
+            _docsetRepository = GetRepository(docsetPath);
+            _fallbackRepository = new Lazy<Repository>(GetFallbackRepository);
         }
 
-        public void ConfigRestoreMap(RestoreGitMap restoreGitMap)
+        public (Repository repo, string pathToRepo) GetRepository(FilePath file)
         {
-            Debug.Assert(_fallbackRepository is null);
-            Debug.Assert(_restoreGitMap is null);
-            Debug.Assert(restoreGitMap != null);
+            switch (file.Origin)
+            {
+                case FileOrigin.Fallback:
+                case FileOrigin.Default:
+                    var fullPath = Path.Combine(_docsetPath, file.Path).Replace('\\', '/');
+                    var repo = GetRepository(fullPath);
+                    var pathToRepo = Path.GetRelativePath(repo.Path, fullPath).Replace('\\', '/');
+                    return (file.Origin == FileOrigin.Default ? repo : _fallbackRepository.Value, pathToRepo);
 
-            _restoreGitMap = restoreGitMap;
-            _fallbackRepository = GetFallbackRepository(_docsetRepository, restoreGitMap);
-            _fallbackDocsetPath = _fallbackRepository?.Path;
-        }
+                case FileOrigin.Dependency:
+                    return (GetRepository(file.Origin, file.DependencyName), file.GetPathToOrigin());
 
-        public void ConfigLocalizationRepo(string localizationDocsetPath, Repository localizationRepository)
-        {
-            Debug.Assert(_fallbackRepository is null);
-
-            _fallbackDocsetPath = _docset;
-            _fallbackRepository = _docsetRepository;
-            _docset = localizationDocsetPath;
-            _docsetRepository = localizationRepository;
-        }
-
-        public void ConfigFallbackDocsetPath(string docsetPath)
-        {
-            _fallbackDocsetPath = docsetPath;
+                default:
+                    throw new NotSupportedException();
+            }
         }
 
         public Repository GetRepository(FileOrigin origin, string dependencyName = null)
         {
-            return GetRepositoryWithEntry(origin, dependencyName).repository;
-        }
-
-        public (string entry, Repository repository) GetRepositoryWithEntry(FileOrigin origin, string dependencyName = null)
-        {
             switch (origin)
             {
-                case FileOrigin.Redirection:
                 case FileOrigin.Default:
-                    return (_docset, _docsetRepository);
+                    return _docsetRepository;
 
                 case FileOrigin.Fallback:
-                    return (_fallbackDocsetPath, _fallbackRepository);
+                    return _fallbackRepository.Value;
 
-                case FileOrigin.Template when _config != null && _restoreGitMap != null:
-                    return _dependencyRepositories.GetOrAdd((origin, dependencyName), _ =>
-                    new Lazy<(string docset, Repository repository)>(() =>
+                case FileOrigin.Template:
                     {
-                        var theme = LocalizationUtility.GetLocalizedTheme(_config.Template, _locale, _config.Localization.DefaultLocale);
+                        // localized template
+                        var config = _config() ?? throw new InvalidOperationException();
+                        return GetRepository(config.Template, bare: false);
+                    }
 
-                        var (templatePath, templateCommit) = _restoreGitMap.GetRestoreGitPath(theme, false);
-
-                        if (theme.Type != PackageType.Git)
-                        {
-                            // point to a folder
-                            return (templatePath, null);
-                        }
-
-                        return (templatePath, Repository.Create(templatePath, theme.Branch, theme.Url, templateCommit));
-                    })).Value;
-
-                case FileOrigin.Dependency when _config != null && _restoreGitMap != null && dependencyName != null:
-                    return _dependencyRepositories.GetOrAdd((origin, dependencyName), _ =>
-                    new Lazy<(string docset, Repository repository)>(() =>
+                case FileOrigin.Dependency when _config != null && _restoreMap != null && dependencyName != null:
+                    return _dependencyRepositories.GetOrAdd(dependencyName, _ =>
                     {
-                        var dependency = _config.Dependencies[dependencyName];
-                        var (dependencyPath, dependencyCommit) = _restoreGitMap.GetRestoreGitPath(dependency, bare: true);
-
-                        if (dependency.Type != PackageType.Git)
-                        {
-                            // point to a folder
-                            return (dependencyPath, null);
-                        }
-
-                        return (dependencyPath, Repository.Create(dependencyPath, dependency.Branch, dependency.Url, dependencyCommit));
-                    })).Value;
+                        var config = _config() ?? throw new InvalidOperationException();
+                        return GetRepository(config.Dependencies[dependencyName], bare: true);
+                    });
             }
 
-            throw new InvalidOperationException();
+            throw new NotSupportedException();
         }
 
-        private static Repository GetFallbackRepository(
-            Repository repository,
-            RestoreGitMap restoreGitMap)
+        public Repository GetRepository(string url, string branch, bool bare)
         {
-            if (LocalizationUtility.TryGetFallbackRepository(repository, out var fallbackRemote, out var fallbackBranch, out _))
+            var restoreMap = _restoreMap() ?? throw new InvalidOperationException();
+            var (path, commit) = restoreMap.GetRestoreGitPath(url, branch, bare);
+
+            return Repository.Create(path, branch, url, commit);
+        }
+
+        private Repository GetRepository(PackagePath packagePath, bool bare)
+        {
+            switch (packagePath.Type)
             {
+                case PackageType.Git:
+                    return GetRepository(packagePath.Url, packagePath.Branch, bare);
+
+                default:
+                    // TODO: can also lookup repository for folder
+                    return null;
+            }
+        }
+
+        private Repository GetFallbackRepository()
+        {
+            if (LocalizationUtility.TryGetFallbackRepository(_docsetRepository, out var fallbackRemote, out var fallbackBranch, out _))
+            {
+                var restoreMap = _restoreMap() ?? throw new InvalidOperationException();
+
                 foreach (var branch in new[] { fallbackBranch, "master" })
                 {
-                    if (restoreGitMap.IsBranchRestored(fallbackRemote, branch))
+                    if (restoreMap.IsBranchRestored(fallbackRemote, branch))
                     {
-                        var (fallbackRepoPath, fallbackRepoCommit) = restoreGitMap.GetRestoreGitPath(new PackagePath(fallbackRemote, branch), bare: false);
-                        return Repository.Create(fallbackRepoPath, branch, fallbackRemote, fallbackRepoCommit);
+                        var (path, commit) = restoreMap.GetRestoreGitPath(fallbackRemote, branch, bare: false);
+                        return Repository.Create(path, branch, fallbackRemote, commit);
                     }
                 }
             }
 
             return default;
+        }
+
+        private Repository GetRepository(string fullPath)
+        {
+            if (GitUtility.IsRepo(fullPath))
+            {
+                return Repository.Create(fullPath, EnvironmentVariable.RepositoryBranch, EnvironmentVariable.RepositoryUrl);
+            }
+
+            var parent = PathUtility.NormalizeFile(Path.GetDirectoryName(fullPath));
+            return !string.IsNullOrEmpty(parent)
+                ? _repositories.GetOrAdd(parent, GetRepository)
+                : null;
         }
     }
 }

--- a/src/docfx/docset/RepositoryProvider.cs
+++ b/src/docfx/docset/RepositoryProvider.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Docs.Build
                 return Repository.Create(fullPath, EnvironmentVariable.RepositoryBranch, EnvironmentVariable.RepositoryUrl);
             }
 
-            var parent = PathUtility.NormalizeFile(Path.GetDirectoryName(fullPath));
+            var parent = PathUtility.NormalizeFile(Path.GetDirectoryName(fullPath) ?? "");
             return !string.IsNullOrEmpty(parent)
                 ? _repositories.GetOrAdd(parent, GetRepository)
                 : null;

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -255,6 +255,8 @@ namespace Microsoft.Docs.Build
 
         public static unsafe byte[] ReadBytes(string repoPath, string filePath, string committish)
         {
+            Debug.Assert(committish != null);
+
             if (git_repository_open(out var repo, repoPath) != 0)
             {
                 return null;

--- a/src/docfx/lib/git/Repository.cs
+++ b/src/docfx/lib/git/Repository.cs
@@ -26,18 +26,10 @@ namespace Microsoft.Docs.Build
         }
 
         /// <summary>
-        /// Create repository from environment variable(remote + branch), fallback to git info if they are not set
-        /// </summary>
-        public static Repository Create(string path)
-        {
-            return Create(path, EnvironmentVariable.RepositoryBranch, EnvironmentVariable.RepositoryUrl);
-        }
-
-        /// <summary>
-        /// Repository's branch info ashould NOT depend on git, unless you are pretty sure about that
+        /// Repository's branch info should NOT depend on git, unless you are pretty sure about that
         /// Repository's url can also be overwritten
         /// </summary>
-        public static Repository Create(string path, string branch, string repoUrl = null, string commit = null)
+        public static Repository Create(string path, string branch = null, string repoUrl = null, string commit = null)
         {
             Debug.Assert(!string.IsNullOrEmpty(path));
 

--- a/src/docfx/localization/LocalizationUtility.cs
+++ b/src/docfx/localization/LocalizationUtility.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Docs.Build
             return (newRemote, newBranch);
         }
 
-        public static bool TryGetLocalizationDocset(RestoreGitMap restoreGitMap, Docset docset, Config config, string docsetSourceFolder, string locale, out string localizationDocsetPath, out Repository localizationRepository)
+        public static bool TryGetLocalizationDocset(RestoreGitMap restoreGitMap, Docset docset, Config config, string locale, out string localizationDocsetPath, out Repository localizationRepository)
         {
             Debug.Assert(docset != null);
             Debug.Assert(!string.IsNullOrEmpty(locale));
@@ -73,8 +73,8 @@ namespace Microsoft.Docs.Build
                             repo.Branch,
                             locale,
                             config.Localization.DefaultLocale);
-                        var (locRepoPath, locCommit) = restoreGitMap.GetRestoreGitPath(new PackagePath(locRemote, locBranch), false);
-                        localizationDocsetPath = PathUtility.NormalizeFolder(Path.Combine(locRepoPath, docsetSourceFolder));
+                        var (locRepoPath, locCommit) = restoreGitMap.GetRestoreGitPath(locRemote, locBranch, false);
+                        localizationDocsetPath = locRepoPath;
                         localizationRepository = Repository.Create(locRepoPath, locBranch, locRemote, locCommit);
                         break;
                     }

--- a/src/docfx/template/TemplateEngine.cs
+++ b/src/docfx/template/TemplateEngine.cs
@@ -141,15 +141,17 @@ namespace Microsoft.Docs.Build
 
         public static TemplateEngine Create(Docset docset, RepositoryProvider repositoryProvider)
         {
-            Debug.Assert(docset != null);
-
-            if (docset.Config.Template.Type == PackageType.None)
+            switch (docset.Config.Template.Type)
             {
-                return new TemplateEngine(Path.Combine(docset.DocsetPath, DefaultTemplateDir));
-            }
+                case PackageType.Folder:
+                    return new TemplateEngine(Path.Combine(docset.DocsetPath, docset.Config.Template.Path));
 
-            var (templateEntry, _) = repositoryProvider.GetRepositoryWithEntry(FileOrigin.Template);
-            return new TemplateEngine(templateEntry);
+                case PackageType.Git:
+                    return new TemplateEngine(repositoryProvider.GetRepository(FileOrigin.Template).Path);
+
+                default:
+                    return new TemplateEngine(Path.Combine(docset.DocsetPath, DefaultTemplateDir));
+            }
         }
 
         private JObject LoadGlobalTokens()

--- a/test/docfx.Test/DocfxTest.cs
+++ b/test/docfx.Test/DocfxTest.cs
@@ -132,24 +132,10 @@ namespace Microsoft.Docs.Build
                 throw new TestSkippedException("Skip watch tests");
             }
 
-            if (!test.Summary.Contains("[from loc]", StringComparison.OrdinalIgnoreCase))
-            {
-                await RunBuild(docsetPath, outputPath, spec, spec.Locale);
-            }
-
-            // Verify build from localization docset also work
-            if (spec.Locale != null)
-            {
-                var locDocsetPath = t_repos.Value.FirstOrDefault(
-                    repo => repo.Key.EndsWith($".{spec.Locale}") || repo.Key.EndsWith(".loc")).Value;
-                if (locDocsetPath != null)
-                {
-                    await RunBuild(locDocsetPath, outputPath, spec, locale: null);
-                }
-            }
+            await RunBuild(docsetPath, outputPath, spec);
         }
 
-        private static async Task RunBuild(string docsetPath, string outputPath, DocfxTestSpec spec, string locale)
+        private static async Task RunBuild(string docsetPath, string outputPath, DocfxTestSpec spec)
         {
             Directory.CreateDirectory(outputPath);
             Directory.Delete(outputPath, recursive: true);
@@ -159,7 +145,7 @@ namespace Microsoft.Docs.Build
 
             using (TestUtility.EnsureFilesNotChanged(docsetPath))
             {
-                var options = $"{(spec.Legacy ? "--legacy" : "")} {(locale != null ? $"--locale {locale}" : "")}"
+                var options = $"{(spec.Legacy ? "--legacy" : "")}"
                     .Split(' ', StringSplitOptions.RemoveEmptyEntries)
                     .Concat(new[] { "--output", outputPath })
                     .ToArray();

--- a/test/docfx.Test/DocfxTestSpec.cs
+++ b/test/docfx.Test/DocfxTestSpec.cs
@@ -21,8 +21,6 @@ namespace Microsoft.Docs.Build
 
         public bool Legacy { get; set; }
 
-        public string Locale { get; set; }
-
         public string[] Environments { get; set; } = Array.Empty<string>();
 
         public Dictionary<string, TestGitCommit[]> Repos { get; set; } = new Dictionary<string, TestGitCommit[]>();

--- a/test/docfx.Test/build/TocTest.cs
+++ b/test/docfx.Test/build/TocTest.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Docs.Build
     public static class TocTest
     {
         private static readonly string s_docsetPath = Directory.GetCurrentDirectory();
-        private static readonly RepositoryProvider s_repositoryProvider = new RepositoryProvider(s_docsetPath, new CommandLineOptions());
-        private static readonly Input s_input = new Input(s_docsetPath, s_repositoryProvider);
+        private static readonly RepositoryProvider s_repositoryProvider = new RepositoryProvider(s_docsetPath, () => null, () => null);
+        private static readonly Input s_input = new Input(s_docsetPath, () => null, s_repositoryProvider);
         private static readonly Config s_config = JsonUtility.Deserialize<Config>("{'output': { 'json': true } }".Replace('\'', '\"'), null);
         private static readonly Docset s_docset = new Docset(Directory.GetCurrentDirectory(), "en-us", s_config, null);
 

--- a/test/docfx.Test/lib/GitUtilityTest.cs
+++ b/test/docfx.Test/lib/GitUtilityTest.cs
@@ -35,13 +35,13 @@ namespace Microsoft.Docs.Build
             var repo = Repository.Create(Path.GetFullPath(file), branch: null);
             Assert.NotNull(repo);
 
-            using (var gitCommitProvider = new GitCommitProvider())
+            using (var gitCommitProvider = new FileCommitProvider(repo, "get-commits-test"))
             {
                 var pathToRepo = PathUtility.NormalizeFile(file);
 
                 // current branch
                 var exe = Exec("git", $"--no-pager log --format=\"%H|%cI|%an|%ae\" -- \"{pathToRepo}\"", repo.Path);
-                var (_, _, lib) = gitCommitProvider.GetCommitHistory(Path.Combine(repo.Path, pathToRepo), repo);
+                var lib = gitCommitProvider.GetCommitHistory(pathToRepo);
 
                 Assert.Equal(
                     exe.Replace("\r", ""),
@@ -49,7 +49,7 @@ namespace Microsoft.Docs.Build
 
                 // another branch
                 exe = Exec("git", $"--no-pager log --format=\"%H|%cI|%an|%ae\" a050eaf -- \"{pathToRepo}\"", repo.Path);
-                (_, _, lib) = gitCommitProvider.GetCommitHistory(Path.Combine(repo.Path, pathToRepo), repo, "a050eaf");
+                lib = gitCommitProvider.GetCommitHistory(pathToRepo, "a050eaf");
 
                 Assert.Equal(
                     exe.Replace("\r", ""),

--- a/test/docfx.Test/restore/RestoreTest.cs
+++ b/test/docfx.Test/restore/RestoreTest.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
-using YamlDotNet.Helpers;
 
 namespace Microsoft.Docs.Build
 {
@@ -22,7 +21,7 @@ namespace Microsoft.Docs.Build
         [InlineData(@"'https://github.com/dotnet/docfx#a\\b/d<e>f*h|i%3C'", PackageType.Git, "https://github.com/dotnet/docfx", @"a\b/d<e>f*h|i%3C", null)]
         [InlineData("{'url': 'https://github.com/dotnet/docfx#unused', 'branch': 'used'}", PackageType.Git, "https://github.com/dotnet/docfx", "used", null)]
         [InlineData("{'url': 'crr/local-path'}", PackageType.Folder, "crr/local-path", null, "crr/local-path")]
-        public static void PackageUrlTest(
+        public static void PackagePathTest(
             string json,
             PackageType expectedPackageType,
             string expectedUrl,
@@ -52,8 +51,7 @@ namespace Microsoft.Docs.Build
             var url = "https://raw.githubusercontent.com/docascode/docfx-test-dependencies-clean/master/README.md";
             var restoreDir = AppData.GetFileDownloadDir(url);
 
-            File.WriteAllText(Path.Combine(docsetPath, "docfx.yml"), $@"
-monikerDefinition: {url}");
+            File.WriteAllText(Path.Combine(docsetPath, "docfx.yml"), $@"monikerDefinition: {url}");
 
             // run restore
             await Docfx.Run(new[] { "restore", docsetPath });


### PR DESCRIPTION
To drop docset, the first step is to consoldiate `RepositoryProvider`. This is the public interface of `RepositoryProvider` I am targeting in this PR:

```csharp
class RepositoryProvider
{
    // For any given file, return the associated git repository
    // and the path to that repository, or default if there is no repository
    (Repository repo, string pathToRepo) GetRepository(FilePath file)

    // Gets the main, fallback, template or dependency repository,
    // or null if there is no repository
    Repository GetRepository(FileOrigin origin, string dependencyName = null)

    // Gets the repository directly from repository url and branch,
    // with a `bare` flag indicating whether the repository is checked out or bare
    // because some repos are bare, some others are checked out at this stage
    //
    // This method seems to duplicate with `RestoreGitMap.GetRestoreGitPath`, 
    // so I putting it here temporally
    Repository GetRepository(string url, string branch, bool bare)
}
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5215)