### PR TITLE
Make default value of CopyResource as true and remove TODO

### DIFF
--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -83,10 +83,9 @@ namespace Microsoft.Docs.Build
         public bool LowerCaseUrl { get; private set; } = true;
 
         /// <summary>
-        /// TODO: whether need to copy resource should be determined by OutputUrlType
         /// Gets whether resources are copied to output.
         /// </summary>
-        public bool CopyResources { get; private set; } = false;
+        public bool CopyResources { get; private set; } = true;
 
         /// <summary>
         /// Gets the maximum errors to output.


### PR DESCRIPTION
- Make default value of CopyResource as true since the default value of `OutputUrlType` is `pretty`(static).
- Remove the TODO since our test set the `CopyResource` as true but `OutputUrlType` as `Docs`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5830)