### PR TITLE
make moniker config nullable

### DIFF
--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -1604,7 +1604,7 @@ inputs:
     routes:
       docs/v1/: docs/
     monikerDefinition: monikerDefinition.json
-  docs/v1/TOC.md: |
+  docs/v1/q.md: |
     ---
     monikers: netcore-2.0
     ---
@@ -1617,8 +1617,8 @@ inputs:
       ]
     }
 outputs:
-  4667fedf/docs/toc.json: |
-    {"metadata":{"monikers":"netcore-2.0"}}
+  4667fedf/docs/q.json: |
+    {"monikers":["netcore-2.0"]}
 ---
 # User defined monikers should not outrange moniker range in config
 inputs:
@@ -1729,7 +1729,7 @@ inputs:
     routes:
       docs/v1/: docs/
     monikerDefinition: monikerDefinition.json
-  docs/v1/TOC.md: |
+  docs/v1/a.md: |
     ---
     monikers: netcore-1.0
     monikerRange:
@@ -1743,8 +1743,8 @@ inputs:
       ]
     }
 outputs:
-  136a42ac/docs/toc.json: |
-    {"metadata":{"monikers":"netcore-1.0"}}
+  136a42ac/docs/a.json: |
+    {"monikers":["netcore-1.0"]}
 ---
 # Should warn if user input monikers with array of empty items
 inputs:

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -1719,4 +1719,58 @@ outputs:
   .errors.log: |
     ["warning","duplicate-moniker-config","Both 'monikers' and 'monikerRange' are defined, 'monikers' is ignored","docs/v1/TOC.md",2,11]
     ["error","moniker-range-out-of-scope","No moniker intersection between docfx.yml/docfx.json and file metadata. Config moniker range '>= netcore-1.0' is 'netcore-1.0', 'netcore-2.0', while file moniker range '>netcore-1.0 <netcore-1.0' is ","docs/v1/TOC.md",3,15]
-
+---
+# Should take monikers as final monikers if user inputs empty string for monikerRange
+# and no duplicate-moniker-config warning
+inputs:
+  docfx.yml: |
+    monikerRange:
+      'docs/v1/**': '>= netcore-1.0'
+    routes:
+      docs/v1/: docs/
+    monikerDefinition: monikerDefinition.json
+  docs/v1/TOC.md: |
+    ---
+    monikers: netcore-1.0
+    monikerRange:
+    ---
+    # Node
+  monikerDefinition.json: |
+    {
+      "monikers": [
+        { "moniker_name": "netcore-1.0", "product_name": ".NET Core" },
+        { "moniker_name": "netcore-2.0", "product_name": ".NET Core" },
+      ]
+    }
+outputs:
+  136a42ac/docs/toc.json: |
+    {"metadata":{"monikers":"netcore-1.0"}}
+---
+# Should warn if user input monikers with array of empty items
+inputs:
+  docfx.yml: |
+    monikerRange:
+      'docs/v1/**': '>= netcore-1.0'
+    routes:
+      docs/v1/: docs/
+    monikerDefinition: monikerDefinition.json
+  docs/v1/TOC.md: |
+    ---
+    monikers:
+      -
+    monikerRange: < netcore-2.0
+    ---
+    # Node
+  monikerDefinition.json: |
+    {
+      "monikers": [
+        { "moniker_name": "netcore-1.0", "product_name": ".NET Core" },
+        { "moniker_name": "netcore-2.0", "product_name": ".NET Core" },
+      ]
+    }
+outputs:
+  136a42ac/docs/toc.json: |
+    {"metadata":{}}
+  .errors.log: |
+    ["warning","null-array-value","'monikers' contains null value, the null value has been removed","docs/v1/TOC.md",3,4]
+    ["warning","duplicate-moniker-config","Both 'monikers' and 'monikerRange' are defined, 'monikers' is ignored"]

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -445,7 +445,7 @@ namespace Microsoft.Docs.Build
             /// Failed to parse moniker string.
             /// </summary>
             /// Behavior: ✔️ Message: ❌
-            public static Error MonikerRangeInvalid(SourceInfo<string> source, Exception ex)
+            public static Error MonikerRangeInvalid(SourceInfo<string?> source, Exception ex)
                 => new Error(ErrorLevel.Error, "moniker-range-invalid", $"Invalid moniker range: '{source}': {ex.Message}", source);
 
             /// <summary>
@@ -461,13 +461,13 @@ namespace Microsoft.Docs.Build
             /// or moniker-zone defined in article.md has no intersection with file-level monikers.
             /// </summary>
             /// Behavior: ✔️ Message: ❌
