### PR TITLE
Pass basePath in publish model instead of baseUrl

### DIFF
--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -101,7 +101,9 @@ repos:
     files:
       docfx.yml: |
         template: https://docs.com/template1
-        baseUrl: https://docs.com/rawmetadata
+        hostName: https://docs.com
+        basePath: rawmetadata
+
       redirections.yml: |
         redirections:
           a.md: /b
@@ -178,7 +180,7 @@ outputs:
         "content_git_url": "https://github.com/a/rawmetadata/blob/master/c.md",
         "original_content_git_url": "https://github.com/a/rawmetadata/blob/master/c.md",
         "original_content_git_url_template": "{repo}/blob/{branch}/c.md",
-        "gitcommit": "https://github.com/a/rawmetadata/blob/e8f058141f57d856be5a0c86b55cba07e0a8bace/c.md",
+        "gitcommit": "https://github.com/a/rawmetadata/blob/9549588dee7108d93d0bee2c9bb1c5659dd3c842/c.md",
         "site_name": "Docs",
         "depot_name": ".",
         "search.ms_docsetname": "",
@@ -326,7 +328,8 @@ inputs:
     monikerRange:
       'docs/v1/**': '< netcore-2.0'
       'docs/v2/**': 'netcore-2.0'
-    baseUrl: https://docs.com/docs
+    hostName: https://docs.com
+    basePath: docs
     routes:
       docs/: .
       docs/v1/: .
@@ -390,7 +393,8 @@ inputs:
     monikerRange:
       'docs/v1/**': 'netcore-1.0'
       'docs/v2/**': 'netcore-2.0'
-    baseUrl: https://docs.com/docs
+    hostName: https://docs.com
+    basePath: docs
     routes:
       docs/: .
       docs/v1/: .

--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -101,8 +101,8 @@ repos:
     files:
       docfx.yml: |
         template: https://docs.com/template1
-        hostName: https://docs.com
-        basePath: rawmetadata
+        hostName: docs.com
+        basePath: /rawmetadata
 
       redirections.yml: |
         redirections:
@@ -180,7 +180,7 @@ outputs:
         "content_git_url": "https://github.com/a/rawmetadata/blob/master/c.md",
         "original_content_git_url": "https://github.com/a/rawmetadata/blob/master/c.md",
         "original_content_git_url_template": "{repo}/blob/{branch}/c.md",
-        "gitcommit": "https://github.com/a/rawmetadata/blob/9549588dee7108d93d0bee2c9bb1c5659dd3c842/c.md",
+        "gitcommit": "https://github.com/a/rawmetadata/blob/dfa40713b23b18bc475f253526f3df9a59a99d3e/c.md",
         "site_name": "Docs",
         "depot_name": ".",
         "search.ms_docsetname": "",
@@ -328,8 +328,8 @@ inputs:
     monikerRange:
       'docs/v1/**': '< netcore-2.0'
       'docs/v2/**': 'netcore-2.0'
-    hostName: https://docs.com
-    basePath: docs
+    hostName: docs.com
+    basePath: /docs
     routes:
       docs/: .
       docs/v1/: .
@@ -393,8 +393,8 @@ inputs:
     monikerRange:
       'docs/v1/**': 'netcore-1.0'
       'docs/v2/**': 'netcore-2.0'
-    hostName: https://docs.com
-    basePath: docs
+    hostName: docs.com
+    basePath: /docs
     routes:
       docs/: .
       docs/v1/: .

--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -180,7 +180,7 @@ outputs:
         "content_git_url": "https://github.com/a/rawmetadata/blob/master/c.md",
         "original_content_git_url": "https://github.com/a/rawmetadata/blob/master/c.md",
         "original_content_git_url_template": "{repo}/blob/{branch}/c.md",
-        "gitcommit": "https://github.com/a/rawmetadata/blob/dfa40713b23b18bc475f253526f3df9a59a99d3e/c.md",
+        "gitcommit": "https://github.com/a/rawmetadata/blob/059da4c838d11026288349e031208d1e1c9aeeb5/c.md",
         "site_name": "Docs",
         "depot_name": ".",
         "search.ms_docsetname": "",

--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -634,11 +634,11 @@ repos:
   https://docs.com/metadata1#master:
     - files:
         docfx.yml: |
-          hostName: https://docs.microsoft.com
+          hostName: docs.microsoft.com
   https://docs.com/metadata1.zh-cn#master:
     - files:
         docfx.yml: |
-          hostName: https://docs.microsoft.com
+          hostName: docs.microsoft.com
         docs/a.md:
 outputs:
   docs/a.json: |
@@ -651,13 +651,13 @@ repos:
   https://docs.com/metadata2#live:
     - files:
         docfx.yml: |
-          hostName: https://docs.microsoft.com
+          hostName: docs.microsoft.com
           localization:
             mapping: Branch
   https://docs.com/metadata2.loc#live.zh-cn:
     - files:
         docfx.yml: |
-          hostName: https://docs.microsoft.com
+          hostName: docs.microsoft.com
         docs/a.md:
 outputs:
   docs/a.json: |
@@ -684,14 +684,14 @@ repos:
   https://docs.com/metadata4#master:
     - files:
         docfx.yml: |
-          hostName: https://docs.microsoft.com
+          hostName: docs.microsoft.com
           localization:
             mapping: Branch
             bilingual: true
   https://docs.com/metadata4.loc#master.zh-cn:
     - files:
         docfx.yml: |
-          hostName: https://docs.microsoft.com
+          hostName: docs.microsoft.com
         docs/a.md:
   https://docs.com/metadata4.loc#master-sxs.zh-cn:
     - files:

--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -668,7 +668,7 @@ outputs:
 locale: zh-cn
 inputs:
   docfx.yml: |
-    baseUrl: https://docs.microsoft.com
+    hostName: docs.microsoft.com
     localization:
       mapping: Folder
   _localization/zh-cn/docs/a.md:

--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -634,11 +634,11 @@ repos:
   https://docs.com/metadata1#master:
     - files:
         docfx.yml: |
-          baseUrl: https://docs.microsoft.com
+          hostName: https://docs.microsoft.com
   https://docs.com/metadata1.zh-cn#master:
     - files:
         docfx.yml: |
-          baseUrl: https://docs.microsoft.com
+          hostName: https://docs.microsoft.com
         docs/a.md:
 outputs:
   docs/a.json: |
@@ -651,13 +651,13 @@ repos:
   https://docs.com/metadata2#live:
     - files:
         docfx.yml: |
-          baseUrl: https://docs.microsoft.com
+          hostName: https://docs.microsoft.com
           localization:
             mapping: Branch
   https://docs.com/metadata2.loc#live.zh-cn:
     - files:
         docfx.yml: |
-          baseUrl: https://docs.microsoft.com
+          hostName: https://docs.microsoft.com
         docs/a.md:
 outputs:
   docs/a.json: |
@@ -684,14 +684,14 @@ repos:
   https://docs.com/metadata4#master:
     - files:
         docfx.yml: |
-          baseUrl: https://docs.microsoft.com
+          hostName: https://docs.microsoft.com
           localization:
             mapping: Branch
             bilingual: true
   https://docs.com/metadata4.loc#master.zh-cn:
     - files:
         docfx.yml: |
-          baseUrl: https://docs.microsoft.com
+          hostName: https://docs.microsoft.com
         docs/a.md:
   https://docs.com/metadata4.loc#master-sxs.zh-cn:
     - files:

--- a/docs/specs/metadata.yml
+++ b/docs/specs/metadata.yml
@@ -76,8 +76,8 @@ inputs:
   sccm/docfx.yml: |
     name: sccm
     product: Win
-    hostName: https://docs.com
-    basePath: sccm
+    hostName: docs.com
+    basePath: /sccm
   sccm/mdt/release-notes.md:
 outputs:
   sccm/sccm/mdt/release-notes.json: |
