### PR TITLE
fix bugs of headings in inclusion

### DIFF
--- a/docs/specs/validation.yml
+++ b/docs/specs/validation.yml
@@ -805,6 +805,7 @@ inputs:
       - c.md
       - d.md
       - e.md
+      - f.md
   rules.json: |
     {
       "headings": {
@@ -845,6 +846,9 @@ inputs:
     [!include[](d.md)]
 
     [!include[](e.md)]
+
+    [!include[](f.md)]
+    ## Title 2
   normal-1.md: |
     # Title 1-3
     ## Title 2
@@ -865,6 +869,7 @@ inputs:
     [!include[](c.md)]
 
     [!include[](d.md)]
+  f.md:
 outputs:
   a.json:
   normal-1.json:

--- a/src/docfx/lib/markdown/validation/ContentValidationExtension.cs
+++ b/src/docfx/lib/markdown/validation/ContentValidationExtension.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Docs.Build
 
                     var allHeadings = getHeadings(documentHeadings);
 
-                    if (InclusionContext.IsInclude && documentHeadings.Any())
+                    if (InclusionContext.IsInclude)
                     {
                         foreach (var (doc, (headings, _)) in allHeadings)
                         {


### PR DESCRIPTION
the case that inclusions don't have any headings was not handled well, the bug was found during azure-docs-pr testing

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5867)