### PR TITLE
Turn merge-conflict into a recoverable warning

### DIFF
--- a/docs/specs/validation.yml
+++ b/docs/specs/validation.yml
@@ -2,12 +2,6 @@
 # Check git merge conflict marker
 inputs:
   docfx.yml:
-  docs/toc.md: |
-    <<<<<<< HEAD
-    foo
-    =======
-    bar
-    >>>>>>> cb1abc6bd98cfc84317f8aa95a7662815417802d
   docs/a.md: |
     baz
     <<<<<<< HEAD
@@ -16,8 +10,8 @@ inputs:
     bar
     >>>>>>> cb1abc6bd98cfc84317f8aa95a7662815417802d
 outputs:
+  docs/a.json:
   .errors.log: |
-    ["warning","merge-conflict","File contains merge conflict","docs/toc.md",1,1]
     ["warning","merge-conflict","File contains merge conflict","docs/a.md",2,1]
 ---
 # Metadata value must be scalar or scalar array

--- a/docs/specs/validation.yml
+++ b/docs/specs/validation.yml
@@ -17,8 +17,8 @@ inputs:
     >>>>>>> cb1abc6bd98cfc84317f8aa95a7662815417802d
 outputs:
   .errors.log: |
-    ["error","merge-conflict","File contains merge conflict","docs/toc.md",1,1]
-    ["error","merge-conflict","File contains merge conflict","docs/a.md",2,1]
+    ["warning","merge-conflict","File contains merge conflict","docs/toc.md",1,1]
+    ["warning","merge-conflict","File contains merge conflict","docs/a.md",2,1]
 ---
 # Metadata value must be scalar or scalar array
 inputs:

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -277,7 +277,7 @@ namespace Microsoft.Docs.Build
         /// </summary>
         /// Behavior: ✔️ Message: ❌
         public static Error MergeConflict(SourceInfo source)
-            => new Error(ErrorLevel.Error, "merge-conflict", "File contains merge conflict", source);
+            => new Error(ErrorLevel.Warning, "merge-conflict", "File contains merge conflict", source);
 
         /// <summary>
         /// Failed to resolve uid defined by @ syntax.

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Docs.Build
         {
             var errors = new List<Error>();
             var content = context.Input.ReadString(file.FilePath);
-            GitUtility.CheckMergeConflictMarker(content, file.FilePath);
+            errors.AddIfNotNull(GitUtility.CheckMergeConflictMarker(content, file.FilePath));
 
             var (markupErrors, htmlDom) = context.MarkdownEngine.ToHtml(content, file, MarkdownPipelineType.Markdown);
             errors.AddRange(markupErrors);

--- a/src/docfx/build/toc/TableOfContentsLoader.cs
+++ b/src/docfx/build/toc/TableOfContentsLoader.cs
@@ -84,9 +84,7 @@ namespace Microsoft.Docs.Build
             else if (filePath.EndsWith(".md", PathUtility.PathComparison))
             {
                 content = content ?? _input.ReadString(file.FilePath);
-                var (errors, model) = MarkdownTocMarkup.Parse(_markdownEngine, content, file);
-                errors.AddIfNotNull(GitUtility.CheckMergeConflictMarker(content, file.FilePath));
-                return (errors, model);
+                return MarkdownTocMarkup.Parse(_markdownEngine, content, file);
             }
 
             throw new NotSupportedException($"{filePath} is an unknown TOC file");

--- a/src/docfx/build/toc/TableOfContentsLoader.cs
+++ b/src/docfx/build/toc/TableOfContentsLoader.cs
@@ -84,8 +84,9 @@ namespace Microsoft.Docs.Build
             else if (filePath.EndsWith(".md", PathUtility.PathComparison))
             {
                 content = content ?? _input.ReadString(file.FilePath);
-                GitUtility.CheckMergeConflictMarker(content, file.FilePath);
-                return MarkdownTocMarkup.Parse(_markdownEngine, content, file);
+                var (errors, model) = MarkdownTocMarkup.Parse(_markdownEngine, content, file);
+                errors.AddIfNotNull(GitUtility.CheckMergeConflictMarker(content, file.FilePath));
+                return (errors, model);
             }
 
             throw new NotSupportedException($"{filePath} is an unknown TOC file");

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -236,7 +236,7 @@ namespace Microsoft.Docs.Build
             return result;
         }
 
-        public static void CheckMergeConflictMarker(string content, FilePath file)
+        public static Error CheckMergeConflictMarker(string content, FilePath file)
         {
             var start = content.StartsWith("<<<<<<<") ? 0 : content.IndexOf("\n<<<<<<<");
             if (start >= 0 && content.Contains("\n>>>>>>>") && content.Contains("\n======="))
@@ -249,8 +249,9 @@ namespace Microsoft.Docs.Build
                 }
 
                 var source = new SourceInfo(file, line, 1);
-                throw Errors.MergeConflict(source).ToException();
+                return Errors.MergeConflict(source);
             }
+            return null;
         }
 
         public static unsafe byte[] ReadBytes(string repoPath, string filePath, string committish)


### PR DESCRIPTION
sample content:

https://docs-archive.visualstudio.com/docs-archive-project/_git/blogs-archive-pr/?path=%2Fblogs-archive%2Foldnewthing%2Fstop-cherry-picking-start-merging-part-1-the-merge-conflict.md&version=GBmaster

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5243)