### PR TITLE
Output config base path as it is

### DIFF
--- a/docs/specs/output.yml
+++ b/docs/specs/output.yml
@@ -31,7 +31,7 @@ outputs:
     {
       "name": "",
       "product": "",
-      "base_path": "base_path"
+      "base_path": "/base_path"
     }
 ---
 # Publish manifest path is source relative path when copyResources is set to false

--- a/docs/specs/output.yml
+++ b/docs/specs/output.yml
@@ -25,13 +25,13 @@ outputs:
 inputs:
   docfx.yml: |
     hostName: docs.com
-    basePath: /base_path
+    basePath: /
 outputs:
   .publish.json: |
     {
       "name": "",
       "product": "",
-      "base_path": "/base_path"
+      "base_path": "/"
     }
 ---
 # Publish manifest path is source relative path when copyResources is set to false

--- a/src/docfx/build/document/DocumentProvider.cs
+++ b/src/docfx/build/document/DocumentProvider.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Docs.Build
         {
             var file = GetDocument(path);
 
-            var outputPath = UrlUtility.Combine(_docset.Config.BasePath, MonikerUtility.GetGroup(monikers) ?? "", file.SitePath);
+            var outputPath = UrlUtility.Combine(_docset.Config.BasePath.RelativePath, MonikerUtility.GetGroup(monikers) ?? "", file.SitePath);
 
             return _docset.Config.Legacy && file.IsPage ? LegacyUtility.ChangeExtension(outputPath, ".raw.page.json") : outputPath;
         }
@@ -185,7 +185,7 @@ namespace Microsoft.Docs.Build
                 sitePath = sitePath.ToLowerInvariant();
             }
 
-            var siteUrl = PathToAbsoluteUrl(Path.Combine(docset.Config.BasePath, sitePath), contentType, mime, docset.Config.Output.Json, isPage);
+            var siteUrl = PathToAbsoluteUrl(Path.Combine(docset.Config.BasePath.RelativePath, sitePath), contentType, mime, docset.Config.Output.Json, isPage);
             var canonicalUrl = GetCanonicalUrl(siteUrl, sitePath, docset, isExperimental, contentType, mime, isPage);
 
             return new Document(docset, path, sitePath, siteUrl, canonicalUrl, contentType, mime, isExperimental, isPage);

--- a/src/docfx/build/legacy/LegacyFileMap.cs
+++ b/src/docfx/build/legacy/LegacyFileMap.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Docs.Build
                 {
                     host = $"https://{docset.Config.HostName}",
                     locale = docset.Locale,
-                    base_path = $"/{docset.Config.BasePath}",
+                    base_path = docset.Config.BasePath.Original,
                     source_base_path = ".",
                     version_info = new { },
                     from_docfx_v3 = true,

--- a/src/docfx/build/legacy/LegacyFileMap.cs
+++ b/src/docfx/build/legacy/LegacyFileMap.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Docs.Build
                         },
                         item => item.fileMapItem),
                 },
-                Path.Combine(docset.Config.BasePath, "filemap.json"));
+                Path.Combine(docset.Config.BasePath.RelativePath, "filemap.json"));
         }
     }
 }

--- a/src/docfx/build/legacy/LegacyUtility.cs
+++ b/src/docfx/build/legacy/LegacyUtility.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Docs.Build
         public static string ToLegacySiteUrlRelativeToBasePath(this Document doc, Docset docset)
         {
             var legacySiteUrlRelativeToBasePath = doc.SiteUrl;
-            if (legacySiteUrlRelativeToBasePath.StartsWith($"{docset.Config.BasePath.Original}", PathUtility.PathComparison))
+            if (legacySiteUrlRelativeToBasePath.StartsWith(docset.Config.BasePath.Original, PathUtility.PathComparison))
             {
                 legacySiteUrlRelativeToBasePath = legacySiteUrlRelativeToBasePath.Substring(1);
                 legacySiteUrlRelativeToBasePath = Path.GetRelativePath(

--- a/src/docfx/build/legacy/LegacyUtility.cs
+++ b/src/docfx/build/legacy/LegacyUtility.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Docs.Build
                 outputPath = context.DocumentProvider.GetOutputPath(doc.FilePath, manifestItem.Monikers);
             }
             var legacyOutputFilePathRelativeToBasePath = Path.GetRelativePath(
-                string.IsNullOrEmpty(docset.Config.BasePath) ? "." : docset.Config.BasePath, outputPath);
+                string.IsNullOrEmpty(docset.Config.BasePath.RelativePath) ? "." : docset.Config.BasePath.RelativePath, outputPath);
 
             return PathUtility.NormalizeFile(legacyOutputFilePathRelativeToBasePath);
         }
