### PR TITLE
Restore dependencies in parallel for implicity restore

### DIFF
--- a/docs/specs/config.yml
+++ b/docs/specs/config.yml
@@ -515,7 +515,6 @@ outputs:
     { "conceptual": "<p>live1</p>" }
 ---
 # Throw error for OPS repos that are not provisioned
-build: false
 repos:
   https://github.com/ops/provision:
   - files:
@@ -532,6 +531,7 @@ environments:
   - DOCS_OPS_TOKEN
 outputs:
   .errors.log: |
+    ["warning","docset-not-provisioned","*"]
     ["warning","docset-not-provisioned","*"]
 ---
 # JSON file as resource

--- a/docs/specs/git.yml
+++ b/docs/specs/git.yml
@@ -407,7 +407,6 @@ repos:
 outputs:
   .errors.log: |
     ["error","committish-not-found","Can't find branch, tag, or commit 'live' for repo *"]
-    ["error","committish-not-found","Can't find branch, tag, or commit 'live' for repo *"]
 ---
 # Use current repo's branch when edit branch isn't specified in contribution config,
 # and contribution config's repository equals to current repo's

--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -74,7 +74,6 @@ outputs:
     { "conceptual": "<p><a href=\"https://docs.microsoft.com/en-us/dotnet/api/system.string\">String</a></p>" }
 ---
 # Restore empty files
-build: false
 inputs:
   docfx.yml: |
     extend: config.json
@@ -102,7 +101,6 @@ outputs:
     {"conceptual":"<p><a href=\"%7E/docfx-test-dependencies1/docs/a.md\">link to 1</a></p>\n<p>d</p>\n"}
 ---
 # Show error when download failed
-build: false
 inputs:
   docfx.yml: |
     extend: https://this-url-does-not-exit.com/this-is-a-bad-url
@@ -118,10 +116,9 @@ inputs:
 outputs:
   .errors.log: |
     ["error","committish-not-found","Can't find branch, tag, or commit 'bad-branch' for repo https://github.com/docascode/docfx-test-dependencies."]
-    ["error","need-restore","Cannot find dependency 'https://github.com/docascode/docfx-test-dependencies#bad-branch', did you forget to run `docfx restore`?"]
 ---
 # Show error when dependent repo can't be found
-restore: false
+noRestore: true
 inputs:
   docfx.yml: |
     dependencies:
@@ -133,7 +130,7 @@ outputs:
     ["error","need-restore","Cannot find dependency 'https://github.com/docascode/docfx-test-dependencies#bad-branch', did you forget to run `docfx restore`?"]
 ---
 # Show error when dependent URL can't be found
-restore: false
+noRestore: true
 inputs:
   docfx.yml: |
     monikerDefinition: https://docs.microsoft.com/bad-url

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Docs.Build
                 var configLoader = new ConfigLoader(repository, errorLog);
                 (errors, config) = configLoader.Load(docsetPath, locale, options);
                 if (errorLog.Write(errors))
-                    return false;
+                    return true;
 
                 using var packageResolver = new PackageResolver(docsetPath, config, options.FetchOptions);
                 var localizationProvider = new LocalizationProvider(packageResolver, config, locale, docsetPath, repository);
@@ -71,7 +71,7 @@ namespace Microsoft.Docs.Build
                 // run build based on docsets
                 outputPath ??= Path.Combine(docsetPath, config.OutputPath);
                 Run(config, docset, fallbackDocset, options, errorLog, outputPath, input, repositoryProvider, localizationProvider, packageResolver);
