### PR TITLE
Remove content output from LinkResolver.ResolveContent

### DIFF
--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -112,8 +112,8 @@ namespace Microsoft.Docs.Build
                 TemplateEngine,
                 FileLinkMapBuilder);
 
-            MarkdownEngine = new MarkdownEngine(Config, FileResolver, LinkResolver, XrefResolver, MonikerProvider, TemplateEngine);
-            TableOfContentsLoader = new TableOfContentsLoader(Input, LinkResolver, XrefResolver, new TableOfContentsParser(MarkdownEngine), MonikerProvider, DependencyMapBuilder);
+            MarkdownEngine = new MarkdownEngine(Config, Input, FileResolver, LinkResolver, XrefResolver, MonikerProvider, TemplateEngine);
+            TableOfContentsLoader = new TableOfContentsLoader(LinkResolver, XrefResolver, new TableOfContentsParser(Input, MarkdownEngine), MonikerProvider, DependencyMapBuilder);
             TocMap = new TableOfContentsMap(ErrorLog, BuildScope, TableOfContentsLoader, DocumentProvider);
         }
 

--- a/src/docfx/build/link/LinkResolver.cs
+++ b/src/docfx/build/link/LinkResolver.cs
@@ -52,53 +52,52 @@ namespace Microsoft.Docs.Build
             _fileLinkMapBuilder = fileLinkMapBuilder;
         }
 
-        public (Error? error, string? content, Document? file) ResolveContent(
-            SourceInfo<string> href, Document referencingFile, DependencyType dependencyType = DependencyType.Inclusion)
+        public (Error? error, Document? file) ResolveContent(SourceInfo<string> href, Document referencingFile, DependencyType dependencyType)
         {
-            var (error, file, _, _, _) = TryResolveFile(referencingFile, href, inclusion: true);
-
-            if (file is null || file.ContentType == ContentType.Redirection)
+            var (error, file, _, _, _) = TryResolveFile(referencingFile, href, true);
+            if (file is null)
             {
                 return default;
             }
 
-            var content = _input.ReadString(file.FilePath);
+            var origin = file.FilePath.Origin;
+            if (origin != FileOrigin.Main && origin != FileOrigin.Fallback && origin != FileOrigin.Dependency)
+            {
+                return default;
+            }
 
             _dependencyMapBuilder.AddDependencyItem(referencingFile, file, dependencyType);
-
-            return (error, content, file);
+            return (error, file);
         }
 
-        public (Error? error, string link, Document? file) ResolveLink(
-            SourceInfo<string> href, Document hrefRelativeTo, Document inclusionRoot)
+        public (Error? error, string link, Document? file) ResolveLink(SourceInfo<string> href, Document referencingFile, Document inclusionRoot)
         {
             if (href.Value.StartsWith("xref:"))
             {
                 var uid = new SourceInfo<string>(href.Value.Substring("xref:".Length), href);
-                var (uidError, uidHref, _, declaringFile) = _xrefResolver.ResolveXref(uid, hrefRelativeTo, inclusionRoot);
+                var (uidError, uidHref, _, declaringFile) = _xrefResolver.ResolveXref(uid, referencingFile, inclusionRoot);
 
                 return (uidError, uidHref ?? href, declaringFile);
             }
 
-            var (error, link, fragment, linkType, file, isCrossReference) = TryResolveAbsoluteLink(href, hrefRelativeTo);
-
+            var (error, link, fragment, linkType, file, isCrossReference) = TryResolveAbsoluteLink(href, referencingFile);
             if (file != null)
             {
                 _buildQueue.Enqueue(file.FilePath);
             }
 
-            inclusionRoot ??= hrefRelativeTo;
+            inclusionRoot ??= referencingFile;
             if (!isCrossReference)
             {
                 if (linkType == LinkType.SelfBookmark || inclusionRoot == file)
                 {
-                    _dependencyMapBuilder.AddDependencyItem(hrefRelativeTo, file, UrlUtility.FragmentToDependencyType(fragment));
-                    _bookmarkValidator.AddBookmarkReference(hrefRelativeTo, inclusionRoot, fragment, true, href);
+                    _dependencyMapBuilder.AddDependencyItem(referencingFile, file, UrlUtility.FragmentToDependencyType(fragment));
+                    _bookmarkValidator.AddBookmarkReference(referencingFile, inclusionRoot, fragment, true, href);
                 }
                 else if (file != null)
                 {
-                    _dependencyMapBuilder.AddDependencyItem(hrefRelativeTo, file, UrlUtility.FragmentToDependencyType(fragment));
-                    _bookmarkValidator.AddBookmarkReference(hrefRelativeTo, file, fragment, false, href);
+                    _dependencyMapBuilder.AddDependencyItem(referencingFile, file, UrlUtility.FragmentToDependencyType(fragment));
+                    _bookmarkValidator.AddBookmarkReference(referencingFile, file, fragment, false, href);
                 }
             }
 
@@ -151,7 +150,7 @@ namespace Microsoft.Docs.Build
         }
 
         private (Error? error, Document? file, string? query, string? fragment, LinkType linkType) TryResolveFile(
-            Document referencingFile, SourceInfo<string> href, bool inclusion = false)
+            Document referencingFile, SourceInfo<string> href, bool lookupGitCommits = false)
         {
             href = new SourceInfo<string>(href.Value.Trim(), href.Source).Or("");
             var (path, query, fragment) = UrlUtility.SplitUrl(href);
@@ -173,8 +172,8 @@ namespace Microsoft.Docs.Build
                     }
 
                     // resolve file
