### PR TITLE
Warning upon href defined side-by-side with uid

### DIFF
--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -555,7 +555,7 @@ outputs:
 # href shouldn't be defined at same level with uid
 inputs:
   docfx.yml: |
-  docs/a.yml: |
+  a.yml: |
     ###YamlMime: TestData
     uid: a
     href: user-defined
@@ -566,8 +566,9 @@ inputs:
       }
     }
 outputs:
+  a.json:
   .errors.log: |
-    ["error","uid-overwrite-href","'UID' and 'href' defined at the same level is not allowed, the href value will be overwritten","docs/a.yml",3,1]
+    ["warning","uid-overwrite-href","'UID' and 'href' defined at the same level is not allowed, the href value will be overwritten","a.yml",3,1]
 ---
 # Xref property field which supports markdown content
 inputs:

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -552,6 +552,23 @@ outputs:
     ["warning","duplicate-uid","UID 'b' is duplicated in 'docs/a.json(6,14)', 'docs/b.json(3,12)'","docs/a.json",6,14]
     ["warning","duplicate-uid","UID 'b' is duplicated in 'docs/a.json(6,14)', 'docs/b.json(3,12)'","docs/b.json",3,12]
 ---
+# href shouldn't be defined at same level with uid
+inputs:
+  docfx.yml: |
+  docs/a.yml: |
+    ###YamlMime: TestData
+    uid: a
+    href: user-defined
+  _themes/ContentTemplate/schemas/TestData.schema.json: |
+    {
+      "properties": {
+        "uid": { "contentType": "uid" }
+      }
+    }
+outputs:
+  .errors.log: |
+    ["error","uid-overwrite-href","'UID' and 'href' defined at the same level is not allowed, the href value will be overwritten","docs/a.yml",3,1]
+---
 # Xref property field which supports markdown content
 inputs:
   docfx.yml: |

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -566,7 +566,7 @@ inputs:
       }
     }
 outputs:
-  a.json:
+  a.json: '{"href": "a.json"}'
   .errors.log: |
     ["warning","uid-overwrite-href","'UID' and 'href' are not allowed to define at the same level. The input 'href' will be ignored","a.yml",3,1]
 ---

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -568,7 +568,7 @@ inputs:
 outputs:
   a.json:
   .errors.log: |
-    ["warning","uid-overwrite-href","'UID' and 'href' defined at the same level is not allowed, the href value will be overwritten","a.yml",3,1]
+    ["warning","uid-overwrite-href","'UID' and 'href' are not allowed to define at the same level. The input 'href' will be ignored","a.yml",3,1]
 ---
 # Xref property field which supports markdown content
 inputs:

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -439,7 +439,7 @@ namespace Microsoft.Docs.Build
             /// </summary>
             /// Behavior: ✔️ Message: ❌
             public static Error UidOverwriteHref(SourceInfo source)
-                => new Error(ErrorLevel.Error, "uid-overwrite-href", $"'UID' and 'href' defined at the same level is not allowed, the href value will be overwritten", source);
+                => new Error(ErrorLevel.Warning, "uid-overwrite-href", $"'UID' and 'href' defined at the same level is not allowed, the href value will be overwritten", source);
         }
 
         public static class Versioning

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -439,7 +439,7 @@ namespace Microsoft.Docs.Build
             /// </summary>
             /// Behavior: ✔️ Message: ❌
             public static Error UidOverwriteHref(SourceInfo source)
-                => new Error(ErrorLevel.Warning, "uid-overwrite-href", $"'UID' and 'href' defined at the same level is not allowed, the href value will be overwritten", source);
+                => new Error(ErrorLevel.Warning, "uid-overwrite-href", $"'UID' and 'href' are not allowed to define at the same level. The input 'href' will be ignored", source);
         }
 
         public static class Versioning

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -433,6 +433,13 @@ namespace Microsoft.Docs.Build
             /// Behavior: ✔️ Message: ❌
             public static Error UidPropertyConflict(string uid, string propertyName, IEnumerable<string?> conflicts)
                 => new Error(ErrorLevel.Warning, "xref-property-conflict", $"UID '{uid}' is defined with different {propertyName}s: {StringUtility.Join(conflicts)}");
+
+            /// <summary>
+            /// Define href property at the same level with uid, href value will be overwritten.
+            /// </summary>
+            /// Behavior: ✔️ Message: ❌
+            public static Error UidOverwriteHref(SourceInfo source)
+                => new Error(ErrorLevel.Error, "uid-overwrite-href", $"'UID' and 'href' defined at the same level is not allowed, the href value will be overwritten", source);
         }
 
         public static class Versioning

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -216,6 +216,10 @@ namespace Microsoft.Docs.Build
                     }
                     if (IsXrefSpec(obj, schema, out var uid))
                     {
+                        if (obj.TryGetValue("href", out var href))
+                        {
+                            errors.Add(Errors.Xref.UidOverwriteHref(href.GetSourceInfo()?.KeySourceInfo!));
+                        }
                         newObject["href"] = PathUtility.GetRelativePathToFile(file.SiteUrl, GetXrefHref(file, uid, uidCount, obj.Parent == null));
                     }
                     return (errors, newObject);


### PR DESCRIPTION
Since we auto inject an `href` property at the same level of `uid` in #5779, we should explicitly forbid user from writing `href` for being prudent.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5814)