### PR TITLE
remove source base path

### DIFF
--- a/docs/specs/metadata.yml
+++ b/docs/specs/metadata.yml
@@ -73,18 +73,13 @@ outputs:
 # document id = md5("Win.sccm|mdt/release-notes.md")
 # version independent id = md5("Win.sccm|mdt/release-notes")
 inputs:
-  docfx.yml: |
-    documentId:
-      sourceBasePath: sccm
+  sccm/docfx.yml: |
     name: sccm
     product: Win
-    files: sccm/**/*
     baseUrl: https://docs.com/sccm
-    routes:
-      sccm/: .
   sccm/mdt/release-notes.md:
 outputs:
-  sccm/mdt/release-notes.json: |
+  sccm/sccm/mdt/release-notes.json: |
     { "document_id": "0b1c8a5d-b639-d555-0850-b98a9010023c", "document_version_independent_id": "b20fdb1c-8d40-c3b2-2265-779a3f2dfe98", "depot_name": "Win.sccm" }
 ---
 # generate index document id and version id
@@ -92,105 +87,90 @@ outputs:
 # document id = md5("Win.sccm|index.md") || md5("Win.sccm|mdm/index.md")
 # version independent id = md5("Win.sccm|index") || md5("Win.sccm|mdm/index")
 inputs:
-  docfx.yml: |
-    documentId:
-      sourceBasePath: sccm
+  sccm/docfx.yml: |
     name: sccm
     product: Win
     files: "**/*"
     baseUrl: https://docs.com/sccm
-    routes:
-      sccm/: .
   sccm/mdm/index.md:
   sccm/index.md:
 outputs:
-  sccm/index.json: |
+  sccm/sccm/index.json: |
     { "document_id": "29602e3e-439e-865c-f1c9-2eb706f97b31", "document_version_independent_id": "34196fc5-28d6-b496-a21f-8661876802c7" }
-  sccm/mdm/index.json: |
+  sccm/sccm/mdm/index.json: |
     { "document_id": "1c42a151-6248-df0c-15e6-3b1158d7bee3", "document_version_independent_id": "beb14a44-b076-14b8-b9c5-b42f9e36b973" }
 ---
 # generate same document id and version id with 'redirection with document id'
 # A => B, B's ids should be same with A's
 inputs:
-  docfx.yml: |
-    documentId:
-      sourceBasePath: docs/
+  docs/docfx.yml: |
     baseUrl: https://docs.com/docs
     routes:
       docs/: .
     redirections:
-      docs/a.md: /docs/x
-      docs/b.md: /docs/y?query=value#bookmark
-      docs/c.md: /docs/folder1/index
-      docs/d.md: /docs/folder2/
-      docs/e.md: /docs/z
-      docs/f.md: /docs/e
+      a.md: /docs/x
+      b.md: /docs/y?query=value#bookmark
+      c.md: /docs/folder1/index
+      d.md: /docs/folder2/
+      e.md: /docs/z
+      f.md: /docs/e
   docs/x.md:
   docs/y.md:
   docs/z.md:
   docs/folder1/index.md:
   docs/folder2/index.md:
 outputs:
-  docs/x.json: |
+  docs/docs/x.json: |
     { "document_id": "780484e9-a367-97ab-ba7d-a19f3b378a80", "document_version_independent_id": "e9b3f4e2-1a78-4b5d-fbb4-03e0a33e38f5" }
-  docs/y.json: |
+  docs/docs/y.json: |
     { "document_id": "746406e9-2aac-1b22-259a-b6712b49c610", "document_version_independent_id": "d93f906b-e1e0-e950-45b4-ce1e777af3e6" }
-  docs/z.json: |
+  docs/docs/z.json: |
     { "document_id": "3c1b64b6-2acf-2a8d-0b02-687e4c6751b6", "document_version_independent_id": "b7faa2da-5935-b5fb-4609-dd030b0e74ab" }
-  docs/folder1/index.json: |
+  docs/docs/folder1/index.json: |
     { "document_id": "fdb5a0d7-b68e-c465-9c5e-54a5cda94902", "document_version_independent_id": "92a5a770-f05f-b8bb-81c9-a8d786a9e608" }