@@ -92,8 +92,8 @@ inputs:
     name: sccm
     product: Win
     files: "**/*"
-    hostName: https://docs.com
-    basePath: sccm
+    hostName: docs.com
+    basePath: /sccm
   sccm/mdm/index.md:
   sccm/index.md:
 outputs:
@@ -195,7 +195,7 @@ outputs:
 inputs:
   docfx.yml: |
     files: "**/*"
-    hostName: https://docs.microsoft.com
+    hostName: docs.microsoft.com
     routes:
       articles/: azure/
   articles/app-service/index.md:

--- a/docs/specs/metadata.yml
+++ b/docs/specs/metadata.yml
@@ -76,7 +76,8 @@ inputs:
   sccm/docfx.yml: |
     name: sccm
     product: Win
-    baseUrl: https://docs.com/sccm
+    hostName: https://docs.com
+    basePath: sccm
   sccm/mdt/release-notes.md:
 outputs:
   sccm/sccm/mdt/release-notes.json: |
@@ -91,7 +92,8 @@ inputs:
     name: sccm
     product: Win
     files: "**/*"
-    baseUrl: https://docs.com/sccm
+    hostName: https://docs.com
+    basePath: sccm
   sccm/mdm/index.md:
   sccm/index.md:
 outputs:
@@ -193,7 +195,7 @@ outputs:
 inputs:
   docfx.yml: |
     files: "**/*"
-    baseUrl: "https://docs.microsoft.com"
+    hostName: https://docs.microsoft.com
     routes:
       articles/: azure/
   articles/app-service/index.md:

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -5,8 +5,8 @@ inputs:
     monikerRange:
       'docs/v1/**': '< netcore-2.0'
       'docs/v2/**': '>= netcore-2.0'
-    hostName: https://docs.com
-    basePath: docs
+    hostName: docs.com
+    basePath: /docs
     routes:
       docs/: .
       docs/v1/: .
@@ -157,8 +157,8 @@ inputs:
     monikerRange:
       'docs/v1/**': '< netcore-2.0'
       'docs/v2/**': '>= netcore-2.0'
-    hostName: https://docs.com
-    basePath: docs
+    hostName: docs.com
+    basePath: /docs
     routes:
       docs/: .
       docs/v1/: .
@@ -1448,8 +1448,8 @@ inputs:
     monikerRange:
       'docs/v1/**': '< netcore-2.0'
       'docs/v2/**': '>= netcore-2.0'
-    hostName: https://docs.com
-    basePath: docs
+    hostName: docs.com
+    basePath: /docs
     routes:
       docs/: .
       docs/v1/: .
@@ -1501,8 +1501,8 @@ inputs:
   docfx.yml: |
     monikerRange:
       'docs/v1/**': 'netcore-1.0'
-    hostName: https://docs.com
-    basePath: docs
+    hostName: docs.com
+    basePath: /docs
     routes:
       docs/: .
       docs/v1/: .
@@ -1549,8 +1549,8 @@ inputs:
     exclude: "**/includes/**"
     monikerRange:
       'docs/v1/**': 'versioning-2.0 || versioning-1.0'
-    hostName: https://docs.com
-    basePath: docs
+    hostName: docs.com
+    basePath: /docs
     routes:
       docs/v1/: .
     monikerDefinition: monikerDefinition.json

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -5,7 +5,8 @@ inputs:
     monikerRange:
       'docs/v1/**': '< netcore-2.0'
       'docs/v2/**': '>= netcore-2.0'
-    baseUrl: https://docs.com/docs
+    hostName: https://docs.com
+    basePath: docs
     routes:
       docs/: .
       docs/v1/: .
@@ -156,7 +157,8 @@ inputs:
     monikerRange:
       'docs/v1/**': '< netcore-2.0'
       'docs/v2/**': '>= netcore-2.0'
-    baseUrl: https://docs.com/docs
+    hostName: https://docs.com
+    basePath: docs
     routes:
       docs/: .
       docs/v1/: .
@@ -1446,7 +1448,8 @@ inputs:
     monikerRange:
       'docs/v1/**': '< netcore-2.0'
       'docs/v2/**': '>= netcore-2.0'
-    baseUrl: https://docs.com/docs
+    hostName: https://docs.com
+    basePath: docs
     routes:
       docs/: .
       docs/v1/: .
@@ -1498,7 +1501,8 @@ inputs:
   docfx.yml: |
     monikerRange:
       'docs/v1/**': 'netcore-1.0'
-    baseUrl: https://docs.com/docs
+    hostName: https://docs.com
+    basePath: docs
     routes:
       docs/: .
       docs/v1/: .
@@ -1545,7 +1549,8 @@ inputs:
     exclude: "**/includes/**"
     monikerRange:
       'docs/v1/**': 'versioning-2.0 || versioning-1.0'
-    baseUrl: https://docs.com/docs
+    hostName: https://docs.com
+    basePath: docs
     routes:
       docs/v1/: .
     monikerDefinition: monikerDefinition.json

--- a/docs/specs/output.yml
+++ b/docs/specs/output.yml
@@ -24,8 +24,8 @@ outputs:
 # Publish manifest contains following properties: name, product, site_base_path
 inputs:
   docfx.yml: |
-    hostName: https://docs.com
-    basePath: base_path
+    hostName: docs.com
+    basePath: /base_path
 outputs:
   .publish.json: |
     {

--- a/docs/specs/output.yml
+++ b/docs/specs/output.yml
@@ -24,13 +24,14 @@ outputs:
 # Publish manifest contains following properties: name, product, site_base_path
 inputs:
   docfx.yml: |
-    baseUrl: https://docs.com/siteBasePath
+    hostName: https://docs.com
+    basePath: base_path
 outputs:
   .publish.json: |
     {
       "name": "",
       "product": "",
-      "site_base_path": "sitebasepath"
+      "base_path": "base_path"
     }
 ---
 # Publish manifest path is source relative path when copyResources is set to false

--- a/docs/specs/output.yml
+++ b/docs/specs/output.yml
@@ -21,15 +21,16 @@ outputs:
       ]
     }
 ---
-# Publish manifest contains following properties: name, product, baseUrl
+# Publish manifest contains following properties: name, product, site_base_path
 inputs:
-  docfx.yml:
+  docfx.yml: |
+    baseUrl: https://docs.com/siteBasePath
 outputs:
   .publish.json: |
     {
       "name": "",
       "product": "",
-      "base_url": "https://docs.com"
+      "site_base_path": "sitebasepath"
     }
 ---
 # Publish manifest path is source relative path when copyResources is set to false

--- a/docs/specs/redirection.yml
+++ b/docs/specs/redirection.yml
@@ -70,7 +70,7 @@ outputs:
 # redirect to can start with https and hostname
 inputs:
   docfx.yml: |
-    baseUrl: https://docs.microsoft.com/
+    hostName: https://docs.microsoft.com
   b.md:
   redirections.yml: |
     renames:
@@ -82,7 +82,7 @@ outputs:
 # redirect to can start with https and hostname with locale
 inputs:
   docfx.yml: |
-    baseUrl: https://docs.microsoft.com/
+    hostName: https://docs.microsoft.com
   b.md:
   redirections.yml: |
     renames:
@@ -119,7 +119,8 @@ outputs:
 # A => B, B's ids should be same with A's
 inputs:
   docs/docfx.yml: |
-    baseUrl: https://docs.com/docs
+    hostName: https://docs.com
+    basePath: docs
     routes:
       docs/: .
   docs/redirections.yml: |
@@ -153,7 +154,8 @@ inputs:
     name: sccm
     product: Win
     files: "**/*"
-    baseUrl: https://docs.com/sccm
+    hostName: https://docs.com
+    basePath: sccm
   redirections.yml: |
     redirections:
       sccm/mdm/index.md: /sccm/mdm/understand/hybrid-mobile-device-management
