### PR TITLE
Enable nullable reference types for docfx

### DIFF
--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [SuppressMessage("Layout", "MEN002", Justification = "Suppress MEN002 for Errors.cs")]

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -8,8 +8,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class Build

--- a/src/docfx/build/context/BuildScope.cs
+++ b/src/docfx/build/context/BuildScope.cs
@@ -6,8 +6,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class BuildScope

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     /// <summary>

--- a/src/docfx/build/context/Input.cs
+++ b/src/docfx/build/context/Input.cs
@@ -9,8 +9,6 @@ using System.IO;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     /// <summary>

--- a/src/docfx/build/context/Output.cs
+++ b/src/docfx/build/context/Output.cs
@@ -5,8 +5,6 @@ using System;
 using System.Diagnostics;
 using System.IO;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class Output

--- a/src/docfx/build/dependency/DependencyItem.cs
+++ b/src/docfx/build/dependency/DependencyItem.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
 using System;
 
 namespace Microsoft.Docs.Build

--- a/src/docfx/build/dependency/DependencyManifestItem.cs
+++ b/src/docfx/build/dependency/DependencyManifestItem.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class DependencyManifestItem

--- a/src/docfx/build/dependency/DependencyMap.cs
+++ b/src/docfx/build/dependency/DependencyMap.cs
@@ -5,8 +5,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class DependencyMap : ReadOnlyDictionary<Document, HashSet<DependencyItem>>

--- a/src/docfx/build/dependency/DependencyMapBuilder.cs
+++ b/src/docfx/build/dependency/DependencyMapBuilder.cs
@@ -5,8 +5,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     /// <summary>

--- a/src/docfx/build/document/Docset.cs
+++ b/src/docfx/build/document/Docset.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Concurrent;
 using System.IO;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     /// <summary>

--- a/src/docfx/build/document/Document.cs
+++ b/src/docfx/build/document/Document.cs
@@ -5,8 +5,6 @@ using System;
 using System.Diagnostics;
 using System.IO;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class Document : IEquatable<Document>, IComparable<Document>

--- a/src/docfx/build/document/DocumentProvider.cs
+++ b/src/docfx/build/document/DocumentProvider.cs
@@ -7,8 +7,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class DocumentProvider

--- a/src/docfx/build/document/RepositoryProvider.cs
+++ b/src/docfx/build/document/RepositoryProvider.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class RepositoryProvider

--- a/src/docfx/build/legacy/Legacy.cs
+++ b/src/docfx/build/legacy/Legacy.cs
@@ -4,8 +4,6 @@
 using System.Collections.Generic;
 using System.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class Legacy

--- a/src/docfx/build/legacy/LegacyAggregatedFileMap.cs
+++ b/src/docfx/build/legacy/LegacyAggregatedFileMap.cs
@@ -6,8 +6,6 @@ using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class LegacyAggregatedFileMap

--- a/src/docfx/build/legacy/LegacyDependencyMap.cs
+++ b/src/docfx/build/legacy/LegacyDependencyMap.cs
@@ -8,8 +8,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class LegacyDependencyMap

--- a/src/docfx/build/legacy/LegacyDependencyMapItem.cs
+++ b/src/docfx/build/legacy/LegacyDependencyMapItem.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class LegacyDependencyMapItem

--- a/src/docfx/build/legacy/LegacyFileMap.cs
+++ b/src/docfx/build/legacy/LegacyFileMap.cs
@@ -7,8 +7,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class LegacyFileMap

--- a/src/docfx/build/legacy/LegacyFileMapItem.cs
+++ b/src/docfx/build/legacy/LegacyFileMapItem.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class LegacyFileMapItem

--- a/src/docfx/build/legacy/LegacyUtility.cs
+++ b/src/docfx/build/legacy/LegacyUtility.cs
@@ -4,8 +4,6 @@
 using System.IO;
 using System.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class LegacyUtility

--- a/src/docfx/build/legacy/manifest/LegacyItemToPublish.cs
+++ b/src/docfx/build/legacy/manifest/LegacyItemToPublish.cs
@@ -4,8 +4,6 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/build/legacy/manifest/LegacyManifest.cs
+++ b/src/docfx/build/legacy/manifest/LegacyManifest.cs
@@ -7,8 +7,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class LegacyManifest

--- a/src/docfx/build/legacy/manifest/LegacyManifestItem.cs
+++ b/src/docfx/build/legacy/manifest/LegacyManifestItem.cs
@@ -4,8 +4,6 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/build/legacy/manifest/LegacyManifestOutput.cs
+++ b/src/docfx/build/legacy/manifest/LegacyManifestOutput.cs
@@ -3,8 +3,6 @@
 
 using Newtonsoft.Json;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class LegacyManifestOutput

--- a/src/docfx/build/legacy/manifest/LegacyManifestOutputItem.cs
+++ b/src/docfx/build/legacy/manifest/LegacyManifestOutputItem.cs
@@ -3,8 +3,6 @@
 
 using Newtonsoft.Json;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class LegacyManifestOutputItem

