### PR TITLE
fix: remove merge conflict check to unblock archive content build

### DIFF
--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -265,21 +265,6 @@ namespace Microsoft.Docs.Build
             => new Error(ErrorLevel.Error, "directory-not-found", $"Invalid directory: '{source}'.", source);
 
         /// <summary>
-        /// File contains git merge conflict.
-        /// Examples:
-        ///   - <![CDATA[
-        ///     <<<<<<< HEAD
-        ///     head content
-        ///     =======
-        ///     branch content
-        ///     >>>>>>> refs/heads/branch
-        /// ]]>
-        /// </summary>
-        /// Behavior: ✔️ Message: ❌
-        public static Error MergeConflict(SourceInfo source)
-            => new Error(ErrorLevel.Error, "merge-conflict", "File contains merge conflict", source);
-
-        /// <summary>
         /// Failed to resolve uid defined by @ syntax.
         /// </summary>
         /// Behavior: ❌ Message: ✔️

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -197,7 +197,6 @@ namespace Microsoft.Docs.Build
         {
             var errors = new List<Error>();
             var content = context.Input.ReadString(file.FilePath);
-            GitUtility.CheckMergeConflictMarker(content, file.FilePath);
 
             var (markupErrors, htmlDom) = context.MarkdownEngine.ToHtml(content, file, MarkdownPipelineType.Markdown);
             errors.AddRange(markupErrors);

--- a/src/docfx/build/toc/TableOfContentsLoader.cs
+++ b/src/docfx/build/toc/TableOfContentsLoader.cs
@@ -84,7 +84,6 @@ namespace Microsoft.Docs.Build
             else if (filePath.EndsWith(".md", PathUtility.PathComparison))
             {
                 content = content ?? _input.ReadString(file.FilePath);
-                GitUtility.CheckMergeConflictMarker(content, file.FilePath);
                 return MarkdownTocMarkup.Parse(_markdownEngine, content, file);
             }
 

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -236,23 +236,6 @@ namespace Microsoft.Docs.Build
             return result;
         }
 
-        public static void CheckMergeConflictMarker(string content, FilePath file)
-        {
-            var start = content.StartsWith("<<<<<<<") ? 0 : content.IndexOf("\n<<<<<<<");
-            if (start >= 0 && content.Contains("\n>>>>>>>") && content.Contains("\n======="))
-            {
-                var line = 1;
-                for (var i = 0; i <= start; i++)
-                {
-                    if (content[i] == '\n')
-                        line++;
-                }
-
-                var source = new SourceInfo(file, line, 1);
-                throw Errors.MergeConflict(source).ToException();
-            }
-        }
-
         public static unsafe byte[] ReadBytes(string repoPath, string filePath, string committish)
         {
             if (git_repository_open(out var repo, repoPath) != 0)


### PR DESCRIPTION
sample content:
https://docs-archive.visualstudio.com/docs-archive-project/_git/blogs-archive-pr/?path=%2Fblogs-archive%2Foldnewthing%2Fstop-cherry-picking-start-merging-part-1-the-merge-conflict.md&version=GBmaster

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5242)