### PR TITLE
Use extend config to restore ops service config

### DIFF
--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -108,7 +108,7 @@ inputs:
     extend: https://this-url-does-not-exit.com/this-is-a-bad-url
 outputs:
   .errors.log: |
-    ["error","download-failed","Download failed for file 'https://this-url-does-not-exit.com/this-is-a-bad-url'. Try closing and reopening the PR. If you get this Error again, file an issue."]
+    ["error","download-failed","Download failed for file 'https://this-url-does-not-exit.com/this-is-a-bad-url*'. Try closing and reopening the PR. If you get this Error again, file an issue."]
 ---
 # Show error when git clone failed
 inputs:

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Docs.Build
                     using (restoreGitMap = RestoreGitMap.Create(docsetPath, locale))
                     {
                         var configLoader = new ConfigLoader(repository, new OpsConfigAdapter(errorLog));
-                        (errors, config) = await configLoader.Load(docsetPath, options, noFetch: true);
+                        (errors, config) = configLoader.Load(docsetPath, locale, options, noFetch: true);
                         if (errorLog.Write(errors))
                             return false;
 

--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -10,12 +10,12 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using System.Web;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build
 {
     internal class OpsConfigAdapter : IDisposable
     {
+        public const string BuildConfigApi = "https://ops/buildconfig/";
         private const string MonikerDefinitionApi = "https://ops/monikerDefinition/";
         private const string MetadataSchemaApi = "https://ops/metadataschema/";
         private const string MarkdownValidationRulesApi = "https://ops/markdownvalidationrules/";
@@ -46,54 +46,10 @@ namespace Microsoft.Docs.Build
             _errorLog = errorLog;
             _apis = new (string, Func<Uri, Task<string>>)[]
             {
+                (BuildConfigApi, GetBuildConfig),
                 (MonikerDefinitionApi, GetMonikerDefinition),
                 (MetadataSchemaApi, GetMetadataSchema),
                 (MarkdownValidationRulesApi, GetMarkdownValidationRules),
-            };
-        }
-
-        public async Task<JObject> GetBuildConfig(SourceInfo<string> name, string repository, string branch)
-        {
-            if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(repository))
-            {
-                return null;
-            }
-
-            var url = $"{s_buildServiceEndpoint}/v2/Queries/Docsets?git_repo_url={repository}&docset_query_status=Created";
-            var docsetInfo = await Fetch(url, s_opsHeaders, nullOn404: true);
-            if (docsetInfo is null)
-            {
-                throw Errors.DocsetNotProvisioned(name).ToException(isError: false);
-            }
-
-            var docsets = JsonConvert.DeserializeAnonymousType(
-                docsetInfo,
-                new[] { new { name = "", base_path = "", site_name = "", product_name = "" } });
-
-            var docset = docsets.FirstOrDefault(d => string.Equals(d.name, name, StringComparison.OrdinalIgnoreCase));
-            if (docset is null)
-            {
-                throw Errors.DocsetNotProvisioned(name).ToException(isError: false);
-            }
-
-            var metadataServiceQueryParams = $"?repository_url={HttpUtility.UrlEncode(repository)}&branch={HttpUtility.UrlEncode(branch)}";
-
-            return new JObject
-            {
-                ["product"] = docset.product_name,
-                ["siteName"] = docset.site_name,
-                ["hostName"] = GetHostName(docset.site_name),
-                ["basePath"] = docset.base_path,
-                ["xrefHostName"] = GetXrefHostName(docset.site_name, branch),
-                ["localization"] = new JObject
-                {
-                    ["defaultLocale"] = GetDefaultLocale(docset.site_name),
-                },
-                ["monikerDefinition"] = MonikerDefinitionApi,
-                ["markdownValidationRules"] = $"{MarkdownValidationRulesApi}{metadataServiceQueryParams}",
-                ["metadataSchema"] = new JArray(
-                    Path.Combine(AppContext.BaseDirectory, "data/schemas/OpsMetadata.json"),
-                    $"{MetadataSchemaApi}{metadataServiceQueryParams}"),
             };
         }
 
@@ -112,6 +68,50 @@ namespace Microsoft.Docs.Build
         public void Dispose()
         {
             _http.Dispose();
+        }
+
+        private async Task<string> GetBuildConfig(Uri url)
+        {
+            var queries = HttpUtility.ParseQueryString(url.Query);
+            var name = queries["name"];
+            var repository = queries["repository_url"];
+            var branch = queries["branch"];
+
+            var fetchUrl = $"{s_buildServiceEndpoint}/v2/Queries/Docsets?git_repo_url={repository}&docset_query_status=Created";
+            var docsetInfo = await Fetch(fetchUrl, s_opsHeaders, nullOn404: true);
+            if (docsetInfo is null)
+            {
+                throw Errors.DocsetNotProvisioned(name).ToException(isError: false);
+            }
+
+            var docsets = JsonConvert.DeserializeAnonymousType(
+                docsetInfo,
+                new[] { new { name = "", base_path = "", site_name = "", product_name = "" } });
+
+            var docset = docsets.FirstOrDefault(d => string.Equals(d.name, name, StringComparison.OrdinalIgnoreCase));
+            if (docset is null)
+            {
+                throw Errors.DocsetNotProvisioned(name).ToException(isError: false);
+            }
+
+            var metadataServiceQueryParams = $"?repository_url={HttpUtility.UrlEncode(repository)}&branch={HttpUtility.UrlEncode(branch)}";
+
+            return JsonConvert.SerializeObject(new
+            {
+                product = docset.product_name,
+                siteName = docset.site_name,
+                hostName = GetHostName(docset.site_name),
+                basePath = docset.base_path,
+                xrefHostName = GetXrefHostName(docset.site_name, branch),
+                localization = new { defaultLocale = GetDefaultLocale(docset.site_name) },
+                monikerDefinition = MonikerDefinitionApi,
+                markdownValidationRules = $"{MarkdownValidationRulesApi}{metadataServiceQueryParams}",
+                metadataSchema = new[]
+                {
+                    Path.Combine(AppContext.BaseDirectory, "data/schemas/OpsMetadata.json"),
+                    $"{MetadataSchemaApi}{metadataServiceQueryParams}",
+                },
+            });
         }
 
         private Task<string> GetMonikerDefinition(Uri url)

--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Docs.Build
             {
                 throw Errors.DocsetNotProvisioned(name).ToException(isError: false);
             }
-            
+
             var docsets = JsonConvert.DeserializeAnonymousType(
                 docsetInfo,
                 new[] { new { name = "", base_path = "", site_name = "", product_name = "" } });

--- a/src/docfx/config/ops/OpsConfigLoader.cs
+++ b/src/docfx/config/ops/OpsConfigLoader.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Docs.Build
             return JsonUtility.Deserialize<OpsConfig>(File.ReadAllText(fullPath), filePath);
         }
 
