### PR TITLE
Report duplicate-uid based on source info

### DIFF
--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -423,7 +423,7 @@ inputs:
   docs/index.md:
 outputs:
   .errors.log: |
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/TOC.md' --> 'docs/f1/TOC.md' --> 'docs/f2/TOC.md' --> 'docs/TOC.md'","docs/TOC.md"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/TOC.md' --> 'docs/f1/TOC.md' --> 'docs/f2/TOC.md' --> 'docs/TOC.md'","docs/TOC.md",1,1]
 ---
 # Circle toc referencing 2
 inputs:
@@ -435,7 +435,7 @@ inputs:
   docs/index.md:
 outputs:
   .errors.log: |
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/TOC.md' --> 'docs/TOC.md'","docs/TOC.md"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'docs/TOC.md' --> 'docs/TOC.md'","docs/TOC.md",1,1]
 ---
 # Reference to a folder, basic usages
 # Reference to a folder behavior is not same with reference to a toc file

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -761,7 +761,7 @@ inputs:
     }
 outputs:
   .errors.log: |
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'a (docs/a.yml(2,6))' --> 'a (docs/a.yml(2,6))'","docs/a.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'a (docs/a.yml(2,6))' --> 'a (docs/a.yml(2,6))'","docs/a.yml",2,6]
 ---
 # circular reference within SDP UID definition a -> b -> c -> a
 inputs:
@@ -788,9 +788,9 @@ inputs:
     }
 outputs:
   .errors.log: |
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'a (docs/a.yml(2,6))' --> 'b (docs/b.yml(2,6))' --> 'c (docs/c.yml(2,6))' --> 'a (docs/a.yml(2,6))'","docs/a.yml"]
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'b (docs/b.yml(2,6))' --> 'c (docs/c.yml(2,6))' --> 'a (docs/a.yml(2,6))' --> 'b (docs/b.yml(2,6))'","docs/b.yml"]
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'c (docs/c.yml(2,6))' --> 'a (docs/a.yml(2,6))' --> 'b (docs/b.yml(2,6))' --> 'c (docs/c.yml(2,6))'","docs/c.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'a (docs/a.yml(2,6))' --> 'b (docs/b.yml(2,6))' --> 'c (docs/c.yml(2,6))' --> 'a (docs/a.yml(2,6))'","docs/a.yml",2,6]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'b (docs/b.yml(2,6))' --> 'c (docs/c.yml(2,6))' --> 'a (docs/a.yml(2,6))' --> 'b (docs/b.yml(2,6))'","docs/b.yml",2,6]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'c (docs/c.yml(2,6))' --> 'a (docs/a.yml(2,6))' --> 'b (docs/b.yml(2,6))' --> 'c (docs/c.yml(2,6))'","docs/c.yml",2,6]
 ---
 # circular reference within SDP UID definition a -> b -> a -> c
 inputs:
@@ -819,8 +819,8 @@ inputs:
 outputs:
   docs/c.json:
   .errors.log: |
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'a (docs/a.yml(2,6))' --> 'b (docs/b.yml(2,6))' --> 'a (docs/a.yml(2,6))'","docs/a.yml"]
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'b (docs/b.yml(2,6))' --> 'a (docs/a.yml(2,6))' --> 'b (docs/b.yml(2,6))'","docs/b.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'a (docs/a.yml(2,6))' --> 'b (docs/b.yml(2,6))' --> 'a (docs/a.yml(2,6))'","docs/a.yml",2,6]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'b (docs/b.yml(2,6))' --> 'a (docs/a.yml(2,6))' --> 'b (docs/b.yml(2,6))'","docs/b.yml",2,6]
 ---
 # display property of non-plain text content type will be ignored
 inputs:

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -328,7 +328,8 @@ outputs:
   base_path/docs/c.json: |
     {"conceptual": "<p>Link to <a href=\"a.json\" data-linktype=\"relative-path\">a</a></p>\n"}
   .errors.log: |
-    ["warning","uid-conflict","UID 'a' is defined in more than one file: 'docs/a.yml', 'docs/b.json'"]
+    ["warning","duplicate-uid","UID 'a' is duplicated in 'docs/a.yml(2,6)', 'docs/b.json(3,12)'","docs/a.yml",2,6]
+    ["warning","duplicate-uid","UID 'a' is duplicated in 'docs/a.yml(2,6)', 'docs/b.json(3,12)'","docs/b.json",3,12]
   .xrefmap.json: | 
     {"references":[{"uid":"a","href":"https://docs.com/base_path/docs/a.json?branch=master"}], "properties": {"tags":["/base_path","internal"]}}
 ---
@@ -516,7 +517,8 @@ outputs:
   docs/b.json: |
     {"xref":{"uid":"a","href":"a.json"}}
   .errors.log: |
-    ["warning","uid-conflict","The same Uid 'a' has been defined multiple times in the same file","docs/a.json",6,14]
+    ["warning","duplicate-uid","UID 'a' is duplicated in 'docs/a.json(3,12)', 'docs/a.json(6,14)'","docs/a.json",3,12]
+    ["warning","duplicate-uid","UID 'a' is duplicated in 'docs/a.json(3,12)', 'docs/a.json(6,14)'","docs/a.json",6,14]
 ---
 # uid conflict in non-root level and another SDP
 inputs:
