### PR TITLE
Remove GitShallowFetch

### DIFF
--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -192,12 +192,6 @@ namespace Microsoft.Docs.Build
         /// </summary>
         public readonly bool UpdateCommitBuildTime = true;
 
-        /// <summary>
-        /// When fetching git dependencies, docfx uses --depth 1 as much as it can to improve performance.
-        /// In certain extreme cases this may degrade performance, this option gives the ability to toggle the behavior.
-        /// </summary>
-        public readonly bool GitShallowFetch = true;
-
         public IEnumerable<SourceInfo<string>> GetFileReferences()
         {
             foreach (var url in Xref)

--- a/src/docfx/restore/PackageResolver.cs
+++ b/src/docfx/restore/PackageResolver.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Docs.Build
         private void DownloadGitRepositoryCore(string cwd, string url, string committish, bool depthOne)
         {
             var fetchOption = "--update-head-ok --prune --force";
-            var depthOneOption = $"--depth {(depthOne && _config.GitShallowFetch ? "1" : "99999999")}";
+            var depthOneOption = $"--depth {(depthOne ? "1" : "99999999")}";
 
             Directory.CreateDirectory(cwd);
             GitUtility.Init(cwd);


### PR DESCRIPTION
This options was added to address a performance problem on server build when PR builds needs to pin a specific dependency repo commit.

Now that we don't need to pin to a specific commit, this flag can be removed to improve first-time build performance for server build

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5518)