### PR TITLE
Run js once, force content property

### DIFF
--- a/docs/specs/template.yml
+++ b/docs/specs/template.yml
@@ -188,7 +188,7 @@ inputs:
       }
     }
   _themes/ContentTemplate/TestData.html.primary.tmpl: |
-    <div>{{content}}</div>
+    <div>{{.}}</div>
   _themes/ContentTemplate/TestData.html.primary.js: |
     exports.transform = function (model) {
       return model.prop;

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -123,15 +123,14 @@ namespace Microsoft.Docs.Build
             return (errors, html, JsonUtility.SortProperties(templateMetadata));
         }
 
-        private static (List<Error> errors, object output, JObject metadata)
-            CreateDataOutput(Context context, Document file, JObject sourceModel)
+        private static (List<Error> errors, object output, JObject metadata) CreateDataOutput(Context context, Document file, JObject sourceModel)
         {
             if (context.Config.DryRun)
             {
                 return (new List<Error>(), new JObject(), new JObject());
             }
 
-            return (new List<Error>(), context.TemplateEngine.RunJint($"{file.Mime}.json.js", sourceModel), new JObject());
+            return (new List<Error>(), context.TemplateEngine.RunJavaScript($"{file.Mime}.json.js", sourceModel), new JObject());
         }
 
         private static (List<Error>, SystemMetadata) CreateSystemMetadata(Context context, Document file, UserMetadata inputMetadata)
@@ -326,8 +325,8 @@ namespace Microsoft.Docs.Build
                 content = "<div></div>";
             }
 
-            var templateMetadata = context.TemplateEngine.RunJint(
-                string.IsNullOrEmpty(file.Mime) ? "Conceptual.mta.json.js" : $"{file.Mime}.mta.json.js", pageModel);
+            var jsName = string.IsNullOrEmpty(file.Mime) ? "Conceptual.mta.json.js" : $"{file.Mime}.mta.json.js";
+            var templateMetadata = context.TemplateEngine.RunJavaScript(jsName, pageModel) as JObject ?? new JObject();
 
             if (TemplateEngine.IsLandingData(file.Mime))
             {
@@ -371,8 +370,8 @@ namespace Microsoft.Docs.Build
             }
 
             // Generate SDP content
-            var jintResult = context.TemplateEngine.RunJint($"{file.Mime}.html.primary.js", pageModel);
-            var content = context.TemplateEngine.RunMustache($"{file.Mime}.html.primary.tmpl", jintResult);
+            var model = context.TemplateEngine.RunJavaScript($"{file.Mime}.html.primary.js", pageModel);
+            var content = context.TemplateEngine.RunMustache($"{file.Mime}.html.primary.tmpl", model);
 
             var htmlDom = HtmlUtility.LoadHtml(content);
             ValidateBookmarks(context, file, htmlDom);

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Docs.Build
                 {
                     if (context.Config.Legacy)
                     {
-                        var output = context.TemplateEngine.RunJint("toc.json.js", JsonUtility.ToJObject(model));
+                        var output = context.TemplateEngine.RunJavaScript("toc.json.js", JsonUtility.ToJObject(model));
                         context.Output.WriteJson(outputPath, output);
                         context.Output.WriteJson(LegacyUtility.ChangeExtension(outputPath, ".mta.json"), model.Metadata);
                     }

--- a/src/docfx/template/TemplateEngine.cs
+++ b/src/docfx/template/TemplateEngine.cs
@@ -74,12 +74,12 @@ namespace Microsoft.Docs.Build
             return _liquid.Render(layout, liquidModel);
         }
 
-        public string RunMustache(string templateName, JObject pageModel)
+        public string RunMustache(string templateName, JToken pageModel)
         {
             return _mustacheTemplate.Render(templateName, pageModel);
         }
 
-        public JObject RunJint(string scriptName, JObject model, string methodName = "transform", bool tryParseFromContent = true)
+        public JToken RunJavaScript(string scriptName, JObject model, string methodName = "transform")
         {
             var scriptPath = Path.Combine(_contentTemplateDir, scriptName);
             if (!File.Exists(scriptPath))
@@ -87,20 +87,9 @@ namespace Microsoft.Docs.Build
                 return model;
             }
 
-            var jsResult = _js.Run(scriptPath, methodName, model);
-
-            var result = new JObject();
-            if (jsResult is JValue)
-            {
-                // workaround for result is not JObject
-                result["content"] = jsResult;
-                return result;
-            }
-
-            result = (JObject)_js.Run(scriptPath, methodName, model);
-            if (tryParseFromContent
-                && result.TryGetValue<JValue>("content", out var value)
-                && value.Value is string content)
+            var result = _js.Run(scriptPath, methodName, model);
+            if (result is JObject obj && obj.TryGetValue("content", out var token) &&
+                token is JValue value && value.Value is string content)
             {
                 try
                 {


### PR DESCRIPTION
[AB#195827](https://dev.azure.com/ceapex/Engineering/_workitems/edit/195827)

#4855 contains a bug to run javascript twice for each file. This change reverted the walk around.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5717)