### PR TITLE
use the stable version of apex validation adapter

### DIFF
--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="Stubble.Core" Version="1.7.2" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180503-2" />
-    <PackageReference Include="Validations.DocFx.Adapter" Version="1.2.22-beta004" />
+    <PackageReference Include="Validations.DocFx.Adapter" Version="1.2.23" />
     <PackageReference Include="YamlDotNet" Version="8.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
as title, just change the version number from previous release to release

[AB#166621](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/166621)
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5701)