### PR TITLE
Refactor build scope to use FilePath

### DIFF
--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -154,8 +154,9 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static async Task BuildFile(Context context, Document file)
+        private static async Task BuildFile(Context context, FilePath path)
         {
+            var file = context.DocumentProvider.GetDocument(path);
             if (!ShouldBuildFile(context, file))
             {
                 return;
@@ -181,7 +182,7 @@ namespace Microsoft.Docs.Build
                         break;
                 }
 
-                var hasErrors = context.ErrorLog.Write(file, errors);
+                var hasErrors = context.ErrorLog.Write(path, errors);
                 if (hasErrors)
                 {
                     context.PublishModelBuilder.MarkError(file);
@@ -191,7 +192,7 @@ namespace Microsoft.Docs.Build
             }
             catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
             {
-                context.ErrorLog.Write(file, dex.Error, isException: true);
+                context.ErrorLog.Write(path, dex.Error, isException: true);
                 context.PublishModelBuilder.MarkError(file);
             }
             catch

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Docs.Build
         public readonly Input Input;
         public readonly BuildScope BuildScope;
         public readonly RedirectionProvider RedirectionProvider;
-        public readonly WorkQueue<Document> BuildQueue;
+        public readonly WorkQueue<FilePath> BuildQueue;
         public readonly DocumentProvider DocumentProvider;
         public readonly MetadataProvider MetadataProvider;
         public readonly MonikerProvider MonikerProvider;
@@ -44,7 +44,7 @@ namespace Microsoft.Docs.Build
             var restoreFileMap = new RestoreFileMap(input);
             DependencyMapBuilder = new DependencyMapBuilder();
             _tocMap = new Lazy<TableOfContentsMap>(() => TableOfContentsMap.Create(this));
-            BuildQueue = new WorkQueue<Document>();
+            BuildQueue = new WorkQueue<FilePath>();
 
             Config = docset.Config;
             RestoreFileMap = restoreFileMap;
@@ -56,7 +56,7 @@ namespace Microsoft.Docs.Build
             MicrosoftGraphCache = new MicrosoftGraphCache(docset.Config);
             MetadataProvider = new MetadataProvider(docset, Input, MicrosoftGraphCache, restoreFileMap, DocumentProvider);
             MonikerProvider = new MonikerProvider(docset.Config, MetadataProvider, restoreFileMap);
-            BuildScope = new BuildScope(Input, DocumentProvider, docset, fallbackDocset);
+            BuildScope = new BuildScope(Config, Input, fallbackDocset);
             RedirectionProvider = new RedirectionProvider(docset.DocsetPath, ErrorLog, BuildScope, DocumentProvider, MonikerProvider);
             GitHubUserCache = new GitHubUserCache(docset.Config);
             GitCommitProvider = new GitCommitProvider();

--- a/src/docfx/build/context/Input.cs
+++ b/src/docfx/build/context/Input.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Docs.Build
                 {
                     // todo: get tree list from repository
                     return GitUtility.ListTree(repository.Path, repository.Commit)
-                        .Select(path => CreateFilePath(path.Replace('\\', '/')))
+                        .Select(path => CreateFilePath(path))
                         .ToArray();
                 }
 
@@ -180,7 +180,7 @@ namespace Microsoft.Docs.Build
 
                 return Directory
                 .GetFiles(entry, "*", SearchOption.AllDirectories)
-                    .Select(path => CreateFilePath(Path.GetRelativePath(entry, path).Replace('\\', '/')))
+                    .Select(path => CreateFilePath(Path.GetRelativePath(entry, path)))
                     .ToArray();
             }
 

--- a/src/docfx/build/dependency/LinkResolver.cs
+++ b/src/docfx/build/dependency/LinkResolver.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Docs.Build
         private readonly Docset _fallbackDocset;
         private readonly BuildScope _buildScope;
         private readonly RedirectionProvider _redirectionProvider;
-        private readonly WorkQueue<Document> _buildQueue;
+        private readonly WorkQueue<FilePath> _buildQueue;
         private readonly DocumentProvider _documentProvider;
         private readonly BookmarkValidator _bookmarkValidator;
         private readonly DependencyMapBuilder _dependencyMapBuilder;
@@ -30,7 +30,7 @@ namespace Microsoft.Docs.Build
             Docset fallbackDocset,
             Input input,
             BuildScope buildScope,
-            WorkQueue<Document> buildQueue,
+            WorkQueue<FilePath> buildQueue,
             RedirectionProvider redirectionProvider,
             DocumentProvider documentProvider,
             GitCommitProvider gitCommitProvider,
@@ -85,7 +85,7 @@ namespace Microsoft.Docs.Build
 
             if (file != null)
             {
-                _buildQueue.Enqueue(file);
+                _buildQueue.Enqueue(file.FilePath);
             }
 
             // NOTE: bookmark validation result depend on current inclusion stack

--- a/src/docfx/build/link/FileLinkMapBuilder.cs
+++ b/src/docfx/build/link/FileLinkMapBuilder.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Docs.Build
             var (error, monikers) = _monikerProvider.GetFileLevelMonikers(file.FilePath);
             if (error != null)
             {
-                _errorLog.Write(file, error);
+                _errorLog.Write(file.FilePath, error);
             }
 
             _links.TryAdd(new FileLinkItem()

--- a/src/docfx/lib/log/ErrorLog.cs
+++ b/src/docfx/lib/log/ErrorLog.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Docs.Build
             return hasErrors;
         }
 
-        public bool Write(Document file, IEnumerable<Error> errors)
+        public bool Write(FilePath file, IEnumerable<Error> errors)
         {
             var hasErrors = false;
             foreach (var error in errors)
@@ -83,12 +83,12 @@ namespace Microsoft.Docs.Build
             return hasErrors;
         }
 
-        public bool Write(Document file, Error error, bool isException = false)
+        public bool Write(FilePath file, Error error, bool isException = false)
         {
             return Write(
-                file.FilePath == error.FilePath || error.FilePath != null
+                file == error.FilePath || error.FilePath != null
                     ? error
-                    : new Error(error.Level, error.Code, error.Message, file.FilePath, error.Line, error.Column),
+                    : new Error(error.Level, error.Code, error.Message, file, error.Line, error.Column),
                 isException);
         }
 


### PR DESCRIPTION
Turn more low level places to use `FilePath` over `Document`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5296)