### PR TITLE
refactor: one method to gather git dependencies

### DIFF
--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -117,14 +117,6 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Fetch a git repository's updates
         /// </summary>
-        public static void Fetch(string path, string url, string committishes, Config config)
-        {
-            Fetch(path, url, new[] { committishes }, config);
-        }
-
-        /// <summary>
-        /// Fetch a git repository's updates
-        /// </summary>
         public static void Fetch(string path, string url, IEnumerable<string> committishes, Config config)
         {
             var refspecs = string.Join(' ', committishes.Select(rev => $"+{rev}:{rev}"));


### PR DESCRIPTION
- Gather all git dependencies in `GetGitDependencies` method, the call just for each restore the result
- always `--prune`

Prep work for https://dev.azure.com/ceapex/Engineering/_workitems/edit/121829/

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5385)