### PR TITLE
Add and track Error.Name

### DIFF
--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -492,147 +492,147 @@ namespace Microsoft.Docs.Build
             /// </summary>
             /// Behavior: ❌ Message: ❌
             public static Error UnknownField(SourceInfo? source, string propName, string typeName)
-                => new Error(ErrorLevel.Warning, "unknown-field", $"Could not find member '{propName}' on object of type '{typeName}'.", source);
+                => new Error(ErrorLevel.Warning, "unknown-field", $"Could not find member '{propName}' on object of type '{typeName}'.", source, propName);
 
             /// <summary>
             /// The input value type does not match expected value type.
             /// </summary>
             /// Behavior: ✔️ Message: ✔️
-            public static Error UnexpectedType(SourceInfo? source, object expectedType, object actualType)
-                => new Error(ErrorLevel.Warning, "unexpected-type", $"Expected type '{expectedType}' but got '{actualType}'", source);
+            public static Error UnexpectedType(SourceInfo? source, object expectedType, object actualType, string? name = null)
+                => new Error(ErrorLevel.Warning, "unexpected-type", $"Expected type '{expectedType}' but got '{actualType}'", source, name);
 
             /// <summary>
             /// The input value is not defined in a valid value list.
             /// </summary>
             /// Behavior: ✔️ Message: ✔️
-            public static Error InvalidValue(SourceInfo? source, string name, object value)
-                => new Error(ErrorLevel.Warning, "invalid-value", $"Invalid value for '{name}': '{value}'", source);
+            public static Error InvalidValue(SourceInfo? source, string name, object value, string? propName = null)
+                => new Error(ErrorLevel.Warning, "invalid-value", $"Invalid value for '{name}': '{value}'", source, propName ?? name);
 
             /// <summary>
             /// The string type's value doesn't match given format.
             /// </summary>
             /// Behavior: ✔️ Message: ❌
-            public static Error FormatInvalid(SourceInfo? source, string value, object type)
-                => new Error(ErrorLevel.Warning, "format-invalid", $"String '{value}' is not a valid '{type}'", source);
+            public static Error FormatInvalid(SourceInfo? source, string value, object type, string propName)
+                => new Error(ErrorLevel.Warning, "format-invalid", $"String '{value}' is not a valid '{type}'", source, propName);
 
             /// <summary>
             /// Array length not within min and max.
             /// </summary>
             /// Behavior: ✔️ Message: ❌
             public static Error ArrayLengthInvalid(SourceInfo? source, string propName, string criteria)
-                => new Error(ErrorLevel.Warning, "array-length-invalid", $"Array '{propName}' length should be {criteria}", source);
+                => new Error(ErrorLevel.Warning, "array-length-invalid", $"Array '{propName}' length should be {criteria}", source, propName);
 
             /// <summary>
             /// Array items not unique.
             /// </summary>
             /// Behavior: ✔️ Message: ❌
             public static Error ArrayNotUnique(SourceInfo? source, string propName)
-                => new Error(ErrorLevel.Warning, "array-not-unique", $"Array '{propName}' items should be unique", source);
+                => new Error(ErrorLevel.Warning, "array-not-unique", $"Array '{propName}' items should be unique", source, propName);
 
             /// <summary>
             /// Array items not unique.
             /// </summary>
             /// Behavior: ✔️ Message: ❌
             public static Error ArrayContainsFailed(SourceInfo? source, string propName)
-                => new Error(ErrorLevel.Warning, "array-contains-failed", $"Array '{propName}' should contain at least one item that matches JSON schema", source);
+                => new Error(ErrorLevel.Warning, "array-contains-failed", $"Array '{propName}' should contain at least one item that matches JSON schema", source, propName);
 
             /// <summary>
             /// Error when JSON boolean schema failed.
             /// </summary>
             /// Behavior: ✔️ Message: ❌
             public static Error BooleanSchemaFailed(SourceInfo? source, string propName)
-                => new Error(ErrorLevel.Warning, "boolean-schema-failed", $"Boolean schema validation failed for '{propName}'", source);
+                => new Error(ErrorLevel.Warning, "boolean-schema-failed", $"Boolean schema validation failed for '{propName}'", source, propName);
 
             /// <summary>
             /// Object property count not within min and max.
             /// </summary>
             /// Behavior: ✔️ Message: ❌
             public static Error PropertyCountInvalid(SourceInfo? source, string propName, string criteria)
-                => new Error(ErrorLevel.Warning, "property-count-invalid", $"Object '{propName}' property count should be {criteria}", source);
+                => new Error(ErrorLevel.Warning, "property-count-invalid", $"Object '{propName}' property count should be {criteria}", source, propName);
 
             /// <summary>
             /// String length not within min and max.
             /// </summary>
             /// Behavior: ✔️ Message: ❌
             public static Error StringLengthInvalid(SourceInfo? source, string propName, string criteria)