-            public static Error MonikeRangeOutOfScope(SourceInfo<string> source, IReadOnlyList<string> zoneLevelMonikers, IReadOnlyList<string> fileLevelMonikers)
+            public static Error MonikeRangeOutOfScope(SourceInfo<string?> source, IReadOnlyList<string> zoneLevelMonikers, IReadOnlyList<string> fileLevelMonikers)
                 => new Error(ErrorLevel.Error, "moniker-range-out-of-scope", $"No intersection between zone and file level monikers. The result of zone level range string '{source}' is {StringUtility.Join(zoneLevelMonikers)}, while file level monikers is {StringUtility.Join(fileLevelMonikers)}.", source);
 
-            public static Error MonikeRangeOutOfScope(SourceInfo<string> configMonikerRange, IReadOnlyList<string> configMonikers, SourceInfo<string> monikerRange, IReadOnlyList<string> fileMonikers)
+            public static Error MonikeRangeOutOfScope(SourceInfo<string?> configMonikerRange, IReadOnlyList<string> configMonikers, SourceInfo<string?> monikerRange, IReadOnlyList<string> fileMonikers)
                 => new Error(ErrorLevel.Error, "moniker-range-out-of-scope", $"No moniker intersection between docfx.yml/docfx.json and file metadata. Config moniker range '{configMonikerRange}' is {StringUtility.Join(configMonikers)}, while file moniker range '{monikerRange}' is {StringUtility.Join(fileMonikers)}", monikerRange);
 
-            public static Error MonikeRangeOutOfScope(SourceInfo<string> configMonikerRange, IReadOnlyList<string> configMonikers, SourceInfo<string>[] monikers, IReadOnlyList<string> fileMonikers)
+            public static Error MonikeRangeOutOfScope(SourceInfo<string?> configMonikerRange, IReadOnlyList<string> configMonikers, SourceInfo<string?>[] monikers, IReadOnlyList<string> fileMonikers)
                 => new Error(ErrorLevel.Error, "moniker-range-out-of-scope", $"No moniker intersection between docfx.yml/docfx.json and file metadata. Config moniker range '{configMonikerRange}' is {StringUtility.Join(configMonikers)}, while file monikers is {StringUtility.Join(fileMonikers)}", monikers.FirstOrDefault());
         }
 

--- a/src/docfx/build/legacy/LegacyDependencyMapItem.cs
+++ b/src/docfx/build/legacy/LegacyDependencyMapItem.cs
@@ -9,11 +9,11 @@ namespace Microsoft.Docs.Build
 
         public string To { get; }
 
-        public string Version { get; }
+        public string? Version { get; }
 
         public LegacyDependencyMapType Type { get; }
 
-        public LegacyDependencyMapItem(string from, string to, string version, LegacyDependencyMapType type)
+        public LegacyDependencyMapItem(string from, string to, string? version, LegacyDependencyMapType type)
         {
             From = from;
             To = to;

--- a/src/docfx/build/legacy/LegacyFileMapItem.cs
+++ b/src/docfx/build/legacy/LegacyFileMapItem.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Docs.Build
         public string AssetId { get; set; }
 
         [JsonProperty(PropertyName = "version")]
-        public string Version { get; set; }
+        public string? Version { get; set; }
 
         [JsonProperty(PropertyName = "is_moniker_range")]
         public bool IsMonikerRange { get; set; } = true;
@@ -33,7 +33,7 @@ namespace Microsoft.Docs.Build
             string legacyOutputFilePathRelativeToBasePath,
             string legacySiteUrlRelativeToBasePath,
             ContentType contentType,
-            string version,
+            string? version,
             IReadOnlyList<string> monikers)
         {
             switch (contentType)
@@ -64,7 +64,7 @@ namespace Microsoft.Docs.Build
             string legacyOutputFilePathRelativeToBasePath,
             string legacySiteUrlRelativeToBasePath,
             ContentType contentType,
-            string version,
+            string? version,
             IReadOnlyList<string> monikers)
         {
             if (contentType == ContentType.TableOfContents || contentType == ContentType.Unknown)

--- a/src/docfx/build/metadata/UserMetadata.cs
+++ b/src/docfx/build/metadata/UserMetadata.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
@@ -18,10 +17,10 @@ namespace Microsoft.Docs.Build
         public SourceInfo<string> BreadcrumbPath { get; private set; } = new SourceInfo<string>("");
 
         [JsonProperty("monikerRange")]
-        public SourceInfo<string> MonikerRange { get; private set; } = new SourceInfo<string>("");
+        public SourceInfo<string?> MonikerRange { get; private set; }
 
         [JsonConverter(typeof(OneOrManyConverter))]
-        public SourceInfo<string>[] Monikers { get; private set; } = Array.Empty<SourceInfo<string>>();
+        public SourceInfo<string?>[]? Monikers { get; private set; }
 
         public SourceInfo<string> Uid { get; private set; } = new SourceInfo<string>("");
 

--- a/src/docfx/build/toc/TableOfContentsMetadata.cs
+++ b/src/docfx/build/toc/TableOfContentsMetadata.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Docs.Build
         [JsonProperty(PropertyName = "monikerRange")]
         public SourceInfo<string?> MonikerRange { get; private set; }
 
+        [JsonConverter(typeof(OneOrManyConverter))]
         public SourceInfo<string?>[]? Monikers { get; private set; }
 
         public string? PdfAbsolutePath { get; set; }

--- a/src/docfx/build/toc/TableOfContentsMetadata.cs
+++ b/src/docfx/build/toc/TableOfContentsMetadata.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
@@ -12,7 +11,9 @@ namespace Microsoft.Docs.Build
     internal class TableOfContentsMetadata
     {
         [JsonProperty(PropertyName = "monikerRange")]
-        public SourceInfo<string?> MonikerRange { get; set; }
+        public SourceInfo<string?> MonikerRange { get; private set; }
+
+        public SourceInfo<string?>[]? Monikers { get; private set; }
 
         public string? PdfAbsolutePath { get; set; }
 
@@ -20,5 +21,7 @@ namespace Microsoft.Docs.Build
         public JObject ExtensionData { get; } = new JObject();
 
         public bool ShouldSerializeMonikerRange() => false;
+
+        public bool ShouldSerializeMonikers() => false;
     }
 }

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Gets the moniker range mapping
         /// </summary>
