### PR TITLE
Fix xref property cache not caching in all cases

### DIFF
--- a/src/docfx/lib/schema/JsonSchema.cs
+++ b/src/docfx/lib/schema/JsonSchema.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Properties that are built into xref map
         /// </summary>
-        public string[] XrefProperties { get; set; } = Array.Empty<string>();
+        public HashSet<string> XrefProperties { get; } = new HashSet<string>();
 
         // JSON schema metadata validation extensions
         //-------------------------------------------


### PR DESCRIPTION
If the SDP page is build first, xref property cache does not work. Thanks to @mingwli 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5638)