### PR TITLE
[Breaking] Support misc .ops.config.json properties

### DIFF
--- a/docs/specs/git.yml
+++ b/docs/specs/git.yml
@@ -138,7 +138,7 @@ repos:
 inputs:
   docfx.yml: |
     contribution:
-      excludedContributors:
+      excludeContributors:
         - AlIcE
         - BoB
 cache:
@@ -171,7 +171,7 @@ repos:
 inputs:
   docfx.yml: |
     contribution:
-      excludedContributors:
+      excludeContributors:
         - Alice
 cache:
   github-users.json: |
@@ -236,7 +236,7 @@ repos:
 inputs:
   docfx.yml: |
     contribution:
-      excludedContributors:
+      excludeContributors:
         - ChArLiE
 cache:
   github-users.json: |
@@ -260,7 +260,7 @@ outputs:
       },
     }
 ---
-# Author CAN be excluded if implicitly extracted from commit history
+# Author CAN be excluded if implicitly extracted from commit history using contributors_to_exclude global metadata
 repos:
   https://github.com/testowner/testrepo#master-exclude-author-from-commit-history:
     - author: Alice
@@ -270,8 +270,8 @@ repos:
           Alice creates this.
 inputs:
   docfx.yml: |
-    contribution:
-      excludedContributors:
+    globalMetadata:
+      contributors_to_exclude:
         - alice
 cache:
   github-users.json: |
@@ -304,13 +304,33 @@ repos:
 inputs:
   docfx.yml: |
     contribution:
-      repository: https://github.com/contrib-owner/contrib-repo#contrib-branch
+      repositoryUrl: https://github.com/contrib-owner/contrib-repo
+      repositoryBranch: contrib-branch
 outputs:
   docs/index.json: |
     {
       "content_git_url": "https://github.com/contrib-owner/contrib-repo/blob/contrib-branch/docs/index.md",
       "original_content_git_url": "https://github.com/testowner/testrepo/blob/master-edit-link/docs/index.md",
       "gitcommit": "https://github.com/testowner/testrepo/blob/e662dbc7c5e582a14b863d6a6a82e495d6272f91/docs/index.md",
+    }
+---
+# Specify editLink repo and branch in .openpublishing.publish.config.json
+repos:
+  https://github.com/testowner/test-op-edit-link-repo#master-edit-link:
+  - files:
+      .openpublishing.publish.config.json: |
+        {
+          "git_repository_url_open_to_public_contributors": "https://github.com/a/b",
+          "git_repository_branch_open_to_public_contributors": "c"
+        }
+      docfx.yml:
+      a.md:
+outputs:
+  a.json: |
+    {
+      "content_git_url": "https://github.com/a/b/blob/c/a.md",
+      "original_content_git_url": "https://github.com/testowner/test-op-edit-link-repo/blob/master-edit-link/a.md",
+      "gitcommit": "https://github.com/testowner/test-op-edit-link-repo/blob/65344f739e0bca9b2d0b93615f905d148af0607f/a.md",
     }
 ---
 # Use commit's time as updated_at when `updateTimeAsCommitBuildTime` is false
@@ -400,7 +420,7 @@ repos:
 inputs:
   docfx.yml: |
     contribution:
