### PR TITLE
Update jQuery and fix removed API.

### DIFF
--- a/src/docfx.website.themes/default/bower.json
+++ b/src/docfx.website.themes/default/bower.json
@@ -20,9 +20,9 @@
     "tests"
   ],
   "dependencies": {
-    "bootstrap": "~3.3.5",
+    "bootstrap": "~3.3.7",
     "highlightjs": "~9.12.0",
-    "jquery": "~2.1.4",
+    "jquery": "~3.4.1",
     "js-url": "1.8.6",
     "lunr.js": "2.1.2",
     "twbs-pagination": "^1.3.1",

--- a/src/docfx.website.themes/default/styles/docfx.js
+++ b/src/docfx.website.themes/default/styles/docfx.js
@@ -1172,7 +1172,7 @@ $(function () {
 
     $(window).on('hashchange', scrollToCurrent);
 
-    $(window).load(function () {
+    $(window).on('load', function () {
         // scroll to the anchor if present, offset by the header
         scrollToCurrent();
     });


### PR DESCRIPTION
- Update jQuery to new version as jQuery 2 is EOL [src](https://github.com/jquery/jquery.com/issues/162).
- jQuery 2 contains a number of security issues.
- Fix removed API.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5567)