### PR TITLE
Deprecate and decouple InclusionContext

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
@@ -174,11 +174,11 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
         protected override void Write(HtmlRenderer renderer, CodeSnippet codeSnippet)
         {
-            var (content, codeSnippetPath) = _context.ReadFile(codeSnippet.CodePath, InclusionContext.File, codeSnippet);
+            var (content, codeSnippetPath) = _context.ReadFile(codeSnippet.CodePath, codeSnippet);
             
             if (content == null)
             {
-                _context.LogWarning("codesnippet-not-found", $"Cannot resolve '{codeSnippet.CodePath}' relative to '{InclusionContext.File}'.", codeSnippet);
+                _context.LogWarning("codesnippet-not-found", $"Invalid code snippet link: '{codeSnippet.CodePath}'.", codeSnippet);
                 renderer.Write(GetWarning());
                 return;
             }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionBlock/HtmlInclusionBlockRenderer.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionBlock/HtmlInclusionBlockRenderer.cs
@@ -21,11 +21,11 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
         protected override void Write(HtmlRenderer renderer, InclusionBlock inclusion)
         {
-            var (content, includeFilePath) = _context.ReadFile(inclusion.IncludedFilePath, InclusionContext.File, inclusion);
+            var (content, includeFilePath) = _context.ReadFile(inclusion.IncludedFilePath, inclusion);
 
             if (content == null)
             {
-                _context.LogWarning("include-not-found", $"Cannot resolve '{inclusion.IncludedFilePath}' relative to '{InclusionContext.File}'.", inclusion);
+                _context.LogWarning("include-not-found", $"Invalid include link: '{inclusion.IncludedFilePath}'.", inclusion);
                 renderer.Write(inclusion.GetRawToken());
                 return;
             }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionContext.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionContext.cs
@@ -16,7 +16,6 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
     /// same markdown pipeline instance at the same time.
     /// Thus a thread static <see cref="InclusionContext"/> class is created to store per document information.
     /// </remarks>
-    [Obsolete("InclusionContext will be removed in docfx v3")]
     public static class InclusionContext
     {
         private static readonly ThreadLocal<Stack<(object file, HashSet<object> dependencies, Stack<object> inclusionStack)>> t_markupStacks

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionContext.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionContext.cs
@@ -16,6 +16,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
     /// same markdown pipeline instance at the same time.
     /// Thus a thread static <see cref="InclusionContext"/> class is created to store per document information.
     /// </remarks>
+    [Obsolete("InclusionContext will be removed in docfx v3")]
     public static class InclusionContext
     {
         private static readonly ThreadLocal<Stack<(object file, HashSet<object> dependencies, Stack<object> inclusionStack)>> t_markupStacks

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionInline/HtmlInclusionInlineRenderer.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionInline/HtmlInclusionInlineRenderer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
         protected override void Write(HtmlRenderer renderer, InclusionInline inclusion)
         {
-            var (content, includeFilePath) = _context.ReadFile(inclusion.IncludedFilePath, InclusionContext.File, inclusion);
+            var (content, includeFilePath) = _context.ReadFile(inclusion.IncludedFilePath, inclusion);
 
             if (content == null)
             {

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownContext.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownContext.cs
@@ -4,7 +4,6 @@
 namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 {
     using System;
-    using System.IO;
     using Markdig.Syntax;
 
     public class MarkdownContext
@@ -18,20 +17,17 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         /// Reads a file as text based on path relative to an existing file.
         /// </summary>
         /// <param name="path">Path to the file being opened.</param>
-        /// <param name="relativeTo">The source file that path is based on.</param>
         /// <param name="origin">The original markdown element that triggered the read request.</param>
         /// <returns>An stream and the opened file, or default if such file does not exists.</returns>
-        public delegate (string content, object file) ReadFileDelegate(string path, object relativeTo, MarkdownObject origin);
+        public delegate (string content, object file) ReadFileDelegate(string path, MarkdownObject origin);
 
         /// <summary>
         /// Allows late binding of urls.
         /// </summary>
         /// <param name="path">Path of the link</param>
-        /// <param name="relativeTo">The source file that path is based on.</param>
-        /// <param name="resultRelativeTo">The entry file that returned URL should be rebased upon.</param>
         /// <param name="origin">The original markdown element that triggered the read request.</param>
         /// <returns>Url bound to the path</returns>
-        public delegate string GetLinkDelegate(string path, object relativeTo, object resultRelativeTo, MarkdownObject origin);
+        public delegate string GetLinkDelegate(string path, MarkdownObject origin);
 
         /// <summary>
         /// Reads a file as text.
@@ -80,24 +76,12 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             GetLinkDelegate getLink = null)
         {
             _getToken = getToken ?? (_ => null);
-            ReadFile = readFile ?? ReadFileDefault;
-            GetLink = getLink ?? ((path, a, b, c) => path);
+            ReadFile = readFile ?? ((a, b) => (a, a));
+            GetLink = getLink ?? ((a, b) => a);
             LogInfo = logInfo ?? ((a, b, c, d) => { });
             LogSuggestion = logSuggestion ?? ((a, b, c, d) => { });
             LogWarning = logWarning ?? ((a, b, c, d) => { });
             LogError = logError ?? ((a, b, c, d) => { });
-        }
-
-        private static (string content, object file) ReadFileDefault(string path, object relativeTo, MarkdownObject origin)
-        {
-            var target = relativeTo != null ? path : Path.Combine(relativeTo.ToString(), path);
-
-            if (File.Exists(target))
-            {
-                return (File.ReadAllText(target), target);
-            }
-
-            return (null, null);
         }
     }
 }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownExtensions.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownExtensions.cs
@@ -22,7 +22,6 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
                 .UsePipeTables()
                 .UseAutoLinks()
                 .UseHeadingIdRewriter()
-                .UseResolveLink(context)
                 .UseIncludeFile(context)
                 .UseCodeSnippet(context)
                 .UseDFMCodeInfoPrefix()
@@ -36,6 +35,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
                 .UseNestedColumn(context)
                 .UseTripleColon(context)
                 .UseNoloc()
+                .UseResolveLink(context)
                 .RemoveUnusedExtensions();
         }
 
@@ -94,19 +94,19 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
         public static MarkdownPipelineBuilder UseResolveLink(this MarkdownPipelineBuilder pipeline, MarkdownContext context)
         {
-            pipeline.Extensions.Insert(0, new ResolveLinkExtension(context));
+            pipeline.Extensions.Add(new ResolveLinkExtension(context));
             return pipeline;
         }
 
         public static MarkdownPipelineBuilder UseIncludeFile(this MarkdownPipelineBuilder pipeline, MarkdownContext context)
         {
-            pipeline.Extensions.Insert(0, new InclusionExtension(context));
+            pipeline.Extensions.Add(new InclusionExtension(context));
             return pipeline;
         }
 
         public static MarkdownPipelineBuilder UseCodeSnippet(this MarkdownPipelineBuilder pipeline, MarkdownContext context)
         {
-            pipeline.Extensions.Insert(0, new CodeSnippetExtension(context));
+            pipeline.Extensions.Add(new CodeSnippetExtension(context));
             return pipeline;
         }
 
@@ -118,7 +118,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
         public static MarkdownPipelineBuilder UseXref(this MarkdownPipelineBuilder pipeline)
         {
-            pipeline.Extensions.Insert(0, new XrefInlineExtension());
+            pipeline.Extensions.Add(new XrefInlineExtension());
             return pipeline;
         }
 

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/ResolveLink/ResolveLinkExtension.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/ResolveLink/ResolveLinkExtension.cs
@@ -28,36 +28,38 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
         private void UpdateLinks(MarkdownObject markdownObject)
         {
-            if (markdownObject == null) return;
+            switch (markdownObject)
+            {
+                case TabTitleBlock _:
+                    break;
 
-            if (markdownObject is LinkInline linkInline && !linkInline.IsAutoLink)
-            {
-                linkInline.Url = _context.GetLink(linkInline.Url, linkInline);
-            }
+                case LinkInline linkInline:
+                    linkInline.Url = _context.GetLink(linkInline.Url, linkInline);
+                    break;
 
-            if (markdownObject is ContainerBlock containerBlock)
-            {
-                foreach (var subBlock in containerBlock)
-                {
-                    UpdateLinks(subBlock);
-                }
-            }
-            else if (markdownObject is LeafBlock leafBlock)
-            {
-                if (leafBlock.Inline != null)
-                {
+                case ContainerBlock containerBlock:
+                    foreach (var subBlock in containerBlock)
+                    {
+                        UpdateLinks(subBlock);
+                    }
+                    break;
+
+                case LeafBlock leafBlock when leafBlock.Inline != null:
                     foreach (var subInline in leafBlock.Inline)
                     {
                         UpdateLinks(subInline);
                     }
-                }
-            }
-            else if (markdownObject is ContainerInline containerInline)
-            {
-                foreach (var subInline in containerInline)
-                {
-                    UpdateLinks(subInline);
-                }
+                    break;
+
+                case ContainerInline containerInline:
+                    foreach (var subInline in containerInline)
+                    {
+                        UpdateLinks(subInline);
+                    }
+                    break;
+
+                default:
+                    break;
             }
         }
     }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/ResolveLink/ResolveLinkExtension.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/ResolveLink/ResolveLinkExtension.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
             if (markdownObject is LinkInline linkInline && !linkInline.IsAutoLink)
             {
-                linkInline.Url = _context.GetLink(linkInline.Url, InclusionContext.File, InclusionContext.RootFile, linkInline);
+                linkInline.Url = _context.GetLink(linkInline.Url, linkInline);
             }
 
             if (markdownObject is ContainerBlock containerBlock)

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/CodeExtension.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/CodeExtension.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 {
-    using Markdig.Parsers;
     using Markdig.Renderers;
     using Markdig.Renderers.Html;
     using Markdig.Syntax;
@@ -103,7 +102,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
                 obj.Attributes.TryGetValue("id", out currentId); //it's okay if this is null
                 obj.Attributes.TryGetValue("range", out currentRange); //it's okay if this is null
                 obj.Attributes.TryGetValue("source", out currentSource); //source has already been checked above
-                var (code, codePath) = _context.ReadFile(currentSource, InclusionContext.File, obj);
+                var (code, codePath) = _context.ReadFile(currentSource, obj);
                 if (string.IsNullOrEmpty(code))
                 {
                     logWarning($"The code snippet \"{currentSource}\" could not be found.");

--- a/src/Microsoft.DocAsCode.MarkdigEngine/MarkdigMarkdownService.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine/MarkdigMarkdownService.cs
@@ -162,14 +162,14 @@ namespace Microsoft.DocAsCode.MarkdigEngine
             return builder.Build();
         }
 
-        private (string content, object file) ReadFile(string path, object relativeTo, MarkdownObject origin)
+        private (string content, object file) ReadFile(string path, MarkdownObject origin)
         {
             if (!PathUtility.IsRelativePath(path))
             {
                 return (null, null);
             }
 
-            var currentFilePath = ((RelativePath)relativeTo).GetPathFromWorkingFolder();
+            var currentFilePath = ((RelativePath)InclusionContext.File).GetPathFromWorkingFolder();
             var includedFilePath = ((RelativePath)path).BasedOn(currentFilePath);
             var includedFilePathWithoutWorkingFolder = includedFilePath.RemoveWorkingFolder();
             var parentFileDirectoryToDocset = Path.GetDirectoryName(Path.Combine(_parameters.BasePath, ((RelativePath)InclusionContext.RootFile).RemoveWorkingFolder()));
@@ -185,11 +185,11 @@ namespace Microsoft.DocAsCode.MarkdigEngine
             return (content, includedFilePath);
         }
 
-        private static string GetLink(string path, object relativeTo, object resultRelativeTo, MarkdownObject origin)
+        private static string GetLink(string path, MarkdownObject origin)
         {
             if (InclusionContext.IsInclude && RelativePath.IsRelativePath(path) && PathUtility.IsRelativePath(path) && !RelativePath.IsPathFromWorkingFolder(path) && !path.StartsWith("#", StringComparison.Ordinal))
             {
-                return ((RelativePath)relativeTo + (RelativePath)path).GetPathFromWorkingFolder();
+                return ((RelativePath)InclusionContext.File + (RelativePath)path).GetPathFromWorkingFolder();
             }
             return path;
         }

--- a/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/ImageTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/ImageTest.cs
@@ -59,8 +59,8 @@ Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
 
             var expected = @"<img src=""example.svg"" role=""presentation"">
 <div class=""mx-imgBorder""><p>
-<img src=""example.jpg"" alt=""example"" aria-describedby=""42570"">
-<div id=""42570"" class=""visually-hidden"">
+<img src=""example.jpg"" alt=""example"" aria-describedby=""3-0"">
+<div id=""3-0"" class=""visually-hidden"">
 <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
 </div>
 </p></div>
@@ -69,15 +69,15 @@ Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
 </p></div>
 <a href=""example-expanded.jpg#lightbox"" data-linktype=""relative-path"">
 <div class=""mx-imgBorder""><p>
-<img src=""example.jpg"" alt=""example"" aria-describedby=""8ce94"">
-<div id=""8ce94"" class=""visually-hidden"">
+<img src=""example.jpg"" alt=""example"" aria-describedby=""9-0"">
+<div id=""9-0"" class=""visually-hidden"">
 <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
 </div>
 </p></div>
 </a>
 <a href=""example-expanded.jpg#lightbox"" data-linktype=""relative-path"">
-<img src=""example.jpg"" alt=""example"" aria-describedby=""9e4c4"">
-<div id=""9e4c4"" class=""visually-hidden"">
+<img src=""example.jpg"" alt=""example"" aria-describedby=""13-0"">
+<div id=""13-0"" class=""visually-hidden"">
 <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
 </div>
 </a>

--- a/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/TestUtility.cs
+++ b/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/TestUtility.cs
@@ -75,9 +75,9 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Tests
                 return (code, message, origin, line) => actualErrors.Add(code);
             }
 
-            (string content, object file) ReadFile(string path, object relativeTo, MarkdownObject origin)
+            (string content, object file) ReadFile(string path, MarkdownObject origin)
             {
-                var key = Path.Combine(Path.GetDirectoryName(relativeTo.ToString()), path).Replace('\\', '/');
+                var key = Path.Combine(Path.GetDirectoryName(InclusionContext.File.ToString()), path).Replace('\\', '/');
 
                 if (path.StartsWith("~/"))
                 {

--- a/test/Microsoft.DocAsCode.MarkdigEngine.Tests/InclusionTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdigEngine.Tests/InclusionTest.cs
@@ -738,10 +738,9 @@ body";
             var root = "[!include[](embed)]";
 
             var context = new MarkdownContext(
-                readFile: (path, relativeTo, _) =>
+                readFile: (path, _) =>
                 {
                     Assert.Equal("embed", path);
-                    Assert.Equal("root", relativeTo);
 
                     Assert.Equal("root", InclusionContext.RootFile);
                     Assert.Equal("root", InclusionContext.File);
@@ -791,8 +790,8 @@ Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
             var marked = TestUtility.MarkupWithoutSourceInfo(r, "r/r.md");
 
             var expected = @"<div class=""mx-imgBorder""><p>
-<img src=""~/r/b/example.jpg"" alt=""example"" aria-describedby=""e68bf"">
-<div id=""e68bf"" class=""visually-hidden"">
+<img src=""~/r/b/example.jpg"" alt=""example"" aria-describedby=""1-0"">
+<div id=""1-0"" class=""visually-hidden"">
 <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
 </div>
 </p></div>


### PR DESCRIPTION
[AB#217876](https://dev.azure.com/ceapex/Engineering/_workitems/edit/217876)

Decouple `InclusionContext` to make `MarkdigEngine.Extensions` project only use `InclusionContext` for v2 only extensions.

![image](https://user-images.githubusercontent.com/511355/81533292-87bf6180-9398-11ea-9347-b0a26740b4c6.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5891)