### PR TITLE
Remove build from en-us for LOC

### DIFF
--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Docs.Build
                     return false;
 
                 using var packageResolver = new PackageResolver(docsetPath, config, noFetch: true);
-                var localizationProvider = new LocalizationProvider(packageResolver, options, config, locale, docsetPath, repository);
+                var localizationProvider = new LocalizationProvider(packageResolver, config, locale, docsetPath, repository);
                 var repositoryProvider = new RepositoryProvider(docsetPath, repository, options, config, packageResolver, localizationProvider);
                 var input = new Input(docsetPath, repositoryProvider, localizationProvider);
 

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Docs.Build
 
                 using var packageResolver = new PackageResolver(docsetPath, config, noFetch: true);
                 var localizationProvider = new LocalizationProvider(packageResolver, config, locale, docsetPath, repository);
-                var repositoryProvider = new RepositoryProvider(docsetPath, repository, options, config, packageResolver, localizationProvider);
+                var repositoryProvider = new RepositoryProvider(docsetPath, repository, config, packageResolver, localizationProvider);
                 var input = new Input(docsetPath, repositoryProvider, localizationProvider);
 
                 // get docsets(build docset, fallback docset and dependency docsets)

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Docs.Build
                 // load and trace entry repository
                 var repository = Repository.Create(docsetPath);
                 Telemetry.SetRepository(repository?.Remote, repository?.Branch);
-                var locale = LocalizationUtility.GetLocale(repository, options);
+                var locale = LocalizationUtility.GetLocale(repository);
 
                 var configLoader = new ConfigLoader(repository, errorLog);
                 (errors, config) = configLoader.Load(docsetPath, locale, options, noFetch: true);

--- a/src/docfx/build/document/RepositoryProvider.cs
+++ b/src/docfx/build/document/RepositoryProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Docs.Build
             _docsetPath = docsetPath;
             _repository = repository;
             _packageResolver = packageResolver;
-            _locale = LocalizationUtility.GetLocale(repository, options);
+            _locale = LocalizationUtility.GetLocale(repository);
             _config = config;
             _localizationProvider = localizationProvider;
             _templateRepository = new Lazy<(string, Repository)>(GetTemplateRepository);

--- a/src/docfx/build/document/RepositoryProvider.cs
+++ b/src/docfx/build/document/RepositoryProvider.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Docs.Build
         public RepositoryProvider(
             string docsetPath,
             Repository repository,
-            CommandLineOptions options,
             Config config = null,
             PackageResolver packageResolver = null,
             LocalizationProvider localizationProvider = null)

--- a/src/docfx/build/localization/LocalizationProvider.cs
+++ b/src/docfx/build/localization/LocalizationProvider.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Diagnostics;
 using System.IO;
 
 namespace Microsoft.Docs.Build
