### PR TITLE
Use standalone appdata path for each test case

### DIFF
--- a/docs/specs/casing.yml
+++ b/docs/specs/casing.yml
@@ -63,7 +63,7 @@ repos:
                 "include_in_build": true
               }]
           }
-        OfficeUpdates/docfx.yml: |
+        OfficeUpdates/docfx.yml:
         OfficeUpdates/a.md:
   https://github.com/dep-include-in-build/casing-diff:
     - files:

--- a/src/docfx/config/AppData.cs
+++ b/src/docfx/config/AppData.cs
@@ -9,17 +9,17 @@ namespace Microsoft.Docs.Build
 {
     internal static class AppData
     {
-        private static readonly string s_root = TestQuirks.AppDataPath?.Invoke() ?? GetAppDataRoot();
+        public static string Root => TestQuirks.AppDataPath?.Invoke() ?? GetAppDataRoot();
 
-        public static string GitRoot => Path.Combine(s_root, "git6");
+        public static string GitRoot => Path.Combine(Root, "git6");
 
-        public static string DownloadsRoot => Path.Combine(s_root, "downloads2");
+        public static string DownloadsRoot => Path.Combine(Root, "downloads2");
 
-        public static string MutexRoot => Path.Combine(s_root, "mutex");
+        public static string MutexRoot => Path.Combine(Root, "mutex");
 
-        public static string CacheRoot => EnvironmentVariable.CachePath ?? Path.Combine(s_root, "cache");
+        public static string CacheRoot => EnvironmentVariable.CachePath ?? Path.Combine(Root, "cache");
 
-        public static string StateRoot => EnvironmentVariable.StatePath ?? Path.Combine(s_root, "state");
+        public static string StateRoot => EnvironmentVariable.StatePath ?? Path.Combine(Root, "state");
 
         public static string GitHubUserCachePath => Path.Combine(CacheRoot, "github-users.json");
 
@@ -42,7 +42,7 @@ namespace Microsoft.Docs.Build
         }
 
         /// <summary>
-        /// Get the global configuration path, default is under <see cref="s_root"/>
+        /// Get the global configuration path, default is under <see cref="Root"/>
         /// </summary>
         public static bool TryGetGlobalConfigPath([NotNullWhen(true)] out string? path)
         {
@@ -52,7 +52,7 @@ namespace Microsoft.Docs.Build
                 return true;
             }
 
-            path = PathUtility.FindYamlOrJson(s_root, "docfx");
+            path = PathUtility.FindYamlOrJson(Root, "docfx");
             return path != null;
         }
 

