### PR TITLE
Handle AggregatedException

### DIFF
--- a/docs/specs/git.yml
+++ b/docs/specs/git.yml
@@ -406,7 +406,7 @@ repos:
 outputs:
   .errors.log: |
     ["error","committish-not-found","Can't find branch, tag, or commit 'live' for repo *"]
-    ["error","committish-not-found","Can't find branch, tag, or commit 'live' for repo *","a.md"]
+    ["error","committish-not-found","Can't find branch, tag, or commit 'live' for repo *"]
 ---
 # Use current repo's branch when edit branch isn't specified in contribution config,
 # and contribution config's repository equals to current repo's

--- a/docs/specs/validation.yml
+++ b/docs/specs/validation.yml
@@ -77,6 +77,23 @@ outputs:
     ["warning","invalid-value","Invalid value for 'key2': 'XNAGameStudio'","docfx.yml",6,13]
     ["warning","unexpected-type","Expected type 'Integer' but got 'String'","a.md",2,7]
 ---
+# Report missing-attribute at file level when yaml header missing
+inputs:
+  docfx.yml: |
+    metadataSchema: schema.json
+  schema.json: |
+    { "required": ["a"] }
+  a.md:
+  b.md: |
+    ---
+    ---
+outputs:
+  a.json:
+  b.json:
+  .errors.log: |
+    ["warning","missing-attribute","Missing required attribute: 'a'","a.md",1,1]
+    ["warning","missing-attribute","Missing required attribute: 'a'","b.md",1,1]
+---
 # Allow multiple metadata schema definitions
 inputs:
   docfx.yml: |

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -468,7 +468,7 @@ outputs:
   docs/b.json: |
     {"xref":{"uid":"a","href":"a.json"}}
   .errors.log: |
-    ["warning","uid-conflict","The same Uid 'a' has been defined multiple times in the same file","docs/a.json"]
+    ["warning","uid-conflict","The same Uid 'a' has been defined multiple times in the same file","docs/a.json",6,14]
 ---
 # uid conflict in non-root level and another SDP
 inputs:

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -561,15 +561,11 @@ namespace Microsoft.Docs.Build
         ///   - both files with no monikers defined same uid
         /// </summary>
         /// Behavior: ✔️ Message: ✔️
-        public static Error UidConflict(string uid, IEnumerable<FilePath> conflicts = null)
-        {
-            if (conflicts is null)
-            {
-                return new Error(ErrorLevel.Warning, "uid-conflict", $"The same Uid '{uid}' has been defined multiple times in the same file");
-            }
+        public static Error UidConflict(string uid, SourceInfo source)
+            => new Error(ErrorLevel.Warning, "uid-conflict", $"The same Uid '{uid}' has been defined multiple times in the same file", source);
 
-            return new Error(ErrorLevel.Warning, "uid-conflict", $"UID '{uid}' is defined in more than one file: {Join(conflicts)}");
-        }
+        public static Error UidConflict(string uid, IEnumerable<FilePath> conflicts)
+            => new Error(ErrorLevel.Warning, "uid-conflict", $"UID '{uid}' is defined in more than one file: {Join(conflicts)}");
 
         /// <summary>
         /// Same uid defined within different versions with the different name.

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -63,8 +63,7 @@ namespace Microsoft.Docs.Build
                 }
                 catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
                 {
-                    Log.Write(dex);
-                    errorLog.Write(dex.Error, dex.OverwriteLevel);
+                    errorLog.Write(dex);
                     return false;
                 }
                 finally
@@ -184,7 +183,7 @@ namespace Microsoft.Docs.Build
                         break;
                 }
 
-                if (context.ErrorLog.Write(path, errors))
+                if (context.ErrorLog.Write(errors))
                 {
                     context.PublishModelBuilder.ExcludeFromOutput(file);
                 }
@@ -193,7 +192,7 @@ namespace Microsoft.Docs.Build
             }
             catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
             {
-                context.ErrorLog.Write(path, dex.Error, dex.OverwriteLevel);
+                context.ErrorLog.Write(dex);
                 context.PublishModelBuilder.ExcludeFromOutput(file);
             }
             catch

