### PR TITLE
Make TocLoader return TocNode

### DIFF
--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -119,8 +119,7 @@ namespace Microsoft.Docs.Build
 
             MarkdownEngine = new MarkdownEngine(Config, FileResolver, LinkResolver, XrefResolver, MonikerProvider, TemplateEngine);
 
-            TableOfContentsLoader = new TableOfContentsLoader(
-                Input, LinkResolver, XrefResolver, MarkdownEngine, MetadataProvider, MonikerProvider, DependencyMapBuilder);
+            TableOfContentsLoader = new TableOfContentsLoader(Input, LinkResolver, XrefResolver, MarkdownEngine, MonikerProvider, DependencyMapBuilder);
         }
 
         public void Dispose()

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -12,8 +12,16 @@ namespace Microsoft.Docs.Build
         {
             Debug.Assert(file.ContentType == ContentType.TableOfContents);
 
-            // load toc model
-            var (errors, model, _, _) = context.TableOfContentsLoader.Load(file);
+            // load toc tree
+            var (errors, node, _, _) = context.TableOfContentsLoader.Load(file);
+
+            var (metadataErrors, metadata) = context.MetadataProvider.GetMetadata(file.FilePath);
+            errors.AddRange(metadataErrors);
+
+            var (validationErrors, tocMetadata) = JsonUtility.ToObject<TableOfContentsMetadata>(metadata.RawJObject);
+            errors.AddRange(validationErrors);
+
+            var model = new TableOfContentsModel(node.Items.ToArray(), tocMetadata);
 
             // enable pdf
             var (monikerErrors, monikers) = context.MonikerProvider.GetFileLevelMonikers(file.FilePath);

--- a/src/docfx/build/toc/TableOfContentsMarkup.cs
+++ b/src/docfx/build/toc/TableOfContentsMarkup.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Docs.Build
 {
     internal static class TableOfContentsMarkup
     {
-        public static (List<Error> errors, TableOfContentsModel model) Parse(MarkdownEngine markdownEngine, string tocContent, FilePath file)
+        public static (List<Error> errors, TableOfContentsNode node) Parse(MarkdownEngine markdownEngine, string tocContent, FilePath file)
         {
             var errors = new List<Error>();
             var headingBlocks = new List<HeadingBlock>();
@@ -39,22 +39,18 @@ namespace Microsoft.Docs.Build
             }
 
             using var reader = new StringReader(tocContent);
-            var items = BuildTree(errors, file, headingBlocks);
-
-            var tocModel = new TableOfContentsModel { Items = items };
-
-            return (errors, tocModel);
+            return (errors, new TableOfContentsNode { Items = BuildTree(errors, file, headingBlocks) });
         }
 
-        private static List<TableOfContentsItem> BuildTree(List<Error> errors, FilePath filePath, List<HeadingBlock> blocks)
+        private static List<TableOfContentsNode> BuildTree(List<Error> errors, FilePath filePath, List<HeadingBlock> blocks)
         {
             if (blocks.Count <= 0)
             {
-                return new List<TableOfContentsItem>();
+                return new List<TableOfContentsNode>();
             }
 
-            var result = new TableOfContentsItem();
-            var stack = new Stack<(int level, TableOfContentsItem item)>();
+            var result = new TableOfContentsNode();
+            var stack = new Stack<(int level, TableOfContentsNode item)>();
 
             // Level of root node is determined by its first child
             var parent = (level: blocks[0].Level - 1, node: result);
@@ -89,9 +85,9 @@ namespace Microsoft.Docs.Build
             return result.Items;
         }
 
-        private static TableOfContentsItem? GetItem(List<Error> errors, FilePath filePath, HeadingBlock block)
+        private static TableOfContentsNode? GetItem(List<Error> errors, FilePath filePath, HeadingBlock block)
         {
-            var currentItem = new TableOfContentsItem();
+            var currentItem = new TableOfContentsNode();
             if (block.Inline is null || !block.Inline.Any())
             {
                 currentItem.Name = new SourceInfo<string?>(null, block.ToSourceInfo(file: filePath));

--- a/src/docfx/build/toc/TableOfContentsModel.cs
+++ b/src/docfx/build/toc/TableOfContentsModel.cs
@@ -1,19 +1,18 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-
 namespace Microsoft.Docs.Build
 {
     internal class TableOfContentsModel
     {
-        public TableOfContentsMetadata Metadata { get; set; } = new TableOfContentsMetadata();
+        public TableOfContentsMetadata Metadata { get; }
 
-        public List<TableOfContentsItem> Items { get; set; } = new List<TableOfContentsItem>();
+        public TableOfContentsNode[] Items { get; }
 
-        [JsonExtensionData(WriteData = false)]
-        public JObject ExtensionData { get; } = new JObject();
+        public TableOfContentsModel(TableOfContentsNode[] items, TableOfContentsMetadata metadata)
+        {
+            Items = items;
+            Metadata = metadata;
+        }
     }
 }

--- a/src/docfx/build/toc/TableOfContentsNode.cs
+++ b/src/docfx/build/toc/TableOfContentsNode.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build
 {
-    internal class TableOfContentsItem
+    internal class TableOfContentsNode
     {
         public SourceInfo<string?> Name { get; set; }
 
@@ -32,7 +32,7 @@ namespace Microsoft.Docs.Build
 
         public IReadOnlyList<string> Monikers { get; set; } = Array.Empty<string>();
 
-        public List<TableOfContentsItem> Items { get; set; } = new List<TableOfContentsItem>();
+        public List<TableOfContentsNode> Items { get; set; } = new List<TableOfContentsNode>();
 
         [JsonExtensionData]
         public JObject ExtensionData { get; set; } = new JObject();
@@ -40,7 +40,7 @@ namespace Microsoft.Docs.Build
         [JsonIgnore]
         public Document? Document { get; set; }
 
-        public TableOfContentsItem(TableOfContentsItem item)
+        public TableOfContentsNode(TableOfContentsNode item)
         {
             Name = item.Name;
             DisplayName = item.DisplayName;
@@ -56,6 +56,6 @@ namespace Microsoft.Docs.Build
             Document = item.Document;
         }
 
-        public TableOfContentsItem() { }
+        public TableOfContentsNode() { }
     }
 }


### PR DESCRIPTION
[192497](https://dev.azure.com/ceapex/Engineering/_workitems/edit/192497/)

Refactor TOC pipeline using a set of small changes. This one decouples `TocModel` from `TocLoader`, so `TocLoader` only has to work with one `TocNode` type