### PR TITLE
Transform <xref> tag in mustache partial

### DIFF
--- a/docs/specs/template.yml
+++ b/docs/specs/template.yml
@@ -274,6 +274,10 @@ inputs:
           "type": "string",
           "contentType": "xref"
         },
+        "uidPartial": {
+          "type": "string",
+          "contentType": "xref"
+        },
         "uids": {
           "type": "array",
           "items": {
@@ -290,29 +294,36 @@ inputs:
         }
       }
     }
-  _themes/ContentTemplate/xref-partial.tmpl.partial: |
+  _themes/ContentTemplate/xref-partial-template.tmpl.partial: |
     <a href="{{href}}" class="partial"> {{name}} </a>
   _themes/ContentTemplate/TestPage.html.primary.tmpl: |
     <p>
       <xref uid="{{uid}}" />
-      <xref uid="{{namespace}}" template="xref-partial.tmpl.partial" />
+      <xref uid="{{namespace}}" template="xref-partial-template.tmpl.partial" />
       {{#uids}}
         <xref uid="{{.}}" />
       {{/uids}}
       {{#namespaces}}
-        <xref uid="{{.}}" template="xref-partial.tmpl.partial"/>
+        <xref uid="{{.}}" template="xref-partial-template.tmpl.partial"/>
       {{/namespaces}}
+      {{>partials/uid-partial}}
     </p>
+  # normal partial include syntax, with <xref /> in partial template
+  _themes/ContentTemplate/partials/uid-partial.tmpl.partial: |
+    <xref uid="{{uidPartial}}"/>
   uid-resolve.yml: |
     ### YamlMime: TestPage
     uid: uid1
   uid-unresolve.yml: |
     ### YamlMime: TestPage
     uid: unresolve
-  uid-partial-resolve.yml: |
+  uid-partial.yml: |
+    ### YamlMime: TestPage
+    uidPartial: uid1
+  uid-partial-template-resolve.yml: |
     ### YamlMime: TestPage
     namespace: uid1
-  uid-partial-unresolve.yml: |
+  uid-partial-template-unresolve.yml: |
     ### YamlMime: TestPage
     namespace: unresolve
   uid-list.yml: |
@@ -334,11 +345,14 @@ outputs:
   uid-unresolve.mta.json:
   uid-unresolve.raw.page.json: |
     {"content": "<p> <span> unresolve </span> </p>"}
-  uid-partial-resolve.mta.json:
-  uid-partial-resolve.raw.page.json: |
+  uid-partial.mta.json:
+  uid-partial.raw.page.json: |
+    {"content": "<p> <a href=\"/en-us/uid1\" data-linktype=\"absolute-path\"> uid1-name </a> </p> "}
+  uid-partial-template-resolve.mta.json:
+  uid-partial-template-resolve.raw.page.json: |
     {"content": "<p> <a href=\"/en-us/uid1\" class=\"partial\" data-linktype=\"absolute-path\"> uid1-name </a> </p>"}
-  uid-partial-unresolve.mta.json:
-  uid-partial-unresolve.raw.page.json: |
+  uid-partial-template-unresolve.mta.json:
+  uid-partial-template-unresolve.raw.page.json: |
     {"content": "<p> <span> unresolve </span> </p>"}
   uid-list.mta.json:
   uid-list.raw.page.json: |
@@ -349,5 +363,5 @@ outputs:
   .errors.log: |
     {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'unresolve'","file":"uid-list.yml","line":4,"end_line":4,"column":5,"end_column":14}
     {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'unresolve'","file":"uid-list-partial.yml","line":4,"end_line":4,"column":5,"end_column":14}
-    {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'unresolve'","file":"uid-partial-unresolve.yml","line":2,"end_line":2,"column":12,"end_column":21}
+    {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'unresolve'","file":"uid-partial-template-unresolve.yml","line":2,"end_line":2,"column":12,"end_column":21}
     {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'unresolve'","file":"uid-unresolve.yml","line":2,"end_line":2,"column":6,"end_column":15}

--- a/src/docfx/template/MustacheTemplate.cs
+++ b/src/docfx/template/MustacheTemplate.cs
@@ -76,16 +76,15 @@ namespace Microsoft.Docs.Build
 
             public IStubbleLoader Clone() => new PartialLoader(_dir);
 
-            public ValueTask<string> LoadAsync(string name) => new ValueTask<string>(Load(name));
+            public ValueTask<string?> LoadAsync(string name) => new ValueTask<string?>(Load(name));
 
-            public string Load(string name) => _cache.GetOrAdd(
+            public string? Load(string name) => _cache.GetOrAdd(
                 name,
                 key => new Lazy<string>(() =>
                 {
                     var fileName = Path.Combine(_dir, name);
-                    if (File.Exists(fileName))
-                        return File.ReadAllText(fileName).Replace("\r", "");
-                    return File.ReadAllText(Path.Combine(_dir, name + ".tmpl.partial")).Replace("\r", "");
+                    fileName = File.Exists(fileName) ? fileName : Path.Combine(_dir, name + ".tmpl.partial");
+                    return MustacheXrefTagParser.ProcessXrefTag(File.ReadAllText(fileName).Replace("\r", ""));
                 })).Value;
         }
     }

--- a/src/docfx/template/MustacheTemplate.cs
+++ b/src/docfx/template/MustacheTemplate.cs
@@ -76,14 +76,15 @@ namespace Microsoft.Docs.Build
 
             public IStubbleLoader Clone() => new PartialLoader(_dir);
 
-            public ValueTask<string?> LoadAsync(string name) => new ValueTask<string?>(Load(name));
+            public ValueTask<string> LoadAsync(string name) => new ValueTask<string>(Load(name));
 
-            public string? Load(string name) => _cache.GetOrAdd(
+            public string Load(string name) => _cache.GetOrAdd(
                 name,
                 key => new Lazy<string>(() =>
                 {
                     var fileName = Path.Combine(_dir, name);
-                    fileName = File.Exists(fileName) ? fileName : Path.Combine(_dir, name + ".tmpl.partial");
+                    if (!File.Exists(fileName))
+                        fileName = Path.Combine(_dir, name + ".tmpl.partial");
                     return MustacheXrefTagParser.ProcessXrefTag(File.ReadAllText(fileName).Replace("\r", ""));
                 })).Value;
         }


### PR DESCRIPTION
[AB#195829](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/195829)
Template partial may also include <xref> tag.

e.g.
[NetMember.html.primary.tmpl](https://ceapex.visualstudio.com/Engineering/_git/docs-ui?path=%2Fpackages%2Fdocfx-templates%2FNetMember.html.primary.tmpl&version=GBdevelop&line=9&lineEnd=9&lineStartColumn=1&lineEndColumn=32&lineStyle=plain)
```
{{>partials/dotnet/typeHeader}}
```
[typeHeader.tmpl.partial](https://ceapex.visualstudio.com/Engineering/_git/docs-ui?path=%2Fpackages%2Fdocfx-templates%2Fpartials%2Fdotnet%2FtypeHeader.tmpl.partial&version=GBdevelop&line=8&lineEnd=9&lineStartColumn=1&lineEndColumn=1&lineStyle=plain)
```
<span class="break-text"> <xref uid="{{ . }}" template="partials/dotnet/xref-name.tmpl" /></span>
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5738)