### PR TITLE
Export href for uid declaration

### DIFF
--- a/docs/specs/template.yml
+++ b/docs/specs/template.yml
@@ -422,3 +422,57 @@ outputs:
           uid has no summary
         </p>"
     }
+---
+# Uid self reference 
+legacy: true
+inputs:
+  docfx.yml:
+  _themes/ContentTemplate/schemas/TestPage.schema.json: |
+    {
+      "type": "object",
+      "properties": {
+        "uid": {"contentType": "uid"},
+        "summary": {"type": "string"},
+        "description": {"type": "string"},
+        "uids": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "uid": {"contentType": "uid"}
+            }
+          }
+        }
+      }
+    }
+  _themes/ContentTemplate/TestPage.html.primary.tmpl: |
+    <p>
+      <xref uid="{{ uid }}" />
+      {{#uids}}
+        <xref uid="{{uid}}" />
+      {{/uids}}
+    </p>
+
+  # normal partial include syntax, with <xref /> in partial template
+ 
+  self-uid.yml: |
+    ### YamlMime: TestPage
+    uid: uid
+    name: root name
+    uids:
+      - uid: child-1
+        name: child-1 name
+      - uid: child-2
+        name: child-2 name
+
+outputs:
+  self-uid.mta.json:
+  self-uid.raw.page.json: |
+    {
+      "content": "
+        <p>
+            <a href=\"self-uid\" data-linktype=\"relative-path\"> root name </a>
+            <a href=\"self-uid#child_1\" data-linktype=\"relative-path\"> child-1 name </a>
+            <a href=\"self-uid#child_2\" data-linktype=\"relative-path\"> child-2 name </a>
+        </p>"
+    }

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Docs.Build
                     }
                     if (IsXrefSpec(obj, schema, out var uid))
                     {
-                        newObject["href"] = GetXrefHref(file, uid, uidCount.Value, obj.Parent == null);
+                        newObject["href"] = PathUtility.GetRelativePathToFile(file.SiteUrl, GetXrefHref(file, uid, uidCount.Value, obj.Parent == null));
                     }
                     return (errors, newObject);
 

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Docs.Build
         private readonly ConcurrentDictionary<JToken, (List<Error>, JToken)> _xrefPropertiesCache =
                      new ConcurrentDictionary<JToken, (List<Error>, JToken)>(ReferenceEqualsComparer.Default);
 
-        private readonly ConcurrentDictionary<Document, Lazy<int>> _uidCountCache =
-                     new ConcurrentDictionary<Document, Lazy<int>>(ReferenceEqualsComparer.Default);
+        private readonly ConcurrentDictionary<Document, int> _uidCountCache =
+                     new ConcurrentDictionary<Document, int>(ReferenceEqualsComparer.Default);
 
         private static ThreadLocal<Stack<SourceInfo<string>>> t_recursionDetector
                  = new ThreadLocal<Stack<SourceInfo<string>>>(() => new Stack<SourceInfo<string>>());
@@ -32,7 +32,7 @@ namespace Microsoft.Docs.Build
 
         public (List<Error> errors, JToken token) TransformContent(Document file, Context context, JToken token)
         {
-            var uidCount = _uidCountCache.GetOrAdd(file, new Lazy<int>(() => GetFileUidCount(_schema, token))).Value;
+            var uidCount = _uidCountCache.GetOrAdd(file, GetFileUidCount(_schema, token));
             return TransformContentCore(file, context, _schema, token, uidCount);
         }
 
@@ -40,7 +40,7 @@ namespace Microsoft.Docs.Build
         {
             var errors = new List<Error>();
             var xrefSpecs = new List<InternalXrefSpec>();
-            var uidCount = _uidCountCache.GetOrAdd(file, new Lazy<int>(() => GetFileUidCount(_schema, token))).Value;
+            var uidCount = _uidCountCache.GetOrAdd(file, GetFileUidCount(_schema, token));
             LoadXrefSpecsCore(file, context, _schema, token, errors, xrefSpecs, uidCount);
             return (errors, xrefSpecs);
         }

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -18,6 +18,15 @@ namespace Microsoft.Docs.Build
         private readonly ConcurrentDictionary<JToken, (List<Error>, JToken)> _xrefPropertiesCache =
                      new ConcurrentDictionary<JToken, (List<Error>, JToken)>(ReferenceEqualsComparer.Default);
 
+        private readonly ConcurrentDictionary<Document, Lazy<int>> _uidCountCache =
+                     new ConcurrentDictionary<Document, Lazy<int>>(ReferenceEqualsComparer.Default);
+
+        private readonly ConcurrentDictionary<JObject, SourceInfo<string>> _xrefUidCache =
+                     new ConcurrentDictionary<JObject, SourceInfo<string>>(ReferenceEqualsComparer.Default);
+
+        private readonly ConcurrentDictionary<JObject, string> _xrefHrefCache =
+                     new ConcurrentDictionary<JObject, string>(ReferenceEqualsComparer.Default);
+
         private static ThreadLocal<Stack<SourceInfo<string>>> t_recursionDetector
                  = new ThreadLocal<Stack<SourceInfo<string>>>(() => new Stack<SourceInfo<string>>());
 
@@ -29,57 +38,50 @@ namespace Microsoft.Docs.Build
 
         public (List<Error> errors, JToken token) TransformContent(Document file, Context context, JToken token)
         {
-            return TransformContentCore(file, context, _schema, token);
+            var uidCount = _uidCountCache.GetOrAdd(file, new Lazy<int>(() => GetFileUidCount(_schema, token)));
+            return TransformContentCore(file, context, _schema, token, uidCount);
         }
 
         public (List<Error>, IReadOnlyList<InternalXrefSpec>) LoadXrefSpecs(Document file, Context context, JToken token)
         {
             var errors = new List<Error>();
             var xrefSpecs = new List<InternalXrefSpec>();
-            LoadXrefSpecsCore(file, context, _schema, token, errors, xrefSpecs);
-
-            // if only one uid defined in the file, remove the bookmark from href if any
-            if (xrefSpecs.Count == 1)
-            {
-                xrefSpecs[0].Href = xrefSpecs[0].Href.Split('#')[0];
-            }
+            var uidCount = _uidCountCache.GetOrAdd(file, new Lazy<int>(() => GetFileUidCount(_schema, token)));
+            LoadXrefSpecsCore(file, context, _schema, token, errors, xrefSpecs, uidCount);
             return (errors, xrefSpecs);
         }
 
-        private void LoadXrefSpecsCore(Document file, Context context, JsonSchema schema, JToken node, List<Error> errors, List<InternalXrefSpec> xrefSpecs)
+        private void LoadXrefSpecsCore(Document file, Context context, JsonSchema schema, JToken node, List<Error> errors, List<InternalXrefSpec> xrefSpecs, Lazy<int> uidCount)
         {
             schema = _definitions.GetDefinition(schema);
             switch (node)
             {
                 case JObject obj:
-                    // A xrefspec MUST be named uid, and the schema contentType MUST also be uid
-                    if (obj.TryGetValue<JValue>("uid", out var uidValue) && uidValue.Value is string uid &&
-                        schema.Properties.TryGetValue("uid", out var uidSchema) && uidSchema.ContentType == JsonSchemaContentType.Uid)
+                    if (IsXrefSpec(obj, schema, out var uid))
                     {
-                        xrefSpecs.Add(LoadXrefSpec(file, context, schema, new SourceInfo<string>(uid, uidValue.GetSourceInfo()), obj));
+                        xrefSpecs.Add(LoadXrefSpec(file, context, schema, uid, obj, uidCount));
                     }
 
                     foreach (var (key, value) in obj)
                     {
                         if (value != null && schema.Properties.TryGetValue(key, out var propertySchema))
                         {
-                            LoadXrefSpecsCore(file, context, propertySchema, value, errors, xrefSpecs);
+                            LoadXrefSpecsCore(file, context, propertySchema, value, errors, xrefSpecs, uidCount);
                         }
                     }
                     break;
                 case JArray array when schema.Items.schema != null:
                     foreach (var item in array)
                     {
-                        LoadXrefSpecsCore(file, context, schema.Items.schema, item, errors, xrefSpecs);
+                        LoadXrefSpecsCore(file, context, schema.Items.schema, item, errors, xrefSpecs, uidCount);
                     }
                     break;
             }
         }
 
-        private InternalXrefSpec LoadXrefSpec(Document file, Context context, JsonSchema schema, SourceInfo<string> uid, JObject obj)
+        private InternalXrefSpec LoadXrefSpec(Document file, Context context, JsonSchema schema, SourceInfo<string> uid, JObject obj, Lazy<int> uidCount)
         {
-            var fragment = $"#{Regex.Replace(uid, @"\W", "_")}";
-            var href = obj.Parent is null ? file.SiteUrl : UrlUtility.MergeUrl(file.SiteUrl, "", fragment);
+            var href = _xrefHrefCache.GetOrAdd(obj, (_) => GetXrefHref(file, uid, uidCount.Value, obj.Parent == null));
             var xref = new InternalXrefSpec(uid, href, file);
 
             foreach (var xrefProperty in schema.XrefProperties)
@@ -97,14 +99,69 @@ namespace Microsoft.Docs.Build
                 }
 
                 xref.XrefProperties[xrefProperty] = new Lazy<JToken>(
-                    () => LoadXrefProperty(file, context, uid, value, propertySchema),
+                    () => LoadXrefProperty(file, context, uid, value, propertySchema, uidCount),
                     LazyThreadSafetyMode.PublicationOnly);
             }
 
             return xref;
         }
 
