### PR TITLE
Consume wildcard in moniker range parser

### DIFF
--- a/src/docfx/lib/moniker/EvaluatorWithMonikersVisitor.cs
+++ b/src/docfx/lib/moniker/EvaluatorWithMonikersVisitor.cs
@@ -23,6 +23,11 @@ namespace Microsoft.Docs.Build
 
         public IEnumerable<Moniker> Visit(ComparatorExpression expression)
         {
+            if (expression.Operator == ComparatorOperatorType.EqualTo && expression.Operand == "*")
+            {
+                return _monikerMap.Values;
+            }
+
             if (!MonikerOrder.TryGetValue(expression.Operand, out var moniker))
             {
                 throw new MonikerRangeException($"Moniker `{expression.Operand}` is not defined");

--- a/src/docfx/lib/moniker/ExpressionCreator.cs
+++ b/src/docfx/lib/moniker/ExpressionCreator.cs
@@ -107,6 +107,12 @@ namespace Microsoft.Docs.Build
                         match = OrSymbolRegex.Match(rangeString);
                         break;
                     case SymbolType.Moniker:
+                        if (rangeString == "*")
+                        {
+                            value = "*";
+                            rangeString = rangeString.Substring(1);
+                            return true;
+                        }
                         match = MonikerSymbolRegex.Match(rangeString);
                         break;
                     case SymbolType.Operator:

--- a/test/docfx.Test/lib/MonikerRangeParserTest.cs
+++ b/test/docfx.Test/lib/MonikerRangeParserTest.cs
@@ -110,6 +110,8 @@ namespace Microsoft.Docs.Build
         [InlineData(
             "azuresqldb-current || azure-sqldw-latest",
             "azure-sqldw-latest azuresqldb-current")]
+        [InlineData("*", "netcore-1.0 netcore-2.0 netcore-3.0 dotnet-1.0 dotnet-2.0 dotnet-3.0 azure-sqldw-latest azuresqldb-current")]
+        [InlineData("=*", "netcore-1.0 netcore-2.0 netcore-3.0 dotnet-1.0 dotnet-2.0 dotnet-3.0 azure-sqldw-latest azuresqldb-current")]
         public void TestEvaluateMonikerRange(string rangeString, string expectedMonikers)
         {
             var result = _monikerRangeParser.Parse(new SourceInfo<string>(rangeString)).ToList();
@@ -126,6 +128,7 @@ namespace Microsoft.Docs.Build
         [InlineData(">netcore<-1.0 ||| >netcore-2.0", "Expect a comparator set, but got `| >netcore-2.0`")]
         [InlineData(">netcore<-1.0 || ||", "Expect a comparator set, but got ` ||`")]
         [InlineData(">netcore<-1.0 || <", "Expect a moniker string, but got ``")]
+        [InlineData(">*", "Moniker `*` is not defined")]
         public void InvalidMonikerRange(string rangeString, string errorMessage)
         {
             var exception = Assert.Throws<DocfxException>(() => _monikerRangeParser.Parse(new SourceInfo<string>(rangeString)));

--- a/test/docfx.Test/lib/MonikerRangeParserTest.cs
+++ b/test/docfx.Test/lib/MonikerRangeParserTest.cs
@@ -129,6 +129,8 @@ namespace Microsoft.Docs.Build
         [InlineData(">netcore<-1.0 || ||", "Expect a comparator set, but got ` ||`")]
         [InlineData(">netcore<-1.0 || <", "Expect a moniker string, but got ``")]
         [InlineData(">*", "Moniker `*` is not defined")]
+        [InlineData("* || *", "Expect a comparator set, but got `* || *`")]
+        [InlineData("* && >netcore-1.0", "Expect a comparator set, but got `* && >netcore-1.0`")]
         public void InvalidMonikerRange(string rangeString, string errorMessage)
         {
             var exception = Assert.Throws<DocfxException>(() => _monikerRangeParser.Parse(new SourceInfo<string>(rangeString)));


### PR DESCRIPTION
- Consume `*`
- The operator should only be `=`, or without operator, which will be default as `=`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5714)