### PR TITLE
remove appending locale to theme

### DIFF
--- a/docs/specs/template.yml
+++ b/docs/specs/template.yml
@@ -241,7 +241,7 @@ repos:
   https://docs.com/loc-template-test.zh-cn:
     - files:
         docfx.yml: |
-          template: https://docs.com/loc-template
+          template: https://docs.com/loc-template.zh-cn
         a.yml: '#YamlMime:TestLocTemplate'
   https://docs.com/loc-template.zh-cn:
     - files:

--- a/src/docfx/lib/LocalizationUtility.cs
+++ b/src/docfx/lib/LocalizationUtility.cs
@@ -80,16 +80,6 @@ namespace Microsoft.Docs.Build
             return AppendLocale(repositoryUrl, locale);
         }
 
-        public static PackagePath GetLocalizedTheme(PackagePath theme, string locale)
-        {
-            return theme.Type switch
-            {
-                PackageType.Folder => new PackagePath(AppendLocale(theme.Path, locale)),
-                PackageType.Git => new PackagePath(AppendLocale(theme.Url, locale), theme.Branch),
-                _ => theme,
-            };
-        }
-
         public static void EnsureLocalizationContributionBranch(PreloadConfig config, Repository? repository)
         {
             // When building the live-sxs branch of a loc repo, only live-sxs branch is cloned,

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -96,8 +96,7 @@ namespace Microsoft.Docs.Build
 
             if (config.Template.Type == PackageType.Git)
             {
-                var template = buildOptions.IsLocalizedBuild ? LocalizationUtility.GetLocalizedTheme(config.Template, buildOptions.Locale) : config.Template;
-                yield return (template, PackageFetchOptions.DepthOne);
+                yield return (config.Template, PackageFetchOptions.DepthOne);
             }
         }
     }

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Docs.Build
         private static void RestorePackages(BuildOptions buildOptions, Config config, PackageResolver packageResolver)
         {
             ParallelUtility.ForEach(
-                GetPackages(config, buildOptions).Distinct(),
+                GetPackages(config).Distinct(),
                 item => packageResolver.DownloadPackage(item.package, item.flags),
                 Progress.Update,
                 maxDegreeOfParallelism: 8);
@@ -87,7 +87,7 @@ namespace Microsoft.Docs.Build
             LocalizationUtility.EnsureLocalizationContributionBranch(config, buildOptions.Repository);
         }
 
-        private static IEnumerable<(PackagePath package, PackageFetchOptions flags)> GetPackages(Config config, BuildOptions buildOptions)
+        private static IEnumerable<(PackagePath package, PackageFetchOptions flags)> GetPackages(Config config)
         {
             foreach (var (_, package) in config.Dependencies)
             {

--- a/src/docfx/template/TemplateEngine.cs
+++ b/src/docfx/template/TemplateEngine.cs
@@ -22,11 +22,10 @@ namespace Microsoft.Docs.Build
 
         public TemplateEngine(Config config, BuildOptions buildOptions, PackageResolver packageResolver)
         {
-            var template = buildOptions.IsLocalizedBuild ? LocalizationUtility.GetLocalizedTheme(config.Template, buildOptions.Locale) : config.Template;
             _templateDir = config.Template.Type switch
             {
                 PackageType.None => Path.Combine(buildOptions.DocsetPath, "_themes"),
-                _ => packageResolver.ResolvePackage(template, PackageFetchOptions.DepthOne),
+                _ => packageResolver.ResolvePackage(config.Template, PackageFetchOptions.DepthOne),
             };
 
             _contentTemplateDir = Path.Combine(_templateDir, "ContentTemplate");


### PR DESCRIPTION
[AB#198860](https://ceapex.visualstudio.com/Engineering/_workitems/edit/198860/)

During the docset provision, the locale has been appended to the theme URL already.
For instance, [azure-docs-pr.de-de](https://github.com/MicrosoftDocs/azure-docs-pr.de-de/blob/23c434acc1548d0659a31fb60b7cc0089c91f1af/.openpublishing.publish.config.json#L55)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5735)