### PR TITLE
Fix perf regression caused by tracking markdown element telemetry

### DIFF
--- a/test/docfx.Test/lib/MarkdownElementTelemetryExtensionTest.cs
+++ b/test/docfx.Test/lib/MarkdownElementTelemetryExtensionTest.cs
@@ -22,13 +22,6 @@ namespace Microsoft.Docs.Build
             Assert.Equal(expectedElementType, MarkdownTelemetryExtension.GetElementType(node));
         }
 
-        [Theory]
-        [MemberData(nameof(TokenTypeTestData))]
-        public static void GetTokenTypeTest(MarkdownObject node, string expectedElementType)
-        {
-            Assert.Equal(expectedElementType, MarkdownTelemetryExtension.GetTokenType(node));
-        }
-
         public static IEnumerable<object[]> ElementTypeTestData =>
             new List<object[]>
             {
@@ -75,18 +68,6 @@ namespace Microsoft.Docs.Build
                 new object[] { new XrefInline (), "Xref" },
                 new object[] { new EmojiInline (), "Emoji" },
                 new object[] { new NolocInline (), "Noloc" },
-            };
-
-        public static IEnumerable<object[]> TokenTypeTestData =>
-            new List<object[]>
-            {
-                new object[] { new HtmlBlock(null) { Type = HtmlBlockType.CData }, "HtmlBlock-CData" },
-                new object[] { new HtmlBlock(null) { Type = HtmlBlockType.Comment }, "HtmlBlock-Comment" },
-                new object[] { new QuoteSectionNoteBlock (null) { QuoteType = QuoteSectionNoteType.MarkdownQuote }, "QuoteSectionNoteBlock-MarkdownQuote" },
-                new object[] { new QuoteSectionNoteBlock (null) { QuoteType = QuoteSectionNoteType.DFMNote, NoteTypeString = "NOTE" }, "QuoteSectionNoteBlock-DFMNote-Note" },
-                new object[] { new QuoteSectionNoteBlock (null) { QuoteType = QuoteSectionNoteType.DFMNote, NoteTypeString = "waRNing" }, "QuoteSectionNoteBlock-DFMNote-Warning" },
-                new object[] { new TripleColonBlock (null) { Extension = new ZoneExtension () }, "TripleColonBlock-Zone" },
-                new object[] { new TripleColonBlock (null) { Extension = new ChromelessFormExtension () }, "TripleColonBlock-Form" },
             };
     }
 }


### PR DESCRIPTION
Found this when I am profiling _HtmlAgilityPack_ performance, and found **AI** surpass _HtmlAgilityPack_ and became the second hotspot.

This PR pre-aggreated element count per file before calling _AI_. I removed `tokenType` because it seems the current `elementType` contains enough information to reverse back to `tokenType`.

**Before:**

![image](https://user-images.githubusercontent.com/511355/79405871-21793600-7fc8-11ea-8955-d6fce9577cba.png)

**After:**
![image](https://user-images.githubusercontent.com/511355/79406312-53d76300-7fc9-11ea-9e30-f195b1ffe2f0.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5783)