### PR TITLE
add attribute values to TripleColonBlock

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/TripleColonBlock.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/TripleColonBlock.cs
@@ -13,5 +13,6 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         public TripleColonBlock(BlockParser parser) : base(parser) { }
         public bool Closed { get; set; }
         public bool EndingTripleColons { get; set; }
+        public IDictionary<string, string> Attributes { get; set; }
     }
 }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/TripleColonParser.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/TripleColonParser.cs
@@ -64,7 +64,8 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
                 Line = processor.LineIndex,
                 Span = new SourceSpan(sourcePosition, slice.End),
                 Extension = extension,
-                RenderProperties = renderProperties
+                RenderProperties = renderProperties,
+                Attributes = attributes
             };
 
             if (htmlAttributes != null)


### PR DESCRIPTION
As part of validation, we want to verify the `loc_scope` attribute value is in the allow list. Currently, there is no `Attributes` property in the `TripleColonBlock`, so this adds it and passes in the parsed values.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5311)