### PR TITLE
fix: handle the case that base path not started by '/'

### DIFF
--- a/azure-pipelines-v3.yml
+++ b/azure-pipelines-v3.yml
@@ -117,6 +117,7 @@ jobs:
 
 # Build integration test
 - job: IntegrationTestBuild
+  dependsOn: WindowsBuild
   condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/v3'), eq(variables['System.PullRequest.TargetBranch'], 'v3')))
   pool:
     name: DocFX

--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Docs.Build
             var xrefMapApiEndpoint = GetXrefMapApiEndpoint(xrefEndpoint);
             if (docset.base_path != "/")
             {
-                xrefQueryTags.Add($"/{docset.base_path.TrimStart('/')}");
+                xrefQueryTags.Add(docset.base_path);
             }
             var xrefMaps = new List<string>();
             foreach (var tag in xrefQueryTags)
@@ -151,7 +151,7 @@ namespace Microsoft.Docs.Build
 
         private async Task<string[]> GetXrefMaps(string xrefMapApiEndpoint, string tag, string xrefMapQueryParams)
         {
-            var url = $"{xrefMapApiEndpoint}/v1/xrefmap{tag}{xrefMapQueryParams}";
+            var url = $"{xrefMapApiEndpoint}/v1/xrefmap/{tag.TrimStart('/')}{xrefMapQueryParams}";
             var response = await Fetch(url, value404: "{}");
             return JsonConvert.DeserializeAnonymousType(response, new { links = new[] { "" } }).links
                 ?? Array.Empty<string>();

--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Docs.Build
             var xrefMapApiEndpoint = GetXrefMapApiEndpoint(xrefEndpoint);
             if (docset.base_path != "/")
             {
-                xrefQueryTags.Add(docset.base_path);
+                xrefQueryTags.Add($"/{docset.base_path.TrimStart('/')}");
             }
             var xrefMaps = new List<string>();
             foreach (var tag in xrefQueryTags)

--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Docs.Build
             var xrefMapApiEndpoint = GetXrefMapApiEndpoint(xrefEndpoint);
             if (docset.base_path != "/")
             {
-                xrefQueryTags.Add(docset.base_path);
+                xrefQueryTags.Add($"/{docset.base_path.TrimStart('/')}");
             }
             var xrefMaps = new List<string>();
             foreach (var tag in xrefQueryTags)
@@ -151,10 +151,9 @@ namespace Microsoft.Docs.Build
 
         private async Task<string[]> GetXrefMaps(string xrefMapApiEndpoint, string tag, string xrefMapQueryParams)
         {
-            var url = $"{xrefMapApiEndpoint}/v1/xrefmap/{tag.TrimStart('/')}{xrefMapQueryParams}";
+            var url = $"{xrefMapApiEndpoint}/v1/xrefmap{tag}{xrefMapQueryParams}";
             var response = await Fetch(url, value404: "{}");
-            return JsonConvert.DeserializeAnonymousType(response, new { links = new[] { "" } }).links
-                ?? Array.Empty<string>();
+            return JsonConvert.DeserializeAnonymousType(response, new { links = new[] { "" } }).links;
         }
 
         private Task<string> GetMonikerDefinition(Uri url)

--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -153,7 +153,8 @@ namespace Microsoft.Docs.Build
         {
             var url = $"{xrefMapApiEndpoint}/v1/xrefmap{tag}{xrefMapQueryParams}";
             var response = await Fetch(url, value404: "{}");
-            return JsonConvert.DeserializeAnonymousType(response, new { links = new[] { "" } }).links;
+            return JsonConvert.DeserializeAnonymousType(response, new { links = new[] { "" } }).links
+                ?? Array.Empty<string>();
         }
 
         private Task<string> GetMonikerDefinition(Uri url)


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5562)