@@ -10,51 +8,38 @@ namespace Microsoft.Docs.Build
     internal class LocalizationProvider
     {
         private readonly PackageResolver _packageResolver;
-        private readonly string _locale;
         private readonly Config _config;
-        private readonly bool _buildFromEnglish;
-        private readonly string _entryDocsetPath;
-        private readonly Repository _entryRepository;
 
+        // entry should always be localization repo
+        private readonly string _localizationDocsetPath;
+        private readonly Repository _localizationRepository;
+
+        // en-us repo is used for fallback
         private string _englishDocsetPath;
         private Repository _englishRepository;
-        private string _localizationDocsetPath;
-        private Repository _localizationRepository;
 
         public bool IsLocalizationBuild { get; }
 
         public bool EnableSideBySide { get; }
 
-        public LocalizationProvider(PackageResolver packageResolver, CommandLineOptions options, Config config, string locale, string docsetPath, Repository repository)
+        public LocalizationProvider(PackageResolver packageResolver, Config config, string locale, string docsetPath, Repository repository)
         {
             _packageResolver = packageResolver;
             _config = config;
-            _locale = locale;
-            _buildFromEnglish = !string.IsNullOrEmpty(options.Locale);
-            _entryDocsetPath = docsetPath;
-            _entryRepository = repository;
+            _localizationDocsetPath = docsetPath;
+            _localizationRepository = repository;
 
             if (!string.IsNullOrEmpty(locale) && !string.Equals(locale, config.Localization.DefaultLocale))
             {
                 IsLocalizationBuild = true;
             }
 
-            if (_buildFromEnglish)
-            {
-                _englishDocsetPath = docsetPath;
-                _englishRepository = repository;
+            _localizationDocsetPath = docsetPath;
+            _localizationRepository = repository;
 
-                EnableSideBySide = config.Localization.Bilingual;
-            }
-            else
-            {
-                _localizationDocsetPath = docsetPath;
-                _localizationRepository = repository;
-
-                EnableSideBySide = repository != null &&
-                    LocalizationUtility.TryGetContributionBranch(repository.Branch, out var contributionBranch) &&
-                    contributionBranch != repository.Branch;
-            }
+            EnableSideBySide = repository != null &&
+                LocalizationUtility.TryGetContributionBranch(repository.Branch, out var contributionBranch) &&
+                contributionBranch != repository.Branch;
 
             SetFallbackRepository();
         }
@@ -71,33 +56,14 @@ namespace Microsoft.Docs.Build
 
         private void SetFallbackRepository()
         {
-            if (_packageResolver is null || _config is null || _entryRepository is null)
+            if (_packageResolver is null || _config is null || _localizationRepository is null)
             {
                 return;
             }
 
-            var docsetSourceFolder = Path.GetRelativePath(_entryRepository.Path, _entryDocsetPath);
+            var docsetSourceFolder = Path.GetRelativePath(_localizationRepository.Path, _localizationDocsetPath);
 
-            if (!_buildFromEnglish)
-            {
-                (_englishDocsetPath, _englishRepository) = _packageResolver != null ? GetFallbackRepository(_entryRepository, _packageResolver, docsetSourceFolder) : default;
-            }
-            else
-            {
-                if (TryGetLocalizationDocset(
-                    _packageResolver,
-                    _entryDocsetPath,
-                    _entryRepository,
-                    _config,
-                    docsetSourceFolder,
-                    _locale,
-                    out var localizationDocsetPath,
-                    out var localizationRepository))
-                {
-                    _localizationDocsetPath = localizationDocsetPath;
-                    _localizationRepository = localizationRepository;
-                }
-            }
+            (_englishDocsetPath, _englishRepository) = _packageResolver != null ? GetFallbackRepository(_localizationRepository, _packageResolver, docsetSourceFolder) : default;
         }
 
         private static (string fallbackDocsetPath, Repository fallbackRepo) GetFallbackRepository(
@@ -119,52 +85,6 @@ namespace Microsoft.Docs.Build
             }
 
             return default;
-        }
-
-        private bool TryGetLocalizationDocset(PackageResolver packageResolver, string docsetPath, Repository docsetRepository, Config config, string docsetSourceFolder, string locale, out string localizationDocsetPath, out Repository localizationRepository)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(locale));
-            Debug.Assert(config != null);
-
-            localizationDocsetPath = null;
-            localizationRepository = null;
-            switch (config.Localization.Mapping)
-            {
-                case LocalizationMapping.Repository:
-                case LocalizationMapping.Branch:
-                    {
-                        var repo = docsetRepository;
-                        if (repo is null)
-                        {
-                            return false;
-                        }
-                        var (locRemote, locBranch) = LocalizationUtility.GetLocalizedRepo(
-                            config.Localization.Mapping,
-                            EnableSideBySide,
-                            repo.Remote,
-                            repo.Branch,
-                            locale,
-                            config.Localization.DefaultLocale);
-                        var locRepoPath = packageResolver.ResolvePackage(new PackagePath(locRemote, locBranch), PackageFetchOptions.None);
-                        localizationDocsetPath = PathUtility.NormalizeFolder(Path.Combine(locRepoPath, docsetSourceFolder));
-                        localizationRepository = Repository.Create(locRepoPath, locBranch, locRemote);
-                        break;
-                    }
-                case LocalizationMapping.Folder:
-                    {
-                        if (config.Localization.Bilingual)
-                        {
-                            throw new NotSupportedException($"{config.Localization.Mapping} is not supporting bilingual build");
-                        }
-                        localizationDocsetPath = Path.Combine(docsetPath, "_localization", locale);
-                        localizationRepository = docsetRepository;
-                        break;
-                    }
-                default:
-                    throw new NotSupportedException($"{config.Localization.Mapping} is not supported yet");
-            }
-
-            return true;
         }
     }
 }

