### PR TITLE
[Breaking] Support overwrite buildtime through config

### DIFF
--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -8,6 +8,8 @@ repos:
       docfx.yml: |
         template: https://docs.com/theme
         metadataSchema: schema.json
+        updateTimeAsCommitBuildTime: true
+        buildTime: 2020-04-01T08:08:08Z
       redirections.yml: |
         redirections:
           a.md: /b
@@ -60,7 +62,7 @@ outputs:
         "robots": undefined,
         "api_name": ["API Name"],
         "_op_gitContributorInformation": {
-          "updated_at_date_time": "2018-10-30T00:00:00.0000000Z"
+          "updated_at_date_time": "2020-04-01T08:08:08Z"
         }
       },
       "themesRelativePathToOutputRoot": "_themes/",
@@ -71,7 +73,7 @@ outputs:
         <meta name=\"depot_name\" content=\".\" />
         <meta name=\"document_id\" content=\"fdb5a0d7-b68e-c465-9c5e-54a5cda94902\" />
         <meta name=\"document_version_independent_id\" content=\"92a5a770-f05f-b8bb-81c9-a8d786a9e608\" />
-        <meta name=\"gitcommit\" content=\"https://github.com/legacy/test/blob/ed16b07c7e69f6ef393855bb424635c0d41a67f2/c.md\" />
+        <meta name=\"gitcommit\" content=\"https://github.com/legacy/test/blob/882f998f63d445aeaae7362eea74195ce5e3c333/c.md\" />
         <meta name=\"locale\" content=\"en-us\" />
         <meta name=\"ms.author\" content=\"yufeih\" />
         <meta name=\"original_content_git_url\" content=\"https://github.com/legacy/test/blob/master/c.md\" />
@@ -81,7 +83,7 @@ outputs:
         <meta name=\"search.ms_product\" content=\"\" />
         <meta name=\"search.ms_sitename\" content=\"Docs\" />
         <meta name=\"site_name\" content=\"Docs\" />
-        <meta name=\"updated_at\" content=\"2018-10-30 12:00 AM\" />
+        <meta name=\"updated_at\" content=\"2020-04-01 08:08 AM\" />
         <meta name=\"wordCount\" content=\"1\" />"
     }
   c.mta.json: |

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -239,6 +239,11 @@ namespace Microsoft.Docs.Build
         public bool UpdateCommitBuildTime { get; private set; } = true;
 
         /// <summary>
+        /// Overwrite current <see cref="CommitBuildTimeProvider._buildTime"/>
+        /// </summary>
+        public DateTime? BuildTime { get; private set; }
+
+        /// <summary>
         /// Token that can be used to access the GitHub API.
         /// </summary>
         public string GithubToken { get; private set; } = "";

--- a/src/docfx/config/EnvironmentVariable.cs
+++ b/src/docfx/config/EnvironmentVariable.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Docs.Build
 
         public static string? CorrelationId => GetValue("DOCFX_CORRELATION_ID");
 
+        public static string? BuildTime => GetValue("DOCFX_BUILD_TIME");
+
         private static string? GetValue(string name)
         {
             var value = Environment.GetEnvironmentVariable(name);

--- a/src/docfx/lib/git/CommitBuildTimeProvider.cs
+++ b/src/docfx/lib/git/CommitBuildTimeProvider.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Docs.Build
 {
     internal class CommitBuildTimeProvider
     {
-        private readonly DateTime _buildTime = DateTime.UtcNow;
+        private readonly DateTime _buildTime;
         private readonly Repository _repo;
         private readonly Config _config;
         private readonly string _commitBuildTimePath;
@@ -21,6 +21,7 @@ namespace Microsoft.Docs.Build
             _repo = repo;
             _config = config;
             _commitBuildTimePath = AppData.GetCommitBuildTimePath(repo.Remote, repo.Branch);
+            _buildTime = config.BuildTime.HasValue? config.BuildTime.Value.ToUniversalTime() : DateTime.UtcNow;
 
             var exists = File.Exists(_commitBuildTimePath);
             Log.Write($"{(exists ? "Using" : "Missing")} git commit build time cache file: '{_commitBuildTimePath}'");

--- a/src/docfx/lib/git/CommitBuildTimeProvider.cs
+++ b/src/docfx/lib/git/CommitBuildTimeProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Docs.Build
             _repo = repo;
             _config = config;
             _commitBuildTimePath = AppData.GetCommitBuildTimePath(repo.Remote, repo.Branch);
-            _buildTime = config.BuildTime.HasValue? config.BuildTime.Value.ToUniversalTime() : DateTime.UtcNow;
+            _buildTime = config.BuildTime ?? DateTime.UtcNow;
 
             var exists = File.Exists(_commitBuildTimePath);
             Log.Write($"{(exists ? "Using" : "Missing")} git commit build time cache file: '{_commitBuildTimePath}'");


### PR DESCRIPTION
Fixing update-time change in integration test.

Since docs-help-pr is always a PR build, the branch state never gets a chance to be updated.
Hence in commit-ci build, thought branch commits moved forward, but no newer state added.

Expecting update-time to be changed to `2020-01-01`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5708)