### PR TITLE
support multiple docset for localization

### DIFF
--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -1395,3 +1395,27 @@ repos:
         b.md: '[](a.md#invalid-bookmark)'
 outputs:
   b.json:
+---
+# Loc with not repo root config
+enableMultipleDocSetForLocalization: true
+locale: zh-cn
+repos:
+  https://docs.com/config-not-root#test:
+    - files:
+        docs/docfx.yml:
+        docs/c/b.md: |
+          test
+  https://docs.com/config-not-root#master:
+    - files:
+        docs/docfx.yml:
+        docs/c/b.md: |
+          master
+  https://docs.com/config-not-root.zh-cn#test:
+    - files:
+        docs/docfx.yml:
+        docs/a.md: |
+          [!include[](./c/b.md)]
+outputs:
+  docs/a.json: |
+    { "conceptual":"<p>test</p>"}
+

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -100,10 +100,12 @@ namespace Microsoft.Docs.Build
                 }
 
                 // todo: get localization repository from repository provider
+                var docsetSourceFolder = Path.GetRelativePath(currentDocset.Repository.Path, currentDocset.DocsetPath);
                 if (LocalizationUtility.TryGetLocalizationDocset(
                     restoreGitMap,
                     currentDocset,
                     config,
+                    docsetSourceFolder,
                     currentDocset.Locale,
                     out var localizationDocset,
                     out var localizationRepository))

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -59,7 +59,10 @@ namespace Microsoft.Docs.Build
                         var (docset, fallbackDocset) = GetDocsetWithFallback(docsetPath, locale, config, repositoryProvider, restoreGitMap);
 
                         // TODO: clean up all the RepositoryProvider config methods