@@ -168,7 +170,8 @@ inputs:
   develop/docfx.yml: |
     name: partner-center-sdk
     product: MSDN
-    baseUrl: https://docs.com/partner-center-sdk
+    hostName: https://docs.com
+    basePath: partner-center-sdk
   develop/redirections.yml: |
     renames:
       agreement-metadata.md: agreement-metadata-resources
@@ -200,7 +203,8 @@ inputs:
     name: sccm
     product: Win
     files: "**/*"
-    baseUrl: https://docs.com/sccm
+    hostName: https://docs.com
+    basePath: sccm
   sccm/redirections.yml: |
     renames:
       mdm/index.md: /sccm/mdm/understand/hybrid-mobile-device-management
@@ -269,7 +273,8 @@ inputs:
         folder_relative_path_in_docset: articles
     name: azure-documents
     product: Azure
-    baseUrl: https://docs.com/Azure
+    hostName: https://docs.com
+    basePath: azure
     routes:
       articles/: .
   articles/iot-central/concepts-architecture.md:
@@ -313,7 +318,8 @@ inputs:
     name: azure-documents
     product: Azure
     files: "**/*"
-    baseUrl: https://docs.com/azure
+    hostName: https://docs.com
+    basePath: azure
     routes:
       articles/: .
   redirections.yml: |
@@ -335,7 +341,8 @@ inputs:
     product: Azure
     name: azure-documents
     files: "**/*"
-    baseUrl: https://docs.com/articles
+    hostName: https://docs.com
+    basePath: azure
     routes:
       articles/: .
   articles/active-directory-b2c/index.yml : |
@@ -345,9 +352,9 @@ inputs:
     ### YamlMime:YamlDocument
     documentType: LandingData
 outputs:
-  articles/active-directory-b2c/index.json: |
+  azure/active-directory-b2c/index.json: |
     {"metadata": { "document_id": "4b5e7225-dae6-053e-4657-c4731dbd7d64", "document_version_independent_id": "fdf17736-63c4-6c9f-825b-393312bbd63a"}}
-  articles/active-directory-b2c/test.json: |
+  azure/active-directory-b2c/test.json: |
     {"metadata": { "document_id": "89987066-1e32-4f92-1957-329cfa9de0a0", "document_version_independent_id": "8f254336-d196-b36f-649e-dec30465941b"}}
 ---
 # index.yml's document id also follows the redirection rules
@@ -357,7 +364,8 @@ inputs:
     product: Azure
     name: azure-documents
     files: "**/*"
-    baseUrl: https://docs.com/azure
+    hostName: https://docs.com
+    basePath: azure
     routes:
       articles/: .
   redirections.yml: |

--- a/docs/specs/redirection.yml
+++ b/docs/specs/redirection.yml
@@ -70,7 +70,7 @@ outputs:
 # redirect to can start with https and hostname
 inputs:
   docfx.yml: |
-    hostName: https://docs.microsoft.com
+    hostName: docs.microsoft.com
   b.md:
   redirections.yml: |
     renames:
@@ -82,11 +82,11 @@ outputs:
 # redirect to can start with https and hostname with locale
 inputs:
   docfx.yml: |
-    hostName: https://docs.microsoft.com
+    hostName: docs.microsoft.com
   b.md:
   redirections.yml: |
     renames:
-      a.md: https://docs.microsoft.com/en-us/b
+      a.md: https://docs.microsoft.com/en-us/b?query#fragment
 outputs:
   b.json: |
    {"document_id": "780484e9-a367-97ab-ba7d-a19f3b378a80", "document_version_independent_id": "e9b3f4e2-1a78-4b5d-fbb4-03e0a33e38f5"}
@@ -119,8 +119,8 @@ outputs:
 # A => B, B's ids should be same with A's
 inputs:
   docs/docfx.yml: |
-    hostName: https://docs.com
-    basePath: docs
+    hostName: docs.com
+    basePath: /docs
     routes:
       docs/: .
   docs/redirections.yml: |
@@ -154,8 +154,8 @@ inputs:
     name: sccm
     product: Win
     files: "**/*"
-    hostName: https://docs.com
-    basePath: sccm
+    hostName: docs.com
+    basePath: /sccm
   redirections.yml: |
     redirections:
       sccm/mdm/index.md: /sccm/mdm/understand/hybrid-mobile-device-management
@@ -170,8 +170,8 @@ inputs:
   develop/docfx.yml: |
     name: partner-center-sdk
     product: MSDN
-    hostName: https://docs.com
-    basePath: partner-center-sdk
+    hostName: docs.com
+    basePath: /partner-center-sdk
   develop/redirections.yml: |
     renames:
       agreement-metadata.md: agreement-metadata-resources
@@ -203,8 +203,8 @@ inputs:
     name: sccm
     product: Win
     files: "**/*"
-    hostName: https://docs.com
-    basePath: sccm
+    hostName: docs.com
+    basePath: /sccm
   sccm/redirections.yml: |
     renames:
       mdm/index.md: /sccm/mdm/understand/hybrid-mobile-device-management
@@ -273,8 +273,8 @@ inputs:
         folder_relative_path_in_docset: articles
     name: azure-documents
     product: Azure
-    hostName: https://docs.com
-    basePath: azure
+    hostName: docs.com
+    basePath: /azure
     routes:
       articles/: .
   articles/iot-central/concepts-architecture.md:
@@ -318,8 +318,8 @@ inputs:
     name: azure-documents
     product: Azure
     files: "**/*"
-    hostName: https://docs.com
-    basePath: azure
+    hostName: docs.com
+    basePath: /azure
     routes:
       articles/: .
   redirections.yml: |
@@ -341,8 +341,8 @@ inputs:
     product: Azure
     name: azure-documents
     files: "**/*"
-    hostName: https://docs.com
-    basePath: azure
+    hostName: docs.com
+    basePath: /azure
     routes:
       articles/: .
   articles/active-directory-b2c/index.yml : |
@@ -364,8 +364,8 @@ inputs:
     product: Azure
     name: azure-documents
     files: "**/*"
-    hostName: https://docs.com
-    basePath: azure
+    hostName: docs.com
+    basePath: /azure
     routes:
       articles/: .
   redirections.yml: |

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -45,7 +45,7 @@ outputs:
 # Should not remove host name if not sharing with xref href
 inputs:
   docfx.yml: |
-    baseUrl: https://docs.microsoft.co
+    hostName: docs.microsoft.co
     xref: 
       - 1.xrefmap.json
   docs/a.md: Link to @System.String?displayProperty=fullName

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -21,7 +21,7 @@ outputs:
 # hostname should be removed if docset sharing the same one
 inputs:
   docfx.yml: |
-    baseUrl: https://docs.microsoft.com
+    hostName: https://docs.microsoft.com
     xref: 
       - 1.xrefmap.json
       - 2.xrefmap.json
@@ -105,8 +105,9 @@ repos:
   https://docs.com/test-uid-conceptual#live:
     - files:
         docfx.yml: |
-          baseUrl: https://docs.com/base_path
-          xrefBaseUrl: https://test.docs.com
+          hostName: https://docs.com
+          basePath: base_path
+          xrefHostName: https://test.docs.com
         docs/a.md: |
           ---
           title: Title from yaml header a
@@ -160,7 +161,8 @@ repos:
   https://docs.com/test-uid-conceptual#live:
     - files:
         docfx.yml: |
-          baseUrl: https://docs.microsoft.com/base_path
+          hostName: https://docs.microsoft.com
+          basePath: base_path
           xref: 
             - 1.xrefmap.json
         docs/a.md: Link to @System.String
@@ -259,7 +261,8 @@ repos:
     - files:
         docfx.yml: |
           template: {APP_BASE_PATH}data/template
-          baseUrl: https://docs.com/base_path
+          hostName: https://docs.com
+          basePath: base_path
         docs/a.yml: |
           #YamlMime:TestData
           uid: a
