### PR TITLE
Improve base path handling

### DIFF
--- a/src/docfx/build/document/DocumentProvider.cs
+++ b/src/docfx/build/document/DocumentProvider.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Docs.Build
         {
             var file = GetDocument(path);
 
-            var outputPath = UrlUtility.Combine(_config.BasePath.RelativePath, MonikerUtility.GetGroup(monikers) ?? "", file.SitePath);
+            var outputPath = UrlUtility.Combine(_config.BasePath, MonikerUtility.GetGroup(monikers) ?? "", file.SitePath);
 
             return _config.Legacy && file.IsPage ? LegacyUtility.ChangeExtension(outputPath, ".raw.page.json") : outputPath;
         }
@@ -187,7 +187,7 @@ namespace Microsoft.Docs.Build
                 sitePath = sitePath.ToLowerInvariant();
             }
 
-            var siteUrl = PathToAbsoluteUrl(Path.Combine(_config.BasePath.RelativePath, sitePath), contentType, mime, _config.OutputJson, isPage);
+            var siteUrl = PathToAbsoluteUrl(Path.Combine(_config.BasePath, sitePath), contentType, mime, _config.OutputJson, isPage);
             var canonicalUrl = GetCanonicalUrl(siteUrl, sitePath, isExperimental, contentType, mime, isPage);
 
             return new Document(docset, path, sitePath, siteUrl, canonicalUrl, contentType, mime, isExperimental, isPage);

--- a/src/docfx/build/legacy/LegacyFileMap.cs
+++ b/src/docfx/build/legacy/LegacyFileMap.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Docs.Build
                 {
                     host = $"https://{context.Config.HostName}",
                     locale = context.LocalizationProvider.Locale,
-                    base_path = context.Config.BasePath.Original,
+                    base_path = context.Config.BasePath.OutputValue,
                     source_base_path = ".",
                     version_info = new { },
                     from_docfx_v3 = true,
@@ -75,7 +75,7 @@ namespace Microsoft.Docs.Build
                         },
                         item => item.fileMapItem),
                 },
-                Path.Combine(context.Config.BasePath.RelativePath, "filemap.json"));
+                Path.Combine(context.Config.BasePath, "filemap.json"));
         }
     }
 }

--- a/src/docfx/build/legacy/LegacyFileMap.cs
+++ b/src/docfx/build/legacy/LegacyFileMap.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Docs.Build
                 {
                     host = $"https://{context.Config.HostName}",
                     locale = context.LocalizationProvider.Locale,
-                    base_path = context.Config.BasePath.OutputValue,
+                    base_path = context.Config.BasePath.ValueWithLeadingSlash,
                     source_base_path = ".",
                     version_info = new { },
                     from_docfx_v3 = true,

--- a/src/docfx/build/legacy/LegacyUtility.cs
+++ b/src/docfx/build/legacy/LegacyUtility.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Docs.Build
                 outputPath = context.DocumentProvider.GetOutputPath(doc.FilePath, manifestItem.Monikers);
             }
             var legacyOutputFilePathRelativeToBasePath = Path.GetRelativePath(
-                string.IsNullOrEmpty(context.Config.BasePath.RelativePath) ? "." : context.Config.BasePath.RelativePath, outputPath);
+                string.IsNullOrEmpty(context.Config.BasePath) ? "." : context.Config.BasePath, outputPath);
 
             return PathUtility.NormalizeFile(legacyOutputFilePathRelativeToBasePath);
         }
@@ -28,7 +28,7 @@ namespace Microsoft.Docs.Build
             {
                 legacySiteUrlRelativeToBasePath = legacySiteUrlRelativeToBasePath.Substring(1);
                 legacySiteUrlRelativeToBasePath = Path.GetRelativePath(
-                    string.IsNullOrEmpty(context.Config.BasePath.RelativePath) ? "." : context.Config.BasePath.RelativePath,
+                    string.IsNullOrEmpty(context.Config.BasePath) ? "." : context.Config.BasePath,
                     string.IsNullOrEmpty(legacySiteUrlRelativeToBasePath) ? "." : legacySiteUrlRelativeToBasePath);
             }
 

