### PR TITLE
Add HtmlWriter, extract HtmlExtension

### DIFF
--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -560,8 +560,8 @@ inputs:
 outputs:
   docs/a.json:
   .errors.log: |
-    ["warning","bookmark-not-found","Cannot find bookmark '#bookmark' in 'docs/a.md'","docs/a.md",2,1]
-    ["warning","bookmark-not-found","Cannot find bookmark '#bookmark' in 'docs/a.md'","docs/a.md",2,2]
+    ["warning","bookmark-not-found","Cannot find bookmark '#bookmark' in 'docs/a.md'","docs/a.md",2,23]
+    ["warning","bookmark-not-found","Cannot find bookmark '#bookmark' in 'docs/a.md'","docs/a.md",2,69]
 ---
 # Report warning for custom 404 page
 inputs:

--- a/docs/specs/resolve.yml
+++ b/docs/specs/resolve.yml
@@ -426,8 +426,8 @@ outputs:
   a.json: |
     { "conceptual": "<p>Link to <a href=\"b.md\" href=\"c.md\">b</a></p>\n" }
   .errors.log: |
-    ["warning","file-not-found","Invalid file link: 'b.md'.","a.md",1,9]
-    ["warning","file-not-found","Invalid file link: 'c.md'.","a.md",1,10]
+    ["warning","file-not-found","Invalid file link: 'b.md'.","a.md",1,12]
+    ["warning","file-not-found","Invalid file link: 'c.md'.","a.md",1,24]
 ---
 # Markdown inclusion using links starting with ~
 inputs:

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -936,7 +936,7 @@ outputs:
   .errors.log: |
     ["warning","xref-not-found","Cross reference not found: 'd'","docs/a.md",2,5]
     ["warning","xref-not-found","Cross reference not found: 'd'","docs/a.md",3,5]
-    ["warning","xref-not-found","Cross reference not found: 'f'","docs/a.md",8,2]
+    ["warning","xref-not-found","Cross reference not found: 'f'","docs/a.md",8,67]
 ---
 # Transform xref in HTML block should not auto close the parent tag
 inputs:

--- a/src/docfx/lib/HtmlUtility.cs
+++ b/src/docfx/lib/HtmlUtility.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Docs.Build
                     var source = block?.ToSourceInfo(columnOffset: attribute.Range.start);
                     var link = HttpUtility.HtmlEncode(transform(new SourceInfo<string>(HttpUtility.HtmlDecode(attribute.Value.ToString()), source)));
 
-                    attribute.Value = link.AsMemory();
+                    attribute = attribute.WithValue(link);
                 }
             }
         }
@@ -152,7 +152,7 @@ namespace Microsoft.Docs.Build
                 ? rawHtml ?? rawSource ?? $"<span class=\"xref\">{(!string.IsNullOrEmpty(display) ? display : (href != null ? UrlUtility.SplitUrl(href).path : uid))}</span>"
                 : $"<a href='{HttpUtility.HtmlEncode(resolvedHref)}'>{HttpUtility.HtmlEncode(display)}</a>";
 
-            token.RawText = resolvedNode.AsMemory();
+            token = token.WithRawText(resolvedNode);
         }
 
         /// <summary>
@@ -264,7 +264,7 @@ namespace Microsoft.Docs.Build
                 {
                     if (attribute.NameIs("src") && attribute.Value.Span.Contains("codepen.io", StringComparison.OrdinalIgnoreCase))
                     {
-                        attribute.Value = (attribute.Value.ToString() + "&rerun-position=hidden&").AsMemory();
+                        attribute = attribute.WithValue(attribute.Value.ToString() + "&rerun-position=hidden&");
                     }
                 }
             }

--- a/src/docfx/lib/HtmlUtility.cs
+++ b/src/docfx/lib/HtmlUtility.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Docs.Build
                 ? rawHtml ?? rawSource ?? $"<span class=\"xref\">{(!string.IsNullOrEmpty(display) ? display : (href != null ? UrlUtility.SplitUrl(href).path : uid))}</span>"
                 : $"<a href='{HttpUtility.HtmlEncode(resolvedHref)}'>{HttpUtility.HtmlEncode(display)}</a>";
 
-            token = token.WithRawText(resolvedNode);
+            token = new HtmlToken(resolvedNode);
         }
 
         /// <summary>

