### PR TITLE
Bump Validation package version to '1.2.18-beta004'

### DIFF
--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Stubble.Core" Version="1.6.3" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180503-2" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.11.0" />
-    <PackageReference Include="Validations.DocFx.Adapter" Version="1.2.17" />
+    <PackageReference Include="Validations.DocFx.Adapter" Version="1.2.18-beta004" />
     <PackageReference Include="YamlDotNet" Version="8.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
- bump Validation package version to '1.2.18-beta004'

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5514)