-  docs/folder2/index.json: |
+  docs/docs/folder2/index.json: |
     { "document_id": "64dd67d2-325f-bc70-d1b3-0106d0cb71e3", "document_version_independent_id": "5f485788-9aee-232c-f1f0-66c205d6e9a9" }
 ---
 # generate different document id and version id with 'redirection without document id'
 inputs:
-  docfx.yml: |
-    documentId:
-      sourceBasePath: sccm
+  sccm/docfx.yml: |
     name: sccm
     product: Win
     files: "**/*"
     baseUrl: https://docs.com/sccm
-    routes:
-      sccm/: .
     redirectionsWithoutId:
       sccm/mdm/index.md: /sccm/mdm/understand/hybrid-mobile-device-management
   sccm/mdm/understand/hybrid-mobile-device-management.md:
 outputs:
-  sccm/mdm/understand/hybrid-mobile-device-management.json: |
+  sccm/sccm/mdm/understand/hybrid-mobile-device-management.json: |
     { "document_id": "7412621b-4920-dc7e-bed6-1f1ea774f7dd", "document_version_independent_id": "de5d1641-2c0e-1158-7611-e52a22d96a5e" }
 ---
 # redirect with document id resolve relative redirect_url
 # publish item's redirect_url keeps user's input
 inputs:
-  docfx.yml: |
-    documentId:
-      sourceBasePath: develop
+  develop/docfx.yml: |
     name: partner-center-sdk
     product: MSDN
-    files: "develop/**/*"
     baseUrl: https://docs.com/partner-center-sdk
-    routes:
-      develop/: .
     redirections:
-      develop/agreement-metadata.md: agreement-metadata-resources
+      agreement-metadata.md: agreement-metadata-resources
   develop/agreement-metadata-resources.md:
 outputs:
-  partner-center-sdk/agreement-metadata-resources.json: |
+  develop/partner-center-sdk/agreement-metadata-resources.json: |
     { "document_id": "ad740933-6e60-291e-14ba-8a4e81133047", "document_version_independent_id": "e8a46a09-153a-2eac-1bd0-0aad104a6616" }
-  .publish.json: |
+  develop/.publish.json: |
     {
       "files": [
           {
               "url": "/partner-center-sdk/agreement-metadata",
-              "source_path": "develop/agreement-metadata.md",
+              "source_path": "agreement-metadata.md",
               "locale": "en-us",
               "redirect_url": "/partner-center-sdk/agreement-metadata-resources"
           },
           {
               "url": "/partner-center-sdk/agreement-metadata-resources",
               "path": "partner-center-sdk/agreement-metadata-resources.json",
-              "source_path": "develop/agreement-metadata-resources.md",
+              "source_path": "agreement-metadata-resources.md",
               "locale": "en-us"
           }
       ]
@@ -198,24 +178,20 @@ outputs:
 ---
 # Show warning if two or more files redirect to the same file with document id
 inputs:
-  docfx.yml: |
-    documentId:
-      sourceBasePath: sccm
+  sccm/docfx.yml: |
     name: sccm
     product: Win
     files: "**/*"
     baseUrl: https://docs.com/sccm
-    routes:
-      sccm/: .
     redirections:
-      sccm/mdm/index.md: /sccm/mdm/understand/hybrid-mobile-device-management
-      sccm/mdm/index2.md: /sccm/mdm/understand/hybrid-mobile-device-management
+      mdm/index.md: /sccm/mdm/understand/hybrid-mobile-device-management
+      mdm/index2.md: /sccm/mdm/understand/hybrid-mobile-device-management
   sccm/mdm/understand/hybrid-mobile-device-management.md:
 outputs:
-  sccm/mdm/understand/hybrid-mobile-device-management.json: |
+  sccm/sccm/mdm/understand/hybrid-mobile-device-management.json: |
     { "document_id": "1c42a151-6248-df0c-15e6-3b1158d7bee3", "document_version_independent_id": "beb14a44-b076-14b8-b9c5-b42f9e36b973" }
-  .errors.log: |
-    ["warning","redirection-url-conflict","The '/sccm/mdm/understand/hybrid-mobile-device-management' appears twice or more in the redirection mappings","docfx.yml",11,23]
+  sccm/.errors.log: |
+    ["warning","redirection-url-conflict","The '/sccm/mdm/understand/hybrid-mobile-device-management' appears twice or more in the redirection mappings","docfx.yml",7,18]
 ---
 # redirect to empty URL
 inputs:

--- a/src/docfx/build/legacy/LegacyAggregatedFileMap.cs
+++ b/src/docfx/build/legacy/LegacyAggregatedFileMap.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Docs.Build
                     type = fileMapItem.Type,
                 };
 
