### PR TITLE
decode specical chars `(` and `)` after Uri.EscapeDataString()

### DIFF
--- a/src/Microsoft.DocAsCode.Common/Path/RelativePath.cs
+++ b/src/Microsoft.DocAsCode.Common/Path/RelativePath.cs
@@ -27,6 +27,11 @@ namespace Microsoft.DocAsCode.Common
         private static readonly string[] EncodedInvalidPartChars = Array.ConvertAll(InvalidPartChars, ch => Uri.EscapeDataString(ch.ToString()));
         private static readonly char[] UnsafeInvalidPartChars = { '/' };
         private static readonly string[] EncodedUnsafeInvalidPartChars = Array.ConvertAll(UnsafeInvalidPartChars, ch => Uri.EscapeDataString(ch.ToString()));
+        private static readonly Dictionary<string, string> SpecialCharactersNeedToDecode = new Dictionary<string, string>
+        {
+            ["%28"] = "(",
+            ["%29"] = ")"
+        };
 
         private readonly bool _isFromWorkingFolder;
         private readonly int _parentDirectoryCount;
@@ -233,7 +238,7 @@ namespace Microsoft.DocAsCode.Common
             var parts = new string[_parts.Length];
             for (int i = 0; i < parts.Length; i++)
             {
-                parts[i] = Uri.EscapeDataString(_parts[i]);
+                parts[i] = DecodeSpecialCharacters(Uri.EscapeDataString(_parts[i]));
             }
             return new RelativePath(_isFromWorkingFolder, _parentDirectoryCount, parts);
         }
@@ -506,6 +511,15 @@ namespace Microsoft.DocAsCode.Common
             }
 
             return parts;
+        }
+
+        private static string DecodeSpecialCharacters(string url)
+        {
+            foreach (var specialCharacterNeedToDecode in SpecialCharactersNeedToDecode)
+            {
+                url = url.Replace(specialCharacterNeedToDecode.Key, specialCharacterNeedToDecode.Value);
+            }
+            return url;
         }
 
         #endregion

--- a/src/Microsoft.DocAsCode.Common/Path/RelativePath.cs
+++ b/src/Microsoft.DocAsCode.Common/Path/RelativePath.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DocAsCode.Common
         private static readonly string[] EncodedInvalidPartChars = Array.ConvertAll(InvalidPartChars, ch => Uri.EscapeDataString(ch.ToString()));
         private static readonly char[] UnsafeInvalidPartChars = { '/' };
         private static readonly string[] EncodedUnsafeInvalidPartChars = Array.ConvertAll(UnsafeInvalidPartChars, ch => Uri.EscapeDataString(ch.ToString()));
-        private static readonly Dictionary<string, string> SpecialCharactersNeedToDecode = new Dictionary<string, string>
+        private static readonly IDictionary<string, string> SpecialCharactersNeedToDecode = new Dictionary<string, string>
         {
             ["%28"] = "(",
             ["%29"] = ")"
@@ -515,11 +515,12 @@ namespace Microsoft.DocAsCode.Common
 
         private static string DecodeSpecialCharacters(string url)
         {
+            var sb = new StringBuilder(url);
             foreach (var specialCharacterNeedToDecode in SpecialCharactersNeedToDecode)
             {
-                url = url.Replace(specialCharacterNeedToDecode.Key, specialCharacterNeedToDecode.Value);
+                sb = sb.Replace(specialCharacterNeedToDecode.Key, specialCharacterNeedToDecode.Value);
             }
-            return url;
+            return sb.ToString();
         }
 
         #endregion

--- a/test/Microsoft.DocAsCode.Build.ManagedReference.WithPlugins.Tests/SplitClassPageToMemberLevelTest.cs
+++ b/test/Microsoft.DocAsCode.Build.ManagedReference.WithPlugins.Tests/SplitClassPageToMemberLevelTest.cs
@@ -279,9 +279,9 @@ namespace Microsoft.DocAsCode.Build.ManagedReference.Tests
                     model.Items[0].Items[1].TopicHref,
                     model.Items[0].Items[2].TopicHref
                 };
-                Assert.Contains("../com.microsoft.azure.management.sql.SqlServer.firewallRules%28Method%29.html", topicHref, FilePathComparer.OSPlatformSensitiveStringComparer);
-                Assert.Contains("../com.microsoft.azure.management.sql.SqlServer.FirewallRules%28Interface%29.html", topicHref, FilePathComparer.OSPlatformSensitiveStringComparer);
-                Assert.Contains("../com.microsoft.azure.management.sql.SqlServer.firewallRules%28Interface%29_1.html", topicHref, FilePathComparer.OSPlatformSensitiveStringComparer);
+                Assert.Contains("../com.microsoft.azure.management.sql.SqlServer.firewallRules(Method).html", topicHref, FilePathComparer.OSPlatformSensitiveStringComparer);
+                Assert.Contains("../com.microsoft.azure.management.sql.SqlServer.FirewallRules(Interface).html", topicHref, FilePathComparer.OSPlatformSensitiveStringComparer);
+                Assert.Contains("../com.microsoft.azure.management.sql.SqlServer.firewallRules(Interface)_1.html", topicHref, FilePathComparer.OSPlatformSensitiveStringComparer);
             }
         }
 


### PR DESCRIPTION
Not encode `(` and `)` for url. 
 
Didn't find unexpected change with test. Only test with partial files in repository [sdk-api](https://github.com/MicrosoftDocs/sdk-api) because the repository is too large size.

Find related workitem [here](https://dev.azure.com/ceapex/Engineering/_workitems/edit/128018/)
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5537)