### PR TITLE
Make json deserialize case insensitive

### DIFF
--- a/docs/specs/redirection.yml
+++ b/docs/specs/redirection.yml
@@ -351,6 +351,15 @@ outputs:
   a/.publish.json: |
     { "files": [{ "source_path": "index.md", "redirect_url": "/a" }] }
 ---
+# redirect_url is case insensitive
+inputs:
+  docfx.yml:
+  .openpublishing.redirection.json: |
+    { "redirections": [{"source_path": "a.md", "redirect_URL": "/"}] }
+outputs:
+  .publish.json: |
+    { "files": [{ "source_path": "a.md", "redirect_url": "/" }] }
+---
 # document_id of .yml redirections are calculated as .md
 inputs:
   docfx.yml:

--- a/src/docfx/lib/ReflectionUtility.cs
+++ b/src/docfx/lib/ReflectionUtility.cs
@@ -20,18 +20,6 @@ namespace Microsoft.Docs.Build
             return (Func<T, TField>)getter.CreateDelegate(typeof(Func<T, TField>));
         }
 
-        public static Action<T, TField> CreateInstanceFieldSetter<T, TField>(string fieldName)
-        {
-            var field = typeof(T).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
-            var setter = new DynamicMethod(Guid.NewGuid().ToString(), null, new[] { typeof(T), typeof(TField) }, true);
-            var il = setter.GetILGenerator();
-            il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Stfld, field);
-            il.Emit(OpCodes.Ret);
-            return (Action<T, TField>)setter.CreateDelegate(typeof(Action<T, TField>));
-        }
-
         public static TDelegate CreateInstanceMethod<T, TDelegate>(string methodName, Type[] types = null) where TDelegate : Delegate
         {
             var methodInfo = typeof(T).GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance, null, types, null);

--- a/src/docfx/lib/json/JsonContractResolver.cs
+++ b/src/docfx/lib/json/JsonContractResolver.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -12,21 +10,6 @@ namespace Microsoft.Docs.Build
 {
     internal class JsonContractResolver : DefaultContractResolver
     {
-        // HACK: Json.NET property deserialization is case insensitive:
-        // https://github.com/JamesNK/Newtonsoft.Json/issues/815,
-        // Force property deserialization to be case sensitive by hijacking GetClosestMatchProperty implementation.
-        private static readonly Action<JsonPropertyCollection, List<JsonProperty>> s_makeJsonCaseSensitive =
-            ReflectionUtility.CreateInstanceFieldSetter<JsonPropertyCollection, List<JsonProperty>>("_list");
-
-        private static readonly List<JsonProperty> s_emptyPropertyList = new List<JsonProperty>();
-
-        protected override JsonObjectContract CreateObjectContract(Type objectType)
-        {
-            var contract = base.CreateObjectContract(objectType);
-            s_makeJsonCaseSensitive(contract.Properties, s_emptyPropertyList);
-            return contract;
-        }
-
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {
             var property = base.CreateProperty(member, memberSerialization);

--- a/test/docfx.Test/lib/JsonUtilityTest.cs
+++ b/test/docfx.Test/lib/JsonUtilityTest.cs
@@ -72,10 +72,10 @@ namespace Microsoft.Docs.Build
         }
 
         [Fact]
-        public void TestJsonDeserializeIsCaseSensitive()
+        public void TestJsonDeserializeCaseInsensitive()
         {
             var (errors, value) = DeserializeWithValidation<BasicClass>("{\"B\":1}");
-            Assert.Equal(0, value.B);
+            Assert.Equal(1, value.B);
         }
 
         [Fact]
@@ -385,6 +385,7 @@ namespace Microsoft.Docs.Build
         [InlineData("{'a':[1]}", "{'a':[2]}", "{'a':[2]}")]
         [InlineData("{'a':{'b':1}}", "{'a':{'b':{}}}", "{'a':{'b':{}}}")]
         [InlineData("{'a':{'b':1}}", "{'a':{'b':2}}", "{'a':{'b':2}}")]
+        [InlineData("{'a':1}", "{'A':2}", "{'a':1,'A':2}")]
         public void TestJsonMerge(string a, string b, string result)
         {
             var container = JObject.Parse(a.Replace('\'', '\"'));


### PR DESCRIPTION
Unfortunately people make mistakes and making it case insensitive is more permissive

https://opbuildstoragesandbox2.blob.core.windows.net/report/2019%5C11%5C5%5C780afb58-7a96-a386-4bca-ef364a1d77bc%5CCommit%5C201911051322557878-docs-build-v3%5Cworkflow_report.html?sv=2016-05-31&sr=b&sig=V1U3XU%2FSeKiLP2%2FWPDghtG9TK3RCgy%2Bn9lIPYHvZes0%3D&st=2019-11-05T13%3A21%3A46Z&se=2019-12-06T13%3A26%3A46Z&sp=r

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5263)