### PR TITLE
Revert "update markdig version (#5259)"

### DIFF
--- a/src/Microsoft.DocAsCode.Build.OverwriteDocuments/Microsoft.DocAsCode.Build.OverwriteDocuments.csproj
+++ b/src/Microsoft.DocAsCode.Build.OverwriteDocuments/Microsoft.DocAsCode.Build.OverwriteDocuments.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../Shared/base.netstandard.props" />
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.18.0" />
+    <PackageReference Include="Markdig" Version="0.16.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DocAsCode.Build.Common\Microsoft.DocAsCode.Build.Common.csproj" />

--- a/src/Microsoft.DocAsCode.Build.SchemaDriven/Microsoft.DocAsCode.Build.SchemaDriven.csproj
+++ b/src/Microsoft.DocAsCode.Build.SchemaDriven/Microsoft.DocAsCode.Build.SchemaDriven.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
-    <PackageReference Include="Markdig" Version="0.18.0" />
+    <PackageReference Include="Markdig" Version="0.16.0" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="2.0.10" />
   </ItemGroup>
 

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Microsoft.DocAsCode.MarkdigEngine.Extensions.csproj
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Microsoft.DocAsCode.MarkdigEngine.Extensions.csproj
@@ -2,7 +2,7 @@
   <Import Project="../Shared/base.netstandard.props" />
 
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.18.0" />
+    <PackageReference Include="Markdig" Version="0.16.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Validators/Microsoft.DocAsCode.MarkdigEngine.Validators.csproj
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Validators/Microsoft.DocAsCode.MarkdigEngine.Validators.csproj
@@ -2,7 +2,7 @@
   <Import Project="../Shared/base.netstandard.props" />
 
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.18.0" />
+    <PackageReference Include="Markdig" Version="0.16.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
 

--- a/src/Microsoft.DocAsCode.MarkdigEngine/Microsoft.DocAsCode.MarkdigEngine.csproj
+++ b/src/Microsoft.DocAsCode.MarkdigEngine/Microsoft.DocAsCode.MarkdigEngine.csproj
@@ -2,7 +2,7 @@
   <Import Project="../Shared/base.netstandard.props" />
 
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.18.0" />
+    <PackageReference Include="Markdig" Version="0.16.0" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.31" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />

--- a/test/Microsoft.DocAsCode.Build.OverwriteDocuments.Tests/Microsoft.DocAsCode.Build.OverwriteDocuments.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Build.OverwriteDocuments.Tests/Microsoft.DocAsCode.Build.OverwriteDocuments.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Shared\test.base.props" />
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.18.0" />
+    <PackageReference Include="Markdig" Version="0.16.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.DocAsCode.Build.OverwriteDocuments\Microsoft.DocAsCode.Build.OverwriteDocuments.csproj" />

--- a/tools/YamlSplitter/YamlSplitter.csproj
+++ b/tools/YamlSplitter/YamlSplitter.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
-    <PackageReference Include="Markdig" Version="0.18.0" />
+    <PackageReference Include="Markdig" Version="0.16.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.5" />
     <PackageReference Include="YamlDotNet.Signed" Version="4.2.2" />


### PR DESCRIPTION
This reverts commit 1e6ae262d24d639f75e9959ae7750f6eb06d9c5e.

This update will also update the syntax to support commonmark 0.29, which will break some of the current content build. So just revert it for now. And will update the markdig version after V3 enabled.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5271)