-                => new Error(ErrorLevel.Warning, "string-length-invalid", $"String '{propName}' length should be {criteria}", source);
+                => new Error(ErrorLevel.Warning, "string-length-invalid", $"String '{propName}' length should be {criteria}", source, propName);
 
             /// <summary>
             /// Number not within min and max.
             /// </summary>
             /// Behavior: ✔️ Message: ❌
-            public static Error NumberInvalid(SourceInfo? source, double value, string criteria)
-                => new Error(ErrorLevel.Warning, "number-invalid", $"Number '{value}' should be {criteria}", source);
+            public static Error NumberInvalid(SourceInfo? source, double value, string criteria, string propName)
+                => new Error(ErrorLevel.Warning, "number-invalid", $"Number '{value}' should be {criteria}", source, propName);
 
             /// <summary>
             /// A required attribute is missing.
             /// </summary>
             /// Behavior: ✔️ Message: ✔️
             public static Error MissingAttribute(SourceInfo? source, string name)
-                => new Error(ErrorLevel.Warning, "missing-attribute", $"Missing required attribute: '{name}'", source);
+                => new Error(ErrorLevel.Warning, "missing-attribute", $"Missing required attribute: '{name}'", source, name);
 
             /// <summary>
             /// An attribute lacks the required dependency.
             /// </summary>
             /// Behavior: ✔️ Message: ✔️
             public static Error MissingPairedAttribute(SourceInfo? source, string name, string otherKey)
-                => new Error(ErrorLevel.Warning, "missing-paired-attribute", $"Missing attribute: '{otherKey}'. If you specify '{name}', you must also specify '{otherKey}'", source);
+                => new Error(ErrorLevel.Warning, "missing-paired-attribute", $"Missing attribute: '{otherKey}'. If you specify '{name}', you must also specify '{otherKey}'", source, otherKey);
 
             /// <summary>
             /// Attributes do not meet the requirements of either logic.
             /// </summary>
             /// Behavior: ✔️ Message: ✔️
-            public static Error MissingEitherAttribute(SourceInfo? source, IEnumerable<object> attributes)
-                => new Error(ErrorLevel.Warning, "missing-either-attribute", $"One of the following attributes is required: {StringUtility.Join(attributes)}", source);
+            public static Error MissingEitherAttribute(SourceInfo? source, IEnumerable<object> attributes, string propName)
+                => new Error(ErrorLevel.Warning, "missing-either-attribute", $"One of the following attributes is required: {StringUtility.Join(attributes)}", source, propName);
 
             /// <summary>
             /// Attributes do not meet the requirements of precludes logic.
             /// </summary>
             /// Behavior: ✔️ Message: ✔️
-            public static Error PrecludedAttributes(SourceInfo? source, IEnumerable<object> attributes)
-                => new Error(ErrorLevel.Warning, "precluded-attributes", $"Only one of the following attributes can exist: {StringUtility.Join(attributes)}", source);
+            public static Error PrecludedAttributes(SourceInfo? source, IEnumerable<object> attributes, string propName)
+                => new Error(ErrorLevel.Warning, "precluded-attributes", $"Only one of the following attributes can exist: {StringUtility.Join(attributes)}", source, propName);
 
             /// <summary>
             /// An attribute doesn't conform to date format.
             /// </summary>
             /// Behavior: ✔️ Message: ✔️
             public static Error DateFormatInvalid(SourceInfo? source, string name, string value)
-                => new Error(ErrorLevel.Warning, "date-format-invalid", $"Invalid date format for '{name}': '{value}'.", source);
+                => new Error(ErrorLevel.Warning, "date-format-invalid", $"Invalid date format for '{name}': '{value}'.", source, name);
 
             /// <summary>
             /// Date out of range.
             /// </summary>
             /// Behavior: ✔️ Message: ✔️
             public static Error DateOutOfRange(SourceInfo? source, string name, string value)
-                => new Error(ErrorLevel.Warning, "date-out-of-range", $"Value out of range for '{name}': '{value}'", source);
+                => new Error(ErrorLevel.Warning, "date-out-of-range", $"Value out of range for '{name}': '{value}'", source, name);
 
             /// <summary>
             /// An attribute is deprecated.
             /// </summary>
             /// Behavior: ✔️ Message: ✔️
             public static Error AttributeDeprecated(SourceInfo? source, string name, string replacedBy)