@@ -918,7 +921,7 @@ outputs:
 # uid resolving should respect the order of xref settings
 inputs:
   docfx.yml: |
-    baseUrl: https://docs.microsoft.com
+    hostName: https://docs.microsoft.com
     xref: 
       - 1.xrefmap.json
       - 2.xrefmap.json
@@ -1022,7 +1025,8 @@ repos:
   https://docs.com/test#live:
     - files:
         docfx.yml: |
-          baseUrl: https://docs.com/base_path
+          hostName: https://docs.com
+          basePath: base_path
         docs/a.md: |
           ---
           title: Title from yaml header a

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -21,7 +21,7 @@ outputs:
 # hostname should be removed if docset sharing the same one
 inputs:
   docfx.yml: |
-    hostName: https://docs.microsoft.com
+    hostName: docs.microsoft.com
     xref: 
       - 1.xrefmap.json
       - 2.xrefmap.json
@@ -105,9 +105,9 @@ repos:
   https://docs.com/test-uid-conceptual#live:
     - files:
         docfx.yml: |
-          hostName: https://docs.com
-          basePath: base_path
-          xrefHostName: https://test.docs.com
+          hostName: docs.com
+          basePath: /base_path
+          xrefhostName: test.docs.com
         docs/a.md: |
           ---
           title: Title from yaml header a
@@ -161,8 +161,8 @@ repos:
   https://docs.com/test-uid-conceptual#live:
     - files:
         docfx.yml: |
-          hostName: https://docs.microsoft.com
-          basePath: base_path
+          hostName: docs.microsoft.com
+          basePath: /base_path
           xref: 
             - 1.xrefmap.json
         docs/a.md: Link to @System.String
@@ -261,8 +261,8 @@ repos:
     - files:
         docfx.yml: |
           template: {APP_BASE_PATH}data/template
-          hostName: https://docs.com
-          basePath: base_path
+          hostName: docs.com
+          basePath: /base_path
         docs/a.yml: |
           #YamlMime:TestData
           uid: a
@@ -921,7 +921,7 @@ outputs:
 # uid resolving should respect the order of xref settings
 inputs:
   docfx.yml: |
-    hostName: https://docs.microsoft.com
+    hostName: docs.microsoft.com
     xref: 
       - 1.xrefmap.json
       - 2.xrefmap.json
@@ -1025,8 +1025,8 @@ repos:
   https://docs.com/test#live:
     - files:
         docfx.yml: |
-          hostName: https://docs.com
-          basePath: base_path
+          hostName: docs.com
+          basePath: /base_path
         docs/a.md: |
           ---
           title: Title from yaml header a

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Docs.Build
             DocumentProvider = new DocumentProvider(docset, fallbackDocset, BuildScope, input, repositoryProvider, TemplateEngine);
             MetadataProvider = new MetadataProvider(docset, Input, MicrosoftGraphAccessor, FileResolver, DocumentProvider);
             MonikerProvider = new MonikerProvider(Config, BuildScope, MetadataProvider, FileResolver);
-            RedirectionProvider = new RedirectionProvider(docset.DocsetPath, docset.HostName, ErrorLog, BuildScope, DocumentProvider, MonikerProvider);
+            RedirectionProvider = new RedirectionProvider(docset.DocsetPath, Config.HostName, ErrorLog, BuildScope, DocumentProvider, MonikerProvider);
             GitHubAccessor = new GitHubAccessor(docset.Config);
             GitCommitProvider = new GitCommitProvider();
             PublishModelBuilder = new PublishModelBuilder(outputPath, docset.Config);

--- a/src/docfx/build/document/Docset.cs
+++ b/src/docfx/build/document/Docset.cs
@@ -45,17 +45,6 @@ namespace Microsoft.Docs.Build
         /// </summary>
         public Repository Repository { get; }
 
-        /// <summary>
-        /// Gets the site base path calculated from <see cref="Config.BaseUrl"/>.
-        /// It is either an empty string, or a path without leading /
-        /// </summary>
-        public string SiteBasePath { get; }
-
-        /// <summary>
-        /// Gets the {Schema}://{HostName}
-        /// </summary>
-        public string HostName { get; }
-
         private readonly ConcurrentDictionary<string, Lazy<Repository>> _repositories;
 
         public Docset(string docsetPath, string locale, Config config, Repository repository)
@@ -64,7 +53,6 @@ namespace Microsoft.Docs.Build
             DocsetPath = PathUtility.NormalizeFolder(Path.GetFullPath(docsetPath));
             Locale = !string.IsNullOrEmpty(locale) ? locale.ToLowerInvariant() : config.Localization.DefaultLocale;
             Culture = CreateCultureInfo(Locale);
-            (HostName, SiteBasePath) = UrlUtility.SplitBaseUrl(config.BaseUrl);
 
             Repository = repository;
 

--- a/src/docfx/build/document/Document.cs
+++ b/src/docfx/build/document/Document.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Docs.Build
         public FilePath FilePath { get; }
 
         /// <summary>
-        /// Gets file path relative to <see cref="Config.BaseUrl"/> that is:
+        /// Gets file path relative to <see cref="Config.BasePath"/> that is:
         /// For dynamic rendering:
         ///       locale  moniker-list-hash    site-path
         ///                       base_path

--- a/src/docfx/build/document/DocumentProvider.cs
+++ b/src/docfx/build/document/DocumentProvider.cs
@@ -267,7 +267,7 @@ namespace Microsoft.Docs.Build
                 siteUrl = PathToAbsoluteUrl(sitePath, contentType, mime, config.Output.Json, isPage);
             }
 
-            return $"{docset.Config.HostName}/{docset.Locale}{siteUrl}";
+            return $"https://{docset.Config.HostName}/{docset.Locale}{siteUrl}";
 
             string ReplaceLast(string source, string find, string replace)
             {

--- a/src/docfx/build/document/DocumentProvider.cs
+++ b/src/docfx/build/document/DocumentProvider.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Docs.Build
         {
             var file = GetDocument(path);
 
-            var outputPath = UrlUtility.Combine(_docset.SiteBasePath, MonikerUtility.GetGroup(monikers) ?? "", file.SitePath);
+            var outputPath = UrlUtility.Combine(_docset.Config.BasePath, MonikerUtility.GetGroup(monikers) ?? "", file.SitePath);
 
             return _docset.Config.Legacy && file.IsPage ? LegacyUtility.ChangeExtension(outputPath, ".raw.page.json") : outputPath;
         }
@@ -187,7 +187,7 @@ namespace Microsoft.Docs.Build
                 sitePath = sitePath.ToLowerInvariant();
             }
 
-            var siteUrl = PathToAbsoluteUrl(Path.Combine(docset.SiteBasePath, sitePath), contentType, mime, docset.Config.Output.Json, isPage);
+            var siteUrl = PathToAbsoluteUrl(Path.Combine(docset.Config.BasePath, sitePath), contentType, mime, docset.Config.Output.Json, isPage);
             var canonicalUrl = GetCanonicalUrl(siteUrl, sitePath, docset, isExperimental, contentType, mime, isPage);
 
             return new Document(docset, path, sitePath, siteUrl, canonicalUrl, contentType, mime, isExperimental, isPage);
@@ -267,7 +267,7 @@ namespace Microsoft.Docs.Build
                 siteUrl = PathToAbsoluteUrl(sitePath, contentType, mime, config.Output.Json, isPage);
             }
 
