### PR TITLE
Make build sync

### DIFF
--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Docs.Build
 {
     internal static class Build
     {
-        public static async Task<int> Run(string workingDirectory, CommandLineOptions options)
+        public static int Run(string workingDirectory, CommandLineOptions options)
         {
             options.UseCache = true;
             var docsets = ConfigLoader.FindDocsets(workingDirectory, options);
@@ -22,11 +22,18 @@ namespace Microsoft.Docs.Build
                 return 1;
             }
 
-            var result = await Task.WhenAll(docsets.Select(docset => BuildDocset(docset.docsetPath, docset.outputPath, options)));
-            return result.All(x => x) ? 0 : 1;
+            var hasError = false;
+            Parallel.ForEach(docsets, docset =>
+            {
+                if (BuildDocset(docset.docsetPath, docset.outputPath, options))
+                {
+                    hasError = true;
+                }
+            });
+            return hasError ? 1 : 0;
         }
 
-        private static async Task<bool> BuildDocset(string docsetPath, string? outputPath, CommandLineOptions options)
+        private static bool BuildDocset(string docsetPath, string? outputPath, CommandLineOptions options)
         {
             List<Error> errors;
             Config? config = null;
@@ -57,7 +64,8 @@ namespace Microsoft.Docs.Build
 
                 // run build based on docsets
                 outputPath ??= Path.Combine(docsetPath, config.OutputPath);
-                await Run(config, docset, fallbackDocset, options, errorLog, outputPath, input, repositoryProvider, localizationProvider, packageResolver);
+                Run(config, docset, fallbackDocset, options, errorLog, outputPath, input, repositoryProvider, localizationProvider, packageResolver);
+                return true;
             }
             catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
             {
@@ -70,10 +78,9 @@ namespace Microsoft.Docs.Build
                 Log.Important($"Build '{config?.Name}' done in {Progress.FormatTimeSpan(stopwatch.Elapsed)}", ConsoleColor.Green);
                 errorLog.PrintSummary();
             }
-            return true;
         }
 
