### PR TITLE
Populate source info to extension data

### DIFF
--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -289,7 +289,7 @@ inputs:
 outputs:
   docs/a.json:
   .errors.log: |
-    ["warning","attribute-reserved","Attribute content_type is reserved for use by Docs. Remove it from your file metadata.","docfx.yml",3,16]
+    ["warning","attribute-reserved","Attribute content_type is reserved for use by Docs. Remove it from your file metadata.","docfx.yml",2,3]
     ["warning","attribute-reserved","Attribute ms.contentlang is reserved for use by Docs. Remove it from your file metadata.","docs/a.md",2,1]
 ---
 # Context object type is TOC

--- a/docs/specs/metadata.yml
+++ b/docs/specs/metadata.yml
@@ -214,7 +214,7 @@ inputs:
 outputs:
   docs/a.json:
   .errors.log: |
-    ["warning","attribute-reserved","Attribute redirect_url is reserved for use by Docs. Remove it from your file metadata.","docfx.yml",3,16]
+    ["warning","attribute-reserved","Attribute redirect_url is reserved for use by Docs. Remove it from your file metadata.","docfx.yml",2,3]
 ---
 # document_id defined in YAML file metadata is not supported
 inputs:

--- a/src/docfx/build/metadata/MetadataProvider.cs
+++ b/src/docfx/build/metadata/MetadataProvider.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 
@@ -56,8 +55,9 @@ namespace Microsoft.Docs.Build
 
             foreach (var (key, item) in docset.Config.FileMetadata)
             {
-                foreach (var (glob, value) in item)
+                foreach (var (glob, value) in item.Value)
                 {
+                    JsonUtility.SetKeySourceInfo(value, item.Source?.KeySourceInfo);
                     _rules.Add((GlobUtility.CreateGlobMatcher(glob), key, value));
                 }
             }
@@ -90,21 +90,20 @@ namespace Microsoft.Docs.Build
                     // Assign a JToken to a property erases line info, so clone here.
                     // See https://github.com/JamesNK/Newtonsoft.Json/issues/2055
                     fileMetadata[key] = JsonUtility.DeepClone(value);
-                    JsonUtility.SetSourceInfo(fileMetadata.Property(key), JsonUtility.GetSourceInfo(value));
                 }
             }
             JsonUtility.Merge(result, fileMetadata);
             JsonUtility.Merge(result, yamlHeader);
 
-            foreach (var property in result.Properties())
+            foreach (var (key, value) in result)
             {
-                if (_reservedMetadata.Contains(property.Name))
+                if (_reservedMetadata.Contains(key))
                 {
-                    errors.Add(Errors.AttributeReserved(JsonUtility.GetSourceInfo(property), property.Name));
+                    errors.Add(Errors.AttributeReserved(JsonUtility.GetKeySourceInfo(value), key));
                 }
-                else if (!IsValidMetadataType(property.Value))
+                else if (!IsValidMetadataType(value))
                 {
-                    errors.Add(Errors.InvalidMetadataType(JsonUtility.GetSourceInfo(property.Value), property.Name));
+                    errors.Add(Errors.InvalidMetadataType(JsonUtility.GetSourceInfo(value), key));
                 }
             }
 

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Docs.Build
         /// Gets the file metadata added to each document.
         /// It is a map of `{metadata-name} -> {glob} -> {metadata-value}`
         /// </summary>
-        public readonly Dictionary<string, Dictionary<string, JToken>> FileMetadata = new Dictionary<string, Dictionary<string, JToken>>();
+        public readonly Dictionary<string, SourceInfo<Dictionary<string, JToken>>> FileMetadata = new Dictionary<string, SourceInfo<Dictionary<string, JToken>>>();
 
         /// <summary>
         /// Gets a map from source folder path and output URL path.

