### PR TITLE
do not warn when certain output is empty

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/TemplateProcessors/TemplateModelTransformer.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/TemplateProcessors/TemplateModelTransformer.cs
@@ -150,19 +150,9 @@ namespace Microsoft.DocAsCode.Build.Engine
 
                     if (_settings.Options.HasFlag(ApplyTemplateOptions.TransformDocument))
                     {
-                        if (string.IsNullOrWhiteSpace(result))
+                        if (string.IsNullOrWhiteSpace(result) && _settings.DebugMode)
                         {
-                            string message;
-                            if (_settings.DebugMode)
-                            {
-                                var viewModelPath = ExportModel(viewModel, outputFile, _settings.ViewModelExportSettingsForDebug);
-                                message = $"Model \"{viewModelPath}\" is transformed to empty string with template \"{template.Name}\"";
-                            }
-                            else
-                            {
-                                message = $"Model is transformed to empty string with template \"{template.Name}\". To get the detailed view model, please run docfx with debug mode --debug";
-                            }
-                            Logger.LogWarning(message, code: WarningCodes.Build.EmptyOutputFiles);
+                            ExportModel(viewModel, outputFile, _settings.ViewModelExportSettingsForDebug);
                         }
 
                         TransformDocument(result ?? string.Empty, extension, _context, outputFile, manifestItem, out List<XRefDetails> invalidXRefs);

--- a/src/Microsoft.DocAsCode.Common/Loggers/WarningCodes.cs
+++ b/src/Microsoft.DocAsCode.Common/Loggers/WarningCodes.cs
@@ -22,7 +22,6 @@ namespace Microsoft.DocAsCode.Common
             public const string EmptyTocItemName = "EmptyTocItemName";
             public const string EmptyInputFiles = "EmptyInputFiles";
             public const string EmptyInputContents = "EmptyInputContents";
-            public const string EmptyOutputFiles = "EmptyOutputFiles";
             public const string InvalidTagParametersConfig = "InvalidTagParametersConfig";
             public const string InvalidTaggedPropertyType = "InvalidTaggedPropertyType";
             // todo : add uid not found in SDP.


### PR DESCRIPTION
[AB#216789](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/216789)

In docs.microsoft.com, Markdown files actually use an empty Mustach template. They reply on post rendering layer to generate HTML. Empty files in docfx output are not actually empty in the final output.

This is also true for community users that apply post postprocessors.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5878)