### PR TITLE
Treat uid in toc.yml as exact uid string

### DIFF
--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -1122,6 +1122,46 @@ outputs:
       ]
     }
 ---
+# uid with fragment reference in yaml toc, treat as exact uid string
+inputs:
+  docfx.yml:
+  docs/a.md: |
+    ---
+    title: a title
+    uid: a
+    ---
+  docs/a-frag.md: |
+    ---
+    title: a-frag title
+    uid: a#frag
+    ---
+  docs/b-frag.md: |
+    ---
+    title: b-frag title
+    uid: b#frag
+    ---
+  docs/TOC.yml: |
+    - name: Uid Ref
+      uid: a
+    - name: Uid Ref 1
+      uid: a#frag
+    - name: Uid Not Found
+      uid: b
+outputs:
+  docs/a.json:
+  docs/a-frag.json:
+  docs/b-frag.json:
+  docs/toc.json: |
+    {
+      "items": [
+        { "name":"Uid Ref","href":"a","monikers": undefined },
+        { "name":"Uid Ref 1","href":"a-frag","monikers": undefined },
+        { "name":"Uid Not Found","href":undefined,"monikers": undefined }
+      ]
+    }
+  .errors.log: |
+    ["warning","xref-not-found","Cross reference not found: 'b'","docs/TOC.yml",6,8]
+---
 # uid reference first in yaml toc
 inputs:
   docfx.yml:

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -1195,24 +1195,21 @@ outputs:
     { "conceptual": "<p>Link to <a href='a?displayname=xxx' data-linktype='relative-path'>Title from yaml header a</a></p>" }
 ---
 # resolve UID with fragment
-# conceptual 
-repos:
-  https://docs.com/unkown-query#live:
-    - files:
-        docfx.yml:
-        docs/a.md: |
-          ---
-          title: a frag
-          uid: a#frag
-          ---
-        docs/a-no-frag.md: |
-          ---
-          title: a
-          uid: a
-          ---
-        docs/b.md: |
-          Link to @a
-          Link to @a#frag
+inputs:
+  docfx.yml:
+  docs/a.md: |
+    ---
+    title: a frag
+    uid: a#frag
+    ---
+  docs/a-no-frag.md: |
+    ---
+    title: a
+    uid: a
+    ---
+  docs/b.md: |
+    Link to @a
+    Link to @a#frag
 outputs:
   docs/a.json:
   docs/a-no-frag.json:

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -1194,6 +1194,31 @@ outputs:
   docs/b.json: |
     { "conceptual": "<p>Link to <a href='a?displayname=xxx' data-linktype='relative-path'>Title from yaml header a</a></p>" }
 ---
+# resolve UID with fragment
+# conceptual 
+repos:
+  https://docs.com/unkown-query#live:
+    - files:
+        docfx.yml:
+        docs/a.md: |
+          ---
+          title: a frag
+          uid: a#frag
+          ---
+        docs/a-no-frag.md: |
+          ---
+          title: a
+          uid: a
+          ---
+        docs/b.md: |
+          Link to @a
+          Link to @a#frag
+outputs:
+  docs/a.json:
+  docs/a-no-frag.json:
+  docs/b.json: |
+    { "conceptual": "<p>Link to <a href='a-no-frag' data-linktype='relative-path'>a</a>Link to <a href='a-no-frag#frag' data-linktype='relative-path'>a</a></p>" }
+---
 # respects content type when loading xref specs
 inputs:
   docfx.yml:

