### PR TITLE
Support escape in title of markdown TOC file

### DIFF
--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -11,6 +11,7 @@ inputs:
     ### [Reference Normal File 3](f1/n1.md?branch=master)
     ### [Reference Normal File 4](~/docs/n1.md)
     ### [@Reference Normal File 5](n1.md)
+    ### [Title with escape '\]'](n1.md)
   docs/index.md:
   docs/n1.md:
   docs/f1/n1.md:
@@ -42,9 +43,13 @@ outputs:
                         "name":"Reference Normal File 4",
                         "href":"n1"
                       },
-                      {  
+                      {
                         "name":"@Reference Normal File 5",
                         "href":"n1"
+                      },
+                      {
+                        "name": "Title with escape ']'",
+                        "href": "n1"
                       }
                   ],
                   "name":"Existing File Reference"

--- a/src/docfx/lib/markdown/MarkdownEngine.cs
+++ b/src/docfx/lib/markdown/MarkdownEngine.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Docs.Build
                 parser is HeadingBlockParser || parser is ParagraphBlockParser ||
                 parser is ThematicBreakParser || parser is HtmlBlockParser));
 
-            builder.InlineParsers.RemoveAll(parser => !(parser is LinkInlineParser));
+            builder.InlineParsers.RemoveAll(parser => !(parser is LinkInlineParser || parser is EscapeInlineParser));
 
             builder.BlockParsers.Find<HeadingBlockParser>().MaxLeadingCount = int.MaxValue;
 


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5654)