--- a/src/docfx/lib/HtmlUtility.cs
+++ b/src/docfx/lib/HtmlUtility.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -15,7 +16,24 @@ namespace Microsoft.Docs.Build
 {
     internal static class HtmlUtility
     {
+        public delegate void TransformHtmlDelegate(ref HtmlToken token);
+
         private static readonly string[] s_allowedStyles = new[] { "text-align: right;", "text-align: left;", "text-align: center;" };
+
+        public static string TransformHtml(string html, TransformHtmlDelegate transform)
+        {
+            var result = new ArrayBufferWriter<char>(html.Length + 64);
+            var reader = new HtmlReader(html);
+            var writer = new HtmlWriter(result);
+
+            while (reader.Read(out var token))
+            {
+                transform(ref token);
+                writer.Write(token);
+            }
+
+            return result.WrittenSpan.ToString();
+        }
 
         public static HtmlNode LoadHtml(string html)
         {
@@ -26,7 +44,7 @@ namespace Microsoft.Docs.Build
 
         public static HtmlNode PostMarkup(this HtmlNode node, bool dryRun)
         {
-            return dryRun ? node : node.StripTags().RemoveRerunCodepenIframes();
+            return dryRun ? node : node.StripTags();
         }
 
         public static long CountWord(this HtmlNode node)
@@ -71,148 +89,70 @@ namespace Microsoft.Docs.Build
             return result;
         }
 
-        public static string TransformLinks(string html, Func<string, int, string> transform)
+        public static void TransformLink(ref HtmlToken token, MarkdownObject? block, Func<SourceInfo<string>, string> transform)
         {
-            // Fast pass it does not have <a> tag or <img> tag
-            if (!((html.Contains("<a", StringComparison.OrdinalIgnoreCase) && html.Contains("href", StringComparison.OrdinalIgnoreCase)) ||
-                  (html.Contains("<img", StringComparison.OrdinalIgnoreCase) && html.Contains("src", StringComparison.OrdinalIgnoreCase))))
+            foreach (ref var attribute in token.Attributes.Span)
             {
-                return html;
-            }
-
-            // <a>b</a> generates 3 inline markdown tokens: <a>, b, </a>.
-            // `HtmlNode.OuterHtml` turns <a> into <a></a>, and generates <a></a>b</a> for the above input.
-            // The following code ensures we preserve the original html when changing links.
-            var pos = 0;
-            var result = new StringBuilder(html.Length + 64);
-            var reader = new HtmlReader(html);
-
-            // TODO: remove this column offset hack while we have accurate line info for link in HTML block
-            var columnOffset = 0;
-
-            while (reader.Read())
-            {
-                if (reader.Type != HtmlTokenType.StartTag)
+                if (IsLink(ref token, attribute))
                 {
-                    continue;
-                }
+                    var source = block?.ToSourceInfo(columnOffset: attribute.Range.start);
+                    var link = HttpUtility.HtmlEncode(transform(new SourceInfo<string>(HttpUtility.HtmlDecode(attribute.Value.ToString()), source)));
 
-                var attributeName = reader.NameIs("a") ? "href" : reader.NameIs("img") ? "src" : null;
-                if (attributeName is null)
-                {
-                    continue;
-                }
-
-                foreach (var attribute in reader.Attributes)
-                {
-                    if (!attribute.NameIs(attributeName))
-                    {
-                        continue;
-                    }
-
-                    var start = attribute.ValueRange.start;
-                    if (start > pos)
-                    {
-                        result.Append(html, pos, start - pos);
-                    }
-
-                    var transformed = transform(HttpUtility.HtmlDecode(attribute.Value.ToString()), columnOffset);
-                    if (!string.IsNullOrEmpty(transformed))
-                    {
-                        result.Append(HttpUtility.HtmlEncode(transformed));
-                    }
-
-                    pos = attribute.ValueRange.start + attribute.ValueRange.length;
-                    columnOffset++;
+                    attribute.Value = link.AsMemory();
                 }
             }
-
-            if (html.Length > pos)
-            {
-                result.Append(html, pos, html.Length - pos);
-            }
-            return result.ToString();
         }
 
-        public static string TransformXref(string html, MarkdownObject block, Func<SourceInfo<string>?, SourceInfo<string>?, bool, (string? href, string display)> resolveXref)
+        public static void TransformXref(ref HtmlToken token, MarkdownObject? block, Func<SourceInfo<string>?, SourceInfo<string>?, bool, (string? href, string display)> resolveXref)
         {
-            // Fast pass it does not have <xref> tag
-            if (!(html.Contains("<xref", StringComparison.OrdinalIgnoreCase)
-                && (html.Contains("href", StringComparison.OrdinalIgnoreCase) || html.Contains("uid", StringComparison.OrdinalIgnoreCase))))
+            if (!token.NameIs("xref"))
             {
-                return html;
+                return;
             }
 
-            var pos = 0;
-            var result = new StringBuilder(html.Length + 64);
-            var reader = new HtmlReader(html);
-
-            // TODO: remove this column offset hack while we have accurate line info for link in HTML block
-            var columnOffset = 0;
-
-            while (reader.Read())
+            if (token.Type != HtmlTokenType.StartTag)
             {
-                if (!reader.NameIs("xref"))
-                {
-                    continue;
-                }
-
-                var start = reader.TokenRange.start;
-                if (start > pos)
-                {
-                    result.Append(html, pos, start - pos);
-                }
-
-                if (reader.Type == HtmlTokenType.StartTag)
-                {
-                    var rawHtml = default(string);
-                    var rawSource = default(string);
-                    var href = default(string);
-                    var uid = default(string);
-
-                    foreach (var attribute in reader.Attributes)
-                    {
-                        if (attribute.NameIs("data-raw-html"))
-                        {
-                            rawHtml = HttpUtility.HtmlDecode(attribute.Value.ToString());
-                        }
-                        else if (attribute.NameIs("data-raw-source"))
-                        {
-                            rawSource = HttpUtility.HtmlDecode(attribute.Value.ToString());
-                        }
-                        else if (attribute.NameIs("href"))
-                        {
-                            href = HttpUtility.HtmlDecode(attribute.Value.ToString());
-                        }
-                        else if (attribute.NameIs("uid"))
-                        {
-                            uid = HttpUtility.HtmlDecode(attribute.Value.ToString());
-                        }
-                    }
-
-                    var isShorthand = (rawHtml ?? rawSource)?.StartsWith("@") ?? false;
-
-                    var (resolvedHref, display) = resolveXref(
-                        href == null ? null : (SourceInfo<string>?)new SourceInfo<string>(href, block.ToSourceInfo(columnOffset: columnOffset)),
-                        uid == null ? null : (SourceInfo<string>?)new SourceInfo<string>(uid, block.ToSourceInfo(columnOffset: columnOffset)),
-                        isShorthand);
-
-                    var resolvedNode = string.IsNullOrEmpty(resolvedHref)
-                        ? rawHtml ?? rawSource ?? $"<span class=\"xref\">{(!string.IsNullOrEmpty(display) ? display : (href != null ? UrlUtility.SplitUrl(href).path : uid))}</span>"
-                        : $"<a href='{HttpUtility.HtmlEncode(resolvedHref)}'>{HttpUtility.HtmlEncode(display)}</a>";
-
-                    result.Append(resolvedNode);
-                }
-
-                pos = reader.TokenRange.start + reader.TokenRange.length;
-                columnOffset++;
+                token = default;
+                return;
             }
 
-            if (html.Length > pos)
+            var rawHtml = default(string);
+            var rawSource = default(string);
+            var href = default(string);
+            var uid = default(string);
+
+            foreach (ref readonly var attribute in token.Attributes.Span)
             {
-                result.Append(html, pos, html.Length - pos);
+                if (attribute.NameIs("data-raw-html"))
+                {
+                    rawHtml = HttpUtility.HtmlDecode(attribute.Value.ToString());
+                }
+                else if (attribute.NameIs("data-raw-source"))
+                {
+                    rawSource = HttpUtility.HtmlDecode(attribute.Value.ToString());
+                }
+                else if (attribute.NameIs("href"))
+                {
+                    href = HttpUtility.HtmlDecode(attribute.Value.ToString());
+                }
+                else if (attribute.NameIs("uid"))
+                {
+                    uid = HttpUtility.HtmlDecode(attribute.Value.ToString());
+                }
             }
-            return result.ToString();
+
+            var isShorthand = (rawHtml ?? rawSource)?.StartsWith("@") ?? false;
+
+            var (resolvedHref, display) = resolveXref(
+                href == null ? null : (SourceInfo<string>?)new SourceInfo<string>(href, block?.ToSourceInfo(columnOffset: token.Range.start)),
+                uid == null ? null : (SourceInfo<string>?)new SourceInfo<string>(uid, block?.ToSourceInfo(columnOffset: token.Range.start)),
+                isShorthand);
+
+            var resolvedNode = string.IsNullOrEmpty(resolvedHref)
+                ? rawHtml ?? rawSource ?? $"<span class=\"xref\">{(!string.IsNullOrEmpty(display) ? display : (href != null ? UrlUtility.SplitUrl(href).path : uid))}</span>"
+                : $"<a href='{HttpUtility.HtmlEncode(resolvedHref)}'>{HttpUtility.HtmlEncode(display)}</a>";
+
+            token.RawText = resolvedNode.AsMemory();
         }
 
         /// <summary>
@@ -314,19 +254,20 @@ namespace Microsoft.Docs.Build
                     .Replace("'", "&#39;");
         }
 
-        internal static HtmlNode RemoveRerunCodepenIframes(this HtmlNode html)
+        internal static void RemoveRerunCodepenIframes(ref HtmlToken token)
         {
             // the rerun button on codepen iframes isn't accessible.
             // rather than get acc bugs or ban codepen, we're just hiding the rerun button using their iframe api
-            foreach (var node in html.Descendants("iframe"))
+            if (token.NameIs("iframe"))
             {
-                var src = node.GetAttributeValue("src", null);
-                if (src != null && src.Contains("codepen.io", StringComparison.OrdinalIgnoreCase))
+                foreach (ref var attribute in token.Attributes.Span)
                 {
-                    node.SetAttributeValue("src", src + "&rerun-position=hidden&");
+                    if (attribute.NameIs("src") && attribute.Value.Span.Contains("codepen.io", StringComparison.OrdinalIgnoreCase))
+                    {
+                        attribute.Value = (attribute.Value.ToString() + "&rerun-position=hidden&").AsMemory();
+                    }
                 }
             }
-            return html;
         }
 
         internal static HtmlNode StripTags(this HtmlNode html)
@@ -402,6 +343,11 @@ namespace Microsoft.Docs.Build
                 }
             }
             return '/' + locale + href;
