### PR TITLE
SDP unresolved xref default as object

### DIFF
--- a/docs/specs/template.yml
+++ b/docs/specs/template.yml
@@ -401,7 +401,6 @@ inputs:
     {{#summary}} uid summary: {{summary}} {{/summary}}
     {{^summary}} uid has no summary {{/summary}}
 
-  # normal partial include syntax, with <xref /> in partial template
   uid-declaration.yml: |
     ### YamlMime: XrefDeclaration
     uid: uid
@@ -429,15 +428,10 @@ inputs:
   docfx.yml:
   _themes/ContentTemplate/schemas/TestPage.schema.json: |
     {
-      "type": "object",
       "properties": {
         "uid": {"contentType": "uid"},
-        "summary": {"type": "string"},
-        "description": {"type": "string"},
         "uids": {
-          "type": "array",
           "items": {
-            "type": "object",
             "properties": {
               "uid": {"contentType": "uid"}
             }
@@ -476,3 +470,53 @@ outputs:
             <a href=\"self-uid#child_2\" data-linktype=\"relative-path\"> child-2 name </a>
         </p>"
     }
+---
+# Parent-contexted uid decalaration should NOT leak into child-context
+legacy: true
+inputs:
+  docfx.yml:
+  _themes/ContentTemplate/schemas/TestPage.schema.json: |
+    {
+      "properties": {
+        "uid": {"contentType": "uid"},
+        "uids": {
+          "items": {
+            "properties": {
+              "uid": {"contentType": "xref"}
+            }
+          }
+        }
+      }
+    }
+  _themes/ContentTemplate/TestPage.html.primary.tmpl: |
+    <p>
+      <xref uid="{{ uid }}" />
+      {{#uids}}
+        <xref uid="{{uid}}" />
+      {{/uids}}
+    </p>
+ 
+  a.yml: |
+    ### YamlMime: TestPage
+    uid: uid
+    name: root name
+    uids:
+      - uid: unresolved1
+        name: unresolved1 name
+      - uid: unresolved2
+        name: unresolved2 name
+
+outputs:
+  a.mta.json:
+  a.raw.page.json: |
+    {
+      "content": "
+        <p>
+            <a href=\"a\" data-linktype=\"relative-path\"> root name </a>
+            <span> unresolved1 </span>
+            <span> unresolved2 </span>
+        </p>"
+    }
+  .errors.log: |
+    {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'unresolved1'","file":"a.yml","line":5,"end_line":5,"column":10,"end_column":21}
+    {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'unresolved2'","file":"a.yml","line":7,"end_line":7,"column":10,"end_column":21}

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -415,7 +415,12 @@ inputs:
     }
 outputs:
   docs/b.json: | 
-    {"xref": "a"}
+    {
+      "xref": {
+        "uid": "a",
+        "href": null
+      }
+     }
   .errors.log: |
     ["error","json-syntax-error","Unexpected character encountered while parsing value: }.","docs/a.json",7]
     ["warning","xref-not-found","Cross reference not found: 'a'","docs/b.json",3,13]
@@ -1285,7 +1290,10 @@ outputs:
        "children":[
           {
              "uid":"child1",
-             "xref":"a"
+             "xref": {
+               "uid": "a",
+               "href": null
+             }
           },
           {
              "uid":"child2",

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -277,19 +277,9 @@ namespace Microsoft.Docs.Build
                     var (xrefError, xrefSpec, href) = context.XrefResolver.ResolveXrefSpec(content, file, file);
                     errors.AddIfNotNull(xrefError);
 
-                    if (xrefSpec != null)
-                    {
-                        var specObj = JsonUtility.ToJObject(xrefSpec.ToExternalXrefSpec(href));
-                        return (errors, specObj);
-                    }
-                    else
-                    {
-                        return (errors, new JObject
-                        {
-                            ["uid"] = value,
-                            ["href"] = null,
-                        });
-                    }
+                    return xrefSpec != null
+                        ? (errors, JsonUtility.ToJObject(xrefSpec.ToExternalXrefSpec(href)))
+                        : (errors, new JObject { ["uid"] = value, ["href"] = null });
             }
 
             return (errors, value);

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -282,8 +282,14 @@ namespace Microsoft.Docs.Build
                         var specObj = JsonUtility.ToJObject(xrefSpec.ToExternalXrefSpec(href));
                         return (errors, specObj);
                     }
-
-                    return (errors, value);
+                    else
+                    {
+                        return (errors, new JObject
+                        {
+                            ["uid"] = value,
+                            ["href"] = null,
+                        });
+                    }
             }
 
             return (errors, value);

--- a/src/docfx/template/MustacheXrefTagParser.cs
+++ b/src/docfx/template/MustacheXrefTagParser.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Docs.Build
         "  @resolvedTag" +
         "{{/href}}" +
         "{{^href}}" +
-        "  <span> {{.}} </span>" +
+        "  <span> {{uid}} </span>" +
         "{{/href}}";
 
         private static readonly char[] s_trimChars = new[] { '{', ' ', '}' };

--- a/test/docfx.Test/template/MustacheTemplateTest.cs
+++ b/test/docfx.Test/template/MustacheTemplateTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Docs.Build
             "{'uid':{'name':'uid-name-resolve','href':'https://domain/path'}}",
             "<a class=\"xref\" href=\"https://domain/path\">uid-name-resolve</a>")]
         [InlineData("xref-list.tmpl",
-            "{'uids': [{'name':'uid-name-resolve', 'href': 'https://domain/path'}, 'uid-name-unresolve']}",
+            "{'uids': [{'name':'uid-name-resolve', 'href': 'https://domain/path'}, {'uid':'uid-name-unresolve', 'href':null}]}",
             "<a href=\"https://domain/path\"> uid-name-resolve </a>\n<span> uid-name-unresolve </span>")]
         [InlineData(
             "include.tmpl",

--- a/test/docfx.Test/template/MustacheXrefTagParserTest.cs
+++ b/test/docfx.Test/template/MustacheXrefTagParserTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Docs.Build
             "    <a href=\"{{href}}\"> {{name}} </a>" +
             "  {{/href}}" +
             "  {{^href}}" +
-            "    <span> {{.}} </span>" +
+            "    <span> {{uid}} </span>" +
             "  {{/href}}" +
             "{{/uid}}"
             )]
@@ -24,7 +24,7 @@ namespace Microsoft.Docs.Build
             "    <a href=\"{{href}}\"> {{name}} </a>" +
             "  {{/href}}" +
             "  {{^href}}" +
-            "    <span> {{.}} </span>" +
+            "    <span> {{uid}} </span>" +
             "  {{/href}}" +
             "{{/uid}}"
             )]
@@ -34,7 +34,7 @@ namespace Microsoft.Docs.Build
             "    <a href='{{href}}'> {{name}} </a>" +
             "  {{/href}}" +
             "  {{^href}}" +
-            "    <span> {{.}} </span>" +
+            "    <span> {{uid}} </span>" +
             "  {{/href}}" +
             "{{/namespace}}"
             )]
@@ -44,7 +44,7 @@ namespace Microsoft.Docs.Build
             "    {{> partials/dotnet/xref-name.tmpl}}" +
             "  {{/href}}" +
             "  {{^href}}" +
-            "    <span> {{.}} </span>" +
+            "    <span> {{uid}} </span>" +
             "  {{/href}}" +
             "{{/uid}}"
             )]
@@ -53,7 +53,7 @@ namespace Microsoft.Docs.Build
             "  <a href=\"{{href}}\"> {{name}} </a>" +
             "{{/href}}" +
             "{{^href}}" +
-            "  <span> {{.}} </span>" +
+            "  <span> {{uid}} </span>" +
             "{{/href}}"
             )]
         public void ProcessXrefTag(string template, string expected)


### PR DESCRIPTION
[AB#204964](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/204964)

Fixing parent-contexted property leaked to child-context.

Current, <xref> mustache parser is using `href` property to decide if spec is resolved, in which case if parent context contains a `href` attribute, the child-context will treat it as uid successfully resolved by mistake.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5788)