-        public static JObject LoadAsDocfxConfig(string docsetPath, string branch)
+        public static JObject LoadDocfxConfig(string docsetPath, string branch)
         {
             var directory = docsetPath;
 
@@ -72,7 +72,12 @@ namespace Microsoft.Docs.Build
 
             if (docsetConfig != null)
             {
-                result["name"] = docsetConfig.DocsetName;
+                if (!string.IsNullOrEmpty(docsetConfig.DocsetName))
+                {
+                    result["name"] = docsetConfig.DocsetName;
+                    result["extend"] = OpsConfigAdapter.BuildConfigApi;
+                }
+
                 result["globalMetadata"] = new JObject
                 {
                     ["open_to_public_contributors"] = docsetConfig.OpenToPublicContributors,

--- a/src/docfx/lib/UrlUtility.cs
+++ b/src/docfx/lib/UrlUtility.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// <paramref name="sourceQuery"/> and <paramref name="sourceFragment"/> will overwrite the ones in <paramref name="targetUrl"/>
         /// </summary>
-        public static string MergeUrl(string targetUrl, string sourceQuery, string sourceFragment)
+        public static string MergeUrl(string targetUrl, string sourceQuery, string sourceFragment = null)
         {
             var (targetPath, targetQuery, targetFragment) = SplitUrl(targetUrl);
 

--- a/src/docfx/restore/FileResolver.cs
+++ b/src/docfx/restore/FileResolver.cs
@@ -156,11 +156,7 @@ namespace Microsoft.Docs.Build
                     return (tempFile, response.Headers.ETag);
                 }
             }
-            catch (Exception ex) when (DocfxException.IsDocfxException(ex, out _))
-            {
-                throw;
-            }
-            catch (Exception ex)
+            catch (Exception ex) when (!DocfxException.IsDocfxException(ex, out _))
             {
                 throw Errors.DownloadFailed(url).ToException(ex);
             }

--- a/src/docfx/restore/FileResolver.cs
+++ b/src/docfx/restore/FileResolver.cs
@@ -156,6 +156,10 @@ namespace Microsoft.Docs.Build
                     return (tempFile, response.Headers.ETag);
                 }
             }
