### PR TITLE
assign code DocumentError to DocumentException

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Common/MarkdownReader.cs
+++ b/src/Microsoft.DocAsCode.Build.Common/MarkdownReader.cs
@@ -101,7 +101,6 @@ namespace Microsoft.DocAsCode.Build.Common
             {
                 Debug.Fail("Markup failed!");
                 var message = $"Markup failed: {ex.Message}.";
-                Logger.LogError(message);
                 throw new DocumentException(message, ex);
             }
         }

--- a/src/Microsoft.DocAsCode.Build.Engine/HostService.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/HostService.cs
@@ -171,7 +171,6 @@ namespace Microsoft.DocAsCode.Build.Engine
             {
                 System.Diagnostics.Debug.Fail("Markup failed!");
                 var message = $"Markup failed: {ex.Message}.";
-                Logger.LogError(message);
                 throw new DocumentException(message, ex);
             }
         }

--- a/src/Microsoft.DocAsCode.Build.Engine/TemplateProcessors/Preprocessors/TemplateUtility.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/TemplateProcessors/Preprocessors/TemplateUtility.cs
@@ -82,7 +82,6 @@ namespace Microsoft.DocAsCode.Build.Engine
             {
                 System.Diagnostics.Debug.Fail("Markup failed!");
                 var message = $"Markup failed: {ex.Message}.";
-                Logger.LogError(message);
                 throw new DocumentException(message, ex);
             }
             return mr.Html;

--- a/src/Microsoft.DocAsCode.Build.Engine/TemplateProcessors/TemplateModelTransformer.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/TemplateProcessors/TemplateModelTransformer.cs
@@ -116,7 +116,6 @@ namespace Microsoft.DocAsCode.Build.Engine
                             message = $"Error transforming model generated from \"{item.LocalPathFromRoot}\" using \"{template.ScriptName}\". To get the detailed raw model, please run docfx with debug mode --debug. {e.Message} ";
                         }
 
-                        Logger.LogError(message);
                         throw new DocumentException(message, e);
                     }
 
@@ -139,7 +138,6 @@ namespace Microsoft.DocAsCode.Build.Engine
                             message = $"Error applying template \"{template.Name}\" generated from \"{item.LocalPathFromRoot}\". To get the detailed view model, please run docfx with debug mode --debug. {e.Message}";
                         }
 
-                        Logger.LogError(message);
                         throw new DocumentException(message, e);
                     }
 

--- a/src/Microsoft.DocAsCode.Build.SchemaDriven/TagInterpreters/PatternedTagInterpreter.cs
+++ b/src/Microsoft.DocAsCode.Build.SchemaDriven/TagInterpreters/PatternedTagInterpreter.cs
@@ -43,8 +43,7 @@ namespace Microsoft.DocAsCode.Build.SchemaDriven.Processors
                 if (!new Regex(pattern).Match(val).Success)
                 {
                     var errorMessage = $"Property {path} with value \"{val}\" is not in valid format, it must follow regular expression \"{pattern}\".";
-                    Logger.LogError(errorMessage, code: ErrorCodes.Build.InvalidPropertyFormat);
-                    throw new DocumentException(errorMessage);
+                    throw new DocumentException(errorMessage, ErrorCodes.Build.InvalidPropertyFormat);
                 }
             }
         }

--- a/src/Microsoft.DocAsCode.Build.UniversalReference/ModelConverter/ModelConverter.cs
+++ b/src/Microsoft.DocAsCode.Build.UniversalReference/ModelConverter/ModelConverter.cs
@@ -286,13 +286,11 @@ namespace Microsoft.DocAsCode.Build.UniversalReference
 
         private static ApiBuildOutput ResolveApiBuildOutput(string uid, IReadOnlyDictionary<string, ApiBuildOutput> children)
         {
-            if (!children.TryGetValue(uid, out ApiBuildOutput result))
+            if (children.TryGetValue(uid, out ApiBuildOutput result))
             {
-                var message = $"Can't find {uid} in items or references";
-                Logger.LogError(message);
-                throw new DocumentException(message, ErrorCodes.Build.InternalUidNotFound);
+                return result;
             }
-            return result;
+            throw new DocumentException($"Can't find {uid} in items or references", ErrorCodes.Build.InternalUidNotFound);
         }
     }
 }

--- a/src/Microsoft.DocAsCode.Build.UniversalReference/ModelConverter/ModelConverter.cs
+++ b/src/Microsoft.DocAsCode.Build.UniversalReference/ModelConverter/ModelConverter.cs
@@ -290,7 +290,7 @@ namespace Microsoft.DocAsCode.Build.UniversalReference
             {
                 var message = $"Can't find {uid} in items or references";
                 Logger.LogError(message);
-                throw new DocumentException(message);
+                throw new DocumentException(message, ErrorCodes.Build.InternalUidNotFound);
             }
             return result;
         }

