### PR TITLE
InternalUidNotFound should NOT be shown as system error

### DIFF
--- a/src/Microsoft.DocAsCode.Build.UniversalReference/UniversalReferenceDocumentProcessor.cs
+++ b/src/Microsoft.DocAsCode.Build.UniversalReference/UniversalReferenceDocumentProcessor.cs
@@ -117,7 +117,7 @@ namespace Microsoft.DocAsCode.Build.UniversalReference
             }
             catch (DocumentException de)
             {
-                Logger.LogError(de.Message, de.Code ?? ErrorCodes.Build.DocumentError);
+                Logger.LogError(de.Message, code: de.Code ?? ErrorCodes.Build.DocumentError);
                 throw;
             }
             catch (Exception e)


### PR DESCRIPTION
Sample report with issue: https://opbuildstoragesandbox2.blob.core.windows.net/report/2020%5C3%5C20%5C926cc3a8-16de-e49d-0a13-85c9fdf37902%5CPullRequest%5C202003200230189728-1%5Cworkflow_report.html?sv=2016-05-31&sr=b&sig=nGJLTClG0wjvwm5n2jT8JU1hgKiPm9eQOishTCJEhK8%3D&st=2020-03-20T02%3A26%3A27Z&se=2020-04-20T02%3A31%3A27Z&sp=r

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5644)