### PR TITLE
Fix TOC inclusion fallback order

### DIFF
--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -1536,6 +1536,8 @@ repos:
   https://github.com/deletedtoc-1/a:
     - files:
         docfx.yml:
+        docs/b.md:
+        docs/c.md:
     - files:
         docfx.yml:
         docs/dir/TOC.json: |

--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -1529,4 +1529,53 @@ repos:
 outputs:
   docs/a.json: |
     { "conceptual":"<p>test</p>"}
-
+---
+# should fallback to deleted TOC.md not TOC.json
+locale: zh-cn
+repos:
+  https://github.com/deletedtoc-1/a:
+    - files:
+        docfx.yml:
+    - files:
+        docfx.yml:
+        docs/dir/TOC.json: |
+          {"items":[{"name":"reference c", "href":"../c.md"}]}
+        docs/dir/TOC.md: |
+          # [reference b.md](../b.md)
+        docs/b.md:
+        docs/c.md:
+  https://github.com/deletedtoc-1/a.zh-cn:
+    - files:
+        docfx.yml:
+        docs/TOC.yml: |
+          - name: name
+            href: dir/
+outputs:
+  docs/toc.json: |
+    {"items":[{"href":"b"}]}
+---
+# should not fallback to deleted TOC.md if TOC.yml exists
+locale: zh-cn
+repos:
+  https://github.com/deletedtoc-2/a:
+    - files:
+        docfx.yml:
+        docs/dir/TOC.yml: |
+          - name: toc existed
+            href: ../a.md
+        docs/a.md:
+        docs/b.md:
+    - files:
+        docfx.yml:
+        docs/dir/TOC.md: |
+          # [reference b.md](../b.md)
+        docs/b.md:
+  https://github.com/deletedtoc-2/a.zh-cn:
+    - files:
+        docfx.yml:
+        docs/TOC.yml: |
+          - name: name
+            href: dir/
+outputs:
+  docs/toc.json: |
+    {"items":[{"href":"a"}]}

--- a/src/docfx/build/toc/TableOfContentsLoader.cs
+++ b/src/docfx/build/toc/TableOfContentsLoader.cs
@@ -394,15 +394,23 @@ namespace Microsoft.Docs.Build
             switch (tocHrefType)
             {
                 case TocHrefType.RelativeFolder:
+                    (string, Document) result = default;
                     foreach (var tocFileName in s_tocFileNames)
                     {
                         var subToc = Resolve(tocFileName);
                         if (subToc != null)
                         {
-                            return subToc.Value;
+                            if (!subToc.Value.filePath.FilePath.IsFromHistory)
+                            {
+                                return subToc.Value;
+                            }
+                            else if (result == default)
+                            {
+                                result = subToc.Value;
+                            }
                         }
                     }
-                    return default;
+                    return result;
 
                 case TocHrefType.TocFile:
                     var (error, referencedTocContent, referencedToc) = _linkResolver.ResolveContent(

--- a/src/docfx/lib/path/FilePath.cs
+++ b/src/docfx/lib/path/FilePath.cs
@@ -12,6 +12,11 @@ namespace Microsoft.Docs.Build
     internal class FilePath : IEquatable<FilePath>, IComparable<FilePath>
     {
         /// <summary>
+        /// Indicate if the file is from git commit history.
+        /// </summary>
+        public bool IsFromHistory => Commit != null;
+
+        /// <summary>
         /// Gets the file path relative to the main docset(fallback docset).
         /// </summary>
         public PathString Path { get; }

--- a/src/docfx/lib/path/FilePath.cs
+++ b/src/docfx/lib/path/FilePath.cs
@@ -12,11 +12,6 @@ namespace Microsoft.Docs.Build
     internal class FilePath : IEquatable<FilePath>, IComparable<FilePath>
     {
         /// <summary>
-        /// Indicate if the file is from git commit history.
-        /// </summary>
-        public bool IsFromHistory => Commit != null;
-
-        /// <summary>
         /// Gets the file path relative to the main docset(fallback docset).
         /// </summary>
         public PathString Path { get; }
@@ -35,6 +30,11 @@ namespace Microsoft.Docs.Build
         /// Gets the commit id if this file is owned by a git repository and is not the latest version.
         /// </summary>
         public string Commit { get; }
+
+        /// <summary>
+        /// Indicate if the file is from git commit history.
+        /// </summary>
+        public bool IsFromHistory => Commit != null;
 
         public FilePath(string path, FileOrigin origin = FileOrigin.Default)
         {


### PR DESCRIPTION
https://ceapex.visualstudio.com/Engineering/_workitems/edit/145742

Fallback order for folder reference of TOC inclusion:
TOC.md -> TOC.json -> TOC.yml

If the build is for localization repo, the existing file should have higher priority than the deleted file from git history.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5317)