### PR TITLE
perf: replace ls-tree with directory search

### DIFF
--- a/src/docfx/build/context/Input.cs
+++ b/src/docfx/build/context/Input.cs
@@ -151,45 +151,37 @@ namespace Microsoft.Docs.Build
                 case FileOrigin.Default:
                     if (_localizationProvider?.IsLocalizationBuild == true)
                     {
-                        var (entry, repository) = _localizationProvider.GetBuildRepositoryWithDocsetEntry();
-                        return ListFilesRecursive(Path.GetFullPath(entry), null);
+                        var (entry, _) = _localizationProvider.GetBuildRepositoryWithDocsetEntry();
+                        return ListFilesRecursive(Path.GetFullPath(entry));
                     }
                     else
                     {
-                        return ListFilesRecursive(_docsetPath, null);
+                        return ListFilesRecursive(_docsetPath);
                     }
 
                 case FileOrigin.Fallback:
-                    var (fallbackEntry, fallbackRepository) = _repositoryProvider.GetRepositoryWithDocsetEntry(origin);
+                    var (fallbackEntry, _) = _repositoryProvider.GetRepositoryWithDocsetEntry(origin);
 
-                    return ListFilesRecursive(fallbackEntry, null);
+                    return ListFilesRecursive(fallbackEntry);
 
                 case FileOrigin.Dependency:
-                    var (dependencyEntry, dependencyRepository) = _repositoryProvider.GetRepositoryWithDocsetEntry(origin, dependencyName);
+                    var (dependencyEntry, _) = _repositoryProvider.GetRepositoryWithDocsetEntry(origin, dependencyName);
 
-                    return ListFilesRecursive(dependencyEntry, dependencyRepository);
+                    return ListFilesRecursive(dependencyEntry);
 
                 default:
                     throw new NotSupportedException($"{nameof(ListFilesRecursive)}: {origin}");
             }
 
-            FilePath[] ListFilesRecursive(string entry, Repository repository)
+            FilePath[] ListFilesRecursive(string entry)
             {
-                if (repository != null)
-                {
-                    // todo: get tree list from repository
-                    return GitUtility.ListTree(repository.Path, repository.Commit)
-                        .Select(path => CreateFilePath(path))
-                        .ToArray();
-                }
-
                 if (!Directory.Exists(entry))
                 {
                     return Array.Empty<FilePath>();
                 }
 
                 return Directory
-                .GetFiles(entry, "*", SearchOption.AllDirectories)
+                    .GetFiles(entry, "*", SearchOption.AllDirectories)
                     .Select(path => CreateFilePath(Path.GetRelativePath(entry, path)))
                     .ToArray();
             }

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -131,12 +131,6 @@ namespace Microsoft.Docs.Build
                     .Split('\n', StringSplitOptions.RemoveEmptyEntries);
         }
 
-        public static string[] ListTree(string cwd, string committish = null)
-        {
-            return Execute(cwd, $"ls-tree {committish ?? "HEAD"} -r --name-only")
-                    .Split('\n', StringSplitOptions.RemoveEmptyEntries);
-        }
-
         public static unsafe byte[] ReadBytes(string repoPath, string filePath, string committish)
         {
             if (git_repository_open(out var repo, repoPath) != 0)


### PR DESCRIPTION
Dependency repositories are full checkouts, thus no need to use `git ls-tree`. Reduced time to glob files from `4s` to `2s`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5422)