### PR TITLE
Report warning on toc folder-inclusion not found

### DIFF
--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -390,7 +390,6 @@ outputs:
     }
 ---
 # Orphan file, with multiple toc of same site path, look up by file path(sub then parent)
-os: windows
 legacy: true # only legacy has toc dependency for orphan file
 inputs:
   docfx.yml: |

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -707,7 +707,7 @@ outputs:
     {"items":[{"name":"Duplicated keys","href":"f1/b"}]}
   .errors.log: |
     ["suggestion","yaml-duplicate-key","Key 'topicHref' is already defined, remove the duplicate key. NOTE: This Suggestion will become a Warning on 06/30/2020.","docs/TOC.yml",3,3]
-    ["warning","file-not-found","Unable to find either toc.yml or toc.md inside f1//. Please make sure the file exists","docs/TOC.yml",4,12]
+    ["warning","file-not-found","Unable to find either toc.yml or toc.md inside f1/ Please make sure the file exists","docs/TOC.yml",4,12]
 ---
 # The included TOC's errors/warning should be assigned to itself, not its parent
 inputs:
@@ -886,7 +886,7 @@ outputs:
   docs/f1/toc.json: |
     { "items":[{"name":"TOC Reference"}] }
   .errors.log: |
-    ["warning","file-not-found","Unable to find either toc.yml or toc.md inside ../f2//. Please make sure the file exists","docs/f1/TOC.md",1,3]
+    ["warning","file-not-found","Unable to find either toc.yml or toc.md inside ../f2/ Please make sure the file exists","docs/f1/TOC.md",1,3]
 ---
 # Toc with null value
 inputs:

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -707,6 +707,7 @@ outputs:
     {"items":[{"name":"Duplicated keys","href":"f1/b"}]}
   .errors.log: |
     ["suggestion","yaml-duplicate-key","Key 'topicHref' is already defined, remove the duplicate key. NOTE: This Suggestion will become a Warning on 06/30/2020.","docs/TOC.yml",3,3]
+    ["warning","file-not-found","Unable to find either toc.yml or toc.md inside f1//. Please make sure the file exists","docs/TOC.yml",4,12]
 ---
 # The included TOC's errors/warning should be assigned to itself, not its parent
 inputs:
@@ -884,6 +885,8 @@ outputs:
   docs/f2/toc.experimental.json:
   docs/f1/toc.json: |
     { "items":[{"name":"TOC Reference"}] }
+  .errors.log: |
+    ["warning","file-not-found","Unable to find either toc.yml or toc.md inside ../f2//. Please make sure the file exists","docs/f1/TOC.md",1,3]
 ---
 # Toc with null value
 inputs:

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -269,9 +269,6 @@ namespace Microsoft.Docs.Build
             /// Behavior: ✔️ Message: ✔️
             public static Error FileNotFound(SourceInfo<string> source)
                 => new Error(ErrorLevel.Warning, "file-not-found", $"Invalid file link: '{source}'.", source);
-
-            public static Error FileNotFound(string message, SourceInfo<string> source)
-                => new Error(ErrorLevel.Warning, "file-not-found", message, source);
         }
 
         public static class UrlPath
@@ -369,6 +366,9 @@ namespace Microsoft.Docs.Build
             /// Behavior: ✔️ Message: ❌
             public static Error InvalidTocHref(SourceInfo<string?> source)
                 => new Error(ErrorLevel.Error, "invalid-toc-href", $"The toc href '{source}' can only reference to a local TOC file, folder or absolute path", source);
+
+            public static Error FileNotFound(SourceInfo<string> source)
+                => new Error(ErrorLevel.Warning, "file-not-found", $"Unable to find either toc.yml or toc.md inside {source} Please make sure the file exists", source);
 
             /// <summary>
             /// In markdown-format toc, defined an empty node(# ) with no content.

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -367,6 +367,10 @@ namespace Microsoft.Docs.Build
             public static Error InvalidTocHref(SourceInfo<string?> source)
                 => new Error(ErrorLevel.Error, "invalid-toc-href", $"The toc href '{source}' can only reference to a local TOC file, folder or absolute path", source);
 
