### PR TITLE
Look up remote commit in case a branch does not have a local tracking branch

### DIFF
--- a/src/docfx/lib/git/FileCommitProvider.cs
+++ b/src/docfx/lib/git/FileCommitProvider.cs
@@ -198,7 +198,8 @@ namespace Microsoft.Docs.Build
             git_revwalk_new(out var walk, _repo);
             git_revwalk_sorting(walk, 1 << 0 | 1 << 1 /* GIT_SORT_TOPOLOGICAL | GIT_SORT_TIME */);
 
-            if (git_revparse_single(out var headCommit, _repo, committish) != 0)
+            if (git_revparse_single(out var headCommit, _repo, committish) != 0 &&
+                git_revparse_single(out headCommit, _repo, $"origin/{committish}") != 0)
             {
                 git_object_free(walk);
                 throw Errors.CommittishNotFound(_repository.Path, committish).ToException();

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -234,7 +234,8 @@ namespace Microsoft.Docs.Build
                 return null;
             }
 
-            if (git_revparse_single(out var commit, repo, committish) != 0)
+            if (git_revparse_single(out var commit, repo, committish) != 0 &&
+                git_revparse_single(out commit, repo, $"origin/{committish}") != 0)
             {
                 git_repository_free(repo);
                 return null;


### PR DESCRIPTION
When docfx build runs a against a remote branch that does not have a local tracking branch, build throws `committish-not-found` error. This can happen when building an ops loc repo using sxs, where the sxs branch has a local tracking branch, but the non-sxs branch does not have a local branch name.

This is a regression of https://github.com/dotnet/docfx/pull/5385, before that change, there is an [explicit fetch](https://github.com/dotnet/docfx/pull/5385/files#diff-0e50288f9abd09bdcec034b69428527fL39)  that ensures none sxs branch also have a local tracking branch to workaround the problem. This PR solves the root cause by fallback to check remote commit if there is no local tracking branch.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5388)