-            return $"{docset.HostName}/{docset.Locale}{siteUrl}";
+            return $"{docset.Config.HostName}/{docset.Locale}{siteUrl}";
 
             string ReplaceLast(string source, string find, string replace)
             {

--- a/src/docfx/build/legacy/LegacyFileMap.cs
+++ b/src/docfx/build/legacy/LegacyFileMap.cs
@@ -30,14 +30,14 @@ namespace Microsoft.Docs.Build
                         {
                             return;
                         }
-                        var legacyOutputFilePathRelativeToSiteBasePath = document.ToLegacyOutputPathRelativeToSiteBasePath(
+                        var legacyOutputFilePathRelativeToBasePath = document.ToLegacyOutputPathRelativeToBasePath(
                             context, docset, fileManifest.Value);
-                        var legacySiteUrlRelativeToSiteBasePath = document.ToLegacySiteUrlRelativeToSiteBasePath(docset);
+                        var legacySiteUrlRelativeToBasePath = document.ToLegacySiteUrlRelativeToBasePath(docset);
 
                         var version = context.MonikerProvider.GetFileLevelMonikerRange(document.FilePath);
                         var fileItem = LegacyFileMapItem.Instance(
-                            legacyOutputFilePathRelativeToSiteBasePath,
-                            legacySiteUrlRelativeToSiteBasePath,
+                            legacyOutputFilePathRelativeToBasePath,
+                            legacySiteUrlRelativeToBasePath,
                             document.ContentType,
                             version,
                             fileManifest.Value.Monikers);
@@ -58,9 +58,9 @@ namespace Microsoft.Docs.Build
             context.Output.WriteJson(
                 new
                 {
-                    host = docset.HostName,
+                    host = docset.Config.HostName,
                     locale = docset.Locale,
-                    base_path = $"/{docset.SiteBasePath}",
+                    base_path = $"/{docset.Config.BasePath}",
                     source_base_path = ".",
                     version_info = new { },
                     from_docfx_v3 = true,
@@ -78,7 +78,7 @@ namespace Microsoft.Docs.Build
                         },
                         item => item.fileMapItem),
                 },
-                Path.Combine(docset.SiteBasePath, "filemap.json"));
+                Path.Combine(docset.Config.BasePath, "filemap.json"));
         }
     }
 }

--- a/src/docfx/build/legacy/LegacyFileMap.cs
+++ b/src/docfx/build/legacy/LegacyFileMap.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Docs.Build
             context.Output.WriteJson(
                 new
                 {
-                    host = docset.Config.HostName,
+                    host = $"https://{docset.Config.HostName}",
                     locale = docset.Locale,
                     base_path = $"/{docset.Config.BasePath}",
                     source_base_path = ".",

--- a/src/docfx/build/legacy/LegacyFileMapItem.cs
+++ b/src/docfx/build/legacy/LegacyFileMapItem.cs
@@ -31,8 +31,8 @@ namespace Microsoft.Docs.Build
         public bool ShouldSerializeIsMonikerRange() => !string.IsNullOrEmpty(Version);
 
         public LegacyFileMapItem(
-            string legacyOutputFilePathRelativeToSiteBasePath,
-            string legacySiteUrlRelativeToSiteBasePath,
+            string legacyOutputFilePathRelativeToBasePath,
+            string legacySiteUrlRelativeToBasePath,
             ContentType contentType,
             string version,
             IReadOnlyList<string> monikers)
@@ -43,15 +43,15 @@ namespace Microsoft.Docs.Build
                 case ContentType.Redirection:
                     Type = "Content";
                     OutputRelativePath = PathUtility.NormalizeFile(
-                        LegacyUtility.ChangeExtension(legacyOutputFilePathRelativeToSiteBasePath, ".html"));
-                    AssetId = legacySiteUrlRelativeToSiteBasePath;
+                        LegacyUtility.ChangeExtension(legacyOutputFilePathRelativeToBasePath, ".html"));
+                    AssetId = legacySiteUrlRelativeToBasePath;
                     Version = version;
                     Monikers = monikers;
                     break;
                 case ContentType.Resource:
                     Type = "Resource";
-                    OutputRelativePath = PathUtility.NormalizeFile(legacyOutputFilePathRelativeToSiteBasePath);
-                    AssetId = legacySiteUrlRelativeToSiteBasePath;
+                    OutputRelativePath = PathUtility.NormalizeFile(legacyOutputFilePathRelativeToBasePath);
+                    AssetId = legacySiteUrlRelativeToBasePath;
                     Version = version;
                     Monikers = monikers;
                     break;
@@ -62,8 +62,8 @@ namespace Microsoft.Docs.Build
         }
 
         public static LegacyFileMapItem Instance(
-            string legacyOutputFilePathRelativeToSiteBasePath,
-            string legacySiteUrlRelativeToSiteBasePath,
+            string legacyOutputFilePathRelativeToBasePath,
+            string legacySiteUrlRelativeToBasePath,
             ContentType contentType,
             string version,
             IReadOnlyList<string> monikers)
@@ -74,7 +74,7 @@ namespace Microsoft.Docs.Build
             }
 
             return new LegacyFileMapItem(
-                legacyOutputFilePathRelativeToSiteBasePath, legacySiteUrlRelativeToSiteBasePath, contentType, version, monikers);
+                legacyOutputFilePathRelativeToBasePath, legacySiteUrlRelativeToBasePath, contentType, version, monikers);
         }
 
         private static string RemoveExtension(string path)

