### PR TITLE
fix: Trim directory name in case file path contain whitespace

### DIFF
--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -636,7 +636,7 @@ inputs:
   docfx.yml: |
     output:
       json: false
-  docs/a b .md:
+  docs/a b.. ..md:
 outputs:
   docs/a b/index.html:
 ---

--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -631,6 +631,15 @@ inputs:
 outputs: 
   docs/a/index.html:
 ---
+# Source file name ending with spaces should not crash
+inputs:
+  docfx.yml: |
+    output:
+      json: false
+  docs/a b .md:
+outputs:
+  docs/a b/index.html:
+---
 # Invalid Link
 inputs: 
   docfx.yml:

--- a/src/docfx/build/document/DocumentProvider.cs
+++ b/src/docfx/build/document/DocumentProvider.cs
@@ -211,7 +211,8 @@ namespace Microsoft.Docs.Build
                         {
                             return Path.ChangeExtension(path, ".html");
                         }
-                        return Path.Combine(Path.GetDirectoryName(path), Path.GetFileNameWithoutExtension(path).Trim(), "index.html").Replace('\\', '/');
+                        var fileName = Path.GetFileNameWithoutExtension(path).TrimEnd(' ', '.');
+                        return Path.Combine(Path.GetDirectoryName(path), fileName, "index.html").Replace('\\', '/');
                     }
                     return Path.ChangeExtension(path, ".json");
                 case ContentType.TableOfContents:

--- a/src/docfx/build/document/DocumentProvider.cs
+++ b/src/docfx/build/document/DocumentProvider.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Docs.Build
                         {
                             return Path.ChangeExtension(path, ".html");
                         }
-                        return Path.Combine(Path.GetDirectoryName(path), Path.GetFileNameWithoutExtension(path), "index.html").Replace('\\', '/');
+                        return Path.Combine(Path.GetDirectoryName(path), Path.GetFileNameWithoutExtension(path).Trim(), "index.html").Replace('\\', '/');
                     }
                     return Path.ChangeExtension(path, ".json");
                 case ContentType.TableOfContents:


### PR DESCRIPTION
Fixes #5494 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5495)