### PR TITLE
fix: image missing when cardsD don't have image href

### DIFF
--- a/src/Microsoft.Docs.Template/Views/Template/BuildItemListPartial.cshtml
+++ b/src/Microsoft.Docs.Template/Views/Template/BuildItemListPartial.cshtml
@@ -155,6 +155,10 @@ else if (Model.Style == "cards")
                                                         <img alt="@listItem?.Image?.Alt" src="@listItem?.Image?.Src">
                                                     </a>
                                                 }
+                                                else if(!string.IsNullOrEmpty(listItem?.Image?.Src))
+                                                {
+                                                    <img alt="@listItem?.Image?.Alt" src="@listItem?.Image?.Src">
+                                                }
                                             </div>
                                         </div>
                                     }


### PR DESCRIPTION
comparing with v2, if the cardsD items don't have image href instead of image src, we still need to show the image here.
https://ceapex.visualstudio.com/Engineering/_workitems/edit/132823

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5217)