### PR TITLE
Fix statictoc in Edge and IE

### DIFF
--- a/src/docfx.website.themes/default/styles/docfx.js
+++ b/src/docfx.website.themes/default/styles/docfx.js
@@ -447,7 +447,11 @@ $(function () {
         var val = this.value;
         //Save filter string to local session storage
         if (typeof(Storage) !== "undefined") {
-          sessionStorage.filterString = val;
+          try {
+            sessionStorage.filterString = val;
+            }
+          catch(e)
+            {}
         }
         if (val === '') {
           // Clear 'filtered' class
@@ -514,14 +518,22 @@ $(function () {
         tocFilterInput.val("");
         tocFilterInput.trigger('input');
         if (typeof(Storage) !== "undefined") {
-          sessionStorage.filterString = "";
+          try {
+            sessionStorage.filterString = "";
+            }
+          catch(e)
+            {}
         }
       });
 
       //Set toc filter from local session storage on page load
       if (typeof(Storage) !== "undefined") {
-        tocFilterInput.val(sessionStorage.filterString);
-        tocFilterInput.trigger('input');
+        try {
+          tocFilterInput.val(sessionStorage.filterString);
+          tocFilterInput.trigger('input');
+          }
+        catch(e)
+          {}
       }
     }
 


### PR DESCRIPTION
If you build with statictoc then the table of contents won't work properly in Edge and IE. The filter box is broken and when you click on a different page the TOC loses its place (i.e., the books all collapse and don't re-expand).  This is because of this line:

`if (typeof(Storage) !== "undefined")`

This is not a valid check in Edge because even if DOM is disabled, `typeof(Storage) `always returns "function" (even if `sessionStorage` doesn't exist). Hence, the calls to `sessionStorage` throw an exception and the subsequent TOC code doesn't run.

This patch wraps calls to `sessionStorage `in try blocks to prevent the exceptions that break the TOC in Edge/IE.  Works fine in Edget/IE/Chrome/Firefox after applying this patch.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5651)