-                => new Error(ErrorLevel.Warning, "attribute-deprecated", $"Deprecated attribute: '{name}'{(string.IsNullOrEmpty(replacedBy) ? "." : $", use '{replacedBy}' instead")}", source);
+                => new Error(ErrorLevel.Warning, "attribute-deprecated", $"Deprecated attribute: '{name}'{(string.IsNullOrEmpty(replacedBy) ? "." : $", use '{replacedBy}' instead")}", source, name);
 
             /// <summary>
             /// The value of paired attribute is invalid.
             /// </summary>
             /// Behavior: ✔️ Message: ✔️
-            public static Error InvalidPairedAttribute(SourceInfo? source, string name, object value, string dependentFieldName, object? dependentFieldValue)
-                => new Error(ErrorLevel.Warning, "invalid-paired-attribute", $"Invalid value for '{name}': '{value}' is not valid with '{dependentFieldName}' value '{dependentFieldValue}'", source);
+            public static Error InvalidPairedAttribute(SourceInfo? source, string name, object value, string dependentFieldName, object? dependentFieldValue, string propName)
+                => new Error(ErrorLevel.Warning, "invalid-paired-attribute", $"Invalid value for '{name}': '{value}' is not valid with '{dependentFieldName}' value '{dependentFieldValue}'", source, propName);
 
             /// <summary>
             /// The value is not a valid Microsoft alias
             /// </summary>
             /// Behavior: ✔️ Message: ✔️
             public static Error MsAliasInvalid(SourceInfo<string> alias, string name)
-                => new Error(ErrorLevel.Warning, "ms-alias-invalid", $"Invalid value for '{name}', '{alias}' is not a valid Microsoft alias", alias);
+                => new Error(ErrorLevel.Warning, "ms-alias-invalid", $"Invalid value for '{name}', '{alias}' is not a valid Microsoft alias", alias, name: name);
 
             /// <summary>
             /// The attribute value is duplicated within docset
             /// </summary>
             /// Behavior: ✔️ Message: ✔️
             public static Error DuplicateAttribute(SourceInfo? source, string name, object value, IEnumerable<SourceInfo> duplicatedSources)
-                => new Error(ErrorLevel.Suggestion, "duplicate-attribute", $"Attribute '{name}' with value '{value}' is duplicated in {StringUtility.Join(duplicatedSources)}", source);
+                => new Error(ErrorLevel.Suggestion, "duplicate-attribute", $"Attribute '{name}' with value '{value}' is duplicated in {StringUtility.Join(duplicatedSources)}", source, name);
         }
 
         public static class Metadata
@@ -652,13 +652,13 @@ namespace Microsoft.Docs.Build
             /// </summary>
             /// Behavior: ✔️ Message: ✔️
             public static Error AttributeReserved(SourceInfo? source, string name)
-                => new Error(ErrorLevel.Warning, "attribute-reserved", $"Attribute {name} is reserved for use by Docs.", source);
+                => new Error(ErrorLevel.Warning, "attribute-reserved", $"Attribute {name} is reserved for use by Docs.", source, name);
 
             /// <summary>
             /// Metadata value must be scalar or arrays of scalars.
             /// </summary>
             public static Error InvalidMetadataType(SourceInfo? source, string name)
-                => new Error(ErrorLevel.Error, "invalid-metadata-type", $"Metadata '{name}' can only be a scalar value or string array", source);
+                => new Error(ErrorLevel.Error, "invalid-metadata-type", $"Metadata '{name}' can only be a scalar value or string array", source, name);
         }
 
         public static class Content

--- a/src/docfx/lib/log/Error.cs
+++ b/src/docfx/lib/log/Error.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Docs.Build
 
         public string Message { get; }
 
+        public string? Name { get; }
+
         public FilePath? FilePath { get; }
 
         public int Line { get; }
@@ -27,11 +29,11 @@ namespace Microsoft.Docs.Build
 
         public int EndColumn { get; }
 
-        public Error(ErrorLevel level, string code, string message, SourceInfo? source)
-            : this(level, code, message, source?.File, source?.Line ?? 0, source?.Column ?? 0, source?.EndLine ?? 0, source?.EndColumn ?? 0)
+        public Error(ErrorLevel level, string code, string message, SourceInfo? source, string? name = null)
+            : this(level, code, message, source?.File, source?.Line ?? 0, source?.Column ?? 0, source?.EndLine ?? 0, source?.EndColumn ?? 0, name)
         { }
 
