### PR TITLE
remove redundant net462 checks

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Common/Microsoft.DocAsCode.Build.Common.csproj
+++ b/src/Microsoft.DocAsCode.Build.Common/Microsoft.DocAsCode.Build.Common.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Composition" Version="1.0.31" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Web" />
   </ItemGroup>
 

--- a/src/Microsoft.DocAsCode.Build.Engine/Microsoft.DocAsCode.Build.Engine.csproj
+++ b/src/Microsoft.DocAsCode.Build.Engine/Microsoft.DocAsCode.Build.Engine.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Nustache" Version="1.15.3.5" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Web" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.IO.Compression" />

--- a/src/Microsoft.DocAsCode.Build.ManagedReference/Microsoft.DocAsCode.Build.ManagedReference.csproj
+++ b/src/Microsoft.DocAsCode.Build.ManagedReference/Microsoft.DocAsCode.Build.ManagedReference.csproj
@@ -9,7 +9,7 @@
     <ProjectReference Include="..\Microsoft.DocAsCode.YamlSerialization\Microsoft.DocAsCode.YamlSerialization.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Web" />
   </ItemGroup>
 

--- a/src/Microsoft.DocAsCode.Build.TableOfContents/Microsoft.DocAsCode.Build.TableOfContents.csproj
+++ b/src/Microsoft.DocAsCode.Build.TableOfContents/Microsoft.DocAsCode.Build.TableOfContents.csproj
@@ -11,7 +11,7 @@
     <ProjectReference Include="..\Microsoft.DocAsCode.YamlSerialization\Microsoft.DocAsCode.YamlSerialization.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Web" />
     <Reference Include="System.IO.Compression" />
   </ItemGroup>

--- a/src/Microsoft.DocAsCode.Build.UniversalReference/Microsoft.DocAsCode.Build.UniversalReference.csproj
+++ b/src/Microsoft.DocAsCode.Build.UniversalReference/Microsoft.DocAsCode.Build.UniversalReference.csproj
@@ -3,7 +3,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="5.2.0" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.DocAsCode.Common/Microsoft.DocAsCode.Common.csproj
+++ b/src/Microsoft.DocAsCode.Common/Microsoft.DocAsCode.Common.csproj
@@ -5,7 +5,7 @@
     <ProjectReference Include="..\Microsoft.DocAsCode.YamlSerialization\Microsoft.DocAsCode.YamlSerialization.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Web" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DocAsCode.DataContracts.Common/Microsoft.DocAsCode.DataContracts.Common.csproj
+++ b/src/Microsoft.DocAsCode.DataContracts.Common/Microsoft.DocAsCode.DataContracts.Common.csproj
@@ -5,7 +5,7 @@
     <ProjectReference Include="..\Microsoft.DocAsCode.Common\Microsoft.DocAsCode.Common.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
   </ItemGroup>

--- a/src/Microsoft.DocAsCode.DataContracts.UniversalReference/Microsoft.DocAsCode.DataContracts.UniversalReference.csproj
+++ b/src/Microsoft.DocAsCode.DataContracts.UniversalReference/Microsoft.DocAsCode.DataContracts.UniversalReference.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../Shared/base.netstandard.props" />
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.DocAsCode.Dfm/Microsoft.DocAsCode.Dfm.csproj
+++ b/src/Microsoft.DocAsCode.Dfm/Microsoft.DocAsCode.Dfm.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="HtmlAgilityPack" Version="1.4.9" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Web" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DocAsCode.Glob/Microsoft.DocAsCode.Glob.csproj
+++ b/src/Microsoft.DocAsCode.Glob/Microsoft.DocAsCode.Glob.csproj
@@ -4,7 +4,7 @@
       <Description>Implements glob utility</Description>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Runtime" />
   </ItemGroup>
 

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/Microsoft.DocAsCode.Metadata.ManagedReference.Common.csproj
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/Microsoft.DocAsCode.Metadata.ManagedReference.Common.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn.csproj
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Microsoft.VisualStudio.RemoteControl" Version="14.0.262-masterA5CACE98" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Microsoft.DocAsCode.Metadata.ManagedReference.csproj
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Microsoft.DocAsCode.Metadata.ManagedReference.csproj
@@ -12,7 +12,7 @@
     <ProjectReference Include="..\Microsoft.DocAsCode.Metadata.ManagedReference.Common\Microsoft.DocAsCode.Metadata.ManagedReference.Common.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />

--- a/src/Shared/base.props
+++ b/src/Shared/base.props
@@ -57,7 +57,7 @@
     <Compile Condition="Exists($(VersionFSFile)) And '$(MSBuildProjectExtension)' == '.fsproj'" Include="$(VersionFSFile)" />
   </ItemGroup>
   
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="SQLitePCLRaw.core" Version="1.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/test/Microsoft.DocAsCode.Build.ConceptualDocuments.Tests/Microsoft.DocAsCode.Build.ConceptualDocuments.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Build.ConceptualDocuments.Tests/Microsoft.DocAsCode.Build.ConceptualDocuments.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Shared\test.base.props" />
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Web" />
   </ItemGroup>
 

--- a/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/Microsoft.DocAsCode.Build.SchemaDriven.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/Microsoft.DocAsCode.Build.SchemaDriven.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Shared\test.base.props" />
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System" />
     <Reference Include="System.Web" />
   </ItemGroup>

--- a/test/Microsoft.DocAsCode.Build.TableOfContents.Tests/Microsoft.DocAsCode.Build.TableOfContents.Tests.csproj
+++ b/test/Microsoft.DocAsCode.Build.TableOfContents.Tests/Microsoft.DocAsCode.Build.TableOfContents.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Shared\test.base.props" />
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Web" />
   </ItemGroup>
 

--- a/tools/MergeDeveloperComments/MergeDeveloperComments.csproj
+++ b/tools/MergeDeveloperComments/MergeDeveloperComments.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Runtime" />
   </ItemGroup>
 

--- a/tools/MergeSourceInfo/MergeSourceInfo.csproj
+++ b/tools/MergeSourceInfo/MergeSourceInfo.csproj
@@ -11,7 +11,7 @@
     <ProjectReference Include="..\..\src\Microsoft.DocAsCode.DataContracts.ManagedReference\Microsoft.DocAsCode.DataContracts.ManagedReference.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Runtime" />
   </ItemGroup>
 


### PR DESCRIPTION
seems no projects target net462, so these checks should be redundant?

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5436)