-        public Dictionary<string, SourceInfo<string>> MonikerRange { get; } = new Dictionary<string, SourceInfo<string>>();
+        public Dictionary<string, SourceInfo<string?>> MonikerRange { get; } = new Dictionary<string, SourceInfo<string?>>();
 
         /// <summary>
         /// Get the definition of monikers

--- a/src/docfx/config/GroupConfig.cs
+++ b/src/docfx/config/GroupConfig.cs
@@ -9,6 +9,6 @@ namespace Microsoft.Docs.Build
     [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
     internal class GroupConfig
     {
-        public SourceInfo<string> MonikerRange { get; private set; } = new SourceInfo<string>("");
+        public SourceInfo<string?> MonikerRange { get; private set; }
     }
 }

--- a/src/docfx/lib/json/YamlUtility.Shared.cs
+++ b/src/docfx/lib/json/YamlUtility.Shared.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Docs.Build
 
             var parser = new Parser(input);
             parser.Consume<StreamStart>();
-            if (!parser.TryConsume<StreamEnd>(out var _))
+            if (!parser.TryConsume<StreamEnd>(out _))
             {
                 parser.Consume<DocumentStart>();
                 result = ToJToken(parser, onKeyDuplicate, onConvert);
@@ -53,7 +53,7 @@ namespace Microsoft.Docs.Build
 
                 case SequenceStart seq:
                     var array = new JArray();
-                    while (!parser.TryConsume<SequenceEnd>(out var _))
+                    while (!parser.TryConsume<SequenceEnd>(out _))
                     {
                         array.Add(ToJToken(parser, onKeyDuplicate, onConvert));
                     }
@@ -61,7 +61,7 @@ namespace Microsoft.Docs.Build
 
                 case MappingStart map:
                     var obj = new JObject();
-                    while (!parser.TryConsume<MappingEnd>(out var _))
+                    while (!parser.TryConsume<MappingEnd>(out _))
                     {
                         var key = parser.Consume<Scalar>();
                         var value = ToJToken(parser, onKeyDuplicate, onConvert);

--- a/src/docfx/lib/markdown/MarkdownEngine.cs
+++ b/src/docfx/lib/markdown/MarkdownEngine.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Docs.Build
             return (link, display);
         }
 
-        private IReadOnlyList<string> GetMonikerRange(SourceInfo<string> monikerRange)
+        private IReadOnlyList<string> GetMonikerRange(SourceInfo<string?> monikerRange)
         {
             var status = t_status.Value!.Peek();
             var (error, monikers) = _monikerProvider.GetZoneLevelMonikers(((Document)InclusionContext.RootFile).FilePath, monikerRange);

--- a/src/docfx/lib/markdown/MonikerZoneExtension.cs
+++ b/src/docfx/lib/markdown/MonikerZoneExtension.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Docs.Build
 {
     internal static class MonikerZoneExtension
     {
-        public static MarkdownPipelineBuilder UseMonikerZone(this MarkdownPipelineBuilder builder, Func<SourceInfo<string>, IReadOnlyList<string>> parseMonikerRange)
+        public static MarkdownPipelineBuilder UseMonikerZone(this MarkdownPipelineBuilder builder, Func<SourceInfo<string?>, IReadOnlyList<string>> parseMonikerRange)
         {
             return builder.Use(document =>
             {
@@ -22,7 +22,7 @@ namespace Microsoft.Docs.Build
                         monikerRangeBlock.GetAttributes().Properties.Remove(new KeyValuePair<string, string>("range", monikerRangeBlock.MonikerRange));
                         monikerRangeBlock.GetAttributes().AddPropertyIfNotExist("data-moniker", string.Join(
                             " ",
-                            parseMonikerRange(new SourceInfo<string>(monikerRangeBlock.MonikerRange, monikerRangeBlock.ToSourceInfo()))));
+                            parseMonikerRange(new SourceInfo<string?>(monikerRangeBlock.MonikerRange, monikerRangeBlock.ToSourceInfo()))));
                     }
                     return node;
                 });

--- a/src/docfx/lib/moniker/MonikerRangeParser.cs
+++ b/src/docfx/lib/moniker/MonikerRangeParser.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Docs.Build
 
         public string[] Parse(SourceInfo<string?> rangeString)
         {
-            var key = (string?)rangeString;
+            var key = rangeString.Value;
             if (string.IsNullOrWhiteSpace(key))
             {
                 return Array.Empty<string>();

--- a/src/docfx/lib/moniker/MonikerRangeParser.cs
+++ b/src/docfx/lib/moniker/MonikerRangeParser.cs
@@ -17,14 +17,15 @@ namespace Microsoft.Docs.Build
             _monikersEvaluator = monikersEvaluator;
         }
 
-        public string[] Parse(SourceInfo<string> rangeString)
+        public string[] Parse(SourceInfo<string?> rangeString)
         {
-            if (string.IsNullOrWhiteSpace(rangeString))
+            var key = (string?)rangeString;
+            if (string.IsNullOrWhiteSpace(key))
             {
                 return Array.Empty<string>();
             }
 
-            return _cache.GetOrAdd(rangeString, value =>
+            return _cache.GetOrAdd(key, value =>
             {
                 try
                 {

--- a/src/docfx/lib/schema/JsonSchemaValidator.cs
+++ b/src/docfx/lib/schema/JsonSchemaValidator.cs
@@ -258,12 +258,12 @@ namespace Microsoft.Docs.Build
             switch (schema.Format)
             {
                 case JsonSchemaStringFormat.DateTime:
-                    if (!DateTime.TryParse(str, CultureInfo.InvariantCulture, DateTimeStyles.None, out var _))
+                    if (!DateTime.TryParse(str, CultureInfo.InvariantCulture, DateTimeStyles.None, out _))
                         errors.Add((name, Errors.JsonSchema.FormatInvalid(JsonUtility.GetSourceInfo(scalar), str, JsonSchemaStringFormat.DateTime)));
                     break;
 
                 case JsonSchemaStringFormat.Date:
-                    if (!DateTime.TryParseExact(str, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var _))
+                    if (!DateTime.TryParseExact(str, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out _))
                         errors.Add((name, Errors.JsonSchema.FormatInvalid(JsonUtility.GetSourceInfo(scalar), str, JsonSchemaStringFormat.Date)));
                     break;
 

--- a/src/docfx/publish/PublishItem.cs
+++ b/src/docfx/publish/PublishItem.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Docs.Build
 
         public string? MonikerGroup { get; }
 
-        public string ConfigMonikerRange { get; }
+        public string? ConfigMonikerRange { get; }
 
         public string Locale { get; }
 
@@ -33,7 +33,7 @@ namespace Microsoft.Docs.Build
         [JsonExtensionData]
         public JObject? ExtensionData { get; set; }
 
-        public PublishItem(string url, string? path, string? sourcePath, string locale, string[] monikers, string configMonikerRange)
+        public PublishItem(string url, string? path, string? sourcePath, string locale, string[] monikers, string? configMonikerRange)
         {
             Url = url;
             Path = path;


### PR DESCRIPTION
- It would be easier to identify if user has written moniker config
- Update `TableOfContentsMetadata` recognize `Monikers` to not output it to metadata

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5699)