@@ -24,11 +24,11 @@ namespace Microsoft.Docs.Build
         public static string ToLegacySiteUrlRelativeToBasePath(this Document doc, Docset docset)
         {
             var legacySiteUrlRelativeToBasePath = doc.SiteUrl;
-            if (legacySiteUrlRelativeToBasePath.StartsWith(docset.Config.BasePath.Original, PathUtility.PathComparison))
+            if (legacySiteUrlRelativeToBasePath.StartsWith(docset.Config.BasePath.ToString(), PathUtility.PathComparison))
             {
                 legacySiteUrlRelativeToBasePath = legacySiteUrlRelativeToBasePath.Substring(1);
                 legacySiteUrlRelativeToBasePath = Path.GetRelativePath(
-                    string.IsNullOrEmpty(docset.Config.BasePath) ? "." : docset.Config.BasePath,
+                    string.IsNullOrEmpty(docset.Config.BasePath.RelativePath) ? "." : docset.Config.BasePath.RelativePath,
                     string.IsNullOrEmpty(legacySiteUrlRelativeToBasePath) ? "." : legacySiteUrlRelativeToBasePath);
             }
 

--- a/src/docfx/build/legacy/LegacyUtility.cs
+++ b/src/docfx/build/legacy/LegacyUtility.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Docs.Build
         public static string ToLegacySiteUrlRelativeToBasePath(this Document doc, Docset docset)
         {
             var legacySiteUrlRelativeToBasePath = doc.SiteUrl;
-            if (legacySiteUrlRelativeToBasePath.StartsWith($"/{docset.Config.BasePath}", PathUtility.PathComparison))
+            if (legacySiteUrlRelativeToBasePath.StartsWith($"{docset.Config.BasePath.Original}", PathUtility.PathComparison))
             {
                 legacySiteUrlRelativeToBasePath = legacySiteUrlRelativeToBasePath.Substring(1);
                 legacySiteUrlRelativeToBasePath = Path.GetRelativePath(

--- a/src/docfx/build/legacy/manifest/LegacyManifest.cs
+++ b/src/docfx/build/legacy/manifest/LegacyManifest.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Docs.Build
                     version_info = new { },
                     items_to_publish = itemsToPublish,
                 },
-                Path.Combine(docset.Config.BasePath, ".manifest.json"));
+                Path.Combine(docset.Config.BasePath.RelativePath, ".manifest.json"));
             }
         }
 

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Docs.Build
             systemMetadata.SearchDocsetName = file.Docset.Config.Name;
 
             systemMetadata.Path = file.SitePath;
-            systemMetadata.CanonicalUrlPrefix = UrlUtility.Combine($"https://{file.Docset.Config.HostName}", systemMetadata.Locale, file.Docset.Config.BasePath) + "/";
+            systemMetadata.CanonicalUrlPrefix = UrlUtility.Combine($"https://{file.Docset.Config.HostName}", systemMetadata.Locale, file.Docset.Config.BasePath.RelativePath) + "/";
 
             if (file.Docset.Config.Output.Pdf)
             {

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Docs.Build
             if (file.Docset.Config.Output.Pdf)
             {
                 model.Metadata.PdfAbsolutePath = "/" +
-                    UrlUtility.Combine(file.Docset.Config.BasePath, "opbuildpdf", monikerGroup ?? string.Empty, LegacyUtility.ChangeExtension(file.SitePath, ".pdf"));
+                    UrlUtility.Combine(file.Docset.Config.BasePath.RelativePath, "opbuildpdf", monikerGroup ?? string.Empty, LegacyUtility.ChangeExtension(file.SitePath, ".pdf"));
             }
 
             // TODO: Add experimental and experiment_id to publish item

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Docs.Build
                     }
                     if (basePath is null)
                     {
-                        basePath = xref.DeclaringFile.Docset.Config.BasePath;
+                        basePath = xref.DeclaringFile.Docset.Config.BasePath.Original;
                     }
 
                     // DHS appends branch infomation from cookie cache to URL, which is wrong for UID resolved URL

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Docs.Build
             if (basePath != null)
             {
                 var properties = new XrefProperties();
-                properties.Tags.Add($"/{basePath}");
+                properties.Tags.Add(basePath);
                 if (repositoryBranch == "master")
                 {
                     properties.Tags.Add("internal");

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Docs.Build
                 HostName = HostName.ToLowerInvariant();
                 if (BasePath != null)
                 {
-                    BasePath = new BasePath(((string)BasePath).ToLowerInvariant());
+                    BasePath.Original = BasePath.Original.ToLowerInvariant();
                 }
             }
         }

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Docs.Build
         /// Gets the site base path.
         /// It is either an empty string, or a path without leading /
         /// </summary>
