### PR TITLE
support validate setex headings

### DIFF
--- a/docs/specs/validation.yml
+++ b/docs/specs/validation.yml
@@ -733,4 +733,67 @@ outputs:
     ["info","disallowed-html","HTML attribute 'onclick' on tag 'div' isn't allowed. Disallowed HTML poses a security risk and must be replaced with approved Docs Markdown syntax.","a.md"]
     ["info","disallowed-html","HTML attribute 'height' on tag 'h1' isn't allowed. Disallowed HTML poses a security risk and must be replaced with approved Docs Markdown syntax.","a.md"]
     ["info","disallowed-html","HTML tag 'button' isn't allowed. Disallowed HTML poses a security risk and must be replaced with approved Docs Markdown syntax.","a.md"]
+---
+# Content Validation - Setex Headings
+inputs:
+  docfx.yml: |
+    markdownValidationRules: rules.json
+    exclude: b.md
+  rules.json: |
+    {
+      "headings": {
+        "name": "Headings",
+        "description": "Validates H1 and other heading content",
+        "aliases": null,
+        "rules": [
+          {
+            "type": "SetexHeadings",
+            "message": "Bad {0} format: '{1}'. Use hashes to create H1(#) or H2(##)",
+            "code": "headings-with-underline",
+            "severity": "SUGGESTION",
+            "exclusions": [
+              "landingPage",
+              "hubPage",
+              "toc"
+            ],
+            "excludedDocfxVersions": [
+              "v2"
+            ]
+          }
+        ]
+      }
+    }
+  a.md: |
+    # Title 1 With Hashe
+    ## Title 2 With Hashes
 
+    Title 1
+    =======
+
+    Title 2
+    -------
+
+    Multiple Title2 Line 1
+    Multiple Title2 Line 2
+    -------
+
+    # Title With Hash and underline
+    ======
+
+        Not A title 1
+    ======
+
+    Not A Title 2
+        ------
+
+    [!include[](b.md)]
+  b.md: |
+    Title 2
+    ------
+outputs:
+  a.json:
+  .errors.log: |
+    ["suggestion","headings-with-underline","Bad 1 format: 'Title 1'. Use hashes to create H1(#) or H2(##)","a.md",5,1]
+    ["suggestion","headings-with-underline","Bad 2 format: 'Title 2'. Use hashes to create H1(#) or H2(##)","a.md",8,1]
+    ["suggestion","headings-with-underline","Bad 2 format: 'Multiple Title2 Line 1\nMultiple Title2 Line 2'. Use hashes to create H1(#) or H2(##)","a.md",12,1]
+    ["suggestion","headings-with-underline","Bad 2 format: 'Title 2'. Use hashes to create H1(#) or H2(##)","b.md",2,1]

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.1.1" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.3" />
-    <PackageReference Include="docs.validation" Version="1.0.0-beta-00079-47509b7" />
+    <PackageReference Include="docs.validation" Version="1.0.0-beta-00090-bd801c2" />
     <PackageReference Include="DotLiquid" Version="2.0.325" />
     <PackageReference Include="Glob" Version="1.1.6" />
     <!-- To keep HTML intact during v3 migration, keep using HtmlAgilityPack 1.4.9 -->

--- a/src/docfx/lib/markdown/validation/ContentValidationExtension.cs
+++ b/src/docfx/lib/markdown/validation/ContentValidationExtension.cs
@@ -33,9 +33,8 @@ namespace Microsoft.Docs.Build
                                 Level = headingBlock.Level,
                                 SourceInfo = headingBlock.ToSourceInfo(),
                                 Content = GetHeadingContent(headingBlock), // used for reporting
-
-                                // HeadingChar = headingBlock.HeadingChar
-                                // RenderedPlainText = MarkdigUtility.ToPlainText(headingBlock), // used for validation
+                                HeadingChar = headingBlock.HeaderChar,
+                                RenderedPlainText = MarkdigUtility.ToPlainText(headingBlock), // used for validation
                             });
                         }
 


### PR DESCRIPTION
setex headings is not allowed in docs repository

[AB#211394](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/211394)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5848)