### PR TITLE
support xrefService as build parameter

### DIFF
--- a/src/docfx/Models/BuildCommandOptions.cs
+++ b/src/docfx/Models/BuildCommandOptions.cs
@@ -31,6 +31,9 @@ namespace Microsoft.DocAsCode
         [OptionList('x', "xref", Separator = ',', HelpText = "Specify the urls of xrefmap used by content files.")]
         public List<string> XRefMaps { get; set; }
 
+        [OptionList("xrefService", Separator = ',', HelpText = "Specify the urls of xrefService for resolving xref used by content files.")]
+        public List<string> XRefService { get; set; }
+
         [OptionList('t', "template", Separator = ',', HelpText = "Specify the template name to apply to. If not specified, output YAML file will not be transformed.")]
         public List<string> Templates { get; set; }
 

--- a/src/docfx/SubCommands/BuildCommand.cs
+++ b/src/docfx/SubCommands/BuildCommand.cs
@@ -215,6 +215,16 @@ namespace Microsoft.DocAsCode.SubCommands
                         .Distinct());
             }
 
+            if (options.XRefService != null)
+            {
+                config.XRefServiceUrls =
+                    new ListWithStringFallback(
+                        (config.XRefServiceUrls ?? new ListWithStringFallback())
+                        .Concat(options.XRefService)
+                        .Where(x => !string.IsNullOrWhiteSpace(x))
+                        .Distinct());
+            }
+
             //to-do: get changelist from options
 
             if (options.Serve)


### PR DESCRIPTION
Sample command: `docfx build docfx.json --xrefService http://xrefService1,http://xrefService2`
The `xrefService` passed by command line will be merged with `xrefService` in build config.

Tested locally, it works fine.
1. create docfx.json with xrefService
![image](https://user-images.githubusercontent.com/25164547/79534321-cff6a700-80ac-11ea-938e-bc3f2e99d42b.png)
2. run docfx.exe with --xrefService
![image](https://user-images.githubusercontent.com/25164547/79534441-2f54b700-80ad-11ea-83ff-4e9a46387510.png)
3. check log if all xrefService are used(test xrefService will throw error)
![image](https://user-images.githubusercontent.com/25164547/79534570-80fd4180-80ad-11ea-986d-9a3bdf5025ce.png)
 
Related issue: #5786

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5794)