@@ -546,7 +548,8 @@ outputs:
   docs/a.json:
   docs/b.json:
   .errors.log: |
-    ["warning","uid-conflict","UID 'b' is defined in more than one file: 'docs/a.json', 'docs/b.json'"]
+    ["warning","duplicate-uid","UID 'b' is duplicated in 'docs/a.json(6,14)', 'docs/b.json(3,12)'","docs/a.json",6,14]
+    ["warning","duplicate-uid","UID 'b' is duplicated in 'docs/a.json(6,14)', 'docs/b.json(3,12)'","docs/b.json",3,12]
 ---
 # Xref property field which supports markdown content
 inputs:
@@ -758,7 +761,7 @@ inputs:
     }
 outputs:
   .errors.log: |
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'a (docs/a.yml)' --> 'a (docs/a.yml)'","docs/a.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'a (docs/a.yml(2,6))' --> 'a (docs/a.yml(2,6))'","docs/a.yml"]
 ---
 # circular reference within SDP UID definition a -> b -> c -> a
 inputs:
@@ -785,9 +788,9 @@ inputs:
     }
 outputs:
   .errors.log: |
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'a (docs/a.yml)' --> 'b (docs/b.yml)' --> 'c (docs/c.yml)' --> 'a (docs/a.yml)'","docs/a.yml"]
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'b (docs/b.yml)' --> 'c (docs/c.yml)' --> 'a (docs/a.yml)' --> 'b (docs/b.yml)'","docs/b.yml"]
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'c (docs/c.yml)' --> 'a (docs/a.yml)' --> 'b (docs/b.yml)' --> 'c (docs/c.yml)'","docs/c.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'a (docs/a.yml(2,6))' --> 'b (docs/b.yml(2,6))' --> 'c (docs/c.yml(2,6))' --> 'a (docs/a.yml(2,6))'","docs/a.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'b (docs/b.yml(2,6))' --> 'c (docs/c.yml(2,6))' --> 'a (docs/a.yml(2,6))' --> 'b (docs/b.yml(2,6))'","docs/b.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'c (docs/c.yml(2,6))' --> 'a (docs/a.yml(2,6))' --> 'b (docs/b.yml(2,6))' --> 'c (docs/c.yml(2,6))'","docs/c.yml"]
 ---
 # circular reference within SDP UID definition a -> b -> a -> c
 inputs:
@@ -816,8 +819,8 @@ inputs:
 outputs:
   docs/c.json:
   .errors.log: |
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'a (docs/a.yml)' --> 'b (docs/b.yml)' --> 'a (docs/a.yml)'","docs/a.yml"]
-    ["error","circular-reference","Build has identified file(s) referencing each other: 'b (docs/b.yml)' --> 'a (docs/a.yml)' --> 'b (docs/b.yml)'","docs/b.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'a (docs/a.yml(2,6))' --> 'b (docs/b.yml(2,6))' --> 'a (docs/a.yml(2,6))'","docs/a.yml"]
+    ["error","circular-reference","Build has identified file(s) referencing each other: 'b (docs/b.yml(2,6))' --> 'a (docs/a.yml(2,6))' --> 'b (docs/b.yml(2,6))'","docs/b.yml"]
 ---
 # display property of non-plain text content type will be ignored
 inputs:

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -263,8 +263,12 @@ namespace Microsoft.Docs.Build
             ///   - a.md references b.json's property with xref syntax, and b.json includes a.md reversely
             /// </summary>
             /// Behavior: ✔️ Message: ✔️
-            public static Error CircularReference<T>(IEnumerable<T> dependencyChain, Document declaringFile)
-                => new Error(ErrorLevel.Error, "circular-reference", $"Build has identified file(s) referencing each other: {string.Join(" --> ", dependencyChain.Select(file => $"'{file}'"))}", file: declaringFile.FilePath);
+            public static Error CircularReference<T>(SourceInfo? source, T current, Stack<T> recursionDetector, Func<T, string?>? display = null)
+            {
+                display ??= obj => obj?.ToString();
+                var dependencyChain = string.Join(" --> ", recursionDetector.Reverse().Concat(new[] { current }).Select(file => $"'{display(file)}'"));
+                return new Error(ErrorLevel.Error, "circular-reference", $"Build has identified file(s) referencing each other: {dependencyChain}", source);
+            }
         }
 
         public static class UrlPath
@@ -407,16 +411,13 @@ namespace Microsoft.Docs.Build
                 => new Error(ErrorLevel.Warning, "xref-not-found", $"Cross reference not found: '{source}'", source);
 
             /// <summary>
-            /// More than one files defined the same uid.
+            /// The same uid of the same version is defined in multiple places
             /// Examples:
             ///   - both files with no monikers defined same uid
             /// </summary>
             /// Behavior: ✔️ Message: ✔️
