### PR TITLE
Update to latest FSharp.Compiler.Service

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,5 +9,6 @@
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
     <add key="netcore" value="https://dotnet.myget.org/F/dotnet-core/" />
     <add key="msbuild" value="https://dotnet.myget.org/F/msbuild/api/v2/" />
+    <add key="fsharp" value ="https://dotnet.myget.org/F/fsharp/api/v2/" />
   </packageSources>
 </configuration>

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp/FSharpProject.fs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp/FSharpProject.fs
@@ -5,7 +5,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference.FSharp
 
 open System.IO
 open System.Collections.Generic
-open Microsoft.FSharp.Compiler.SourceCodeServices
+open FSharp.Compiler.SourceCodeServices
 open Microsoft.DocAsCode.Metadata.ManagedReference
 
 

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.fsproj
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.fsproj
@@ -27,8 +27,8 @@
 
   <ItemGroup>
     <PackageReference Include="Dotnet.ProjInfo" version="0.9.0" />
-    <PackageReference Include="FSharp.Compiler.Service" version="17.0.1" />
-    <PackageReference Include="FSharp.Compiler.Service.MSBuild.v12" version="17.0.1" />
+    <PackageReference Include="FSharp.Compiler.Service" version="34.1.1" />
+    <PackageReference Include="FSharp.Compiler.Service.MSBuild.v12" version="34.1.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net472'">

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.Tests/FSharpCompilationTests.fs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.Tests/FSharpCompilationTests.fs
@@ -8,7 +8,7 @@ open System.IO
 open System.Collections.Generic
 open Xunit
 open Xunit.Abstractions
-open Microsoft.FSharp.Compiler.SourceCodeServices
+open FSharp.Compiler.SourceCodeServices
 
 open Microsoft.DocAsCode.Metadata.ManagedReference
 open Microsoft.DocAsCode.Metadata.ManagedReference.FSharp

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.Tests/FSharpCompilationTests.fs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.Tests/FSharpCompilationTests.fs
@@ -219,8 +219,7 @@ type FSharpCompilationTests (output: ITestOutputHelper) =
         printfn "func: %s" (metadataItemString md)        
 
         Assert.Equal (md.Name, "NetCoreProject.Module1.Func2(string -> int)")
-        // TODO: F# compiler returns wrong CommentId without module.
-        Assert.Equal (md.CommentId, "M:NetCoreProject.Func2(System.String,System.Int32)") 
+        Assert.Equal (md.CommentId, "M:NetCoreProject.Module1.Func2(System.String,System.Int32)")
         Assert.Equal (md.Language, SyntaxLanguage.FSharp)
         Assert.Equal (md.DisplayNames.[SyntaxLanguage.FSharp], "val Func2: string -> int -> string * int option")
         Assert.Equal (md.DisplayNamesWithType.[SyntaxLanguage.FSharp], "val Module1.Func2: string -> int -> string * int option")

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.Tests/FSharpProjectTests.fs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.Tests/FSharpProjectTests.fs
@@ -7,7 +7,7 @@ open System.IO
 open System.Collections.Generic
 open Xunit
 open Xunit.Abstractions
-open Microsoft.FSharp.Compiler.SourceCodeServices
+open FSharp.Compiler.SourceCodeServices
 
 open Microsoft.DocAsCode.Metadata.ManagedReference
 open Microsoft.DocAsCode.Metadata.ManagedReference.FSharp

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.Tests/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.Tests.fsproj
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.Tests/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.Tests.fsproj
@@ -36,8 +36,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Compiler.Service" version="17.0.1" />
-    <PackageReference Include="FSharp.Compiler.Service.MSBuild.v12" version="17.0.1" />
+    <PackageReference Include="FSharp.Compiler.Service" version="34.1.1" />
+    <PackageReference Include="FSharp.Compiler.Service.MSBuild.v12" version="34.1.1" />
     <PackageReference Update="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 

--- a/test/docfx.Tests/app.config
+++ b/test/docfx.Tests/app.config
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.1.0.0" newVersion="15.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Conversion.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.1.0.0" newVersion="15.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Engine" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.1.0.0" newVersion="15.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.1.0.0" newVersion="15.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Tasks.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.1.0.0" newVersion="15.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Utilities.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.1.0.0" newVersion="15.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
- There don't appear to be any changes in FCS API semantics, only changes to names (and removal of the `Microsoft.` namespace prefix), so this was a straightforward edit.
- FCS factored some dependencies out into a new `FSharp.Compiler.Service.MSBuild.v12.0` package which is hosted on a `myget` feed, so this feed needed to be added to the `NuGet.Config` file.

#3679

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5637)