### PR TITLE
Move exception handling to ParallelUtility

### DIFF
--- a/src/docfx/build/context/BuildScope.cs
+++ b/src/docfx/build/context/BuildScope.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Docs.Build
         /// </summary>
         public IEnumerable<FilePath> Files => _files.Keys;
 
-        public BuildScope(Config config, Input input, BuildOptions buildOptions)
+        public BuildScope(ErrorLog errorLog, Config config, Input input, BuildOptions buildOptions)
         {
             _config = config;
             _globs = CreateGlobs(config);
@@ -41,7 +41,7 @@ namespace Microsoft.Docs.Build
             {
                 var (fileNames, allFiles) = ListFiles(config, input, buildOptions);
 
-                ParallelUtility.ForEach(allFiles, file =>
+                ParallelUtility.ForEach(errorLog, allFiles, file =>
                 {
                     if (Glob(file.Path))
                     {

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Docs.Build
             Output = new Output(buildOptions.OutputPath, Input, Config.DryRun);
             TemplateEngine = new TemplateEngine(config, buildOptions, PackageResolver);
             MicrosoftGraphAccessor = new MicrosoftGraphAccessor(Config);
-            BuildScope = new BuildScope(Config, Input, buildOptions);
+            BuildScope = new BuildScope(ErrorLog, Config, Input, buildOptions);
             DocumentProvider = new DocumentProvider(config, buildOptions, BuildScope, Input, TemplateEngine);
             MetadataProvider = new MetadataProvider(Config, Input, MicrosoftGraphAccessor, FileResolver, DocumentProvider);
             MonikerProvider = new MonikerProvider(Config, BuildScope, MetadataProvider, FileResolver);

--- a/src/docfx/build/toc/TableOfContentsMap.cs
+++ b/src/docfx/build/toc/TableOfContentsMap.cs
@@ -145,9 +145,9 @@ namespace Microsoft.Docs.Build
                 var tocReferences = new ConcurrentDictionary<Document, (List<Document> docs, List<Document> tocs)>();
 
                 ParallelUtility.ForEach(
+                    _errorLog,
                     _buildScope.GetFiles(ContentType.TableOfContents),
-                    file => LoadToc(file, tocReferences),
-                    Progress.Update);
+                    file => LoadToc(file, tocReferences));
 
                 var includedTocs = tocReferences.Values.SelectMany(item => item.tocs).ToHashSet();
 
@@ -168,20 +168,13 @@ namespace Microsoft.Docs.Build
 
         private void LoadToc(FilePath path, ConcurrentDictionary<Document, (List<Document> files, List<Document> tocs)> tocReferences)
         {
-            try
-            {
-                var file = _documentProvider.GetDocument(path);
-                Debug.Assert(file.ContentType == ContentType.TableOfContents);
+            var file = _documentProvider.GetDocument(path);
+            Debug.Assert(file.ContentType == ContentType.TableOfContents);
 
-                var (errors, _, referencedDocuments, referencedTocs) = _tocLoader.Load(file);
-                _errorLog.Write(errors);
+            var (errors, _, referencedDocuments, referencedTocs) = _tocLoader.Load(file);
+            _errorLog.Write(errors);
 
-                tocReferences.TryAdd(file, (referencedDocuments, referencedTocs));
-            }
-            catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
-            {
-                _errorLog.Write(dex);
-            }
+            tocReferences.TryAdd(file, (referencedDocuments, referencedTocs));
         }
     }
 }

--- a/src/docfx/lib/ParallelUtility.cs
+++ b/src/docfx/lib/ParallelUtility.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Docs.Build
             EnsureOrdered = false,
         };
 
-        public static void ForEach<T>(IEnumerable<T> source, Action<T> action, Action<int, int>? progress = null, int? maxDegreeOfParallelism = null)
+        public static void ForEach<T>(ErrorLog errorLog, IEnumerable<T> source, Action<T> action, int? maxDegreeOfParallelism = null)
         {
             Debug.Assert(maxDegreeOfParallelism == null || maxDegreeOfParallelism.Value > 0);
 
@@ -37,16 +37,30 @@ namespace Microsoft.Docs.Build
                 },
                 item =>
                 {
-                    action(item);
-                    progress?.Invoke(Interlocked.Increment(ref done), total);
+                    try
+                    {
+                        action(item);
+                    }
+                    catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
+                    {
+                        errorLog.Write(dex);
+                    }
+                    catch
+                    {
+                        Console.WriteLine($"Error processing '{item}'");
+                        throw;
+                    }
+
+                    Progress.Update(Interlocked.Increment(ref done), total);
                 });
         }
 
-        public static async Task ForEach<T>(IEnumerable<T> source, Func<T, Task> action, Action<int, int>? progress = null)
+        public static async Task ForEach<T>(ErrorLog errorLog, IEnumerable<T> source, Func<T, Task> action)
         {
             var done = 0;
             var total = 0;
             var queue = new ActionBlock<T>(Run, s_dataflowOptions);
+
             foreach (var item in source)
             {
                 var posted = queue.Post(item);
@@ -78,13 +92,23 @@ namespace Microsoft.Docs.Build
                 {
                     await action(item);
                 }
+                catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
+                {
+                    errorLog.Write(dex);
+                }
                 catch (OperationCanceledException oce)
                 {
                     // Action block catches cancellation exceptions
                     // https://github.com/dotnet/corefx/blob/4b36fba308d8e2d3207773952c30268ac3365eed/src/System.Threading.Tasks.Dataflow/src/Blocks/ActionBlock.cs#L142
                     throw new WrapException(oce);
                 }
-                progress?.Invoke(Interlocked.Increment(ref done), total);
+                catch
+                {
+                    Console.WriteLine($"Error processing '{item}'");
+                    throw;
+                }
+
+                Progress.Update(Interlocked.Increment(ref done), total);
             }
         }
 

