### PR TITLE
fix cardF className

### DIFF
--- a/src/Microsoft.Docs.Template/Views/Template/BuildItemListPartial.cshtml
+++ b/src/Microsoft.Docs.Template/Views/Template/BuildItemListPartial.cshtml
@@ -91,15 +91,19 @@ else if (Model.Style == "cards")
             {
                 className = "panelContent " + Model.ClassName;
             }
+            else
+            {
+                className = Model.ClassName;
+            }
             if (Model.Columns is JValue value)
             {
                 if (int.TryParse(value.ToString(), out var i))
                 {
-                    className = Model.ClassName + " cols cols" + i.ToString();
+                    className += " cols cols" + i.ToString();
                 }
                 else
                 {
-                    className += Model.ClassName + " cols cols4";
+                    className += " cols cols4";
                 }
             }
         }

--- a/src/Microsoft.Docs.Template/Views/Template/BuildItemListPartial.cshtml
+++ b/src/Microsoft.Docs.Template/Views/Template/BuildItemListPartial.cshtml
@@ -95,16 +95,13 @@ else if (Model.Style == "cards")
             {
                 className = Model.ClassName;
             }
-            if (Model.Columns is JValue value)
+            if (Model.Columns is JValue value && int.TryParse(value.ToString(), out var i))
             {
-                if (int.TryParse(value.ToString(), out var i))
-                {
-                    className += " cols cols" + i.ToString();
-                }
-                else
-                {
-                    className += " cols cols4";
-                }
+                className += " cols cols" + i.ToString();
+            }
+            else
+            {
+                className += " cols cols4";
             }
         }
         else


### PR DESCRIPTION
Compare with [v2 card list template](https://github.com/microsoft/templates.docs.msft/blob/master/ContentTemplate/LandingData.html.primary.js#L49-L53), we need add `panelContent ` to `cardF className` and avoid `Model.ClassName` being added to `className` twice

Find related workitem [here](https://ceapex.visualstudio.com/Engineering/_workitems/edit/143283?src=WorkItemMention&src-action=artifact_link)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5353)