### PR TITLE
return -1 for user error

### DIFF
--- a/src/docfx/Program.cs
+++ b/src/docfx/Program.cs
@@ -22,8 +22,7 @@ namespace Microsoft.DocAsCode
                 // TLS best practices for .NET: https://docs.microsoft.com/en-us/dotnet/framework/network-programming/tls
                 ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-                var result = ExecSubCommand(args);
-                return Logger.HasError ? 1 : result;
+                return ExecSubCommand(args);
             }
             finally
             {
@@ -90,7 +89,7 @@ namespace Microsoft.DocAsCode
                 }
 
                 command.Exec(context);
-                return 0;
+                return Logger.HasError ? -1 : 0;
             }
             catch (AggregateException ae)
             {


### PR DESCRIPTION
Return code:

* `0`: normal execution
* `1`: terminating error: which prevents docfx from building to the end. Usually, an exception happened in this case. Note that `DocumentExcpetion` can lead to this terminating error, while it is caused by user inputs.
* `-1`: non-terminating error: error caused by user inputs. e.g. some referenced code snippet or Markdown is missing, which leads to a page's result incomplete.

[AB#196389](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/196389)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5734)