### PR TITLE
Use updated_at to represent when a cache entry will expire

### DIFF
--- a/docs/specs/validation.yml
+++ b/docs/specs/validation.yml
@@ -204,7 +204,7 @@ cache:
     { 
       "items": [
         { "alias": "over123" },
-        { "alias": "zikun", "expiry": "2019-06-08T01:40:33.1981669Z" }
+        { "alias": "zikun", "updated_at": "2018-06-08T01:40:33.1981669Z" }
       ]
     }
 environments:
@@ -242,7 +242,7 @@ cache:
     { 
       "items": [
         { "alias": "yazhao" },
-        { "alias": "123over123", "expiry": "2019-06-08T01:40:33.1981669Z" }
+        { "alias": "123over123", "updated_at": "2018-06-08T01:40:33.1981669Z" }
       ]
     }
 environments:

--- a/src/docfx/lib/cache/ICacheObject{TKey}.cs
+++ b/src/docfx/lib/cache/ICacheObject{TKey}.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Docs.Build
 {
     internal interface ICacheObject<TKey>
     {
-        DateTime? Expiry { get; set; }
+        DateTime? UpdatedAt { get; set; }
 
         IEnumerable<TKey> GetKeys();
     }

--- a/src/docfx/lib/cache/JsonDiskCache.cs
+++ b/src/docfx/lib/cache/JsonDiskCache.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Docs.Build
         private bool HasExpired(TValue value)
         {
             var updatedAt = value.UpdatedAt ?? ((DateTime)(value.UpdatedAt = GetRandomUpdatedAt()));
-            var expiry = updatedAt.Millisecond / 1000.0 * _expirationInSeconds;
+            var expiry = (0.5 + (updatedAt.Millisecond / 1000.0)) * _expirationInSeconds;
 
             return updatedAt.AddSeconds(expiry) < DateTime.UtcNow;
         }

--- a/src/docfx/lib/cache/JsonDiskCache.cs
+++ b/src/docfx/lib/cache/JsonDiskCache.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Docs.Build
         private bool HasExpired(TValue value)
         {
             var updatedAt = value.UpdatedAt ?? ((DateTime)(value.UpdatedAt = GetRandomUpdatedAt()));
-            var expiry = (0.5 + (updatedAt.Millisecond / 1000.0)) * _expirationInSeconds;
+            var expiry = (0.5 + (updatedAt.Millisecond / 2000.0)) * _expirationInSeconds;
 
             return updatedAt.AddSeconds(expiry) < DateTime.UtcNow;
         }

--- a/src/docfx/lib/cache/JsonDiskCache.cs
+++ b/src/docfx/lib/cache/JsonDiskCache.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Docs.Build
                     {
                         if (value != null)
                         {
-                            value.Expiry = DateTime.UtcNow.AddSeconds(NextEvenDistribution(_expirationInSeconds));
+                            value.UpdatedAt = GetRandomUpdatedAt();
 
                             foreach (var cacheKey in value.GetKeys())
                             {
@@ -135,14 +135,17 @@ namespace Microsoft.Docs.Build
             });
         }
 
-        private static double NextEvenDistribution(double value)
+        private static DateTime GetRandomUpdatedAt()
         {
-            return (value / 2) + (t_random.Value.NextDouble() * value / 2);
+            return DateTime.UtcNow.AddMilliseconds(1000.0 * t_random.Value.NextDouble());
         }
 
-        private static bool HasExpired(TValue value)
+        private bool HasExpired(TValue value)
         {
-            return value.Expiry != null && value.Expiry < DateTime.UtcNow;
+            var updatedAt = value.UpdatedAt ?? ((DateTime)(value.UpdatedAt = GetRandomUpdatedAt()));
+            var expiry = updatedAt.Millisecond / 1000.0 * _expirationInSeconds;
+
+            return updatedAt.AddSeconds(expiry) < DateTime.UtcNow;
         }
 
         private class CacheFile

--- a/src/docfx/lib/github/GitHubUser.cs
+++ b/src/docfx/lib/github/GitHubUser.cs
@@ -3,9 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Docs.Build
 {
+    [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
     internal class GitHubUser : ICacheObject<string>
     {
         public int? Id { get; set; }
@@ -16,7 +19,7 @@ namespace Microsoft.Docs.Build
 
         public string[] Emails { get; set; } = Array.Empty<string>();
 
-        public DateTime? Expiry { get; set; }
+        public DateTime? UpdatedAt { get; set; }
 
         public bool IsValid() => Id != null;
 

--- a/src/docfx/lib/msgraph/MicrosoftGraphUser.cs
+++ b/src/docfx/lib/msgraph/MicrosoftGraphUser.cs
@@ -3,14 +3,17 @@
 
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Docs.Build
 {
+    [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
     internal class MicrosoftGraphUser : ICacheObject<string>
     {
         public string Alias { get; set; }
 
-        public DateTime? Expiry { get; set; }
+        public DateTime? UpdatedAt { get; set; }
 
         public IEnumerable<string> GetKeys()
         {

--- a/test/docfx.Test/lib/JsonDiskCacheTest.cs
+++ b/test/docfx.Test/lib/JsonDiskCacheTest.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Docs.Build
             Assert.Equal(0, counter);
 
             // When cache expires, don't block caller, trigger asynchronous update
-            (await cache.GetOrAdd(9999, CreateValue)).value.UpdatedAt = DateTime.UtcNow.AddHours(-1);
+            (await cache.GetOrAdd(9999, CreateValue)).value.UpdatedAt = DateTime.MinValue;
             Assert.Equal(1234, (await cache.GetOrAdd(9999, CreateValue)).value.Snapshot);
 
             // Save waits for asynchronous update to complete

--- a/test/docfx.Test/lib/JsonDiskCacheTest.cs
+++ b/test/docfx.Test/lib/JsonDiskCacheTest.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Docs.Build
             Assert.Equal(0, counter);
 
             // When cache expires, don't block caller, trigger asynchronous update
-            (await cache.GetOrAdd(9999, CreateValue)).value.Expiry = DateTime.UtcNow.AddHours(-1);
+            (await cache.GetOrAdd(9999, CreateValue)).value.UpdatedAt = DateTime.UtcNow.AddHours(-1);
             Assert.Equal(1234, (await cache.GetOrAdd(9999, CreateValue)).value.Snapshot);
 
             // Save waits for asynchronous update to complete
@@ -68,7 +68,7 @@ namespace Microsoft.Docs.Build
 
             public int Snapshot { get; set; }
 
-            public DateTime? Expiry { get; set; }
+            public DateTime? UpdatedAt { get; set; }
 
             public IEnumerable<int> GetKeys() => new[] { Id };
         }


### PR DESCRIPTION
The original cache uses `expiry` to represent when a cache item expires, this is a time into the future. The problem with that approach is that changes to `expiration` config does not take effect immediately, the `expiry` is only updated slowly after they have actually expired calculated using the old `expiration` value.

This PR stores `updated_at` to the cache file. To ensure even distribution of cache items across the whole expiration period, we randomize the `milliseconds` component of `updated_at`, and use it as a deterministic random factor to check if the item has expired. `milliseconds` range from 0 to 999, creating 1000 bucket of ~10 minutes if the total expiration is a week. This precision satisfies the requirements of docs.

The change is backward compatible, all existing cache entries are treated as updated just now.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5393)