--- a/src/docfx/build/link/FileLinkMapBuilder.cs
+++ b/src/docfx/build/link/FileLinkMapBuilder.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Docs.Build
             var (error, monikers) = _monikerProvider.GetFileLevelMonikers(file.FilePath);
             if (error != null)
             {
-                _errorLog.Write(file.FilePath, error);
+                _errorLog.Write(error);
             }
 
             _links.TryAdd(new FileLinkItem()

--- a/src/docfx/build/metadata/MetadataProvider.cs
+++ b/src/docfx/build/metadata/MetadataProvider.cs
@@ -89,14 +89,8 @@ namespace Microsoft.Docs.Build
         {
             var result = new JObject();
             var errors = new List<Error>();
-            var yamlHeader = new JObject();
 
-            if (file.ContentType == ContentType.Page || file.ContentType == ContentType.TableOfContents)
-            {
-                (errors, yamlHeader) = LoadMetadata(file);
-                JsonUtility.SetSourceInfo(result, JsonUtility.GetSourceInfo(yamlHeader));
-            }
-
+            JsonUtility.SetSourceInfo(result, new SourceInfo(file.FilePath, 1, 1));
             JsonUtility.Merge(result, _globalMetadata);
 
             var fileMetadata = new JObject();
@@ -110,7 +104,18 @@ namespace Microsoft.Docs.Build
                 }
             }
             JsonUtility.Merge(result, fileMetadata);
-            JsonUtility.Merge(result, yamlHeader);
+
+            if (file.ContentType == ContentType.Page || file.ContentType == ContentType.TableOfContents)
+            {
+                var (yamlHeaderErrors, yamlHeader) = LoadYamlHeader(file);
+                errors.AddRange(yamlHeaderErrors);
+
+                if (yamlHeader.Count > 0)
+                {
+                    JsonUtility.Merge(result, yamlHeader);
+                    JsonUtility.SetSourceInfo(result, JsonUtility.GetSourceInfo(yamlHeader));
+                }
+            }
 
             foreach (var (key, value) in result)
             {
@@ -157,7 +162,7 @@ namespace Microsoft.Docs.Build
             return true;
         }
 
-        private (List<Error> errors, JObject metadata) LoadMetadata(Document file)
+        private (List<Error> errors, JObject yamlHeader) LoadYamlHeader(Document file)
         {
             if (file.FilePath.EndsWith(".md"))
             {
@@ -169,18 +174,18 @@ namespace Microsoft.Docs.Build
 
             if (file.FilePath.EndsWith(".yml"))
             {
-                return LoadSchemaDocumentMetadata(_input.ReadYaml(file.FilePath), file);
+                return LoadSchemaDocumentYamlHeader(_input.ReadYaml(file.FilePath), file);
             }
 
             if (file.FilePath.EndsWith(".json"))
             {
-                return LoadSchemaDocumentMetadata(_input.ReadJson(file.FilePath), file);
+                return LoadSchemaDocumentYamlHeader(_input.ReadJson(file.FilePath), file);
             }
 
             return (new List<Error>(), new JObject());
         }
 
-        private static (List<Error> errors, JObject metadata) LoadSchemaDocumentMetadata((List<Error>, JToken) document, Document file)
+        private static (List<Error> errors, JObject metadata) LoadSchemaDocumentYamlHeader((List<Error>, JToken) document, Document file)
         {
             var (errors, token) = document;
             var metadata = token is JObject tokenObj ? tokenObj["metadata"] : null;

--- a/src/docfx/build/toc/TableOfContentsMap.cs
+++ b/src/docfx/build/toc/TableOfContentsMap.cs
@@ -105,13 +105,13 @@ namespace Microsoft.Docs.Build
                 }
 
                 var (errors, _, referencedDocuments, referencedTocs) = context.TableOfContentsLoader.Load(file);
-                context.ErrorLog.Write(path, errors);
+                context.ErrorLog.Write(errors);
 
                 tocMapBuilder.Add(file, referencedDocuments, referencedTocs);
             }
             catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
             {
-                context.ErrorLog.Write(path, dex.Error, dex.OverwriteLevel);
+                context.ErrorLog.Write(dex);
             }
         }
 

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -74,11 +74,11 @@ namespace Microsoft.Docs.Build
                     errors.AddRange(schemaErrors);
                     xrefs.AddRange(specs);
                 }