-            public static Error UidConflict(string uid, SourceInfo? source)
-                => new Error(ErrorLevel.Warning, "uid-conflict", $"The same Uid '{uid}' has been defined multiple times in the same file", source);
-
-            public static Error UidConflict(string uid, IEnumerable<FilePath> conflicts)
-                => new Error(ErrorLevel.Warning, "uid-conflict", $"UID '{uid}' is defined in more than one file: {StringUtility.Join(conflicts)}");
+            public static Error DuplicateUid(SourceInfo<string> uid, IEnumerable<SourceInfo> conflicts)
+                => new Error(ErrorLevel.Warning, "duplicate-uid", $"UID '{uid}' is duplicated in {StringUtility.Join(conflicts)}", uid);
 
             /// <summary>
             /// Same uid defined within different versions with the different name.

--- a/src/docfx/build/metadata/UserMetadata.cs
+++ b/src/docfx/build/metadata/UserMetadata.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Docs.Build
         [JsonProperty("monikerRange")]
         public SourceInfo<string> MonikerRange { get; private set; } = new SourceInfo<string>("");
 
-        public string? Uid { get; private set; }
+        public SourceInfo<string> Uid { get; private set; } = new SourceInfo<string>("");
 
         [JsonProperty("_tocRel")]
         public string? TocRel { get; private set; }

--- a/src/docfx/build/toc/TableOfContentsLoader.cs
+++ b/src/docfx/build/toc/TableOfContentsLoader.cs
@@ -118,9 +118,7 @@ namespace Microsoft.Docs.Build
             var recursionDetector = t_recursionDetector.Value!;
             if (recursionDetector.Contains(file))
             {
-                var dependencyChain = recursionDetector.Reverse().ToList();
-                dependencyChain.Add(file);
-                throw Errors.Link.CircularReference(dependencyChain, file).ToException();
+                throw Errors.Link.CircularReference(new SourceInfo(file.FilePath, 1, 1), file, recursionDetector).ToException();
             }
 
             var (errors, model) = LoadTocModel(file.FilePath, content);

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Docs.Build
 
             var result =
                 from spec in builder.ToList()
-                group spec by spec.Uid into g
+                group spec by spec.Uid.Value into g
                 let uid = g.Key
                 let spec = AggregateXrefSpecs(context, uid, g.ToArray())
                 select (uid, spec);
@@ -118,11 +118,14 @@ namespace Microsoft.Docs.Build
 
             // multiple uid conflicts without moniker range definition
             // log an warning and take the first one order by the declaring file
-            var conflictsWithoutMoniker = specsWithSameUid.Where(item => item.Monikers.Count == 0).ToArray();
-            if (conflictsWithoutMoniker.Length > 1)
+            var duplicatedSpecs = specsWithSameUid.Where(item => item.Monikers.Count == 0).ToArray();
+            if (duplicatedSpecs.Length > 1)
             {
-                var orderedConflict = conflictsWithoutMoniker.OrderBy(item => item.DeclaringFile);
-                context.ErrorLog.Write(Errors.Xref.UidConflict(uid, orderedConflict.Select(x => x.DeclaringFile.FilePath)));
+                var duplicatedSources = (from spec in duplicatedSpecs where spec.Uid.Source != null select spec.Uid.Source).ToArray();
+                foreach (var spec in duplicatedSpecs)
+                {
+                    context.ErrorLog.Write(Errors.Xref.DuplicateUid(spec.Uid, duplicatedSources));
+                }
             }
 
             // uid conflicts with overlapping monikers

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -9,11 +9,11 @@ namespace Microsoft.Docs.Build
 {
     internal class InternalXrefSpec : IXrefSpec
     {
-        public string Uid { get; set; }
+        public SourceInfo<string> Uid { get; }
 
-        public string Href { get; set; }
+        public string Href { get; }
 
-        public Document DeclaringFile { get; set; }
+        public Document DeclaringFile { get; }
 
         public HashSet<string> Monikers { get; set; } = new HashSet<string>();
 
@@ -21,7 +21,9 @@ namespace Microsoft.Docs.Build
 
         public Dictionary<string, JsonSchemaContentType> PropertyContentTypeMapping { get; } = new Dictionary<string, JsonSchemaContentType>();
 
-        public InternalXrefSpec(string uid, string href, Document declaringFile)
+        string IXrefSpec.Uid => Uid.Value;
+
+        public InternalXrefSpec(SourceInfo<string> uid, string href, Document declaringFile)
         {
             Uid = uid;
             Href = href;

--- a/src/docfx/lib/log/SourceInfo.cs
+++ b/src/docfx/lib/log/SourceInfo.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Docs.Build
 
         public override string ToString()
         {
-            return Line == 0 && Column == 0 ? File.ToString() : $"{File}({Line},{Column})";
+            return Line <= 1 && Column <= 1 ? File.ToString() : $"{File}({Line},{Column})";
         }
 
         public int CompareTo(SourceInfo other)


### PR DESCRIPTION
Consolidate 2 phase duplicate uid detection into single phase duplicate uid detection by using source info as uid identifier.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5633)