-        private JToken LoadXrefProperty(Document file, Context context, SourceInfo<string> uid, JToken value, JsonSchema schema)
+        private int GetFileUidCount(JsonSchema schema, JToken node)
+        {
+            schema = _definitions.GetDefinition(schema);
+            var count = 0;
+            switch (node)
+            {
+                case JObject obj:
+                    if (IsXrefSpec(obj, schema, out _))
+                    {
+                        count++;
+                    }
+
+                    foreach (var (key, value) in obj)
+                    {
+                        if (value != null && schema.Properties.TryGetValue(key, out var propertySchema))
+                        {
+                            count += GetFileUidCount(propertySchema, value);
+                        }
+                    }
+                    break;
+                case JArray array when schema.Items.schema != null:
+                    foreach (var item in array)
+                    {
+                        count += GetFileUidCount(schema.Items.schema, item);
+                    }
+                    break;
+            }
+            return count;
+        }
+
+        private bool IsXrefSpec(JObject obj, JsonSchema schema, out SourceInfo<string> uid)
+        {
+            if (_xrefUidCache.TryGetValue(obj, out uid))
+            {
+                return true;
+            }
+            else
+            {
+                uid = default;
+
+                // A xrefspec MUST be named uid, and the schema contentType MUST also be uid
+                if (obj.TryGetValue<JValue>("uid", out var uidValue) && uidValue.Value is string tempUid &&
+                   schema.Properties.TryGetValue("uid", out var uidSchema) && uidSchema.ContentType == JsonSchemaContentType.Uid)
+                {
+                    uid = new SourceInfo<string>(tempUid, uidValue.GetSourceInfo());
+                    _xrefUidCache.TryAdd(obj, uid);
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private string GetXrefHref(Document file, string uid, int uidCount, bool isRootLevel)
+            => !isRootLevel && uidCount > 1 ? UrlUtility.MergeUrl(file.SiteUrl, "", $"#{Regex.Replace(uid, @"\W", "_")}") : file.SiteUrl;
+
+        private JToken LoadXrefProperty(Document file, Context context, SourceInfo<string> uid, JToken value, JsonSchema schema, Lazy<int> uidCount)
         {
             var recursionDetector = t_recursionDetector.Value!;
             if (recursionDetector.Contains(uid))
@@ -115,7 +172,7 @@ namespace Microsoft.Docs.Build
             try
             {
                 recursionDetector.Push(uid);
-                var (transformErrors, transformedToken) = _xrefPropertiesCache.GetOrAdd(value, _ => TransformContentCore(file, context, schema, value));
+                var (transformErrors, transformedToken) = _xrefPropertiesCache.GetOrAdd(value, _ => TransformContentCore(file, context, schema, value, uidCount));
                 context.ErrorLog.Write(transformErrors);
                 return transformedToken;
             }
@@ -126,7 +183,7 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private (List<Error>, JToken) TransformContentCore(Document file, Context context, JsonSchema schema, JToken token)
+        private (List<Error>, JToken) TransformContentCore(Document file, Context context, JsonSchema schema, JToken token, Lazy<int> uidCount)
         {
             var errors = new List<Error>();
             schema = _definitions.GetDefinition(schema);
@@ -142,7 +199,7 @@ namespace Microsoft.Docs.Build
                     var newArray = new JArray();
                     foreach (var item in array)
                     {
-                        var (arrayErrors, newItem) = TransformContentCore(file, context, schema.Items.schema, item);
+                        var (arrayErrors, newItem) = TransformContentCore(file, context, schema.Items.schema, item, uidCount);
                         errors.AddRange(arrayErrors);
                         newArray.Add(newItem);
                     }
@@ -161,8 +218,8 @@ namespace Microsoft.Docs.Build
                         {
                             var isXrefProperty = schema.XrefProperties.Contains(key);
                             var (propertyErrors, transformedValue) = isXrefProperty
-                                ? _xrefPropertiesCache.GetOrAdd(value, _ => TransformContentCore(file, context, propertySchema, value))
-                                : TransformContentCore(file, context, propertySchema, value);
+                                ? _xrefPropertiesCache.GetOrAdd(value, _ => TransformContentCore(file, context, propertySchema, value, uidCount))
+                                : TransformContentCore(file, context, propertySchema, value, uidCount);
                             errors.AddRange(propertyErrors);
                             newObject[key] = transformedValue;
                         }
@@ -170,6 +227,10 @@ namespace Microsoft.Docs.Build
                         {
                             newObject[key] = value;
                         }
+                    }
+                    if (IsXrefSpec(obj, schema, out var uid))
+                    {
+                        newObject["href"] = _xrefHrefCache.GetOrAdd(obj, (_) => GetXrefHref(file, uid, uidCount.Value, obj.Parent == null));
                     }
                     return (errors, newObject);
 
@@ -236,6 +297,10 @@ namespace Microsoft.Docs.Build
                         return (errors, specObj);
                     }
 
+                    return (errors, value);
+
+                case JsonSchemaContentType.Uid:
+                    context.XrefResolver.ResolveXrefSpec(content, file, file);
                     return (errors, value);
             }
 


### PR DESCRIPTION
[AB#195829](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/195829)

1. traverse before `build xrefmap` & `content transform` to get `uidCount`
2. cached:
   - document uid count
   - jobject -> uid (faster is uid declaration check)
   - jobject -> uid-href