### PR TITLE
Fix CommitBuildTime not saved using process lock

### DIFF
--- a/src/docfx/lib/git/CommitBuildTimeProvider.cs
+++ b/src/docfx/lib/git/CommitBuildTimeProvider.cs
@@ -58,7 +58,8 @@ namespace Microsoft.Docs.Build
             }
 
             Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(_commitBuildTimePath)));
-            File.WriteAllText(
+
+            ProcessUtility.WriteFile(
                 _commitBuildTimePath,
                 JsonUtility.Serialize(new CommitBuildTime { Commits = commits }));
         }


### PR DESCRIPTION
Fixes https://opbuildstorageprod.blob.core.windows.net/report/2019%5C11%5C14%5C6223da3c-63a4-481f-d52e-6b87321cd42f%5CCommit%5C201911140800483291-docfxConfig%5Crawlog.txt?sv=2016-05-31&sr=b&sig=yFUF%2BmHbJWDswp6TT3IETWjs4vhLiB%2Bhwstte3ZZ6Ys%3D&st=2019-11-14T07%3A56%3A10Z&se=2019-12-15T08%3A01%3A10Z&sp=r

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5292)