### PR TITLE
Using win7-x64 as rid for windows package

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -40,7 +40,7 @@ function publishBinaryPackages() {
     $stagingPath = "$packagesBasePath\staging"
     New-Item -Path $stagingPath -ItemType "directory" -ErrorAction SilentlyContinue
 
-    $rids = @("win-x64", "osx-x64", "linux-x64")
+    $rids = @("win7-x64", "osx-x64", "linux-x64") # Microsoft.ChakraCore doesn't provide win-x64 runtime build, using win7-x64
     foreach ($rid in $rids) {
         $packageName = "docfx-$rid-$version"
         exec "dotnet publish src\docfx\docfx.csproj -c release -r $rid -o $packagesBasePath/$rid /p:Version=$version /p:InformationalVersion=$version /p:PackAsTool=false"


### PR DESCRIPTION
ChakraCore doesn't have a compatible build for win-x64.
It only supports:
![image](https://user-images.githubusercontent.com/42199316/71508062-8e55ac80-28c1-11ea-8b2b-6cf50f74061b.png)


see [RID graph](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog#rid-graph)
```
win7-x64    win7-x86
       |   \   /    |
       |   win7     |
       |     |      |
    win-x64  |  win-x86
          \  |  /
            win
             |
            any
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5407)