### PR TITLE
Relative plugin config path to docset root

### DIFF
--- a/docs/specs/ecma2Yaml.yml
+++ b/docs/specs/ecma2Yaml.yml
@@ -8,25 +8,25 @@ repos:
         {
           "docsets_to_publish": [
           { 
-            "build_source_folder": ".",
-            "ECMA2Yaml":
-            {
-              "SourceXmlFolder": "xml",
-              "OutputYamlFolder": "api",
-              "Flatten": true,
-              "SDPMode": true,
-            },
+            "build_source_folder": "cat",
           }],
+          "ECMA2Yaml": {
+            "SourceXmlFolder": "cat/xml",
+            "OutputYamlFolder": "cat/api",
+            "Flatten": true,
+            "SDPMode": true,
+          },
         }
-      docfx.yml:
-      xml/ns-CatLibrary.xml: |
+      cat/docfx.yml: |
+        template: ../_themes
+      cat/xml/ns-CatLibrary.xml: |
         <Namespace Name="CatLibrary">
           <Docs>
             <summary>To be added.</summary>
             <remarks>To be added.</remarks>
           </Docs>
         </Namespace>
-      xml/CatLibrary/Cat`2.xml: |
+      cat/xml/CatLibrary/Cat`2.xml: |
         <Type Name="Cat&lt;T,K&gt;" FullName="CatLibrary.Cat&lt;T,K&gt;">
           <TypeSignature Language="C#" Value="public class Cat&lt;T,K&gt; where T : class, new() where K : struct" />
           <TypeSignature Language="ILAsm" Value=".class public auto ansi serializable beforefieldinit Cat`2&lt;class .ctor T, struct .ctor (class System.ValueType) K&gt; extends System.Object" />
@@ -72,7 +72,7 @@ repos:
             </Member>
           </Members>
         </Type>
-      xml/FrameworksIndex/cat-1.0.xml: |
+      cat/xml/FrameworksIndex/cat-1.0.xml: |
         <?xml version="1.0" encoding="utf-8"?>
         <Framework Name="cat-1.0">
           <Assemblies>
@@ -91,11 +91,11 @@ repos:
       _themes/ContentTemplate/schemas/NetType.schema.json: |
         {}
 outputs:
-  .errors.log: |
+  cat/.errors.log: |
     ["warning","xref-not-found","Cross reference not found: 'CatLibrary'","api/toc.yml",3,8]
     ["warning","xref-not-found","Cross reference not found: 'CatLibrary.Cat`2'","api/toc.yml",6,10]
     ["warning","xref-not-found","Cross reference not found: 'CatLibrary.Cat`2.#ctor*'","api/toc.yml",9,12]
-  api/toc.json:
-  api/catlibrary.cat-2.-ctor.json:
-  api/catlibrary.cat-2.json:
-  api/catlibrary.json:
+  cat/api/toc.json:
+  cat/api/catlibrary.cat-2.-ctor.json:
+  cat/api/catlibrary.cat-2.json:
+  cat/api/catlibrary.json:

--- a/src/docfx/config/ops/OpsConfigLoader.cs
+++ b/src/docfx/config/ops/OpsConfigLoader.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using ECMA2Yaml;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build
@@ -79,7 +80,7 @@ namespace Microsoft.Docs.Build
 
             result["fileMetadata"] = GenerateJoinTocMetadata(docsetConfig?.JoinTOCPlugin ?? opsConfig.JoinTOCPlugin ?? Array.Empty<OpsJoinTocConfig>());
 
-            var monodoc = docsetConfig?.ECMA2Yaml ?? opsConfig.ECMA2Yaml;
+            var monodoc = GetMonodocConfig(docsetConfig, opsConfig, buildSourceFolder);
             if (monodoc != null)
             {
                 result["monodoc"] = JsonUtility.ToJObject(monodoc);
@@ -101,6 +102,22 @@ namespace Microsoft.Docs.Build
                     ["branch"] = depBranch,
                 }
                 select (obj, path, dep.PathToRoot)).ToArray();
+        }
+
+        private static JObject? GetMonodocConfig(OpsDocsetConfig? docsetConfig, OpsConfig opsConfig, string buildSourceFolder)
+        {
+            var result = default(JObject);
+            if (docsetConfig?.ECMA2Yaml != null)
+            {
+                result = JsonUtility.ToJObject(docsetConfig.ECMA2Yaml);
+            }
+            else if (opsConfig.ECMA2Yaml != null)
+            {
+                result = JsonUtility.ToJObject(opsConfig.ECMA2Yaml);
+                result[nameof(ECMA2YamlRepoConfig.SourceXmlFolder)] = Path.GetRelativePath(buildSourceFolder, opsConfig.ECMA2Yaml.SourceXmlFolder);
+                result[nameof(ECMA2YamlRepoConfig.OutputYamlFolder)] = Path.GetRelativePath(buildSourceFolder, opsConfig.ECMA2Yaml.OutputYamlFolder);
+            }
+            return result;
         }
 
         private static JObject GenerateJoinTocMetadata(OpsJoinTocConfig[] configs)


### PR DESCRIPTION
Fixing: https://github.com/OPS-E2E-PPE/roslyn-api-docs/blob/docfx-migration/.openpublishing.publish.config.json#L75

[Build Report](https://opbuildstoragesandbox2.blob.core.windows.net/report/2020%5C4%5C23%5Ca832b13d-313c-cd07-a6fb-6ebfcc7ff71b%5CCommit%5C202004230831412694-docs-build-v3%5Crawlog.txt?sv=2016-05-31&sr=b&sig=mcAGXKmqOVKNZzXQyu%2FBp3ASVHlt%2B4mI3grgartEbEc%3D&st=2020-04-23T08%3A27%3A19Z&se=2020-05-24T08%3A32%3A19Z&sp=r)
![image](https://user-images.githubusercontent.com/42199316/80086541-71d63200-858c-11ea-8d2c-55fb3efd7f20.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5822)