### PR TITLE
fix for xref tag not found

### DIFF
--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -140,7 +140,8 @@ namespace Microsoft.Docs.Build
         {
             var url = $"{xrefMapApiEndpoint}/v1/xrefmap{tag}{xrefMapQueryParams}";
             var response = await Fetch(url, value404: "{}");
-            return JsonConvert.DeserializeAnonymousType(response, new { links = new[] { "" } }).links;
+            return JsonConvert.DeserializeAnonymousType(response, new { links = new[] { "" } }).links
+                ?? Array.Empty<string>();
         }
 
         private Task<string> GetMonikerDefinition(Uri url)


### PR DESCRIPTION
cause by #5533 

https://dev.azure.com/ceapex/Engineering/_workitems/edit/178653
Throw at https://github.com/dotnet/docfx/blob/ce425ca97bcaa3a9ef2ac5910c4ef19d25b152d2/src/docfx/config/ops/OpsConfigAdapter.cs#L106
Here `links` can not be null

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5548)