### PR TITLE
Ignore __global property for output, it is HUGE

### DIFF
--- a/src/docfx/lib/js/ChakraCoreJsEngine.cs
+++ b/src/docfx/lib/js/ChakraCoreJsEngine.cs
@@ -285,7 +285,10 @@ namespace Microsoft.Docs.Build
                     for (var i = 0; i < namesLength; i++)
                     {
                         var name = names.GetIndexedProperty(JavaScriptValue.FromInt32(i)).ToString();
-                        obj[name] = ToJToken(value.GetProperty(JavaScriptPropertyId.FromString(name)));
+                        if (name != "__global")
+                        {
+                            obj[name] = ToJToken(value.GetProperty(JavaScriptPropertyId.FromString(name)));
+                        }
                     }
                     return obj;
 

--- a/src/docfx/lib/js/JintJsEngine.cs
+++ b/src/docfx/lib/js/JintJsEngine.cs
@@ -129,9 +129,9 @@ namespace Microsoft.Docs.Build
 
         private static JToken ToJToken(JsValue token)
         {
-            if (token.AsObject() is ObjectInstance obj)
+            if (token.IsObject())
             {
-                obj.Delete("__global", throwOnError: false);
+                token.AsObject().Delete("__global", throwOnError: false);
             }
             return JToken.Parse(s_engine.Json.Stringify(null, new[] { token }).AsString());
         }

--- a/src/docfx/lib/js/JintJsEngine.cs
+++ b/src/docfx/lib/js/JintJsEngine.cs
@@ -129,6 +129,10 @@ namespace Microsoft.Docs.Build
 
         private static JToken ToJToken(JsValue token)
         {
+            if (token.AsObject() is ObjectInstance obj)
+            {
+                obj.Delete("__global", throwOnError: false);
+            }
             return JToken.Parse(s_engine.Json.Stringify(null, new[] { token }).AsString());
         }
     }

--- a/src/docfx/template/MustacheTemplate.cs
+++ b/src/docfx/template/MustacheTemplate.cs
@@ -18,11 +18,11 @@ namespace Microsoft.Docs.Build
         private readonly IStubbleRenderer _renderer;
         private readonly ConcurrentDictionary<string, Lazy<string?>> _templates = new ConcurrentDictionary<string, Lazy<string?>>();
 
-        public MustacheTemplate(string templateDir)
+        public MustacheTemplate(string templateDir, JObject? global = null)
         {
             _templateDir = templateDir;
             _renderer = new StubbleBuilder().Configure(
-                settings => UseJson(settings).SetPartialTemplateLoader(new PartialLoader(templateDir))).Build();
+                settings => UseJson(settings, global).SetPartialTemplateLoader(new PartialLoader(templateDir))).Build();
         }
 
         public string Render(string templateFileName, JToken model)
@@ -36,10 +36,11 @@ namespace Microsoft.Docs.Build
                     ? MustacheXrefTagParser.ProcessXrefTag(File.ReadAllText(fileName).Replace("\r", ""))
                     : null;
                 })).Value;
+
             return template == null ? JsonUtility.Serialize(model) : _renderer.Render(template, model);
         }
 
-        private static RendererSettingsBuilder UseJson(RendererSettingsBuilder settings)
+        private static RendererSettingsBuilder UseJson(RendererSettingsBuilder settings, JObject? global)
         {
             // JObject implements IEnumerable, stubble treats IEnumerable as array,
             // need to put it to section blacklist and overwrite the truthy check method.
@@ -53,6 +54,11 @@ namespace Microsoft.Docs.Build
 
             object? GetJObjectValue(object value, string key, bool ignoreCase)
             {
+                if (key == "__global" && global != null)
+                {
+                    return global;
+                }
+
                 var token = (JObject)value;
                 var childToken = token.GetValue(key, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
 

--- a/src/docfx/template/TemplateEngine.cs
+++ b/src/docfx/template/TemplateEngine.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Docs.Build
                 ? (IJavaScriptEngine)new ChakraCoreJsEngine(_contentTemplateDir, _global)
                 : new JintJsEngine(_contentTemplateDir, _global);
 
-            _mustacheTemplate = new MustacheTemplate(_contentTemplateDir);
+            _mustacheTemplate = new MustacheTemplate(_contentTemplateDir, _global);
         }
 
         public bool IsPage(string? mime)

--- a/test/docfx.Test/lib/JavascriptEngineTest.cs
+++ b/test/docfx.Test/lib/JavascriptEngineTest.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Docs.Build
             foreach (var engine in _engines)
             {
                 var outputJson = engine.Run("index.js", "main", inputJson);
-                (outputJson as JObject)?.Property("__global")?.Remove();
                 Assert.Equal(output.Replace('\'', '"'), outputJson.ToString(Formatting.None));
             }
         }


### PR DESCRIPTION
[AB#195827](https://dev.azure.com/ceapex/Engineering/_workitems/edit/195827)

Reduces `azure-docs-rest-api` build time from `2:00` to `1:30`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5718)