### PR TITLE
apply source map for more output

### DIFF
--- a/docs/specs/output.yml
+++ b/docs/specs/output.yml
@@ -672,6 +672,13 @@ outputs:
     {"message_severity":"error","code":"schema-not-found","message":"Unknown schema ''","file":"a/original.xml"}
   .dependencymap.json: |
     {"dependencies":{"a/b.original.xml":[{"source":"a/original.xml","type":"file"}]}}
+  .publish.json: |
+    {
+      "files": [
+        {"url": "/b", "source_path": "a/b.original.xml"},
+        {"url": "/c", "source_path": "a/original.xml"},
+      ]
+    }
 ---
 # Reference between the same original file, dependencies should be ignored
 repos:
@@ -700,3 +707,74 @@ outputs:
     {"message_severity":"error","code":"schema-not-found","message":"Unknown schema ''","file":"a/original.xml"}
   .dependencymap.json: |
     {"dependencies":undefined}
+---
+# verify legacy output with source map
+legacy: true
+repos:
+  https://github.com/relocate/source-file:
+    - files:
+        docfx.yml: |
+          sourceMap: a/sourceMap.json
+        a/sourceMap.json: |
+          {
+            "files": 
+            {
+              "../a.yml": "original.xml",
+              "..\\b.md": "b.original.xml",
+              "..\\c.md": "original.xml",
+            }
+          }
+        a/original.xml:
+        a/b.original.xml:
+        a.yml:
+        b.md: '[](c.md)'
+        c.md:
+outputs:
+  .errors.log: |
+    {"message_severity":"error","code":"schema-not-found","message":"Unknown schema ''","file":"a/original.xml"}
+  b.mta.json:
+  b.raw.page.json:
+  c.mta.json:
+  c.raw.page.json:
+  op_aggregated_file_map_info.json: |
+    {
+      "aggregated_file_map_items": 
+      {
+        "a/b.original.xml": 
+        {
+            "dependencies": [
+                {
+                    "from_file_path": "a/b.original.xml",
+                    "to_file_path": "a/original.xml",
+                    "dependency_type": "file"
+                }
+            ],
+        },
+        "a/original.xml": { "type": "Content" }
+      }
+    }
+  filemap.json: |
+    {
+      "file_mapping": 
+      {
+          "b.md": 
+          {
+              "type": "Content",
+              "output_relative_path": "b.html",
+              "asset_id": "b"
+          },
+          "c.md": 
+          {
+              "type": "Content",
+              "output_relative_path": "c.html",
+              "asset_id": "c"
+          }
+      }
+    }
+  .manifest.json: |
+    {
+      "files": [
+        {"asset_id": "b", "original": "a/b.original.xml", "source_relative_path": "a/b.original.xml"},
+        {"asset_id": "c", "original": "a/original.xml", "source_relative_path": "a/original.xml"},
+      ]
+    }

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -66,6 +66,8 @@ namespace Microsoft.Docs.Build
 
         public TableOfContentsMap TocMap { get; }
 
+        public SourceMap SourceMap { get; }
+
         public Context(ErrorLog errorLog, Config config, BuildOptions buildOptions, PackageResolver packageResolver, FileResolver fileResolver, SourceMap sourceMap)
         {
             DependencyMapBuilder = new DependencyMapBuilder(sourceMap);
@@ -76,6 +78,7 @@ namespace Microsoft.Docs.Build
             BuildOptions = buildOptions;
             PackageResolver = packageResolver;
             FileResolver = fileResolver;
+            SourceMap = sourceMap;
 
             RepositoryProvider = new RepositoryProvider(buildOptions.Repository);
             Input = new Input(buildOptions, config, packageResolver, RepositoryProvider);

--- a/src/docfx/build/legacy/LegacyAggregatedFileMap.cs
+++ b/src/docfx/build/legacy/LegacyAggregatedFileMap.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Docs.Build
         {
             var aggregatedFileMapItems = new List<(string path, object item)>();
 
-            foreach (var (path, item) in items.GroupBy(x => x.legacyFilePathRelativeToBaseFolder).ToDictionary(g => g.Key, g => g.ToList().First()))
+            foreach (var (path, fileMapItem) in items.GroupBy(x => x.legacyFilePathRelativeToBaseFolder).ToDictionary(g => g.Key, g => g.ToList().First().fileMapItem))
             {
-                if (item.fileMapItem.Type == "Resource")
+                if (fileMapItem.Type == "Resource")
                 {
                     continue;
                 }
@@ -36,10 +36,10 @@ namespace Microsoft.Docs.Build
                                             Version = x.Version,
                                         })
                                     : new List<DependencyItem>(),
-                    aggregated_monikers = item.fileMapItem.Monikers,
+                    aggregated_monikers = fileMapItem.Monikers,
                     docset_names = new[] { context.Config.Name },
-                    has_non_moniker_url = item.fileMapItem.Monikers.Count == 0,
-                    type = item.fileMapItem.Type,
+                    has_non_moniker_url = fileMapItem.Monikers.Count == 0,
+                    type = fileMapItem.Type,
                 };
 
                 aggregatedFileMapItems.Add((path, aggregatedFileMapItem));