--- a/src/docfx/build/link/LinkResolver.cs
+++ b/src/docfx/build/link/LinkResolver.cs
@@ -74,8 +74,10 @@ namespace Microsoft.Docs.Build
         {
             if (href.Value.StartsWith("xref:"))
             {
-                var uid = new SourceInfo<string>(href.Value.Substring("xref:".Length), href);
-                var (uidError, uidHref, _, declaringFile) = _xrefResolver.ResolveXref(uid, referencingFile, inclusionRoot);
+                var (uidError, uidHref, _, declaringFile) = _xrefResolver.ResolveXrefByHref(
+                    new SourceInfo<string>(href.Value.Substring("xref:".Length), href),
+                    referencingFile,
+                    inclusionRoot);
 
                 return (uidError, uidHref ?? href, declaringFile);
             }

--- a/src/docfx/build/link/LinkResolver.cs
+++ b/src/docfx/build/link/LinkResolver.cs
@@ -74,12 +74,12 @@ namespace Microsoft.Docs.Build
         {
             if (href.Value.StartsWith("xref:"))
             {
-                var (uidError, uidHref, _, declaringFile) = _xrefResolver.ResolveXrefByHref(
+                var (xrefError, resolvedHref, _, declaringFile) = _xrefResolver.ResolveXrefByHref(
                     new SourceInfo<string>(href.Value.Substring("xref:".Length), href),
                     referencingFile,
                     inclusionRoot);
 
-                return (uidError, uidHref ?? href, declaringFile);
+                return (xrefError, resolvedHref ?? href, declaringFile);
             }
 
             var (error, link, fragment, linkType, file, isCrossReference) = TryResolveAbsoluteLink(href, referencingFile);

--- a/src/docfx/build/toc/TableOfContentsLoader.cs
+++ b/src/docfx/build/toc/TableOfContentsLoader.cs
@@ -274,17 +274,17 @@ namespace Microsoft.Docs.Build
             // process uid first
             if (!string.IsNullOrEmpty(uid.Value))
             {
-                var (uidError, uidLink, display, declaringFile) = _xrefResolver.ResolveXref(new SourceInfo<string>(uid.Value, uid), filePath, rootPath);
-                errors.AddIfNotNull(uidError);
+                var (xrefError, xrefSpec, href) = _xrefResolver.ResolveXrefSpec(new SourceInfo<string>(uid.Value, uid), filePath, rootPath);
+                errors.AddIfNotNull(xrefError);
 
-                if (declaringFile != null)
+                if (xrefSpec?.DeclaringFile != null)
                 {
-                    referencedFiles.Add(declaringFile);
+                    referencedFiles.Add(xrefSpec.DeclaringFile);
                 }
 
-                if (!string.IsNullOrEmpty(uidLink))
+                if (!string.IsNullOrEmpty(href))
                 {
-                    return (new SourceInfo<string?>(uidLink, uid), new SourceInfo<string?>(display, uid), declaringFile);
+                    return (new SourceInfo<string?>(href, uid), new SourceInfo<string?>(xrefSpec.Name, uid), xrefSpec.DeclaringFile);
                 }
             }
 

--- a/src/docfx/build/toc/TableOfContentsLoader.cs
+++ b/src/docfx/build/toc/TableOfContentsLoader.cs
@@ -174,17 +174,17 @@ namespace Microsoft.Docs.Build
             // Process uid
             if (!string.IsNullOrEmpty(node.Uid.Value))
             {
-                var (xrefError, xrefSpec, resolvedHref) = _xrefResolver.ResolveXrefSpec(new SourceInfo<string>(node.Uid.Value, node.Uid), filePath, rootPath);
+                var (xrefError, resolvedHref, display, declaringFile) = _xrefResolver.ResolveXrefByUid(new SourceInfo<string>(node.Uid.Value, node.Uid), filePath, rootPath);
                 errors.AddIfNotNull(xrefError);
 
-                if (xrefSpec?.DeclaringFile != null)
+                if (declaringFile != null)
                 {
-                    referencedFiles.Add(xrefSpec.DeclaringFile);
+                    referencedFiles.Add(declaringFile);
                 }
 
                 if (!string.IsNullOrEmpty(resolvedHref))
                 {
-                    return (new SourceInfo<string?>(resolvedHref, node.Uid), new SourceInfo<string?>(xrefSpec.Name, node.Uid), xrefSpec.DeclaringFile);
+                    return (new SourceInfo<string?>(resolvedHref, node.Uid), new SourceInfo<string?>(display, node.Uid), declaringFile);
                 }
             }
 

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Docs.Build
             _xrefHostName = string.IsNullOrEmpty(config.XrefHostName) ? config.HostName : config.XrefHostName;
         }
 
-        public (Error? error, string? href, string display, Document? declaringFile) ResolveXref(
+        public (Error? error, string? href, string display, Document? declaringFile) ResolveXrefByHref(
             SourceInfo<string> href, Document referencingFile, Document inclusionRoot)
         {
             var (uid, query, fragment) = UrlUtility.SplitUrl(href);
@@ -82,6 +82,19 @@ namespace Microsoft.Docs.Build
 
             resolvedHref = UrlUtility.MergeUrl(resolvedHref, query, fragment);
             return (null, resolvedHref, display, xrefSpec?.DeclaringFile);
+        }
+
+        public (Error? error, string? href, string display, Document? declaringFile) ResolveXrefByUid(
+            SourceInfo<string> uid, Document referencingFile, Document inclusionRoot)
+        {
+            // need to url decode uid from input content
+            var (xrefError, xrefSpec, resolvedHref) = ResolveXrefSpec(new SourceInfo<string>(uid, uid.Source), referencingFile, inclusionRoot);
+            if (xrefError != null || xrefSpec == null || resolvedHref == null)
+            {
+                return (xrefError, null, "", null);
+            }
+            _fileLinkMapBuilder.AddFileLink(inclusionRoot.FilePath, inclusionRoot.SiteUrl, xrefSpec.Href);
+            return (null, resolvedHref, xrefSpec.Name ?? "", xrefSpec.DeclaringFile);
         }
 
         public (Error?, IXrefSpec?, string? href) ResolveXrefSpec(SourceInfo<string> uid, Document referencingFile, Document inclusionRoot)

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -88,13 +88,13 @@ namespace Microsoft.Docs.Build
             SourceInfo<string> uid, Document referencingFile, Document inclusionRoot)
         {
             // need to url decode uid from input content
-            var (xrefError, xrefSpec, resolvedHref) = ResolveXrefSpec(new SourceInfo<string>(uid, uid.Source), referencingFile, inclusionRoot);
-            if (xrefError != null || xrefSpec == null || resolvedHref == null)
+            var (error, xrefSpec, href) = ResolveXrefSpec(uid, referencingFile, inclusionRoot);
+            if (error != null || xrefSpec == null || href == null)
             {
-                return (xrefError, null, "", null);
+                return (error, null, "", null);
             }
             _fileLinkMapBuilder.AddFileLink(inclusionRoot.FilePath, inclusionRoot.SiteUrl, xrefSpec.Href);
-            return (null, resolvedHref, xrefSpec.Name ?? "", xrefSpec.DeclaringFile);
+            return (null, href, xrefSpec.Name ?? "", xrefSpec.DeclaringFile);
         }
 
         public (Error?, IXrefSpec?, string? href) ResolveXrefSpec(SourceInfo<string> uid, Document referencingFile, Document inclusionRoot)

--- a/src/docfx/lib/markdown/MarkdownEngine.cs
+++ b/src/docfx/lib/markdown/MarkdownEngine.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Docs.Build
         private (string? href, string display) GetXref(SourceInfo<string> href, bool isShorthand)
         {
             var status = t_status.Value!.Peek();
-            var (error, link, display, _) = _xrefResolver.ResolveXref(
+            var (error, link, display, _) = _xrefResolver.ResolveXrefByHref(
                 href, (Document)InclusionContext.File, (Document)InclusionContext.RootFile);
 
             if (!isShorthand)


### PR DESCRIPTION
[AB#188564](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/188564)

Separate resolveXref => resolveXrefByHref & resolveXrefByUid
resolveXrefByHref: invoked by link resolve in markdown syntax
resolveXrefByUid: invoked by uid resolve by SDP & yaml toc node

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5742)