### PR TITLE
keep using StringComparer.Ordinal for moniker sorting

### DIFF
--- a/src/docfx/lib/moniker/MonikerRangeParser.cs
+++ b/src/docfx/lib/moniker/MonikerRangeParser.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Docs.Build
                     return ExpressionCreator.Create(value)
                         .Accept(_monikersEvaluator)
                         .Select(x => x.MonikerName.ToLowerInvariant())
-                        .OrderBy(_ => _, StringComparer.OrdinalIgnoreCase)
+                        .OrderBy(_ => _, StringComparer.Ordinal)
                         .ToArray();
                 }
                 catch (MonikerRangeException ex)

--- a/src/docfx/lib/moniker/MonikerRangeParser.cs
+++ b/src/docfx/lib/moniker/MonikerRangeParser.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Docs.Build
                     return ExpressionCreator.Create(value)
                         .Accept(_monikersEvaluator)
                         .Select(x => x.MonikerName.ToLowerInvariant())
-                        .OrderBy(_ => _)
+                        .OrderBy(_ => _, StringComparer.OrdinalIgnoreCase)
                         .ToArray();
                 }
                 catch (MonikerRangeException ex)

--- a/test/docfx.Test/lib/MonikerRangeParserTest.cs
+++ b/test/docfx.Test/lib/MonikerRangeParserTest.cs
@@ -41,10 +41,21 @@ namespace Microsoft.Docs.Build
                     Order = 3
                 },
                 new Moniker
-                {
+                 {
                     MonikerName = "netcore-2.0",
                     ProductName = ".NET Core",
                     Order = 2
+                },
+                new Moniker
+                {
+                    MonikerName = "azuresqldb-current",
+                    ProductName = "sql",
+                    Order = 2
+                },
+                new Moniker
+                {
+                    MonikerName = "azure-sqldw-latest",
+                    ProductName = "sql"
                 },
             }
         };
@@ -96,6 +107,9 @@ namespace Microsoft.Docs.Build
         [InlineData(
             ">= netcore-2.0 > dotnet-2.0",
             "")]
+        [InlineData(
+            "azuresqldb-current || azure-sqldw-latest",
+            "azure-sqldw-latest azuresqldb-current")]
         public void TestEvaluateMonikerRange(string rangeString, string expectedMonikers)
         {
             var result = _monikerRangeParser.Parse(new SourceInfo<string>(rangeString)).ToList();

--- a/test/docfx.Test/lib/MonikerRangeParserTest.cs
+++ b/test/docfx.Test/lib/MonikerRangeParserTest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Docs.Build
                     Order = 3
                 },
                 new Moniker
-                 {
+                {
                     MonikerName = "netcore-2.0",
                     ProductName = ".NET Core",
                     Order = 2


### PR DESCRIPTION
revert the change in #5543 

monikers `["azuresqldb-current", "azure-sqldw-latest"]`  
by using the default comparer, it will be sorted to  `["azuresqldb-current", "azure-sqldw-latest"]`
by using the `StringComparer.OrdinalIgnoreCase`, it will be sorted to  `["azure-sqldw-latest", "azuresqldb-current"]`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5559)