### PR TITLE
only encode ampersand and double quotes for metadata value

### DIFF
--- a/src/docfx/lib/HtmlUtility.cs
+++ b/src/docfx/lib/HtmlUtility.cs
@@ -325,10 +325,7 @@ namespace Microsoft.Docs.Build
         internal static string Encode(string s)
         {
             return s.Replace("&", "&amp;")
-                    .Replace("<", "&lt;")
-                    .Replace(">", "&gt;")
-                    .Replace("\"", "&quot;")
-                    .Replace("'", "&#39;");
+                    .Replace("\"", "&quot;");
         }
 
         internal static void RemoveRerunCodepenIframes(ref HtmlToken token)

--- a/test/docfx.Test/lib/HtmlUtilityTest.cs
+++ b/test/docfx.Test/lib/HtmlUtilityTest.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Docs.Build
         [Theory]
         [InlineData("", "")]
         [InlineData("rétablir", "rétablir")]
-        [InlineData("&<>\"'", "&amp;&lt;&gt;&quot;&#39;")]
+        [InlineData("&<>\"'", "&amp;<>&quot;'")]
         public static void Encode(string input, string expected)
         {
             Assert.Equal(expected, HtmlUtility.Encode(input));


### PR DESCRIPTION
only encode ampersand and double quotes for metadata value

[AB#209207](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/209207)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5861)