### PR TITLE
fix for xref restore order

### DIFF
--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -20,15 +20,27 @@ outputs:
 # Restore xref map from configured url and use the map for resolving
 # hostname should be removed if docset sharing the same one
 # xref should be unioned from different sources
+# original config should have higher priority than extend config
 inputs:
   docfx.yml: |
     hostName: docs.microsoft.com
     xref:
     - 2.xrefmap.json
+    - high.xrefmap.json
     extend: _shared/extend.json
   _shared/extend.json: |
     {"xref":["1.xrefmap.json"]}
   docs/a.md: Link to @System.String?displayProperty=fullName
+  high.xrefmap.json: |
+    {
+      "references":[{
+          "uid": "System.String",
+          "name": "String",
+          "fullName": "System.String.Higher",
+          "href": "https://docs.microsoft.com/dotnet/api/system.string",
+          "nameWithType": "System.String"
+      }]
+    }
   1.xrefmap.json: |
     {
       "references":[{
@@ -43,7 +55,7 @@ inputs:
     { "references":[{"uid": "a", "name": "a", "fullName": "a", "href": "https://docs.microsoft.com/a", "nameWithType": "a"}]}
 outputs:
   docs/a.json: |
-    { "conceptual": "<p>Link to <a href=\"/en-us/dotnet/api/system.string\">System.String</a></p>\n"}
+    { "conceptual": "<p>Link to <a href=\"/en-us/dotnet/api/system.string\">System.String.Higher</a></p>\n"}
 ---
 # Should not remove host name if not sharing with xref href
 inputs:

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -20,12 +20,36 @@ outputs:
 # Restore xref map from configured url and use the map for resolving
 # hostname should be removed if docset sharing the same one
 # xref should be unioned from different sources
-# original config should have higher priority than extend config
 inputs:
   docfx.yml: |
     hostName: docs.microsoft.com
     xref:
     - 2.xrefmap.json
+    extend: _shared/extend.json
+  _shared/extend.json: |
+    {"xref":["1.xrefmap.json"]}
+  docs/a.md: Link to @System.String?displayProperty=fullName
+  1.xrefmap.json: |
+    {
+      "references":[{
+          "uid": "System.String",
+          "name": "String",
+          "fullName": "System.String",
+          "href": "https://docs.microsoft.com/dotnet/api/system.string",
+          "nameWithType": "System.String"
+      }]
+    }
+  2.xrefmap.json: |
+    { "references":[{"uid": "a", "name": "a", "fullName": "a", "href": "https://docs.microsoft.com/a", "nameWithType": "a"}]}
+outputs:
+  docs/a.json: |
+    { "conceptual": "<p>Link to <a href=\"/en-us/dotnet/api/system.string\">System.String</a></p>\n"}
+---
+# original config should have higher priority than extend config
+inputs:
+  docfx.yml: |
+    hostName: docs.microsoft.com
+    xref:
     - high.xrefmap.json
     extend: _shared/extend.json
   _shared/extend.json: |
@@ -51,8 +75,6 @@ inputs:
           "nameWithType": "System.String"
       }]
     }
-  2.xrefmap.json: |
-    { "references":[{"uid": "a", "name": "a", "fullName": "a", "href": "https://docs.microsoft.com/a", "nameWithType": "a"}]}
 outputs:
   docs/a.json: |
     { "conceptual": "<p>Link to <a href=\"/en-us/dotnet/api/system.string\">System.String.Higher</a></p>\n"}

--- a/src/docfx/lib/json/JsonUtility.cs
+++ b/src/docfx/lib/json/JsonUtility.cs
@@ -236,7 +236,7 @@ namespace Microsoft.Docs.Build
                 else if (container[key] is JArray array && value is JArray newArray && unionProperties?.Contains(key) == true)
                 {
                     // TODO: need to check if miss line info for JArray
-                    container[key] = new JArray(array.Union(newArray));
+                    container[key] = new JArray(newArray.Union(array));
                 }
                 else
                 {

--- a/test/docfx.Test/lib/JsonUtilityTest.cs
+++ b/test/docfx.Test/lib/JsonUtilityTest.cs
@@ -392,7 +392,7 @@ namespace Microsoft.Docs.Build
         [InlineData("{'a':[1]}", "{'a':[2]}", "{'a':[2]}", "b")]
         [InlineData("{'a':[1]}", "{'a':'2'}", "{'a':'2'}")]
         [InlineData("{'a':[1]}", "{'a':[2]}", "{'a':[2]}")]
-        [InlineData("{'a':[1]}", "{'a':[2]}", "{'a':[1,2]}", "a")]
+        [InlineData("{'a':[1]}", "{'a':[2]}", "{'a':[2,1]}", "a")]
         public void TestJsonMergeWithUnionProperties(string a, string b, string result, params string[] unionProperties)
         {
             var container = JObject.Parse(a.Replace('\'', '\"'));


### PR DESCRIPTION
During JSON merge, the new `JArray` should have higher priority than the original

Fix for https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=110532&view=results

![image](https://user-images.githubusercontent.com/5196139/71520005-f07bd500-28f4-11ea-8c8a-ba6f34ca97fa.png)
In DocFX v2 build, the uid was resolved from `docfx.json` xref config, which is a local zip file.
In DocFX v3 build, the uid was resolved from xref query tags in `.openpublishing.publish.config.json`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5409)