### PR TITLE
[.links.json]Exclude non-build toc files from .links.json

### DIFF
--- a/docs/specs/output.yml
+++ b/docs/specs/output.yml
@@ -515,8 +515,6 @@ outputs:
 # source_url should be the includer of TOC
 inputs:
   docfx.yml: |
-    exclude: 
-      - docs/a/TOC.yml
     globalMetadata:
       "breadcrumb_path": "/docs/breadcrumbs/toc.json"
   docs/breadcrumbs/TOC.yml: |
@@ -545,33 +543,33 @@ outputs:
     {
       "links": [
         {
-          "source_url": "/docs/a",
-          "target_url": "/docs/breadcrumbs/toc.json"
+            "source_url": "/docs/a",
+            "target_url": "/docs/breadcrumbs/toc.json"
         },
         {
-          "source_url": "/docs/b",
-          "target_url": "/docs/breadcrumbs/toc.json"
+            "source_url": "/docs/b",
+            "target_url": "/docs/breadcrumbs/toc.json"
         },
         {
-          "source_url": "/docs/breadcrumbs/toc.json",
-          "target_url": "/"
+            "source_url": "/docs/breadcrumbs/toc.json",
+            "target_url": "/"
         },
         {
-          "source_url": "/docs/c",
-          "target_url": "/docs/breadcrumbs/toc.json"
+            "source_url": "/docs/c",
+            "target_url": "/docs/breadcrumbs/toc.json"
         },
         {
-          "source_url": "/docs/toc.json",
-          "target_url": "/docs/a"
+            "source_url": "/docs/toc.json",
+            "target_url": "/docs/a"
         },
         {
-          "source_url": "/docs/toc.json",
-          "target_url": "/docs/b"
+            "source_url": "/docs/toc.json",
+            "target_url": "/docs/b"
         },
         {
-          "source_url": "/docs/toc.json",
-          "target_url": "/docs/c"
-        },
+            "source_url": "/docs/toc.json",
+            "target_url": "/docs/c"
+        }
       ]
     }
   docs/a.json:

--- a/docs/specs/output.yml
+++ b/docs/specs/output.yml
@@ -543,33 +543,33 @@ outputs:
     {
       "links": [
         {
-            "source_url": "/docs/a",
-            "target_url": "/docs/breadcrumbs/toc.json"
+          "source_url": "/docs/a",
+          "target_url": "/docs/breadcrumbs/toc.json"
         },
         {
-            "source_url": "/docs/b",
-            "target_url": "/docs/breadcrumbs/toc.json"
+          "source_url": "/docs/b",
+          "target_url": "/docs/breadcrumbs/toc.json"
         },
         {
-            "source_url": "/docs/breadcrumbs/toc.json",
-            "target_url": "/"
+          "source_url": "/docs/breadcrumbs/toc.json",
+          "target_url": "/"
         },
         {
-            "source_url": "/docs/c",
-            "target_url": "/docs/breadcrumbs/toc.json"
+          "source_url": "/docs/c",
+          "target_url": "/docs/breadcrumbs/toc.json"
         },
         {
-            "source_url": "/docs/toc.json",
-            "target_url": "/docs/a"
+          "source_url": "/docs/toc.json",
+          "target_url": "/docs/a"
         },
         {
-            "source_url": "/docs/toc.json",
-            "target_url": "/docs/b"
+          "source_url": "/docs/toc.json",
+          "target_url": "/docs/b"
         },
         {
-            "source_url": "/docs/toc.json",
-            "target_url": "/docs/c"
-        }
+          "source_url": "/docs/toc.json",
+          "target_url": "/docs/c"
+        },
       ]
     }
   docs/a.json:

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Docs.Build
             PublishModelBuilder = new PublishModelBuilder(outputPath, docset.Config);
             BookmarkValidator = new BookmarkValidator(errorLog, PublishModelBuilder);
             ContributionProvider = new ContributionProvider(Input, docset, fallbackDocset, GitHubUserCache, GitCommitProvider);
-            FileLinkMapBuilder = new FileLinkMapBuilder(MonikerProvider, errorLog);
+            FileLinkMapBuilder = new FileLinkMapBuilder(MonikerProvider, errorLog, this);
             XrefResolver = new XrefResolver(this, docset, restoreFileMap, DependencyMapBuilder, FileLinkMapBuilder);
 
             LinkResolver = new LinkResolver(

--- a/src/docfx/build/link/FileLinkItem.cs
+++ b/src/docfx/build/link/FileLinkItem.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Docs.Build
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
     internal struct FileLinkItem : IEquatable<FileLinkItem>, IComparable<FileLinkItem>
     {
+        [JsonIgnore]
+        public Document SourceFile { get; set; }
+
         public string SourceUrl { get; set; }
 
         public string SourceMonikerGroup { get; set; }

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Web;
-using Microsoft.DocAsCode.MarkdigEngine.Extensions;
 
 namespace Microsoft.Docs.Build
 {


### PR DESCRIPTION
Follow up on #5282 

The included TOC files are not explicitly excluded from build in config, but excluded during the build process:
https://github.com/dotnet/docfx/blob/b6fb6518d42359c37443e173e0a54a018461c9f7/src/docfx/build/Build.cs#L208

https://dev.azure.com/ceapex/Engineering/_workitems/edit/139450

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5290)