--- a/src/docfx/build/localization/LocalizationUtility.cs
+++ b/src/docfx/build/localization/LocalizationUtility.cs
@@ -60,11 +60,11 @@ namespace Microsoft.Docs.Build
             return TryGetFallbackRepository(repository.Remote, repository.Branch, out fallbackRemote, out fallbackBranch, out locale);
         }
 
-        public static string GetLocale(Repository repository, CommandLineOptions options)
+        public static string GetLocale(Repository repository)
         {
-            return options.Locale ?? (TryRemoveLocale(repository?.Branch, out _, out var branchLocale)
+            return TryRemoveLocale(repository?.Branch, out _, out var branchLocale)
                 ? branchLocale : TryRemoveLocale(repository?.Remote, out _, out var remoteLocale)
-                ? remoteLocale : default);
+                ? remoteLocale : default;
         }
 
         public static bool TryGetContributionBranch(string branch, out string contributionBranch)

--- a/src/docfx/cli/CommandLineOptions.cs
+++ b/src/docfx/cli/CommandLineOptions.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Docs.Build
         public bool Verbose;
         public bool DryRun;
         public bool Stdin;
-        public string Locale;
         public string Template;
         public int Port;
 

--- a/src/docfx/cli/Docfx.cs
+++ b/src/docfx/cli/Docfx.cs
@@ -129,7 +129,6 @@ namespace Microsoft.Docs.Build
                     options.StdinConfig = JsonUtility.Deserialize<JObject>(Console.ReadLine(), new FilePath("--stdin"));
                 }
 
-                options.Locale = options.Locale?.ToLowerInvariant();
                 return (command, workingDirectory, options);
             }
             catch (ArgumentSyntaxException ex)
@@ -142,7 +141,6 @@ namespace Microsoft.Docs.Build
         private static void DefineCommonOptions(ArgumentSyntax syntax, ref string workingDirectory, CommandLineOptions options)
         {
             syntax.DefineOption("template", ref options.Template, "The directory or git repository that contains website template.");
-            syntax.DefineOption("locale", ref options.Locale, "The locale of the docset to build");
             syntax.DefineOption("v|verbose", ref options.Verbose, "Enable diagnostics console output.");
             syntax.DefineOption("stdin", ref options.Stdin, "Enable additional config in JSON one liner using standard input.");
             syntax.DefineOption("legacy", ref options.Legacy, "Enable legacy output for backward compatibility.");

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -165,22 +165,6 @@ namespace Microsoft.Docs.Build
                 yield return (new PackagePath(fallbackRemote, "master"), PackageFetchOptions.IgnoreError | PackageFetchOptions.None);
                 yield break;
             }
-
-            // build from English
-            var (remote, branch) = LocalizationUtility.GetLocalizedRepo(
-                config.Localization.Mapping,
-                config.Localization.Bilingual,
-                repository.Remote,
-                repository.Branch,
-                locale,
-                config.Localization.DefaultLocale);
-
-            yield return (new PackagePath(remote, branch), PackageFetchOptions.None);
-
-            if (config.Localization.Bilingual && LocalizationUtility.TryGetContributionBranch(repository.Branch, out var contributionBranch))
-            {
-                yield return (new PackagePath(repository.Remote, contributionBranch), PackageFetchOptions.None);
-            }
         }
     }
 }

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Docs.Build
                     // load and trace entry repository
                     var repository = Repository.Create(docsetPath);
                     Telemetry.SetRepository(repository?.Remote, repository?.Branch);
-                    var locale = LocalizationUtility.GetLocale(repository, options);
+                    var locale = LocalizationUtility.GetLocale(repository);
 
                     // load configuration from current entry or fallback repository
                     var configLoader = new ConfigLoader(repository, errorLog);

--- a/test/docfx.Test/DocfxTest.cs
+++ b/test/docfx.Test/DocfxTest.cs
@@ -133,30 +133,25 @@ namespace Microsoft.Docs.Build
                 throw new TestSkippedException("Skip watch tests");
             }
 
