### PR TITLE
Fix JsonSchemaTransfomer traversal algorithm

### DIFF
--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -835,7 +835,7 @@ inputs:
       "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TestData.json",
       "name": "name for b",
       "uid": "b",
-      "inlineDescription": "description for b",
+      "inlineDescription": "description for _b_",
       "summary": "Link to @a",
     }
   _themes/ContentTemplate/schemas/TestData.schema.json: |
@@ -853,17 +853,17 @@ outputs:
     {
       "uid": "a",
       "name": "name for a",
-      "inlineDescription": "Link to <a href=\"b.json\">name for b</a>",
+      "inlineDescription": "Link to <a href=\"b.json\">description for &lt;em&gt;b&lt;/em&gt;</a>",
       "summary": "
           <p>
-            Link to <a href=\"b.json\">name for b</a>
+            Link to <a href=\"b.json\">&lt;p&gt;Link to &lt;a href=&quot;a.json&quot;&gt;name for a&lt;/a&gt;&lt;/p&gt;</a>
           </p>"
     }
   docs/b.json: |
     {
       "name": "name for b",
       "uid": "b",
-      "inlineDescription": "description for b",
+      "inlineDescription": "description for <em>b</em>",
       "summary": "
           <p>
             Link to <a href=\"a.json\">name for a</a>
@@ -1314,3 +1314,24 @@ inputs:
 outputs:
   .errors.log: |
     ["error","file-not-found","Invalid file link: '1.xrefmap.json'.","docfx.yml",1,7]
+---
+# Export all xrefProperties regardless of jschema properties
+repos:
+  https://docs.com/test-xref-sdp#live:
+    - files:
+        docfx.yml: |
+        docs/a.json: |
+          {
+            "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TestData.json",
+            "uid": "a",
+            "name": "test"
+          }
+        _themes/ContentTemplate/schemas/TestData.schema.json: |
+          {
+            "xrefProperties": ["name"],
+            "properties": { "uid": { "contentType": "uid" } }
+          }
+outputs:
+  docs/a.json:
+  .xrefmap.json: | 
+    { "references": [{ "uid": "a", "href": "https://docs.com/docs/a.json", "name": "test" }] }

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Docs.Build
             }
 
             var xref = new InternalXrefSpec(metadata.Uid, file.SiteUrl, file);
-            xref.ExtensionData["name"] = new Lazy<JToken>(() => new JValue(string.IsNullOrEmpty(metadata.Title) ? metadata.Uid : metadata.Title));
+            xref.XrefProperties["name"] = new Lazy<JToken>(() => new JValue(string.IsNullOrEmpty(metadata.Title) ? metadata.Uid : metadata.Title));
 
             var (error, monikers) = context.MonikerProvider.GetFileLevelMonikers(file.FilePath);
             xref.Monikers = monikers.ToHashSet();

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Docs.Build
 
         public HashSet<string> Monikers { get; set; } = new HashSet<string>();
 
-        public Dictionary<string, Lazy<JToken>> ExtensionData { get; } = new Dictionary<string, Lazy<JToken>>();
+        public Dictionary<string, Lazy<JToken>> XrefProperties { get; } = new Dictionary<string, Lazy<JToken>>();
 
         public Dictionary<string, JsonSchemaContentType> PropertyContentTypeMapping { get; } = new Dictionary<string, JsonSchemaContentType>();
 
@@ -30,13 +30,7 @@ namespace Microsoft.Docs.Build
 
         public string? GetXrefPropertyValueAsString(string propertyName)
         {
-            // for internal UID, the display property should only be plain text
-            var contentType = GetXrefPropertyContentType(propertyName);
-            if (contentType == JsonSchemaContentType.None)
-            {
-                return ExtensionData.TryGetValue(propertyName, out var property) && property.Value is JValue propertyValue && propertyValue.Value is string internalStr ? internalStr : null;
-            }
-            return null;
+            return XrefProperties.TryGetValue(propertyName, out var property) && property.Value is JValue propertyValue && propertyValue.Value is string internalStr ? internalStr : null;
         }
 
         public string? GetName() => GetXrefPropertyValueAsString("name");
@@ -50,19 +44,11 @@ namespace Microsoft.Docs.Build
                 Monikers = Monikers,
             };
 
-            foreach (var (key, value) in ExtensionData)
+            foreach (var (key, value) in XrefProperties)
             {
                 spec.ExtensionData[key] = value.Value;
             }
             return spec;
-        }
-
-        private JsonSchemaContentType GetXrefPropertyContentType(string propertyName)
-        {
-            if (propertyName is null)
-                return default;
-
-            return PropertyContentTypeMapping.TryGetValue(propertyName, out var value) ? value : default;
         }
     }
 }

