### PR TITLE
De-dup .links output

### DIFF
--- a/docs/specs/output.yml
+++ b/docs/specs/output.yml
@@ -479,7 +479,6 @@ outputs:
         {"source_url":"/docs/b","source_moniker_group":"23d205a5","target_url":"/docs/a"},
         {"source_url":"/docs/b","source_moniker_group":"9d4e15fd","target_url":"/docs/a"},
         {"source_url":"/docs/b","source_moniker_group":"9d4e15fd","target_url":"/docs/c"},
-        {"source_url":"/docs/b","source_moniker_group":"9d4e15fd","target_url":"/docs/c"},
         {"source_url":"/docs/b","source_moniker_group":"9d4e15fd","target_url":"/docs/d#title-1"},
         {"source_url":"/docs/b","source_moniker_group":"9d4e15fd","target_url":"/docs/d.md#title-1"},
         {"source_url":"/docs/b","source_moniker_group":"9d4e15fd","target_url":"/docs/e.png"},

--- a/src/docfx/build/link/FileLinkItem.cs
+++ b/src/docfx/build/link/FileLinkItem.cs
@@ -1,19 +1,47 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
+using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
-    internal class FileLinkItem
+    internal struct FileLinkItem : IEquatable<FileLinkItem>, IComparable<FileLinkItem>
     {
         public string SourceUrl { get; set; }
 
         public string SourceMonikerGroup { get; set; }
 
         public string TargetUrl { get; set; }
+
+        public int CompareTo(FileLinkItem other)
+        {
+            var result = string.CompareOrdinal(SourceUrl, other.SourceUrl);
+            if (result == 0)
+                result = string.CompareOrdinal(TargetUrl, other.TargetUrl);
+            if (result == 0)
+                result = string.CompareOrdinal(SourceMonikerGroup, other.SourceMonikerGroup);
+
+            return result;
+        }
+
+        public bool Equals(FileLinkItem other)
+        {
+            return SourceUrl == other.SourceUrl
+                && TargetUrl == other.TargetUrl
+                && SourceMonikerGroup == other.SourceMonikerGroup;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is FileLinkItem && Equals((FileLinkItem)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(SourceUrl, TargetUrl, SourceMonikerGroup);
+        }
     }
 }


### PR DESCRIPTION
`.links.json` diff in https://github.com/dotnet/docfx/pull/5212 not expected due to result not de-duped.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5244)