### PR TITLE
Remove PublishModelBuilder.ExcludeFromOutput

### DIFF
--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -914,6 +914,7 @@ inputs:
     - name: Invalid TocHref Reference
       tocHref: index.md
 outputs:
+  docs/toc.json:
   .errors.log: |
     ["warning","file-not-found","Invalid file link: 'index.md'.","docs/f1/TOC.yml",2,9]
     ["error","invalid-toc-href","The toc href 'index.md' can only reference to a local TOC file, folder or absolute path","docs/f1/TOC.yml",4,12]

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Docs.Build
             /// Files published to the same url have no monikers or share common monikers.
             /// </summary>
             /// Behavior: ✔️ Message: ❌
-            public static Error PublishUrlConflict(string url, IReadOnlyDictionary<Document, IReadOnlyList<string>> files, List<string> conflictMonikers)
+            public static Error PublishUrlConflict(string url, IReadOnlyDictionary<FilePath, IReadOnlyList<string>> files, List<string> conflictMonikers)
             {
                 var nonVersion = conflictMonikers.Contains(PublishModelBuilder.NonVersion);
                 var message = conflictMonikers.Count != 0 && !nonVersion ? $" of the same version({StringUtility.Join(conflictMonikers)})" : null;
@@ -290,7 +290,7 @@ namespace Microsoft.Docs.Build
             ///   - different file extension with same filename, like `Toc.yml` and `Toc.md`
             /// </summary>
             /// Behavior: ✔️ Message: ❌
-            public static Error OutputPathConflict(string path, IEnumerable<Document> files)
+            public static Error OutputPathConflict(string path, IEnumerable<FilePath> files)
                 => new Error(ErrorLevel.Error, "output-path-conflict", $"Two or more files output to the same path '{path}': {StringUtility.Join(files)}");
         }
 

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -137,7 +137,6 @@ namespace Microsoft.Docs.Build
             var file = context.DocumentProvider.GetDocument(path);
             if (!ShouldBuildFile(context, file))
             {
-                context.PublishModelBuilder.ExcludeFromOutput(file);
                 return;
             }
 
@@ -161,17 +160,12 @@ namespace Microsoft.Docs.Build
                         break;
                 }
 
-                if (context.ErrorLog.Write(errors))
-                {
-                    context.PublishModelBuilder.ExcludeFromOutput(file);
-                }
-
+                context.ErrorLog.Write(errors);
                 Telemetry.TrackBuildItemCount(file.ContentType);
             }
             catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
             {
                 context.ErrorLog.Write(dex);
-                context.PublishModelBuilder.ExcludeFromOutput(file);
             }
             catch
             {

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -90,8 +90,8 @@ namespace Microsoft.Docs.Build
             RedirectionProvider = new RedirectionProvider(docset.DocsetPath, Config.HostName, ErrorLog, BuildScope, repositoryProvider, DocumentProvider, MonikerProvider);
             GitHubAccessor = new GitHubAccessor(Config);
             GitCommitProvider = new GitCommitProvider();
-            PublishModelBuilder = new PublishModelBuilder(outputPath, Config, Output);
-            BookmarkValidator = new BookmarkValidator(errorLog, PublishModelBuilder);
+            PublishModelBuilder = new PublishModelBuilder(outputPath, Config, Output, ErrorLog);
+            BookmarkValidator = new BookmarkValidator(errorLog);
             ContributionProvider = new ContributionProvider(config, localizationProvider, Input, fallbackDocset, GitHubAccessor, GitCommitProvider);
             FileLinkMapBuilder = new FileLinkMapBuilder(errorLog, MonikerProvider, PublishModelBuilder);
             XrefResolver = new XrefResolver(this, config, FileResolver, DependencyMapBuilder, FileLinkMapBuilder);

--- a/src/docfx/build/legacy/Legacy.cs
+++ b/src/docfx/build/legacy/Legacy.cs
@@ -11,17 +11,17 @@ namespace Microsoft.Docs.Build
         public static void ConvertToLegacyModel(
             Docset docset,
             Context context,
-            Dictionary<Document, PublishItem> fileManifests,
+            Dictionary<FilePath, PublishItem> fileManifests,
             DependencyMap dependencyMap)
         {
             using (Progress.Start("Converting to legacy"))
             {
-                fileManifests = fileManifests.Where(f => !f.Value.HasError).ToDictionary(k => k.Key, v => v.Value);
-                var files = fileManifests.Keys.ToList();
+                var documents = fileManifests.Where(f => !f.Value.HasError).ToDictionary(
+                    k => context.DocumentProvider.GetDocument(k.Key), v => v.Value);
 
-                LegacyManifest.Convert(docset, context, fileManifests);
-                var legacyDependencyMap = LegacyDependencyMap.Convert(docset, context, files, dependencyMap);
-                LegacyFileMap.Convert(context, legacyDependencyMap, fileManifests);
+                LegacyManifest.Convert(docset, context, documents);
+                var legacyDependencyMap = LegacyDependencyMap.Convert(docset, context, documents.Keys.ToList(), dependencyMap);
+                LegacyFileMap.Convert(context, legacyDependencyMap, documents);
             }
         }
     }

