### PR TITLE
Handle TOC build scope in TocMap

### DIFF
--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -10,8 +10,6 @@ namespace Microsoft.Docs.Build
     /// </summary>
     internal sealed class Context : IDisposable
     {
-        private readonly Lazy<TableOfContentsMap> _tocMap;
-
         public Config Config { get; }
 
         public BuildOptions BuildOptions { get; }
@@ -68,12 +66,11 @@ namespace Microsoft.Docs.Build
 
         public ContentValidator ContentValidator { get; }
 
-        public TableOfContentsMap TocMap => _tocMap.Value;
+        public TableOfContentsMap TocMap { get; }
 
         public Context(ErrorLog errorLog, Config config, BuildOptions buildOptions, PackageResolver packageResolver, FileResolver fileResolver)
         {
             DependencyMapBuilder = new DependencyMapBuilder();
-            _tocMap = new Lazy<TableOfContentsMap>(() => TableOfContentsMap.Create(this));
             BuildQueue = new WorkQueue<FilePath>();
 
             Config = config;
@@ -116,8 +113,8 @@ namespace Microsoft.Docs.Build
                 FileLinkMapBuilder);
 
             MarkdownEngine = new MarkdownEngine(Config, FileResolver, LinkResolver, XrefResolver, MonikerProvider, TemplateEngine);
-
             TableOfContentsLoader = new TableOfContentsLoader(Input, LinkResolver, XrefResolver, new TableOfContentsParser(MarkdownEngine), MonikerProvider, DependencyMapBuilder);
+            TocMap = TableOfContentsMap.Create(this);
         }
 
         public void Dispose()

--- a/src/docfx/build/link/LinkResolver.cs
+++ b/src/docfx/build/link/LinkResolver.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Docs.Build
                     }
 
                     // resolve file
-                    var lookupFallbackCommits = inclusion || _documentProvider.GetContentType(path) == ContentType.Resource;
+                    var lookupFallbackCommits = inclusion || _buildScope.GetContentType(path) == ContentType.Resource;
                     var file = TryResolveRelativePath(referencingFile.FilePath, path, lookupFallbackCommits);
 
                     // for LandingPage should not be used,

--- a/src/docfx/build/redirection/RedirectionProvider.cs
+++ b/src/docfx/build/redirection/RedirectionProvider.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Docs.Build
                     continue;
                 }
 
-                var type = _documentProvider.GetContentType(path);
+                var type = _buildScope.GetContentType(path);
                 if (type != ContentType.Page)
                 {
                     _errorLog.Write(Errors.Redirection.RedirectionInvalid(redirectUrl, path));

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -23,13 +23,14 @@ namespace Microsoft.Docs.Build
 
             var model = new TableOfContentsModel(node.Items.ToArray(), tocMetadata);
 
-            // enable pdf
+            // TODO: improve error message for toc monikers overlap
             var (monikerErrors, monikers) = context.MonikerProvider.GetFileLevelMonikers(file.FilePath);
             errors.AddRange(monikerErrors);
 
             var outputPath = context.DocumentProvider.GetOutputPath(file.FilePath, monikers);
             var monikerGroup = MonikerUtility.GetGroup(monikers);
 
+            // enable pdf
             if (context.Config.OutputPdf)
             {
                 model.Metadata.PdfAbsolutePath = "/" +

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Docs.Build
             using (Progress.Start("Building Xref map"))
             {
                 ParallelUtility.ForEach(
-                    context.BuildScope.Files,
+                    context.BuildScope.GetFiles(ContentType.Page),
                     file => Load(context, builder, file),
                     Progress.Update);
             }


### PR DESCRIPTION
[AB#192497](https://dev.azure.com/ceapex/Engineering/_workitems/edit/192497/)

Refactor TOC pipeline using a set of small changes. 

This PR moves TOC build scope to `TocMap`, because `splitItems` will produce more TOCs then what's inside `BuildScope`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5709)