### PR TITLE
Referenced image in fallback origin should also be built in static output mode

### DIFF
--- a/docs/specs/static.yml
+++ b/docs/specs/static.yml
@@ -116,7 +116,7 @@ inputs:
         content: JSON.stringify(model)
       };
     }
-  _themes/Conceptual.html.liquid: |
+  _themes/Conceptual.html.liquid:
   b.md:
 outputs:
   b.html:
@@ -270,3 +270,38 @@ inputs:
 outputs:
   a.json: |
     {"result": "value has run js data transform"}
+---
+# Referenced image in fallback origin should also be built in static output mode
+locale: zh-cn
+repos: 
+  https://github.com/c/image1#master:
+    - files:
+        docfx.yml:
+        docs/b.png:
+  https://github.com/c/image1.zh-cn#master:
+    - files:
+        docfx.yml: |
+          outputType: html
+          outputUrlType: ugly
+        _themes/ContentTemplate/Conceptual.mta.json.js: |
+          exports.transform = function (model) {
+            model.layout = "Conceptual";
+            return {
+              content: JSON.stringify(model)
+            };
+          }
+        _themes/Conceptual.html.liquid: |
+          {{content}}
+        docs/a.md: |
+          ![B](b.png)
+outputs:
+  docs/a.html: |
+    <p><img src="b.png" alt="B" data-linktype="relative-path"></p>
+  docs/b.png:
+  .publish.json: |
+    {
+      "files": [
+        { "url": "/docs/a.html" },
+        { "url": "/docs/b.png" }
+      ]
+    }

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Docs.Build
             var errors = file.ContentType switch
             {
                 ContentType.TableOfContents => BuildTableOfContents.Build(context, file),
-                ContentType.Resource when path.Origin != FileOrigin.Fallback => BuildResource.Build(context, file),
+                ContentType.Resource when path.Origin != FileOrigin.Fallback || context.Config.OutputType == OutputType.Html => BuildResource.Build(context, file),
                 ContentType.Page when path.Origin != FileOrigin.Fallback => BuildPage.Build(context, file),
                 ContentType.Redirection when path.Origin != FileOrigin.Fallback => BuildRedirection.Build(context, file),
                 _ => new List<Error>(),


### PR DESCRIPTION
[AB#204994](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/204994)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5906)