### PR TITLE
disallow thousands seperator when deserailizing yaml

### DIFF
--- a/src/docfx/lib/json/YamlUtility.Shared.cs
+++ b/src/docfx/lib/json/YamlUtility.Shared.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Docs.Build
             {
                 return new JValue(l);
             }
-            if (double.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out var d) &&
+            if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var d) &&
                 !double.IsNaN(d) && !double.IsPositiveInfinity(d) && !double.IsNegativeInfinity(d))
             {
                 return new JValue(d);

--- a/test/docfx.Test/lib/YamlUtilityTest.cs
+++ b/test/docfx.Test/lib/YamlUtilityTest.cs
@@ -85,6 +85,16 @@ namespace Microsoft.Docs.Build
         }
 
         [Fact]
+        public void TestDisallowThousands()
+        {
+            var yaml = "a: 123,456";
+            var (errors, value) = DeserializeWithValidation<Dictionary<string, object>>(yaml);
+            Assert.Empty(errors);
+            Assert.NotNull(value);
+            Assert.Equal("123,456", value["a"]);
+        }
+
+        [Fact]
         public void TestNotprimitiveKey()
         {
             var yaml = @"


### PR DESCRIPTION
According to the [yaml spec](https://yaml.org/spec/1.2/2009-07-21/spec.html)(you can also reference [here](https://github.com/dotnet/docfx/blob/v3/src/docfx/lib/json/YamlUtility.Shared.cs#L89) ), thousands separator is not allowed in value, so `123,456` should be treated as a string.

Fix: https://dev.azure.com/ceapex/Engineering/_workitems/edit/134564?src=WorkItemMention&src-action=artifact_link


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5274)