--- a/src/docfx/build/legacy/LegacyUtility.cs
+++ b/src/docfx/build/legacy/LegacyUtility.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Docs.Build
         public static string ToLegacySiteUrlRelativeToBasePath(this Document doc, Context context)
         {
             var legacySiteUrlRelativeToBasePath = doc.SiteUrl;
-            if (legacySiteUrlRelativeToBasePath.StartsWith(context.Config.BasePath.ToString(), PathUtility.PathComparison))
+            if (legacySiteUrlRelativeToBasePath.StartsWith(context.Config.BasePath.ValueWithLeadingSlash, PathUtility.PathComparison))
             {
                 legacySiteUrlRelativeToBasePath = legacySiteUrlRelativeToBasePath.Substring(1);
                 legacySiteUrlRelativeToBasePath = Path.GetRelativePath(

--- a/src/docfx/build/legacy/manifest/LegacyManifest.cs
+++ b/src/docfx/build/legacy/manifest/LegacyManifest.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Docs.Build
                     version_info = new { },
                     items_to_publish = itemsToPublish,
                 },
-                Path.Combine(context.Config.BasePath.RelativePath, ".manifest.json"));
+                Path.Combine(context.Config.BasePath, ".manifest.json"));
             }
         }
 

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Docs.Build
             systemMetadata.Locale = context.LocalizationProvider.Locale;
             systemMetadata.CanonicalUrl = file.CanonicalUrl;
             systemMetadata.Path = file.SitePath;
-            systemMetadata.CanonicalUrlPrefix = UrlUtility.Combine($"https://{context.Config.HostName}", systemMetadata.Locale, context.Config.BasePath.RelativePath) + "/";
+            systemMetadata.CanonicalUrlPrefix = UrlUtility.Combine($"https://{context.Config.HostName}", systemMetadata.Locale, context.Config.BasePath) + "/";
 
             systemMetadata.TocRel = !string.IsNullOrEmpty(inputMetadata.TocRel)
                 ? inputMetadata.TocRel : context.TocMap.FindTocRelativePath(file);

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Docs.Build
             if (context.Config.OutputPdf)
             {
                 model.Metadata.PdfAbsolutePath = "/" +
-                    UrlUtility.Combine(context.Config.BasePath.RelativePath, "opbuildpdf", monikerGroup ?? string.Empty, LegacyUtility.ChangeExtension(file.SitePath, ".pdf"));
+                    UrlUtility.Combine(context.Config.BasePath, "opbuildpdf", monikerGroup ?? string.Empty, LegacyUtility.ChangeExtension(file.SitePath, ".pdf"));
             }
 
             // TODO: Add experimental and experiment_id to publish item

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Docs.Build
                     }
                     if (basePath is null)
                     {
-                        basePath = _config.BasePath.Original;
+                        basePath = _config.BasePath.OutputValue;
                     }
 
                     // DHS appends branch infomation from cookie cache to URL, which is wrong for UID resolved URL

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Docs.Build
                     }
                     if (basePath is null)
                     {
-                        basePath = _config.BasePath.OutputValue;
+                        basePath = _config.BasePath.ValueWithLeadingSlash;
                     }
 
                     // DHS appends branch infomation from cookie cache to URL, which is wrong for UID resolved URL

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Gets the site base path.
         /// </summary>
-        public BasePath BasePath { get; private set; } = new BasePath("/");
+        public BasePath BasePath { get; private set; }
 
         /// <summary>
         /// Gets host name used for generating .xrefmap.json
@@ -298,7 +298,7 @@ namespace Microsoft.Docs.Build
             if (LowerCaseUrl)
             {
                 HostName = HostName.ToLowerInvariant();
-                BasePath = new BasePath(BasePath.Original.ToLowerInvariant());
+                BasePath = new BasePath(BasePath.Value.ToLowerInvariant());
             }
 
             DefaultLocale = DefaultLocale.ToLowerInvariant();

--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Docs.Build
             var docsetInfo = await Fetch(fetchUrl, value404: "[]");
             var docsets = JsonConvert.DeserializeAnonymousType(
                 docsetInfo,
-                new[] { new { name = "", base_path = "", site_name = "", product_name = "" } });
+                new[] { new { name = "", base_path = default(BasePath), site_name = "", product_name = "" } });
 
             var docset = docsets.FirstOrDefault(d => string.Equals(d.name, name, StringComparison.OrdinalIgnoreCase));
             if (docset is null)
@@ -105,7 +105,7 @@ namespace Microsoft.Docs.Build
             var xrefMapApiEndpoint = GetXrefMapApiEndpoint(xrefEndpoint);
             if (docset.base_path != "/")
             {
-                xrefQueryTags.Add($"/{docset.base_path.TrimStart('/')}");
+                xrefQueryTags.Add(docset.base_path.OutputValue);
             }
             var xrefMaps = new List<string>();
             foreach (var tag in xrefQueryTags)
@@ -119,7 +119,7 @@ namespace Microsoft.Docs.Build
                 product = docset.product_name,
                 siteName = docset.site_name,
                 hostName = GetHostName(docset.site_name),
