### PR TITLE
fix url of index page in ugly outputUrlType

### DIFF
--- a/docs/specs/static.yml
+++ b/docs/specs/static.yml
@@ -89,8 +89,17 @@ inputs:
     }
   _themes/Conceptual.html.liquid: |
   a.md:
+  index.md:
 outputs:
   a.html:
+  index.html:
+  .publish.json: |
+    {
+      "files": [
+        { "url": "/a.html" },
+        { "url": "/index.html"}
+      ]
+    }
 ---
 # Always ues Docs URL to check redirection rule with document_id as true
 inputs:
@@ -182,7 +191,6 @@ outputs:
       "items": [{"name": "A","href": "../136a42ac/a.html"}],
       "_path": "1dd7adba/toc.html"
     }
-  1dd7adba/toc.mta.json:
   136a42ac/a.html: |
     <!DOCTYPE html>
     <div><p><a href="../218c13d0/b.html" data-linktype="relative-path">B</a></p></div>

--- a/src/docfx/build/document/DocumentProvider.cs
+++ b/src/docfx/build/document/DocumentProvider.cs
@@ -187,11 +187,13 @@ namespace Microsoft.Docs.Build
 
             if (contentType == ContentType.Redirection || contentType == ContentType.TableOfContents || (contentType == ContentType.Page && isPage))
             {
-                var fileName = Path.GetFileNameWithoutExtension(path);
-                if (fileName.Equals("index", PathUtility.PathComparison))
+                if (outputUrlType != OutputUrlType.Ugly)
                 {
-                    var i = url.LastIndexOf('/');
-                    return i >= 0 ? url.Substring(0, i + 1) : "./";
+                    if (Path.GetFileNameWithoutExtension(path).Equals("index", PathUtility.PathComparison))
+                    {
+                        var i = url.LastIndexOf('/');
+                        return i >= 0 ? url.Substring(0, i + 1) : "./";
+                    }
                 }
                 if (outputUrlType == OutputUrlType.Docs && contentType != ContentType.TableOfContents)
                 {

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -53,7 +53,17 @@ namespace Microsoft.Docs.Build
             {
                 if (!context.Config.DryRun)
                 {
-                    if (context.Config.Legacy || context.Config.OutputType == OutputType.Html)
+                    if (context.Config.OutputType == OutputType.Html)
+                    {
+                        // Just for current PDF build. toc.json is used for generate PDF outline
+                        var output = context.TemplateEngine.RunJavaScript("toc.json.js", JsonUtility.ToJObject(model));
+                        context.Output.WriteJson(LegacyUtility.ChangeExtension(outputPath, ".json"), output);
+
+                        var viewModel = context.TemplateEngine.RunJavaScript($"toc.html.js", JsonUtility.ToJObject(model));
+                        var html = context.TemplateEngine.RunMustache($"toc.html.tmpl", viewModel);
+                        context.Output.WriteText(outputPath, html);
+                    }
+                    else if (context.Config.Legacy)
                     {
                         var output = context.TemplateEngine.RunJavaScript("toc.json.js", JsonUtility.ToJObject(model));
                         context.Output.WriteJson(LegacyUtility.ChangeExtension(outputPath, ".json"), output);
@@ -62,13 +72,6 @@ namespace Microsoft.Docs.Build
                     else
                     {
                         context.Output.WriteJson(outputPath, model);
-                    }
-
-                    if (context.Config.OutputType == OutputType.Html)
-                    {
-                        var viewModel = context.TemplateEngine.RunJavaScript($"toc.html.js", JsonUtility.ToJObject(model));
-                        var html = context.TemplateEngine.RunMustache($"toc.html.tmpl", viewModel);
-                        context.Output.WriteText(outputPath, html);
                     }
                 }
             });


### PR DESCRIPTION
- should not remove index.html in `ugly` outputUrlType
- do not generate  `toc.mta.json` in `html` outputType

[AB#204994](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/204994)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5843)