-                aggregatedFileMapItems.Add((legacyFilePathRelativeToBaseFolder,aggregatedFileMapItem));
+                aggregatedFileMapItems.Add((legacyFilePathRelativeToBaseFolder, aggregatedFileMapItem));
             }
 
             context.Output.WriteJson(

--- a/src/docfx/build/legacy/LegacyAggregatedFileMap.cs
+++ b/src/docfx/build/legacy/LegacyAggregatedFileMap.cs
@@ -33,10 +33,8 @@ namespace Microsoft.Docs.Build
                                     ? dependencyMap[legacyFilePathRelativeToBaseFolder].Select(
                                         x => new DependencyItem
                                         {
-                                            FromFilePath = PathUtility.NormalizeFile(
-                                                Path.Combine(docset.Config.DocumentId.SourceBasePath, x.From)),
-                                            ToFilePath = PathUtility.NormalizeFile(
-                                                Path.Combine(docset.Config.DocumentId.SourceBasePath, x.To)),
+                                            FromFilePath = x.From,
+                                            ToFilePath = x.To,
                                             DependencyType = x.Type,
                                             Version = x.Version,
                                         })
@@ -47,9 +45,7 @@ namespace Microsoft.Docs.Build
                     type = fileMapItem.Type,
                 };
 
-                aggregatedFileMapItems.Add(
-                    (PathUtility.NormalizeFile(Path.Combine(docset.Config.DocumentId.SourceBasePath, legacyFilePathRelativeToBaseFolder)),
-                    aggregatedFileMapItem));
+                aggregatedFileMapItems.Add((legacyFilePathRelativeToBaseFolder,aggregatedFileMapItem));
             }
 
             context.Output.WriteJson(
@@ -62,7 +58,7 @@ namespace Microsoft.Docs.Build
                         [docset.Config.Name] = new
                         {
                             docset_name = docset.Config.Name,
-                            docset_path_to_root = docset.Config.DocumentId.SourceBasePath.TrimStart(new char[] { '.', '/', '\\' }),
+                            docset_path_to_root = string.Empty,
                         },
                     },
                 }, "op_aggregated_file_map_info.json");

--- a/src/docfx/build/legacy/LegacyDependencyMap.cs
+++ b/src/docfx/build/legacy/LegacyDependencyMap.cs
@@ -40,8 +40,8 @@ namespace Microsoft.Docs.Build
                         {
                             legacyDependencyMap.Add(new LegacyDependencyMapItem
                             {
-                                From = $"~/{document.ToLegacyPathRelativeToBasePath(docset)}",
-                                To = $"~/{toc.ToLegacyPathRelativeToBasePath(docset)}",
+                                From = $"~/{document.FilePath.Path}",
+                                To = $"~/{toc.FilePath.Path}",
                                 Type = LegacyDependencyMapType.Metadata,
                                 Version = legacyVersionProvider.GetLegacyVersion(document),
                             });
@@ -59,8 +59,8 @@ namespace Microsoft.Docs.Build
 
                         legacyDependencyMap.Add(new LegacyDependencyMapItem
                         {
-                            From = $"~/{source.ToLegacyPathRelativeToBasePath(docset)}",
-                            To = $"~/{dependencyItem.To.ToLegacyPathRelativeToBasePath(docset)}",
+                            From = $"~/{source.FilePath.Path}",
+                            To = $"~/{dependencyItem.To.FilePath.Path}",
                             Type = dependencyItem.Type.ToLegacyDependencyMapType(),
                             Version = legacyVersionProvider.GetLegacyVersion(source),
                         });
@@ -77,10 +77,8 @@ namespace Microsoft.Docs.Build
                     select JsonUtility.Serialize(new
                     {
                         dependency_type = dep.Type,
-                        from_file_path = Path.GetFullPath(
-                            Path.Combine(docset.DocsetPath, docset.Config.DocumentId.SourceBasePath, dep.From.Substring(2))),
-                        to_file_path = Path.GetFullPath(
-                            Path.Combine(docset.DocsetPath, docset.Config.DocumentId.SourceBasePath, dep.To.Substring(2))),
+                        from_file_path = Path.GetFullPath(Path.Combine(docset.DocsetPath, dep.From.Substring(2))),
+                        to_file_path = Path.GetFullPath(Path.Combine(docset.DocsetPath, dep.To.Substring(2))),
                         version = dep.Version,
                     });
 

--- a/src/docfx/build/legacy/LegacyFileMap.cs
+++ b/src/docfx/build/legacy/LegacyFileMap.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Docs.Build
                             fileManifest.Value.Monikers);
                         if (fileItem != null)
                         {
-                            listBuilder.Add((PathUtility.NormalizeFile(document.ToLegacyPathRelativeToBasePath(docset)), fileItem));
+                            listBuilder.Add((document.FilePath.Path, fileItem));
                         }
                     });
 