+        }
+
+        private static bool IsLink(ref HtmlToken token, in HtmlAttribute attribute)
+        {
+            return (token.NameIs("a") && attribute.NameIs("href")) || (token.NameIs("img") && attribute.NameIs("src"));
         }
 
         private static int CountWordInText(string text)

--- a/src/docfx/lib/html/HtmlAttribute.cs
+++ b/src/docfx/lib/html/HtmlAttribute.cs
@@ -5,23 +5,54 @@ using System;
 
 namespace Microsoft.Docs.Build
 {
-    internal struct HtmlAttribute
+    internal readonly struct HtmlAttribute
     {
-        public HtmlAttributeType Type { get; set; }
+        public readonly HtmlAttributeType Type { get; }
 
-        public ReadOnlyMemory<char> Name { get; set; }
+        public readonly ReadOnlyMemory<char> Name { get; }
 
-        public ReadOnlyMemory<char> Value { get; set; }
+        public readonly ReadOnlyMemory<char> Value { get; }
 
-        public ReadOnlyMemory<char> RawText { get; set; }
+        public readonly ReadOnlyMemory<char> RawText { get; }
 
-        public (int start, int length) ValueRange { get; set; }
+        public readonly (int start, int length) Range { get; }
 
-        public (int start, int length) Range { get; set; }
+        public readonly (int start, int length) ValueRange { get; }
 
         public bool NameIs(string name)
         {
             return Name.Span.Equals(name, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public HtmlAttribute(
+            HtmlAttributeType type,
+            ReadOnlyMemory<char> name,
+            ReadOnlyMemory<char> value,
+            ReadOnlyMemory<char> rawText,
+            (int start, int length) range,
+            (int start, int length) valueRange)
+        {
+            Type = type;
+            Name = name;
+            Value = value;
+            RawText = rawText;
+            Range = range;
+            ValueRange = valueRange;
+        }
+
+        public HtmlAttribute(string name, string? value = default, HtmlAttributeType? type = null)
+        {
+            Type = value is null ? HtmlAttributeType.NameOnly : (type ?? HtmlAttributeType.DoubleQuoted);
+            Name = name.AsMemory();
+            Value = value.AsMemory();
+            RawText = default;
+            Range = default;
+            ValueRange = default;
+        }
+
+        public HtmlAttribute WithValue(string value)
+        {
+            return new HtmlAttribute(Type, Name, value.AsMemory(), default, Range, ValueRange);
         }
     }
 }

--- a/src/docfx/lib/html/HtmlAttribute.cs
+++ b/src/docfx/lib/html/HtmlAttribute.cs
@@ -24,7 +24,17 @@ namespace Microsoft.Docs.Build
             return Name.Span.Equals(name, StringComparison.OrdinalIgnoreCase);
         }
 
-        public HtmlAttribute(
+        public HtmlAttribute(string name, string? value = default, HtmlAttributeType? type = null)
+        {
+            Type = value is null ? HtmlAttributeType.NameOnly : (type ?? HtmlAttributeType.DoubleQuoted);
+            Name = name.AsMemory();
+            Value = value.AsMemory();
+            RawText = default;
+            Range = default;
+            ValueRange = default;
+        }
+
+        internal HtmlAttribute(
             HtmlAttributeType type,
             ReadOnlyMemory<char> name,
             ReadOnlyMemory<char> value,
@@ -38,16 +48,6 @@ namespace Microsoft.Docs.Build
             RawText = rawText;
             Range = range;
             ValueRange = valueRange;
-        }
-
-        public HtmlAttribute(string name, string? value = default, HtmlAttributeType? type = null)
-        {
-            Type = value is null ? HtmlAttributeType.NameOnly : (type ?? HtmlAttributeType.DoubleQuoted);
-            Name = name.AsMemory();
-            Value = value.AsMemory();
-            RawText = default;
-            Range = default;
-            ValueRange = default;
         }
 
         public HtmlAttribute WithValue(string value)

--- a/src/docfx/lib/html/HtmlAttributeType.cs
+++ b/src/docfx/lib/html/HtmlAttributeType.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Docs.Build
+{
+    internal enum HtmlAttributeType
+    {
+        NameOnly,
+
+        DoubleQuoted,
+
+        SingleQuoted,
+
+        Unquoted,
+    }
+}

--- a/src/docfx/lib/html/HtmlReader.cs
+++ b/src/docfx/lib/html/HtmlReader.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Docs.Build
     /// Provides a high-performance, fault-tolerant, standard-compliant API
     /// for forward-only, read-only access to HTML text.
     /// </summary>
-    internal class HtmlReader
+    internal ref struct HtmlReader
     {
         private readonly string _html;
         private readonly int _length;
@@ -30,6 +30,7 @@ namespace Microsoft.Docs.Build
         private int _attributesLength;
 
         public HtmlReader(string html)
+            : this()
         {
             _html = html;
             _length = html.Length;

--- a/src/docfx/lib/html/HtmlReader.cs
+++ b/src/docfx/lib/html/HtmlReader.cs
@@ -70,15 +70,13 @@ namespace Microsoft.Docs.Build
 
             _range.length = _position - _range.start;
 
-            token = new HtmlToken
-            {
-                Type = _type,
-                IsSelfClosing = _isSelfClosing,
-                Name = _html.AsMemory(_nameRange.start, _nameRange.length),
-                RawText = _html.AsMemory(_range.start, _range.length),
-                Attributes = _attributes.AsMemory(0, _attributesLength),
-                Range = _range,
-            };
+            token = new HtmlToken(
+                _type,
+                _isSelfClosing,
+                _html.AsMemory(_nameRange.start, _nameRange.length),
+                _html.AsMemory(_range.start, _range.length),
+                _attributes.AsMemory(0, _attributesLength),
+                _range);
 
             return true;
         }
@@ -630,15 +628,13 @@ namespace Microsoft.Docs.Build
                 _attributes = newAttributes;
             }
 
-            _attributes[_attributesLength++] = new HtmlAttribute
-            {
-                Type = _attributeType,
-                Name = _html.AsMemory(_attributeNameRange.start, _attributeNameRange.length),
-                Value = _html.AsMemory(_attributeValueRange.start, _attributeValueRange.length),
-                RawText = _html.AsMemory(_attributeRange.start, _attributeRange.length),
-                Range = _attributeRange,
-                ValueRange = _attributeValueRange,
-            };
+            _attributes[_attributesLength++] = new HtmlAttribute(
+                _attributeType,
+                _html.AsMemory(_attributeNameRange.start, _attributeNameRange.length),
+                _html.AsMemory(_attributeValueRange.start, _attributeValueRange.length),
+                _html.AsMemory(_attributeRange.start, _attributeRange.length),
+                _attributeRange,
+                _attributeValueRange);
         }
 
         private char Consume()

--- a/src/docfx/lib/html/HtmlReader.cs
+++ b/src/docfx/lib/html/HtmlReader.cs
@@ -402,11 +402,6 @@ namespace Microsoft.Docs.Build
 
         private void BeforeAttributeName()
         {
-            _attributeType = HtmlAttributeType.NameOnly;
-            _attributeNameRange = default;
-            _attributeRange = default;
-            _attributeValueRange = default;
-
             while (true)
             {
                 switch (Consume())
@@ -426,22 +421,24 @@ namespace Microsoft.Docs.Build
                         break;
 
                     case '=':
-                        _attributeNameRange.start = _attributeRange.start = _position - 1;
-                        AttributeName();
+                        AttributeName(-1);
                         return;
 
                     default:
                         Back();
-
-                        _attributeNameRange.start = _attributeRange.start = _position;
                         AttributeName();
                         return;
                 }
             }
         }
 
