### PR TITLE
WorkQueue to run items on enqueue

### DIFF
--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Docs.Build
         public Context(ErrorLog errorLog, Config config, BuildOptions buildOptions, PackageResolver packageResolver, FileResolver fileResolver)
         {
             DependencyMapBuilder = new DependencyMapBuilder();
-            BuildQueue = new WorkQueue<FilePath>();
+            BuildQueue = new WorkQueue<FilePath>(errorLog);
 
             Config = config;
             ErrorLog = errorLog;

--- a/src/docfx/lib/collections/WorkQueue.cs
+++ b/src/docfx/lib/collections/WorkQueue.cs
@@ -13,17 +13,20 @@ namespace Microsoft.Docs.Build
     {
         private static readonly int s_maxParallelism = Math.Max(8, Environment.ProcessorCount * 2);
 
+        private readonly ErrorLog _errorLog;
         private readonly ConcurrentQueue<T> _queue = new ConcurrentQueue<T>();
         private readonly ConcurrentHashSet<T> _duplicationDetector = new ConcurrentHashSet<T>();
 
         private readonly TaskCompletionSource<int> _drainTcs = new TaskCompletionSource<int>();
+
+        private volatile Action<T>? _run;
 
         // For progress reporting
         private int _totalCount = 0;
         private int _processedCount = 0;
 
         // For completion detection
-        private int _remainingCount = 0;
+        private int _remainingCount = 1;
 
         // When an exception occurs, store it here,
         // then wait until all jobs to complete before Drain returns.
@@ -34,6 +37,11 @@ namespace Microsoft.Docs.Build
         private int _parallelism;
 
         private int _drained;
+
+        public WorkQueue(ErrorLog errorLog)
+        {
+            _errorLog = errorLog;
+        }
 
         public void Enqueue(IEnumerable<T> items)
         {
@@ -52,113 +60,123 @@ namespace Microsoft.Docs.Build
 
             if (_drainTcs.Task.IsCompleted)
             {
-                throw new InvalidOperationException("Cannot enqueue new items after the queue is drained");
+                throw new InvalidOperationException();
             }
 
             _queue.Enqueue(item);
 
             Interlocked.Increment(ref _totalCount);
             Interlocked.Increment(ref _remainingCount);
+
+            DrainCore();
         }
 
-        public void Drain(ErrorLog errorLog, Action<T> run)
+        public void Start(Action<T> run)
+        {
+            if (Interlocked.CompareExchange(ref _run, run, null) != null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            _run = run;
+        }
+
+        public void WaitForCompletion()
         {
             if (Interlocked.Exchange(ref _drained, 1) == 1)
             {
-                throw new InvalidOperationException("Can only drain once");
+                throw new InvalidOperationException();
             }
 
-            if (_queue.Count == 0)
+            OnComplete();
+
+            _drainTcs.Task.GetAwaiter().GetResult();
+        }
+
+        private void DrainCore()
+        {
+            while (!_drainTcs.Task.IsCompleted)
             {
+                if (!_queue.TryPeek(out var item))
+                {
+                    break;
+                }
+
+                if (Volatile.Read(ref _parallelism) > s_maxParallelism)
+                {
+                    break;
+                }
+
+                if (!_queue.TryDequeue(out item))
+                {
+                    break;
+                }
+
+                Interlocked.Increment(ref _parallelism);
+
+                ThreadPool.QueueUserWorkItem(Run, item, preferLocal: true);
+            }
+        }
+
+        private void Run(T item)
+        {
+            if (_exception != null)
+            {
+                OnComplete();
                 return;
             }
 
-            DrainCore();
-            _drainTcs.Task.GetAwaiter().GetResult();
+            var run = _run ?? throw new InvalidOperationException();
 
-            void DrainCore()
+            try
             {
-                while (!_drainTcs.Task.IsCompleted)
-                {
-                    if (!_queue.TryPeek(out var item))
-                    {
-                        break;
-                    }
+                _run(item);
+                OnComplete();
+            }
+            catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
+            {
+                _errorLog.Write(dex);
+                OnComplete();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error processing '{item}'");
+                OnComplete(ex);
+            }
+        }
 
-                    if (Volatile.Read(ref _parallelism) > s_maxParallelism)
-                    {
-                        break;
-                    }
+        private void OnComplete(Exception? exception = null)
+        {
+            Interlocked.Decrement(ref _parallelism);
 
-                    if (!_queue.TryDequeue(out item))
-                    {
-                        break;
-                    }
-
-                    Interlocked.Increment(ref _parallelism);
-
-                    ThreadPool.QueueUserWorkItem(Run, item, preferLocal: true);
-                }
+            try
+            {
+                Progress.Update(Interlocked.Increment(ref _processedCount), _totalCount);
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
             }
 
-            void Run(T item)
+            if (exception != null)
             {
-                if (_exception != null)
-                {
-                    OnComplete();
-                    return;
-                }
-
-                try
-                {
-                    run(item);
-                    OnComplete();
-                }
-                catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
-                {
-                    errorLog.Write(dex);
-                    OnComplete();
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine($"Error processing '{item}'");
-                    OnComplete(ex);
-                }
+                _exception = exception;
             }
 
-            void OnComplete(Exception? exception = null)
+            if (Interlocked.Decrement(ref _remainingCount) == 0)
             {
-                Interlocked.Decrement(ref _parallelism);
-
-                try
+                if (_exception is null)
                 {
-                    Progress.Update(Interlocked.Increment(ref _processedCount), _totalCount);
-                }
-                catch (Exception ex)
-                {
-                    exception = ex;
-                }
-
-                if (exception != null)
-                {
-                    _exception = exception;
-                }
-
-                if (Interlocked.Decrement(ref _remainingCount) == 0)
-                {
-                    if (_exception is null)
-                    {
-                        _drainTcs.SetResult(0);
-                    }
-                    else
-                    {
-                        _drainTcs.SetException(_exception);
-                    }
+                    _drainTcs.SetResult(0);
                 }
                 else
                 {
-                    DrainCore();
+                    _drainTcs.SetException(_exception);
                 }
+            }
+            else
+            {
+                DrainCore();
             }
         }
     }


### PR DESCRIPTION
Update WorkQueue to allow execution on enqueue. This is a minor improvement and allows more parallelism. The true bottleneck is still TOC accessing monikers sequentially. 

[195849](https://dev.azure.com/ceapex/Engineering/_workitems/edit/195849)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5752)