### PR TITLE
fix for invalid ending json

### DIFF
--- a/src/docfx/lib/json/JsonUtility.cs
+++ b/src/docfx/lib/json/JsonUtility.cs
@@ -124,7 +124,11 @@ namespace Microsoft.Docs.Build
 
                 t_status.Value.Push(status);
 
-                return s_serializer.Deserialize<T>(reader) ?? new T();
+                var result = s_serializer.Deserialize<T>(reader) ?? new T();
+
+                // work around for invalid ending json
+                reader.Read();
+                return result;
             }
             catch (JsonReaderException ex)
             {

--- a/src/docfx/lib/json/JsonUtility.cs
+++ b/src/docfx/lib/json/JsonUtility.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Docs.Build
 
                 var result = s_serializer.Deserialize<T>(reader) ?? new T();
 
-                // work around for invalid ending json
+                // workaround for invalid ending json
                 reader.Read();
                 return result;
             }

--- a/test/docfx.Test/lib/JsonUtilityTest.cs
+++ b/test/docfx.Test/lib/JsonUtilityTest.cs
@@ -445,6 +445,14 @@ namespace Microsoft.Docs.Build
             Assert.Equal("{\"b\":1,\"d\":false}", result);
         }
 
+        [Theory]
+        [InlineData("{}---")]
+        [InlineData("{}{}")]
+        public void TestInvalidJson(string json)
+        {
+            Assert.Throws<DocfxException>(() => JsonUtility.Deserialize<ClassWithSourceInfo>(json, new FilePath("path")));
+        }
+
         [Fact]
         public void TestDeserializeWithSourceInfo()
         {
@@ -459,7 +467,7 @@ namespace Microsoft.Docs.Build
         [Fact]
         public void TestExtensionDataWithSourceInfo()
         {
-            var (_, result) = DeserializeWithValidation<ClassWithExtensionData>("{\"a\": 1}");
+            var (_, result) = DeserializeWithValidation<ClassWithExtensionData>("{\"a\": 1} ");
             Assert.NotNull(result.ExtensionData["a"]);
 
             var valueSource = JsonUtility.GetSourceInfo(result.ExtensionData["a"]);


### PR DESCRIPTION
- workaround for invalid ending JSON de-serialization
- space should be valid ending

The root cause is from `JSON.NET`, filed an [issue](https://github.com/JamesNK/Newtonsoft.Json/issues/2256) for it


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5478)