--- a/src/Microsoft.DocAsCode.Common/Loggers/ErrorCodes.cs
+++ b/src/Microsoft.DocAsCode.Common/Loggers/ErrorCodes.cs
@@ -9,6 +9,7 @@ namespace Microsoft.DocAsCode.Common
         {
             public const string InvalidPropertyFormat = "InvalidPropertyFormat";
             public const string InvalidInputFile = "InvalidInputFile";
+            public const string InternalUidNotFound = "InternalUidNotFound";
             public const string DocumentError = "DocumentError";
             public const string FatalError = "FatalError";
         }

--- a/src/Microsoft.DocAsCode.Common/Loggers/ErrorCodes.cs
+++ b/src/Microsoft.DocAsCode.Common/Loggers/ErrorCodes.cs
@@ -9,6 +9,7 @@ namespace Microsoft.DocAsCode.Common
         {
             public const string InvalidPropertyFormat = "InvalidPropertyFormat";
             public const string InvalidInputFile = "InvalidInputFile";
+            public const string DocumentError = "DocumentError";
             public const string FatalError = "FatalError";
         }
     }

--- a/src/Microsoft.DocAsCode.Plugins/DocumentException.cs
+++ b/src/Microsoft.DocAsCode.Plugins/DocumentException.cs
@@ -10,9 +10,14 @@
         public string File { get; set; }
         public int Line { get; set; }
         public int Column { get; set; }
+        public string Code { get; set; }
 
         public DocumentException() { }
         public DocumentException(string message) : base(message) { }
+        public DocumentException(string message, string code) : this(message)
+        {
+            Code = code;
+        }
         public DocumentException(string message, Exception inner) : base(message, inner) { }
         protected DocumentException(SerializationInfo info, StreamingContext context)
             : base(info, context)

--- a/src/docfx/Program.cs
+++ b/src/docfx/Program.cs
@@ -92,9 +92,9 @@ namespace Microsoft.DocAsCode
                 command.Exec(context);
                 return 0;
             }
-            catch (Exception e) when (e is DocumentException)
+            catch (Exception e) when (e is DocumentException de)
             {
-                Logger.LogError(e.Message, code: ErrorCodes.Build.DocumentError);
+                Logger.LogError(e.Message, code: de.Code ?? ErrorCodes.Build.DocumentError);
                 return 1;
             }
             catch (Exception e) when (e is DocfxException)

--- a/src/docfx/Program.cs
+++ b/src/docfx/Program.cs
@@ -92,7 +92,12 @@ namespace Microsoft.DocAsCode
                 command.Exec(context);
                 return 0;
             }
-            catch (Exception e) when (e is DocumentException || e is DocfxException)
+            catch (Exception e) when (e is DocumentException)
+            {
+                Logger.LogError(e.Message, code: ErrorCodes.Build.DocumentError);
+                return 1;
+            }
+            catch (Exception e) when (e is DocfxException)
             {
                 Logger.LogError(e.Message, code: ErrorCodes.Build.FatalError);
                 return 1;

--- a/src/docfx/SubCommands/DocumentBuilderWrapper.cs
+++ b/src/docfx/SubCommands/DocumentBuilderWrapper.cs
@@ -91,10 +91,6 @@ namespace Microsoft.DocAsCode.SubCommands
                 {
                     throw new DocfxException(e.Message);
                 }
-                catch (DocumentException e)
-                {
-                    throw new DocfxException(e.Message);
-                }
                 catch (Exception e)
                 {
                     throw new DocfxException(e.ToString());

--- a/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/SchemaDrivenProcessorTest.cs
+++ b/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/SchemaDrivenProcessorTest.cs
@@ -484,7 +484,7 @@ uid: invalid.azure.hello2
                 },
             }));
 
-            Assert.Equal(2, listener.Items.Count(s => s.Code == ErrorCodes.Build.InvalidPropertyFormat));
+            Assert.Equal(0, listener.Items.Count(s => s.Code == ErrorCodes.Build.InvalidPropertyFormat));
         }
 
         [Fact]


### PR DESCRIPTION
In OPS, it treats `FatalError` as system error rather than user error. This is not true for `DocumentException`, which is actually user error.

I also removed all other `LogError`s when throwing `DocumentException`, except for few places where `LogError` is used to fetch detailed file info from `LoggerScope`.

https://ceapex.visualstudio.com/Engineering/_workitems/edit/188506/

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5624)