### PR TITLE
Avoid non-deterministic output

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/ExtractSearchIndex.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/PostProcessors/ExtractSearchIndex.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DocAsCode.Build.Engine
             {
                 throw new ArgumentNullException("Base directory can not be null");
             }
-            var indexData = new Dictionary<string, SearchIndexItem>();
+            var indexData = new SortedDictionary<string, SearchIndexItem>();
             var indexDataFilePath = Path.Combine(outputFolder, IndexFileName);
             var htmlFiles = (from item in manifest.Files ?? Enumerable.Empty<ManifestItem>()
                              from output in item.OutputFiles

--- a/src/Microsoft.DocAsCode.Plugins/IncrementalInfo.cs
+++ b/src/Microsoft.DocAsCode.Plugins/IncrementalInfo.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DocAsCode.Plugins
     public class IncrementalInfo
     {
         private readonly object _syncRoot = new object();
-        private readonly Dictionary<string, IncrementalStatus> _processors = new Dictionary<string, IncrementalStatus>();
+        private readonly SortedDictionary<string, IncrementalStatus> _processors = new SortedDictionary<string, IncrementalStatus>();
 
         [JsonProperty("status")]
         public IncrementalStatus Status { get; } = new IncrementalStatus();


### PR DESCRIPTION
index.json and incremental_info.processors in manifest.json are now generated
from sorted dictionaries and are now the same on every run.

#4569

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5524)