### PR TITLE
Safe guard against not existing definition when inheriting doc

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Resolvers/CopyInheritedDocumentation.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Resolvers/CopyInheritedDocumentation.cs
@@ -142,7 +142,9 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 if (!context.References.TryGetValue(srcName, out var referenceItem) || referenceItem.Definition == null ||
                     !context.Members.TryGetValue(referenceItem.Definition, out src))
                 {
-                    Logger.LogWarning($"Could not resolve base documentation for '{dest.Name}'");
+                    Logger.LogWarning($"Could not resolve base documentation for '{dest.Name}'",
+                                      file: dest.Source.Path,
+                                      line: dest.Source.StartLine != 0 ? dest.Source.StartLine.ToString() : null);
                     return;
                 }
                     

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Resolvers/CopyInheritedDocumentation.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Resolvers/CopyInheritedDocumentation.cs
@@ -139,8 +139,13 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             if (src == null && !context.Members.TryGetValue(srcName, out src))
             {
                 // Try to resolve any templated references before giving up
-                if (!context.References.TryGetValue(srcName, out var referenceItem) || referenceItem.Definition == null || !context.Members.TryGetValue(referenceItem.Definition, out src))
+                if (!context.References.TryGetValue(srcName, out var referenceItem) || referenceItem.Definition == null ||
+                    !context.Members.TryGetValue(referenceItem.Definition, out src))
+                {
+                    Logger.LogWarning($"Could not resolve base documentation for '{dest.Name}'");
                     return;
+                }
+                    
             }
 
             Copy(dest, src, context);

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Resolvers/CopyInheritedDocumentation.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Resolvers/CopyInheritedDocumentation.cs
@@ -139,7 +139,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             if (src == null && !context.Members.TryGetValue(srcName, out src))
             {
                 // Try to resolve any templated references before giving up
-                if (!context.References.TryGetValue(srcName, out var referenceItem) || !context.Members.TryGetValue(referenceItem.Definition, out src))
+                if (!context.References.TryGetValue(srcName, out var referenceItem) || referenceItem.Definition == null || !context.Members.TryGetValue(referenceItem.Definition, out src))
                     return;
             }
 


### PR DESCRIPTION
When using inheritdoc on members or classes where no base documentation can be resolved docfx can throw a ArgumentNullException.

#5536 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5561)