### PR TITLE
fix: VisualStudioVersion including minor version breaks UWP project

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/MsBuildEnvironmentScope.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/MsBuildEnvironmentScope.cs
@@ -73,6 +73,8 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                     return new EnvironmentScope(new Dictionary<string, string>
                     {
                         ["VSINSTALLDIR"] = latest.VisualStudioRootPath,
+                        // VS2019 defines VisualStudioVersion=16.0. Do not include minor version here to avoid breaking UWP projects.
+                        // See: https://github.com/dotnet/docfx/issues/5011
                         ["VisualStudioVersion"] = $"{latest.Version.Major}.0",
                     });
                 }

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/MsBuildEnvironmentScope.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/MsBuildEnvironmentScope.cs
@@ -73,7 +73,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                     return new EnvironmentScope(new Dictionary<string, string>
                     {
                         ["VSINSTALLDIR"] = latest.VisualStudioRootPath,
-                        ["VisualStudioVersion"] = latest.Version.ToString(2),
+                        ["VisualStudioVersion"] = $"{latest.Version.Major}.0",
                     });
                 }
                 else


### PR DESCRIPTION
#5011
root cause: https://developercommunity.visualstudio.com/content/problem/862455/wrong-import-path-for-microsoftwindowsuixamlcsharp.html#comment-863292

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5382)