### PR TITLE
Reduce tests execution time

### DIFF
--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Docs.Build
         {
             List<Error> errors;
             Config config = null;
+            options.NoFetch = true;
 
             using var errorLog = new ErrorLog(docsetPath, outputPath, () => config, options.Legacy);
             var stopwatch = Stopwatch.StartNew();
@@ -41,11 +42,11 @@ namespace Microsoft.Docs.Build
                 var locale = LocalizationUtility.GetLocale(repository);
 
                 var configLoader = new ConfigLoader(repository, errorLog);
-                (errors, config) = configLoader.Load(docsetPath, locale, options, noFetch: true);
+                (errors, config) = configLoader.Load(docsetPath, locale, options);
                 if (errorLog.Write(errors))
                     return false;
 
-                using var packageResolver = new PackageResolver(docsetPath, config, noFetch: true);
+                using var packageResolver = new PackageResolver(docsetPath, config, options.FetchOptions);
                 var localizationProvider = new LocalizationProvider(packageResolver, config, locale, docsetPath, repository);
                 var repositoryProvider = new RepositoryProvider(docsetPath, repository, config, packageResolver, localizationProvider);
                 var input = new Input(docsetPath, repositoryProvider, localizationProvider);
@@ -100,7 +101,7 @@ namespace Microsoft.Docs.Build
             RepositoryProvider repositoryProvider,
             LocalizationProvider localizationProvider)
         {
-            using var context = new Context(outputPath, errorLog, docset, fallbackDocset, input, repositoryProvider, localizationProvider);
+            using var context = new Context(outputPath, errorLog, docset, fallbackDocset, input, repositoryProvider, localizationProvider, options.FetchOptions);
             context.BuildQueue.Enqueue(context.BuildScope.Files.Concat(context.RedirectionProvider.Files));
 
             using (Progress.Start("Building files"))

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Docs.Build
 
         private readonly Lazy<TableOfContentsMap> _tocMap;
 
-        public Context(string outputPath, ErrorLog errorLog, Docset docset, Docset fallbackDocset, Input input, RepositoryProvider repositoryProvider, LocalizationProvider localizationProvider)
+        public Context(string outputPath, ErrorLog errorLog, Docset docset, Docset fallbackDocset, Input input, RepositoryProvider repositoryProvider, LocalizationProvider localizationProvider, FetchOptions fetchOptions)
         {
             var credentialProvider = docset.Config.GetCredentialProvider();
 
@@ -50,7 +50,7 @@ namespace Microsoft.Docs.Build
 
             Config = docset.Config;
             ErrorLog = errorLog;
-            FileResolver = new FileResolver(docset.DocsetPath, credentialProvider, new OpsConfigAdapter(errorLog, credentialProvider), noFetch: true);
+            FileResolver = new FileResolver(docset.DocsetPath, credentialProvider, new OpsConfigAdapter(errorLog, credentialProvider), fetchOptions);
             Input = input;
             LocalizationProvider = localizationProvider;
             Output = new Output(outputPath, input, Config.DryRun);

--- a/src/docfx/cli/CommandLineOptions.cs
+++ b/src/docfx/cli/CommandLineOptions.cs
@@ -12,10 +12,16 @@ namespace Microsoft.Docs.Build
         public bool Verbose;
         public bool DryRun;
         public bool Stdin;
+        public bool UseCache;
+        public bool NoFetch;
         public string Template;
         public int Port;
 
         public JObject StdinConfig;
+
+        public FetchOptions FetchOptions => NoFetch
+            ? FetchOptions.NoFetch
+            : (UseCache ? FetchOptions.UseCache : FetchOptions.None);
 
         public JObject ToJObject()
         {

--- a/src/docfx/cli/Docfx.cs
+++ b/src/docfx/cli/Docfx.cs
@@ -110,6 +110,7 @@ namespace Microsoft.Docs.Build
                     // Restore command
                     syntax.DefineCommand("restore", ref command, "Restores dependencies before build.");
                     syntax.DefineOption("o|output", ref options.Output, "Output directory in which to place restore log.");
+                    syntax.DefineOption("use-cache", ref options.UseCache, "ONly fetch latest content if it does not exist or read from disk cache.");
                     DefineCommonOptions(syntax, ref workingDirectory, options);
 
                     // Build command

--- a/src/docfx/config/ConfigLoader.cs
+++ b/src/docfx/config/ConfigLoader.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Load the config under <paramref name="docsetPath"/>
         /// </summary>
-        public (List<Error> errors, Config config) Load(string docsetPath, string locale, CommandLineOptions options, bool noFetch = false)
+        public (List<Error> errors, Config config) Load(string docsetPath, string locale, CommandLineOptions options)
         {
             var configPath = PathUtility.FindYamlOrJson(docsetPath, "docfx");
             if (configPath is null)
@@ -77,7 +77,7 @@ namespace Microsoft.Docs.Build
             // Download dependencies
             var credentialProvider = preloadConfig.GetCredentialProvider();
             var configAdapter = new OpsConfigAdapter(_errorLog, credentialProvider);
-            var fileResolver = new FileResolver(docsetPath, credentialProvider, configAdapter, noFetch);
+            var fileResolver = new FileResolver(docsetPath, credentialProvider, configAdapter, options.FetchOptions);
             var extendConfig = DownloadExtendConfig(errors, locale, preloadConfig, xrefEndpoint, xrefQueryTags, _repository, fileResolver);
 
             // Create full config

--- a/src/docfx/restore/FetchOptions.cs
+++ b/src/docfx/restore/FetchOptions.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Docs.Build
+{
+    internal enum FetchOptions
+    {
+        /// <summary>
+        /// Default restore option: always fetch the latest content, without reading from disk cache.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Do not restore dependencies, throw `need-restore` when encounter missing dependencies.
+        /// </summary>
+        NoFetch = 0b0001,
+
+        /// <summary>
+        /// Only fetch latest content if it does not exist or read from disk cache
+        /// </summary>
+        UseCache = 0b0010,
+    }
+}

--- a/src/docfx/restore/PackageResolver.cs
+++ b/src/docfx/restore/PackageResolver.cs
@@ -13,15 +13,15 @@ namespace Microsoft.Docs.Build
 
         private readonly string _docsetPath;
         private readonly Config _config;
-        private readonly bool _noFetch;
+        private readonly FetchOptions _fetchOptions;
 
         private readonly Dictionary<PathString, InterProcessReaderWriterLock> _gitReaderLocks = new Dictionary<PathString, InterProcessReaderWriterLock>();
 
-        public PackageResolver(string docsetPath, Config config, bool noFetch = false)
+        public PackageResolver(string docsetPath, Config config, FetchOptions fetchOptions = default)
         {
             _docsetPath = docsetPath;
             _config = config;
-            _noFetch = noFetch;
+            _fetchOptions = fetchOptions;
         }
 
         public bool TryResolvePackage(PackagePath package, PackageFetchOptions options, out string path)
@@ -40,7 +40,7 @@ namespace Microsoft.Docs.Build
 
         public string ResolvePackage(PackagePath package, PackageFetchOptions options)
         {
-            if (!_noFetch)
+            if (_fetchOptions != FetchOptions.NoFetch)
             {
                 DownloadPackage(package, options);
             }
@@ -108,6 +108,10 @@ namespace Microsoft.Docs.Build
             {
                 if (File.Exists(gitDocfxHead))
                 {
+                    if (_fetchOptions == FetchOptions.UseCache)
+                    {
+                        return;
+                    }
                     File.Delete(gitDocfxHead);
                 }
                 DownloadGitRepositoryCore(gitPath, url, committish, depthOne);

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Graph;
 
 namespace Microsoft.Docs.Build
 {
@@ -58,8 +59,8 @@ namespace Microsoft.Docs.Build
 
                     // download dependencies to disk
                     Parallel.Invoke(
-                        () => RestoreFiles(docsetPath, config, errorLog).GetAwaiter().GetResult(),
-                        () => RestorePackages(docsetPath, config, locale, repository));
+                        () => RestoreFiles(docsetPath, config, errorLog, options.FetchOptions).GetAwaiter().GetResult(),
+                        () => RestorePackages(docsetPath, config, locale, repository, options.FetchOptions));
                 }
                 catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
                 {
@@ -75,16 +76,16 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static async Task RestoreFiles(string docsetPath, Config config, ErrorLog errorLog)
+        private static async Task RestoreFiles(string docsetPath, Config config, ErrorLog errorLog, FetchOptions fetchOptions)
         {
             var credentialProvider = config.GetCredentialProvider();
-            var fileResolver = new FileResolver(docsetPath, credentialProvider, new OpsConfigAdapter(errorLog, credentialProvider));
+            var fileResolver = new FileResolver(docsetPath, credentialProvider, new OpsConfigAdapter(errorLog, credentialProvider), fetchOptions);
             await ParallelUtility.ForEach(config.GetFileReferences(), fileResolver.Download);
         }
 
-        private static void RestorePackages(string docsetPath, Config config, string locale, Repository repository)
+        private static void RestorePackages(string docsetPath, Config config, string locale, Repository repository, FetchOptions fetchOptions)
         {
-            using var packageResolver = new PackageResolver(docsetPath, config);
+            using var packageResolver = new PackageResolver(docsetPath, config, fetchOptions);
             ParallelUtility.ForEach(
                 GetPackages(config, locale, repository).Distinct(),
                 item => packageResolver.DownloadPackage(item.package, item.flags),

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Graph;
 
 namespace Microsoft.Docs.Build
 {

--- a/test/docfx.Test/DocfxTest.cs
+++ b/test/docfx.Test/DocfxTest.cs
@@ -170,7 +170,9 @@ namespace Microsoft.Docs.Build
 
                 if (spec.Restore)
                 {
-                    await Docfx.Run(new[] { "restore", docsetPath }.Concat(options).ToArray());
+                    await Docfx.Run(new[] { "restore", docsetPath }.Concat(options)
+                        .Concat(new[] { "--use-cache" })
+                        .ToArray());
                 }
                 if (spec.Build)
                 {

--- a/test/docfx.Test/DocfxTest.cs
+++ b/test/docfx.Test/DocfxTest.cs
@@ -170,9 +170,7 @@ namespace Microsoft.Docs.Build
 
                 if (spec.Restore)
                 {
-                    await Docfx.Run(new[] { "restore", docsetPath }.Concat(options)
-                        .Concat(new[] { "--use-cache" })
-                        .ToArray());
+                    await Docfx.Run(new[] { "restore", docsetPath }.Concat(options).Concat(new[] { "--use-cache" }).ToArray());
                 }
                 if (spec.Build)
                 {

--- a/test/docfx.Test/DocfxTest.cs
+++ b/test/docfx.Test/DocfxTest.cs
@@ -54,11 +54,11 @@ namespace Microsoft.Docs.Build
 
                 if (OsMatches(spec.OS))
                 {
-                    await RunCore(test, docsetPath, outputPath, spec);
+                    await RunCore(docsetPath, outputPath, spec);
                 }
                 else
                 {
-                    await Assert.ThrowsAnyAsync<Exception>(() => RunCore(test, docsetPath, outputPath, spec));
+                    await Assert.ThrowsAnyAsync<Exception>(() => RunCore(docsetPath, outputPath, spec));
                 }
             }
             finally
@@ -126,7 +126,7 @@ namespace Microsoft.Docs.Build
             return (docsetPath, cachePath, statePath, outputPath, repos);
         }
 
-        private async static Task RunCore(TestData test, string docsetPath, string outputPath, DocfxTestSpec spec)
+        private async static Task RunCore(string docsetPath, string outputPath, DocfxTestSpec spec)
         {
             if (spec.Watch)
             {

--- a/test/docfx.Test/restore/RestoreTest.cs
+++ b/test/docfx.Test/restore/RestoreTest.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Docs.Build
         public static async Task DownloadFile_NoFetch_Should_Fail()
         {
             await Assert.ThrowsAsync<DocfxException>(() =>
-                new FileResolver(".", noFetch: true).Download(
+                new FileResolver(".", fetchOptions: FetchOptions.NoFetch).Download(
                     new SourceInfo<string>("https://raw.githubusercontent.com/docascode/docfx-test-dependencies-clean/master/README.md")));
         }
 


### PR DESCRIPTION
Based on #5440 
- Turn `noFetch` flag into enum `FetchOption`:
  - None(default: always fetch latest)
  - NoFetch
  - UseCache(only fetch latest if cache does not exist)
- Add `--use-cache` to specify `FetchOption.UseCahce` for `restore`
- This reduces tests execution time with cache locally from 1:30 to 00:30



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5456)