### PR TITLE
Use resolved to mark xref resolved in SDP

### DIFF
--- a/docs/specs/template.yml
+++ b/docs/specs/template.yml
@@ -169,6 +169,8 @@ inputs:
         href: https://docs.com/uid1
       - uid: uid2
         href: https://docfx.com/uid2
+      - uid: uid-non-href
+        name: uni-non-href-name-use-span
     
   _themes/ContentTemplate/schemas/TestPage.schema.json: |
     {
@@ -225,6 +227,9 @@ inputs:
   uid-unresolve.yml: |
     ### YamlMime: TestPage
     uid: unresolve
+  uid-non-href.yml: |
+    ### YamlMime: TestPage
+    uid: uid-non-href
   uid-partial.yml: |
     ### YamlMime: TestPage
     uidPartial: uid1
@@ -253,6 +258,9 @@ outputs:
   uid-unresolve.mta.json:
   uid-unresolve.raw.page.json: |
     {"content": "<p> <span> unresolve </span> </p>"}
+  uid-non-href.mta.json:
+  uid-non-href.raw.page.json: |
+    {"content": "<p> <span> uni-non-href-name-use-span </span> </p> "}
   uid-partial.mta.json:
   uid-partial.raw.page.json: |
     {"content": "<p> <a href=\"/en-us/uid1\" data-linktype=\"absolute-path\"> uid1-name </a> </p> "}

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -413,8 +413,8 @@ outputs:
   docs/b.json: | 
     {
       "xref": {
-        "uid": "a",
-        "href": undefined
+        "name": "a",
+        "href": null
       }
      }
   .errors.log: |
@@ -1318,8 +1318,8 @@ outputs:
           {
              "uid":"child1",
              "xref": {
-               "uid": "a",
-               "href": undefined
+               "name": "a",
+               "href": null
              }
           },
           {

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -414,7 +414,7 @@ outputs:
     {
       "xref": {
         "uid": "a",
-        "href": null
+        "href": undefined
       }
      }
   .errors.log: |
@@ -1319,7 +1319,7 @@ outputs:
              "uid":"child1",
              "xref": {
                "uid": "a",
-               "href": null
+               "href": undefined
              }
           },
           {

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -283,10 +283,13 @@ namespace Microsoft.Docs.Build
                     // the content here must be an UID, not href
                     var (xrefError, xrefSpec, href) = context.XrefResolver.ResolveXrefSpec(content, file, file);
                     errors.AddIfNotNull(xrefError);
-
-                    return xrefSpec != null
-                        ? (errors, JsonUtility.ToJObject(xrefSpec.ToExternalXrefSpec(href)))
-                        : (errors, new JObject { ["uid"] = value, ["href"] = null });
+                    if (xrefSpec != null)
+                    {
+                        var result = JsonUtility.ToJObject(xrefSpec.ToExternalXrefSpec(href));
+                        result.Add("resolved", new JValue(true));
+                        return (errors, result);
+                    }
+                    return (errors, new JObject { ["uid"] = value, ["resolved"] = false });
             }
 
             return (errors, value);

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -283,13 +283,10 @@ namespace Microsoft.Docs.Build
                     // the content here must be an UID, not href
                     var (xrefError, xrefSpec, href) = context.XrefResolver.ResolveXrefSpec(content, file, file);
                     errors.AddIfNotNull(xrefError);
-                    if (xrefSpec != null)
-                    {
-                        var result = JsonUtility.ToJObject(xrefSpec.ToExternalXrefSpec(href));
-                        result.Add("resolved", new JValue(true));
-                        return (errors, result);
-                    }
-                    return (errors, new JObject { ["uid"] = value, ["resolved"] = false });
+
+                    return xrefSpec != null
+                        ? (errors, JsonUtility.ToJObject(xrefSpec.ToExternalXrefSpec(href)))
+                        : (errors, new JObject { ["name"] = value, ["href"] = null });
             }
 
             return (errors, value);

