### PR TITLE
Fetch git dependencies with --depth 1

### DIFF
--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -31,7 +31,7 @@ inputs:
   docfx.yml: |
     dependencies:
       docfx-test-dependencies1: https://docascode.visualstudio.com/project/_git/a
-      docfx-test-dependencies2: https://docascode.visualstudio.com/project/_git/a#b6720c99618c1d080f48da04922fc9756e93818c
+      docfx-test-dependencies2: https://docascode.visualstudio.com/project/_git/a#b6720c99618c
   docs/a.md: |
     [link to 1](~/docfx-test-dependencies1/docs/a.md)
     [!include[include to 2](~/docfx-test-dependencies2/docs/a.md)]

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -197,9 +197,9 @@ namespace Microsoft.Docs.Build
         ///   - restore a repo with bad url
         /// </summary>
         /// Behavior: ✔️ Message: ✔️
-        public static Error GitCloneFailed(string url, IEnumerable<string> branches)
+        public static Error GitCloneFailed(string url, string branch)
         {
-            var message = $"Failure to clone the repository `{url} ({Join(branches)})`."
+            var message = $"Failure to clone the repository `{url}#{branch}`."
                       + "This could be caused by an incorrect repository URL, please verify the URL on the Docs Portal (https://ops.microsoft.com)."
                       + "This could also be caused by not having the proper permission the repository, "
                       + "please confirm that the GitHub group/team that triggered the build has access to the repository.";

--- a/src/docfx/build/document/RepositoryProvider.cs
+++ b/src/docfx/build/document/RepositoryProvider.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Docs.Build
                     return _dependencyRepositories.GetOrAdd(dependencyName.Value, _ => new Lazy<(string docset, Repository repository)>(() =>
                     {
                         var dependency = _config.Dependencies[dependencyName.Value];
-                        var (dependencyPath, dependencyCommit) = _restoreGitMap.GetRestoreGitPath(dependency, bare: true);
+                        var (dependencyPath, dependencyCommit) = _restoreGitMap.GetRestoreGitPath(dependency, dependency.RestoreFlags);
 
                         if (dependency.Type != PackageType.Git)
                         {
@@ -79,7 +79,7 @@ namespace Microsoft.Docs.Build
         {
             var theme = LocalizationUtility.GetLocalizedTheme(_config.Template, _locale, _config.Localization.DefaultLocale);
 
-            var (templatePath, templateCommit) = _restoreGitMap.GetRestoreGitPath(theme, false);
+            var (templatePath, templateCommit) = _restoreGitMap.GetRestoreGitPath(theme, RestoreGitFlags.DepthOne);
 
             if (theme.Type != PackageType.Git)
             {

--- a/src/docfx/build/localization/LocalizationProvider.cs
+++ b/src/docfx/build/localization/LocalizationProvider.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Docs.Build
                 {
                     if (restoreGitMap.IsBranchRestored(fallbackRemote, branch))
                     {
-                        var (fallbackRepoPath, fallbackRepoCommit) = restoreGitMap.GetRestoreGitPath(new PackagePath(fallbackRemote, branch), bare: false);
+                        var (fallbackRepoPath, fallbackRepoCommit) = restoreGitMap.GetRestoreGitPath(new PackagePath(fallbackRemote, branch), RestoreGitFlags.None);
                         return (PathUtility.NormalizeFolder(Path.Combine(fallbackRepoPath, docsetSourceFolder)),
                             Repository.Create(fallbackRepoPath, branch, fallbackRemote, fallbackRepoCommit));
                     }
@@ -145,7 +145,7 @@ namespace Microsoft.Docs.Build
                             repo.Branch,
                             locale,
                             config.Localization.DefaultLocale);
-                        var (locRepoPath, locCommit) = restoreGitMap.GetRestoreGitPath(new PackagePath(locRemote, locBranch), false);
+                        var (locRepoPath, locCommit) = restoreGitMap.GetRestoreGitPath(new PackagePath(locRemote, locBranch), RestoreGitFlags.None);
                         localizationDocsetPath = PathUtility.NormalizeFolder(Path.Combine(locRepoPath, docsetSourceFolder));
                         localizationRepository = Repository.Create(locRepoPath, locBranch, locRemote, locCommit);
                         break;

--- a/src/docfx/config/AppData.cs
+++ b/src/docfx/config/AppData.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Docs.Build
         internal static Func<string> GetCachePath;
         internal static Func<string> GetStatePath;
 
-        public static string GitRoot => Path.Combine(s_root, "git4");
+        public static string GitRoot => Path.Combine(s_root, "git5");
 
         public static string DownloadsRoot => Path.Combine(s_root, "downloads2");
 

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -193,6 +193,12 @@ namespace Microsoft.Docs.Build
         /// </summary>
         public readonly bool UpdateCommitBuildTime = true;
 
+        /// <summary>
+        /// When fetching git dependencies, docfx trys to use --depth 1 as much as it can to improve performance.
+        /// Occasionally this may degrade performance, this switch gives the ability to always fetch as much as possible.
+        /// </summary>
+        public readonly bool NoGitShallowFetch = false;
+
         public IEnumerable<SourceInfo<string>> GetFileReferences()
         {
             foreach (var url in Xref)

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -194,10 +194,10 @@ namespace Microsoft.Docs.Build
         public readonly bool UpdateCommitBuildTime = true;
 
         /// <summary>
-        /// When fetching git dependencies, docfx trys to use --depth 1 as much as it can to improve performance.
-        /// Occasionally this may degrade performance, this switch gives the ability to always fetch as much as possible.
+        /// When fetching git dependencies, docfx uses --depth 1 as much as it can to improve performance.
+        /// In certain extreme cases this may degrade performance, this option gives the ability to toggle the behavior.
         /// </summary>
-        public readonly bool NoGitShallowFetch = false;
+        public readonly bool GitShallowFetch = true;
 
         public IEnumerable<SourceInfo<string>> GetFileReferences()
         {

--- a/src/docfx/config/DependencyConfig.cs
+++ b/src/docfx/config/DependencyConfig.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Newtonsoft.Json;
+
 namespace Microsoft.Docs.Build
 {
     internal class DependencyConfig : PackagePath
@@ -9,6 +11,9 @@ namespace Microsoft.Docs.Build
         /// Indicate the dependency repository may be added to <see cref="BuildScope"/> and treated as inScope.
         /// </summary>
         public bool IncludeInBuild { get; private set; }
+
+        [JsonIgnore]
+        public RestoreGitFlags RestoreFlags => RestoreGitFlags.Bare | (IncludeInBuild ? RestoreGitFlags.None : RestoreGitFlags.DepthOne);
 
         public DependencyConfig()
             : base()

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Docs.Build
                 url = GitRemoteProxy(url);
             }
 
-            if (config.NoGitShallowFetch)
+            if (!config.GitShallowFetch)
             {
                 depthOne = false;
             }

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -98,46 +98,40 @@ namespace Microsoft.Docs.Build
             => Execute(path, $"-c core.longpaths=true status --porcelain").Split('\n', StringSplitOptions.RemoveEmptyEntries).Any();
 
         /// <summary>
-        /// Clones or update a git repository to the latest version.
-        /// </summary>
-        public static void InitFetchCheckout(string path, string url, string committish, Config config = null)
-        {
-            InitFetch(path, url, new[] { committish }, bare: false, config);
-            ExecuteNonQuery(path, $"-c core.longpaths=true checkout --force --progress {committish}");
-        }
-
-        /// <summary>
         /// Clones or update a git bare repository to the latest version.
         /// </summary>
-        public static void InitFetchBare(string path, string url, IEnumerable<string> committishes, Config config = null)
+        public static void InitFetchBare(Config config, string path, string url, string committish, bool depthOne = false)
         {
-            InitFetch(path, url, committishes, bare: true, config);
+            InitFetch(config, path, url, committish, bare: true, depthOne);
         }
 
         /// <summary>
         /// Fetch a git repository's updates
         /// </summary>
-        public static void Fetch(string path, string url, IEnumerable<string> committishes, Config config)
+        public static void Fetch(Config config, string path, string url, string committish, bool depthOne = false)
         {
-            var refspecs = string.Join(' ', committishes.Select(rev => $"+{rev}:{rev}"));
-
             // Allow test to proxy remotes to local folder
             if (GitRemoteProxy != null)
             {
                 url = GitRemoteProxy(url);
             }
 
-            var (httpConfig, secrets) = GetGitCommandLineConfig(url, config);
+            if (config.NoGitShallowFetch)
+            {
+                depthOne = false;
+            }
+
+            var (http, secrets) = GetGitCommandLineConfig(url, config);
+            var options = "--progress --update-head-ok --prune";
 
             try
             {
-                ExecuteNonQuery(path, $"{httpConfig} fetch --progress --update-head-ok --prune \"{url}\" {refspecs}", secrets);
+                ExecuteNonQuery(path, $"{http} fetch {options} --depth {(depthOne ? "1" : "99999999")} \"{url}\" +{committish}:{committish}", secrets);
             }
             catch (InvalidOperationException)
             {
                 // Fallback to fetch all branches and tags if the input committish is not supported by fetch
-                refspecs = "+refs/heads/*:refs/remotes/origin/*";
-                ExecuteNonQuery(path, $"{httpConfig} fetch --progress --update-head-ok --prune \"{url}\" {refspecs}", secrets);
+                ExecuteNonQuery(path, $"{http} fetch {options} --depth 99999999 \"{url}\" +refs/heads/*:refs/heads/*", secrets);
             }
         }
 
@@ -275,7 +269,7 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Clones or update a git repository to the latest version.
         /// </summary>
-        private static void InitFetch(string path, string url, IEnumerable<string> committishes, bool bare, Config config)
+        private static void InitFetch(Config config, string path, string url, string committish, bool bare, bool depthOne)
         {
             Directory.CreateDirectory(path);
 
@@ -294,7 +288,7 @@ namespace Microsoft.Docs.Build
 
             git_repository_free(repo);
 
-            Fetch(path, url, committishes, config);
+            Fetch(config, path, url, committish, depthOne);
         }
 
         private static void ExecuteNonQuery(string cwd, string commandLineArgs, string[] secrets = null)

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -131,13 +131,13 @@ namespace Microsoft.Docs.Build
 
             try
             {
-                ExecuteNonQuery(path, $"{httpConfig} fetch --tags --progress --update-head-ok --prune \"{url}\" {refspecs}", secrets);
+                ExecuteNonQuery(path, $"{httpConfig} fetch --progress --update-head-ok --prune \"{url}\" {refspecs}", secrets);
             }
             catch (InvalidOperationException)
             {
                 // Fallback to fetch all branches and tags if the input committish is not supported by fetch
-                refspecs = "+refs/heads/*:refs/heads/* +refs/tags/*:refs/tags/*";
-                ExecuteNonQuery(path, $"{httpConfig} fetch --tags --progress --update-head-ok --prune \"{url}\" {refspecs}", secrets);
+                refspecs = "+refs/heads/*:refs/remotes/origin/*";
+                ExecuteNonQuery(path, $"{httpConfig} fetch --progress --update-head-ok --prune \"{url}\" {refspecs}", secrets);
             }
         }
 

--- a/src/docfx/restore/RestoreGit.cs
+++ b/src/docfx/restore/RestoreGit.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Docs.Build
 {
     internal static class RestoreGit
     {
-        internal static IReadOnlyList<RestoreGitResult> Restore(
+        public static IReadOnlyList<RestoreGitResult> Restore(
             Config config, string locale, Repository repository, DependencyLockProvider dependencyLockProvider)
         {
             var results = new ListBuilder<RestoreGitResult>();
@@ -28,7 +28,7 @@ namespace Microsoft.Docs.Build
             return results.ToList();
         }
 
-        internal static RestoreGitResult RestoreGitRepo(
+        private static RestoreGitResult RestoreGitRepo(
             Config config, string remote, string branch, RestoreGitFlags flags, DependencyLockProvider dependencyLockProvider)
         {
             var repoDir = AppData.GetGitDir(remote);

--- a/src/docfx/restore/RestoreGitFlags.cs
+++ b/src/docfx/restore/RestoreGitFlags.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Docs.Build
     internal enum RestoreGitFlags
     {
         None = 0,
-        NoCheckout = 0b0010,
+        DepthOne = 0b0001,
+        Bare = 0b0010,
     }
 }

--- a/src/docfx/restore/RestoreGitMap.cs
+++ b/src/docfx/restore/RestoreGitMap.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public (string path, string commit) GetRestoreGitPath(PackagePath packagePath, bool bare /* remove this flag once all dependency repositories are bare cloned*/)
+        public (string path, string commit) GetRestoreGitPath(PackagePath packagePath, RestoreGitFlags flags)
         {
             switch (packagePath.Type)
             {
@@ -53,7 +53,7 @@ namespace Microsoft.Docs.Build
 
                     var path = AppData.GetGitDir(packagePath.Url);
 
-                    if (!bare)
+                    if (!flags.HasFlag(RestoreGitFlags.Bare))
                     {
                         path = Path.Combine(path, "1");
                     }


### PR DESCRIPTION
`--depth 1` was originally enabled in https://github.com/dotnet/docfx/pull/3668 to speed up dependency repo restore speed, but was removed in #4997 due to performance problem on the server.

This PR adds back `--depth 1` to improve local build speed, and add an option `gitShallowFetch` for server to opt out of the behavior.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5392)