--- a/src/docfx/build/legacy/LegacyUtility.cs
+++ b/src/docfx/build/legacy/LegacyUtility.cs
@@ -8,35 +8,35 @@ namespace Microsoft.Docs.Build
 {
     internal static class LegacyUtility
     {
-        public static string ToLegacyOutputPathRelativeToSiteBasePath(this Document doc, Context context, Docset docset, PublishItem manifestItem)
+        public static string ToLegacyOutputPathRelativeToBasePath(this Document doc, Context context, Docset docset, PublishItem manifestItem)
         {
             var outputPath = manifestItem.Path;
             if (doc.ContentType == ContentType.Resource && !doc.Docset.Config.Output.CopyResources)
             {
                 outputPath = context.DocumentProvider.GetOutputPath(doc.FilePath, manifestItem.Monikers);
             }
-            var legacyOutputFilePathRelativeToSiteBasePath = Path.GetRelativePath(
-                string.IsNullOrEmpty(docset.SiteBasePath) ? "." : docset.SiteBasePath, outputPath);
+            var legacyOutputFilePathRelativeToBasePath = Path.GetRelativePath(
+                string.IsNullOrEmpty(docset.Config.BasePath) ? "." : docset.Config.BasePath, outputPath);
 
-            return PathUtility.NormalizeFile(legacyOutputFilePathRelativeToSiteBasePath);
+            return PathUtility.NormalizeFile(legacyOutputFilePathRelativeToBasePath);
         }
 
-        public static string ToLegacySiteUrlRelativeToSiteBasePath(this Document doc, Docset docset)
+        public static string ToLegacySiteUrlRelativeToBasePath(this Document doc, Docset docset)
         {
-            var legacySiteUrlRelativeToSiteBasePath = doc.SiteUrl;
-            if (legacySiteUrlRelativeToSiteBasePath.StartsWith($"/{docset.SiteBasePath}", PathUtility.PathComparison))
+            var legacySiteUrlRelativeToBasePath = doc.SiteUrl;
+            if (legacySiteUrlRelativeToBasePath.StartsWith($"/{docset.Config.BasePath}", PathUtility.PathComparison))
             {
-                legacySiteUrlRelativeToSiteBasePath = legacySiteUrlRelativeToSiteBasePath.Substring(1);
-                legacySiteUrlRelativeToSiteBasePath = Path.GetRelativePath(
-                    string.IsNullOrEmpty(docset.SiteBasePath) ? "." : docset.SiteBasePath,
-                    string.IsNullOrEmpty(legacySiteUrlRelativeToSiteBasePath) ? "." : legacySiteUrlRelativeToSiteBasePath);
+                legacySiteUrlRelativeToBasePath = legacySiteUrlRelativeToBasePath.Substring(1);
+                legacySiteUrlRelativeToBasePath = Path.GetRelativePath(
+                    string.IsNullOrEmpty(docset.Config.BasePath) ? "." : docset.Config.BasePath,
+                    string.IsNullOrEmpty(legacySiteUrlRelativeToBasePath) ? "." : legacySiteUrlRelativeToBasePath);
             }
 
             return PathUtility.NormalizeFile(
                 Path.GetFileNameWithoutExtension(doc.FilePath.Path).Equals("index", PathUtility.PathComparison)
                 && doc.ContentType != ContentType.Resource
-                ? $"{legacySiteUrlRelativeToSiteBasePath}/index"
-                : legacySiteUrlRelativeToSiteBasePath);
+                ? $"{legacySiteUrlRelativeToBasePath}/index"
+                : legacySiteUrlRelativeToBasePath);
         }
 
         public static string ChangeExtension(string filePath, string extension, string[] acceptableExtension = null)

--- a/src/docfx/build/legacy/manifest/LegacyManifest.cs
+++ b/src/docfx/build/legacy/manifest/LegacyManifest.cs
@@ -25,9 +25,9 @@ namespace Microsoft.Docs.Build
                 Parallel.ForEach(fileManifests, fileManifest =>
                     {
                         var document = fileManifest.Key;
-                        var legacyOutputPathRelativeToSiteBasePath = document.ToLegacyOutputPathRelativeToSiteBasePath(
+                        var legacyOutputPathRelativeToBasePath = document.ToLegacyOutputPathRelativeToBasePath(
                             context, docset, fileManifest.Value);
-                        var legacySiteUrlRelativeToSiteBasePath = document.ToLegacySiteUrlRelativeToSiteBasePath(docset);
+                        var legacySiteUrlRelativeToBasePath = document.ToLegacySiteUrlRelativeToBasePath(docset);
 
                         var output = new LegacyManifestOutput
                         {
@@ -37,8 +37,8 @@ namespace Microsoft.Docs.Build
                             {
                                 IsRawPage = false,
                                 RelativePath = document.ContentType == ContentType.Resource
-                                ? legacyOutputPathRelativeToSiteBasePath + ".mta.json"
-                                : LegacyUtility.ChangeExtension(legacyOutputPathRelativeToSiteBasePath, ".mta.json"),
+                                ? legacyOutputPathRelativeToBasePath + ".mta.json"
+                                : LegacyUtility.ChangeExtension(legacyOutputPathRelativeToBasePath, ".mta.json"),
                             },
                         };
 
@@ -46,7 +46,7 @@ namespace Microsoft.Docs.Build
                         {
                             var resourceOutput = new LegacyManifestOutputItem
                             {
-                                RelativePath = legacyOutputPathRelativeToSiteBasePath,
+                                RelativePath = legacyOutputPathRelativeToBasePath,
                                 IsRawPage = false,
                             };
                             if (!docset.Config.Output.CopyResources)
@@ -61,7 +61,7 @@ namespace Microsoft.Docs.Build
                             output.TocOutput = new LegacyManifestOutputItem
                             {
                                 IsRawPage = false,
-                                RelativePath = legacyOutputPathRelativeToSiteBasePath,
+                                RelativePath = legacyOutputPathRelativeToBasePath,
                             };
                         }
 
@@ -72,7 +72,7 @@ namespace Microsoft.Docs.Build
                                 output.PageOutput = new LegacyManifestOutputItem
                                 {
                                     IsRawPage = false,
-                                    RelativePath = LegacyUtility.ChangeExtension(legacyOutputPathRelativeToSiteBasePath, ".raw.page.json"),
+                                    RelativePath = LegacyUtility.ChangeExtension(legacyOutputPathRelativeToBasePath, ".raw.page.json"),
                                 };
                             }
                             else
@@ -80,14 +80,14 @@ namespace Microsoft.Docs.Build
                                 output.TocOutput = new LegacyManifestOutputItem
                                 {
                                     IsRawPage = false,
-                                    RelativePath = legacyOutputPathRelativeToSiteBasePath,
+                                    RelativePath = legacyOutputPathRelativeToBasePath,
                                 };
                             }
                         }
 
                         var file = new LegacyManifestItem
                         {
-                            AssetId = legacySiteUrlRelativeToSiteBasePath,
+                            AssetId = legacySiteUrlRelativeToBasePath,
                             Original = fileManifest.Value.SourcePath,
                             SourceRelativePath = document.FilePath.Path,
                             OriginalType = GetOriginalType(document.ContentType),
@@ -128,7 +128,7 @@ namespace Microsoft.Docs.Build
                     version_info = new { },
                     items_to_publish = itemsToPublish,
                 },
-                Path.Combine(docset.SiteBasePath, ".manifest.json"));
+                Path.Combine(docset.Config.BasePath, ".manifest.json"));
             }
         }
 

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -164,12 +164,12 @@ namespace Microsoft.Docs.Build
             systemMetadata.SearchDocsetName = file.Docset.Config.Name;
 
             systemMetadata.Path = file.SitePath;
-            systemMetadata.CanonicalUrlPrefix = UrlUtility.Combine(file.Docset.Config.HostName, systemMetadata.Locale, file.Docset.Config.BasePath) + "/";
+            systemMetadata.CanonicalUrlPrefix = UrlUtility.Combine($"https://{file.Docset.Config.HostName}", systemMetadata.Locale, file.Docset.Config.BasePath) + "/";
 
             if (file.Docset.Config.Output.Pdf)
             {
                 systemMetadata.PdfUrlPrefixTemplate = UrlUtility.Combine(
-                    file.Docset.Config.HostName, "pdfstore", systemMetadata.Locale, $"{file.Docset.Config.Product}.{file.Docset.Config.Name}", "{branchName}");
+                    $"https://{file.Docset.Config.HostName}", "pdfstore", systemMetadata.Locale, $"{file.Docset.Config.Product}.{file.Docset.Config.Name}", "{branchName}");
             }
 
             return (errors, systemMetadata);

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -164,12 +164,12 @@ namespace Microsoft.Docs.Build
             systemMetadata.SearchDocsetName = file.Docset.Config.Name;
 
             systemMetadata.Path = file.SitePath;
-            systemMetadata.CanonicalUrlPrefix = UrlUtility.Combine(file.Docset.HostName, systemMetadata.Locale, file.Docset.SiteBasePath) + "/";
+            systemMetadata.CanonicalUrlPrefix = UrlUtility.Combine(file.Docset.Config.HostName, systemMetadata.Locale, file.Docset.Config.BasePath) + "/";
 
             if (file.Docset.Config.Output.Pdf)
             {
                 systemMetadata.PdfUrlPrefixTemplate = UrlUtility.Combine(
-                    file.Docset.HostName, "pdfstore", systemMetadata.Locale, $"{file.Docset.Config.Product}.{file.Docset.Config.Name}", "{branchName}");
+                    file.Docset.Config.HostName, "pdfstore", systemMetadata.Locale, $"{file.Docset.Config.Product}.{file.Docset.Config.Name}", "{branchName}");
             }
 
             return (errors, systemMetadata);

