### PR TITLE
Fix for progress updating all the time

### DIFF
--- a/src/docfx/lib/log/Progress.cs
+++ b/src/docfx/lib/log/Progress.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Docs.Build
         {
             public string Name { get; }
 
-            public Stopwatch Stopwatch{ get; }
+            public Stopwatch Stopwatch { get; }
 
             public long LastElapsedMs { get; set; }
 

--- a/src/docfx/lib/log/Progress.cs
+++ b/src/docfx/lib/log/Progress.cs
@@ -63,19 +63,18 @@ namespace Microsoft.Docs.Build
             return Math.Round(value.TotalMilliseconds, digits: 2) + "ms";
         }
 
-        private struct LogScope : IDisposable
+        private class LogScope : IDisposable
         {
-            public readonly string Name;
+            public string Name { get; }
 
-            public readonly Stopwatch Stopwatch;
+            public Stopwatch Stopwatch{ get; }
 
-            public long LastElapsedMs;
+            public long LastElapsedMs { get; set; }
 
             public LogScope(string name, Stopwatch stopwatch)
             {
                 Name = name;
                 Stopwatch = stopwatch;
-                LastElapsedMs = 0;
             }
 
             public void Dispose()


### PR DESCRIPTION
https://dev.azure.com/ceapex/Engineering/_workitems/edit/185533

https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/choosing-between-class-and-struct

The root cause is that, struct state update not stored as reference type.
Basically, we should only use `readonly struct`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5604)