### PR TITLE
Split toc wrap into items

### DIFF
--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -1494,26 +1494,43 @@ inputs:
     splitItemsBy: name
     items:
     - name: 1
+      href: a.md
       items:
       - name: 1-1
-        href: a.md
+        href: b.md
     - name: 2
-      href: b.md
+      href: c.md
   a.md:
   b.md:
+  c.md:
 outputs:
   a.json: '{ "_tocRel": "_splitted/1/toc.json" }'
-  b.json: '{ "_tocRel": "toc.json" }'
+  b.json: '{ "_tocRel": "_splitted/1/toc.json" }'
+  c.json: '{ "_tocRel": "toc.json" }'
   toc.json: |
     {
       "items": [
         { "name": "1", "href": "a", "items": undefined },
-        { "name": "2", "href": "b", "items": undefined }
+        { "name": "2", "href": "c", "items": undefined }
       ],
       "splitItemsBy": undefined
     }
   _splitted/1/toc.json: |
-    { "items": [{ "name": "1-1", "href": "../../a", "items": undefined }] }
+    {
+      "items": [
+        {
+          "name": "1",
+          "href": "../../a",
+          "items": [
+            { 
+              "name": "1-1", 
+              "href": "../../b", 
+              "items": undefined
+            }
+          ]
+        }
+      ]
+    }
 ---
 # TOC splitItemsBy respect metadata config
 inputs:

--- a/src/docfx/build/toc/TableOfContentsMap.cs
+++ b/src/docfx/build/toc/TableOfContentsMap.cs
@@ -230,7 +230,7 @@ namespace Microsoft.Docs.Build
                 var newNodeFilePath = new PathString(Path.Combine(Path.GetDirectoryName(file.Path) ?? "", $"_splitted/{name}/TOC.yml"));
                 var newNodeFile = FilePath.Generated(newNodeFilePath);
 
-                _input.AddGeneratedContent(newNodeFile, newNodeToken);
+                _input.AddGeneratedContent(newNodeFile, new JArray { newNodeToken });
                 result.Add(newNodeFile);
 
                 var newChild = new TableOfContentsNode(child)


### PR DESCRIPTION
[AB#210316](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/210316)

 wrap splitted item root into items, otherwise its properties will be [lost after loading toc as object](https://github.com/dotnet/docfx/blob/v3/src/docfx/build/toc/TableOfContentsParser.cs#L54)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5839)