--- a/src/docfx/build/link/FileLinkItem.cs
+++ b/src/docfx/build/link/FileLinkItem.cs
@@ -5,8 +5,6 @@ using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/build/link/FileLinkMapBuilder.cs
+++ b/src/docfx/build/link/FileLinkMapBuilder.cs
@@ -4,8 +4,6 @@
 using System.Collections.Concurrent;
 using System.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class FileLinkMapBuilder

--- a/src/docfx/build/link/LinkResolver.cs
+++ b/src/docfx/build/link/LinkResolver.cs
@@ -4,8 +4,6 @@
 using System;
 using System.IO;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class LinkResolver

--- a/src/docfx/build/localization/LocalizationProvider.cs
+++ b/src/docfx/build/localization/LocalizationProvider.cs
@@ -5,8 +5,6 @@ using System;
 using System.Globalization;
 using System.IO;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class LocalizationProvider

--- a/src/docfx/build/localization/LocalizationUtility.cs
+++ b/src/docfx/build/localization/LocalizationUtility.cs
@@ -8,8 +8,6 @@ using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class LocalizationUtility

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -8,8 +8,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class ContributionProvider

--- a/src/docfx/build/metadata/GlobalMetadata.cs
+++ b/src/docfx/build/metadata/GlobalMetadata.cs
@@ -7,8 +7,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/build/metadata/MetadataProvider.cs
+++ b/src/docfx/build/metadata/MetadataProvider.cs
@@ -7,8 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class MetadataProvider

--- a/src/docfx/build/metadata/SystemMetadata.cs
+++ b/src/docfx/build/metadata/SystemMetadata.cs
@@ -5,8 +5,6 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/build/metadata/UserMetadata.cs
+++ b/src/docfx/build/metadata/UserMetadata.cs
@@ -5,8 +5,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/build/moniker/MonikerProvider.cs
+++ b/src/docfx/build/moniker/MonikerProvider.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class MonikerProvider

--- a/src/docfx/build/page/BookmarkValidator.cs
+++ b/src/docfx/build/page/BookmarkValidator.cs
@@ -4,8 +4,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class BookmarkValidator

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -9,8 +9,6 @@ using System.Threading.Tasks;
 using HtmlAgilityPack;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class BuildPage

--- a/src/docfx/build/page/ConceptualModel.cs
+++ b/src/docfx/build/page/ConceptualModel.cs
@@ -5,8 +5,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/build/page/ContributionInfo.cs
+++ b/src/docfx/build/page/ContributionInfo.cs
@@ -6,8 +6,6 @@ using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/build/page/Contributor.cs
+++ b/src/docfx/build/page/Contributor.cs
@@ -5,8 +5,6 @@ using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/build/redirection/BuildRedirection.cs
+++ b/src/docfx/build/redirection/BuildRedirection.cs
@@ -4,8 +4,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class BuildRedirection

--- a/src/docfx/build/redirection/RedirectionItem.cs
+++ b/src/docfx/build/redirection/RedirectionItem.cs
@@ -4,8 +4,6 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/build/redirection/RedirectionModel.cs
+++ b/src/docfx/build/redirection/RedirectionModel.cs
@@ -5,8 +5,6 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/build/redirection/RedirectionProvider.cs
+++ b/src/docfx/build/redirection/RedirectionProvider.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class RedirectionProvider

--- a/src/docfx/build/resource/BuildResource.cs
+++ b/src/docfx/build/resource/BuildResource.cs
@@ -5,8 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class BuildResource

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -4,8 +4,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class BuildTableOfContents

--- a/src/docfx/build/toc/TableOfContentsItem.cs
+++ b/src/docfx/build/toc/TableOfContentsItem.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class TableOfContentsItem

--- a/src/docfx/build/toc/TableOfContentsLoader.cs
+++ b/src/docfx/build/toc/TableOfContentsLoader.cs
@@ -10,8 +10,6 @@ using System.Linq;
 using System.Threading;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class TableOfContentsLoader

--- a/src/docfx/build/toc/TableOfContentsMap.cs
+++ b/src/docfx/build/toc/TableOfContentsMap.cs
@@ -7,8 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     /// <summary>

--- a/src/docfx/build/toc/TableOfContentsMapBuilder.cs
+++ b/src/docfx/build/toc/TableOfContentsMapBuilder.cs
@@ -5,8 +5,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     /// <summary>

--- a/src/docfx/build/toc/TableOfContentsMarkup.cs
+++ b/src/docfx/build/toc/TableOfContentsMarkup.cs
@@ -11,8 +11,6 @@ using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 using Microsoft.DocAsCode.MarkdigEngine.Extensions;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class TableOfContentsMarkup

--- a/src/docfx/build/toc/TableOfContentsMetadata.cs
+++ b/src/docfx/build/toc/TableOfContentsMetadata.cs
@@ -6,8 +6,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/build/toc/TableOfContentsModel.cs
+++ b/src/docfx/build/toc/TableOfContentsModel.cs
@@ -5,8 +5,6 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class TableOfContentsModel

--- a/src/docfx/build/xref/ExternalXrefMapLoader.cs
+++ b/src/docfx/build/xref/ExternalXrefMapLoader.cs
@@ -8,8 +8,6 @@ using System.IO.Compression;
 using System.Text;
 using System.Text.Json;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class ExternalXrefMapLoader

