### PR TITLE
Support name**.yml

### DIFF
--- a/src/docfx/lib/GlobUtility.cs
+++ b/src/docfx/lib/GlobUtility.cs
@@ -10,14 +10,6 @@ namespace Microsoft.Docs.Build
 {
     internal static class GlobUtility
     {
-        private static readonly Dictionary<string, string> s_globNormalizers = new Dictionary<string, string>
-        {
-            { @"\*{2,}", "**" }, // **** => **
-            { @"^\*{2}(?=\.)", "**/*" }, // ^**.md => ^**/*.md
-            { @"(?<=\/)\*{2}(?=\.)", "**/*" }, // /**.md => /**/*.md
-            { @"(?<!\/)\*{2}(?=\.)", "*" }, // text**.md => text*.md
-        };
-
         public static Func<string, bool> CreateGlobMatcher(string pattern)
         {
             var glob = CreateGlob(pattern);
@@ -79,11 +71,11 @@ namespace Microsoft.Docs.Build
 
         private static string PreProcessPattern(string pattern)
         {
-            foreach (var (regex, replace) in s_globNormalizers)
-            {
-                pattern = Regex.Replace(pattern, regex, replace);
-            }
-            return pattern;
+            // Pre process glob pattern so `**.md` means `**/*.md`
+            // **** => **, **.md => **/*.md
+            pattern = Regex.Replace(pattern, @"\*{2,}", "**");
+            pattern = Regex.Replace(pattern, @"^\*{2}\.", "**/*.");
+            return pattern.Replace("/**.", "/**/*.");
         }
     }
 }

--- a/test/docfx.Test/lib/GlobUtilityTest.cs
+++ b/test/docfx.Test/lib/GlobUtilityTest.cs
@@ -60,6 +60,8 @@ namespace Microsoft.Docs.Build
         [InlineData("**/[EJ]/*.{md,cs,csproj}", "Root/M/K.md, Root/J\\K.csp", false)]
         [InlineData("a**/*.md", "ab/c.md, a/b.md", true)]
         [InlineData("a**/*.md", "a/b/c.md, a/b.cs", false)]
+        [InlineData("a.b**.md", "a.b.c.md, a.b.c.a.md", true)]
+        [InlineData("a.b**.md", "a.e.md, a.c.a.md", false)]
 
         // For backward compatibility with v2
         [InlineData("****", "a.md, a/b.md", true)]


### PR DESCRIPTION
`name**.yml` => match `name.xx.xx.yml`(normalized as `name*.yml`

e.g. [dotnet-api-docs/docfx.json](https://github.com/dotnet/dotnet-api-docs/blob/master/docfx.json#L59):
```json
"fileMetadata": {
      "author": {
        "api/Microsoft.SqlServer**.yml": "stevestein",
        "api/System.Data**.yml": "stevestein",
        "api/System.Net**.yml": "karelz",
        "api/System.Web**.yml": "scottaddie",
        "api/Microsoft.VisualBasic**.yml": "KathleenDollard"
      }
}
```
filepath
`api/microsoft.build.buildengine.invalidtoolsetdefinitionexception.getobjectdata.yml`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5889)