### PR TITLE
Redirect url support starting with https://hostName

### DIFF
--- a/docs/specs/redirection.yml
+++ b/docs/specs/redirection.yml
@@ -67,6 +67,18 @@ inputs:
       b.md: a
 outputs:
 ---
+# redirect to can start with https and hostname
+inputs:
+  docfx.yml: |
+    baseUrl: https://docs.microsoft.com/
+  b.md:
+  redirections.yml: |
+    renames:
+      a.md: https://docs.microsoft.com/b
+outputs:
+  b.json: |
+   {"document_id": "780484e9-a367-97ab-ba7d-a19f3b378a80", "document_version_independent_id": "e9b3f4e2-1a78-4b5d-fbb4-03e0a33e38f5"}
+---
 # Redirection files have conflicted ids
 # all redirection files will be built
 # redirection document id is retrieved from the first redirection file (a.md for below case)

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Docs.Build
             DocumentProvider = new DocumentProvider(docset, fallbackDocset, BuildScope, input, repositoryProvider, TemplateEngine);
             MetadataProvider = new MetadataProvider(docset, Input, MicrosoftGraphCache, restoreFileMap, DocumentProvider);
             MonikerProvider = new MonikerProvider(Config, BuildScope, MetadataProvider, restoreFileMap);
-            RedirectionProvider = new RedirectionProvider(docset.DocsetPath, ErrorLog, BuildScope, DocumentProvider, MonikerProvider);
+            RedirectionProvider = new RedirectionProvider(docset.DocsetPath, docset.HostName, ErrorLog, BuildScope, DocumentProvider, MonikerProvider);
             GitHubUserCache = new GitHubUserCache(docset.Config);
             GitCommitProvider = new GitCommitProvider();
             PublishModelBuilder = new PublishModelBuilder(outputPath, docset.Config);


### PR DESCRIPTION
While redirect_document_id, support redirect-url starting with `https://hostName`.

Fixing: [DevOps#141966](https://dev.azure.com/ceapex/Engineering/_workitems/edit/141966)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5301)