### PR TITLE
support v3 only validation rules in apex validation

### DIFF
--- a/docs/specs/validation.yml
+++ b/docs/specs/validation.yml
@@ -526,6 +526,9 @@ inputs:
               "landingPage",
               "hubPage",
               "toc"
+            ],
+            "excludedDocfxVersions": [
+              "v2"
             ]
           }
         ]

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="Stubble.Core" Version="1.6.3" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180503-2" />
-    <PackageReference Include="Validations.DocFx.Adapter" Version="1.2.21" />
+    <PackageReference Include="Validations.DocFx.Adapter" Version="1.2.22-beta004" />
     <PackageReference Include="YamlDotNet" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/docfx/lib/markdown/validation/ContentValidationContext.cs
+++ b/src/docfx/lib/markdown/validation/ContentValidationContext.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Docs.Build
         private const int ValidationRetryDelaySeconds = 3;
         private const int ValidationMaxTransientFailureCount = 20;
 
+        public string DocfxVersion { get; set; }
+
         public string MarkdownRulesFilePath { get; set; }
 
         public string? MetadataRulesFilePath { get; set; }
@@ -37,6 +39,7 @@ namespace Microsoft.Docs.Build
             RepositoryUrl = EnvironmentVariable.RepositoryUrl;
             Branch = EnvironmentVariable.RepositoryBranch;
             ApiBase = OpsConfigAdapter.ValidationServiceEndpoint;
+            DocfxVersion = "v3";
             RequestTimeout = TimeSpan.FromSeconds(ValidationRequestTimeoutInSeconds);
             MaxTries = ValidationMaxTries;
             RetryDelaySeconds = ValidationRetryDelaySeconds;


### PR DESCRIPTION
1. fix some bugs inside Apex.Validation.Adapter
2. pass current docfx version to Apex Validator to implement the v3 only rules

[AB#191629](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/191629)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5691)