### PR TITLE
Optimize JsonSchemaTransformer to cache only xref properties

### DIFF
--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -19,8 +19,6 @@ namespace Microsoft.Docs.Build
 
         public Dictionary<string, Lazy<JToken>> ExtensionData { get; } = new Dictionary<string, Lazy<JToken>>();
 
-        public Dictionary<string, JsonSchemaContentType> PropertyContentTypeMapping { get; } = new Dictionary<string, JsonSchemaContentType>();
-
         public InternalXrefSpec(string uid, string href, Document declaringFile)
         {
             Uid = uid;
@@ -31,12 +29,7 @@ namespace Microsoft.Docs.Build
         public string? GetXrefPropertyValueAsString(string propertyName)
         {
             // for internal UID, the display property should only be plain text
-            var contentType = GetXrefPropertyContentType(propertyName);
-            if (contentType == JsonSchemaContentType.None)
-            {
-                return ExtensionData.TryGetValue(propertyName, out var property) && property.Value is JValue propertyValue && propertyValue.Value is string internalStr ? internalStr : null;
-            }
-            return null;
+            return ExtensionData.TryGetValue(propertyName, out var property) && property.Value is JValue propertyValue && propertyValue.Value is string internalStr ? internalStr : null;
         }
 
         public string? GetName() => GetXrefPropertyValueAsString("name");
@@ -55,14 +48,6 @@ namespace Microsoft.Docs.Build
                 spec.ExtensionData[key] = value.Value;
             }
             return spec;