-        public string BasePath { get; private set; } = string.Empty;
+        public BasePath BasePath { get; private set; } = new BasePath("");
 
         /// <summary>
         /// Gets host name used for generating .xrefmap.json
@@ -216,7 +216,10 @@ namespace Microsoft.Docs.Build
             if (Output.LowerCaseUrl)
             {
                 HostName = HostName.ToLowerInvariant();
-                BasePath = BasePath.ToLowerInvariant().TrimStart('/');
+                if (BasePath != null)
+                {
+                    BasePath = new BasePath(((string)BasePath).ToLowerInvariant());
+                }
             }
         }
     }

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -75,9 +75,8 @@ namespace Microsoft.Docs.Build
 
         /// <summary>
         /// Gets the site base path.
-        /// It is either an empty string, or a path without leading /
         /// </summary>
-        public BasePath BasePath { get; private set; } = new BasePath("");
+        public BasePath BasePath { get; private set; } = new BasePath("/");
 
         /// <summary>
         /// Gets host name used for generating .xrefmap.json
@@ -216,7 +215,7 @@ namespace Microsoft.Docs.Build
             if (Output.LowerCaseUrl)
             {
                 HostName = HostName.ToLowerInvariant();
-                BasePath.Original = BasePath.Original.ToLowerInvariant();
+                BasePath = new BasePath(BasePath.Original.ToLowerInvariant());
             }
         }
     }

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -216,10 +216,7 @@ namespace Microsoft.Docs.Build
             if (Output.LowerCaseUrl)
             {
                 HostName = HostName.ToLowerInvariant();
-                if (BasePath != null)
-                {
-                    BasePath.Original = BasePath.Original.ToLowerInvariant();
-                }
+                BasePath.Original = BasePath.Original.ToLowerInvariant();
             }
         }
     }