-        private void AttributeName()
+        private void AttributeName(int offset = 0)
         {
+            _attributeType = HtmlAttributeType.NameOnly;
+            _attributeNameRange.length = _attributeRange.length = 0;
+            _attributeNameRange.start = _attributeRange.start = _position + offset;
+            _attributeValueRange = default;
+
             while (true)
             {
                 switch (Consume())
@@ -512,7 +509,6 @@ namespace Microsoft.Docs.Build
                     default:
                         AddAttribute();
                         Back();
-                        _attributeNameRange.start = _attributeRange.start = _position;
                         AttributeName();
                         return;
                 }
@@ -636,6 +632,8 @@ namespace Microsoft.Docs.Build
                 _html.AsMemory(_attributeRange.start, _attributeRange.length),
                 _attributeRange,
                 _attributeValueRange);
+
+            _attributeNameRange = default;
         }
 
         private char Consume()

--- a/src/docfx/lib/html/HtmlToken.cs
+++ b/src/docfx/lib/html/HtmlToken.cs
@@ -24,9 +24,10 @@ namespace Microsoft.Docs.Build
             return Name.Span.Equals(name, StringComparison.OrdinalIgnoreCase);
         }
 
-        public HtmlToken WithRawText(string rawText)
+        public HtmlToken(string rawText)
+            : this()
         {
-            return new HtmlToken(default, default, default, rawText: rawText.AsMemory(), default, default);
+            RawText = rawText.AsMemory();
         }
 
         internal HtmlToken(

--- a/src/docfx/lib/html/HtmlToken.cs
+++ b/src/docfx/lib/html/HtmlToken.cs
@@ -5,17 +5,17 @@ using System;
 
 namespace Microsoft.Docs.Build
 {
-    internal struct HtmlAttribute
+    internal struct HtmlToken
     {
-        public HtmlAttributeType Type { get; set; }
+        public HtmlTokenType Type { get; set; }
+
+        public bool IsSelfClosing { get; set; }
 
         public ReadOnlyMemory<char> Name { get; set; }
 
-        public ReadOnlyMemory<char> Value { get; set; }
-
         public ReadOnlyMemory<char> RawText { get; set; }
 
-        public (int start, int length) ValueRange { get; set; }
+        public Memory<HtmlAttribute> Attributes { get; set; }
 
         public (int start, int length) Range { get; set; }
 

--- a/src/docfx/lib/html/HtmlToken.cs
+++ b/src/docfx/lib/html/HtmlToken.cs
@@ -24,7 +24,12 @@ namespace Microsoft.Docs.Build
             return Name.Span.Equals(name, StringComparison.OrdinalIgnoreCase);
         }
 
-        public HtmlToken(
+        public HtmlToken WithRawText(string rawText)
+        {
+            return new HtmlToken(default, default, default, rawText: rawText.AsMemory(), default, default);
+        }
+
+        internal HtmlToken(
             HtmlTokenType type,
             bool isSelfClosing,
             ReadOnlyMemory<char> name,
@@ -38,11 +43,6 @@ namespace Microsoft.Docs.Build
             RawText = rawText;
             Attributes = attributes;
             Range = range;
-        }
-
-        public HtmlToken WithRawText(string rawText)
-        {
-            return new HtmlToken(default, default, default, rawText: rawText.AsMemory(), default, default);
         }
     }
 }

--- a/src/docfx/lib/html/HtmlToken.cs
+++ b/src/docfx/lib/html/HtmlToken.cs
@@ -7,21 +7,42 @@ namespace Microsoft.Docs.Build
 {
     internal struct HtmlToken
     {
-        public HtmlTokenType Type { get; set; }
+        public HtmlTokenType Type { get; }
 
-        public bool IsSelfClosing { get; set; }
+        public bool IsSelfClosing { get; }
 
-        public ReadOnlyMemory<char> Name { get; set; }
+        public ReadOnlyMemory<char> Name { get; }
 
-        public ReadOnlyMemory<char> RawText { get; set; }
+        public ReadOnlyMemory<char> RawText { get; }
 
-        public Memory<HtmlAttribute> Attributes { get; set; }
+        public Memory<HtmlAttribute> Attributes { get; }
 
-        public (int start, int length) Range { get; set; }
+        public (int start, int length) Range { get; }
 
         public bool NameIs(string name)
         {
             return Name.Span.Equals(name, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public HtmlToken(
+            HtmlTokenType type,
+            bool isSelfClosing,
+            ReadOnlyMemory<char> name,
+            ReadOnlyMemory<char> rawText,
+            Memory<HtmlAttribute> attributes,
+            (int start, int length) range)
+        {
+            Type = type;
+            IsSelfClosing = isSelfClosing;
+            Name = name;
+            RawText = rawText;
+            Attributes = attributes;
+            Range = range;
+        }
+
+        public HtmlToken WithRawText(string rawText)
+        {
+            return new HtmlToken(default, default, default, rawText: rawText.AsMemory(), default, default);
         }
     }
 }

--- a/src/docfx/lib/html/HtmlWriter.cs
+++ b/src/docfx/lib/html/HtmlWriter.cs
@@ -19,24 +19,7 @@ namespace Microsoft.Docs.Build
         {
             if (token.Type == HtmlTokenType.StartTag)
             {
-                // Detect if attributes have changed
-                var raw = true;
-                foreach (ref readonly var attribute in token.Attributes.Span)
-                {
-                    if (attribute.RawText.Length == 0)
-                    {
-                        raw = false;
-                    }
-                }
-
-                if (raw)
-                {
-                    _writer.Write(token.RawText.Span);
-                }
-                else
-                {
-                    WriteStartTag(token.Name.Span, token.Attributes.Span, token.IsSelfClosing);
-                }
+                WriteStartTag(token.Name.Span, token.Attributes.Span, token.IsSelfClosing);
             }
             else if (token.RawText.Length > 0)
             {

--- a/src/docfx/lib/html/HtmlWriter.cs
+++ b/src/docfx/lib/html/HtmlWriter.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Buffers;
+
+namespace Microsoft.Docs.Build
+{
+    internal class HtmlWriter
+    {
+        private readonly IBufferWriter<char> _writer;
+
+        public HtmlWriter(IBufferWriter<char> writer)
+        {
+            _writer = writer;
+        }
+
+        public void Write(in HtmlToken token)
+        {
+            if (token.RawText.Length > 0)
+            {
+                _writer.Write(token.RawText.Span);
+            }
+            else if (token.Type == HtmlTokenType.StartTag)
+            {
+                WriteStartTag(token.Name.Span, token.Attributes.Span, token.IsSelfClosing);
+            }
+        }
+
+        public void Write(ReadOnlySpan<char> rawText)
+        {
+            _writer.Write(rawText);
+        }
+
+        public void WriteStartTag(ReadOnlySpan<char> name, ReadOnlySpan<HtmlAttribute> attributes, bool isSelfClosing)
+        {
+            // Estimate length
+            var sizeHint = 1 + name.Length + 2;
+            foreach (ref readonly var attribute in attributes)
+            {
+                if (attribute.RawText.Length > 0)
+                {
+                    sizeHint += attribute.RawText.Length;
+                }
+                else
+                {
+                    sizeHint += attribute.Name.Length + attribute.Value.Length + 3;
+                }
+            }
+
+            // Write
+            var pos = 0;
+            var span = _writer.GetSpan(sizeHint);
+            span[pos++] = '<';
+            name.CopyTo(span.Slice(pos));
+            pos += name.Length;
+
+            foreach (ref readonly var attribute in attributes)
+            {
+                span[pos++] = ' ';
+
+                if (attribute.RawText.Length > 0)
+                {
+                    attribute.RawText.Span.CopyTo(span.Slice(pos));
+                    pos += attribute.RawText.Length;
+                    continue;
+                }
+
+                attribute.Name.Span.CopyTo(span.Slice(pos));
+                pos += attribute.Name.Length;
+
+                switch (attribute.Type)
+                {
+                    case HtmlAttributeType.NameOnly:
+                        break;
+
+                    case HtmlAttributeType.Unquoted:
+                        span[pos++] = '=';
+                        attribute.Value.Span.CopyTo(span.Slice(pos));
+                        pos += attribute.Name.Length;
+                        break;
+
+                    case HtmlAttributeType.SingleQuoted:
+                        span[pos++] = '=';
+                        span[pos++] = '\'';
+                        attribute.Value.Span.CopyTo(span.Slice(pos));
+                        pos += attribute.Value.Length;
+                        span[pos++] = '\'';
+                        break;
+
+                    case HtmlAttributeType.DoubleQuoted:
+                        span[pos++] = '=';
+                        span[pos++] = '"';
+                        attribute.Value.Span.CopyTo(span.Slice(pos));
+                        pos += attribute.Value.Length;
+                        span[pos++] = '"';
+                        break;
+                }
+            }
+
+            if (isSelfClosing)
+            {
+                span[pos++] = '/';
+            }
+            span[pos++] = '>';
+
+            _writer.Advance(pos);
+        }
+    }
+}

--- a/src/docfx/lib/html/HtmlWriter.cs
+++ b/src/docfx/lib/html/HtmlWriter.cs
@@ -6,7 +6,7 @@ using System.Buffers;
 
 namespace Microsoft.Docs.Build
 {
-    internal class HtmlWriter
+    internal ref struct HtmlWriter
     {
         private readonly IBufferWriter<char> _writer;
 

--- a/src/docfx/lib/markdown/HtmlExtension.cs
+++ b/src/docfx/lib/markdown/HtmlExtension.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Markdig;
+using Markdig.Helpers;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+using Microsoft.DocAsCode.MarkdigEngine.Extensions;
+
+namespace Microsoft.Docs.Build
+{
+    internal static class HtmlExtension
+    {
+        public static MarkdownPipelineBuilder UseHtml(
+            this MarkdownPipelineBuilder builder,
+            Func<SourceInfo<string>, string> getLink,
+            Func<SourceInfo<string>?, SourceInfo<string>?, bool, (string? href, string display)> resolveXref)
+        {
+            return builder.Use(document =>
+            {
+                document.Visit(node =>
+                {
+                    switch (node)
+                    {
+                        case TabTitleBlock _:
+                            return true;
+                        case HtmlBlock block:
+                            block.Lines = new StringLineGroup(ProcessHtml(block.Lines.ToString(), block));
+                            return false;
+                        case HtmlInline inline:
+                            inline.Tag = ProcessHtml(inline.Tag, inline);
+                            return false;
+                        default:
+                            return false;
+                    }
+                });
+            });
+
+            string ProcessHtml(string html, MarkdownObject block)
+            {
+                // <a>b</a> generates 3 inline markdown tokens: <a>, b, </a>.
+                // `HtmlNode.OuterHtml` turns <a> into <a></a>, and generates <a></a>b</a> for the above input.
+                // The following code ensures we preserve the original html when changing links.
+                return HtmlUtility.TransformHtml(html, (ref HtmlToken token) =>
+                {
+                    HtmlUtility.TransformLink(ref token, block, getLink);
+                    HtmlUtility.TransformXref(ref token, block, resolveXref);
+                    HtmlUtility.RemoveRerunCodepenIframes(ref token);
+                });
+            }
+        }
+    }
+}

--- a/src/docfx/lib/markdown/LinkExtension.cs
+++ b/src/docfx/lib/markdown/LinkExtension.cs
@@ -4,9 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Markdig;
-using Markdig.Helpers;
 using Markdig.Renderers.Html;
-using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 using Microsoft.DocAsCode.MarkdigEngine.Extensions;
 
@@ -30,14 +28,6 @@ namespace Microsoft.Docs.Build
                         var href = new SourceInfo<string>(link.Url, link.ToSourceInfo());
                         link.Url = getLink(href);
                     }
-                    else if (node is HtmlBlock block)
-                    {
-                        block.Lines = new StringLineGroup(ResolveLinks(block.Lines.ToString(), block));
-                    }
-                    else if (node is HtmlInline inline)
-                    {
-                        inline.Tag = ResolveLinks(inline.Tag, inline);
-                    }
                     else if (node is TripleColonBlock tripleColonBlock && tripleColonBlock.Extension is ImageExtension)
                     {
                         var blockProperties = tripleColonBlock.GetAttributes().Properties;
@@ -54,14 +44,6 @@ namespace Microsoft.Docs.Build
                     return false;
                 });
             });
-
-            string ResolveLinks(string html, MarkdownObject block)
-            {
-                return HtmlUtility.TransformLinks(
-                    html,
-                    (href, columnOffset) => getLink(
-                        new SourceInfo<string>(href, block.ToSourceInfo(columnOffset: columnOffset))));
-            }
         }
     }
 }