-        public Error(ErrorLevel level, string code, string message, FilePath? file = null, int line = 0, int column = 0, int endLine = 0, int endColumn = 0)
+        public Error(ErrorLevel level, string code, string message, FilePath? file = null, int line = 0, int column = 0, int endLine = 0, int endColumn = 0, string? name = null)
         {
             Level = level;
             Code = code;
@@ -41,6 +43,7 @@ namespace Microsoft.Docs.Build
             Column = column;
             EndLine = endLine;
             EndColumn = endColumn;
+            Name = name;
         }
 
         public Error WithCustomError(CustomError customError)
@@ -53,12 +56,13 @@ namespace Microsoft.Docs.Build
                 Line,
                 Column,
                 EndLine,
-                EndColumn);
+                EndColumn,
+                Name);
         }
 
         public Error WithLevel(ErrorLevel level)
         {
-            return new Error(level, Code, Message, FilePath, Line, Column, EndLine, EndColumn);
+            return new Error(level, Code, Message, FilePath, Line, Column, EndLine, EndColumn, Name);
         }
 
         public override string ToString() => ToString(Level, null);
@@ -89,6 +93,7 @@ namespace Microsoft.Docs.Build
                 return x.Level == y.Level &&
                        x.Code == y.Code &&
                        x.Message == y.Message &&
+                       x.Name == y.Name &&
                        x.FilePath == y.FilePath &&
                        x.Line == y.Line &&
                        x.Column == y.Column;
@@ -100,6 +105,7 @@ namespace Microsoft.Docs.Build
                     obj.Level,
                     obj.Code,
                     obj.Message,
+                    obj.Name,
                     obj.FilePath,
                     obj.Line,
                     obj.Column);

--- a/src/docfx/lib/log/ErrorLog.cs
+++ b/src/docfx/lib/log/ErrorLog.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Docs.Build
 
         private void WriteCore(Error error, ErrorLevel level)
         {
-            Telemetry.TrackErrorCount(error.Code, level);
+            Telemetry.TrackErrorCount(error.Code, level, error.Name);
 
             if (level == ErrorLevel.Error && error.FilePath != null)
             {

--- a/src/docfx/lib/log/Telemetry.cs
+++ b/src/docfx/lib/log/Telemetry.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Docs.Build
         private static readonly MetricConfiguration s_metricConfiguration = new MetricConfiguration(1000, int.MaxValue, new MetricSeriesConfigurationForMeasurement(false));
 
         private static readonly Metric s_operationTimeMetric = s_telemetryClient.GetMetric(new MetricIdentifier(null, $"Time", "Name", "OS", "Version", "Repo", "Branch", "CorrelationId"), s_metricConfiguration);
-        private static readonly Metric s_errorCountMetric = s_telemetryClient.GetMetric(new MetricIdentifier(null, $"BuildLog", "Code", "Level", "Type", "OS", "Version", "Repo", "Branch", "CorrelationId"), s_metricConfiguration);
+        private static readonly Metric s_errorCountMetric = s_telemetryClient.GetMetric(new MetricIdentifier(null, $"BuildLog", "Code", "Level", "Name", "Type", "OS", "Version", "Repo", "Branch", "CorrelationId"), s_metricConfiguration);
         private static readonly Metric s_cacheCountMetric = s_telemetryClient.GetMetric(new MetricIdentifier(null, $"Cache", "Name", "State", "OS", "Version", "Repo", "Branch", "CorrelationId"), s_metricConfiguration);
         private static readonly Metric s_buildCommitCountMetric = s_telemetryClient.GetMetric(new MetricIdentifier(null, $"BuildCommitCount", "Name", "OS", "Version", "Repo", "Branch", "CorrelationId"), s_metricConfiguration);
         private static readonly Metric s_buildFileTypeCountMetric = s_telemetryClient.GetMetric(new MetricIdentifier(null, "BuildFileType", "FileExtension", "DocumentType", "MimeType", "OS", "Version", "Repo", "Branch", "CorrelationId"), s_metricConfiguration);
@@ -64,9 +64,9 @@ namespace Microsoft.Docs.Build
             return new PerfScope(name.ToString());
         }
 
-        public static void TrackErrorCount(string code, ErrorLevel level)
+        public static void TrackErrorCount(string code, ErrorLevel level, string? name)
         {
-            s_errorCountMetric.TrackValue(1, code, level.ToString(), "User", s_os, s_version, s_repo, s_branch, s_correlationId);
+            s_errorCountMetric.TrackValue(1, code, level.ToString(), CoalesceEmpty(name), "User", s_os, s_version, s_repo, s_branch, s_correlationId);
         }
 
         public static void TrackCacheTotalCount(TelemetryName name)


### PR DESCRIPTION
#5823 #5817

Several cases requires tracking additional dimension in addition to error code. This PR adds a `Name` property to `Error` and use it to:
- Track additional telemetry associated with the error
- Customize error code, error message based on `Name`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5835)