--- a/src/docfx/build/redirection/RedirectionProvider.cs
+++ b/src/docfx/build/redirection/RedirectionProvider.cs
@@ -224,14 +224,15 @@ namespace Microsoft.Docs.Build
 
         private static string RemoveLeadingHostNameLocale(string redirectionUrl, string hostName)
         {
-            var (redirectHostName, redirectPath) = UrlUtility.SplitBaseUrl(redirectionUrl);
-            if (!string.Equals(redirectHostName, hostName, StringComparison.OrdinalIgnoreCase))
+            var uri = new Uri(redirectionUrl);
+            var redirectPath = UrlUtility.MergeUrl(uri.PathAndQuery, "", uri.Fragment).TrimStart('/');
+            if (!string.Equals(uri.Host, hostName, StringComparison.OrdinalIgnoreCase))
             {
                 return redirectionUrl;
             }
 
             int slashIndex = redirectPath.IndexOf('/');
-            if (redirectPath.IndexOf('/') < 0)
+            if (slashIndex < 0)
             {
                 return $"/{redirectPath}";
             }

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Docs.Build
             if (file.Docset.Config.Output.Pdf)
             {
                 model.Metadata.PdfAbsolutePath = "/" +
-                    UrlUtility.Combine(file.Docset.SiteBasePath, "opbuildpdf", monikerGroup ?? string.Empty, LegacyUtility.ChangeExtension(file.SitePath, ".pdf"));
+                    UrlUtility.Combine(file.Docset.Config.BasePath, "opbuildpdf", monikerGroup ?? string.Empty, LegacyUtility.ChangeExtension(file.SitePath, ".pdf"));
             }
 
             // TODO: Add experimental and experiment_id to publish item

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Docs.Build
                     // DHS appends branch infomation from cookie cache to URL, which is wrong for UID resolved URL
                     // output xref map with URL appending "?branch=master" for master branch
                     var (_, _, fragment) = UrlUtility.SplitUrl(xref.Href);
-                    var path = $"{_xrefHostName}{xref.DeclaringFile.SiteUrl}";
+                    var path = $"https://{_xrefHostName}{xref.DeclaringFile.SiteUrl}";
                     var query = repositoryBranch == "master" ? "?branch=master" : "";
                     xrefSpec.Href = UrlUtility.MergeUrl(path, query, fragment);
                     return xrefSpec;
@@ -149,13 +149,13 @@ namespace Microsoft.Docs.Build
 
         private string RemoveSharingHost(string url, string hostName)
         {
-            if (url.StartsWith($"{hostName}/", StringComparison.OrdinalIgnoreCase))
+            if (url.StartsWith($"https://{hostName}/", StringComparison.OrdinalIgnoreCase))
             {
-                return url.Substring(hostName.Length);
+                return url.Substring($"https://{hostName}".Length);
             }
 
             // TODO: this workaround can be removed when all xref related repos migrated to v3
-            if (hostName.Equals("https://docs.microsoft.com", StringComparison.OrdinalIgnoreCase)
+            if (hostName.Equals("docs.microsoft.com", StringComparison.OrdinalIgnoreCase)
                         && url.StartsWith($"https://review.docs.microsoft.com/", StringComparison.OrdinalIgnoreCase))
             {
                 return url.Substring("https://review.docs.microsoft.com".Length);

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Docs.Build
 
             _dependencyMapBuilder = dependencyMapBuilder;
             _fileLinkMapBuilder = fileLinkMapBuilder;
-            _xrefHostName = string.IsNullOrEmpty(context.Config.XrefBaseUrl) ? docset.HostName : context.Config.XrefBaseUrl;
+            _xrefHostName = string.IsNullOrEmpty(context.Config.XrefHostName) ? docset.Config.HostName : context.Config.XrefHostName;
         }
 
         public (Error error, string href, string display, Document declaringFile) ResolveAbsoluteXref(
@@ -72,7 +72,7 @@ namespace Microsoft.Docs.Build
                 queries["view"] = moniker;
             }
             var resolvedHref = UrlUtility.MergeUrl(
-                RemoveSharingHost(xrefSpec.Href, referencingFile.Docset.HostName),
+                RemoveSharingHost(xrefSpec.Href, referencingFile.Docset.Config.HostName),
                 queries.AllKeys.Length == 0 ? "" : "?" + string.Join('&', queries),
                 fragment.Length == 0 ? "" : fragment);
 
@@ -104,7 +104,7 @@ namespace Microsoft.Docs.Build
         public XrefMapModel ToXrefMapModel()
         {
             string repositoryBranch = null;
-            string siteBasePath = null;
+            string basePath = null;
             var references = _internalXrefMap.Value.Values
                 .Select(xref =>
                 {
@@ -113,9 +113,9 @@ namespace Microsoft.Docs.Build
                     {
                         repositoryBranch = xref.DeclaringFile.Docset.Repository?.Branch;
                     }
-                    if (siteBasePath is null)
+                    if (basePath is null)
                     {
-                        siteBasePath = xref.DeclaringFile.Docset.SiteBasePath;
+                        basePath = xref.DeclaringFile.Docset.Config.BasePath;
                     }
 
                     // DHS appends branch infomation from cookie cache to URL, which is wrong for UID resolved URL
@@ -129,10 +129,10 @@ namespace Microsoft.Docs.Build
                 .OrderBy(xref => xref.Uid).ToArray();
 
             var model = new XrefMapModel { References = references };
-            if (siteBasePath != null)
+            if (basePath != null)
             {
                 var properties = new XrefProperties();
-                properties.Tags.Add($"/{siteBasePath}");
+                properties.Tags.Add($"/{basePath}");
                 if (repositoryBranch == "master")
                 {
                     properties.Tags.Add("internal");

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Docs.Build
             if (Output.LowerCaseUrl)
             {
                 HostName = HostName.ToLowerInvariant();
-                BasePath = BasePath.ToLowerInvariant();
+                BasePath = BasePath.ToLowerInvariant().TrimStart('/');
             }
         }
     }

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -69,14 +69,20 @@ namespace Microsoft.Docs.Build
         public readonly GlobalMetadata GlobalMetadata = new GlobalMetadata();
 
         /// <summary>
-        /// {Schema}://{Hostname}/{SiteBasePath}: https://docs.microsoft.com/dotnet
+        /// Gets the {Schema}://{HostName}
         /// </summary>
-        public string BaseUrl { get; private set; } = string.Empty;
+        public string HostName { get; private set; } = string.Empty;
 
         /// <summary>
-        /// host name used for generating .xrefmap.json
+        /// Gets the site base path.
+        /// It is either an empty string, or a path without leading /
         /// </summary>
-        public string XrefBaseUrl { get; private set; } = string.Empty;
+        public string BasePath { get; private set; } = string.Empty;
+
+        /// <summary>
+        /// Gets host name used for generating .xrefmap.json
+        /// </summary>
+        public string XrefHostName { get; private set; } = string.Empty;
 
         /// <summary>
         /// Gets whether we are running in legacy mode
@@ -209,7 +215,8 @@ namespace Microsoft.Docs.Build
         {
             if (Output.LowerCaseUrl)
             {
-                BaseUrl = BaseUrl.ToLowerInvariant();
+                HostName = HostName.ToLowerInvariant();
+                BasePath = BasePath.ToLowerInvariant();
             }
         }
     }

--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -40,10 +40,9 @@ namespace Microsoft.Docs.Build
             {
                 ["product"] = docset.product_name,
                 ["siteName"] = docset.site_name,
-                ["hostName"] = $"https://{GetHostName(docset.site_name)}",
-                ["basePath"] = docset.base_path.TrimStart('/'),
-                ["baseUrl"] = $"https://{GetHostName(docset.site_name)}{docset.base_path}",
-                ["xrefBaseUrl"] = $"https://{GetXrefHostName(docset.site_name, branch)}",
+                ["hostName"] = GetHostName(docset.site_name),
+                ["basePath"] = docset.base_path,
+                ["xrefHostName"] = GetXrefHostName(docset.site_name, branch),
                 ["localization"] = new JObject
                 {
                     ["defaultLocale"] = GetDefaultLocale(docset.site_name),

--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Docs.Build
             {
                 ["product"] = docset.product_name,
                 ["siteName"] = docset.site_name,
+                ["hostName"] = $"https://{GetHostName(docset.site_name)}",
+                ["basePath"] = docset.base_path.TrimStart('/'),
                 ["baseUrl"] = $"https://{GetHostName(docset.site_name)}{docset.base_path}",
                 ["xrefBaseUrl"] = $"https://{GetXrefHostName(docset.site_name, branch)}",
                 ["localization"] = new JObject

--- a/src/docfx/lib/UrlUtility.cs
+++ b/src/docfx/lib/UrlUtility.cs
@@ -68,28 +68,6 @@ namespace Microsoft.Docs.Build
         }
 
         /// <summary>
-        /// Split an absolute URL into a host name (including https://) and a base path (never starts with /)
-        /// </summary>
-        public static (string host, string basePath) SplitBaseUrl(string url)
-        {
-            url = url.Replace('\\', '/');
-
-            var i = url.IndexOf("://");
-            if (i < 0)
-            {
-                return ("", url.TrimStart('/'));
-            }
-
-            i = url.IndexOf('/', i + 3);
-            if (i < 0)
-            {
-                return (url, "");
-            }
-
-            return (url.Substring(0, i), url.Substring(i).TrimStart('/'));
-        }
-
-        /// <summary>
         /// Combines URL segments into a single URL.
         /// </summary>
         public static string Combine(params string[] urlSegments)

--- a/src/docfx/publish/PublishModel.cs
+++ b/src/docfx/publish/PublishModel.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -15,7 +14,7 @@ namespace Microsoft.Docs.Build
 
         public string Product { get; set; }
 
-        public string SiteBasePath { get; set; }
+        public string BasePath { get; set; }
 
         public PublishItem[] Files { get; set; }
 

--- a/src/docfx/publish/PublishModel.cs
+++ b/src/docfx/publish/PublishModel.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Docs.Build
 
         public string Product { get; set; }
 
-        public string BaseUrl { get; set; }
+        public string SiteBasePath { get; set; }
 
         public PublishItem[] Files { get; set; }
 

--- a/src/docfx/publish/PublishModelBuilder.cs
+++ b/src/docfx/publish/PublishModelBuilder.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Docs.Build
             {
                 Name = _config.Name,
                 Product = _config.Product,
-                BaseUrl = _config.BaseUrl,
+                SiteBasePath = UrlUtility.SplitBaseUrl(_config.BaseUrl).basePath,
                 Files = _publishItems.Values
                     .OrderBy(item => item.Locale)
                     .ThenBy(item => item.Path)

--- a/src/docfx/publish/PublishModelBuilder.cs
+++ b/src/docfx/publish/PublishModelBuilder.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Docs.Build
             {
                 Name = _config.Name,
                 Product = _config.Product,
-                SiteBasePath = UrlUtility.SplitBaseUrl(_config.BaseUrl).basePath,
+                BasePath = _config.BasePath,
                 Files = _publishItems.Values
                     .OrderBy(item => item.Locale)
                     .ThenBy(item => item.Path)

--- a/test/docfx.Test/ModuleInitializer.cs
+++ b/test/docfx.Test/ModuleInitializer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Docs.Build
         public static void Initialize()
         {
             Environment.SetEnvironmentVariable("DOCFX_APPDATA_PATH", Path.GetFullPath("appdata"));
-            Environment.SetEnvironmentVariable("DOCFX_BASE_URL", "https://docs.com");
+            Environment.SetEnvironmentVariable("DOCFX_HOST_NAME", "https://docs.com");
             Environment.SetEnvironmentVariable("DOCFX_OUTPUT__JSON", "true");
             Environment.SetEnvironmentVariable("DOCFX_OUTPUT__COPY_RESOURCES", "true");
 

--- a/test/docfx.Test/ModuleInitializer.cs
+++ b/test/docfx.Test/ModuleInitializer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Docs.Build
         public static void Initialize()
         {
             Environment.SetEnvironmentVariable("DOCFX_APPDATA_PATH", Path.GetFullPath("appdata"));
-            Environment.SetEnvironmentVariable("DOCFX_HOST_NAME", "https://docs.com");
+            Environment.SetEnvironmentVariable("DOCFX_HOST_NAME", "docs.com");
             Environment.SetEnvironmentVariable("DOCFX_OUTPUT__JSON", "true");
             Environment.SetEnvironmentVariable("DOCFX_OUTPUT__COPY_RESOURCES", "true");
 

--- a/test/docfx.Test/build/OpsConfigAdapterTest.cs
+++ b/test/docfx.Test/build/OpsConfigAdapterTest.cs
@@ -14,22 +14,22 @@ namespace Microsoft.Docs.Build
             "azure-documents",
             "https://github.com/MicrosoftDocs/azure-docs-pr",
             "master",
-            "{'product':'Azure','siteName':'Docs','baseUrl':'https://docs.microsoft.com/azure','xrefBaseUrl':'https://review.docs.microsoft.com','localization':{'defaultLocale':'en-us'}}")]
+            "{'product':'Azure','siteName':'Docs','hostName':'docs.microsoft.com','basePath':'/azure','xrefHostName':'review.docs.microsoft.com','localization':{'defaultLocale':'en-us'}}")]
         [InlineData(
             "azure-documents",
             "https://github.com/MicrosoftDocs/azure-docs-pr",
             "live",
-            "{'product':'Azure','siteName':'Docs','baseUrl':'https://docs.microsoft.com/azure','xrefBaseUrl':'https://docs.microsoft.com','localization':{'defaultLocale':'en-us'}}")]
+            "{'product':'Azure','siteName':'Docs','hostName':'docs.microsoft.com','basePath':'/azure','xrefHostName':'docs.microsoft.com','localization':{'defaultLocale':'en-us'}}")]
         [InlineData(
             "azure-documents",
             "https://github.com/MicrosoftDocs/azure-docs-pr.zh-cn",
             "live-sxs",
-            "{'product':'Azure','siteName':'Docs','baseUrl':'https://docs.microsoft.com/azure','xrefBaseUrl':'https://docs.microsoft.com','localization':{'defaultLocale':'en-us'}}")]
+            "{'product':'Azure','siteName':'Docs','hostName':'docs.microsoft.com','basePath':'/azure','xrefHostName':'docs.microsoft.com','localization':{'defaultLocale':'en-us'}}")]
         [InlineData(
             "mooncake-docs",
             "https://github.com/MicrosoftDocs/mc-docs-pr",
             "master",
-            "{'product':'Azure','siteName':'DocsAzureCN','baseUrl':'https://docs.azure.cn/','xrefBaseUrl':'https://review.docs.azure.cn','localization':{'defaultLocale':'zh-cn'}}")]
+            "{'product':'Azure','siteName':'DocsAzureCN','hostName':'docs.azure.cn','basePath':'/','xrefHostName':'review.docs.azure.cn','localization':{'defaultLocale':'zh-cn'}}")]
         public static void AdaptOpsServiceConfig(string name, string repository, string branch, string expectedJson)
         {
             var token = Environment.GetEnvironmentVariable("DOCS_OPS_TOKEN");

--- a/test/docfx.Test/lib/UrlUtilityTest.cs
+++ b/test/docfx.Test/lib/UrlUtilityTest.cs
@@ -27,23 +27,6 @@ namespace Microsoft.Docs.Build
         }
 
         [Theory]
-        [InlineData("", "", "")]
-        [InlineData("/", "", "")]
-        [InlineData("/a", "", "a")]
-        [InlineData("https://github.com", "https://github.com", "")]
-        [InlineData("https://github.com/", "https://github.com", "")]
-        [InlineData("https://github.com/a", "https://github.com", "a")]
-        [InlineData("https://github.com/a/b", "https://github.com", "a/b")]
-        [InlineData("https://github.com/a/b/", "https://github.com", "a/b/")]
-        public static void SplitBaseUrl(string url, string host, string basePath)
-        {
-            var (ahost, abasePath) = UrlUtility.SplitBaseUrl(url);
-
-            Assert.Equal(host, ahost);
-            Assert.Equal(basePath, abasePath);
-        }
-
-        [Theory]
         [InlineData("", "", "", "")]
         [InlineData("", "?b", "#c", "?b#c")]
         [InlineData("a", "?b=1", "#c", "a?b=1#c")]


### PR DESCRIPTION
1. break baseUrl docfx config into hostName and basePath
2. rename siteBasePath to basePath to be consistent with OP
3. pass basePath inside publish model instead of baseUrl to avoid repeated combine/split

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5352)