### PR TITLE
Add --no-cache option to build

### DIFF
--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Docs.Build
     {
         public static int Run(string workingDirectory, CommandLineOptions options)
         {
-            options.UseCache = true;
             var docsets = ConfigLoader.FindDocsets(workingDirectory, options);
             if (docsets.Length == 0)
             {

--- a/src/docfx/cli/CommandLineOptions.cs
+++ b/src/docfx/cli/CommandLineOptions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Docs.Build
         public bool Verbose;
         public bool DryRun;
         public bool Stdin;
-        public bool UseCache;
+        public bool NoCache;
         public bool NoRestore;
         public string? Template;
 
@@ -22,7 +22,7 @@ namespace Microsoft.Docs.Build
 
         public FetchOptions FetchOptions => NoRestore
             ? FetchOptions.NoFetch
-            : (UseCache ? FetchOptions.UseCache : FetchOptions.Latest);
+            : (NoCache ? FetchOptions.Latest : FetchOptions.UseCache);
 
         public JObject ToJObject()
         {

--- a/src/docfx/cli/Docfx.cs
+++ b/src/docfx/cli/Docfx.cs
@@ -110,7 +110,8 @@ namespace Microsoft.Docs.Build
                     syntax.DefineCommand("build", ref command, "Builds a docset.");
                     syntax.DefineOption("o|output", ref options.Output, "Output directory in which to place built artifacts.");
                     syntax.DefineOption("dry-run", ref options.DryRun, "Do not produce build artifact and only produce validation result.");
-                    syntax.DefineOption("no-restore", ref options.NoRestore, "Do not restore dependencies before building.");
+                    syntax.DefineOption("no-restore", ref options.NoRestore, "Do not restore dependencies before build.");
+                    syntax.DefineOption("no-cache", ref options.NoCache, "Do not use cache dependencies in build, always fetch latest dependencies.");
                     DefineCommonOptions(syntax, ref workingDirectory, options);
                 });
 

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Docs.Build
     {
         public static int Run(string workingDirectory, CommandLineOptions options)
         {
+            options.NoCache = true;
             var docsets = ConfigLoader.FindDocsets(workingDirectory, options);
             if (docsets.Length == 0)
             {


### PR DESCRIPTION
[AB#212605](https://dev.azure.com/ceapex/Engineering/_workitems/edit/212605)

Add a `--no-cache` option to `docfx build` to always fetch latest dependencies.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5853)