-                return true;
+                return false;
             }
             catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
             {

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -25,6 +25,12 @@ namespace Microsoft.Docs.Build
             var hasError = false;
             Parallel.ForEach(docsets, docset =>
             {
+                if (!options.NoRestore && Restore.RestoreDocset(docset.docsetPath, docset.outputPath, options))
+                {
+                    hasError = true;
+                    return;
+                }
+
                 if (BuildDocset(docset.docsetPath, docset.outputPath, options))
                 {
                     hasError = true;
@@ -69,8 +75,7 @@ namespace Microsoft.Docs.Build
             }
             catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
             {
-                errorLog.Write(dex);
-                return false;
+                return errorLog.Write(dex);
             }
             finally
             {

--- a/src/docfx/cli/CommandLineOptions.cs
+++ b/src/docfx/cli/CommandLineOptions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Docs.Build
 
         public FetchOptions FetchOptions => NoRestore
             ? FetchOptions.NoFetch
-            : (UseCache ? FetchOptions.UseCache : FetchOptions.None);
+            : (UseCache ? FetchOptions.UseCache : FetchOptions.Latest);
 
         public JObject ToJObject()
         {

--- a/src/docfx/cli/Docfx.cs
+++ b/src/docfx/cli/Docfx.cs
@@ -11,7 +11,6 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Web;
 using Newtonsoft.Json.Linq;
 
@@ -74,14 +73,12 @@ namespace Microsoft.Docs.Build
                 var minThreads = Math.Max(32, Environment.ProcessorCount * 4);
                 ThreadPool.SetMinThreads(minThreads, minThreads);
 
-                switch (command)
+                return command switch
                 {
-                    case "restore":
-                        return Restore.Run(workingDirectory, options);
-                    case "build":
-                        return Build.Run(workingDirectory, options);
-                }
-                return 0;
+                    "restore" => Restore.Run(workingDirectory, options),
+                    "build" => Build.Run(workingDirectory, options),
+                    _ => 0,
+                };
             }
         }
 

--- a/src/docfx/config/TestQuirks.cs
+++ b/src/docfx/config/TestQuirks.cs
@@ -13,8 +13,6 @@ namespace Microsoft.Docs.Build
 
         public static Func<string, string>? GitRemoteProxy { get; set; }
 
-        public static Func<bool>? RestoreUseCache { get; set; }
-
         public static bool? Verbose { get; set; }
     }
 }

--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -141,11 +141,11 @@ namespace Microsoft.Docs.Build
             }
             return environment switch
             {
-                    DocsEnvironment.Prod => "https://op-build-prod.azurewebsites.net",
-                    DocsEnvironment.PPE => "https://op-build-sandbox2.azurewebsites.net",
-                    DocsEnvironment.Internal => "https://op-build-internal.azurewebsites.net",
-                    DocsEnvironment.Perf => "https://op-build-perf.azurewebsites.net",
-                    _ => throw new NotSupportedException()
+                DocsEnvironment.Prod => "https://op-build-prod.azurewebsites.net",
+                DocsEnvironment.PPE => "https://op-build-sandbox2.azurewebsites.net",
+                DocsEnvironment.Internal => "https://op-build-internal.azurewebsites.net",
+                DocsEnvironment.Perf => "https://op-build-perf.azurewebsites.net",
+                _ => throw new NotSupportedException()
             };
         }
 