--- a/src/docfx/lib/markdown/MarkdownEngine.cs
+++ b/src/docfx/lib/markdown/MarkdownEngine.cs
@@ -108,6 +108,7 @@ namespace Microsoft.Docs.Build
                 .UseTelemetry()
                 .UseLink(GetLink)
                 .UseXref(GetXref)
+                .UseHtml(GetLink, GetXref)
                 .UseMonikerZone(GetMonikerRange)
                 .UseContentValidation(_validatorProvider)
                 .Build();
@@ -121,6 +122,7 @@ namespace Microsoft.Docs.Build
                 .UseTelemetry()
                 .UseLink(GetLink)
                 .UseXref(GetXref)
+                .UseHtml(GetLink, GetXref)
                 .UseMonikerZone(GetMonikerRange)
                 .UseContentValidation(_validatorProvider)
                 .UseInlineOnly()

--- a/src/docfx/lib/markdown/XrefExtension.cs
+++ b/src/docfx/lib/markdown/XrefExtension.cs
@@ -4,9 +4,7 @@
 using System;
 using System.Linq;
 using Markdig;
-using Markdig.Helpers;
 using Markdig.Renderers.Html;
-using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 using Microsoft.DocAsCode.MarkdigEngine.Extensions;
 
@@ -37,18 +35,6 @@ namespace Microsoft.Docs.Build
                         }
 
                         return new LinkInline(href, null).AppendChild(new LiteralInline(display));