--- a/src/docfx/build/link/FileLinkItem.cs
+++ b/src/docfx/build/link/FileLinkItem.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Docs.Build
     internal class FileLinkItem : IEquatable<FileLinkItem>, IComparable<FileLinkItem>
     {
         [JsonIgnore]
-        public Document SourceFile { get; }
+        public FilePath SourceFile { get; }
 
         public string SourceUrl { get; }
 
@@ -19,7 +19,7 @@ namespace Microsoft.Docs.Build
 
         public string TargetUrl { get; }
 
-        public FileLinkItem(Document sourceFile, string sourceUrl, string? sourceMonikerGroup, string targetUrl)
+        public FileLinkItem(FilePath sourceFile, string sourceUrl, string? sourceMonikerGroup, string targetUrl)
         {
             SourceFile = sourceFile;
             SourceUrl = sourceUrl;

--- a/src/docfx/build/link/FileLinkMapBuilder.cs
+++ b/src/docfx/build/link/FileLinkMapBuilder.cs
@@ -20,28 +20,28 @@ namespace Microsoft.Docs.Build
             _publishModelBuilder = publishModelBuilder;
         }
 
-        public void AddFileLink(Document file, string targetUrl)
+        public void AddFileLink(FilePath file, string sourceUrl, string targetUrl)
         {
-            if (string.IsNullOrEmpty(targetUrl) || file.SiteUrl == targetUrl)
+            if (string.IsNullOrEmpty(targetUrl) || sourceUrl == targetUrl)
             {
                 return;
             }
 
-            var (error, monikers) = _monikerProvider.GetFileLevelMonikers(file.FilePath);
+            var (error, monikers) = _monikerProvider.GetFileLevelMonikers(file);
             if (error != null)
             {
                 _errorLog.Write(error);
             }
 
-            _links.TryAdd(new FileLinkItem(file, file.SiteUrl, MonikerUtility.GetGroup(monikers), targetUrl));
+            _links.TryAdd(new FileLinkItem(file, sourceUrl, MonikerUtility.GetGroup(monikers), targetUrl));
         }
 
-        public object Build() =>
-            new
+        public object Build()
+        {
+            return new
             {
-                Links = _links
-                .Where(x => _publishModelBuilder.IsIncludedInOutput(x.SourceFile))
-                .OrderBy(_ => _),
+                Links = from link in _links where _publishModelBuilder.HasOutput(link.SourceFile) orderby link select link,
             };
     }
+}
 }

--- a/src/docfx/build/link/LinkResolver.cs
+++ b/src/docfx/build/link/LinkResolver.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Docs.Build
                 }
             }
 
