### PR TITLE
refactor: Clean up dependencies on `IsBranchRestored` and `DependencyLockProvider.ListAll`

### DIFF
--- a/src/docfx/build/localization/LocalizationProvider.cs
+++ b/src/docfx/build/localization/LocalizationProvider.cs
@@ -109,9 +109,9 @@ namespace Microsoft.Docs.Build
             {
                 foreach (var branch in new[] { fallbackBranch, "master" })
                 {
-                    if (restoreGitMap.IsBranchRestored(fallbackRemote, branch))
+                    if (restoreGitMap.TryGetRestoreGitPath(
+                        new PackagePath(fallbackRemote, branch), RestoreGitFlags.None, out var fallbackRepoPath, out var fallbackRepoCommit))
                     {
-                        var (fallbackRepoPath, fallbackRepoCommit) = restoreGitMap.GetRestoreGitPath(new PackagePath(fallbackRemote, branch), RestoreGitFlags.None);
                         return (PathUtility.NormalizeFolder(Path.Combine(fallbackRepoPath, docsetSourceFolder)),
                             Repository.Create(fallbackRepoPath, branch, fallbackRemote, fallbackRepoCommit));
                     }

--- a/src/docfx/config/AppData.cs
+++ b/src/docfx/config/AppData.cs
@@ -31,10 +31,10 @@ namespace Microsoft.Docs.Build
 
         public static string MicrosoftGraphCachePath => Path.Combine(CacheRoot, "microsoft-graph.json");
 
-        public static string GetGitDir(string remote)
+        public static PathString GetGitDir(string remote)
         {
             Debug.Assert(!remote.Contains('#'));
-            return PathUtility.NormalizeFolder(Path.Combine(GitRoot, PathUtility.UrlToShortName(remote)));
+            return new PathString(Path.Combine(GitRoot, PathUtility.UrlToShortName(remote)));
         }
 
         public static string GetFileDownloadDir(string url)

--- a/src/docfx/restore/RestoreGitMap.cs
+++ b/src/docfx/restore/RestoreGitMap.cs
@@ -29,6 +29,20 @@ namespace Microsoft.Docs.Build
             }
         }
 
+        public bool TryGetRestoreGitPath(PackagePath packagePath, RestoreGitFlags flags, out string path, out string commit)
+        {
+            try
+            {
+                (path, commit) = GetRestoreGitPath(packagePath, flags);
+                return true;
+            }
+            catch (DocfxException)
+            {
+                path = commit = default;
+                return false;
+            }
+        }
+
         public (string path, string commit) GetRestoreGitPath(PackagePath packagePath, RestoreGitFlags flags)
         {
             switch (packagePath.Type)
@@ -68,18 +82,6 @@ namespace Microsoft.Docs.Build
                 default:
                     throw new NotSupportedException($"Unknown package url: '{packagePath}'");
             }
-        }
-
-        public bool IsBranchRestored(string remote, string branch)
-        {
-            var gitLock = _dependencyLockProvider.GetGitLock(remote, branch);
-
-            if (gitLock is null || gitLock.Commit is null)
-            {
-                return false;
-            }
-
-            return true;
         }
 
         public void Dispose()

--- a/src/docfx/restore/RestoreGitMap.cs
+++ b/src/docfx/restore/RestoreGitMap.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO;
 
@@ -11,7 +11,7 @@ namespace Microsoft.Docs.Build
     internal class RestoreGitMap : IDisposable
     {
         private readonly string _docsetPath;
-        private readonly List<InterProcessReaderWriterLock> _sharedLocks = new List<InterProcessReaderWriterLock>();
+        private readonly ConcurrentDictionary<PathString, InterProcessReaderWriterLock> _locks = new ConcurrentDictionary<PathString, InterProcessReaderWriterLock>();
         private readonly DependencyLockProvider _dependencyLockProvider;
 
         private RestoreGitMap(DependencyLockProvider dependencyLockProvider, string docsetPath)
@@ -21,12 +21,6 @@ namespace Microsoft.Docs.Build
 
             _docsetPath = docsetPath;
             _dependencyLockProvider = dependencyLockProvider;
-
-            foreach (var (url, _, _) in _dependencyLockProvider.ListAll())
-            {
-                var sharedLock = InterProcessReaderWriterLock.CreateReaderLock(url);
-                _sharedLocks.Add(sharedLock);
-            }
         }
 
         public bool TryGetRestoreGitPath(PackagePath packagePath, RestoreGitFlags flags, out string path, out string commit)
@@ -69,13 +63,15 @@ namespace Microsoft.Docs.Build
 
                     if (!flags.HasFlag(RestoreGitFlags.Bare))
                     {
-                        path = Path.Combine(path, "1");
+                        path = new PathString(Path.Combine(path, "1"));
                     }
 
                     if (!Directory.Exists(path))
                     {
                         throw Errors.NeedRestore($"{packagePath}").ToException();
                     }
+
+                    _locks.TryAdd(path, InterProcessReaderWriterLock.CreateReaderLock(path));
 
                     return (path, gitLock.Commit);
 
@@ -86,7 +82,7 @@ namespace Microsoft.Docs.Build
 
         public void Dispose()
         {
-            foreach (var sharedLock in _sharedLocks)
+            foreach (var sharedLock in _locks.Values)
             {
                 sharedLock.Dispose();
             }

--- a/src/docfx/restore/lock/DependencyLockProvider.cs
+++ b/src/docfx/restore/lock/DependencyLockProvider.cs
@@ -29,11 +29,6 @@ namespace Microsoft.Docs.Build
             return null;
         }
 
-        public IEnumerable<(string url, string branch, DependencyGitLock)> ListAll()
-        {
-            return _dependencyGitLock.Select(k => (k.Key.url, k.Key.branch, k.Value));
-        }
-
         public static DependencyLockProvider CreateFromAppData(string docset, string locale)
         {
             var file = AppData.GetDependencyLockFile(docset, locale);


### PR DESCRIPTION
With that, `DependencyLockProvider` only affects restore and `RestoreGitMap.GetRestorePath` method

Prep work for https://dev.azure.com/ceapex/Engineering/_workitems/edit/121829/

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5400)