-            // build from en-us repo
-            // disable for now because of radom failure
-            //await RunBuild(docsetPath, outputPath, spec, spec.Locale);
-
             if (spec.Locale != null)
             {
-                // Verify build from localization docset also work
-                // Disable build from English test to see if it helps with loc test instability
+                // always build from localization docset for localization tests
                 // https://dev.azure.com/ceapex/Engineering/_build/results?buildId=97101&view=logs&j=133bd042-0fac-58b5-e6e7-01018e6dc4d4&t=b907bda6-23f1-5af4-47fe-b951a88dbb9a&l=10898
                 var locDocsetPath = t_repos.Value.FirstOrDefault(
                     repo => repo.Key.EndsWith($".{spec.Locale}") || repo.Key.EndsWith(".loc")).Value;
 
                 if (locDocsetPath != null)
                 {
-                    await RunBuild(locDocsetPath, outputPath, spec, locale: null);
+                    await RunBuild(locDocsetPath, outputPath, spec);
                 }
             }
             else
             {
-                await RunBuild(docsetPath, outputPath, spec, spec.Locale);
+                await RunBuild(docsetPath, outputPath, spec);
             }
         }
 
-        private static async Task RunBuild(string docsetPath, string outputPath, DocfxTestSpec spec, string locale, bool dryRun = false)
+        private static async Task RunBuild(string docsetPath, string outputPath, DocfxTestSpec spec, bool dryRun = false)
         {
             var randomOutputPath = Path.ChangeExtension(outputPath, $".{Guid.NewGuid()}");
 
@@ -164,9 +159,7 @@ namespace Microsoft.Docs.Build
 
             using (TestUtility.EnsureFilesNotChanged(docsetPath))
             {
-                var commandLine =
-                    (spec.Legacy ? "--legacy" : "") +
-                    (locale != null ? $"--locale {locale}" : "");
+                var commandLine = spec.Legacy ? "--legacy" : "";
 
                 var options = commandLine
                     .Split(' ', StringSplitOptions.RemoveEmptyEntries)
@@ -196,7 +189,7 @@ namespace Microsoft.Docs.Build
 
             if (!dryRun && !spec.NoDryRun && spec.Outputs.ContainsKey(".errors.log"))
             {
-                await RunBuild(docsetPath, outputPath, spec, locale, dryRun: true);
+                await RunBuild(docsetPath, outputPath, spec, dryRun: true);
             }
         }
 

--- a/test/docfx.Test/build/TocTest.cs
+++ b/test/docfx.Test/build/TocTest.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Docs.Build
     public static class TocTest
     {
         private static readonly string s_docsetPath = Directory.GetCurrentDirectory();
-        private static readonly RepositoryProvider s_repositoryProvider = new RepositoryProvider(s_docsetPath, Repository.Create(s_docsetPath), new CommandLineOptions());
+        private static readonly RepositoryProvider s_repositoryProvider = new RepositoryProvider(s_docsetPath, Repository.Create(s_docsetPath));
         private static readonly Input s_input = new Input(s_docsetPath, s_repositoryProvider);
         private static readonly Config s_config = JsonUtility.Deserialize<Config>("{'output': { 'json': true } }".Replace('\'', '\"'), null);
         private static readonly Docset s_docset = new Docset(Directory.GetCurrentDirectory(), "en-us", s_config, null);


### PR DESCRIPTION
Build from en-us for localization repos are not in use, remove it to simplify the code.

While build from en-us, the local repo is en-us and the loc repo needs to be restored(including all branches). For the case that `live-sxs` branch needs to [get contributor information from `live` branch](https://github.com/dotnet/docfx/blob/aa164bcc41046447a47582f4dfde03e6062f3ba8/src/docfx/lib/git/FileCommitProvider.cs#L201), we would need to get data from `live` based on the restored `live-sxs` branch. 

But these two are restored as totally separated folders, the current implementation of restoring Git repo is to fetch a specific [Commitish(would be a branch in this case)](https://github.com/dotnet/docfx/blob/aa164bcc41046447a47582f4dfde03e6062f3ba8/src/docfx/restore/PackageResolver.cs#L128), not all the branches for better performance.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5437)