### PR TITLE
Create azure-pipelines-stable.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For more information see the [.NET Foundation Code of Conduct](http://www.dotnet
 
 | master | dev
 | - | -
-| [![Build Status](https://ceapex.visualstudio.com/Engineering/_apis/build/status/Docs.Build/docfx-v2-master-release?branchName=master)](https://ceapex.visualstudio.com/Engineering/_build/latest?definitionId=1503&branchName=master) | [![Build Status](https://mseng.visualstudio.com/VSChina/_apis/build/status/docfx/v2/docfx-nightly-build)](https://mseng.visualstudio.com/VSChina/_build/latest?definitionId=7829)
+| [![Build Status](https://ceapex.visualstudio.com/Engineering/_apis/build/status/Docs.Build/docfx-v2-master-release?branchName=master)](https://ceapex.visualstudio.com/Engineering/_build/latest?definitionId=1503&branchName=master) | [![Build Status](https://ceapex.visualstudio.com/Engineering/_apis/build/status/Docs.Build/docfx-v2-dev-release?branchName=dev)](https://ceapex.visualstudio.com/Engineering/_build/latest?definitionId=1743&branchName=dev)
 
 ### Packages
 

--- a/azure-pipelines-stable.yml
+++ b/azure-pipelines-stable.yml
@@ -1,0 +1,44 @@
+pool:
+  name: Hosted Windows 2019 with VS2019
+  vmImage: 'windows-2019'
+steps:
+- task: NodeTool@0
+  displayName: 'Use Node 8.x'
+  inputs:
+    versionSpec: 8.x
+
+- task: NuGetToolInstaller@0
+  displayName: 'Use NuGet 4.3.0'
+
+- task: CmdLine@1
+  displayName: 'npm install'
+  inputs:
+    filename: npm
+    arguments: install
+    workingFolder: tools/Deployment
+
+- task: CmdLine@1
+  displayName: 'tsc compile'
+  inputs:
+    filename: node
+    arguments: '.\node_modules\typescript\bin\tsc'
+    workingFolder: tools/Deployment
+
+- task: CmdLine@1
+  displayName: 'gulp build'
+  inputs:
+    filename: node
+    arguments: '.\node_modules\gulp\bin\gulp.js dev:release'
+    workingFolder: tools/Deployment
+
+- task: PublishBuildArtifacts@1
+  condition: always()
+  inputs:
+    pathtoPublish: 'target\Release\docfx'
+    artifactName: target
+
+- task: PublishBuildArtifacts@1
+  condition: always()
+  inputs:
+    pathtoPublish: 'test\docfx-seed\_site'
+    artifactName: docfx-seed-site


### PR DESCRIPTION
This CI/CD to release PPE packages is still in VSChina project. It is failing these days. I plan to move it to ceapex and concrete it in YAML.

We can merge this with `azure-pipelines.yml`, but need introduce some logic. We can add it later.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5459)