### PR TITLE
Move strip tags to HtmlExtension

### DIFF
--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Docs.Build
             var (markupErrors, html) = context.MarkdownEngine.ToHtml(content, file, MarkdownPipelineType.Markdown);
             errors.AddRange(markupErrors);
 
-            var htmlDom = HtmlUtility.LoadHtml(html).PostMarkup(context.Config.DryRun);
+            var htmlDom = HtmlUtility.LoadHtml(html);
             ValidateBookmarks(context, file, htmlDom);
             if (!HtmlUtility.TryExtractTitle(htmlDom, out var title, out var rawTitle))
             {
@@ -312,7 +312,7 @@ namespace Microsoft.Docs.Build
                 errors.AddRange(deserializeErrors);
 
                 var razorHtml = RazorTemplate.Render(file.Mime, landingData).GetAwaiter().GetResult();
-                var htmlDom = HtmlUtility.LoadHtml(razorHtml).PostMarkup(context.Config.DryRun);
+                var htmlDom = HtmlUtility.LoadHtml(razorHtml);
                 ValidateBookmarks(context, file, htmlDom);
 
                 pageModel = JsonUtility.ToJObject(new ConceptualModel

--- a/src/docfx/lib/HtmlUtility.cs
+++ b/src/docfx/lib/HtmlUtility.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Docs.Build
 {
     internal static class HtmlUtility
     {
-        public delegate void TransformHtmlDelegate(ref HtmlToken token);
+        public delegate void TransformHtmlDelegate(ref HtmlReader reader, ref HtmlToken token);
 
         public static string TransformHtml(string html, TransformHtmlDelegate transform)
         {
@@ -26,7 +26,7 @@ namespace Microsoft.Docs.Build
 
             while (reader.Read(out var token))
             {
-                transform(ref token);
+                transform(ref reader, ref token);
                 writer.Write(token);
             }
 
@@ -96,7 +96,7 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public static void TransformXref(ref HtmlToken token, MarkdownObject? block, Func<SourceInfo<string>?, SourceInfo<string>?, bool, (string? href, string display)> resolveXref)
+        public static void TransformXref(ref HtmlReader reader, ref HtmlToken token, MarkdownObject? block, Func<SourceInfo<string>?, SourceInfo<string>?, bool, (string? href, string display)> resolveXref)
         {
             if (!token.NameIs("xref"))
             {
@@ -108,6 +108,8 @@ namespace Microsoft.Docs.Build
                 token = default;
                 return;
             }
+
+            reader.ReadToEndTag(token.Name.Span);
 
             var rawHtml = default(string);
             var rawSource = default(string);
@@ -263,10 +265,11 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        internal static void StripTags(ref HtmlToken token)
+        internal static void StripTags(ref HtmlReader reader, ref HtmlToken token)
         {
             if (token.NameIs("script") || token.NameIs("link") || token.NameIs("style"))
             {
+                reader.ReadToEndTag(token.Name.Span);
                 token = default;
                 return;
             }

--- a/src/docfx/lib/html/HtmlReader.cs
+++ b/src/docfx/lib/html/HtmlReader.cs
@@ -36,6 +36,25 @@ namespace Microsoft.Docs.Build
             _length = html.Length;
         }
 
+        public bool ReadToEndTag(ReadOnlySpan<char> name)
+        {
+            if (((_type == HtmlTokenType.StartTag && _isSelfClosing) || _type == HtmlTokenType.EndTag) &&
+                _html.AsSpan(_nameRange.start, _nameRange.length).Equals(name, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            while (Read(out var token))
+            {
+                if (token.Type == HtmlTokenType.EndTag && token.NameIs(name))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public bool Read(out HtmlToken token)
         {
             // Simplified pasing algorithm based on https://html.spec.whatwg.org/multipage/parsing.html

--- a/src/docfx/lib/html/HtmlToken.cs
+++ b/src/docfx/lib/html/HtmlToken.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Docs.Build
 
         public (int start, int length) Range { get; }
 
-        public bool NameIs(string name)
+        public bool NameIs(ReadOnlySpan<char> name)
         {
             return Name.Span.Equals(name, StringComparison.OrdinalIgnoreCase);
         }

--- a/src/docfx/lib/markdown/HtmlExtension.cs
+++ b/src/docfx/lib/markdown/HtmlExtension.cs
@@ -42,12 +42,12 @@ namespace Microsoft.Docs.Build
                 // <a>b</a> generates 3 inline markdown tokens: <a>, b, </a>.
                 // `HtmlNode.OuterHtml` turns <a> into <a></a>, and generates <a></a>b</a> for the above input.
                 // The following code ensures we preserve the original html when changing links.
-                return HtmlUtility.TransformHtml(html, (ref HtmlToken token) =>
+                return HtmlUtility.TransformHtml(html, (ref HtmlReader reader, ref HtmlToken token) =>
                 {
                     HtmlUtility.TransformLink(ref token, block, getLink);
-                    HtmlUtility.TransformXref(ref token, block, resolveXref);
+                    HtmlUtility.TransformXref(ref reader, ref token, block, resolveXref);
                     HtmlUtility.RemoveRerunCodepenIframes(ref token);
-                    HtmlUtility.StripTags(ref token);
+                    HtmlUtility.StripTags(ref reader, ref token);
                 });
             }
         }

--- a/src/docfx/lib/markdown/HtmlExtension.cs
+++ b/src/docfx/lib/markdown/HtmlExtension.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Docs.Build
                     HtmlUtility.TransformLink(ref token, block, getLink);
                     HtmlUtility.TransformXref(ref token, block, resolveXref);
                     HtmlUtility.RemoveRerunCodepenIframes(ref token);
+                    HtmlUtility.StripTags(ref token);
                 });
             }
         }

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -256,14 +256,14 @@ namespace Microsoft.Docs.Build
                     errors.AddRange(markupErrors);
 
                     // todo: use BuildPage.CreateHtmlContent() when we only validate markdown properties' bookmarks
-                    return (errors, HtmlUtility.LoadHtml(html).PostMarkup(context.Config.DryRun).WriteTo());
+                    return (errors, html);
 
                 case JsonSchemaContentType.InlineMarkdown:
                     var (inlineMarkupErrors, inlineHtml) = context.MarkdownEngine.ToHtml(content, file, MarkdownPipelineType.InlineMarkdown);
                     errors.AddRange(inlineMarkupErrors);
 
                     // todo: use BuildPage.CreateHtmlContent() when we only validate markdown properties' bookmarks
-                    return (errors, HtmlUtility.LoadHtml(inlineHtml).PostMarkup(context.Config.DryRun).WriteTo());
+                    return (errors, inlineHtml);
 
                 // TODO: remove JsonSchemaContentType.Html after LandingData is migrated
                 case JsonSchemaContentType.Html:

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -267,7 +267,7 @@ namespace Microsoft.Docs.Build
 
                 // TODO: remove JsonSchemaContentType.Html after LandingData is migrated
                 case JsonSchemaContentType.Html:
-                    var htmlWithLinks = HtmlUtility.TransformHtml(content, (ref HtmlToken token) =>
+                    var htmlWithLinks = HtmlUtility.TransformHtml(content, (ref HtmlReader reader, ref HtmlToken token) =>
                     {
                         HtmlUtility.TransformLink(ref token, null, href =>
                         {

--- a/test/docfx.Test/lib/HtmlReaderWriterTest.cs
+++ b/test/docfx.Test/lib/HtmlReaderWriterTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Text;
 using Xunit;
 
 namespace Microsoft.Docs.Build
@@ -150,6 +151,26 @@ namespace Microsoft.Docs.Build
             }
 
             Assert.Equal(expected, string.Join(", ", actual));
+        }
+
+        [Theory]
+        [InlineData("<a/>b", "b")]
+        [InlineData("</a>b", "b")]
+        [InlineData("<a>b</a>c", "c")]
+        [InlineData("<a></a>b</a>c", "b</a>c")]
+        [InlineData("<a><a></a>b</a>c", "b</a>c")]
+        public void ReadToCloseTag(string html, string expected)
+        {
+            var reader = new HtmlReader(html);
+            Assert.True(reader.Read(out var token));
+            Assert.True(reader.ReadToEndTag(token.Name.Span));
+
+            var actual = new StringBuilder();
+            while (reader.Read(out token))
+            {
+                actual.Append(token.RawText);
+            }
+            Assert.Equal(expected, actual.ToString());
         }
 
         [Fact]

--- a/test/docfx.Test/lib/HtmlUtilityTest.cs
+++ b/test/docfx.Test/lib/HtmlUtilityTest.cs
@@ -48,23 +48,7 @@ namespace Microsoft.Docs.Build
         [InlineData("<div><script></script></div>", "<div></div>")]
         public void HtmlStripTags(string input, string output)
         {
-            var actual = HtmlUtility.LoadHtml(input).StripTags().WriteTo();
-
-            Assert.Equal(JsonDiff.NormalizeHtml(output), JsonDiff.NormalizeHtml(actual));
-        }
-
-        [Theory]
-        [InlineData("<th style='text-align: left;'>", "<th style='text-align: left;'>")]
-        [InlineData("<th style='text-align: center;'>", "<th style='text-align: center;'>")]
-        [InlineData("<th style='text-align: right;'>", "<th style='text-align: right;'>")]
-        [InlineData("<td style='text-align: left;'>", "<td style='text-align: left;'>")]
-        [InlineData("<td style='text-align: center;'>", "<td style='text-align: center;'>")]
-        [InlineData("<td style='text-align: right;'>", "<td style='text-align: right;'>")]
-        [InlineData("<table style='text-align: right;'>", "<table style='text-align: right;'>")]
-        [InlineData("<table style='text-align: right; background-color: yellow'>", "<table/>")]
-        public void HtmlStripTableStyles(string input, string output)
-        {
-            var actual = HtmlUtility.LoadHtml(input).StripTags().WriteTo();
+            var actual = HtmlUtility.TransformHtml(input, HtmlUtility.StripTags);
 
             Assert.Equal(JsonDiff.NormalizeHtml(output), JsonDiff.NormalizeHtml(actual));
         }

--- a/test/docfx.Test/lib/HtmlUtilityTest.cs
+++ b/test/docfx.Test/lib/HtmlUtilityTest.cs
@@ -35,7 +35,9 @@ namespace Microsoft.Docs.Build
         [InlineData("<iframe src='//codepen.io/a' />", "<iframe src='//codepen.io/a&rerun-position=hidden&' />")]
         public void HtmlRemoveRerunCodepenIframes(string input, string output)
         {
-            var actual = HtmlUtility.TransformHtml(input, HtmlUtility.RemoveRerunCodepenIframes);
+            var actual = HtmlUtility.TransformHtml(
+                input,
+                (ref HtmlReader reader, ref HtmlToken token) => HtmlUtility.RemoveRerunCodepenIframes(ref token));
 
             Assert.Equal(JsonDiff.NormalizeHtml(output), JsonDiff.NormalizeHtml(actual));
         }
@@ -48,7 +50,9 @@ namespace Microsoft.Docs.Build
         [InlineData("<div><script></script></div>", "<div></div>")]
         public void HtmlStripTags(string input, string output)
         {
-            var actual = HtmlUtility.TransformHtml(input, HtmlUtility.StripTags);
+            var actual = HtmlUtility.TransformHtml(
+                input,
+                (ref HtmlReader reader, ref HtmlToken token) => HtmlUtility.StripTags(ref reader, ref token));
 
             Assert.Equal(JsonDiff.NormalizeHtml(output), JsonDiff.NormalizeHtml(actual));
         }
@@ -68,7 +72,9 @@ namespace Microsoft.Docs.Build
         [InlineData("<div><img src='a/b.png' /><a href='hello'></div>", "666", "<div><img src='666'/><a href='666'></div>")]
         public void TransformLinks(string input, string link, string output)
         {
-            var actual = HtmlUtility.TransformHtml(input, (ref HtmlToken token) => HtmlUtility.TransformLink(ref token, null, _ => link));
+            var actual = HtmlUtility.TransformHtml(
+                input,
+                (ref HtmlReader reader, ref HtmlToken token) => HtmlUtility.TransformLink(ref token, null, _ => link));
 
             Assert.Equal(output, actual);
         }
@@ -78,6 +84,7 @@ namespace Microsoft.Docs.Build
         [InlineData("<a href='hello'>", "a", "a", "<a href='hello'>")]
         [InlineData("<xref href='hello'>", "a", "b", "<a href='a'>b</a>")]
         [InlineData("<xref uid='hello'>", "a", "b", "<a href='a'>b</a>")]
+        [InlineData("<xref href='hello'>x</xref>", "a", "b", "<a href='a'>b</a>")]
         [InlineData("<xref href='hello' uid='hello'>", "a", "b", "<a href='a'>b</a>")]
         [InlineData(@"<xref href='hello' data-raw-html='@higher&amp;' data-raw-source='@lower'>", "", "", @"@higher&")]
         [InlineData(@"<xref uid='hello' data-raw-html='@higher&amp;' data-raw-source='@lower'>", "", "", @"@higher&")]
@@ -87,7 +94,9 @@ namespace Microsoft.Docs.Build
         [InlineData(@"<xref uid='a&amp;b' data-raw-source='@lower&amp;'>", "c&d", "", @"<a href='c&amp;d'></a>")]
         public void TransformXrefs(string input, string xref, string display, string output)
         {
-            var actual = HtmlUtility.TransformHtml(input, (ref HtmlToken token) => HtmlUtility.TransformXref(ref token, null, (href, uid, isShorthand) => (xref, display)));
+            var actual = HtmlUtility.TransformHtml(
+                input,
+                (ref HtmlReader reader, ref HtmlToken token) => HtmlUtility.TransformXref(ref reader, ref token, null, (href, uid, isShorthand) => (xref, display)));
 
             Assert.Equal(output, actual);
         }


### PR DESCRIPTION
This way, we only strip user HTML, not HTML generated from markup.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5833)