--- a/src/docfx/build/xref/ExternalXrefSpec.cs
+++ b/src/docfx/build/xref/ExternalXrefSpec.cs
@@ -5,8 +5,6 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class ExternalXrefSpec : IXrefSpec

--- a/src/docfx/build/xref/IXrefSpec.cs
+++ b/src/docfx/build/xref/IXrefSpec.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal interface IXrefSpec

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -7,8 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class InternalXrefMapBuilder

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class InternalXrefSpec : IXrefSpec

--- a/src/docfx/build/xref/XrefMapModel.cs
+++ b/src/docfx/build/xref/XrefMapModel.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class XrefMapModel

--- a/src/docfx/build/xref/XrefProperties.cs
+++ b/src/docfx/build/xref/XrefProperties.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class XrefProperties

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -7,8 +7,6 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Web;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class XrefResolver

--- a/src/docfx/cli/CommandLineOptions.cs
+++ b/src/docfx/cli/CommandLineOptions.cs
@@ -4,8 +4,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1401:FieldsMustBePrivate", Justification = "<Skipping>")]

--- a/src/docfx/cli/Docfx.cs
+++ b/src/docfx/cli/Docfx.cs
@@ -15,8 +15,6 @@ using System.Threading.Tasks;
 using System.Web;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     public static class Docfx

--- a/src/docfx/config/AppData.cs
+++ b/src/docfx/config/AppData.cs
@@ -5,8 +5,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class AppData

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -7,8 +7,6 @@ using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class Config : PreloadConfig

--- a/src/docfx/config/ConfigLoader.cs
+++ b/src/docfx/config/ConfigLoader.cs
@@ -9,8 +9,6 @@ using System.Linq;
 using System.Net;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class ConfigLoader

--- a/src/docfx/config/DependencyConfig.cs
+++ b/src/docfx/config/DependencyConfig.cs
@@ -3,8 +3,6 @@
 
 using Newtonsoft.Json;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class DependencyConfig : PackagePath

--- a/src/docfx/config/DocsetsConfig.cs
+++ b/src/docfx/config/DocsetsConfig.cs
@@ -4,8 +4,6 @@
 using System;
 using Newtonsoft.Json;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     /// <summary>

--- a/src/docfx/config/DocumentIdConfig.cs
+++ b/src/docfx/config/DocumentIdConfig.cs
@@ -4,8 +4,6 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/config/EnvironmentVariable.cs
+++ b/src/docfx/config/EnvironmentVariable.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     public static class EnvironmentVariable

--- a/src/docfx/config/FileMappingConfig.cs
+++ b/src/docfx/config/FileMappingConfig.cs
@@ -4,8 +4,6 @@
 using System;
 using Newtonsoft.Json;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class FileMappingConfig

--- a/src/docfx/config/GroupConfig.cs
+++ b/src/docfx/config/GroupConfig.cs
@@ -4,8 +4,6 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/config/HttpConfig.cs
+++ b/src/docfx/config/HttpConfig.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal sealed class HttpConfig

--- a/src/docfx/config/PreloadConfig.cs
+++ b/src/docfx/config/PreloadConfig.cs
@@ -7,8 +7,6 @@ using System.Linq;
 using System.Net.Http;
 using Newtonsoft.Json;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     /// <summary>

--- a/src/docfx/config/TestQuirks.cs
+++ b/src/docfx/config/TestQuirks.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class TestQuirks

--- a/src/docfx/config/ops/DocsEnvironment.cs
+++ b/src/docfx/config/ops/DocsEnvironment.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     public enum DocsEnvironment

--- a/src/docfx/config/ops/OpsConfig.cs
+++ b/src/docfx/config/ops/OpsConfig.cs
@@ -5,8 +5,6 @@ using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -11,8 +11,6 @@ using System.Threading.Tasks;
 using System.Web;
 using Newtonsoft.Json;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class OpsConfigAdapter : IDisposable

--- a/src/docfx/config/ops/OpsConfigLoader.cs
+++ b/src/docfx/config/ops/OpsConfigLoader.cs
@@ -6,8 +6,6 @@ using System.IO;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class OpsConfigLoader

--- a/src/docfx/config/ops/OpsDependencyConfig.cs
+++ b/src/docfx/config/ops/OpsDependencyConfig.cs
@@ -5,8 +5,6 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/config/ops/OpsDocsetConfig.cs
+++ b/src/docfx/config/ops/OpsDocsetConfig.cs
@@ -5,8 +5,6 @@ using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/config/ops/OpsMetadataRule.cs
+++ b/src/docfx/config/ops/OpsMetadataRule.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class OpsMetadataRule

--- a/src/docfx/config/ops/OpsMetadataRuleConverter.cs
+++ b/src/docfx/config/ops/OpsMetadataRuleConverter.cs
@@ -7,8 +7,6 @@ using System.Linq;
 using Docs.MetadataService.Models;
 using Newtonsoft.Json;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class OpsMetadataRuleConverter

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -6,6 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackAsTool>true</PackAsTool>
     <DefineConstants>DOCFX</DefineConstants>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/docfx/lib/GlobUtility.cs
+++ b/src/docfx/lib/GlobUtility.cs
@@ -5,8 +5,6 @@ using System;
 using System.Text.RegularExpressions;
 using GlobExpressions;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class GlobUtility