--- a/src/docfx/lib/path/BasePath.cs
+++ b/src/docfx/lib/path/BasePath.cs
@@ -7,19 +7,24 @@ using Newtonsoft.Json;
 namespace Microsoft.Docs.Build
 {
     [JsonConverter(typeof(BasePathJsonConverter))]
-    internal class BasePath
+    internal readonly struct BasePath
     {
-        public string Original { get; set; }
+        private readonly string _original;
 
-        private string RelativePath
-            => Original.StartsWith('/') ? Original.TrimStart('/') : Original;
+        private readonly string _relativePath;
+
+        public string Original => _original ?? "";
+
+        // It is either an empty string, or a path without leading /
+        public string RelativePath => _relativePath ?? "";
 
         public BasePath(string value)
         {
-            Original = value;
+            _original = value;
+            _relativePath = value.StartsWith('/') ? value.TrimStart('/') : value;
         }
 
-        public static implicit operator string(in BasePath basePath) => basePath.RelativePath;
+        public override string ToString() => _original;
 
         private class BasePathJsonConverter : JsonConverter
         {

--- a/src/docfx/lib/path/BasePath.cs
+++ b/src/docfx/lib/path/BasePath.cs
@@ -1,0 +1,18 @@
+namespace Microsoft.Docs.Build
+{
+    internal readonly struct BasePath
+    {
+        public readonly string Original;
+
+        private readonly string _relativePath;
+
+        public BasePath(string value)
+        {
+            Original = value;
+            var path = string.IsNullOrEmpty(value) || value == "/" ? "." : value;
+            _relativePath = path.StartsWith('/') ? path.TrimStart('/') : path;
+        }
+
+        public static implicit operator string(in BasePath basePath) => basePath._relativePath;
+    }
+}

--- a/src/docfx/lib/path/BasePath.cs
+++ b/src/docfx/lib/path/BasePath.cs
@@ -1,18 +1,66 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using Newtonsoft.Json;
+
 namespace Microsoft.Docs.Build
 {
-    internal readonly struct BasePath
+    [JsonConverter(typeof(BasePathJsonConverter))]
+    [TypeConverter(typeof(BasePathTypeConverter))]
+    internal class BasePath
     {
-        public readonly string Original;
+        public string Original { get; set; }
 
-        private readonly string _relativePath;
+        private string RelativePath
+            => Original.StartsWith('/') ? Original.TrimStart('/') : Original;
 
         public BasePath(string value)
         {
             Original = value;
-            var path = string.IsNullOrEmpty(value) || value == "/" ? "." : value;
-            _relativePath = path.StartsWith('/') ? path.TrimStart('/') : path;
         }
 
-        public static implicit operator string(in BasePath basePath) => basePath._relativePath;
+        public static implicit operator string(in BasePath basePath) => basePath.RelativePath;
+
+        private class BasePathJsonConverter : JsonConverter
+        {
+            public override bool CanConvert(Type objectType) => objectType == typeof(PathString);
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            {
+                var value = serializer.Deserialize<string>(reader);
+                return new BasePath(value);
+            }
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                writer.WriteValue((BasePath)value);
+            }
+        }
+
+        private class BasePathTypeConverter : TypeConverter
+        {
+            public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+            {
+                return sourceType == typeof(string) ? true : base.CanConvertFrom(context, sourceType);
+            }
+
+            public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+            {
+                return destinationType == typeof(string) ? true : base.CanConvertTo(context, destinationType);
+            }
+
+            public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+            {
+                return value is string str ? new BasePath(str) : base.ConvertFrom(context, culture, value);
+            }
+
+            public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+            {
+                return destinationType == typeof(string) ? (BasePath)value : base.ConvertTo(context, culture, value, destinationType);
+            }
+        }
     }
 }

--- a/src/docfx/lib/path/BasePath.cs
+++ b/src/docfx/lib/path/BasePath.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Docs.Build
 
         private readonly string _relativePath;
 
-        public string Original => _original ?? "";
+        public string Original => _original ?? "/";
 
         // It is either an empty string, or a path without leading /
         public string RelativePath => _relativePath ?? "";

--- a/src/docfx/lib/path/BasePath.cs
+++ b/src/docfx/lib/path/BasePath.cs
@@ -2,14 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.ComponentModel;
-using System.Globalization;
 using Newtonsoft.Json;
 
 namespace Microsoft.Docs.Build
 {
     [JsonConverter(typeof(BasePathJsonConverter))]
-    [TypeConverter(typeof(BasePathTypeConverter))]
     internal class BasePath
     {
         public string Original { get; set; }
@@ -35,32 +32,7 @@ namespace Microsoft.Docs.Build
             }
 
             public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-            {
-                writer.WriteValue((BasePath)value);
-            }
-        }
-
-        private class BasePathTypeConverter : TypeConverter
-        {
-            public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
-            {
-                return sourceType == typeof(string) ? true : base.CanConvertFrom(context, sourceType);
-            }
-
-            public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
-            {
-                return destinationType == typeof(string) ? true : base.CanConvertTo(context, destinationType);
-            }
-
-            public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
-            {
-                return value is string str ? new BasePath(str) : base.ConvertFrom(context, culture, value);
-            }
-
-            public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
-            {
-                return destinationType == typeof(string) ? (BasePath)value : base.ConvertTo(context, culture, value, destinationType);
-            }
+                => throw new NotSupportedException();
         }
     }
 }

--- a/src/docfx/publish/PublishModelBuilder.cs
+++ b/src/docfx/publish/PublishModelBuilder.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Docs.Build
             {
                 Name = _config.Name,
                 Product = _config.Product,
-                BasePath = _config.BasePath,
+                BasePath = _config.BasePath.Original,
                 Files = _publishItems.Values
                     .OrderBy(item => item.Locale)
                     .ThenBy(item => item.Path)


### PR DESCRIPTION
when base_path is `/`, the output `base_path` in `.publish.json` should be `/`

Found the issue in this [PR](https://ceapex.visualstudio.com/Engineering/_git/Docs.Build/pullrequest/18812)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5380)