-            _fileLinkMapBuilder.AddFileLink(inclusionRoot, link);
+            _fileLinkMapBuilder.AddFileLink(inclusionRoot.FilePath, inclusionRoot.SiteUrl, link);
 
             if (file != null)
             {

--- a/src/docfx/build/page/BookmarkValidator.cs
+++ b/src/docfx/build/page/BookmarkValidator.cs
@@ -9,16 +9,14 @@ namespace Microsoft.Docs.Build
     internal class BookmarkValidator
     {
         private readonly ErrorLog _errorLog;
-        private readonly PublishModelBuilder _publishModelBuilder;
 
         private readonly DictionaryBuilder<Document, HashSet<string>> _bookmarksByFile = new DictionaryBuilder<Document, HashSet<string>>();
         private readonly ListBuilder<(Document file, Document dependency, string bookmark, bool isSelfBookmark, SourceInfo? source)>
             _references = new ListBuilder<(Document file, Document dependency, string bookmark, bool isSelfBookmark, SourceInfo? source)>();
 
-        public BookmarkValidator(ErrorLog errorLog, PublishModelBuilder publishModelBuilder)
+        public BookmarkValidator(ErrorLog errorLog)
         {
             _errorLog = errorLog;
-            _publishModelBuilder = publishModelBuilder;
         }
 
         public void AddBookmarkReference(Document file, Document reference, string? fragment, bool isSelfBookmark, SourceInfo? source)
@@ -56,12 +54,7 @@ namespace Microsoft.Docs.Build
                 if (bookmarks.Contains(bookmark))
                     continue;
 
-                var error = Errors.Content.BookmarkNotFound(source, isSelfBookmark ? file : reference, bookmark, bookmarks);
-
-                if (_errorLog.Write(error))
-                {
-                    _publishModelBuilder.ExcludeFromOutput(file);
-                }
+                _errorLog.Write(Errors.Content.BookmarkNotFound(source, isSelfBookmark ? file : reference, bookmark, bookmarks));
             }
         }
     }

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Docs.Build
                 monikers,
                 context.MonikerProvider.GetConfigMonikerRange(file.FilePath));
 
-            var shouldWriteOutput = context.PublishModelBuilder.TryAdd(file, publishItem);
+            var shouldWriteOutput = context.PublishModelBuilder.TryAdd(file.FilePath, publishItem);
 
             if (errors.Any(e => e.Level == ErrorLevel.Error))
                 return errors;

--- a/src/docfx/build/redirection/BuildRedirection.cs
+++ b/src/docfx/build/redirection/BuildRedirection.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Docs.Build
 
             publishItem.RedirectUrl = context.RedirectionProvider.GetRedirectUrl(file.FilePath);
 
-            if (context.PublishModelBuilder.TryAdd(file, publishItem) && publishItem.Path != null && !context.Config.DryRun)
+            if (context.PublishModelBuilder.TryAdd(file.FilePath, publishItem) && publishItem.Path != null && !context.Config.DryRun)
             {
                 var metadataPath = publishItem.Path.Substring(0, publishItem.Path.Length - ".raw.page.json".Length) + ".mta.json";
                 var metadata = new

--- a/src/docfx/build/resource/BuildResource.cs
+++ b/src/docfx/build/resource/BuildResource.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Docs.Build
                 monikers,
                 context.MonikerProvider.GetConfigMonikerRange(file.FilePath));
 
-            if (context.PublishModelBuilder.TryAdd(file, publishItem) && copy && !context.Config.DryRun)
+            if (context.PublishModelBuilder.TryAdd(file.FilePath, publishItem) && copy && !context.Config.DryRun)
             {
                 context.Output.Copy(file, outputPath);
             }

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Docs.Build
                 model.Metadata.Monikers,
                 context.MonikerProvider.GetConfigMonikerRange(file.FilePath));
 
-            if (context.PublishModelBuilder.TryAdd(file, publishItem) && !context.Config.DryRun)
+            if (context.PublishModelBuilder.TryAdd(file.FilePath, publishItem) && !context.Config.DryRun)
             {
                 if (context.Config.Legacy)
                 {

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -80,7 +80,8 @@ namespace Microsoft.Docs.Build
                 fragment.Length == 0 ? "" : fragment);
 
             // NOTE: this should also be relative to root file
-            _fileLinkMapBuilder.AddFileLink(inclusionRoot ?? hrefRelativeTo, resolvedHref);
+            var sourceFile = inclusionRoot ?? hrefRelativeTo;
+            _fileLinkMapBuilder.AddFileLink(sourceFile.FilePath, sourceFile.SiteUrl, resolvedHref);
 
             if (xrefSpec?.DeclaringFile != null && inclusionRoot != null)
             {

--- a/src/docfx/lib/log/ErrorLog.cs
+++ b/src/docfx/lib/log/ErrorLog.cs
@@ -6,7 +6,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
 using System.Threading;
 
 namespace Microsoft.Docs.Build


### PR DESCRIPTION
Make `PublishModelBuilder` read file with errors from `ErrorLog`, writers to `ErrorLog` don't need to worry about excluding the file from publish model.

Makes it easier for #5617 


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5621)