-                    }
-                    else if (node is HtmlBlock block)
-                    {
-                        // inside html block
-                        // <p> <xref href="" uid=""/> </p>
-                        block.Lines = new StringLineGroup(HtmlUtility.TransformXref(block.Lines.ToString(), block, resolveXref));
-                    }
-                    else if (node is HtmlInline inline)
-                    {
-                        // inside html inline
-                        // text <xref href="" uid=""/> text
-                        inline.Tag = HtmlUtility.TransformXref(inline.Tag, inline, resolveXref);
                     }
                     return node;
                 });

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 using System.Threading;
+using Markdig.Syntax.Inlines;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build
@@ -266,12 +267,14 @@ namespace Microsoft.Docs.Build
 
                 // TODO: remove JsonSchemaContentType.Html after LandingData is migrated
                 case JsonSchemaContentType.Html:
-                    var htmlWithLinks = HtmlUtility.TransformLinks(content, (href, _) =>
+                    var htmlWithLinks = HtmlUtility.TransformHtml(content, (ref HtmlToken token) =>
                     {
-                        var (htmlError, htmlLink, _) = context.LinkResolver.ResolveLink(
-                            new SourceInfo<string>(href, content), file, file);
-                        errors.AddIfNotNull(htmlError);
-                        return htmlLink;
+                        HtmlUtility.TransformLink(ref token, null, href =>
+                        {
+                            var (htmlError, htmlLink, _) = context.LinkResolver.ResolveLink(new SourceInfo<string>(href, content), file, file);
+                            errors.AddIfNotNull(htmlError);
+                            return htmlLink;
+                        });
                     });
 
                     return (errors, htmlWithLinks);

--- a/test/docfx.Test/lib/HtmlReaderWriterTest.cs
+++ b/test/docfx.Test/lib/HtmlReaderWriterTest.cs
@@ -168,10 +168,10 @@ namespace Microsoft.Docs.Build
                 "a",
                 new []
                 {
-                    new HtmlAttribute { Name = "b".AsMemory() },
-                    new HtmlAttribute { Name = "b".AsMemory(), Value = "c".AsMemory(), Type = HtmlAttributeType.DoubleQuoted },
-                    new HtmlAttribute { Name = "b".AsMemory(), Value = "c".AsMemory(), Type = HtmlAttributeType.SingleQuoted },
-                    new HtmlAttribute { Name = "b".AsMemory(), Value = "c".AsMemory(), Type = HtmlAttributeType.Unquoted },
+                    new HtmlAttribute("b"),
+                    new HtmlAttribute("b", "c"),
+                    new HtmlAttribute("b", "c", HtmlAttributeType.SingleQuoted),
+                    new HtmlAttribute("b", "c", HtmlAttributeType.Unquoted),
                 },
                 isSelfClosing: false);
 

