### PR TITLE
fix: handle encoded url in relative path

### DIFF
--- a/src/Microsoft.DocAsCode.Common/Path/RelativePath.cs
+++ b/src/Microsoft.DocAsCode.Common/Path/RelativePath.cs
@@ -397,6 +397,7 @@ namespace Microsoft.DocAsCode.Common
                 switch (parts[i])
                 {
                     case "~":
+                    case "%7E":
                         if (parentCount > 0 || stack.Count > 0 || isFromWorkingFolder)
                         {
                             throw new InvalidOperationException($"Invalid path: {path}");

--- a/test/Microsoft.DocAsCode.Build.ConceptualDocuments.Tests/ConceptualDocumentProcessorTest.cs
+++ b/test/Microsoft.DocAsCode.Build.ConceptualDocuments.Tests/ConceptualDocumentProcessorTest.cs
@@ -61,16 +61,18 @@ namespace Microsoft.DocAsCode.Build.ManagedReference.Tests
             base.Dispose();
         }
 
-        [Fact]
-        public void ProcessMarkdownResultWithEncodedUrlShouldSucceed()
+        [Theory]
+        [InlineData(@"<p><a href=""%7E/docs/csharp/language-reference/keywords/select-clause.md""></p>", "~/docs/csharp/language-reference/keywords/select-clause.md")]
+        [InlineData(@"<p><a href=""%7E/../samples/readme.md""></p>", "~/../samples/readme.md")]
+        public void ProcessMarkdownResultWithEncodedUrlShouldSucceed(string htmlContent, string expectedFileLink)
         {
             var markdownResult = new MarkupResult
             {
-                Html = @"<p><a href=""%7E/docs/csharp/language-reference/keywords/select-clause.md""></p>"
+                Html = htmlContent
             };
 
             markdownResult = MarkupUtility.Parse(markdownResult, "docs/framework/data/wcf/how-to-project-query-results-wcf-data-services.md", ImmutableDictionary.Create<string, FileAndType>());
-            Assert.Equal("~/docs/csharp/language-reference/keywords/select-clause.md", markdownResult.LinkToFiles.First());
+            Assert.Equal(expectedFileLink, markdownResult.LinkToFiles.First());
         }
 
         [Fact]


### PR DESCRIPTION
### Example:
**%7E/../samples/MyGraph/README.md** path should be **~/../samples/MyGraph/README.md** after parse and decode.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5223)