### PR TITLE
Update Microsoft.DocAsCode.MarkdigEngine.Extensions package to "2.47.0"

### DIFF
--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
     <PackageReference Include="Microsoft.ChakraCore" Version="1.11.11" />
-    <PackageReference Include="Microsoft.DocAsCode.MarkdigEngine.Extensions" Version="2.48.0-b-191105003-g1e6ae2" />
+    <PackageReference Include="Microsoft.DocAsCode.MarkdigEngine.Extensions" Version="2.47.0" />
     <PackageReference Include="Microsoft.Graph" Version="1.16.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
@@ -32,7 +32,7 @@
     <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180503-2" />
     <PackageReference Include="System.Text.Json" Version="4.6.0-preview6.19259.10" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
-    <PackageReference Include="Validations.DocFx.Adapter" Version="1.2.14-alpha006" />
+    <PackageReference Include="Validations.DocFx.Adapter" Version="1.2.14-alpha007" />
     <PackageReference Include="YamlDotNet" Version="6.1.2" />
   </ItemGroup>
 


### PR DESCRIPTION
- update Microsoft.DocAsCode.MarkdigEngine.Extensions package to "2.47.0"

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5280)