-                basePath = docset.base_path,
+                basePath = docset.base_path.Value,
                 xrefHostName = GetXrefHostName(docset.site_name, branch),
                 monikerDefinition = MonikerDefinitionApi,
                 markdownValidationRules = $"{MarkdownValidationRulesApi}{metadataServiceQueryParams}",

--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -103,9 +103,9 @@ namespace Microsoft.Docs.Build
 
             var xrefMapQueryParams = $"?site_name={docset.site_name}&branch_name={branch}&exclude_depot_name={docset.product_name}.{name}";
             var xrefMapApiEndpoint = GetXrefMapApiEndpoint(xrefEndpoint);
-            if (docset.base_path != "/")
+            if (!string.IsNullOrEmpty(docset.base_path))
             {
-                xrefQueryTags.Add(docset.base_path.OutputValue);
+                xrefQueryTags.Add(docset.base_path.ValueWithLeadingSlash);
             }
             var xrefMaps = new List<string>();
             foreach (var tag in xrefQueryTags)
@@ -119,7 +119,7 @@ namespace Microsoft.Docs.Build
                 product = docset.product_name,
                 siteName = docset.site_name,
                 hostName = GetHostName(docset.site_name),
-                basePath = docset.base_path.Value,
+                basePath = docset.base_path.ValueWithLeadingSlash,
                 xrefHostName = GetXrefHostName(docset.site_name, branch),
                 monikerDefinition = MonikerDefinitionApi,
                 markdownValidationRules = $"{MarkdownValidationRulesApi}{metadataServiceQueryParams}",

--- a/src/docfx/lib/path/BasePath.cs
+++ b/src/docfx/lib/path/BasePath.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Docs.Build
 
         public BasePath(string value)
         {
-            _value = value.Trim().Trim('/').Replace('\\', '/');
+            _value = value.Replace('\\', '/').TrimStart('/');
         }
 
         public override string ToString() => Value;

--- a/src/docfx/lib/path/BasePath.cs
+++ b/src/docfx/lib/path/BasePath.cs
@@ -11,22 +11,26 @@ namespace Microsoft.Docs.Build
     [JsonConverter(typeof(BasePathJsonConverter))]
     internal readonly struct BasePath
     {
-        private readonly string? _original;
+        private readonly string? _value;
 
-        private readonly string? _relativePath;
+        /// <summary>
+        /// It is either an empty string, or a path without leading or trailing /
+        /// </summary>
+        public string Value => _value ?? "";
 
-        public string Original => _original ?? "/";
-
-        // It is either an empty string, or a path without leading /
-        public string RelativePath => _relativePath ?? "";
+        /// <summary>
+        /// Gets or a path starting with `/` for output.
+        /// </summary>
+        public string OutputValue => $"/{_value}";
 
         public BasePath(string value)
         {
-            _original = value;
-            _relativePath = value.StartsWith('/') ? value.TrimStart('/') : value;
+            _value = value.Trim('/').Replace('\\', '/');
         }
 
-        public override string? ToString() => _original;
+        public override string ToString() => Value;
+
+        public static implicit operator string(BasePath value) => value.Value;
 
         private class BasePathJsonConverter : JsonConverter
         {

--- a/src/docfx/lib/path/BasePath.cs
+++ b/src/docfx/lib/path/BasePath.cs
@@ -21,11 +21,11 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Gets or a path starting with `/` for output.
         /// </summary>
-        public string OutputValue => $"/{_value}";
+        public string ValueWithLeadingSlash => $"/{_value}";
 
         public BasePath(string value)
         {
-            _value = value.Trim('/').Replace('\\', '/');
+            _value = value.Trim().Trim('/').Replace('\\', '/');
         }
 
         public override string ToString() => Value;

--- a/src/docfx/publish/PublishModelBuilder.cs
+++ b/src/docfx/publish/PublishModelBuilder.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Docs.Build
             {
                 Name = _config.Name,
                 Product = _config.Product,
-                BasePath = _config.BasePath.Original,
+                BasePath = _config.BasePath.OutputValue,
                 Files = _publishItems.Values
                     .OrderBy(item => item.Locale)
                     .ThenBy(item => item.Path)

--- a/src/docfx/publish/PublishModelBuilder.cs
+++ b/src/docfx/publish/PublishModelBuilder.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Docs.Build
             {
                 Name = _config.Name,
                 Product = _config.Product,
-                BasePath = _config.BasePath.OutputValue,
+                BasePath = _config.BasePath.ValueWithLeadingSlash,
                 Files = _publishItems.Values
                     .OrderBy(item => item.Locale)
                     .ThenBy(item => item.Path)


### PR DESCRIPTION
We have an existing `BasePath` class, this change ensures that `BasePath` in docfx is defined as a string without leading or trailing slash to make it easier for path combine operations. BasePath output are produced as `/`.

#5562 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5566)