-                        repositoryProvider.ConfigFallbackDocsetPath(fallbackDocset.DocsetPath);
+                        if (fallbackDocset != null)
+                        {
+                            repositoryProvider.ConfigFallbackDocsetPath(fallbackDocset.DocsetPath);
+                        }
 
                         if (!string.Equals(docset.DocsetPath, PathUtility.NormalizeFolder(docsetPath), PathUtility.PathComparison))
                         {

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -57,6 +57,10 @@ namespace Microsoft.Docs.Build
                         // get docsets(build docset, fallback docset and dependency docsets)
                         repositoryProvider.Config(config);
                         var (docset, fallbackDocset) = GetDocsetWithFallback(docsetPath, locale, config, repositoryProvider, restoreGitMap);
+
+                        // TODO: clean up all the RepositoryProvider config methods
+                        repositoryProvider.ConfigFallbackDocsetPath(fallbackDocset.DocsetPath);
+
                         if (!string.Equals(docset.DocsetPath, PathUtility.NormalizeFolder(docsetPath), PathUtility.PathComparison))
                         {
                             // entry docset is not the docset to build
@@ -93,14 +97,14 @@ namespace Microsoft.Docs.Build
             var currentDocset = new Docset(docsetPath, locale, config, repositoryProvider.GetRepository(FileOrigin.Default));
             if (!string.IsNullOrEmpty(currentDocset.Locale) && !string.Equals(currentDocset.Locale, config.Localization.DefaultLocale))
             {
+                var docsetSourceFolder = Path.GetRelativePath(currentDocset.Repository.Path, currentDocset.DocsetPath);
                 var fallbackRepo = repositoryProvider.GetRepository(FileOrigin.Fallback);
                 if (fallbackRepo != null)
                 {
-                    return (currentDocset, new Docset(fallbackRepo.Path, locale, config, fallbackRepo));
+                    return (currentDocset, new Docset(PathUtility.NormalizeFolder(Path.Combine(fallbackRepo.Path, docsetSourceFolder)), locale, config, fallbackRepo));
                 }
 
                 // todo: get localization repository from repository provider
-                var docsetSourceFolder = Path.GetRelativePath(currentDocset.Repository.Path, currentDocset.DocsetPath);
                 if (LocalizationUtility.TryGetLocalizationDocset(
                     restoreGitMap,
                     currentDocset,

--- a/src/docfx/docset/RepositoryProvider.cs
+++ b/src/docfx/docset/RepositoryProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Docs.Build
 
         private string _locale;
         private string _docset;
-        private string _fallbackDocset;
+        private string _fallbackRepositoryPath;
         private Repository _docsetRepository;
         private Repository _fallbackRepository;
         private RestoreGitMap _restoreGitMap;
@@ -26,7 +26,7 @@ namespace Microsoft.Docs.Build
             _docsetRepository = Repository.Create(docsetPath);
             _locale = LocalizationUtility.GetLocale(_docsetRepository, options);
 
-            _fallbackDocset = default;
+            _fallbackRepositoryPath = default;
             _fallbackRepository = default;
             _restoreGitMap = default;
             _config = default;
@@ -36,7 +36,7 @@ namespace Microsoft.Docs.Build
         {
             Debug.Assert(_fallbackRepository is null);
 
-            _fallbackDocset = fallbackRepository.Path;
+            _fallbackRepositoryPath = fallbackRepository.Path;
             _fallbackRepository = fallbackRepository;
         }
 
@@ -55,14 +55,14 @@ namespace Microsoft.Docs.Build
 
             _restoreGitMap = restoreGitMap;
             _fallbackRepository = GetFallbackRepository(_docsetRepository, restoreGitMap);
-            _fallbackDocset = _fallbackRepository?.Path;
+            _fallbackRepositoryPath = _fallbackRepository?.Path;
         }
 
         public void ConfigLocalizationRepo(string localizationDocsetPath, Repository localizationRepository)
         {
             Debug.Assert(_fallbackRepository is null);
 
-            _fallbackDocset = _docset;
+            _fallbackRepositoryPath = _docset;
             _fallbackRepository = _docsetRepository;
             _docset = localizationDocsetPath;
             _docsetRepository = localizationRepository;
@@ -82,7 +82,7 @@ namespace Microsoft.Docs.Build
                     return (_docset, _docsetRepository);
 
                 case FileOrigin.Fallback:
-                    return (_fallbackDocset, _fallbackRepository);
+                    return (_fallbackRepositoryPath, _fallbackRepository);
 
                 case FileOrigin.Template when _config != null && _restoreGitMap != null:
                     return _dependencyRepositories.GetOrAdd((origin, dependencyName), _ =>

--- a/src/docfx/docset/RepositoryProvider.cs
+++ b/src/docfx/docset/RepositoryProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Docs.Build
 
         private string _locale;
         private string _docset;
-        private string _fallbackRepositoryPath;
+        private string _fallbackDocsetPath;
         private Repository _docsetRepository;
         private Repository _fallbackRepository;
         private RestoreGitMap _restoreGitMap;
@@ -26,7 +26,7 @@ namespace Microsoft.Docs.Build
             _docsetRepository = Repository.Create(docsetPath);
             _locale = LocalizationUtility.GetLocale(_docsetRepository, options);
 
-            _fallbackRepositoryPath = default;
+            _fallbackDocsetPath = default;
             _fallbackRepository = default;
             _restoreGitMap = default;
             _config = default;
@@ -36,7 +36,7 @@ namespace Microsoft.Docs.Build
         {
             Debug.Assert(_fallbackRepository is null);
 
-            _fallbackRepositoryPath = fallbackRepository.Path;
+            _fallbackDocsetPath = fallbackRepository.Path;
             _fallbackRepository = fallbackRepository;
         }
 
@@ -55,14 +55,14 @@ namespace Microsoft.Docs.Build
 
             _restoreGitMap = restoreGitMap;
             _fallbackRepository = GetFallbackRepository(_docsetRepository, restoreGitMap);
-            _fallbackRepositoryPath = _fallbackRepository?.Path;
+            _fallbackDocsetPath = _fallbackRepository?.Path;
         }
 
         public void ConfigLocalizationRepo(string localizationDocsetPath, Repository localizationRepository)
         {
             Debug.Assert(_fallbackRepository is null);
 
-            _fallbackRepositoryPath = _docset;
+            _fallbackDocsetPath = _docset;
             _fallbackRepository = _docsetRepository;
             _docset = localizationDocsetPath;
             _docsetRepository = localizationRepository;
@@ -82,7 +82,7 @@ namespace Microsoft.Docs.Build
                     return (_docset, _docsetRepository);
 
                 case FileOrigin.Fallback:
-                    return (_fallbackRepositoryPath, _fallbackRepository);
+                    return (_fallbackDocsetPath, _fallbackRepository);
 
                 case FileOrigin.Template when _config != null && _restoreGitMap != null:
                     return _dependencyRepositories.GetOrAdd((origin, dependencyName), _ =>

--- a/src/docfx/docset/RepositoryProvider.cs
+++ b/src/docfx/docset/RepositoryProvider.cs
@@ -68,6 +68,11 @@ namespace Microsoft.Docs.Build
             _docsetRepository = localizationRepository;
         }
 
+        public void ConfigFallbackDocsetPath(string docsetPath)
+        {
+            _fallbackDocsetPath = docsetPath;
+        }
+
         public Repository GetRepository(FileOrigin origin, string dependencyName = null)
         {
             return GetRepositoryWithEntry(origin, dependencyName).repository;

--- a/src/docfx/localization/LocalizationUtility.cs
+++ b/src/docfx/localization/LocalizationUtility.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Docs.Build
             return (newRemote, newBranch);
         }
 
-        public static bool TryGetLocalizationDocset(RestoreGitMap restoreGitMap, Docset docset, Config config, string locale, out string localizationDocsetPath, out Repository localizationRepository)
+        public static bool TryGetLocalizationDocset(RestoreGitMap restoreGitMap, Docset docset, Config config, string docsetSourceFolder, string locale, out string localizationDocsetPath, out Repository localizationRepository)
         {
             Debug.Assert(docset != null);
             Debug.Assert(!string.IsNullOrEmpty(locale));
@@ -74,7 +74,7 @@ namespace Microsoft.Docs.Build
                             locale,
                             config.Localization.DefaultLocale);
                         var (locRepoPath, locCommit) = restoreGitMap.GetRestoreGitPath(new PackagePath(locRemote, locBranch), false);
-                        localizationDocsetPath = locRepoPath;
+                        localizationDocsetPath = PathUtility.NormalizeFolder(Path.Combine(locRepoPath, docsetSourceFolder));
                         localizationRepository = Repository.Create(locRepoPath, locBranch, locRemote, locCommit);
                         break;
                     }

--- a/test/docfx.Test/DocfxTest.cs
+++ b/test/docfx.Test/DocfxTest.cs
@@ -142,8 +142,7 @@ namespace Microsoft.Docs.Build
             }
 
             // Verify build from localization docset also work
-            // TODO: support multiple docset for building from localization docset
-            if (spec.Locale != null && !spec.EnableMultipleDocSetForLocalization)
+            if (spec.Locale != null)
             {
                 var locDocsetPath = t_repos.Value.FirstOrDefault(
                     repo => repo.Key.EndsWith($".{spec.Locale}") || repo.Key.EndsWith(".loc")).Value;

--- a/test/docfx.Test/DocfxTest.cs
+++ b/test/docfx.Test/DocfxTest.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Docs.Build
 
             try
             {
-                t_disableMultipleDocsets.Value = spec.Locale != null;
+                t_disableMultipleDocsets.Value = spec.Locale != null && !spec.EnableMultipleDocSetForLocalization;
                 t_repos.Value = repos;
                 t_cachePath.Value = cachePath;
                 t_statePath.Value = statePath;
@@ -142,7 +142,8 @@ namespace Microsoft.Docs.Build
             }
 
             // Verify build from localization docset also work
-            if (spec.Locale != null)
+            // TODO: support multiple docset for building from localization docset
+            if (spec.Locale != null && !spec.EnableMultipleDocSetForLocalization)
             {
                 var locDocsetPath = t_repos.Value.FirstOrDefault(
                     repo => repo.Key.EndsWith($".{spec.Locale}") || repo.Key.EndsWith(".loc")).Value;

--- a/test/docfx.Test/DocfxTestSpec.cs
+++ b/test/docfx.Test/DocfxTestSpec.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Docs.Build
 {
     public class DocfxTestSpec
     {
+        public bool EnableMultipleDocSetForLocalization { get; set; }
+
         public string OS { get; set; }
 
         public string Cwd { get; set; }


### PR DESCRIPTION
https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=92985
There was an assumption that docset path is the same as repository root path, which is not anymore while supporting multiple docset.

- add `enableMultipleDocSetForLocalization` to test spec
- add test of multiple docset for localization building from both en-us and localization repo
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5221)