### PR TITLE
Move TOC deserialization to TOC parser

### DIFF
--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Docs.Build
 
             MarkdownEngine = new MarkdownEngine(Config, FileResolver, LinkResolver, XrefResolver, MonikerProvider, TemplateEngine);
 
-            TableOfContentsLoader = new TableOfContentsLoader(Input, LinkResolver, XrefResolver, MarkdownEngine, MonikerProvider, DependencyMapBuilder);
+            TableOfContentsLoader = new TableOfContentsLoader(Input, LinkResolver, XrefResolver, new TableOfContentsParser(MarkdownEngine), MonikerProvider, DependencyMapBuilder);
         }
 
         public void Dispose()


### PR DESCRIPTION
[192497](https://dev.azure.com/ceapex/Engineering/_workitems/edit/192497/)

Refactor TOC pipeline using a set of small changes. This one moves `LoadTocModel` to `TocParser`, because `splitItems` happens between `LoadTocModel` and `ResolveTocModelItems`.

For `TocLoader`, simplifies error handling using args over return value.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5707)