### PR TITLE
fix: Fetch loc live branch to generate the correct contributor list

### DIFF
--- a/src/docfx/lib/git/FileCommitProvider.cs
+++ b/src/docfx/lib/git/FileCommitProvider.cs
@@ -198,8 +198,7 @@ namespace Microsoft.Docs.Build
             git_revwalk_new(out var walk, _repo);
             git_revwalk_sorting(walk, 1 << 0 | 1 << 1 /* GIT_SORT_TOPOLOGICAL | GIT_SORT_TIME */);
 
-            if (git_revparse_single(out var headCommit, _repo, committish) != 0 &&
-                git_revparse_single(out headCommit, _repo, $"origin/{committish}") != 0)
+            if (git_revparse_single(out var headCommit, _repo, committish) != 0)
             {
                 git_object_free(walk);
                 throw Errors.CommittishNotFound(_repository.Path, committish).ToException();

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -131,13 +131,13 @@ namespace Microsoft.Docs.Build
 
             try
             {
-                ExecuteNonQuery(path, $"{httpConfig} fetch --tags --progress --update-head-ok --prune \"{url}\" {refspecs}", secrets);
+                ExecuteNonQuery(path, $"{httpConfig} fetch --progress --update-head-ok --prune \"{url}\" {refspecs}", secrets);
             }
             catch (InvalidOperationException)
             {
                 // Fallback to fetch all branches and tags if the input committish is not supported by fetch
-                refspecs = "+refs/heads/*:refs/heads/* +refs/tags/*:refs/tags/*";
-                ExecuteNonQuery(path, $"{httpConfig} fetch --tags --progress --update-head-ok --prune \"{url}\" {refspecs}", secrets);
+                refspecs = "+refs/heads/*:refs/remotes/origin/*";
+                ExecuteNonQuery(path, $"{httpConfig} fetch --progress --update-head-ok --prune \"{url}\" {refspecs}", secrets);
             }
         }
 
@@ -282,14 +282,6 @@ namespace Microsoft.Docs.Build
             // - git remote set url
             // - git fetch
             // - git checkout (if not a bar repo)
-            if (GitRemoteProxy != null &&
-                GitRemoteProxy(url) != url &&
-                Directory.Exists(path))
-            {
-                // optimize for test fetching
-                return;
-            }
-
             Directory.CreateDirectory(path);
 
             if (git_repository_init(out var repo, path, is_bare: bare ? 1 : 0) != 0)

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -234,8 +234,7 @@ namespace Microsoft.Docs.Build
                 return null;
             }
 
-            if (git_revparse_single(out var commit, repo, committish) != 0 &&
-                git_revparse_single(out commit, repo, $"origin/{committish}") != 0)
+            if (git_revparse_single(out var commit, repo, committish) != 0)
             {
                 git_repository_free(repo);
                 return null;

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -131,13 +131,13 @@ namespace Microsoft.Docs.Build
 
             try
             {
-                ExecuteNonQuery(path, $"{httpConfig} fetch --progress --update-head-ok --prune \"{url}\" {refspecs}", secrets);
+                ExecuteNonQuery(path, $"{httpConfig} fetch --tags --progress --update-head-ok --prune \"{url}\" {refspecs}", secrets);
             }
             catch (InvalidOperationException)
             {
                 // Fallback to fetch all branches and tags if the input committish is not supported by fetch
-                refspecs = "+refs/heads/*:refs/remotes/origin/*";
-                ExecuteNonQuery(path, $"{httpConfig} fetch --progress --update-head-ok --prune \"{url}\" {refspecs}", secrets);
+                refspecs = "+refs/heads/*:refs/heads/* +refs/tags/*:refs/tags/*";
+                ExecuteNonQuery(path, $"{httpConfig} fetch --tags --progress --update-head-ok --prune \"{url}\" {refspecs}", secrets);
             }
         }
 
@@ -277,11 +277,6 @@ namespace Microsoft.Docs.Build
         /// </summary>
         private static void InitFetch(string path, string url, IEnumerable<string> committishes, bool bare, Config config)
         {
-            // Unifies clone and fetch using a single flow:
-            // - git init
-            // - git remote set url
-            // - git fetch
-            // - git checkout (if not a bar repo)
             Directory.CreateDirectory(path);
 
             if (git_repository_init(out var repo, path, is_bare: bare ? 1 : 0) != 0)


### PR DESCRIPTION
This is to fix a regression caused by https://github.com/dotnet/docfx/pull/5385, when building the sxs branch of a loc repo, we need the none-sxs branch history to compute the correct contributor list, but the cloning process of the loc repo is managed outside of docfx, and it may only clone the sxs branch content for performance reasons.

https://github.com/dotnet/docfx/pull/5388 appeared to have fixed the problem because we are in the transition to a more performant clone process, some test machines still preserve full history but in the future only the branch to build will be cloned.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5391)