### PR TITLE
use text as the default type value so the html will be used when type is undefined

### DIFF
--- a/src/Microsoft.Docs.Template/Models/LandingData.cs
+++ b/src/Microsoft.Docs.Template/Models/LandingData.cs
@@ -78,11 +78,11 @@ namespace Microsoft.Docs.Build
 
     public enum LandingDataType
     {
+        Text,
         Paragraph,
         List,
         Table,
         Markdown,
-        Text,
         Grid,
     }
 


### PR DESCRIPTION
Fix Bug: https://dev.azure.com/ceapex/Engineering/_workitems/edit/144988?src=WorkItemMention&src-action=artifact_link  
according to the template, when the type of landingdata section items is undefined, we should HTML property directly.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5320)