--- a/src/docfx/build/legacy/LegacyFileMap.cs
+++ b/src/docfx/build/legacy/LegacyFileMap.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Docs.Build
             using (Progress.Start("Convert Legacy File Map"))
             {
                 var listBuilder = new ListBuilder<(string legacyFilePathRelativeToBaseFolder, LegacyFileMapItem fileMapItem)>();
+                var filemapBuilder = new ListBuilder<(string legacyFilePathRelativeToBaseFolder, LegacyFileMapItem fileMapItem)>();
 
                 Parallel.ForEach(
                     fileManifests,
@@ -40,13 +41,13 @@ namespace Microsoft.Docs.Build
                             fileManifest.Value.Monikers);
                         if (fileItem != null)
                         {
-                            listBuilder.Add((document.FilePath.Path, fileItem));
+                            listBuilder.Add((context.SourceMap.GetOriginalFilePath(document.FilePath) ?? document.FilePath.Path, fileItem));
+                            filemapBuilder.Add((document.FilePath.Path, fileItem));
                         }
                     });
 
-                var fileMapItems = listBuilder.ToList();
-                Convert(context, fileMapItems);
-                LegacyAggregatedFileMap.Convert(context, fileMapItems, dependencyMap);
+                Convert(context, filemapBuilder.ToList());
+                LegacyAggregatedFileMap.Convert(context, listBuilder.ToList(), dependencyMap);
             }
         }
 

--- a/src/docfx/build/legacy/LegacyFileMapItem.cs
+++ b/src/docfx/build/legacy/LegacyFileMapItem.cs
@@ -75,10 +75,5 @@ namespace Microsoft.Docs.Build
             return new LegacyFileMapItem(
                 legacyOutputFilePathRelativeToBasePath, legacySiteUrlRelativeToBasePath, contentType, version, monikers);
         }
-
-        private static string RemoveExtension(string path)
-        {
-            return path.Substring(0, path.LastIndexOf('.'));
-        }
     }
 }

--- a/src/docfx/build/legacy/manifest/LegacyManifest.cs
+++ b/src/docfx/build/legacy/manifest/LegacyManifest.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Docs.Build
                         {
                             AssetId = legacySiteUrlRelativeToBasePath,
                             Original = fileManifest.Value.SourcePath,
-                            SourceRelativePath = document.FilePath.Path,
+                            SourceRelativePath = context.SourceMap.GetOriginalFilePath(document.FilePath) ?? document.FilePath.Path,
                             OriginalType = GetOriginalType(document.ContentType),
                             Type = GetType(context, document.ContentType, document),
                             Output = output,

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Docs.Build
             var publishItem = new PublishItem(
                 file.SiteUrl,
                 outputPath,
-                file.FilePath.Path,
+                context.SourceMap.GetOriginalFilePath(file.FilePath) ?? file.FilePath.Path,
                 context.BuildOptions.Locale,
                 monikers,
                 context.MonikerProvider.GetConfigMonikerRange(file.FilePath),

--- a/src/docfx/build/redirection/BuildRedirection.cs
+++ b/src/docfx/build/redirection/BuildRedirection.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Docs.Build
             var publishItem = new PublishItem(
                 file.SiteUrl,
                 context.Config.Legacy ? context.DocumentProvider.GetOutputPath(file.FilePath) : null,
-                file.FilePath.Path,
+                context.SourceMap.GetOriginalFilePath(file.FilePath) ?? file.FilePath.Path,
                 context.BuildOptions.Locale,
                 monikers,
                 context.MonikerProvider.GetConfigMonikerRange(file.FilePath),

--- a/src/docfx/build/resource/BuildResource.cs
+++ b/src/docfx/build/resource/BuildResource.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Docs.Build
             var publishItem = new PublishItem(
                 file.SiteUrl,
                 publishPath,
-                file.FilePath.Path,
+                context.SourceMap.GetOriginalFilePath(file.FilePath) ?? file.FilePath.Path,
                 context.BuildOptions.Locale,
                 monikers,
                 context.MonikerProvider.GetConfigMonikerRange(file.FilePath),

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Docs.Build
             var publishItem = new PublishItem(
                 file.SiteUrl,
                 outputPath,
-                file.FilePath.Path,
+                context.SourceMap.GetOriginalFilePath(file.FilePath) ?? file.FilePath.Path,
                 context.BuildOptions.Locale,
                 monikers,
                 context.MonikerProvider.GetConfigMonikerRange(file.FilePath),

--- a/src/docfx/publish/PublishItem.cs
+++ b/src/docfx/publish/PublishItem.cs
@@ -14,6 +14,10 @@ namespace Microsoft.Docs.Build
 
         public string? Path { get; }
 
+        /// <summary>
+        /// File source relative path to docset root
+        /// will be used for PR comments
+        /// </summary>
         public string? SourcePath { get; }
 
         [JsonIgnore]


### PR DESCRIPTION
[AB#215115](https://dev.azure.com/ceapex/Engineering/_workitems/edit/215115)

Apply source map for more output:
- .manifet.json
- .publish.json
- op_aggregated_file_map_info.json

Leave `filemap.json` as it is, because it is supposed to be 1 to 1 relationship, which would be 1 to many with source map.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5868)