### PR TITLE
enable nuget debug for docs-validation package

### DIFF
--- a/docs/specs/validation.yml
+++ b/docs/specs/validation.yml
@@ -568,6 +568,6 @@ outputs:
   b.json:
   c.json:
   .errors.log: |
-    ["suggestion","duplicate-h1","H1 'Title 1' is duplicated with other articles: 'a.md,b.md'","a.md"]
-    ["suggestion","duplicate-h1","H1 'Title 1' is duplicated with other articles: 'a.md,b.md'","b.md"]
+    ["suggestion","duplicate-h1","H1 'Title 1' is duplicated with other articles: 'a.md, b.md'","a.md"]
+    ["suggestion","duplicate-h1","H1 'Title 1' is duplicated with other articles: 'a.md, b.md'","b.md"]
 ---

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="docs.validation" Version="1.0.0-beta-00065-40c9851" />
+    <PackageReference Include="docs.validation" Version="1.0.0-beta-00073-35c596d" />
     <PackageReference Include="DotLiquid" Version="2.0.325" />
     <PackageReference Include="Glob" Version="1.1.6" />
     <!-- To keep HTML intact during v3 migration, keep using HtmlAgilityPack 1.4.9 -->


### PR DESCRIPTION
since the azure devops artifacts server doesn't support symbol service and separated pdf file can not be copied to bin folder due to dotnet sdk bug https://github.com/dotnet/sdk/issues/1458, docs-validation uses embeded pdf to resolve this problem.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5722)