-        private static async Task Run(
+        private static void Run(
             Config config,
             Docset docset,
             Docset? fallbackDocset,
@@ -90,7 +97,7 @@ namespace Microsoft.Docs.Build
 
             using (Progress.Start("Building files"))
             {
-                await context.BuildQueue.Drain(file => BuildFile(context, file), Progress.Update);
+                context.BuildQueue.Drain(file => BuildFile(context, file), Progress.Update);
             }
 
             context.BookmarkValidator.Validate();
@@ -128,11 +135,11 @@ namespace Microsoft.Docs.Build
             context.ContributionProvider.Save();
             context.GitCommitProvider.Save();
 
-            errorLog.Write(await context.GitHubAccessor.Save());
-            errorLog.Write(await context.MicrosoftGraphAccessor.Save());
+            errorLog.Write(context.GitHubAccessor.Save());
+            errorLog.Write(context.MicrosoftGraphAccessor.Save());
         }
 
-        private static async Task BuildFile(Context context, FilePath path)
+        private static void BuildFile(Context context, FilePath path)
         {
             var file = context.DocumentProvider.GetDocument(path);
             if (!ShouldBuildFile(context, file))
@@ -150,7 +157,7 @@ namespace Microsoft.Docs.Build
                         errors = BuildResource.Build(context, file);
                         break;
                     case ContentType.Page:
-                        errors = await BuildPage.Build(context, file);
+                        errors = BuildPage.Build(context, file);
                         break;
                     case ContentType.TableOfContents:
                         // TODO: improve error message for toc monikers overlap

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -6,7 +6,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace Microsoft.Docs.Build
 {
@@ -33,7 +32,7 @@ namespace Microsoft.Docs.Build
             _fallbackDocset = fallbackDocset;
         }
 
-        public async Task<(List<Error> errors, ContributionInfo?)> GetContributionInfo(Document document, SourceInfo<string> authorName)
+        public (List<Error> errors, ContributionInfo?) GetContributionInfo(Document document, SourceInfo<string> authorName)
         {
             var errors = new List<Error>();
             var (repo, _, commits) = _gitCommitProvider.GetCommitHistory(document);
@@ -73,7 +72,7 @@ namespace Microsoft.Docs.Build
             {
                 foreach (var commit in contributionCommits)
                 {
-                    var (error, githubUser) = await _githubAccessor.GetUserByEmail(commit.AuthorEmail, repoOwner, repoName, commit.Sha);
+                    var (error, githubUser) = _githubAccessor.GetUserByEmail(commit.AuthorEmail, repoOwner, repoName, commit.Sha);
                     errors.AddIfNotNull(error);
                     var contributor = githubUser?.ToContributor();
                     if (!string.IsNullOrEmpty(contributor?.Name) && !excludes.Contains(contributor.Name))
@@ -87,7 +86,7 @@ namespace Microsoft.Docs.Build
             if (!string.IsNullOrEmpty(authorName))
             {
                 // Remove author from contributors if author name is specified
-                var (error, githubUser) = await _githubAccessor.GetUserByLogin(authorName);
+                var (error, githubUser) = _githubAccessor.GetUserByLogin(authorName);
                 errors.AddIfNotNull(error);
                 author = githubUser?.ToContributor();
             }

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using HtmlAgilityPack;
 using Newtonsoft.Json.Linq;
 
@@ -13,13 +12,13 @@ namespace Microsoft.Docs.Build
 {
     internal static class BuildPage
     {
-        public static async Task<List<Error>> Build(Context context, Document file)
+        public static List<Error> Build(Context context, Document file)
         {
             Debug.Assert(file.ContentType == ContentType.Page);
 
             var errors = new List<Error>();
 
-            var (loadErrors, sourceModel) = await Load(context, file);
+            var (loadErrors, sourceModel) = Load(context, file);
             errors.AddRange(loadErrors);
 
             var (monikerError, monikers) = context.MonikerProvider.GetFileLevelMonikers(file.FilePath);
@@ -41,7 +40,7 @@ namespace Microsoft.Docs.Build
                 return errors;
 
             var (outputErrors, output, metadata) = file.IsPage
-                ? await CreatePageOutput(context, file, sourceModel)
+                ? CreatePageOutput(context, file, sourceModel)
                 : CreateDataOutput(context, file, sourceModel);
             errors.AddRange(outputErrors);
             publishItem.ExtensionData = metadata;
@@ -73,7 +72,7 @@ namespace Microsoft.Docs.Build
             return errors;
         }
 
-        private static async Task<(List<Error> errors, object output, JObject metadata)> CreatePageOutput(
+        private static (List<Error> errors, object output, JObject metadata) CreatePageOutput(
             Context context, Document file, JObject sourceModel)
         {
             var errors = new List<Error>();
@@ -82,7 +81,7 @@ namespace Microsoft.Docs.Build
 
             var (inputMetadataErrors, userMetadata) = context.MetadataProvider.GetMetadata(file.FilePath);
             errors.AddRange(inputMetadataErrors);
-            var (systemMetadataErrors, systemMetadata) = await CreateSystemMetadata(context, file, userMetadata);
+            var (systemMetadataErrors, systemMetadata) = CreateSystemMetadata(context, file, userMetadata);
             errors.AddRange(systemMetadataErrors);
 
             // Mandatory metadata are metadata that are required by template to successfully ran to completion.
@@ -136,7 +135,7 @@ namespace Microsoft.Docs.Build
             return (new List<Error>(), context.TemplateEngine.RunJint($"{file.Mime}.json.js", sourceModel), new JObject());
         }
 
-        private static async Task<(List<Error>, SystemMetadata)> CreateSystemMetadata(Context context, Document file, UserMetadata inputMetadata)
+        private static (List<Error>, SystemMetadata) CreateSystemMetadata(Context context, Document file, UserMetadata inputMetadata)
         {
             var errors = new List<Error>();
             var systemMetadata = new SystemMetadata();
@@ -162,7 +161,7 @@ namespace Microsoft.Docs.Build
 
             // To speed things up for dry runs, ignore metadata that does not produce errors.
             // We also ignore GitHub author validation for dry runs because we are not calling GitHub in local validation anyway.
-            var (contributorErrors, contributionInfo) = await context.ContributionProvider.GetContributionInfo(file, inputMetadata.Author);
+            var (contributorErrors, contributionInfo) = context.ContributionProvider.GetContributionInfo(file, inputMetadata.Author);
             errors.AddRange(contributorErrors);
             systemMetadata.ContributionInfo = contributionInfo;
 
@@ -197,7 +196,7 @@ namespace Microsoft.Docs.Build
             return (errors, systemMetadata);
         }
 
-        private static async Task<(List<Error> errors, JObject model)> Load(Context context, Document file)
+        private static (List<Error> errors, JObject model) Load(Context context, Document file)
         {
             if (file.FilePath.EndsWith(".md"))
             {
@@ -205,11 +204,11 @@ namespace Microsoft.Docs.Build
             }
             if (file.FilePath.EndsWith(".yml"))
             {
-                return await LoadYaml(context, file);
+                return LoadYaml(context, file);
             }
 
             Debug.Assert(file.FilePath.EndsWith(".json"));
-            return await LoadJson(context, file);
+            return LoadJson(context, file);
         }
 
         private static (List<Error> errors, JObject model) LoadMarkdown(Context context, Document file)
@@ -247,22 +246,21 @@ namespace Microsoft.Docs.Build
             return (errors, pageModel);
         }
 
-        private static async Task<(List<Error> errors, JObject model)> LoadYaml(Context context, Document file)
+        private static (List<Error> errors, JObject model) LoadYaml(Context context, Document file)
         {
             var (errors, token) = context.Input.ReadYaml(file.FilePath);
 
-            return await LoadSchemaDocument(context, errors, token, file);
+            return LoadSchemaDocument(context, errors, token, file);
         }
 
-        private static async Task<(List<Error> errors, JObject model)> LoadJson(Context context, Document file)
+        private static (List<Error> errors, JObject model) LoadJson(Context context, Document file)
         {
             var (errors, token) = context.Input.ReadJson(file.FilePath);
 
-            return await LoadSchemaDocument(context, errors, token, file);
+            return LoadSchemaDocument(context, errors, token, file);
         }
 
-        private static async Task<(List<Error> errors, JObject model)>
-            LoadSchemaDocument(Context context, List<Error> errors, JToken token, Document file)
+        private static (List<Error> errors, JObject model) LoadSchemaDocument(Context context, List<Error> errors, JToken token, Document file)
         {
             var schemaTemplate = context.TemplateEngine.GetSchema(file.Mime);
 
@@ -296,7 +294,8 @@ namespace Microsoft.Docs.Build
                 var (deserializeErrors, landingData) = JsonUtility.ToObject<LandingData>(pageModel);
                 errors.AddRange(deserializeErrors);
 
-                var htmlDom = HtmlUtility.LoadHtml(await RazorTemplate.Render(file.Mime, landingData)).PostMarkup(context.Config.DryRun);
+                var razorHtml = RazorTemplate.Render(file.Mime, landingData).GetAwaiter().GetResult();
+                var htmlDom = HtmlUtility.LoadHtml(razorHtml).PostMarkup(context.Config.DryRun);
                 ValidateBookmarks(context, file, htmlDom);
 
                 pageModel = JsonUtility.ToJObject(new ConceptualModel

--- a/src/docfx/cli/Docfx.cs
+++ b/src/docfx/cli/Docfx.cs
@@ -19,11 +19,11 @@ namespace Microsoft.Docs.Build
 {
     public static class Docfx
     {
-        internal static async Task<int> Main(params string[] args)
+        internal static int Main(params string[] args)
         {
             try
             {
-                return await Run(args);
+                return Run(args);
             }
             catch (Exception ex)
             {
@@ -51,7 +51,7 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        internal static async Task<int> Run(string[] args)
+        internal static int Run(string[] args)
         {
             if (args.Length == 1 && args[0] == "--version")
             {
@@ -79,7 +79,7 @@ namespace Microsoft.Docs.Build
                     case "restore":
                         return Restore.Run(workingDirectory, options);
                     case "build":
-                        return await Build.Run(workingDirectory, options);
+                        return Build.Run(workingDirectory, options);
                 }
                 return 0;
             }

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -30,7 +30,6 @@
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="Stubble.Core" Version="1.6.3" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180503-2" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.11.0" />
     <PackageReference Include="Validations.DocFx.Adapter" Version="1.2.19" />
     <PackageReference Include="YamlDotNet" Version="8.0.0" />
   </ItemGroup>

--- a/src/docfx/lib/github/GitHubAccessor.cs
+++ b/src/docfx/lib/github/GitHubAccessor.cs
@@ -43,9 +43,9 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public async Task<(Error?, GitHubUser?)> GetUserByLogin(SourceInfo<string> login)
+        public (Error?, GitHubUser?) GetUserByLogin(SourceInfo<string> login)
         {
-            var (error, user) = await _userCache.GetOrAdd(login.Value, GetUserByLoginCore);
+            var (error, user) = _userCache.GetOrAdd(login.Value, GetUserByLoginCore);
             if (user != null && !user.IsValid())
             {
                 return (Errors.Metadata.AuthorNotFound(login), null);
@@ -54,13 +54,13 @@ namespace Microsoft.Docs.Build
             return (error, user);
         }
 
-        public async Task<(Error?, GitHubUser?)> GetUserByEmail(string email, string owner, string name, string commit)
+        public (Error?, GitHubUser?) GetUserByEmail(string email, string owner, string name, string commit)
         {
-            var (error, user) = await _userCache.GetOrAdd(email, _ => GetUserByEmailCore(email, owner, name, commit));
+            var (error, user) = _userCache.GetOrAdd(email, _ => GetUserByEmailCore(email, owner, name, commit));
             return (error, user != null && user.IsValid() ? user : null);
         }
 
-        public Task<Error[]> Save()
+        public Error[] Save()
         {
             return _userCache.Save();
         }

--- a/src/docfx/lib/msgraph/MicrosoftGraphAccessor.cs
+++ b/src/docfx/lib/msgraph/MicrosoftGraphAccessor.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public async Task<Error?> ValidateMicrosoftAlias(SourceInfo<string> alias, string name)
+        public Error? ValidateMicrosoftAlias(SourceInfo<string> alias, string name)
         {
             if (_msGraphClient is null)
             {
@@ -41,12 +41,12 @@ namespace Microsoft.Docs.Build
                 return null;
             }
 
-            var (error, user) = await _aliasCache.GetOrAdd(alias.Value, GetMicrosoftGraphUserCore);
+            var (error, user) = _aliasCache.GetOrAdd(alias.Value, GetMicrosoftGraphUserCore);
 
             return error ?? (user is null ? Errors.JsonSchema.MsAliasInvalid(alias, name) : null);
         }
 
-        public Task<Error[]> Save()
+        public Error[] Save()
         {
             return _aliasCache.Save();
         }

--- a/src/docfx/lib/schema/JsonSchemaValidator.cs
+++ b/src/docfx/lib/schema/JsonSchemaValidator.cs
@@ -428,8 +428,7 @@ namespace Microsoft.Docs.Build
                 {
                     if (_microsoftGraphAccessor != null)
                     {
-                        var error = _microsoftGraphAccessor.ValidateMicrosoftAlias(
-                            new SourceInfo<string>(alias, JsonUtility.GetSourceInfo(scalar)), name).GetAwaiter().GetResult();
+                        var error = _microsoftGraphAccessor.ValidateMicrosoftAlias(new SourceInfo<string>(alias, JsonUtility.GetSourceInfo(scalar)), name);
                         if (error != null)
                         {
                             errors.Add((name, error));

--- a/test/docfx.Test/DocfxTest.cs
+++ b/test/docfx.Test/DocfxTest.cs
@@ -169,11 +169,11 @@ namespace Microsoft.Docs.Build
 
                 if (spec.Restore)
                 {
-                    await Docfx.Run(new[] { "restore", docsetPath }.Concat(options).ToArray());
+                    Docfx.Run(new[] { "restore", docsetPath }.Concat(options).ToArray());
                 }
                 if (spec.Build)
                 {
-                    await Docfx.Run(new[] { "build", docsetPath }.Concat(options).Concat(dryRunOptions).Concat(new[] { "--no-restore" }).ToArray());
+                    Docfx.Run(new[] { "build", docsetPath }.Concat(options).Concat(dryRunOptions).Concat(new[] { "--no-restore" }).ToArray());
                 }
             }
 

--- a/test/docfx.Test/lib/GitHubAccessorTest.cs
+++ b/test/docfx.Test/lib/GitHubAccessorTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Docs.Build
@@ -18,9 +17,9 @@ namespace Microsoft.Docs.Build
         [InlineData("OPSTest", 23694395, "OPSTest", "OPSTest")]
         [InlineData("luyajun0205", 15990849, "luyajun0205", "luyajun0205")]
         [InlineData("N1o2t3E4x5i6s7t8N9a0m9e", null, null, null)]
-        public static async Task GetUserByLogin(string login, int? expectedId, string expectedName, string expectedLogin)
+        public static void GetUserByLogin(string login, int? expectedId, string expectedName, string expectedLogin)
         {
-            var (error, user) = await s_github.GetUserByLogin(new SourceInfo<string>(login));
+            var (error, user) = s_github.GetUserByLogin(new SourceInfo<string>(login));
 
             // skip check if the machine exceeds the GitHub API rate limit
             if (!string.IsNullOrEmpty(s_token))
@@ -51,10 +50,10 @@ namespace Microsoft.Docs.Build
         [InlineData("error@example.com", null, null, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", null, null, null, null)]
         [InlineData("51308672+disabled-account-osmond@users.noreply.github.com", "docascode", "contribution-test", "b2b280fbc64790011c7a4d01bca5b84b6d98e386", null, null, null, null)]
         [InlineData("yufeih@live.com", "docascode", "contribution-test", "6d0e5bc3595e3841ac62dc545dfbb2c01fe64e7c", "yufeih", 511355, "Yufei Huang", new[] { "yufeih@live.com", "yufeih@microsoft.com" })]
-        public static async Task GetUserByEmail(
+        public static void GetUserByEmail(
             string email, string repoOwner, string repoName, string commit, string expectedLogin, int? expectedId, string expectedName, string[] expectedEmails)
         {
-            var (error, user) = await s_github.GetUserByEmail(email, repoOwner, repoName, commit);
+            var (error, user) = s_github.GetUserByEmail(email, repoOwner, repoName, commit);
 
             // skip check if the machine exceeds the GitHub API rate limit
             if (!string.IsNullOrEmpty(s_token))

--- a/test/docfx.Test/lib/JsonDiskCacheTest.cs
+++ b/test/docfx.Test/lib/JsonDiskCacheTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Docs.Build
     public static class JsonDiskCacheTest
     {
         [Fact]
-        public static async Task JsonDiskCache_BlockUpdate_MissingItems()
+        public static void JsonDiskCache_BlockUpdate_MissingItems()
         {
             var counter = 0;
             var cache = new JsonDiskCache<string, int, TestCacheObject>($"jsondiskcache/{Guid.NewGuid()}", TimeSpan.FromHours(1));
@@ -21,10 +21,10 @@ namespace Microsoft.Docs.Build
             Assert.Equal(0, counter);
 
             // First call is a blocking call
-            Assert.Equal(1, (await cache.GetOrAdd(9999, CreateValue)).value.Snapshot);
+            Assert.Equal(1, (cache.GetOrAdd(9999, CreateValue)).value.Snapshot);
 
             // Subsequent calls does not trigger valueFactory
-            Assert.Equal(1, (await cache.GetOrAdd(9999, CreateValue)).value.Snapshot);
+            Assert.Equal(1, (cache.GetOrAdd(9999, CreateValue)).value.Snapshot);
 
             async Task<(string, TestCacheObject)> CreateValue(int id)
             {
@@ -34,7 +34,7 @@ namespace Microsoft.Docs.Build
         }
 
         [Fact]
-        public static async Task JsonDiskCache_AsynchronousUpdate_ExpiredItems()
+        public static void JsonDiskCache_AsynchronousUpdate_ExpiredItems()
         {
             var counter = 0;
             var filename = $"jsondiskcache/{Guid.NewGuid()}";
@@ -44,16 +44,16 @@ namespace Microsoft.Docs.Build
             var cache = new JsonDiskCache<string, int, TestCacheObject>(filename, TimeSpan.FromHours(1));
 
             // Read existing items from cache does not trigger valueFactory
-            Assert.Equal(1234, (await cache.GetOrAdd(9999, CreateValue)).value.Snapshot);
+            Assert.Equal(1234, (cache.GetOrAdd(9999, CreateValue)).value.Snapshot);
             Assert.Equal(0, counter);
 
             // When cache expires, don't block caller, trigger asynchronous update
-            (await cache.GetOrAdd(9999, CreateValue)).value.UpdatedAt = DateTime.MinValue;
-            Assert.Equal(1234, (await cache.GetOrAdd(9999, CreateValue)).value.Snapshot);
+            (cache.GetOrAdd(9999, CreateValue)).value.UpdatedAt = DateTime.MinValue;
+            Assert.Equal(1234, (cache.GetOrAdd(9999, CreateValue)).value.Snapshot);
 
             // Save waits for asynchronous update to complete
-            await cache.Save();
-            Assert.Equal(1, (await cache.GetOrAdd(9999, CreateValue)).value.Snapshot);
+            cache.Save();
+            Assert.Equal(1, (cache.GetOrAdd(9999, CreateValue)).value.Snapshot);
 
             async Task<(string, TestCacheObject)> CreateValue(int id)
             {

--- a/test/docfx.Test/restore/RestoreTest.cs
+++ b/test/docfx.Test/restore/RestoreTest.cs
@@ -54,9 +54,9 @@ namespace Microsoft.Docs.Build
         }
 
         [Fact]
-        public static async Task RestoreAgainstFileShouldNotCrash()
+        public static void RestoreAgainstFileShouldNotCrash()
         {
-            await Docfx.Run(new [] { "restore", "docfx.Test.dll" });
+            Docfx.Run(new [] { "restore", "docfx.Test.dll" });
         }
     }
 }


### PR DESCRIPTION
Docfx build is very compute intensive. The async programming model does not provide much benefit here. This PR makes build sync, to eliminate async overhead, and open up room to leverage [ref struct](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/ref#ref-struct-types) for better error collection.

The things in build that are currently async are:

- `GitHubAcessor` is an HTTP call but it is synchronized internally anyway because of API rate limit
- `MicrosoftGraphAccessor` is an HTTP call but it is calling `GetAwaiter().GetResult()` at JSON schema layer anyway.
- `RazorTemplate` is async but it is a legacy component to be retired.

Use `Parallel` to build docsets in true parallel. Before this change, `Task.WhenAll` isn't truly parallel.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5623)