-                    var lookupFallbackCommits = inclusion || _buildScope.GetContentType(path) == ContentType.Resource;
-                    var file = TryResolveRelativePath(referencingFile.FilePath, path, lookupFallbackCommits);
+                    lookupGitCommits |= _buildScope.GetContentType(path) == ContentType.Resource;
+                    var file = TryResolveRelativePath(referencingFile.FilePath, path, lookupGitCommits);
 
                     // for LandingPage should not be used,
                     // it is a hack to handle some specific logic for landing page based on the user input for now
@@ -184,7 +183,7 @@ namespace Microsoft.Docs.Build
                         if (file is null)
                         {
                             // try to resolve with .md for landing page
-                            file = TryResolveRelativePath(referencingFile.FilePath, $"{path}.md", lookupFallbackCommits);
+                            file = TryResolveRelativePath(referencingFile.FilePath, $"{path}.md", lookupGitCommits);
                         }
 
                         // Do not report error for landing page

--- a/src/docfx/build/toc/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/TableOfContentsParser.cs
@@ -17,20 +17,22 @@ namespace Microsoft.Docs.Build
 {
     internal class TableOfContentsParser
     {
+        private readonly Input _input;
         private readonly MarkdownEngine _markdownEngine;
 
-        public TableOfContentsParser(MarkdownEngine markdownEngine)
+        public TableOfContentsParser(Input input, MarkdownEngine markdownEngine)
         {
+            _input = input;
             _markdownEngine = markdownEngine;
         }
 
-        public TableOfContentsNode Parse(string content, FilePath file, List<Error> errors)
+        public TableOfContentsNode Parse(FilePath file, List<Error> errors)
         {
             return file.Format switch
             {
-                FileFormat.Yaml => Deserialize(YamlUtility.Parse(content, file), errors),
-                FileFormat.Json => Deserialize(JsonUtility.Parse(content, file), errors),
-                FileFormat.Markdown => ParseMarkdown(content, file, errors),
+                FileFormat.Yaml => Deserialize(_input.ReadYaml(file), errors),
+                FileFormat.Json => Deserialize(_input.ReadJson(file), errors),
+                FileFormat.Markdown => ParseMarkdown(_input.ReadString(file), file, errors),
                 _ => throw new NotSupportedException($"'{file}' is an unknown TOC file"),
             };
         }


### PR DESCRIPTION
[AB#192497](https://dev.azure.com/ceapex/Engineering/_workitems/edit/192497/) #5729 

Refactor TOC pipeline using a set of small changes. 

This PR removes `string content` from `LinkResolver.ResolveContent`. `TocLoader` will delegate to  `TocParser` and use `_input.ReadJson` instead to resolve include. Because `splitItem` will produce TOCs that are not strings.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5728)