### PR TITLE
Split git commit URL from content url

### DIFF
--- a/src/docfx/build/link/FileLinkItem.cs
+++ b/src/docfx/build/link/FileLinkItem.cs
@@ -13,10 +13,7 @@ namespace Microsoft.Docs.Build
         [JsonIgnore]
         public FilePath InclusionRoot { get; }
 
-        [JsonIgnore]
-        public FilePath ReferencingFile { get; }
-
-        public string SourceGitUrl { get; set; } = "";
+        public string? SourceGitUrl { get; }
 
         public int SourceLine { get; }
 
@@ -26,11 +23,12 @@ namespace Microsoft.Docs.Build
 
         public string TargetUrl { get; }
 
-        public FileLinkItem(FilePath inclusionRoot, FilePath referencingFile, string sourceUrl, string? sourceMonikerGroup, string targetUrl, int sourceLine)
+        public FileLinkItem(
+            FilePath inclusionRoot, string sourceUrl, string? sourceMonikerGroup, string targetUrl, string? sourceGitUrl, int sourceLine)
         {
             InclusionRoot = inclusionRoot;
-            ReferencingFile = referencingFile;
             SourceUrl = sourceUrl;
+            SourceGitUrl = sourceGitUrl;
             SourceMonikerGroup = sourceMonikerGroup;
             TargetUrl = targetUrl;
             SourceLine = sourceLine;

--- a/src/docfx/build/link/FileLinkMapBuilder.cs
+++ b/src/docfx/build/link/FileLinkMapBuilder.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Docs.Build
             _contributionProvider = contributionProvider;
         }
 
-        public void AddFileLink(FilePath inclusionRoot, FilePath referecningFile, string sourceUrl, string targetUrl, SourceInfo? source)
+        public void AddFileLink(FilePath inclusionRoot, FilePath referencingFile, string sourceUrl, string targetUrl, SourceInfo? source)
         {
             if (string.IsNullOrEmpty(targetUrl) || sourceUrl == targetUrl)
             {
@@ -30,7 +30,7 @@ namespace Microsoft.Docs.Build
             }
 
             var (errors, monikers) = _monikerProvider.GetFileLevelMonikers(inclusionRoot);
-            var sourceGitUrl = _contributionProvider.GetGitUrl(referecningFile).originalContentGitUrl;
+            var sourceGitUrl = _contributionProvider.GetGitUrl(referencingFile).originalContentGitUrl;
 
             _errorLog.Write(errors);
             _links.TryAdd(new FileLinkItem(inclusionRoot, sourceUrl, MonikerUtility.GetGroup(monikers), targetUrl, sourceGitUrl, source is null ? 1 : source.Line));

--- a/src/docfx/build/link/FileLinkMapBuilder.cs
+++ b/src/docfx/build/link/FileLinkMapBuilder.cs
@@ -30,8 +30,10 @@ namespace Microsoft.Docs.Build
             }
 
             var (errors, monikers) = _monikerProvider.GetFileLevelMonikers(inclusionRoot);
+            var sourceGitUrl = _contributionProvider.GetGitUrl(referecningFile).originalContentGitUrl;
+
             _errorLog.Write(errors);
-            _links.TryAdd(new FileLinkItem(inclusionRoot, referecningFile, sourceUrl, MonikerUtility.GetGroup(monikers), targetUrl, source is null ? 1 : source.Line));
+            _links.TryAdd(new FileLinkItem(inclusionRoot, sourceUrl, MonikerUtility.GetGroup(monikers), targetUrl, sourceGitUrl, source is null ? 1 : source.Line));
         }
 
         public object Build()
@@ -41,15 +43,7 @@ namespace Microsoft.Docs.Build
                 Links = _links
                         .Where(x => _publishModelBuilder.HasOutput(x.InclusionRoot))
                         .OrderBy(x => x)
-                        .Select(x =>
-                        {
-                            var (_, originalContentGitUrl, _, _) = _contributionProvider.GetGitUrls(x.ReferencingFile);
-                            if (!string.IsNullOrEmpty(originalContentGitUrl))
-                            {
-                                x.SourceGitUrl = originalContentGitUrl;
-                            }
-                            return x;
-                        }),
+                        .ToArray(),
             };
         }
     }

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -184,8 +184,9 @@ namespace Microsoft.Docs.Build
             (systemMetadata.DocumentId, systemMetadata.DocumentVersionIndependentId)
                 = context.DocumentProvider.GetDocumentId(context.RedirectionProvider.GetOriginalFile(file.FilePath));
 
-            (systemMetadata.ContentGitUrl, systemMetadata.OriginalContentGitUrl, systemMetadata.OriginalContentGitUrlTemplate,
-                systemMetadata.Gitcommit) = context.ContributionProvider.GetGitUrls(file.FilePath);
+            (systemMetadata.ContentGitUrl, systemMetadata.OriginalContentGitUrl, systemMetadata.OriginalContentGitUrlTemplate)
+                = context.ContributionProvider.GetGitUrl(file.FilePath);
+            systemMetadata.Gitcommit = context.ContributionProvider.GetGitCommitUrl(file.FilePath);
 
             systemMetadata.Author = systemMetadata.ContributionInfo?.Author?.Name;
             systemMetadata.UpdatedAt = systemMetadata.ContributionInfo?.UpdatedAtDateTime.ToString("yyyy-MM-dd hh:mm tt");


### PR DESCRIPTION
Fixes #5791 

Retrieving git commit URL causes git history calculation. When the input file is from a dependency repo, `GitCommitProvider` failed due to --depth 1 clone.

This PR split the commit URL from content URL to save the call to `GetCommitHistory`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5797)