### PR TITLE
Return type.uid if other types don't contain required property

### DIFF
--- a/src/docfx.website.themes/common/UniversalReference.common.js
+++ b/src/docfx.website.themes/common/UniversalReference.common.js
@@ -116,13 +116,15 @@ function handleInheritance(tree) {
 function joinType(parameter) {
   // change type in syntax from array to string
   var joinTypeProperty = function (type, key) {
-    if (!type || !type[0] || !type[0][key]) return null;
+    if (!type) return null;
     var value = type.map(function (t) {
+      if (!t || !t[key]) return null;
       return t[key][0].value;
-    }).join(' | ');
+    });
+    if (value.includes(null)) return null;
     return [{
       lang: type[0][key][0].lang,
-      value: value
+      value: value.join(' | ')
     }];
   };
   if (parameter.type) {

--- a/src/docfx.website.themes/common/UniversalReference.common.js
+++ b/src/docfx.website.themes/common/UniversalReference.common.js
@@ -117,9 +117,9 @@ function joinType(parameter) {
   // change type in syntax from array to string
   var joinTypeProperty = function (type, key) {
     if (!type) return null;
-    if (type.some((t) => { t && t[key] })) {
+    if (type.some((t) => { return t && t[key] })) {
       var value = type.map(function (t) {
-        if (!t) return undefined;
+        if (!t) return null;
         if (!t[key]) return t.uid;
         return t[key][0].value;
       }).join(' | ');

--- a/src/docfx.website.themes/common/UniversalReference.common.js
+++ b/src/docfx.website.themes/common/UniversalReference.common.js
@@ -117,7 +117,7 @@ function joinType(parameter) {
   // change type in syntax from array to string
   var joinTypeProperty = function (type, key) {
     if (!type) return null;
-    if (type.some((t) => { !t && !t[key] })) {
+    if (type.some((t) => { t && t[key] })) {
       var value = type.map(function (t) {
         if (!t) return undefined;
         if (!t[key]) return t.uid;

--- a/src/docfx.website.themes/common/UniversalReference.common.js
+++ b/src/docfx.website.themes/common/UniversalReference.common.js
@@ -116,19 +116,16 @@ function handleInheritance(tree) {
 function joinType(parameter) {
   // change type in syntax from array to string
   var joinTypeProperty = function (type, key) {
-    if (!type) return null;
-    if (type.some((t) => { return t && t[key] })) {
-      var value = type.map(function (t) {
-        if (!t) return null;
-        if (!t[key]) return t.uid;
-        return t[key][0].value;
-      }).join(' | ');
-      return [{
-        lang: type[0][key][0].lang,
-        value: value
-      }];
-    }
-    return null;
+    if (!type || !type[0] || !type[0][key]) return null;
+    var value = type.map(function (t) {
+      if (!t) return null;
+      if (!t[key]) return t.uid;
+      return t[key][0].value;
+    }).join(' | ');
+    return [{
+      lang: type[0][key][0].lang,
+      value: value
+    }];
   };
   if (parameter.type) {
     parameter.type = {

--- a/src/docfx.website.themes/common/UniversalReference.common.js
+++ b/src/docfx.website.themes/common/UniversalReference.common.js
@@ -117,15 +117,18 @@ function joinType(parameter) {
   // change type in syntax from array to string
   var joinTypeProperty = function (type, key) {
     if (!type) return null;
-    var value = type.map(function (t) {
-      if (!t || !t[key]) return null;
-      return t[key][0].value;
-    });
-    if (value.includes(null)) return null;
-    return [{
-      lang: type[0][key][0].lang,
-      value: value.join(' | ')
-    }];
+    if (type.some((t) => { !t && !t[key] })) {
+      var value = type.map(function (t) {
+        if (!t) return undefined;
+        if (!t[key]) return t.uid;
+        return t[key][0].value;
+      }).join(' | ');
+      return [{
+        lang: type[0][key][0].lang,
+        value: value
+      }];
+    }
+    return null;
   };
   if (parameter.type) {
     parameter.type = {


### PR DESCRIPTION
Check if key exist for all type when map, if key doesn't exist, return uid instead.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5781)