--- a/test/docfx.Test/lib/HtmlReaderWriterTest.cs
+++ b/test/docfx.Test/lib/HtmlReaderWriterTest.cs
@@ -95,6 +95,7 @@ namespace Microsoft.Docs.Build
         [InlineData("<!--a-->   </b>", "Comment:<!--a-->, Text:   , EndTag:b")]
         [InlineData("a < b <c>", "Text:a , Text:< b , StartTag:c")]
         [InlineData("<a b='cd>'></a>", "StartTag:a(b:cd>[b='cd>']), EndTag:a")]
+        [InlineData("<HTTP Setting name>", "StartTag:HTTP(Setting:[Setting], name:[name])")]
 
         // Parsing errors https://html.spec.whatwg.org/multipage/parsing.html#parse-errors
         // CDATA, DOCTYPE and script tag specialties are ignored

--- a/test/docfx.Test/lib/HtmlReaderWriterTest.cs
+++ b/test/docfx.Test/lib/HtmlReaderWriterTest.cs
@@ -120,11 +120,9 @@ namespace Microsoft.Docs.Build
         [InlineData("<div foo=\"bar\" =\"baz\">", "StartTag:div(foo:bar[foo=\"bar\"], =\"baz\":[=\"baz\"])")]
         [InlineData("<?xml-stylesheet type=\"text/css\" href=\"style.css\"?>", "Comment:<?xml-stylesheet type=\"text/css\" href=\"style.css\"?>")]
         [InlineData("<div / id=\"foo\">", "StartTag:div(id:foo[id=\"foo\"])")]