--- a/src/docfx/lib/schema/JsonSchema.cs
+++ b/src/docfx/lib/schema/JsonSchema.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Properties that are transformed using specified pipeline like 'markup'
         /// </summary>
-        public JsonSchemaContentType ContentType { get; set; }
+        public JsonSchemaContentType? ContentType { get; set; }
 
         /// <summary>
         /// Properties that are built into xref map

--- a/src/docfx/lib/schema/JsonSchemaContentType.cs
+++ b/src/docfx/lib/schema/JsonSchemaContentType.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Docs.Build
 {
     public enum JsonSchemaContentType
     {
-        None,
         Href,
         Markdown,
         InlineMarkdown,

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -16,199 +16,180 @@ namespace Microsoft.Docs.Build
     {
         private readonly JsonSchema _schema;
         private readonly JsonSchemaDefinition _definitions;
-        private readonly ConcurrentDictionary<JToken, (List<Error>, JToken)> _transformedProperties;
+        private readonly ConcurrentDictionary<JToken, (List<Error>, JToken)> _xrefPropertiesCache =
+                     new ConcurrentDictionary<JToken, (List<Error>, JToken)>(ReferenceEqualsComparer.Default);
+
         private static ThreadLocal<Stack<(string uid, Document declaringFile)>> t_recursionDetector
-            = new ThreadLocal<Stack<(string, Document)>>(() => new Stack<(string, Document)>());
+                 = new ThreadLocal<Stack<(string, Document)>>(() => new Stack<(string, Document)>());
 
         public JsonSchemaTransformer(JsonSchema schema)
         {
             _schema = schema;
             _definitions = new JsonSchemaDefinition(schema);
-            _transformedProperties = new ConcurrentDictionary<JToken, (List<Error>, JToken)>(ReferenceEqualsComparer.Default);
         }
 
         public (List<Error> errors, JToken token) TransformContent(Document file, Context context, JToken token)
         {
-            return TransformToken(file, context, _schema, token);
+            return TransformContentCore(file, context, _schema, token);
         }
 
         public (List<Error>, IReadOnlyList<InternalXrefSpec>) LoadXrefSpecs(Document file, Context context, JToken token)
         {
             var errors = new List<Error>();
-            var uids = new HashSet<string>();
+            var xrefSpecs = new Dictionary<string, InternalXrefSpec>();
+            LoadXrefSpecsCore(file, context, _schema, token, errors, xrefSpecs);
+            return (errors, xrefSpecs.Values.ToArray());
+        }
 
-            return (errors, LoadXrefSpecs(_schema, token));
-
-            List<InternalXrefSpec> LoadXrefSpecs(JsonSchema schema, JToken node)
+        private void LoadXrefSpecsCore(Document file, Context context, JsonSchema schema, JToken node, List<Error> errors, Dictionary<string, InternalXrefSpec> xrefSpecs)
+        {
+            schema = _definitions.GetDefinition(schema);
+            switch (node)
             {
-                var xrefSpecs = new List<InternalXrefSpec>();
-                schema = _definitions.GetDefinition(schema);
-                switch (node)
-                {
-                    case JObject obj:
-                        if (!schema.Properties.TryGetValue("uid", out var uidSchema) || uidSchema.ContentType != JsonSchemaContentType.Uid)
-                        {
-                            TraverseObjectXref(obj);
-                            break;
-                        }
-
-                        if (!obj.TryGetValue<JValue>("uid", out var uidValue) || !(uidValue.Value is string uid))
-                        {
-                            TraverseObjectXref(obj);
-                            break;
-                        }
-
-                        if (uids.Add(uid))
-                        {
-                            xrefSpecs.Add(GetXrefSpec(uid, obj));
-                        }
-                        else
+                case JObject obj:
+                    // A xrefspec MUST be named uid, and the schema contentType MUST also be uid
+                    if (obj.TryGetValue<JValue>("uid", out var uidValue) && uidValue.Value is string uid &&
+                        schema.Properties.TryGetValue("uid", out var uidSchema) && uidSchema.ContentType == JsonSchemaContentType.Uid)
+                    {
+                        if (xrefSpecs.ContainsKey(uid))
                         {
                             errors.Add(Errors.Xref.UidConflict(uid, JsonUtility.GetSourceInfo(uidValue)));
                         }
-
-                        break;
-                    case JArray array:
-                        foreach (var item in array)
+                        else
                         {
-                            if (schema.Items.schema != null)
-                                xrefSpecs.AddRange(LoadXrefSpecs(schema.Items.schema, item));
+                            xrefSpecs.Add(uid, LoadXrefSpec(file, context, schema, uid, obj));
                         }
-                        break;
-                }
+                    }
 
-                return xrefSpecs;
-
-                InternalXrefSpec GetXrefSpec(string uid, JObject obj)
-                {
-                    var contentTypeProperties = new Dictionary<string, JsonSchemaContentType>();
-                    var xrefProperties = new Dictionary<string, Lazy<JToken>>();
-                    TraverseObjectXref(obj, (propertySchema, key, value) =>
-                    {
-                        if (schema.XrefProperties.Contains(key))
-                        {
-                            contentTypeProperties[key] = propertySchema.ContentType;
-                            xrefProperties[key] = new Lazy<JToken>(
-                                () =>
-                                {
-                                    var recursionDetector = t_recursionDetector.Value!;
-                                    if (recursionDetector.Contains((uid, file)))
-                                    {
-                                        var referenceMap = recursionDetector.Select(x => $"{x.uid} ({x.declaringFile})").Reverse().ToList();
-                                        referenceMap.Add($"{uid} ({file})");
-                                        throw Errors.Link.CircularReference(referenceMap, file).ToException();
-                                    }
-
-                                    try
-                                    {
-                                        recursionDetector.Push((uid, file));
-                                        var (transformErrors, transformedToken) = TransformToken(file, context, propertySchema, value);
-                                        context.ErrorLog.Write(transformErrors);
-                                        return transformedToken;
-                                    }
-                                    finally
-                                    {
-                                        Debug.Assert(recursionDetector.Count > 0);
-                                        recursionDetector.Pop();
-                                    }
-                                }, LazyThreadSafetyMode.PublicationOnly);
-                            return true;
-                        }
-
-                        return false;
-                    });
-
-                    var href = obj.Parent is null ? file.SiteUrl : UrlUtility.MergeUrl(file.SiteUrl, "", $"#{GetBookmarkFromUid(uid)}");
-                    var xref = new InternalXrefSpec(uid, href, file);
-                    xref.ExtensionData.AddRange(xrefProperties);
-                    xref.PropertyContentTypeMapping.AddRange(contentTypeProperties);
-                    return xref;
-                }
-
-                string GetBookmarkFromUid(string uid)
-                    => Regex.Replace(uid, @"\W", "_");
-
-                void TraverseObjectXref(JObject obj, Func<JsonSchema, string, JToken, bool>? action = null)
-                {
                     foreach (var (key, value) in obj)
                     {
                         if (value != null && schema.Properties.TryGetValue(key, out var propertySchema))
                         {
-                            if (action?.Invoke(propertySchema, key, value) ?? false)
-                                continue;
-
-                            xrefSpecs.AddRange(LoadXrefSpecs(propertySchema, value));
+                            LoadXrefSpecsCore(file, context, propertySchema, value, errors, xrefSpecs);
                         }
                     }
-                }
+                    break;
+                case JArray array when schema.Items.schema != null:
+                    foreach (var item in array)
+                    {
+                        LoadXrefSpecsCore(file, context, schema.Items.schema, item, errors, xrefSpecs);
+                    }
+                    break;
             }
         }
 
-        private (List<Error>, JToken) TransformToken(Document file, Context context, JsonSchema schema, JToken token)
+        private InternalXrefSpec LoadXrefSpec(Document file, Context context, JsonSchema schema, string uid, JObject obj)
         {
-            schema = _definitions.GetDefinition(schema);
+            var fragment = $"#{Regex.Replace(uid, @"\W", "_")}";
+            var href = obj.Parent is null ? file.SiteUrl : UrlUtility.MergeUrl(file.SiteUrl, "", fragment);
+            var xref = new InternalXrefSpec(uid, href, file);
 
-            if (schema == null)
+            foreach (var xrefProperty in schema.XrefProperties)
             {
-                return (new List<Error>(), token);
+                if (!obj.TryGetValue(xrefProperty, out var value))
+                {
+                    continue;
+                }
+
+                if (!schema.Properties.TryGetValue(xrefProperty, out var propertySchema))
+                {
+                    xref.XrefProperties[xrefProperty] = new Lazy<JToken>(() => value);
+                    continue;
+                }
+
+                xref.XrefProperties[xrefProperty] = new Lazy<JToken>(
+                    () => LoadXrefProperty(file, context, uid, value, propertySchema),
+                    LazyThreadSafetyMode.PublicationOnly);
             }
 
-            return _transformedProperties.GetOrAdd(token, _ =>
+            return xref;
+        }
+
+        private JToken LoadXrefProperty(Document file, Context context, string uid, JToken value, JsonSchema schema)
+        {
+            var recursionDetector = t_recursionDetector.Value!;
+            if (recursionDetector.Contains((uid, file)))
             {
-                var errors = new List<Error>();
-                switch (token)
-                {
-                    // transform array and object is not supported yet
-                    case JArray array:
-                        if (schema.Items.schema is null)
+                var referenceMap = recursionDetector.Select(x => $"{x.uid} ({x.declaringFile})").Reverse().ToList();
+                referenceMap.Add($"{uid} ({file})");
+                throw Errors.Link.CircularReference(referenceMap, file).ToException();
+            }
+
+            try
+            {
+                recursionDetector.Push((uid, file));
+                var (transformErrors, transformedToken) = _xrefPropertiesCache.GetOrAdd(value, _ => TransformContentCore(file, context, schema, value));
+                context.ErrorLog.Write(transformErrors);
+                return transformedToken;
+            }
+            finally
+            {
+                Debug.Assert(recursionDetector.Count > 0);
+                recursionDetector.Pop();
+            }
+        }
+
+        private (List<Error>, JToken) TransformContentCore(Document file, Context context, JsonSchema schema, JToken token)
+        {
+            if (_xrefPropertiesCache.TryGetValue(token, out var result))
+            {
+                return result;
+            }
+
+            var errors = new List<Error>();
+            schema = _definitions.GetDefinition(schema);
+            switch (token)
+            {
+                // transform array and object is not supported yet
+                case JArray array:
+                    if (schema.Items.schema is null)
+                    {
+                        return (errors, array);
+                    }
+
+                    var newArray = new JArray();
+                    foreach (var item in array)
+                    {
+                        var (arrayErrors, newItem) = TransformContentCore(file, context, schema.Items.schema, item);
+                        errors.AddRange(arrayErrors);
+                        newArray.Add(newItem);
+                    }
+
+                    return (errors, newArray);
+
+                case JObject obj:
+                    var newObject = new JObject();
+                    foreach (var (key, value) in obj)
+                    {
+                        if (value is null)
                         {
-                            return (errors, array);
+                            continue;
                         }
-
-                        var newArray = new JArray();
-                        foreach (var item in array)
+                        else if (schema.Properties.TryGetValue(key, out var propertySchema))
                         {
-                            var (arrayErrors, newItem) = TransformToken(file, context, schema.Items.schema, item);
-                            errors.AddRange(arrayErrors);
-                            newArray.Add(newItem);
+                            var (propertyErrors, transformedValue) = TransformContentCore(file, context, propertySchema, value);
+                            errors.AddRange(propertyErrors);
+                            newObject[key] = transformedValue;
                         }
-
-                        return (errors, newArray);
-
-                    case JObject obj:
-                        var newObject = new JObject();
-                        foreach (var (key, value) in obj)
+                        else
                         {
-                            if (value is null)
-                            {
-                                continue;
-                            }
-                            else if (schema.Properties.TryGetValue(key, out var propertySchema))
-                            {
-                                var (propertyErrors, transformedValue) = TransformToken(file, context, propertySchema, value);
-                                errors.AddRange(propertyErrors);
-                                newObject[key] = transformedValue;
-                            }
-                            else
-                            {
-                                newObject[key] = value;
-                            }
+                            newObject[key] = value;
                         }
-                        return (errors, newObject);
+                    }
+                    return (errors, newObject);
 
-                    case JValue value:
-                        return TransformScalar(schema, file, context, value);
+                case JValue value:
+                    return TransformScalar(schema, file, context, value);
 
-                    default:
-                        throw new NotSupportedException();
-                }
-            });
+                default:
+                    throw new NotSupportedException();
+            }
         }
 
         private (List<Error>, JToken) TransformScalar(JsonSchema schema, Document file, Context context, JValue value)
         {
             var errors = new List<Error>();
-            if (value.Type == JTokenType.Null || schema.ContentType == JsonSchemaContentType.None)
+            if (value.Type == JTokenType.Null || schema.ContentType is null)
             {
                 return (errors, value);
             }


### PR DESCRIPTION
Fixes a bunch of problems with the current SDP transform in _JsonSchemaTransformer_:

- Export all `xrefProperties` regardless if it is defined in schema
- Any `contentType` can be referenced by `@uid?displayName=xrefPropertyName` as long as the content transform result is a string
- Cache only nodes marked as `xrefProperties`. Before the change, all nodes are cached.

This PR removes inner functions in _JsonSchemaTransformer_ to clarify the traverse process. Big, recursive inner functions makes bugs hard to spot.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5630)