--- a/src/docfx/lib/HashUtility.cs
+++ b/src/docfx/lib/HashUtility.cs
@@ -6,8 +6,6 @@ using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class HashUtility

--- a/src/docfx/lib/HtmlUtility.cs
+++ b/src/docfx/lib/HtmlUtility.cs
@@ -10,8 +10,6 @@ using System.Web;
 using HtmlAgilityPack;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class HtmlUtility

--- a/src/docfx/lib/Levenshtein.cs
+++ b/src/docfx/lib/Levenshtein.cs
@@ -5,8 +5,6 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class Levenshtein

--- a/src/docfx/lib/ParallelUtility.cs
+++ b/src/docfx/lib/ParallelUtility.cs
@@ -10,8 +10,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class ParallelUtility

--- a/src/docfx/lib/ReflectionUtility.cs
+++ b/src/docfx/lib/ReflectionUtility.cs
@@ -5,8 +5,6 @@ using System;
 using System.Reflection;
 using System.Reflection.Emit;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class ReflectionUtility

--- a/src/docfx/lib/StringUtility.cs
+++ b/src/docfx/lib/StringUtility.cs
@@ -7,8 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class StringUtility

--- a/src/docfx/lib/UrlUtility.cs
+++ b/src/docfx/lib/UrlUtility.cs
@@ -9,8 +9,6 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Web;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class UrlUtility

--- a/src/docfx/lib/cache/ICacheObject{TKey}.cs
+++ b/src/docfx/lib/cache/ICacheObject{TKey}.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal interface ICacheObject<TKey> where TKey : notnull

--- a/src/docfx/lib/cache/JsonDiskCache.cs
+++ b/src/docfx/lib/cache/JsonDiskCache.cs
@@ -9,8 +9,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class JsonDiskCache<TError, TKey, TValue>

--- a/src/docfx/lib/collections/CollectionUtility.cs
+++ b/src/docfx/lib/collections/CollectionUtility.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class CollectionUtility

--- a/src/docfx/lib/collections/ConcurrentHashSet.cs
+++ b/src/docfx/lib/collections/ConcurrentHashSet.cs
@@ -4,8 +4,6 @@
 using System.Collections.Generic;
 using System.Linq;
 
