### PR TITLE
Remove \r in ResolveContent

### DIFF
--- a/src/docfx/lib/HtmlUtility.cs
+++ b/src/docfx/lib/HtmlUtility.cs
@@ -391,7 +391,7 @@ namespace Microsoft.Docs.Build
 
             foreach (var ch in text)
             {
-                if (ch == ' ' || ch == '\t' || ch == '\n')
+                if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r')
                 {
                     if (word)
                     {

--- a/src/docfx/lib/markdown/MarkdownEngine.cs
+++ b/src/docfx/lib/markdown/MarkdownEngine.cs
@@ -157,12 +157,12 @@ namespace Microsoft.Docs.Build
             t_status.Value!.Peek().Errors.Add(new Error(ErrorLevel.Suggestion, code, message, origin.ToSourceInfo(line)));
         }
 
-        private (string content, object? file) ReadFile(string path, object relativeTo, MarkdownObject origin)
+        private (string? content, object? file) ReadFile(string path, object relativeTo, MarkdownObject origin)
         {
             var status = t_status.Value!.Peek();
             var (error, content, file) = _linkResolver.ResolveContent(new SourceInfo<string>(path, origin.ToSourceInfo()), (Document)relativeTo);
             status.Errors.AddIfNotNull(error);
-            return (content, file);
+            return (content?.Replace("\r", ""), file);
         }
 
         private string GetLink(SourceInfo<string> href)


### PR DESCRIPTION
Fixes `\r` diff seen in code snippet

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5677)