+            catch (Exception ex) when (DocfxException.IsDocfxException(ex, out _))
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 throw Errors.DownloadFailed(url).ToException(ex);

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Docs.Build
                     var opsConfigAdapter = new OpsConfigAdapter(errorLog);
                     var configLoader = new ConfigLoader(repository, opsConfigAdapter);
 
-                    (errors, config) = await configLoader.Load(docsetPath, options);
+                    (errors, config) = configLoader.Load(docsetPath, locale, options);
                     if (errorLog.Write(errors))
                         return true;
 

--- a/test/docfx.Test/build/OpsConfigAdapterTest.cs
+++ b/test/docfx.Test/build/OpsConfigAdapterTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -12,28 +13,19 @@ namespace Microsoft.Docs.Build
     public static class OpsConfigAdapterTest
     {
         [Theory]
-        [InlineData("", "", "", "null")]
         [InlineData(
-            "azure-documents",
-            "https://github.com/MicrosoftDocs/azure-docs-pr",
-            "master",
+            "https://ops/buildconfig/?name=azure-documents&repository_url=https://github.com/MicrosoftDocs/azure-docs-pr",
             "{'product':'Azure','siteName':'Docs','hostName':'docs.microsoft.com','basePath':'/azure','xrefHostName':'review.docs.microsoft.com','localization':{'defaultLocale':'en-us'}}")]
         [InlineData(
-            "azure-documents",
-            "https://github.com/MicrosoftDocs/azure-docs-pr",
-            "live",
+            "https://ops/buildconfig/?name=azure-documents&repository_url=https://github.com/MicrosoftDocs/azure-docs-pr&branch=live",
             "{'product':'Azure','siteName':'Docs','hostName':'docs.microsoft.com','basePath':'/azure','xrefHostName':'docs.microsoft.com','localization':{'defaultLocale':'en-us'}}")]
         [InlineData(
-            "azure-documents",
-            "https://github.com/MicrosoftDocs/azure-docs-pr.zh-cn",
-            "live-sxs",
+            "https://ops/buildconfig/?name=azure-documents&repository_url=https://github.com/MicrosoftDocs/azure-docs-pr.zh-cn&branch=live-sxs",
             "{'product':'Azure','siteName':'Docs','hostName':'docs.microsoft.com','basePath':'/azure','xrefHostName':'docs.microsoft.com','localization':{'defaultLocale':'en-us'}}")]
         [InlineData(
-            "mooncake-docs",
-            "https://github.com/MicrosoftDocs/mc-docs-pr",
-            "master",
+            "https://ops/buildconfig/?name=mooncake-docs&repository_url=https://github.com/MicrosoftDocs/mc-docs-pr",
             "{'product':'Azure','siteName':'DocsAzureCN','hostName':'docs.azure.cn','basePath':'/','xrefHostName':'review.docs.azure.cn','localization':{'defaultLocale':'zh-cn'}}")]
-        public static async Task AdaptOpsServiceConfig(string name, string repository, string branch, string expectedJson)
+        public static async Task AdaptOpsServiceConfig(string url, string expectedJson)
         {
             var token = Environment.GetEnvironmentVariable("DOCS_OPS_TOKEN");
             if (string.IsNullOrEmpty(token))
@@ -41,9 +33,12 @@ namespace Microsoft.Docs.Build
                 return;
             }
 
-            var actualConfig = await new OpsConfigAdapter(null).GetBuildConfig(new SourceInfo<string>(name), repository, branch);
+            var response = await new OpsConfigAdapter(null).InterceptHttpRequest(new HttpRequestMessage { RequestUri = new Uri(url) });
+            var actualConfig = await response.EnsureSuccessStatusCode().Content.ReadAsStringAsync();
 
-            new JsonDiffBuilder().UseAdditionalProperties().Build().Verify(JToken.Parse(expectedJson.Replace('\'', '"')), actualConfig);
+            new JsonDiffBuilder().UseAdditionalProperties().Build().Verify(
+                JToken.Parse(expectedJson.Replace('\'', '"')),
+                JToken.Parse(actualConfig));
         }
     }
 }


### PR DESCRIPTION
Without this, we call ops service to retrieve service config in both restore and build. All ops calls are gated behind the proxy behind `OpsConfigAdapter`, and use `FileResolver` can cache HTTP response for build.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5369)