### PR TITLE
F#: Cache project infos

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.fsproj
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.fsproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dotnet.ProjInfo" version="0.9.0" />
-    <PackageReference Include="FSharp.Compiler.Service" version="34.1.1" />
-    <PackageReference Include="FSharp.Compiler.Service.MSBuild.v12" version="34.1.1" />
+    <PackageReference Include="Dotnet.ProjInfo" Version="0.9.0" />
+    <PackageReference Include="FSharp.Compiler.Service" Version="34.1.1" />
+    <PackageReference Include="FSharp.Compiler.Service.MSBuild.v12" Version="34.1.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.Tests/FSharpCompilationTests.fs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.Tests/FSharpCompilationTests.fs
@@ -23,9 +23,7 @@ type FSharpCompilationTests (output: ITestOutputHelper) =
         let msBuildProps = Dictionary<string, string> ()
         let fsLoader = FSharpProjectLoader (msBuildProps)
         let loader = AbstractProjectLoader ([fsLoader])
-        let checker = FSharpChecker.Create()    
-        let proj = FSharpProject (projPath, msBuildProps, loader, checker)
-        proj
+        loader.Load(projPath)
 
     let getCompilation projPath =
         let proj = getProject projPath

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.Tests/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.Tests.fsproj
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.Tests/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.Tests.fsproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="TestData/**" />
     <Compile Include="FSharpCompilationTests.fs" />
     <Compile Include="FSharpProjectTests.fs" />
   </ItemGroup>
@@ -36,8 +37,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Compiler.Service" version="34.1.1" />
-    <PackageReference Include="FSharp.Compiler.Service.MSBuild.v12" version="34.1.1" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.Tests/TestData/NetCoreLibProjectCopy/Library.fs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.Tests/TestData/NetCoreLibProjectCopy/Library.fs
@@ -1,0 +1,5 @@
+namespace NetCoreLibProject
+
+module Say =
+    let hello name =
+        printfn "Hello %s" name

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.Tests/TestData/NetCoreLibProjectCopy/NetCoreLibProjectCopy.fsproj
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.Tests/TestData/NetCoreLibProjectCopy/NetCoreLibProjectCopy.fsproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Library.fs" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Project infos are now cached as they're expensive to calculate. The RoslynProjectLoader already does this.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5810)