### PR TITLE
Filter expired cache item when saving

### DIFF
--- a/src/docfx/lib/cache/JsonDiskCache.cs
+++ b/src/docfx/lib/cache/JsonDiskCache.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Docs.Build
 
             if (_needUpdate)
             {
-                var content = JsonUtility.Serialize(new { items = _cache.Values.Distinct() });
+                var content = JsonUtility.Serialize(new { items = _cache.Values.Distinct().Where(value => !HasExpired(value)) });
 
                 Directory.CreateDirectory(Path.GetDirectoryName(_cachePath));
                 ProcessUtility.WriteFile(_cachePath, content);


### PR DESCRIPTION
Filtering expired cache item for preventing github user rename case, considering following case:
```text
1. contributor with email 'me@cvollmann.de' is resolved for the first time.
{
        "login": "cvollmann",
        "name": "Christoph Vollmann",
        "emails": ["me@cvollmann.de"],
        "updated_at": "2019-12-30T18:10:01.1657961Z"
}
2. next time this entry will be loaded with 'login' and 'emails' as keys
3. after a while, this entry goes expired, and trigger a cache update, and result shows user changes login.
{
        "login": "cloudchristoph",  // <- login changed
        "name": "Christoph Vollmann",
        "emails": ["me@cvollmann.de"],
        "updated_at": "2020-02-17T20:39:04.7245791Z"
    }
entry: me@cvollmann.de is updated, but remember old entry **cvollmann** is still in the cache map
4. upon saving, cache items cache[cvollmann] and cache[me@cvollmann.de] will both be saved without sorting.
5. next time in cache loading, both item will be added, and cache[me@cvollmann.de] depends on their order.
```
Above is a real case that I found in sql-docs-pr, hence we should clean up the expired cache item upon saving.
Still keep the logic that consumes expired cache and update later.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5535)