@@ -259,42 +259,38 @@ namespace Microsoft.Docs.Build
 
         private static string GetHostName(string siteName)
         {
-            switch (siteName)
+            return siteName switch
             {
-                case "DocsAzureCN":
-                    return s_docsEnvironment switch
-                    {
-                        DocsEnvironment.Prod => "docs.azure.cn",
-                        DocsEnvironment.PPE => "ppe.docs.azure.cn",
-                        DocsEnvironment.Internal => "ppe.docs.azure.cn",
-                        DocsEnvironment.Perf => "ppe.docs.azure.cn",
-                        _ => throw new NotSupportedException()
-                    };
-                case "dev.microsoft.com":
-                    return s_docsEnvironment switch
-                    {
-                        DocsEnvironment.Prod => "developer.microsoft.com",
-                        DocsEnvironment.PPE => "devmsft-sandbox.azurewebsites.net",
-                        DocsEnvironment.Internal => "devmsft-sandbox.azurewebsites.net",
-                        DocsEnvironment.Perf => "devmsft-sandbox.azurewebsites.net",
-                        _ => throw new NotSupportedException()
-                    };
-                case "rd.microsoft.com":
-                    return s_docsEnvironment switch
-                    {
-                        DocsEnvironment.Prod => "rd.microsoft.com",
-                        _ => throw new NotSupportedException()
-                    };
-                default:
-                    return s_docsEnvironment switch
-                    {
-                        DocsEnvironment.Prod => "docs.microsoft.com",
-                        DocsEnvironment.PPE => "ppe.docs.microsoft.com",
-                        DocsEnvironment.Internal => "ppe.docs.microsoft.com",
-                        DocsEnvironment.Perf => "ppe.docs.microsoft.com",
-                        _ => throw new NotSupportedException()
-                    };
-            }
+                "DocsAzureCN" => s_docsEnvironment switch
+                {
+                    DocsEnvironment.Prod => "docs.azure.cn",
+                    DocsEnvironment.PPE => "ppe.docs.azure.cn",
+                    DocsEnvironment.Internal => "ppe.docs.azure.cn",
+                    DocsEnvironment.Perf => "ppe.docs.azure.cn",
+                    _ => throw new NotSupportedException()
+                },
+                "dev.microsoft.com" => s_docsEnvironment switch
+                {
+                    DocsEnvironment.Prod => "developer.microsoft.com",
+                    DocsEnvironment.PPE => "devmsft-sandbox.azurewebsites.net",
+                    DocsEnvironment.Internal => "devmsft-sandbox.azurewebsites.net",
+                    DocsEnvironment.Perf => "devmsft-sandbox.azurewebsites.net",
+                    _ => throw new NotSupportedException()
+                },
+                "rd.microsoft.com" => s_docsEnvironment switch
+                {
+                    DocsEnvironment.Prod => "rd.microsoft.com",
+                    _ => throw new NotSupportedException()
+                },
+                _ => s_docsEnvironment switch
+                {
+                    DocsEnvironment.Prod => "docs.microsoft.com",
+                    DocsEnvironment.PPE => "ppe.docs.microsoft.com",
+                    DocsEnvironment.Internal => "ppe.docs.microsoft.com",
+                    DocsEnvironment.Perf => "ppe.docs.microsoft.com",
+                    _ => throw new NotSupportedException()
+                },
+            };
         }
 
         private static string GetXrefHostName(string siteName, string branch)

--- a/src/docfx/restore/FetchOptions.cs
+++ b/src/docfx/restore/FetchOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Default restore option: Always fetch the latest content, without reading from disk cache.
         /// </summary>
-        None = 0,
+        Latest = 0,
 
         /// <summary>
         /// Do not restore dependencies, throw `need-restore` when encounter missing dependencies.

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -13,8 +13,6 @@ namespace Microsoft.Docs.Build
     {
         public static int Run(string workingDirectory, CommandLineOptions options)
         {
-            options.UseCache = TestQuirks.RestoreUseCache?.Invoke() ?? options.UseCache;
-
             var docsets = ConfigLoader.FindDocsets(workingDirectory, options);
             if (docsets.Length == 0)
             {
@@ -33,7 +31,7 @@ namespace Microsoft.Docs.Build
             return hasError ? 1 : 0;
         }
 
-        private static bool RestoreDocset(string docsetPath, string? outputPath, CommandLineOptions options)
+        public static bool RestoreDocset(string docsetPath, string? outputPath, CommandLineOptions options)
         {
             List<Error> errors;
             Config? config = null;

--- a/test/docfx.Test/DocfxTestSpec.cs
+++ b/test/docfx.Test/DocfxTestSpec.cs
@@ -13,11 +13,9 @@ namespace Microsoft.Docs.Build
 
         public string Cwd { get; set; }
 
-        public bool Restore { get; set; } = true;
-
-        public bool Build { get; set; } = true;
-
         public bool NoDryRun { get; set; }
+
+        public bool NoRestore { get; set; }
 
         public bool Legacy { get; set; }
 


### PR DESCRIPTION
The current implementation of implicit restore is restore on demand, while this has the benefit of only download content when needed, the dependencies are downloaded sequentially. Running `docfx build` against a new repo takes a lot longer.

This PR changes implicit restore to call `docfx restore` instead, allowing more parallelism and speed up things significantly.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5647)