-        }
-
-        private JsonSchemaContentType GetXrefPropertyContentType(string propertyName)
-        {
-            if (propertyName is null)
-                return default;
-
-            return PropertyContentTypeMapping.TryGetValue(propertyName, out var value) ? value : default;
         }
     }
 }

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -16,193 +16,159 @@ namespace Microsoft.Docs.Build
     {
         private readonly JsonSchema _schema;
         private readonly JsonSchemaDefinition _definitions;
-        private readonly ConcurrentDictionary<JToken, (List<Error>, JToken)> _transformedProperties;
+        private readonly ConcurrentDictionary<JToken, (List<Error>, JToken)> _xrefPropertiesCache =
+                     new ConcurrentDictionary<JToken, (List<Error>, JToken)>(ReferenceEqualsComparer.Default);
         private static ThreadLocal<Stack<(string uid, Document declaringFile)>> t_recursionDetector
-            = new ThreadLocal<Stack<(string, Document)>>(() => new Stack<(string, Document)>());
+                 = new ThreadLocal<Stack<(string, Document)>>(() => new Stack<(string, Document)>());
 
         public JsonSchemaTransformer(JsonSchema schema)
         {
             _schema = schema;
             _definitions = new JsonSchemaDefinition(schema);
-            _transformedProperties = new ConcurrentDictionary<JToken, (List<Error>, JToken)>(ReferenceEqualsComparer.Default);
         }
 
         public (List<Error> errors, JToken token) TransformContent(Document file, Context context, JToken token)
         {
-            return TransformToken(file, context, _schema, token);
+            return TransformContentCore(file, context, _schema, token);
         }
 
         public (List<Error>, IReadOnlyList<InternalXrefSpec>) LoadXrefSpecs(Document file, Context context, JToken token)
         {
             var errors = new List<Error>();
-            var uids = new HashSet<string>();
+            var xrefSpecs = new List<InternalXrefSpec>();
+            LoadXrefSpecsCore(file, context, _schema, token, errors, xrefSpecs);
+            return (errors, xrefSpecs);
+        }
 
-            return (errors, LoadXrefSpecs(_schema, token));
-
-            List<InternalXrefSpec> LoadXrefSpecs(JsonSchema schema, JToken node)
+        private void LoadXrefSpecsCore(Document file, Context context, JsonSchema schema, JToken node, List<Error> errors, List<InternalXrefSpec> xrefSpecs)
+        {
+            schema = _definitions.GetDefinition(schema);
+            switch (node)
             {
-                var xrefSpecs = new List<InternalXrefSpec>();
-                schema = _definitions.GetDefinition(schema);
-                switch (node)
-                {
-                    case JObject obj:
-                        if (!schema.Properties.TryGetValue("uid", out var uidSchema) || uidSchema.ContentType != JsonSchemaContentType.Uid)
-                        {
-                            TraverseObjectXref(obj);
-                            break;
-                        }
-
-                        if (!obj.TryGetValue<JValue>("uid", out var uidValue) || !(uidValue.Value is string uid))
-                        {
-                            TraverseObjectXref(obj);
-                            break;
-                        }
-
-                        if (uids.Add(uid))
-                        {
-                            xrefSpecs.Add(GetXrefSpec(uid, obj));
-                        }
-                        else
-                        {
-                            errors.Add(Errors.Xref.UidConflict(uid, JsonUtility.GetSourceInfo(uidValue)));
-                        }
-
-                        break;
-                    case JArray array:
-                        foreach (var item in array)
-                        {
-                            if (schema.Items.schema != null)
-                                xrefSpecs.AddRange(LoadXrefSpecs(schema.Items.schema, item));
-                        }
-                        break;
-                }
-
-                return xrefSpecs;
-
-                InternalXrefSpec GetXrefSpec(string uid, JObject obj)
-                {
-                    var contentTypeProperties = new Dictionary<string, JsonSchemaContentType>();
-                    var xrefProperties = new Dictionary<string, Lazy<JToken>>();
-                    TraverseObjectXref(obj, (propertySchema, key, value) =>
+                case JObject obj:
+                    if (obj.TryGetValue<JValue>("uid", out var uidValue) && uidValue.Value is string uid)
                     {
-                        if (schema.XrefProperties.Contains(key))
-                        {
-                            contentTypeProperties[key] = propertySchema.ContentType;
-                            xrefProperties[key] = new Lazy<JToken>(
-                                () =>
-                                {
-                                    var recursionDetector = t_recursionDetector.Value!;
-                                    if (recursionDetector.Contains((uid, file)))
-                                    {
-                                        var referenceMap = recursionDetector.Select(x => $"{x.uid} ({x.declaringFile})").Reverse().ToList();
-                                        referenceMap.Add($"{uid} ({file})");
-                                        throw Errors.Link.CircularReference(referenceMap, file).ToException();
-                                    }
-
-                                    try
-                                    {
-                                        recursionDetector.Push((uid, file));
-                                        var (transformErrors, transformedToken) = TransformToken(file, context, propertySchema, value);
-                                        context.ErrorLog.Write(transformErrors);
-                                        return transformedToken;
-                                    }
-                                    finally
-                                    {
-                                        Debug.Assert(recursionDetector.Count > 0);
-                                        recursionDetector.Pop();
-                                    }
-                                }, LazyThreadSafetyMode.PublicationOnly);
-                            return true;
-                        }
-
-                        return false;
-                    });
-
-                    var href = obj.Parent is null ? file.SiteUrl : UrlUtility.MergeUrl(file.SiteUrl, "", $"#{GetBookmarkFromUid(uid)}");
-                    var xref = new InternalXrefSpec(uid, href, file);
-                    xref.ExtensionData.AddRange(xrefProperties);
-                    xref.PropertyContentTypeMapping.AddRange(contentTypeProperties);
-                    return xref;
-                }
-
-                string GetBookmarkFromUid(string uid)
-                    => Regex.Replace(uid, @"\W", "_");
-
-                void TraverseObjectXref(JObject obj, Func<JsonSchema, string, JToken, bool>? action = null)
-                {
+                        xrefSpecs.Add(LoadXrefSpec(file, context, schema, uid, obj));
+                    }
                     foreach (var (key, value) in obj)
                     {
                         if (value != null && schema.Properties.TryGetValue(key, out var propertySchema))
                         {
-                            if (action?.Invoke(propertySchema, key, value) ?? false)
-                                continue;
-
-                            xrefSpecs.AddRange(LoadXrefSpecs(propertySchema, value));
+                            LoadXrefSpecsCore(file, context, propertySchema, value, errors, xrefSpecs);
                         }
                     }
-                }
+                    break;
+                case JArray array when schema.Items.schema != null:
+                    foreach (var item in array)
+                    {
+                        LoadXrefSpecsCore(file, context, schema.Items.schema, item, errors, xrefSpecs);
+                    }
+                    break;
             }
         }
 