--- a/src/docfx/template/MustacheXrefTagParser.cs
+++ b/src/docfx/template/MustacheXrefTagParser.cs
@@ -12,12 +12,12 @@ namespace Microsoft.Docs.Build
         /// Using `href` property to indicate xref spec resolve success.
         /// </summary>
         private const string XrefTagTemplate =
-        "{{#resolved}}" +
+        "{{#href}}" +
         "  @resolvedTag" +
-        "{{/resolved}}" +
-        "{{^resolved}}" +
-        "  <span> {{uid}} </span>" +
-        "{{/resolved}}";
+        "{{/href}}" +
+        "{{^href}}" +
+        "  <span> {{name}} </span>" +
+        "{{/href}}";
 
         private static readonly char[] s_trimChars = new[] { '{', ' ', '}' };
 

--- a/src/docfx/template/MustacheXrefTagParser.cs
+++ b/src/docfx/template/MustacheXrefTagParser.cs
@@ -12,12 +12,12 @@ namespace Microsoft.Docs.Build
         /// Using `href` property to indicate xref spec resolve success.
         /// </summary>
         private const string XrefTagTemplate =
-        "{{#href}}" +
+        "{{#resolved}}" +
         "  @resolvedTag" +
-        "{{/href}}" +
-        "{{^href}}" +
+        "{{/resolved}}" +
+        "{{^resolved}}" +
         "  <span> {{uid}} </span>" +
-        "{{/href}}";
+        "{{/resolved}}";
 
         private static readonly char[] s_trimChars = new[] { '{', ' ', '}' };
 

--- a/test/docfx.Test/template/MustacheTemplateTest.cs
+++ b/test/docfx.Test/template/MustacheTemplateTest.cs
@@ -28,14 +28,14 @@ namespace Microsoft.Docs.Build
         [InlineData("section.tmpl", "{'section':1}", "<p></p>")]
         [InlineData("section.tmpl", "{'section':'string'}", "<p></p>")]
         [InlineData("section.tmpl", "{'section':''}", "")]
