### PR TITLE
fix docfx crashed caused by invalid link

### DIFF
--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -633,3 +633,15 @@ inputs:
   docs/a.md: Hello `docfx`! 
 outputs: 
   docs/a/index.html:
+---
+# Invalid Link
+inputs: 
+  docfx.yml:
+  docs/a.md: |
+    [A](b.md/)
+  docs/b.md:
+outputs:
+  docs/a.json:
+  docs/b.json:
+  .errors.log: |
+    ["warning","file-not-found","Invalid file link: 'b.md/'.","docs/a.md",1,1]

--- a/src/docfx/build/context/Input.cs
+++ b/src/docfx/build/context/Input.cs
@@ -41,11 +41,11 @@ namespace Microsoft.Docs.Build
 
             if (commit is null)
             {
-                return File.Exists(PathUtility.NormalizeFile(Path.Combine(docsetPath, pathToDocset)));
+                return File.Exists(PathUtility.Normalize(Path.Combine(docsetPath, pathToDocset)));
             }
 
             var repoPath = GitUtility.FindRepo(docsetPath);
-            var pathToRepo = PathUtility.NormalizeFile(Path.GetRelativePath(repoPath, PathUtility.NormalizeFile(Path.Combine(docsetPath, pathToDocset))));
+            var pathToRepo = PathUtility.Normalize(Path.GetRelativePath(repoPath, PathUtility.Normalize(Path.Combine(docsetPath, pathToDocset))));
             return _gitBlobCache.GetOrAdd(file, _ => GitUtility.ReadBytes(repoPath, pathToRepo, commit)) != null;
         }
 


### PR DESCRIPTION
docfx will crash when there is an invalid link with `/` suffix: `[a](b.md/)`
Fix: https://ceapex.visualstudio.com/Engineering/_workitems/edit/141914

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5294)