### PR TITLE
Sdp xref href relative resolve

### DIFF
--- a/docs/specs/template.yml
+++ b/docs/specs/template.yml
@@ -330,22 +330,22 @@ inputs:
 outputs:
   uid-resolve.mta.json:
   uid-resolve.raw.page.json: |
-    {"content": "<p> <a href=\"uid1\" data-linktype=\"relative-path\"> uid1-name </a> </p> "}
+    {"content": "<p> <a href=\"/en-us/uid1\" data-linktype=\"absolute-path\"> uid1-name </a> </p> "}
   uid-unresolve.mta.json:
   uid-unresolve.raw.page.json: |
     {"content": "<p> <span> unresolve </span> </p>"}
   uid-partial-resolve.mta.json:
   uid-partial-resolve.raw.page.json: |
-    {"content": "<p> <a href=\"uid1\" class=\"partial\" data-linktype=\"relative-path\"> uid1-name </a> </p>"}
+    {"content": "<p> <a href=\"/en-us/uid1\" class=\"partial\" data-linktype=\"absolute-path\"> uid1-name </a> </p>"}
   uid-partial-unresolve.mta.json:
   uid-partial-unresolve.raw.page.json: |
     {"content": "<p> <span> unresolve </span> </p>"}
   uid-list.mta.json:
   uid-list.raw.page.json: |
-    {"content": "<p> <a href=\"uid1\" data-linktype=\"relative-path\"> uid1-name </a> <span> unresolve </span> <a href=\"https://docfx.com/uid2\" data-linktype=\"external\"> uid2 </a> </p> "}
+    {"content": "<p> <a href=\"/en-us/uid1\" data-linktype=\"absolute-path\"> uid1-name </a> <span> unresolve </span> <a href=\"https://docfx.com/uid2\" data-linktype=\"external\"> uid2 </a> </p> "}
   uid-list-partial.mta.json:
   uid-list-partial.raw.page.json: |