-        public void ReadWriteHtml(string html, string expected)
+        public void ReadHtml(string html, string expected)
         {
             var actual = new List<string>();
-            var htmlWriter = new ArrayBufferWriter<char>();
-            var writer = new HtmlWriter(htmlWriter);
             var reader = new HtmlReader(html);
 
             while (reader.Read(out var token))
@@ -148,12 +146,9 @@ namespace Microsoft.Docs.Build
                 }
 
                 actual.Add($"{token.Type}:{content}");
-
-                writer.Write(token);
             }
 
             Assert.Equal(expected, string.Join(", ", actual));
-            Assert.Equal(html, htmlWriter.WrittenSpan.ToString());
         }
 
         [Fact]

--- a/test/docfx.Test/lib/HtmlUtilityTest.cs
+++ b/test/docfx.Test/lib/HtmlUtilityTest.cs
@@ -76,12 +76,12 @@ namespace Microsoft.Docs.Build
         [InlineData("<a href='hello'>", null, "<a href=''>")]
         [InlineData("<a href='hello'>", "~!@#$%^&*()<>?:,./][{}|", "<a href='~!@#$%^&amp;*()&lt;&gt;?:,./][{}|'>")]
         [InlineData("<A hrEf=''>", "666", "<A hrEf='666'>")]
-        [InlineData("<a href = 'hello'>", "666", "<a href = '666'>")]
-        [InlineData("<a   target='_blank'   href='h'>", "666", "<a   target='_blank'   href='666'>")]
-        [InlineData("<img src='a/b.png' />", "666", "<img src='666' />")]
-        [InlineData("<iMg sRc = 'a/b.png' />", "666", "<iMg sRc = '666' />")]
-        [InlineData("<div><a href='hello'><img src='a/b.png' /></div>", "666", "<div><a href='666'><img src='666' /></div>")]
-        [InlineData("<div><img src='a/b.png' /><a href='hello'></div>", "666", "<div><img src='666' /><a href='666'></div>")]
+        [InlineData("<a href = 'hello'>", "666", "<a href='666'>")]
+        [InlineData("<a   target='_blank'   href='h'>", "666", "<a target='_blank' href='666'>")]
+        [InlineData("<img src='a/b.png' />", "666", "<img src='666'/>")]
+        [InlineData("<iMg sRc = 'a/b.png' />", "666", "<iMg sRc='666'/>")]
+        [InlineData("<div><a href='hello'><img src='a/b.png' /></div>", "666", "<div><a href='666'><img src='666'/></div>")]
+        [InlineData("<div><img src='a/b.png' /><a href='hello'></div>", "666", "<div><img src='666'/><a href='666'></div>")]
         public void TransformLinks(string input, string link, string output)
         {
             var actual = HtmlUtility.TransformHtml(input, (ref HtmlToken token) => HtmlUtility.TransformLink(ref token, null, _ => link));

--- a/test/docfx.Test/lib/HtmlUtilityTest.cs
+++ b/test/docfx.Test/lib/HtmlUtilityTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Docs.Build
         [InlineData("<iframe src='//codepen.io/a' />", "<iframe src='//codepen.io/a&rerun-position=hidden&' />")]
         public void HtmlRemoveRerunCodepenIframes(string input, string output)
         {
-            var actual = HtmlUtility.LoadHtml(input).RemoveRerunCodepenIframes().WriteTo();
+            var actual = HtmlUtility.TransformHtml(input, HtmlUtility.RemoveRerunCodepenIframes);
 
             Assert.Equal(JsonDiff.NormalizeHtml(output), JsonDiff.NormalizeHtml(actual));
         }
@@ -84,7 +84,9 @@ namespace Microsoft.Docs.Build
         [InlineData("<div><img src='a/b.png' /><a href='hello'></div>", "666", "<div><img src='666' /><a href='666'></div>")]
         public void TransformLinks(string input, string link, string output)
         {
-            Assert.Equal(output, HtmlUtility.TransformLinks(input, (href, _) => link));
+            var actual = HtmlUtility.TransformHtml(input, (ref HtmlToken token) => HtmlUtility.TransformLink(ref token, null, _ => link));
+
+            Assert.Equal(output, actual);
         }
 
         [Theory]
@@ -101,7 +103,9 @@ namespace Microsoft.Docs.Build
         [InlineData(@"<xref uid='a&amp;b' data-raw-source='@lower&amp;'>", "c&d", "", @"<a href='c&amp;d'></a>")]
         public void TransformXrefs(string input, string xref, string display, string output)
         {
-            Assert.Equal(output, HtmlUtility.TransformXref(input, null, (href, uid, isShorthand) => (xref, display)));
+            var actual = HtmlUtility.TransformHtml(input, (ref HtmlToken token) => HtmlUtility.TransformXref(ref token, null, (href, uid, isShorthand) => (xref, display)));
+
+            Assert.Equal(output, actual);
         }
 
         [Theory]


### PR DESCRIPTION
[AB#200575](https://dev.azure.com/ceapex/Engineering/_workitems/edit/200575/)

This PR adds `HtmlWriter` and refactors `TransformLink`, `TransformXref` and `RemoveRerunCodepenIframes` to use `HtmlReader/HtmlWriter`.

It extracts an `HtmlExtension` that process user HTML content inside markdown, so that each HTML block or HTML inline is parsed only once.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5809)