### PR TITLE
Update dotnet SDK to fix a null check bug

### DIFF
--- a/azure-pipelines-v3.yml
+++ b/azure-pipelines-v3.yml
@@ -7,7 +7,7 @@ trigger:
 pr:
 - v3
 variables:
-  dotnetVersion: 3.1.100
+  dotnetVersion: 3.1.102
   runCodesignValidationInjection: false
 
 jobs:

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -611,8 +611,8 @@ namespace Microsoft.Docs.Build
             /// The attribute value is duplicated within docset
             /// </summary>
             /// Behavior: ✔️ Message: ✔️
-            public static Error DuplicateAttribute(SourceInfo? source, string name, string value, List<SourceInfo> duplicatedFiles)
-                => new Error(ErrorLevel.Suggestion, "duplicate-attribute", $"Attribute '{name}' with value '{value}' is duplicated in {StringUtility.Join(duplicatedFiles.Select(d => d.File))}", source);
+            public static Error DuplicateAttribute(SourceInfo? source, string name, string value, IEnumerable<FilePath> duplicatedFiles)
+                => new Error(ErrorLevel.Suggestion, "duplicate-attribute", $"Attribute '{name}' with value '{value}' is duplicated in {StringUtility.Join(duplicatedFiles)}", source);
         }
 
         public static class Metadata


### PR DESCRIPTION
The latest dotnet SDK fixes the null-able check bug.

![image](https://user-images.githubusercontent.com/511355/76746825-178aca00-67b3-11ea-8c5b-d5b2921cd48c.png)

#5622 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5627)