-        [InlineData("xref.tmpl", "{'uid':{'name':'uid-name-resolve','href':'https://domain/path'}}", "<a href=\"https://domain/path\"> uid-name-resolve </a>")]
+        [InlineData("xref.tmpl", "{'uid':{'name':'uid-name-resolve','href':'https://domain/path','resolved':true}}", "<a href=\"https://domain/path\"> uid-name-resolve </a>")]
         [InlineData("xref.tmpl", "{'uid':'uid-name-unresolve'}", "<span> uid-name-unresolve </span>")]
         [InlineData("xref-partial.tmpl", "{'uid':'uid-name-unresolve'}", "<span> uid-name-unresolve </span>")]
         [InlineData("xref-partial.tmpl",
-            "{'uid':{'name':'uid-name-resolve','href':'https://domain/path'}}",
+            "{'uid':{'name':'uid-name-resolve','href':'https://domain/path','resolved':true}}",
             "<a class=\"xref\" href=\"https://domain/path\">uid-name-resolve</a>")]
         [InlineData("xref-list.tmpl",
-            "{'uids': [{'name':'uid-name-resolve', 'href': 'https://domain/path'}, {'uid':'uid-name-unresolve', 'href':null}]}",
+            "{'uids': [{'name':'uid-name-resolve', 'href': 'https://domain/path','resolved':true}, {'uid':'uid-name-unresolve', 'href':null}]}",
             "<a href=\"https://domain/path\"> uid-name-resolve </a>\n<span> uid-name-unresolve </span>")]
         [InlineData(
             "include.tmpl",

--- a/test/docfx.Test/template/MustacheTemplateTest.cs
+++ b/test/docfx.Test/template/MustacheTemplateTest.cs
@@ -28,14 +28,14 @@ namespace Microsoft.Docs.Build
         [InlineData("section.tmpl", "{'section':1}", "<p></p>")]
         [InlineData("section.tmpl", "{'section':'string'}", "<p></p>")]
         [InlineData("section.tmpl", "{'section':''}", "")]
-        [InlineData("xref.tmpl", "{'uid':{'name':'uid-name-resolve','href':'https://domain/path','resolved':true}}", "<a href=\"https://domain/path\"> uid-name-resolve </a>")]
-        [InlineData("xref.tmpl", "{'uid':'uid-name-unresolve'}", "<span> uid-name-unresolve </span>")]
-        [InlineData("xref-partial.tmpl", "{'uid':'uid-name-unresolve'}", "<span> uid-name-unresolve </span>")]
+        [InlineData("xref.tmpl", "{'uid':{'name':'uid-name-resolve','href':'https://domain/path'}}", "<a href=\"https://domain/path\"> uid-name-resolve </a>")]
+        [InlineData("xref.tmpl", "{'uid':{'name':'uid-name-unresolve'}}", "<span> uid-name-unresolve </span>")]
+        [InlineData("xref-partial.tmpl", "{'uid':{'name':'uid-name-unresolve'}}", "<span> uid-name-unresolve </span>")]
         [InlineData("xref-partial.tmpl",
-            "{'uid':{'name':'uid-name-resolve','href':'https://domain/path','resolved':true}}",
+            "{'uid':{'name':'uid-name-resolve','href':'https://domain/path'}}",
             "<a class=\"xref\" href=\"https://domain/path\">uid-name-resolve</a>")]
         [InlineData("xref-list.tmpl",
-            "{'uids': [{'name':'uid-name-resolve', 'href': 'https://domain/path','resolved':true}, {'uid':'uid-name-unresolve', 'href':null}]}",
+            "{'uids': [{'name':'uid-name-resolve', 'href': 'https://domain/path'}, {'name':'uid-name-unresolve', 'href':null }]}",
             "<a href=\"https://domain/path\"> uid-name-resolve </a>\n<span> uid-name-unresolve </span>")]
         [InlineData(
             "include.tmpl",

--- a/test/docfx.Test/template/MustacheXrefTagParserTest.cs
+++ b/test/docfx.Test/template/MustacheXrefTagParserTest.cs
@@ -10,51 +10,51 @@ namespace Microsoft.Docs.Build
         [Theory]
         [InlineData("<xref/>",
             "{{#uid}}" +
-            "  {{#href}}" +
+            "  {{#resolved}}" +
             "    <a href=\"{{href}}\"> {{name}} </a>" +
-            "  {{/href}}" +
-            "  {{^href}}" +
+            "  {{/resolved}}" +
+            "  {{^resolved}}" +
             "    <span> {{uid}} </span>" +
-            "  {{/href}}" +
+            "  {{/resolved}}" +
             "{{/uid}}"
             )]
         [InlineData("<xref uid='{{uid}}'/>",
             "{{#uid}}" +
-            "  {{#href}}" +
+            "  {{#resolved}}" +
             "    <a href=\"{{href}}\"> {{name}} </a>" +
-            "  {{/href}}" +
-            "  {{^href}}" +
+            "  {{/resolved}}" +
+            "  {{^resolved}}" +
             "    <span> {{uid}} </span>" +
-            "  {{/href}}" +
+            "  {{/resolved}}" +
             "{{/uid}}"
             )]
         [InlineData("<xref uid='{{namespace}}'/>",
             "{{#namespace}}" +
-            "  {{#href}}" +
+            "  {{#resolved}}" +
             "    <a href='{{href}}'> {{name}} </a>" +
-            "  {{/href}}" +
-            "  {{^href}}" +
+            "  {{/resolved}}" +
+            "  {{^resolved}}" +
             "    <span> {{uid}} </span>" +
-            "  {{/href}}" +
+            "  {{/resolved}}" +
             "{{/namespace}}"
             )]
         [InlineData("<xref uid='{{ uid }}' template='partials/dotnet/xref-name.tmpl' />",
             "{{#uid}}" +
-            "  {{#href}}" +
+            "  {{#resolved}}" +
             "    {{> partials/dotnet/xref-name.tmpl}}" +
-            "  {{/href}}" +
-            "  {{^href}}" +
+            "  {{/resolved}}" +
+            "  {{^resolved}}" +
             "    <span> {{uid}} </span>" +
-            "  {{/href}}" +
+            "  {{/resolved}}" +
             "{{/uid}}"
             )]
         [InlineData("<xref uid='{{ . }}'/>",
-            "{{#href}}" +
+            "{{#resolved}}" +
             "  <a href=\"{{href}}\"> {{name}} </a>" +
-            "{{/href}}" +
-            "{{^href}}" +
+            "{{/resolved}}" +
+            "{{^resolved}}" +
             "  <span> {{uid}} </span>" +
-            "{{/href}}"
+            "{{/resolved}}"
             )]
         public void ProcessXrefTag(string template, string expected)
         {

--- a/test/docfx.Test/template/MustacheXrefTagParserTest.cs
+++ b/test/docfx.Test/template/MustacheXrefTagParserTest.cs
@@ -10,51 +10,51 @@ namespace Microsoft.Docs.Build
         [Theory]
         [InlineData("<xref/>",
             "{{#uid}}" +
-            "  {{#resolved}}" +
+            "  {{#href}}" +
             "    <a href=\"{{href}}\"> {{name}} </a>" +
-            "  {{/resolved}}" +
-            "  {{^resolved}}" +
-            "    <span> {{uid}} </span>" +
-            "  {{/resolved}}" +
+            "  {{/href}}" +
+            "  {{^href}}" +
+            "    <span> {{name}} </span>" +
+            "  {{/href}}" +
             "{{/uid}}"
             )]
         [InlineData("<xref uid='{{uid}}'/>",
             "{{#uid}}" +
-            "  {{#resolved}}" +
+            "  {{#href}}" +
             "    <a href=\"{{href}}\"> {{name}} </a>" +
-            "  {{/resolved}}" +
-            "  {{^resolved}}" +
-            "    <span> {{uid}} </span>" +
-            "  {{/resolved}}" +
+            "  {{/href}}" +
+            "  {{^href}}" +
+            "    <span> {{name}} </span>" +
+            "  {{/href}}" +
             "{{/uid}}"
             )]
         [InlineData("<xref uid='{{namespace}}'/>",
             "{{#namespace}}" +
-            "  {{#resolved}}" +
+            "  {{#href}}" +
             "    <a href='{{href}}'> {{name}} </a>" +
-            "  {{/resolved}}" +
-            "  {{^resolved}}" +
-            "    <span> {{uid}} </span>" +
-            "  {{/resolved}}" +
+            "  {{/href}}" +
+            "  {{^href}}" +
+            "    <span> {{name}} </span>" +
+            "  {{/href}}" +
             "{{/namespace}}"
             )]
         [InlineData("<xref uid='{{ uid }}' template='partials/dotnet/xref-name.tmpl' />",
             "{{#uid}}" +
-            "  {{#resolved}}" +
+            "  {{#href}}" +
             "    {{> partials/dotnet/xref-name.tmpl}}" +
-            "  {{/resolved}}" +
-            "  {{^resolved}}" +
-            "    <span> {{uid}} </span>" +
-            "  {{/resolved}}" +
+            "  {{/href}}" +
+            "  {{^href}}" +
+            "    <span> {{name}} </span>" +
+            "  {{/href}}" +
             "{{/uid}}"
             )]
         [InlineData("<xref uid='{{ . }}'/>",
-            "{{#resolved}}" +
+            "{{#href}}" +
             "  <a href=\"{{href}}\"> {{name}} </a>" +
-            "{{/resolved}}" +
-            "{{^resolved}}" +
-            "  <span> {{uid}} </span>" +
-            "{{/resolved}}"
+            "{{/href}}" +
+            "{{^href}}" +
+            "  <span> {{name}} </span>" +
+            "{{/href}}"
             )]
         public void ProcessXrefTag(string template, string expected)
         {


### PR DESCRIPTION
[AB#217870](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/217870)

using `resolved` attribute to mark xref resolved at musatche rendering time.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5904)