-      repository: https://github.com/testowner/testrepo
+      repositoryUrl: https://github.com/testowner/testrepo
 outputs:
   docs/index.json: |
     {
@@ -418,7 +438,7 @@ repos:
 inputs:
   docfx.yml: |
     contribution:
-      repository: https://github.com/contrib-owner/contrib-repo
+      repositoryUrl: https://github.com/contrib-owner/contrib-repo
 outputs:
   docs/index.json: |
     {
@@ -435,7 +455,7 @@ repos:
 inputs:
   docfx.yml: |
     contribution:
-      repository: https://github.com/docascode/a
+      repositoryUrl: https://github.com/docascode/a
 outputs:
   docs/index.json: |
     {
@@ -471,7 +491,7 @@ inputs:
     gitHub:
       authToken: {DOCS_GITHUB_TOKEN}
     contribution:
-      repository: https://github.com/docascode/contribution-test
+      repositoryUrl: https://github.com/docascode/contribution-test
 cache:
   github-users.json: |
       { "users": [
@@ -522,7 +542,7 @@ repos:
 inputs:
   docfx.yml: |
     contribution:
-      repository: https://docascode.visualstudio.com/contribution1/_git/a
+      repositoryUrl: https://docascode.visualstudio.com/contribution1/_git/a
 cache:
   github-users.json: |
       { "users": [
@@ -594,7 +614,8 @@ repos:
     - files:
         docfx.yml: |
           contribution:
-            repository: https://github.com/contrib-owner/contrib-repo#contrib-branch
+            repositoryUrl: https://github.com/contrib-owner/contrib-repo
+            repositoryBranch: contrib-branch
           files:
             - "docs/**/*"
             - "crrb/**/*"

--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -156,12 +156,12 @@ repos:
     - files:
         docfx.yml: |
           contribution:
-            repository: https://github.com/dotnet/docfx
+            repositoryUrl: https://github.com/dotnet/docfx
   https://docfx.com/edit-url1.zh-cn#live:
     - files:
         docfx.yml: |
           contribution:
-            repository: https://github.com/dotnet/docfx
+            repositoryUrl: https://github.com/dotnet/docfx
         docs/a.md:
 outputs:
   docs/a.json: |
@@ -177,14 +177,14 @@ repos:
           localization:
             mapping: Branch
           contribution:
-            repository: https://github.com/dotnet/docfx
+            repositoryUrl: https://github.com/dotnet/docfx
   https://docfx.com/edit-url2.loc#live.zh-cn:
     - files:
         docfx.yml: |
           localization:
             mapping: Branch
           contribution:
-            repository: https://github.com/dotnet/docfx
+            repositoryUrl: https://github.com/dotnet/docfx
         docs/a.md:
 outputs:
   docs/a.json: |
@@ -198,12 +198,12 @@ repos:
     - files:
         docfx.yml: |
           contribution:
-            repository: https://github.com/dotnet/docfx.en-us
+            repositoryUrl: https://github.com/dotnet/docfx.en-us
   https://docfx.com/edit-url3.zh-cn#live:
     - files:
         docfx.yml: |
           contribution:
-            repository: https://github.com/dotnet/docfx.en-us
+            repositoryUrl: https://github.com/dotnet/docfx.en-us
         docs/a.md:
 outputs:
   docs/a.json: |
@@ -218,14 +218,14 @@ repos:
     - files:
         docfx.yml: |
           contribution:
-            repository: https://github.com/dotnet/docfx
+            repositoryUrl: https://github.com/dotnet/docfx
           localization:
             mapping: Branch
   https://docfx.com/edit-url4.loc#live.zh-cn:
     - files:
         docfx.yml: |
           contribution:
-            repository: https://github.com/dotnet/docfx
+            repositoryUrl: https://github.com/dotnet/docfx
           localization:
             mapping: Branch
         docs/a.md:
@@ -242,7 +242,7 @@ repos:
   - files:
       docfx.yml: |
         contribution:
-          repository: https://github.com/dotnet/docfx.en-us
+          repositoryUrl: https://github.com/dotnet/docfx.en-us
         localization:
           mapping: Folder
       _localization/zh-cn/docs/a.md:
@@ -260,14 +260,14 @@ repos:
     - files:
         docfx.yml: |
           contribution:
-            repository: https://github.com/dotnet/docfx#master
+            repositoryUrl: https://github.com/dotnet/docfx
           localization:
             mapping: Branch
   https://docfx.com/edit-url5.loc#live-sxs.zh-cn:
     - files:
         docfx.yml: |
           contribution:
-            repository: https://github.com/dotnet/docfx#master
+            repositoryUrl: https://github.com/dotnet/docfx
           localization:
             mapping: Branch
         docs/a.md:
@@ -276,7 +276,7 @@ repos:
         docs/a.md:
 outputs:
   docs/a.json: |
-    { "content_git_url": "*dotnet/docfx.loc/blob/master.zh-cn/docs/*"}
+    { "content_git_url": "*dotnet/docfx.loc/blob/live.zh-cn/docs/*"}
 ---
 # loc file contributor info 1
 # [repository mapping]
@@ -326,14 +326,16 @@ repos:
             mapping: Branch
   https://github.com/c/contribution3.loc#master.zh-cn:
     - files:
-        docfx.yml:
+        docfx.yml: |
+          localization:
+            mapping: Branch
         docs/a.md:
 outputs:
   docs/a.json: |
     {
       "content_git_url":"https://github.com/c/contribution3.loc/blob/master.zh-cn/docs/a.md",
       "original_content_git_url":"https://github.com/c/contribution3.loc/blob/master.zh-cn/docs/a.md",
-      "gitcommit":"https://github.com/c/contribution3.loc/blob/81c533a0b7cc78260c82fb4e3b878f66158a9aca/docs/a.md"
+      "gitcommit":"https://github.com/c/contribution3.loc/blob/920e86f61c36833c2bde899880f15329a5ecdfaf/docs/a.md"
     }
 ---
 # loc file contributor info 4
@@ -372,7 +374,10 @@ repos:
             mapping: Branch
   https://github.com/c/contribution5.loc#master-sxs.zh-cn:
     - files:
-        docfx.yml:
+        docfx.yml: |
+          localization:
+            bilingual: true
+            mapping: Branch
         docs/a.md:
   https://github.com/c/contribution5.loc#master.zh-cn:
     - files:
@@ -382,7 +387,7 @@ outputs:
     {
       "content_git_url":"https://github.com/c/contribution5.loc/blob/master.zh-cn/docs/a.md",
       "original_content_git_url":"https://github.com/c/contribution5.loc/blob/master-sxs.zh-cn/docs/a.md",
-      "gitcommit":"https://github.com/c/contribution5.loc/blob/81c533a0b7cc78260c82fb4e3b878f66158a9aca/docs/a.md"
+      "gitcommit":"https://github.com/c/contribution5.loc/blob/16537a7ca422b81ba2e1a97b6f58bf3a6c5890cf/docs/a.md"
     }
 ---
 # loc page link and content fallback 1
@@ -1104,14 +1109,14 @@ repos:
     - files:
         docfx.yml: |
           contribution:
-            repository: https://github.com/dotnet/docfx
+            repositoryUrl: https://github.com/dotnet/docfx
         docs/a.md:
   https://github.com/locconfig/a.zh-cn:
     - files:
         docs/a.md:
         docfx.yml: |
           contribution:
-            repository: https://github.com/dotnet/docfx.zh-cn
+            repositoryUrl: https://github.com/dotnet/docfx.zh-cn
 outputs:
   docs/a.json: |
     { "content_git_url": "*dotnet/docfx.zh-cn/blob/master/*"}
@@ -1125,7 +1130,8 @@ repos:
     - files:
         docfx.yml: |
           contribution:
-            repository: https://github.com/dotnet/docfx#live
+            repositoryUrl: https://github.com/dotnet/docfx
+            repositoryBranch: live
           localization:
             mapping: Branch
         docs/a.md:
@@ -1134,7 +1140,8 @@ repos:
         docs/a.md:
         docfx.yml: |
           contribution:
-            repository: https://github.com/dotnet/docfx.loc#live
+            repositoryUrl: https://github.com/dotnet/docfx.loc
+            repositoryBranch: live
           localization:
             mapping: Branch
 outputs:
@@ -1150,7 +1157,7 @@ repos:
     - files:
         docfx.yml: |
           contribution:
-            repository: https://github.com/dotnet/docfx
+            repositoryUrl: https://github.com/dotnet/docfx
           localization:
             bilingual: true
         docs/a.md:
@@ -1159,7 +1166,7 @@ repos:
         docs/a.md:
         docfx.yml: |
           contribution:
-            repository: https://github.com/dotnet/docfx.zh-cn
+            repositoryUrl: https://github.com/dotnet/docfx.zh-cn
           localization:
             bilingual: true
   https://github.com/locconfig/c.zh-cn:
@@ -1178,7 +1185,8 @@ repos:
     - files:
         docfx.yml: |
           contribution:
-            repository: https://github.com/dotnet/docfx#live
+            repositoryUrl: https://github.com/dotnet/docfx
+            repositoryBranch: live
           localization:
             mapping: Branch
             bilingual: true
@@ -1188,7 +1196,8 @@ repos:
         docs/a.md:
         docfx.yml: |
           contribution:
-            repository: https://github.com/dotnet/docfx.loc#live
+            repositoryUrl: https://github.com/dotnet/docfx.loc
+            repositoryBranch: live
           localization:
             mapping: Branch
             bilingual: true

--- a/docs/specs/metadata.yml
+++ b/docs/specs/metadata.yml
@@ -332,3 +332,23 @@ inputs:
 outputs:
   docs/a.json: |
     {"title": "Title to overwrite"}
+---
+# Generate _op_pdfUrlPrefixTemplate when pdf is true
+inputs:
+  docfx.yml: |
+    output:
+      pdf: true
+  a.md:
+outputs:
+  a.json: |
+    { "_op_pdfUrlPrefixTemplate": "https://docs.com/pdfstore/en-us/./{branchName}" }
+---
+# Generate _op_pdfUrlPrefixTemplate when need_generate_pdf_url_template in .openpublishing.publish.config.json is true
+inputs:
+  .openpublishing.publish.config.json: |
+    { "need_generate_pdf_url_template": true }
+  docfx.yml:
+  a.md:
+outputs:
+  a.json: |
+    { "_op_pdfUrlPrefixTemplate": "https://docs.com/pdfstore/en-us/./{branchName}" }

--- a/src/docfx/build/metadata/GlobalMetadata.cs
+++ b/src/docfx/build/metadata/GlobalMetadata.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Docs.Build
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
     internal class GlobalMetadata
     {
-        [Obsolete("v2 backward compatibility")]
-        public string[] ContributorsToExclude { get; set; } = Array.Empty<string>();
+        // For v2 backward compatibility
+        public HashSet<string> ContributorsToExclude { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         // For v2 backward compatibility
         [JsonProperty("_op_documentIdPathDepotMapping")]

--- a/src/docfx/config/ConfigLoader.cs
+++ b/src/docfx/config/ConfigLoader.cs
@@ -223,31 +223,5 @@ namespace Microsoft.Docs.Build
                 config.Remove(overwriteConfigIdentifier);
             }
         }
-
-        private static OpsDocsetConfig LoadOpsDocsetConfig(string docsetPath)
-        {
-            var directory = docsetPath;
-
-            do
-            {
-                var fullPath = Path.Combine(directory, ".openpublishing.publish.config.json");
-                if (!File.Exists(fullPath))
-                {
-                    directory = Path.GetDirectoryName(directory);
-                    continue;
-                }
-
-                var filePath = new FilePath(Path.GetRelativePath(docsetPath, fullPath));
-                var opsConfig = JsonUtility.Deserialize<OpsConfig>(File.ReadAllText(fullPath), filePath);
-                var buildSourceFolder = PathUtility.NormalizeFolder(Path.GetRelativePath(directory, docsetPath));
-
-                return opsConfig.DocsetsToPublish.FirstOrDefault(config =>
-                    PathUtility.PathComparer.Equals(
-                        PathUtility.NormalizeFolder(config.BuildSourceFolder), buildSourceFolder));
-            }
-            while (!string.IsNullOrEmpty(directory));
-
-            return null;
-        }
     }
 }

--- a/src/docfx/config/ContributionConfig.cs
+++ b/src/docfx/config/ContributionConfig.cs
@@ -10,14 +10,17 @@ namespace Microsoft.Docs.Build
     {
         /// <summary>
         /// Specify the repository url for contribution
-        /// <protocol>://<hostname>[:<port>][:][/]<path>[#<branch>]
-        /// Fallback to git origin if not set.
         /// </summary>
-        public readonly string Repository;
+        public readonly string RepositoryUrl;
+
+        /// <summary>
+        /// Specify the repository branch for contribution
+        /// </summary>
+        public readonly string RepositoryBranch;
 
         /// <summary>
         /// The excluded contributors which you don't want to show
         /// </summary>
-        public readonly HashSet<string> ExcludedContributors = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        public readonly HashSet<string> ExcludeContributors = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/docfx/config/OutputConfig.cs
+++ b/src/docfx/config/OutputConfig.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Gets whether resources are copied to output.
         /// </summary>
-        public readonly bool CopyResources = true;
+        public readonly bool CopyResources = false;
 
         /// <summary>
         /// Gets the maximum errors to output.

--- a/src/docfx/config/ops/OpsConfig.cs
+++ b/src/docfx/config/ops/OpsConfig.cs
@@ -17,6 +17,12 @@ namespace Microsoft.Docs.Build
 
         public readonly OpsDependencyConfig[] DependentRepositories = Array.Empty<OpsDependencyConfig>();
 
+        public readonly string GitRepositoryBranchOpenToPublicContributors;
+
+        public readonly string GitRepositoryUrlOpenToPublicContributors;
+
+        public readonly bool NeedGeneratePdfUrlTemplate;
+
         public static bool TryLoad(string docsetPath, string branch, out JObject result)
         {
             var directory = docsetPath;
@@ -57,6 +63,14 @@ namespace Microsoft.Docs.Build
 
             result["template"] = dependencies.FirstOrDefault(
                 dep => dep.name.Equals("_themes", StringComparison.OrdinalIgnoreCase)).obj;
+
+            result["output"] = new JObject { ["pdf"] = opsConfig.NeedGeneratePdfUrlTemplate };
+
+            result["contribution"] = new JObject
+            {
+                ["repositoryUrl"] = opsConfig.GitRepositoryUrlOpenToPublicContributors,
+                ["repositoryBranch"] = opsConfig.GitRepositoryBranchOpenToPublicContributors,
+            };
 
             var docsetConfig = opsConfig.DocsetsToPublish.FirstOrDefault(config =>
                 PathUtility.PathComparer.Equals(

--- a/test/docfx.Test/docfx.test.yml
+++ b/test/docfx.Test/docfx.test.yml
@@ -2,5 +2,6 @@
 baseUrl: https://docs.com
 output:
   json: true
+  copyResources: true
 gitHub:
   userCacheExpirationInHours: 876000


### PR DESCRIPTION
Changes to existing config:
- Split `contribution.repository` to 2 properties `repositoryUrl` + `repositoryBranch`
- `excludedContributors` --> `excludeContributors`

Supported `.ops.config.json` values:
- git_repository_url_open_to_public_contributors
- git_repository_branch_open_to_public_contributors
- need_generate_pdf_url_template
- globalMetadata.contributors_to_exclude

Paired change: https://dev.azure.com/ceapex/Engineering/_git/Docs.Build/pullrequest/18284?_a=overview

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5308)