### PR TITLE
Fix PackagePath json serialize

### DIFF
--- a/docs/specs/config.yml
+++ b/docs/specs/config.yml
@@ -586,47 +586,6 @@ outputs:
   docs/path1.json: |
     {"document_id": "780484e9-a367-97ab-ba7d-a19f3b378a80", "document_version_independent_id": "e9b3f4e2-1a78-4b5d-fbb4-03e0a33e38f5",}
 ---
-# branch property has higher priority than branch defined in url
-repos:
-  https://docs.com/branch-priority/1:
-    - files:
-        docfx.yml: |
-          dependencies:
-            crr:
-              url: https://docs.com/branch-priority/2#unused
-              branch: master
-              includeInBuild: true
-  https://docs.com/branch-priority/2#master:
-    - files:
-        b.md: 
-  https://docs.com/branch-priority/2#unused:
-    - files:
-        c.md: 
-outputs:
-  crr/b.json:
----
-# dependencyPackageUrl can use relative path by setting path or url
-# path has higher priority than url
-inputs:
-  docfx.yml: |
-    files:
-    - crr1/**/*.md
-    - crr2/**/*.md
-    dependencies:
-      crr1:
-        path: crr-by-path
-        includeInBuild: true
-      crr2:
-        url: crr-priority-url
-        path: crr-priority-path
-        includeInBuild: true
-  crr-by-path/crr-by-path.md:
-  crr-priority-url/crr-priority-url.md:
-  crr-priority-path/crr-priority-path.md:
-outputs:
-  crr1/crr-by-path.json:
-  crr2/crr-priority-path.json:
----
 # dependencyPackageUrl's path using git url won't restore the git repo
 repos:
   https://docs.com/crr-url-using-path/1:

--- a/test/docfx.Test/restore/RestoreTest.cs
+++ b/test/docfx.Test/restore/RestoreTest.cs
@@ -20,13 +20,16 @@ namespace Microsoft.Docs.Build
         [InlineData("'https://github.com/dotnet/docfx#986127a'", PackageType.Git, "https://github.com/dotnet/docfx", "986127a", null)]
         [InlineData("'https://github.com/dotnet/docfx#a#a'", PackageType.Git, "https://github.com/dotnet/docfx", "a#a", null)]
         [InlineData(@"'https://github.com/dotnet/docfx#a\\b/d<e>f*h|i%3C'", PackageType.Git, "https://github.com/dotnet/docfx", @"a\b/d<e>f*h|i%3C", null)]
-        [InlineData("{'url': 'https://github.com/dotnet/docfx#unused', 'branch': 'used'}", PackageType.Git, "https://github.com/dotnet/docfx", "used", null)]
-        [InlineData("{'url': 'crr/local-path'}", PackageType.Folder, "crr/local-path", null, "crr/local-path")]
+        [InlineData("{'url': 'https://github.com/dotnet/docfx', 'branch': 'used'}", PackageType.Git, "https://github.com/dotnet/docfx", "used", null)]
+        [InlineData("{'url': 'https://github.com/dotnet/docfx', 'path': 'a-path'}", PackageType.Git, "https://github.com/dotnet/docfx", "master", null)]
+        [InlineData("{'url': 'https://github.com/dotnet/docfx#unused', 'branch': 'used'}", PackageType.Git, "https://github.com/dotnet/docfx#unused", "used", null)]
+        [InlineData("{'url': 'crr/local-path'}", PackageType.Git, "crr/local-path", "master", null)]
+        [InlineData("{'path': 'crr/local-path'}", PackageType.Folder, null, null, "crr/local-path")]
         public static void PackageUrlTest(
             string json,
             PackageType expectedPackageType,
             string expectedUrl,
-            string expectedRev,
+            string expectedBranch,
             string expectedPath)
         {
             // Act
@@ -35,7 +38,7 @@ namespace Microsoft.Docs.Build
             // Assert
             Assert.Equal(expectedUrl, packageUrl.Url);
             Assert.Equal(expectedPackageType, packageUrl.Type);
-            Assert.Equal(expectedRev, packageUrl.Branch);
+            Assert.Equal(expectedBranch, packageUrl.Branch);
             Assert.Equal(expectedPath, packageUrl.Path);
         }
 


### PR DESCRIPTION
Clarifies that `url` means repository url (without any branch info), `path` means a local folder.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5229)