### PR TITLE
Support fallback of xref map

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/DocumentBuildContext.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/DocumentBuildContext.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.DocAsCode.Build.Engine
 {
     using System;
+    using System.Collections;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Collections.Immutable;
@@ -52,7 +53,7 @@ namespace Microsoft.DocAsCode.Build.Engine
             {
                 _reader = new XRefCollection(
                     from u in parameters.XRefMaps
-                    select new Uri(u, UriKind.RelativeOrAbsolute)).GetReaderAsync(parameters.Files.DefaultBaseDir);
+                    select new Uri(u, UriKind.RelativeOrAbsolute)).GetReaderAsync(parameters.Files.DefaultBaseDir, GetFallbackFolders(parameters.MarkdownEngineParameters));
             }
             RootTocPath = parameters.RootTocPath;
 
@@ -657,6 +658,23 @@ namespace Microsoft.DocAsCode.Build.Engine
                 return null;
             }
             return YamlUtility.ConvertTo<XRefSpec>(vm);
+        }
+
+        private static IReadOnlyList<string> GetFallbackFolders(ImmutableDictionary<string, object> markdownEngineParameters)
+        {
+            IReadOnlyList<string> fallbackFolders = null;
+            if (markdownEngineParameters.TryGetValue("fallbackFolders", out object obj))
+            {
+                try
+                {
+                    fallbackFolders = ((IEnumerable)obj).Cast<string>().ToList();
+                }
+                catch
+                {
+                    // Swallow cast exception. 
+                }
+            }
+            return fallbackFolders;
         }
     }
 }

--- a/src/Microsoft.DocAsCode.Build.Engine/XRefMaps/XRefCollection.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/XRefMaps/XRefCollection.cs
@@ -26,9 +26,9 @@ namespace Microsoft.DocAsCode.Build.Engine
 
         public ImmutableList<Uri> Uris { get; set; }
 
-        public Task<IXRefContainerReader> GetReaderAsync(string baseFolder)
+        public Task<IXRefContainerReader> GetReaderAsync(string baseFolder, IReadOnlyList<string> fallbackFolders = null)
         {
-            var creator = new ReaderCreator(Uris, MaxParallelism, baseFolder);
+            var creator = new ReaderCreator(Uris, MaxParallelism, baseFolder, fallbackFolders);
             return creator.CreateAsync();
         }
 
@@ -39,10 +39,10 @@ namespace Microsoft.DocAsCode.Build.Engine
             private readonly Dictionary<Task<IXRefContainer>, Uri> _processing = new Dictionary<Task<IXRefContainer>, Uri>();
             private readonly XRefMapDownloader _downloader;
 
-            public ReaderCreator(ImmutableList<Uri> uris, int maxParallelism, string baseFolder)
+            public ReaderCreator(ImmutableList<Uri> uris, int maxParallelism, string baseFolder, IReadOnlyList<string> fallbackFolders)
             {
                 _uris = uris;
-                _downloader = new XRefMapDownloader(baseFolder, maxParallelism);
+                _downloader = new XRefMapDownloader(baseFolder, fallbackFolders, maxParallelism);
             }
 
             public async Task<IXRefContainerReader> CreateAsync()

--- a/src/Microsoft.DocAsCode.Build.Engine/XRefMaps/XRefMapDownloader.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/XRefMaps/XRefMapDownloader.cs
@@ -15,7 +15,6 @@ namespace Microsoft.DocAsCode.Build.Engine
     public class XRefMapDownloader
     {
         private readonly SemaphoreSlim _semaphore;
-        private readonly string _baseFolder;
         private readonly IReadOnlyList<string> _localFileFolders;
 
         public XRefMapDownloader(string baseFolder = null, IReadOnlyList<string> fallbackFolders = null, int maxParallelism = 0x10)
@@ -23,13 +22,13 @@ namespace Microsoft.DocAsCode.Build.Engine
             _semaphore = new SemaphoreSlim(maxParallelism);
             if (baseFolder == null)
             {
-                _baseFolder = Directory.GetCurrentDirectory();
+                baseFolder = Directory.GetCurrentDirectory();
             }
             else
             {
-                _baseFolder = Path.Combine(Directory.GetCurrentDirectory(), baseFolder);
+                baseFolder = Path.Combine(Directory.GetCurrentDirectory(), baseFolder);
             }
-            var localFileFolders = new List<string>() { _baseFolder };
+            var localFileFolders = new List<string>() { baseFolder };
             if (fallbackFolders != null)
             {
                 localFileFolders.AddRange(fallbackFolders);


### PR DESCRIPTION
Support find xref map files in fallback folders.

[Related workitem](https://dev.azure.com/ceapex/Engineering/_workitems/edit/178611/)

Tested the code locally, it can resolve the uid which only defines in fallback xref map files.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5593)