@@ -62,7 +62,7 @@ namespace Microsoft.Docs.Build
                     host = docset.HostName,
                     locale = docset.Locale,
                     base_path = $"/{docset.SiteBasePath}",
-                    source_base_path = docset.Config.DocumentId.SourceBasePath,
+                    source_base_path = ".",
                     version_info = new { },
                     from_docfx_v3 = true,
                     file_mapping = items.OrderBy(item => item.path).ToDictionary(

--- a/src/docfx/build/legacy/LegacyUtility.cs
+++ b/src/docfx/build/legacy/LegacyUtility.cs
@@ -8,11 +8,6 @@ namespace Microsoft.Docs.Build
 {
     internal static class LegacyUtility
     {
-        public static string ToLegacyPathRelativeToBasePath(this Document doc, Docset docset)
-        {
-            return PathUtility.NormalizeFile(Path.GetRelativePath(docset.Config.DocumentId.SourceBasePath, doc.FilePath.Path));
-        }
-
         public static string ToLegacyOutputPathRelativeToSiteBasePath(this Document doc, Docset docset, PublishItem manifestItem)
         {
             var outputPath = manifestItem.Path;

--- a/src/docfx/build/legacy/manifest/LegacyManifest.cs
+++ b/src/docfx/build/legacy/manifest/LegacyManifest.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Docs.Build
                         {
                             AssetId = legacySiteUrlRelativeToSiteBasePath,
                             Original = fileManifest.Value.SourcePath,
-                            SourceRelativePath = document.ToLegacyPathRelativeToBasePath(docset),
+                            SourceRelativePath = document.FilePath.Path,
                             OriginalType = GetOriginalType(document.ContentType),
                             Type = GetType(document.ContentType, document),
                             Output = output,
@@ -124,7 +124,7 @@ namespace Microsoft.Docs.Build
                     files = convertedItems
                         .OrderBy(f => f.manifestItem.AssetId + f.manifestItem.SourceRelativePath).Select(f => f.manifestItem),
                     is_already_processed = true,
-                    source_base_path = docset.Config.DocumentId.SourceBasePath,
+                    source_base_path = ".",
                     version_info = new { },
                     items_to_publish = itemsToPublish,
                 },

--- a/src/docfx/config/DocumentIdConfig.cs
+++ b/src/docfx/config/DocumentIdConfig.cs
@@ -9,12 +9,6 @@ namespace Microsoft.Docs.Build
     internal sealed class DocumentIdConfig
     {
         /// <summary>
-        /// For backward compatibility, the source path prefix
-        /// Used for resolving docId in <see cref="Document.LoadDocumentId()"/>
-        /// </summary>
-        public readonly string SourceBasePath = ".";
-
-        /// <summary>
         /// The mappings between depot and files/directory
         /// Used for backward compatibility
         /// </summary>

--- a/src/docfx/docset/Document.cs
+++ b/src/docfx/docset/Document.cs
@@ -382,7 +382,7 @@ namespace Microsoft.Docs.Build
 
         private (string docId, string versionIndependentId) LoadDocumentId()
         {
-            var sourcePath = PathUtility.NormalizeFile(Path.GetRelativePath(Docset.Config.DocumentId.SourceBasePath, FilePath.Path));
+            var sourcePath = FilePath.Path;
 
             var (mappedDepotName, mappedSourcePath) = Docset.Config.DocumentId.GetMapping(sourcePath);
 


### PR DESCRIPTION
it's always '.' in docset, all relative|combile operation can be removed
document id can use filePath directly

[DevOps#132567](https://dev.azure.com/ceapex/Engineering/_workitems/edit/132567)
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5216)