-                context.ErrorLog.Write(path, errors);
+                context.ErrorLog.Write(errors);
             }
             catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
             {
-                context.ErrorLog.Write(path, dex.Error, dex.OverwriteLevel);
+                context.ErrorLog.Write(dex);
             }
             catch
             {

--- a/src/docfx/lib/git/FileCommitProvider.cs
+++ b/src/docfx/lib/git/FileCommitProvider.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Docs.Build
             if (git_revparse_single(out var headCommit, _repo, committish) != 0)
             {
                 git_object_free(walk);
-                throw Errors.CommittishNotFound(_repository.Path, committish).ToException();
+                throw Errors.CommittishNotFound(_repository.Remote, committish).ToException();
             }
 
             var lastCommitId = *git_object_id(headCommit);

--- a/src/docfx/lib/log/DocfxException.cs
+++ b/src/docfx/lib/log/DocfxException.cs
@@ -23,20 +23,14 @@ namespace Microsoft.Docs.Build
             OverwriteLevel = overwriteLevel;
         }
 
-        public static bool IsDocfxException(Exception ex, out IEnumerable<DocfxException> exceptions)
+        public static bool IsDocfxException(Exception ex, out List<DocfxException> exceptions)
         {
-            List<DocfxException> result = null;
-            ExtractDocfxException(ex, ref result);
-            if (result != null && result.Count > 0)
-            {
-                exceptions = result;
-                return true;
-            }
-            exceptions = null;
-            return false;
+            exceptions = new List<DocfxException>();
+            ExtractDocfxException(ex, exceptions);
+            return exceptions.Count > 0;
         }
 
-        private static void ExtractDocfxException(Exception ex, ref List<DocfxException> result)
+        private static void ExtractDocfxException(Exception ex, List<DocfxException> result)
         {
             switch (ex)
             {
@@ -44,20 +38,18 @@ namespace Microsoft.Docs.Build
                     break;
 
                 case DocfxException dex:
-                    result = result ?? new List<DocfxException>();
                     result.Add(dex);
                     break;
 
                 case AggregateException aex:
-                    result = result ?? new List<DocfxException>();
                     foreach (var innerException in aex.InnerExceptions)
                     {
-                        ExtractDocfxException(innerException, ref result);
+                        ExtractDocfxException(innerException, result);
                     }
                     break;
 
                 default:
-                    ExtractDocfxException(ex.InnerException, ref result);
+                    ExtractDocfxException(ex.InnerException, result);
                     break;
             }
         }

--- a/src/docfx/lib/log/ErrorLog.cs
+++ b/src/docfx/lib/log/ErrorLog.cs
@@ -70,26 +70,18 @@ namespace Microsoft.Docs.Build
             return hasErrors;
         }
 
-        public bool Write(FilePath file, IEnumerable<Error> errors)
+        public bool Write(IEnumerable<DocfxException> exceptions)
         {
             var hasErrors = false;
-            foreach (var error in errors)
+            foreach (var exception in exceptions)
             {
-                if (Write(file, error))
+                Log.Write(exception);
+                if (Write(exception.Error, exception.OverwriteLevel))
                 {
                     hasErrors = true;
                 }
             }
             return hasErrors;
-        }
-
-        public bool Write(FilePath file, Error error, ErrorLevel? overwriteLevel = null)
-        {
-            return Write(
-                file == error.FilePath || error.FilePath != null
-                    ? error
-                    : new Error(error.Level, error.Code, error.Message, file, error.Line, error.Column),
-                overwriteLevel);
         }
 
         public bool Write(Error error, ErrorLevel? overwriteLevel = null)

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Docs.Build
                         }
                         else
                         {
-                            errors.Add(Errors.UidConflict(uid));
+                            errors.Add(Errors.UidConflict(uid, JsonUtility.GetSourceInfo(uidValue)));
                         }
 
                         break;

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -63,8 +63,7 @@ namespace Microsoft.Docs.Build
                 }
                 catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
                 {
-                    Log.Write(dex);
-                    return errorLog.Write(dex.Error);
+                    return errorLog.Write(dex);
                 }
                 finally
                 {


### PR DESCRIPTION
`Parallel.ForEach` generates `AggregatedException` that contains error for each item. Make `DocfxException.IsDocfxException` friendly to `AggregatedException`.

Removed file override, error source info are populated when the error was created.

https://dev.azure.com/ceapex/Engineering/_workitems/edit/160455/

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5426)