-        private (List<Error>, JToken) TransformToken(Document file, Context context, JsonSchema schema, JToken token)
+        private InternalXrefSpec LoadXrefSpec(Document file, Context context, JsonSchema schema, string uid, JObject obj)
         {
-            schema = _definitions.GetDefinition(schema);
+            var fragment = $"#{Regex.Replace(uid, @"\W", "_")}";
+            var href = obj.Parent is null ? file.SiteUrl : UrlUtility.MergeUrl(file.SiteUrl, "", fragment);
+            var xref = new InternalXrefSpec(uid, href, file);
 
-            if (schema == null)
+            foreach (var xrefProperty in schema.XrefProperties)
             {
-                return (new List<Error>(), token);
+                if (!obj.TryGetValue(xrefProperty, out var value))
+                {
+                    continue;
+                }
+
+                if (!schema.Properties.TryGetValue(xrefProperty, out var propertySchema))
+                {
+                    xref.ExtensionData[xrefProperty] = new Lazy<JToken>(() => value);
+                    continue;
+                }
+
+                xref.ExtensionData[xrefProperty] = new Lazy<JToken>(() =>
+                {
+                    var recursionDetector = t_recursionDetector.Value!;
+                    if (recursionDetector.Contains((uid, file)))
+                    {
+                        var referenceMap = recursionDetector.Select(x => $"{x.uid} ({x.declaringFile})").Reverse().ToList();
+                        referenceMap.Add($"{uid} ({file})");
+                        throw Errors.Link.CircularReference(referenceMap, file).ToException();
+                    }
+
+                    try
+                    {
+                        recursionDetector.Push((uid, file));
+                        var (transformErrors, transformedToken) = _xrefPropertiesCache.GetOrAdd(value, _ => TransformContentCore(file, context, propertySchema, value));
+                        context.ErrorLog.Write(transformErrors);
+                        return transformedToken;
+                    }
+                    finally
+                    {
+                        Debug.Assert(recursionDetector.Count > 0);
+                        recursionDetector.Pop();
+                    }
+                }, LazyThreadSafetyMode.PublicationOnly);
             }
 
-            return _transformedProperties.GetOrAdd(token, _ =>
+            return xref;
+        }
+
+        private (List<Error>, JToken) TransformContentCore(Document file, Context context, JsonSchema schema, JToken token)
+        {
+            if (_xrefPropertiesCache.TryGetValue(token, out var result))
             {
-                var errors = new List<Error>();
-                switch (token)
-                {
-                    // transform array and object is not supported yet
-                    case JArray array:
-                        if (schema.Items.schema is null)
+                return result;
+            }
+
+            var errors = new List<Error>();
+            schema = _definitions.GetDefinition(schema);
+            switch (token)
+            {
+                // transform array and object is not supported yet
+                case JArray array:
+                    if (schema.Items.schema is null)
+                    {
+                        return (errors, array);
+                    }
+
+                    var newArray = new JArray();
+                    foreach (var item in array)
+                    {
+                        var (arrayErrors, newItem) = TransformContentCore(file, context, schema.Items.schema, item);
+                        errors.AddRange(arrayErrors);
+                        newArray.Add(newItem);
+                    }
+
+                    return (errors, newArray);
+
+                case JObject obj:
+                    var newObject = new JObject();
+                    foreach (var (key, value) in obj)
+                    {
+                        if (value is null)
                         {
-                            return (errors, array);
+                            continue;
                         }
-
-                        var newArray = new JArray();
-                        foreach (var item in array)
+                        else if (schema.Properties.TryGetValue(key, out var propertySchema))
                         {
-                            var (arrayErrors, newItem) = TransformToken(file, context, schema.Items.schema, item);
-                            errors.AddRange(arrayErrors);
-                            newArray.Add(newItem);
+                            var (propertyErrors, transformedValue) = TransformContentCore(file, context, propertySchema, value);
+                            errors.AddRange(propertyErrors);
+                            newObject[key] = transformedValue;
                         }
-
-                        return (errors, newArray);
-
-                    case JObject obj:
-                        var newObject = new JObject();
-                        foreach (var (key, value) in obj)
+                        else
                         {
-                            if (value is null)
-                            {
-                                continue;
-                            }
-                            else if (schema.Properties.TryGetValue(key, out var propertySchema))
-                            {
-                                var (propertyErrors, transformedValue) = TransformToken(file, context, propertySchema, value);
-                                errors.AddRange(propertyErrors);
-                                newObject[key] = transformedValue;
-                            }
-                            else
-                            {
-                                newObject[key] = value;
-                            }
+                            newObject[key] = value;
                         }
-                        return (errors, newObject);
+                    }
+                    return (errors, newObject);
 
-                    case JValue value:
-                        return TransformScalar(schema, file, context, value);
+                case JValue value:
+                    return TransformScalar(schema, file, context, value);
 
-                    default:
-                        throw new NotSupportedException();
-                }
-            });
+                default:
+                    throw new NotSupportedException();
+            }
         }
 
         private (List<Error>, JToken) TransformScalar(JsonSchema schema, Document file, Context context, JValue value)


### PR DESCRIPTION
The current `JsonSchemaTransformer` caches every node, this is a huge waste of memory. The only node that needs cache is the node with xref properties. Without cache, these nodes are transformed twice, building xrefmap and building SDP content.

There is still a cache of all YAML node tree in `Input`, it will be addressed later. 

This PR converts the inner functions into member functions, to make the logic clear, and it changes some code path to make function recursion calls easy to spot.

https://ceapex.visualstudio.com/Engineering/_workitems/edit/188536/

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5629)