### PR TITLE
Fix incorrect source info for duplicate value

### DIFF
--- a/docs/specs/validation.yml
+++ b/docs/specs/validation.yml
@@ -471,6 +471,29 @@ outputs:
   a.json:
   b.json:
 ---
+# Json schema docset unique: global metadata and file metadata
+inputs:
+  docfx.yml: |
+    metadataSchema:
+      - schema.json
+    globalMetadata:
+      description: abc
+  schema.json: |
+    {
+      "docsetUnique": ["description"]
+    }
+  a.md: |
+    ---
+    description: abc
+    ---
+  b.md:
+outputs:
+  a.json:
+  b.json:
+  .errors.log: |
+    ["suggestion","duplicate-attribute","Attribute 'description' with value 'abc' is duplicated in 'a.md(2,14)', 'docfx.yml(4,16)'","a.md",2,14]
+    ["suggestion","duplicate-attribute","Attribute 'description' with value 'abc' is duplicated in 'a.md(2,14)', 'docfx.yml(4,16)'","docfx.yml",4,16]
+---
 # Json schema length rule: the length of string must be in range of MinLength and MaxLength
 inputs:
   docfx.yml: |

--- a/src/docfx/build/metadata/MetadataProvider.cs
+++ b/src/docfx/build/metadata/MetadataProvider.cs
@@ -111,9 +111,7 @@ namespace Microsoft.Docs.Build
             {
                 if (glob(file.FilePath.Path))
                 {
-                    // Assign a JToken to a property erases line info, so clone here.
-                    // See https://github.com/JamesNK/Newtonsoft.Json/issues/2055
-                    fileMetadata[key] = JsonUtility.DeepClone(value);
+                    fileMetadata.SetProperty(key, value);
                 }
             }
             JsonUtility.Merge(result, fileMetadata);

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -233,7 +233,6 @@ namespace Microsoft.Docs.Build
                     if (xrefSpec != null)
                     {
                         var specObj = JsonUtility.ToJObject(xrefSpec);
-                        JsonUtility.SetSourceInfo(specObj, content);
                         return (errors, specObj);
                     }
 


### PR DESCRIPTION
[AB#194073](https://dev.azure.com/ceapex/Engineering/_workitems/edit/194073/)

There is a check on setting property in Json.NET that looks like:

```csharp
if (newValue == oldValue)
    return;
```

Thus, `Merge` does not set source info right when the new value is the same as the old one,  `duplicate-attribute` happens to hit this corner case...

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5692)