### PR TITLE
Parent TOC not participating in _tocRel resolve

### DIFF
--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -453,10 +453,10 @@ inputs:
     - name: parent-b
       tocHref: child-b/
       topicHref: ../b.md
-  docs/child-a/toc.yml: |
+  docs/child-a/TOC.yml: |
     - name: child-a
       topicHref: ../../a.md
-  docs/child-b/toc.yml: |
+  docs/child-b/TOC.yml: |
     - name: child-b
       topicHref: ../../b.md
   a.md:

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -443,6 +443,33 @@ outputs:
       ]
     }
 ---
+# Parent(including) toc doesn't participate in _tocRel resolution
+inputs:
+  docfx.yml:
+  docs/TOC.yml: |
+    - name: parent-a
+      tocHref: child-a/
+      topicHref: ../a.md
+    - name: parent-b
+      tocHref: child-b/
+      topicHref: ../b.md
+  docs/child-a/toc.yml: |
+    - name: child-a
+      topicHref: ../../a.md
+  docs/child-b/toc.yml: |
+    - name: child-b
+      topicHref: ../../b.md
+  a.md:
+  b.md:
+outputs:
+  docs/toc.json:
+  docs/child-a/toc.json:
+  docs/child-b/toc.json:
+  a.json: |
+    {"_tocRel": "docs/child-a/toc.json"}
+  b.json: |
+    {"_tocRel": "docs/child-b/toc.json"}
+---
 # Combine toc href, topic href => href + items
 inputs:
   docfx.yml:


### PR DESCRIPTION
[AB#188564](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/188564)

Following v2 logic [here](https://github.com/dotnet/docfx/blob/dev/src/Microsoft.DocAsCode.Build.TableOfContents/TocDocumentProcessor.cs#L61)
If current node's including a toc(either by directory or by exact toc file), it won't be added to TocMap for resolving article's `_tocRel`. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5763)