-#nullable enable
-
 namespace System.Collections.Concurrent
 {
     internal class ConcurrentHashSet<T> : IEnumerable<T> where T : notnull

--- a/src/docfx/lib/collections/DictionaryBuilder.cs
+++ b/src/docfx/lib/collections/DictionaryBuilder.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace System.Collections.Concurrent
 {
     internal class DictionaryBuilder<TKey, TValue> where TKey : notnull

--- a/src/docfx/lib/collections/ListBuilder.cs
+++ b/src/docfx/lib/collections/ListBuilder.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace System.Collections.Concurrent
 {
     internal class ListBuilder<T> where T : notnull

--- a/src/docfx/lib/collections/WorkQueue.cs
+++ b/src/docfx/lib/collections/WorkQueue.cs
@@ -7,8 +7,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class WorkQueue<T> where T : notnull

--- a/src/docfx/lib/git/CommitBuildTime.cs
+++ b/src/docfx/lib/git/CommitBuildTime.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class CommitBuildTime

--- a/src/docfx/lib/git/CommitBuildTimeItem.cs
+++ b/src/docfx/lib/git/CommitBuildTimeItem.cs
@@ -5,8 +5,6 @@ using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/lib/git/CommitBuildTimeProvider.cs
+++ b/src/docfx/lib/git/CommitBuildTimeProvider.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class CommitBuildTimeProvider

--- a/src/docfx/lib/git/FileCommitProvider.cs
+++ b/src/docfx/lib/git/FileCommitProvider.cs
@@ -12,8 +12,6 @@ using System.Threading.Tasks;
 
 using static Microsoft.Docs.Build.LibGit2;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal sealed class FileCommitProvider : IDisposable

--- a/src/docfx/lib/git/GitCommit.cs
+++ b/src/docfx/lib/git/GitCommit.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     /// <summary>

--- a/src/docfx/lib/git/GitCommitCache.cs
+++ b/src/docfx/lib/git/GitCommitCache.cs
@@ -8,8 +8,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class GitCommitCache

--- a/src/docfx/lib/git/GitCommitProvider.cs
+++ b/src/docfx/lib/git/GitCommitProvider.cs
@@ -4,8 +4,6 @@ using System;
 using System.Collections.Concurrent;
 using System.IO;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal sealed class GitCommitProvider : IDisposable

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -12,8 +12,6 @@ using System.Runtime.InteropServices;
 
 using static Microsoft.Docs.Build.LibGit2;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     /// <summary>

--- a/src/docfx/lib/git/LibGit2.cs
+++ b/src/docfx/lib/git/LibGit2.cs
@@ -8,8 +8,6 @@ using System.Runtime.InteropServices;
 #pragma warning disable SA1307 // AccessibleFieldsMustBeginWithUpperCaseLetter
 #pragma warning disable IDE1006 // Naming Styles
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class LibGit2

--- a/src/docfx/lib/git/MergeConflict.cs
+++ b/src/docfx/lib/git/MergeConflict.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class MergeConflict

--- a/src/docfx/lib/git/Repository.cs
+++ b/src/docfx/lib/git/Repository.cs
@@ -4,8 +4,6 @@
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class Repository

--- a/src/docfx/lib/github/GitHubAccessor.cs
+++ b/src/docfx/lib/github/GitHubAccessor.cs
@@ -17,8 +17,6 @@ using Newtonsoft.Json;
 using Polly;
 using Polly.Extensions.Http;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal sealed class GitHubAccessor : IDisposable

--- a/src/docfx/lib/github/GitHubQueries.cs
+++ b/src/docfx/lib/github/GitHubQueries.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class GitHubQueries

--- a/src/docfx/lib/github/GitHubUser.cs
+++ b/src/docfx/lib/github/GitHubUser.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/lib/js/ChakraCoreJsEngine.cs
+++ b/src/docfx/lib/js/ChakraCoreJsEngine.cs
@@ -11,8 +11,6 @@ using System.Threading;
 using ChakraHost.Hosting;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     /// <summary>

--- a/src/docfx/lib/js/IJavaScriptEngine.cs
+++ b/src/docfx/lib/js/IJavaScriptEngine.cs
@@ -3,8 +3,6 @@
 
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal interface IJavaScriptEngine

--- a/src/docfx/lib/js/JintJsEngine.cs
+++ b/src/docfx/lib/js/JintJsEngine.cs
@@ -14,8 +14,6 @@ using Jint.Runtime;
 using Jint.Runtime.Interop;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class JintJsEngine : IJavaScriptEngine

--- a/src/docfx/lib/js/chakra/JavaScriptPropertyId.cs
+++ b/src/docfx/lib/js/chakra/JavaScriptPropertyId.cs
@@ -2,8 +2,6 @@ namespace ChakraHost.Hosting
 {
     using System;
 
-#nullable enable
-
     /// <summary>
     ///     A property identifier.
     /// </summary>

--- a/src/docfx/lib/js/chakra/JavaScriptRuntime.cs
+++ b/src/docfx/lib/js/chakra/JavaScriptRuntime.cs
@@ -2,8 +2,6 @@ namespace ChakraHost.Hosting
 {
     using System;
 
-#nullable enable
-
     /// <summary>
     ///     A Chakra runtime.
     /// </summary>

--- a/src/docfx/lib/js/chakra/JavaScriptSourceContext.cs
+++ b/src/docfx/lib/js/chakra/JavaScriptSourceContext.cs
@@ -2,8 +2,6 @@ namespace ChakraHost.Hosting
 {
     using System;
 
-#nullable enable
-
     /// <summary>
     ///     A cookie that identifies a script for debugging purposes.
     /// </summary>

--- a/src/docfx/lib/js/chakra/Native.cs
+++ b/src/docfx/lib/js/chakra/Native.cs
@@ -1,7 +1,5 @@
 namespace ChakraHost.Hosting
 {
-#nullable enable
-
     using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Runtime.InteropServices;

--- a/src/docfx/lib/json/JTokenDeepEqualsComparer.cs
+++ b/src/docfx/lib/json/JTokenDeepEqualsComparer.cs
@@ -4,8 +4,6 @@
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class JTokenDeepEqualsComparer : IEqualityComparer<JToken>

--- a/src/docfx/lib/json/JTokenJsonConverter.cs
+++ b/src/docfx/lib/json/JTokenJsonConverter.cs
@@ -5,8 +5,6 @@ using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class JTokenJsonConverter : JsonConverter

--- a/src/docfx/lib/json/JsonContractResolver.cs
+++ b/src/docfx/lib/json/JsonContractResolver.cs
@@ -8,8 +8,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class JsonContractResolver : DefaultContractResolver

--- a/src/docfx/lib/json/JsonUtility.cs
+++ b/src/docfx/lib/json/JsonUtility.cs
@@ -13,8 +13,6 @@ using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class JsonUtility

--- a/src/docfx/lib/json/OneOrManyConverter.cs
+++ b/src/docfx/lib/json/OneOrManyConverter.cs
@@ -4,8 +4,6 @@
 using System;
 using Newtonsoft.Json;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class OneOrManyConverter : JsonConverter

--- a/src/docfx/lib/json/ShortHandConverter.cs
+++ b/src/docfx/lib/json/ShortHandConverter.cs
@@ -6,8 +6,6 @@ using System.Collections.Concurrent;
 using System.Linq;
 using Newtonsoft.Json;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     /// <summary>

--- a/src/docfx/lib/json/SourceInfoJsonConverter.cs
+++ b/src/docfx/lib/json/SourceInfoJsonConverter.cs
@@ -5,8 +5,6 @@ using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class SourceInfoJsonConverter : JsonConverter

--- a/src/docfx/lib/json/UnionTypeConverter.cs
+++ b/src/docfx/lib/json/UnionTypeConverter.cs
@@ -5,8 +5,6 @@ using System;
 using System.Runtime.CompilerServices;
 using Newtonsoft.Json;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     /// <summary>

--- a/src/docfx/lib/json/YamlUtility.Shared.cs
+++ b/src/docfx/lib/json/YamlUtility.Shared.cs
@@ -9,8 +9,6 @@ using Newtonsoft.Json.Linq;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal partial class YamlUtility

--- a/src/docfx/lib/json/YamlUtility.cs
+++ b/src/docfx/lib/json/YamlUtility.cs
@@ -10,8 +10,6 @@ using Newtonsoft.Json.Linq;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static partial class YamlUtility

--- a/src/docfx/lib/log/CustomError.cs
+++ b/src/docfx/lib/log/CustomError.cs
@@ -3,8 +3,6 @@
 
 using Newtonsoft.Json;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonConverter(typeof(ShortHandConverter))]

--- a/src/docfx/lib/log/DocfxException.cs
+++ b/src/docfx/lib/log/DocfxException.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     /// <summary>

--- a/src/docfx/lib/log/Error.cs
+++ b/src/docfx/lib/log/Error.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class Error

--- a/src/docfx/lib/log/ErrorLog.cs
+++ b/src/docfx/lib/log/ErrorLog.cs
@@ -8,8 +8,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal sealed class ErrorLog : IDisposable

--- a/src/docfx/lib/log/ISourceInfo.cs
+++ b/src/docfx/lib/log/ISourceInfo.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal interface ISourceInfo

--- a/src/docfx/lib/log/Log.cs
+++ b/src/docfx/lib/log/Log.cs
@@ -5,8 +5,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [SuppressMessage("Reliability", "CA2002", Justification = "Lock Console.Out")]

--- a/src/docfx/lib/log/PerfScope.cs
+++ b/src/docfx/lib/log/PerfScope.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Diagnostics;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal struct PerfScope : IDisposable

--- a/src/docfx/lib/log/Progress.cs
+++ b/src/docfx/lib/log/Progress.cs
@@ -6,8 +6,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class Progress

--- a/src/docfx/lib/log/SourceInfo.cs
+++ b/src/docfx/lib/log/SourceInfo.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class SourceInfo : IEquatable<SourceInfo>, IComparable<SourceInfo>

--- a/src/docfx/lib/log/SourceInfo{T}.cs
+++ b/src/docfx/lib/log/SourceInfo{T}.cs
@@ -3,8 +3,6 @@
 
 using System.Runtime.CompilerServices;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal readonly struct SourceInfo<T> : ISourceInfo

--- a/src/docfx/lib/log/Telemetry.cs
+++ b/src/docfx/lib/log/Telemetry.cs
@@ -11,8 +11,6 @@ using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Metrics;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class Telemetry

--- a/src/docfx/lib/markdown/ExtractYamlHeader.cs
+++ b/src/docfx/lib/markdown/ExtractYamlHeader.cs
@@ -6,8 +6,6 @@ using System.IO;
 using System.Text;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class ExtractYamlHeader

--- a/src/docfx/lib/markdown/LinkExtension.cs
+++ b/src/docfx/lib/markdown/LinkExtension.cs
@@ -10,8 +10,6 @@ using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 using Microsoft.DocAsCode.MarkdigEngine.Extensions;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class LinkExtension

--- a/src/docfx/lib/markdown/MarkdigUtility.cs
+++ b/src/docfx/lib/markdown/MarkdigUtility.cs
@@ -9,8 +9,6 @@ using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 using Microsoft.DocAsCode.MarkdigEngine.Extensions;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class MarkdigUtility

--- a/src/docfx/lib/markdown/MarkdownEngine.cs
+++ b/src/docfx/lib/markdown/MarkdownEngine.cs
@@ -10,8 +10,6 @@ using Markdig.Parsers.Inlines;
 using Markdig.Syntax;
 using Microsoft.DocAsCode.MarkdigEngine.Extensions;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class MarkdownEngine

--- a/src/docfx/lib/markdown/MonikerZoneExtension.cs
+++ b/src/docfx/lib/markdown/MonikerZoneExtension.cs
@@ -7,8 +7,6 @@ using Markdig;
 using Markdig.Renderers.Html;
 using Microsoft.DocAsCode.MarkdigEngine.Extensions;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class MonikerZoneExtension

--- a/src/docfx/lib/markdown/XrefExtension.cs
+++ b/src/docfx/lib/markdown/XrefExtension.cs
@@ -10,8 +10,6 @@ using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 using Microsoft.DocAsCode.MarkdigEngine.Extensions;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class XrefExtension

--- a/src/docfx/lib/markdown/validation/ContentValidationContext.cs
+++ b/src/docfx/lib/markdown/validation/ContentValidationContext.cs
@@ -4,8 +4,6 @@
 using System;
 using Validations.DocFx.Adapter;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class ContentValidationContext : IValidationContext

--- a/src/docfx/lib/markdown/validation/ContentValidationExtension.cs
+++ b/src/docfx/lib/markdown/validation/ContentValidationExtension.cs
@@ -5,8 +5,6 @@ using Markdig;
 using Microsoft.DocAsCode.MarkdigEngine.Extensions;
 using Validations.DocFx.Adapter;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class ContentValidationExtension

--- a/src/docfx/lib/markdown/validation/ContentValidationLogger.cs
+++ b/src/docfx/lib/markdown/validation/ContentValidationLogger.cs
@@ -5,8 +5,6 @@ using Apex.Validation.Shared;
 using Markdig.Syntax;
 using Microsoft.DocAsCode.MarkdigEngine.Extensions;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class ContentValidationLogger : IValidationLogger

--- a/src/docfx/lib/moniker/ComparatorExpression.cs
+++ b/src/docfx/lib/moniker/ComparatorExpression.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class ComparatorExpression : IExpression

--- a/src/docfx/lib/moniker/EvaluatorWithMonikersVisitor.cs
+++ b/src/docfx/lib/moniker/EvaluatorWithMonikersVisitor.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class EvaluatorWithMonikersVisitor

--- a/src/docfx/lib/moniker/ExpressionCreator.cs
+++ b/src/docfx/lib/moniker/ExpressionCreator.cs
@@ -4,8 +4,6 @@
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class ExpressionCreator

--- a/src/docfx/lib/moniker/IExpression.cs
+++ b/src/docfx/lib/moniker/IExpression.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal interface IExpression

--- a/src/docfx/lib/moniker/LogicExpression.cs
+++ b/src/docfx/lib/moniker/LogicExpression.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class LogicExpression : IExpression

--- a/src/docfx/lib/moniker/Moniker.cs
+++ b/src/docfx/lib/moniker/Moniker.cs
@@ -5,8 +5,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/lib/moniker/MonikerComparer.cs
+++ b/src/docfx/lib/moniker/MonikerComparer.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class MonikerComparer : IComparer<string>

--- a/src/docfx/lib/moniker/MonikerDefinitionModel.cs
+++ b/src/docfx/lib/moniker/MonikerDefinitionModel.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class MonikerDefinitionModel

--- a/src/docfx/lib/moniker/MonikerRangeException.cs
+++ b/src/docfx/lib/moniker/MonikerRangeException.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class MonikerRangeException : Exception

--- a/src/docfx/lib/moniker/MonikerRangeParser.cs
+++ b/src/docfx/lib/moniker/MonikerRangeParser.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class MonikerRangeParser

--- a/src/docfx/lib/moniker/MonikerUtility.cs
+++ b/src/docfx/lib/moniker/MonikerUtility.cs
@@ -4,8 +4,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     public static class MonikerUtility

--- a/src/docfx/lib/msgraph/MicrosoftGraphAccessor.cs
+++ b/src/docfx/lib/msgraph/MicrosoftGraphAccessor.cs
@@ -7,8 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.Graph;
 using Polly;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class MicrosoftGraphAccessor : IDisposable

--- a/src/docfx/lib/msgraph/MicrosoftGraphAuthenticationProvider.cs
+++ b/src/docfx/lib/msgraph/MicrosoftGraphAuthenticationProvider.cs
@@ -9,8 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.Graph;
 using Microsoft.Identity.Client;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class MicrosoftGraphAuthenticationProvider : IAuthenticationProvider, IDisposable

--- a/src/docfx/lib/msgraph/MicrosoftGraphUser.cs
+++ b/src/docfx/lib/msgraph/MicrosoftGraphUser.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/lib/path/BasePath.cs
+++ b/src/docfx/lib/path/BasePath.cs
@@ -4,8 +4,6 @@
 using System;
 using Newtonsoft.Json;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonConverter(typeof(BasePathJsonConverter))]

--- a/src/docfx/lib/path/FilePath.cs
+++ b/src/docfx/lib/path/FilePath.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Diagnostics;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     /// <summary>

--- a/src/docfx/lib/path/PackagePath.cs
+++ b/src/docfx/lib/path/PackagePath.cs
@@ -5,8 +5,6 @@ using System;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     /// <summary>

--- a/src/docfx/lib/path/PathString.cs
+++ b/src/docfx/lib/path/PathString.cs
@@ -7,8 +7,6 @@ using System.Globalization;
 using System.IO;
 using Newtonsoft.Json;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     /// <summary>

--- a/src/docfx/lib/path/PathUtility.cs
+++ b/src/docfx/lib/path/PathUtility.cs
@@ -11,8 +11,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     /// <summary>

--- a/src/docfx/lib/process/InterProcessMutex.cs
+++ b/src/docfx/lib/process/InterProcessMutex.cs
@@ -6,8 +6,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal struct InterProcessMutex : IDisposable

--- a/src/docfx/lib/process/InterProcessReaderWriterLock.cs
+++ b/src/docfx/lib/process/InterProcessReaderWriterLock.cs
@@ -6,8 +6,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     public struct InterProcessReaderWriterLock : IDisposable

--- a/src/docfx/lib/process/ProcessUtility.cs
+++ b/src/docfx/lib/process/ProcessUtility.cs
@@ -8,8 +8,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     /// <summary>

--- a/src/docfx/lib/schema/EnumDependenciesSchema.cs
+++ b/src/docfx/lib/schema/EnumDependenciesSchema.cs
@@ -4,8 +4,6 @@
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     // string -> attribute name, JToken -> valid value, EnumDependenciesSchema -> other attribute depends top attribute value

--- a/src/docfx/lib/schema/JsonSchema.cs
+++ b/src/docfx/lib/schema/JsonSchema.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonConverter(typeof(JsonSchemaConverter))]

--- a/src/docfx/lib/schema/JsonSchemaConverter.cs
+++ b/src/docfx/lib/schema/JsonSchemaConverter.cs
@@ -4,8 +4,6 @@
 using System;
 using Newtonsoft.Json;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class JsonSchemaConverter : JsonConverter

--- a/src/docfx/lib/schema/JsonSchemaDefinition.cs
+++ b/src/docfx/lib/schema/JsonSchemaDefinition.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class JsonSchemaDefinition

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -10,8 +10,6 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class JsonSchemaTransformer

--- a/src/docfx/lib/schema/JsonSchemaValidator.cs
+++ b/src/docfx/lib/schema/JsonSchemaValidator.cs
@@ -8,8 +8,6 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class JsonSchemaValidator

--- a/src/docfx/lib/schema/MicrosoftAliasSchema.cs
+++ b/src/docfx/lib/schema/MicrosoftAliasSchema.cs
@@ -3,8 +3,6 @@
 
 using System;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class MicrosoftAliasSchema

--- a/src/docfx/lib/schema/ReferenceEqualsComparer.cs
+++ b/src/docfx/lib/schema/ReferenceEqualsComparer.cs
@@ -5,8 +5,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class ReferenceEqualsComparer : IEqualityComparer, IEqualityComparer<object>

--- a/src/docfx/publish/PublishItem.cs
+++ b/src/docfx/publish/PublishItem.cs
@@ -5,8 +5,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/publish/PublishModel.cs
+++ b/src/docfx/publish/PublishModel.cs
@@ -5,8 +5,6 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]

--- a/src/docfx/publish/PublishModelBuilder.cs
+++ b/src/docfx/publish/PublishModelBuilder.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class PublishModelBuilder

--- a/src/docfx/restore/FileResolver.cs
+++ b/src/docfx/restore/FileResolver.cs
@@ -10,8 +10,6 @@ using System.Threading.Tasks;
 using Polly;
 using Polly.Extensions.Http;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class FileResolver

--- a/src/docfx/restore/PackageResolver.cs
+++ b/src/docfx/restore/PackageResolver.cs
@@ -7,8 +7,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class PackageResolver : IDisposable

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -7,8 +7,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class Restore

--- a/src/docfx/template/MustacheTemplate.cs
+++ b/src/docfx/template/MustacheTemplate.cs
@@ -10,8 +10,6 @@ using Stubble.Core.Builders;
 using Stubble.Core.Interfaces;
 using Stubble.Core.Settings;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class MustacheTemplate

--- a/src/docfx/template/RazorTemplate.cs
+++ b/src/docfx/template/RazorTemplate.cs
@@ -20,8 +20,6 @@ using Microsoft.Extensions.Hosting;
 
 [assembly: ApplicationPart("Microsoft.Docs.Template")]
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class RazorTemplate

--- a/src/docfx/template/TemplateEngine.cs
+++ b/src/docfx/template/TemplateEngine.cs
@@ -9,8 +9,6 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class TemplateEngine

--- a/src/docfx/template/TemplateModel.cs
+++ b/src/docfx/template/TemplateModel.cs
@@ -3,8 +3,6 @@
 
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class TemplateModel

--- a/src/docfx/template/TemplateSchema.cs
+++ b/src/docfx/template/TemplateSchema.cs
@@ -5,8 +5,6 @@ using System;
 using System.Diagnostics;
 using System.IO;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class TemplateSchema

--- a/src/docfx/template/liquid/JavaScriptTag.cs
+++ b/src/docfx/template/liquid/JavaScriptTag.cs
@@ -5,8 +5,6 @@ using System;
 using System.IO;
 using DotLiquid;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class JavaScriptTag : Tag

--- a/src/docfx/template/liquid/LiquidFilter.cs
+++ b/src/docfx/template/liquid/LiquidFilter.cs
@@ -6,8 +6,6 @@ using System.Web;
 using HtmlAgilityPack;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal static class LiquidFilter

--- a/src/docfx/template/liquid/LiquidTemplate.cs
+++ b/src/docfx/template/liquid/LiquidTemplate.cs
@@ -11,8 +11,6 @@ using DotLiquid;
 using DotLiquid.FileSystems;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class LiquidTemplate

--- a/src/docfx/template/liquid/LocalizeTag.cs
+++ b/src/docfx/template/liquid/LocalizeTag.cs
@@ -5,8 +5,6 @@ using System.Collections.Generic;
 using System.IO;
 using DotLiquid;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class LocalizeTag : Tag

--- a/src/docfx/template/liquid/StyleTag.cs
+++ b/src/docfx/template/liquid/StyleTag.cs
@@ -4,8 +4,6 @@
 using System.IO;
 using DotLiquid;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class StyleTag : Tag

--- a/src/docfx/watch/Watch.cs
+++ b/src/docfx/watch/Watch.cs
@@ -8,8 +8,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     internal class Watch

--- a/test/docfx.Test/lib/ExtractYamlHeaderTest.cs
+++ b/test/docfx.Test/lib/ExtractYamlHeaderTest.cs
@@ -4,8 +4,6 @@
 using System.IO;
 using Xunit;
 
-#nullable enable
-
 namespace Microsoft.Docs.Build
 {
     public class ExtractYamlHeaderTest


### PR DESCRIPTION
#5515 👏👏👏👏👏

Now `docfx.csproj` has enabled nullable reference types globally

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5602)