+            /// <summary>
+            /// Toc inclusion with relative folder, no toc.{md,yml} file in corresponding folder.
+            /// </summary>
+            /// Behavior: ✔️ Message: ❌
             public static Error FileNotFound(SourceInfo<string> source)
                 => new Error(ErrorLevel.Warning, "file-not-found", $"Unable to find either toc.yml or toc.md inside {source} Please make sure the file exists", source);
 

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -209,16 +209,6 @@ namespace Microsoft.Docs.Build
                 => new Error(ErrorLevel.Error, "locale-invalid", $"Invalid locale: '{locale}'.");
 
             /// <summary>
-            /// Can't find a file referenced by configuration, or user writes a non-existing link.
-            /// Examples:
-            ///   - define user_profile.json file in config, while the file doesn't exist
-            ///   - href referencing a non-existing file
-            /// </summary>
-            /// Behavior: ✔️ Message: ✔️
-            public static Error FileNotFound(SourceInfo<string> source)
-                => new Error(ErrorLevel.Warning, "file-not-found", $"Invalid file link: '{source}'.", source);
-
-            /// <summary>
             /// Can't find a folder.
             /// Examples: pointing template to a local folder that does not exist
             /// </summary>
@@ -269,6 +259,19 @@ namespace Microsoft.Docs.Build
                 var dependencyChain = string.Join(" --> ", recursionDetector.Reverse().Concat(new[] { current }).Select(file => $"'{display(file)}'"));
                 return new Error(ErrorLevel.Error, "circular-reference", $"Build has identified file(s) referencing each other: {dependencyChain}", source);
             }
+
+            /// <summary>
+            /// Can't find a file referenced by configuration, or user writes a non-existing link.
+            /// Examples:
+            ///   - define user_profile.json file in config, while the file doesn't exist
+            ///   - href referencing a non-existing file
+            /// </summary>
+            /// Behavior: ✔️ Message: ✔️
+            public static Error FileNotFound(SourceInfo<string> source)
+                => new Error(ErrorLevel.Warning, "file-not-found", $"Invalid file link: '{source}'.", source);
+
+            public static Error FileNotFound(string message, SourceInfo<string> source)
+                => new Error(ErrorLevel.Warning, "file-not-found", message, source);
         }
 
         public static class UrlPath

--- a/src/docfx/build/link/LinkResolver.cs
+++ b/src/docfx/build/link/LinkResolver.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Docs.Build
 
                     if (file is null)
                     {
-                        return (Errors.Config.FileNotFound(
+                        return (Errors.Link.FileNotFound(
                             new SourceInfo<string>(path, href)), null, query, fragment, LinkType.RelativePath);
                     }
 

--- a/src/docfx/build/toc/TableOfContentsLoader.cs
+++ b/src/docfx/build/toc/TableOfContentsLoader.cs
@@ -333,6 +333,10 @@ namespace Microsoft.Docs.Build
                             }
                         }
                     }
+                    if (result == null)
+                    {
+                        errors.Add(Errors.Link.FileNotFound($"Unable to find either toc.yml or toc.md inside {href}/. Please make sure the file exists", href));
+                    }
                     return result;
 
                 case TocHrefType.TocFile:

--- a/src/docfx/build/toc/TableOfContentsLoader.cs
+++ b/src/docfx/build/toc/TableOfContentsLoader.cs
@@ -335,7 +335,7 @@ namespace Microsoft.Docs.Build
                     }
                     if (result == null)
                     {
-                        errors.Add(Errors.Link.FileNotFound($"Unable to find either toc.yml or toc.md inside {href}/. Please make sure the file exists", href));
+                        errors.Add(Errors.TableOfContents.FileNotFound(href));
                     }
                     return result;
 

--- a/src/docfx/restore/FileResolver.cs
+++ b/src/docfx/restore/FileResolver.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Docs.Build
                     return localFilePath;
                 }
 
-                throw Errors.Config.FileNotFound(file).ToException();
+                throw Errors.Link.FileNotFound(file).ToException();
             }
 
             var filePath = GetRestorePathFromUrl(file);


### PR DESCRIPTION
Fixing [AB#206730](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/206730)
![image](https://user-images.githubusercontent.com/42199316/79824798-b5347300-83c9-11ea-8d03-b433c002811d.png)


- Report warning when no toc.yml nor toc.md found using folder relative syntax to include sub-toc file.
- Move file-not-found under Link category

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5805)