--- a/src/docfx/lib/HtmlUtility.cs
+++ b/src/docfx/lib/HtmlUtility.cs
@@ -233,10 +233,8 @@ namespace Microsoft.Docs.Build
         {
             var result = new StringBuilder();
 
-            foreach (var property in metadata.Properties())
+            foreach (var (key, value) in metadata)
             {
-                var key = property.Name;
-                var value = property.Value;
                 if (value is JObject || htmlMetaHidden.Contains(key))
                 {
                     continue;

--- a/src/docfx/lib/json/JsonUtility.cs
+++ b/src/docfx/lib/json/JsonUtility.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Docs.Build
 
         internal static JsonSerializer Serializer => s_serializer;
 
-        internal static Status State => t_status.Value.Peek();
+        internal static Status State => t_status.Value.TryPeek(out var result) ? result : null;
 
         static JsonUtility()
         {
@@ -222,11 +222,8 @@ namespace Microsoft.Docs.Build
             if (overwrite is null)
                 return;
 
-            foreach (var property in overwrite.Properties())
+            foreach (var (key, value) in overwrite)
             {
-                var key = property.Name;
-                var value = property.Value;
-
                 if (container[key] is JObject containerObj && value is JObject overwriteObj)
                 {
                     Merge(containerObj, overwriteObj);
@@ -234,7 +231,6 @@ namespace Microsoft.Docs.Build
                 else
                 {
                     container[key] = DeepClone(value);
-                    SetSourceInfo(container.Property(key), property.Annotation<SourceInfo>());
                 }
             }
         }
@@ -249,10 +245,9 @@ namespace Microsoft.Docs.Build
             if (token is JObject obj)
             {
                 var result = new JObject();
-                foreach (var prop in obj.Properties())
+                foreach (var (key, value) in obj)
                 {
-                    result[prop.Name] = DeepClone(prop.Value);
-                    SetSourceInfo(result.Property(prop.Name), prop.Annotation<SourceInfo>());
+                    result[key] = DeepClone(value);
                 }
                 return SetSourceInfo(result, token.Annotation<SourceInfo>());
             }
@@ -307,11 +302,11 @@ namespace Microsoft.Docs.Build
                 }
                 else if (token is JObject obj)
                 {
-                    foreach (var prop in obj.Properties())
+                    foreach (var (key, value) in obj)
                     {
-                        if (!prop.Value.IsNullOrUndefined())
+                        if (!value.IsNullOrUndefined())
                         {
-                            RemoveNullsCore(prop.Value, prop.Name);
+                            RemoveNullsCore(value, key);
                         }
                     }
                 }
@@ -340,12 +335,27 @@ namespace Microsoft.Docs.Build
             return token.Annotation<SourceInfo>();
         }
 
-        internal static JToken SetSourceInfo(JToken token, SourceInfo source)
+        public static JToken SetSourceInfo(JToken token, SourceInfo source)
         {
             token.RemoveAnnotations<SourceInfo>();
             if (source != null)
             {
                 token.AddAnnotation(source);
+            }
+            return token;
+        }
+
+        public static SourceInfo GetKeySourceInfo(JToken token)
+        {
+            return token.Annotation<SourceInfo>()?.KeySourceInfo;
+        }
+
+        public static JToken SetKeySourceInfo(JToken token, SourceInfo source)
+        {
+            var sourceInfo = token.Annotation<SourceInfo>();
+            if (sourceInfo != null)
+            {
+                sourceInfo.KeySourceInfo = source;
             }
             return token;
         }
@@ -402,10 +412,16 @@ namespace Microsoft.Docs.Build
                 (token.Type == JTokenType.Undefined);
         }
 
-        private static JToken SetSourceInfo(JToken token, FilePath file)
+        private static JToken SetSourceInfo(JToken token, FilePath file, JProperty property = null)
         {
             var lineInfo = (IJsonLineInfo)token;
-            SetSourceInfo(token, new SourceInfo(file, lineInfo.LineNumber, lineInfo.LinePosition));
+            var sourceInfo = new SourceInfo(file, lineInfo.LineNumber, lineInfo.LinePosition);
+            if (property != null)
+            {
+                var keyLineInfo = (IJsonLineInfo)property;
+                sourceInfo.KeySourceInfo = new SourceInfo(file, keyLineInfo.LineNumber, keyLineInfo.LinePosition);
+            }
+            SetSourceInfo(token, sourceInfo);
 
             switch (token)
             {
@@ -423,7 +439,7 @@ namespace Microsoft.Docs.Build
                 case JObject obj:
                     foreach (var prop in obj.Properties())
                     {
-                        SetSourceInfo(prop, file);
+                        SetSourceInfo(prop.Value, file, prop);
                     }
                     break;
             }

--- a/src/docfx/lib/json/YamlUtility.cs
+++ b/src/docfx/lib/json/YamlUtility.cs
@@ -114,7 +114,19 @@ namespace Microsoft.Docs.Build
                 var result = ToJToken(
                     input,
                     onKeyDuplicate: key => errors.Add(Errors.YamlDuplicateKey(ToSourceInfo(key, file), key.Value)),
-                    onConvert: (token, node) => JsonUtility.SetSourceInfo(token, ToSourceInfo(node, file)));
+                    onConvert: (token, node) =>
+                    {
+                        if (token is JProperty property)
+                        {
+                            var sourceInfo = JsonUtility.GetSourceInfo(property.Value);
+                            if (sourceInfo != null)
+                            {
+                                sourceInfo.KeySourceInfo = ToSourceInfo(node, file);
+                            }
+                            return token;
+                        }
+                        return JsonUtility.SetSourceInfo(token, ToSourceInfo(node, file));
+                    });
 
                 return (errors, result);
             }

