### PR TITLE
provide monikers and zone infor to validation nodes

### DIFF
--- a/src/docfx/lib/markdown/MarkdigUtility.cs
+++ b/src/docfx/lib/markdown/MarkdigUtility.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Traverse the markdown object graph, returns true to skip the current node.
         /// </summary>
-        public static void Visit(this MarkdownObject? obj, Func<MarkdownObject, bool> action)
+        public static void Visit(this MarkdownObject? obj, Func<MarkdownObject, bool> action, Action<MarkdownObject>? postAction = null)
         {
             if (obj is null)
             {
@@ -86,6 +86,8 @@ namespace Microsoft.Docs.Build
             {
                 Visit(leaf.Inline, action);
             }
+
+            postAction?.Invoke(obj);
         }
 
         /// <summary>

--- a/src/docfx/lib/markdown/validation/ContentValidationExtension.cs
+++ b/src/docfx/lib/markdown/validation/ContentValidationExtension.cs
@@ -81,8 +81,16 @@ namespace Microsoft.Docs.Build
                         },
                         node =>
                         {
-                            monikers = null;
-                            zoneTarget = null;
+                            // moniker range and triple colon zone can NOT be nested
+                            if (node is MonikerRangeBlock)
+                            {
+                                monikers = null;
+                            }
+
+                            if (node is TripleColonBlock tripleColonBlock && tripleColonBlock.Extension.Name == "zone")
+                            {
+                                zoneTarget = null;
+                            }
                         });
 
                     var allHeadings = getHeadings(documentHeadings);


### PR DESCRIPTION
that's a draft pr to add addition info like monikers and zone to validation node, which would help some validation scenarios like skipped level headings in different zone or in different monikers.


[AB#133216](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/133216)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5902)