-    {"content": "<p> <a href=\"uid1\" class=\"partial\" data-linktype=\"relative-path\"> uid1-name </a> <span> unresolve </span> <a href=\"https://docfx.com/uid2\" class=\"partial\" data-linktype=\"external\"> uid2 </a> </p> "}
+    {"content": "<p> <a href=\"/en-us/uid1\" class=\"partial\" data-linktype=\"absolute-path\"> uid1-name </a> <span> unresolve </span> <a href=\"https://docfx.com/uid2\" class=\"partial\" data-linktype=\"external\"> uid2 </a> </p> "}
   .errors.log: |
     {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'unresolve'","file":"uid-list.yml","line":4,"end_line":4,"column":5,"end_column":14}
     {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'unresolve'","file":"uid-list-partial.yml","line":4,"end_line":4,"column":5,"end_column":14}

--- a/docs/specs/template.yml
+++ b/docs/specs/template.yml
@@ -260,7 +260,7 @@ inputs:
         name: uid1-name
         href: https://docs.com/uid1
       - uid: uid2
-        href: https://docs.com/uid2
+        href: https://docfx.com/uid2
     
   _themes/ContentTemplate/schemas/TestPage.schema.json: |
     {
@@ -330,22 +330,22 @@ inputs:
 outputs:
   uid-resolve.mta.json:
   uid-resolve.raw.page.json: |
-    {"content": "<p> <a href=\"https://docs.com/uid1\" data-linktype=\"external\"> uid1-name </a> </p> "}
+    {"content": "<p> <a href=\"uid1\" data-linktype=\"relative-path\"> uid1-name </a> </p> "}
   uid-unresolve.mta.json:
   uid-unresolve.raw.page.json: |
     {"content": "<p> <span> unresolve </span> </p>"}
   uid-partial-resolve.mta.json:
   uid-partial-resolve.raw.page.json: |
-    {"content": "<p> <a href=\"https://docs.com/uid1\" class=\"partial\" data-linktype=\"external\"> uid1-name </a> </p>"}
+    {"content": "<p> <a href=\"uid1\" class=\"partial\" data-linktype=\"relative-path\"> uid1-name </a> </p>"}
   uid-partial-unresolve.mta.json:
   uid-partial-unresolve.raw.page.json: |
     {"content": "<p> <span> unresolve </span> </p>"}
   uid-list.mta.json:
   uid-list.raw.page.json: |
-    {"content": "<p> <a href=\"https://docs.com/uid1\" data-linktype=\"external\"> uid1-name </a> <span> unresolve </span> <a href=\"https://docs.com/uid2\" data-linktype=\"external\"> uid2 </a> </p> "}
+    {"content": "<p> <a href=\"uid1\" data-linktype=\"relative-path\"> uid1-name </a> <span> unresolve </span> <a href=\"https://docfx.com/uid2\" data-linktype=\"external\"> uid2 </a> </p> "}
   uid-list-partial.mta.json:
   uid-list-partial.raw.page.json: |
-    {"content": "<p> <a href=\"https://docs.com/uid1\" class=\"partial\" data-linktype=\"external\"> uid1-name </a> <span> unresolve </span> <a href=\"https://docs.com/uid2\" class=\"partial\" data-linktype=\"external\"> uid2 </a> </p> "}
+    {"content": "<p> <a href=\"uid1\" class=\"partial\" data-linktype=\"relative-path\"> uid1-name </a> <span> unresolve </span> <a href=\"https://docfx.com/uid2\" class=\"partial\" data-linktype=\"external\"> uid2 </a> </p> "}
   .errors.log: |
     {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'unresolve'","file":"uid-list.yml","line":4,"end_line":4,"column":5,"end_column":14}
     {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'unresolve'","file":"uid-list-partial.yml","line":4,"end_line":4,"column":5,"end_column":14}

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -346,7 +346,7 @@ repos:
             "fullName": "test.test",
             "description": "a.description"
           }
-        docs/b.json: | 
+        docs/f1/f2/b.json: | 
           {
             "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TestData.json",
             "xref": "a"
@@ -364,11 +364,11 @@ repos:
           }
 outputs:
   docs/a.json:
-  docs/b.json: | 
+  docs/f1/f2/b.json: | 
     {
       "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TestData.json",
       "xref": {
-          "href": "a.json",
+          "href": "../../a.json",
           "uid": "a",
           "name": "test",
           "fullName": "test.test",
@@ -380,7 +380,7 @@ outputs:
   .dependencymap.json: |
     {
       "dependencies": {
-          "docs/b.json": [
+          "docs/f1/f2/b.json": [
               {
                   "source": "docs/a.json",
                   "type": "uidInclusion"

--- a/src/docfx/build/xref/ExternalXrefSpec.cs
+++ b/src/docfx/build/xref/ExternalXrefSpec.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Docs.Build
         public HashSet<string> Monikers { get; private set; } = new HashSet<string>();
 
         [JsonExtensionData]
-        public JObject ExtensionData { get; } = new JObject();
+        public JObject ExtensionData { get; private set; } = new JObject();
 
         public ExternalXrefSpec() { }
 
@@ -48,6 +48,10 @@ namespace Microsoft.Docs.Build
             return null;
         }
 
-        public ExternalXrefSpec ToExternalXrefSpec(string? overwriteHref = null) => this;
+        public ExternalXrefSpec ToExternalXrefSpec(string? overwriteHref = null) =>
+            new ExternalXrefSpec(Name, Uid, overwriteHref ?? Href, Monikers)
+            {
+                ExtensionData = ExtensionData,
+            };
     }
 }

--- a/src/docfx/build/xref/ExternalXrefSpec.cs
+++ b/src/docfx/build/xref/ExternalXrefSpec.cs
@@ -11,9 +11,9 @@ namespace Microsoft.Docs.Build
     {
         private string? _name;
 
-        public string Uid { get; set; } = "";
+        public string Uid { get; private set; } = "";
 
-        public string Href { get; set; } = "";
+        public string Href { get; private set; } = "";
 
         public string Name
         {
@@ -24,10 +24,20 @@ namespace Microsoft.Docs.Build
         Document? IXrefSpec.DeclaringFile => null;
 
         [JsonIgnore]
-        public HashSet<string> Monikers { get; set; } = new HashSet<string>();
+        public HashSet<string> Monikers { get; private set; } = new HashSet<string>();
 
         [JsonExtensionData]
         public JObject ExtensionData { get; } = new JObject();
+
+        public ExternalXrefSpec() { }
+
+        public ExternalXrefSpec(string? name, string uid, string href, HashSet<string> monikers)
+        {
+            _name = name;
+            Uid = uid;
+            Href = href;
+            Monikers = monikers;
+        }
 
         public string? GetXrefPropertyValueAsString(string propertyName)
         {
@@ -38,6 +48,6 @@ namespace Microsoft.Docs.Build
             return null;
         }
 
-        public ExternalXrefSpec ToExternalXrefSpec() => this;
+        public ExternalXrefSpec ToExternalXrefSpec(string? overwriteHref = null) => this;
     }
 }

--- a/src/docfx/build/xref/IXrefSpec.cs
+++ b/src/docfx/build/xref/IXrefSpec.cs
@@ -19,6 +19,6 @@ namespace Microsoft.Docs.Build
 
         string? GetXrefPropertyValueAsString(string propertyName);
 
-        ExternalXrefSpec ToExternalXrefSpec();
+        ExternalXrefSpec ToExternalXrefSpec(string? overwriteHref = null);
     }
 }

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -35,15 +35,9 @@ namespace Microsoft.Docs.Build
             return XrefProperties.TryGetValue(propertyName, out var property) && property.Value is JValue propertyValue && propertyValue.Value is string internalStr ? internalStr : null;
         }
 
-        public ExternalXrefSpec ToExternalXrefSpec()
+        public ExternalXrefSpec ToExternalXrefSpec(string? overwriteHref = null)
         {
-            var spec = new ExternalXrefSpec
-            {
-                Href = Href,
-                Uid = Uid,
-                Monikers = Monikers,
-                Name = Name,
-            };
+            var spec = new ExternalXrefSpec(Name, Uid, overwriteHref ?? Href, Monikers);
 
             foreach (var (key, value) in XrefProperties)
             {

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Docs.Build
         {
             var spec = new ExternalXrefSpec
             {
-                Href = PathUtility.GetRelativePathToFile(DeclaringFile.SiteUrl, Href),
+                Href = Href,
                 Uid = Uid,
                 Monikers = Monikers,
                 Name = Name,

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Docs.Build
             }
 
             query = queries.AllKeys.Length == 0 ? "" : "?" + string.Join('&', queries);
-            var fileLink = UrlUtility.MergeUrl( xrefSpec.Href, query, fragment);
+            var fileLink = UrlUtility.MergeUrl(xrefSpec.Href, query, fragment);
             _fileLinkMapBuilder.AddFileLink(inclusionRoot.FilePath, inclusionRoot.SiteUrl, fileLink);
 
             resolvedHref = UrlUtility.MergeUrl(resolvedHref, query, fragment);

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Docs.Build
             queries.Remove("displayProperty");
 
             // need to url decode uid from input content
-            var (xrefError, xrefSpec, resolvedHref) = ResolveXrefSpec(new SourceInfo<string>(uid, href.Source), hrefRelativeTo, inclusionRoot);
+            var (xrefError, xrefSpec, resolvedHref) = ResolveXrefSpec(new SourceInfo<string>(uid, href.Source), inclusionRoot ?? hrefRelativeTo, writeFileLink: true);
             if (xrefError != null || xrefSpec is null || resolvedHref == null)
             {
                 return (xrefError, null, "", null);
@@ -84,7 +84,7 @@ namespace Microsoft.Docs.Build
             return (null, resolvedHref, display, xrefSpec?.DeclaringFile);
         }
 
-        public (Error?, IXrefSpec?, string? href) ResolveXrefSpec(SourceInfo<string> uid, Document referencingFile, Document? inclusionRoot = null)
+        public (Error?, IXrefSpec?, string? href) ResolveXrefSpec(SourceInfo<string> uid, Document referencingFile, bool writeFileLink = false)
         {
             var (error, xrefSpec) = Resolve(uid, referencingFile);
             if (xrefSpec == null)
@@ -92,10 +92,7 @@ namespace Microsoft.Docs.Build
 
             var href = RemoveSharingHost(xrefSpec.Href, _config.HostName);
 
-            // NOTE: this should also be relative to root file
-            // Using inclusionRoot to decide whether write link
-            referencingFile = inclusionRoot ?? referencingFile;
-            if (inclusionRoot != null)
+            if (writeFileLink)
                 _fileLinkMapBuilder.AddFileLink(referencingFile.FilePath, referencingFile.SiteUrl, href);
 
             if (xrefSpec?.DeclaringFile != null && referencingFile != null)

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Docs.Build
                 .OrderBy(xref => xref.Uid).ToArray();
 
             var model = new XrefMapModel { References = references };
-            if (basePath != null)
+            if (basePath != null && references.Length > 0)
             {
                 var properties = new XrefProperties();
                 properties.Tags.Add(basePath);

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -123,14 +123,14 @@ namespace Microsoft.Docs.Build
             var references = _internalXrefMap.Value.Values
                 .Select(xref =>
                 {
-                    var xrefSpec = xref.ToExternalXrefSpec();
-
                     // DHS appends branch infomation from cookie cache to URL, which is wrong for UID resolved URL
                     // output xref map with URL appending "?branch=master" for master branch
                     var (href, _, fragment) = UrlUtility.SplitUrl(xref.Href);
                     var path = $"https://{_xrefHostName}{href}";
                     var query = repositoryBranch == "master" ? "?branch=master" : "";
-                    xrefSpec.Href = UrlUtility.MergeUrl(path, query, fragment);
+                    href = UrlUtility.MergeUrl(path, query, fragment);
+
+                    var xrefSpec = xref.ToExternalXrefSpec(href);
                     return xrefSpec;
                 })
                 .OrderBy(xref => xref.Uid).ToArray();

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -76,18 +76,11 @@ namespace Microsoft.Docs.Build
                 queries["view"] = moniker;
             }
 
-            var fileLink = UrlUtility.MergeUrl(
-                xrefSpec.Href,
-                queries.AllKeys.Length == 0 ? "" : "?" + string.Join('&', queries),
-                fragment.Length == 0 ? "" : fragment);
-
+            query = queries.AllKeys.Length == 0 ? "" : "?" + string.Join('&', queries);
+            var fileLink = UrlUtility.MergeUrl( xrefSpec.Href, query, fragment);
             _fileLinkMapBuilder.AddFileLink(inclusionRoot.FilePath, inclusionRoot.SiteUrl, fileLink);
 
-            resolvedHref = UrlUtility.MergeUrl(
-                resolvedHref,
-                queries.AllKeys.Length == 0 ? "" : "?" + string.Join('&', queries),
-                fragment.Length == 0 ? "" : fragment);
-
+            resolvedHref = UrlUtility.MergeUrl(resolvedHref, query, fragment);
             return (null, resolvedHref, display, xrefSpec?.DeclaringFile);
         }
 

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -125,10 +125,8 @@ namespace Microsoft.Docs.Build
                 {
                     // DHS appends branch infomation from cookie cache to URL, which is wrong for UID resolved URL
                     // output xref map with URL appending "?branch=master" for master branch
-                    var (href, _, fragment) = UrlUtility.SplitUrl(xref.Href);
-                    var path = $"https://{_xrefHostName}{href}";
                     var query = repositoryBranch == "master" ? "?branch=master" : "";
-                    href = UrlUtility.MergeUrl(path, query, fragment);
+                    var href = UrlUtility.MergeUrl($"https://{_xrefHostName}{xref.Href}", query);
 
                     var xrefSpec = xref.ToExternalXrefSpec(href);
                     return xrefSpec;

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -93,25 +93,26 @@ namespace Microsoft.Docs.Build
             return (null, resolvedHref, display, xrefSpec?.DeclaringFile);
         }
 
-        public (Error?, ExternalXrefSpec?) ResolveXrefSpec(SourceInfo<string> uid, Document referencingFile)
+        public (Error?, ExternalXrefSpec?, string? href) ResolveXrefSpec(SourceInfo<string> uid, Document referencingFile)
         {
             var (error, xrefSpec) = Resolve(uid, referencingFile);
             if (xrefSpec == null)
-                return (error, null);
+                return (error, null, null);
 
             var externalXrefSpec = xrefSpec.ToExternalXrefSpec();
             var (href, _, fragment) = UrlUtility.SplitUrl(externalXrefSpec.Href);
             href = RemoveSharingHost(href, _config.HostName);
             if (UrlUtility.GetLinkType(href) != LinkType.External)
             {
-                href = PathUtility.GetRelativePathToFile(referencingFile.SiteUrl, href);
-                externalXrefSpec.Href = PathUtility.Normalize(UrlUtility.MergeUrl(href, "", fragment));
+                href = PathUtility.Normalize(
+                    UrlUtility.MergeUrl(PathUtility.GetRelativePathToFile(referencingFile.SiteUrl, href), "", fragment));
             }
             else
             {
-                externalXrefSpec.Href = UrlUtility.MergeUrl(href, "", fragment);
+                href = UrlUtility.MergeUrl(href, "", fragment);
             }
-            return (error, externalXrefSpec);
+
+            return (error, externalXrefSpec, href);
         }
 
         public XrefMapModel ToXrefMapModel()

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -231,9 +231,7 @@ namespace Microsoft.Docs.Build
 
                     if (xrefSpec != null)
                     {
-                        var specObj = JsonUtility.ToJObject(xrefSpec);
-                        if (!string.IsNullOrEmpty(href))
-                            specObj["href"] = href;
+                        var specObj = JsonUtility.ToJObject(xrefSpec.ToExternalXrefSpec(href));
                         JsonUtility.SetSourceInfo(specObj, content);
                         return (errors, specObj);
                     }

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Docs.Build
 
                 case JsonSchemaContentType.Xref:
                     // the content here must be an UID, not href
-                    var (xrefError, xrefSpec, href) = context.XrefResolver.ResolveXrefSpec(content, file);
+                    var (xrefError, xrefSpec, href) = context.XrefResolver.ResolveXrefSpec(content, file, file);
                     errors.AddIfNotNull(xrefError);
 
                     if (xrefSpec != null)

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using Newtonsoft.Json.Linq;
@@ -227,12 +226,14 @@ namespace Microsoft.Docs.Build
 
                 case JsonSchemaContentType.Xref:
                     // the content here must be an UID, not href
-                    var (xrefError, xrefSpec) = context.XrefResolver.ResolveXrefSpec(content, file);
+                    var (xrefError, xrefSpec, href) = context.XrefResolver.ResolveXrefSpec(content, file);
                     errors.AddIfNotNull(xrefError);
 
                     if (xrefSpec != null)
                     {
                         var specObj = JsonUtility.ToJObject(xrefSpec);
+                        if (!string.IsNullOrEmpty(href))
+                            specObj["href"] = href;
                         JsonUtility.SetSourceInfo(specObj, content);
                         return (errors, specObj);
                     }


### PR DESCRIPTION
[AB#192954](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/192954)

In SDP, referencing file is not taken considered during xref transform for calculating relative href.
Make external xrefSpec href private settable

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5689)