--- a/src/docfx/lib/log/SourceInfo.cs
+++ b/src/docfx/lib/log/SourceInfo.cs
@@ -32,6 +32,10 @@ namespace Microsoft.Docs.Build
         /// </summary>
         public readonly int EndColumn;
 
+        // A special storage for source info of the JObject property key
+        // if this is a JObject property value.
+        internal SourceInfo KeySourceInfo { get; set; }
+
         public SourceInfo(FilePath file, int line, int column)
             : this(file, line, column, line, column)
         { }

--- a/src/docfx/lib/schema/JsonSchemaValidator.cs
+++ b/src/docfx/lib/schema/JsonSchemaValidator.cs
@@ -168,15 +168,12 @@ namespace Microsoft.Docs.Build
             if (schema.MinProperties.HasValue && map.Count < schema.MinProperties.Value)
                 errors.Add((name, Errors.PropertyCountInvalid(JsonUtility.GetSourceInfo(map), name, $">= {schema.MinProperties}")));
 
-            foreach (var property in map.Properties())
+            foreach (var (key, value) in map)
             {
-                var key = property.Name;
-                var value = property.Value;
-
                 if (schema.PropertyNames != null)
                 {
                     var propertyName = new JValue(key);
-                    JsonUtility.SetSourceInfo(propertyName, JsonUtility.GetSourceInfo(property));
+                    JsonUtility.SetSourceInfo(propertyName, JsonUtility.GetKeySourceInfo(value));
                     Validate(schema.PropertyNames, key, propertyName, errors);
                 }
 

--- a/test/docfx.Test/lib/JsonUtilityTest.cs
+++ b/test/docfx.Test/lib/JsonUtilityTest.cs
@@ -449,6 +449,23 @@ namespace Microsoft.Docs.Build
             Assert.Equal("a value", result.A.Value);
         }
 
+        [Fact]
+        public void TestExtensionDataWithSourceInfo()
+        {
+            var (_, result) = DeserializeWithValidation<ClassWithExtensionData>("{\"a\": 1}");
+            Assert.NotNull(result.ExtensionData["a"]);
+
+            var valueSource = JsonUtility.GetSourceInfo(result.ExtensionData["a"]);
+            Assert.NotNull(valueSource);
+            Assert.Equal(1, valueSource.Line);
+            Assert.Equal(7, valueSource.Column);
+
+            var keySource = JsonUtility.GetKeySourceInfo(result.ExtensionData["a"]);
+            Assert.NotNull(keySource);
+            Assert.Equal(1, keySource.Line);
+            Assert.Equal(5, keySource.Column);
+        }
+
         /// <summary>
         /// Deserialize from yaml string, return error list at the same time
         /// </summary>
@@ -548,6 +565,12 @@ namespace Microsoft.Docs.Build
         internal sealed class NestedClass
         {
             public string ValueWithLengthRestriction { get; set; }
+        }
+
+        internal class ClassWithExtensionData
+        {
+            [JsonExtensionData]
+            public JObject ExtensionData { get; set; } = new JObject();
         }
 
         internal enum BasicEnum


### PR DESCRIPTION
The source info for property keys used to be stored in `JProperty`, this creates a challenge to propagate property name source info for extension data due to the limitation of `ExtensionDataSetter` (`setExtensinoData(string key, object value)`) does not have a place to store property name source info, it only has room for property value source info).

This PR moves property key source info from `JProperty` to `JProperty.Value`, to retrieve key source info, use `JsonUtility.GetKeySourceInfo`. 

It also fixed a bug where source info was reported incorrectly for `fileMetadata` due to property name transformation.

This is needed for #5260 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5268)