### PR TITLE
skip log InvalidInputFile error if from DocumentException

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/HostServiceCreator.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/HostServiceCreator.cs
@@ -81,9 +81,12 @@ namespace Microsoft.DocAsCode.Build.Engine
                 }
                 catch (Exception e)
                 {
-                    Logger.LogError(
-                        $"Unable to load file '{file.File}' via processor '{processor.Name}': {e.Message}",
-                        code: ErrorCodes.Build.InvalidInputFile);
+                    if (!(e is DocumentException))
+                    {
+                        Logger.LogError(
+                            $"Unable to load file '{file.File}' via processor '{processor.Name}': {e.Message}",
+                            code: ErrorCodes.Build.InvalidInputFile);
+                    }
                     return (null, false);
                 }
             }

--- a/src/Microsoft.DocAsCode.Build.SchemaDriven/Models/DocumentSchema.cs
+++ b/src/Microsoft.DocAsCode.Build.SchemaDriven/Models/DocumentSchema.cs
@@ -48,7 +48,9 @@ namespace Microsoft.DocAsCode.Build.SchemaDriven
             }
             catch (Exception e) when (e is JSchemaException || e is JsonException)
             {
-                throw new InvalidSchemaException($"{title} is not a valid schema: {e.Message}", e);
+                var message = ($"{title} is not a valid schema: {e.Message}");
+                Logger.LogError(message, code: ErrorCodes.Build.ViolateSchema);
+                throw new InvalidSchemaException(message, e);
             }
 
             var validator = new SchemaValidator(jObject, jSchema);
@@ -67,26 +69,34 @@ namespace Microsoft.DocAsCode.Build.SchemaDriven
             }
             catch (Exception e)
             {
-                throw new InvalidSchemaException($"{title} is not a valid schema: {e.Message}", e);
+                var message = $"{title} is not a valid schema: {e.Message}";
+                Logger.LogError(message, code: ErrorCodes.Build.ViolateSchema);
+                throw new InvalidSchemaException(message, e);
             }
 
             if (string.IsNullOrWhiteSpace(schema.Title))
             {
                 if (string.IsNullOrWhiteSpace(title))
                 {
-                    throw new InvalidSchemaException("Title of schema must be specified.");
+                    var message = "Title of schema must be specified.";
+                    Logger.LogError(message, code: ErrorCodes.Build.ViolateSchema);
+                    throw new InvalidSchemaException(message);
                 }
                 schema.Title = title;
             }
 
             if (schema.Type != JSchemaType.Object)
             {
-                throw new InvalidSchemaException("Type for the root schema object must be object");
+                var message = "Type for the root schema object must be object";
+                Logger.LogError(message, code: ErrorCodes.Build.ViolateSchema);
+                throw new InvalidSchemaException(message);
             }
 
             if (!JsonPointer.TryCreate(schema.Metadata, out var pointer))
             {
-                throw new InvalidJsonPointerException($"Metadata's json pointer {schema.Metadata} is invalid.");
+                var message = $"Metadata's json pointer {schema.Metadata} is invalid.";
+                Logger.LogError(message, code: ErrorCodes.Build.ViolateSchema);
+                throw new InvalidSchemaException(message);
             }
 
             var metadataSchema = pointer.FindSchema(schema);

--- a/src/Microsoft.DocAsCode.Build.SchemaDriven/Validators/SchemaValidateService.cs
+++ b/src/Microsoft.DocAsCode.Build.SchemaDriven/Validators/SchemaValidateService.cs
@@ -71,7 +71,9 @@ namespace Microsoft.DocAsCode.Build.SchemaDriven
             if (errors.Count > 0)
             {
                 var idInfo = schema.Id == null ? string.Empty : $" ({schema.Id})";
-                throw new InvalidSchemaException($"Schema validation failed. Please validate the file and make sure it conforms to schema '{schema.Title}'{idInfo}: \n{errors.ToDelimitedString("\n")}");
+                var message = $"Schema validation failed. Please validate the file and make sure it conforms to schema '{schema.Title}'{idInfo}: \n{errors.ToDelimitedString("\n")}";
+                Logger.LogError(message, code: ErrorCodes.Build.ViolateSchema);
+                throw new InvalidSchemaException(message);
             }
         }
 

--- a/src/Microsoft.DocAsCode.Build.SchemaDriven/Validators/SchemaValidator.cs
+++ b/src/Microsoft.DocAsCode.Build.SchemaDriven/Validators/SchemaValidator.cs
@@ -5,7 +5,7 @@ namespace Microsoft.DocAsCode.Build.SchemaDriven
 {
     using System;
     using System.IO;
-
+    using Microsoft.DocAsCode.Common;
     using Microsoft.DocAsCode.Exceptions;
 
     using Newtonsoft.Json.Linq;
@@ -33,7 +33,9 @@ namespace Microsoft.DocAsCode.Build.SchemaDriven
         {
             if (!ValidateSchemaUrl(_jSchema.SchemaVersion))
             {
-                throw new InvalidSchemaException($"Schema {_jSchema.SchemaVersion} is not supported. Current supported schemas are: {SupportedMetaSchemaUri.OriginalString}.");
+                var message = $"Schema {_jSchema.SchemaVersion} is not supported. Current supported schemas are: {SupportedMetaSchemaUri.OriginalString}.";
+                Logger.LogError(message, code: ErrorCodes.Build.ViolateSchema);
+                throw new InvalidSchemaException(message);
             }
 
             using var stream = typeof(DocumentSchema).Assembly.GetManifestResourceStream("Microsoft.DocAsCode.Build.SchemaDriven.schemas.v1._0.schema.json");

--- a/src/Microsoft.DocAsCode.Common/Loggers/ErrorCodes.cs
+++ b/src/Microsoft.DocAsCode.Common/Loggers/ErrorCodes.cs
@@ -7,6 +7,7 @@ namespace Microsoft.DocAsCode.Common
     {
         public static class Build
         {
+            public const string ViolateSchema = "ViolateSchema";
             public const string InvalidPropertyFormat = "InvalidPropertyFormat";
             public const string InvalidInputFile = "InvalidInputFile";
             public const string InvalidRelativePath = "InvalidRelativePath";

--- a/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/SchemaDrivenProcessorTest.cs
+++ b/test/Microsoft.DocAsCode.Build.SchemaDriven.Tests/SchemaDrivenProcessorTest.cs
@@ -515,9 +515,8 @@ metadata: Web Apps Documentation
             FileCollection files = new FileCollection(_defaultFiles);
             files.Add(DocumentType.Article, new[] { inputFile }, _inputFolder);
             BuildDocument(files);
-            var errors = listener.Items.Where(s => s.Code == "InvalidInputFile").ToList();
+            var errors = listener.Items.Where(s => s.Code == "ViolateSchema").ToList();
             Assert.Single(errors);
-            Assert.Equal($"Unable to load file '{inputFile}' via processor 'MetadataReferenceTest': Schema validation failed. Please validate the file and make sure it conforms to schema 'MetadataReferenceTest' (https://contoso.com/template/schemas/mta.reference.test.schema.json): \nInvalid type. Expected Object but got String. Path 'metadata'.", errors[0].Message);
         }
 
         [Fact]


### PR DESCRIPTION
[AB#195833](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/195833)

With extra Error logged in below change, now we have duplicate Error `InvalidYamlFile` and `InvalidInputFile`. Remove the later one in this PR.

https://github.com/dotnet/docfx/pull/5662/files#diff-2b03bbd85428fd280f9e178a76460f14R178

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5702)