--- a/src/docfx/config/AppData.cs
+++ b/src/docfx/config/AppData.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Docs.Build
 {
     internal static class AppData
     {
-        private static readonly string s_root = GetAppDataRoot();
+        private static readonly string s_root = TestQuirks.AppDataPath?.Invoke() ?? GetAppDataRoot();
 
         public static string GitRoot => Path.Combine(s_root, "git6");
 
@@ -17,9 +17,9 @@ namespace Microsoft.Docs.Build
 
         public static string MutexRoot => Path.Combine(s_root, "mutex");
 
-        public static string CacheRoot => TestQuirks.CachePath?.Invoke() ?? EnvironmentVariable.CachePath ?? Path.Combine(s_root, "cache");
+        public static string CacheRoot => EnvironmentVariable.CachePath ?? Path.Combine(s_root, "cache");
 
-        public static string StateRoot => TestQuirks.StatePath?.Invoke() ?? EnvironmentVariable.StatePath ?? Path.Combine(s_root, "state");
+        public static string StateRoot => EnvironmentVariable.StatePath ?? Path.Combine(s_root, "state");
 
         public static string GitHubUserCachePath => Path.Combine(CacheRoot, "github-users.json");
 

--- a/src/docfx/config/TestQuirks.cs
+++ b/src/docfx/config/TestQuirks.cs
@@ -7,9 +7,7 @@ namespace Microsoft.Docs.Build
 {
     internal static class TestQuirks
     {
-        public static Func<string>? CachePath { get; set; }
-
-        public static Func<string>? StatePath { get; set; }
+        public static Func<string>? AppDataPath { get; set; }
 
         public static Func<string, string>? GitRemoteProxy { get; set; }
 

--- a/test/docfx.Test/DocfxTest.cs
+++ b/test/docfx.Test/DocfxTest.cs
@@ -69,12 +69,12 @@ namespace Microsoft.Docs.Build
             CreateDocset(TestData test, DocfxTestSpec spec)
         {
             var testName = $"{Path.GetFileName(test.FilePath)}-{test.Ordinal:D2}-{HashUtility.GetMd5HashShort(test.Content)}";
-            var basePath = Path.GetFullPath(Path.Combine(spec.Temp ? Path.GetTempPath() : "docfx-test", testName));
+            var basePath = Path.GetFullPath(Path.Combine(spec.Temp ? Path.GetTempPath() : "docfx-tests", testName));
             var outputPath = Path.GetFullPath(Path.Combine(basePath, "outputs"));
+            var markerPath = Path.Combine(basePath, "marker");
             var appDataPath = Path.Combine(basePath, "appdata");
             var cachePath = Path.Combine(appDataPath, "cache");
             var statePath = Path.Combine(appDataPath, "state");
-            var markerPath = Path.Combine(basePath, ".marker");
 
             var variables = new Dictionary<string, string>
             {

--- a/test/docfx.Test/DocfxTest.cs
+++ b/test/docfx.Test/DocfxTest.cs
@@ -21,13 +21,11 @@ namespace Microsoft.Docs.Build
         private static readonly JsonDiff s_jsonDiff = CreateJsonDiff();
 
         private static readonly AsyncLocal<IReadOnlyDictionary<string, string>> t_repos = new AsyncLocal<IReadOnlyDictionary<string, string>>();
-        private static readonly AsyncLocal<string> t_cachePath = new AsyncLocal<string>();
-        private static readonly AsyncLocal<string> t_statePath = new AsyncLocal<string>();
+        private static readonly AsyncLocal<string> t_appDataPath = new AsyncLocal<string>();
 
         static DocfxTest()
         {
-            TestQuirks.CachePath = () => t_cachePath.Value;
-            TestQuirks.StatePath = () => t_statePath.Value;
+            TestQuirks.AppDataPath = () => t_appDataPath.Value;
 
             TestQuirks.GitRemoteProxy = remote =>
             {
@@ -44,13 +42,12 @@ namespace Microsoft.Docs.Build
         [MarkdownTest("~/docs/designs/**/*.md")]
         public static async Task Run(TestData test, DocfxTestSpec spec)
         {
-            var (docsetPath, cachePath, statePath, outputPath, repos) = CreateDocset(test, spec);
+            var (docsetPath, appDataPath, outputPath, repos) = CreateDocset(test, spec);
 
             try
             {
                 t_repos.Value = repos;
-                t_cachePath.Value = cachePath;
-                t_statePath.Value = statePath;
+                t_appDataPath.Value = appDataPath;
 
                 if (OsMatches(spec.OS))
                 {
@@ -64,20 +61,20 @@ namespace Microsoft.Docs.Build
             finally
             {
                 t_repos.Value = null;
-                t_cachePath.Value = null;
-                t_statePath.Value = null;
+                t_appDataPath.Value = null;
             }
         }
 
-        private static (string docsetPath, string cachePath, string statePath, string outputPath, Dictionary<string, string> repos)
+        private static (string docsetPath, string appDataPath, string outputPath, Dictionary<string, string> repos)
             CreateDocset(TestData test, DocfxTestSpec spec)
         {
             var testName = $"{Path.GetFileName(test.FilePath)}-{test.Ordinal:D2}-{HashUtility.GetMd5HashShort(test.Content)}";
             var basePath = Path.GetFullPath(Path.Combine(spec.Temp ? Path.GetTempPath() : "docfx-test", testName));
             var outputPath = Path.GetFullPath(Path.Combine(basePath, "outputs"));
-            var cachePath = Path.Combine(basePath, "cache");
-            var statePath = Path.Combine(basePath, "state");
-            var markerPath = Path.Combine(basePath, "marker");
+            var appDataPath = Path.Combine(basePath, "appdata");
+            var cachePath = Path.Combine(appDataPath, "cache");
+            var statePath = Path.Combine(appDataPath, "state");
+            var markerPath = Path.Combine(basePath, ".marker");
 
             var variables = new Dictionary<string, string>
             {
@@ -123,7 +120,7 @@ namespace Microsoft.Docs.Build
                 File.WriteAllText(markerPath, "");
             }
 
-            return (docsetPath, cachePath, statePath, outputPath, repos);
+            return (docsetPath, appDataPath, outputPath, repos);
         }
 
         private async static Task RunCore(string docsetPath, string outputPath, DocfxTestSpec spec)


### PR DESCRIPTION
Fixes test framework problems due to shared appdata path: 

- Test won't pick up changes in dependency repo due to the cache in appdata
- Test fails if two cases uses the same repo url or file url due to the shared appdata cache



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5706)