--- a/src/docfx/lib/log/ErrorLog.cs
+++ b/src/docfx/lib/log/ErrorLog.cs
@@ -142,8 +142,7 @@ namespace Microsoft.Docs.Build
                                             : WarningCount > 0 ? ConsoleColor.Yellow
                                             : ConsoleColor.Magenta;
                     Console.WriteLine();
-                    Console.WriteLine(
-                        $"  {ErrorCount} Error(s), {WarningCount} Warning(s), {SuggestionCount} Suggestion(s)");
+                    Console.WriteLine($"  {ErrorCount} Error(s), {WarningCount} Warning(s), {SuggestionCount} Suggestion(s)");
                 }
 
                 Console.ResetColor();
@@ -240,16 +239,11 @@ namespace Microsoft.Docs.Build
 
         private bool IncrementExceedMaxErrors(Config? config, ErrorLevel level)
         {
-            if (config == null)
-            {
-                return false;
-            }
-
             return level switch
             {
-                ErrorLevel.Error => Interlocked.Increment(ref _errorCount) > config.MaxErrors,
-                ErrorLevel.Warning => Interlocked.Increment(ref _warningCount) > config.MaxWarnings,
-                ErrorLevel.Suggestion => Interlocked.Increment(ref _suggestionCount) > config.MaxSuggestions,
+                ErrorLevel.Error => Interlocked.Increment(ref _errorCount) > (config?.MaxErrors ?? int.MaxValue),
+                ErrorLevel.Warning => Interlocked.Increment(ref _warningCount) > (config?.MaxWarnings ?? int.MaxValue),
+                ErrorLevel.Suggestion => Interlocked.Increment(ref _suggestionCount) > (config?.MaxSuggestions ?? int.MaxValue),
                 _ => false,
             };
         }

--- a/src/docfx/lib/log/ErrorLog.cs
+++ b/src/docfx/lib/log/ErrorLog.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Docs.Build
 
         public IEnumerable<FilePath> ErrorFiles => _errorFiles;
 
-        public ErrorLog(string? outputPath, bool legacy = false)
+        public ErrorLog(string? outputPath = null, bool legacy = false)
         {
             _legacy = legacy;
             _output = new Lazy<TextWriter>(() => outputPath is null ? TextWriter.Null : CreateOutput(outputPath));

--- a/src/docfx/lib/log/Progress.cs
+++ b/src/docfx/lib/log/Progress.cs
@@ -29,7 +29,11 @@ namespace Microsoft.Docs.Build
 
         public static void Update(int done, int total)
         {
-            var scope = t_scope.Value!.Peek();
+            var scope = t_scope.Value?.Peek();
+            if (scope is null)
+            {
+                return;
+            }
 
             // Only write progress if it takes longer than 2 seconds
             var elapsedMs = scope.Stopwatch.ElapsedMilliseconds;
@@ -43,6 +47,7 @@ namespace Microsoft.Docs.Build
             {
                 return;
             }
+
             scope.LastElapsedMs = elapsedMs;
 
             var eol = done == total ? '\n' : '\r';

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -56,10 +56,12 @@ namespace Microsoft.Docs.Build
                             () => RestoreFiles(errorLog, config, fileResolver).GetAwaiter().GetResult(),
                             () => RestorePackages(errorLog, buildOptions, config, packageResolver));
                     }
+                    return errorLog.ErrorCount > 0;
                 }
                 catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
                 {
-                    return errorLog.Write(dex);
+                    errorLog.Write(dex);
+                    return errorLog.ErrorCount > 0;
                 }
                 finally
                 {
@@ -67,7 +69,6 @@ namespace Microsoft.Docs.Build
                     Log.Important($"Restore done in {Progress.FormatTimeSpan(stopwatch.Elapsed)}", ConsoleColor.Green);
                     errorLog.PrintSummary();
                 }
-                return false;
             }
         }
 

--- a/test/docfx.Test/lib/WorkQueueTest.cs
+++ b/test/docfx.Test/lib/WorkQueueTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Docs.Build
             var queue = new WorkQueue<int>();
             queue.Enqueue(Enumerable.Range(0, 1000));
 
-            var exception = Assert.ThrowsAny<Exception>(() => queue.Drain(Run));
+            var exception = Assert.ThrowsAny<Exception>(() => queue.Drain(new ErrorLog(), Run));
             Assert.Equal(exceptionType, exception.GetType());
 
             void Run(int n)
@@ -39,7 +39,7 @@ namespace Microsoft.Docs.Build
             var queue = new WorkQueue<int>();
             queue.Enqueue(Enumerable.Range(0, total));
 
-            queue.Drain(Run);
+            queue.Drain(new ErrorLog(), Run);
 
             void Run(int n)
             {


### PR DESCRIPTION
#5729 

Makes it easier to write parallel looks without try catch.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5747)