### PR TITLE
Turn InclusionBlock into ContainerBlock

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/ExtensionsHelper.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/ExtensionsHelper.cs
@@ -117,7 +117,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             return false;
         }
 
-        public static bool MatchInlcusionEnd(ref StringSlice slice)
+        public static bool MatchInclusionEnd(ref StringSlice slice)
         {
             if (slice.CurrentChar != ']')
             {

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionBlock/InclusionBlock.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionBlock/InclusionBlock.cs
@@ -6,7 +6,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
     using Markdig.Parsers;
     using Markdig.Syntax;
 
-    public class InclusionBlock : LeafBlock
+    public class InclusionBlock : ContainerBlock
     {
         public string Title { get; set; }
 

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionBlock/InclusionBlockParser.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionBlock/InclusionBlockParser.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
             string title = null, path = null;
 
-            if (!ExtensionsHelper.MatchLink(ref line, ref title, ref path) || !ExtensionsHelper.MatchInlcusionEnd(ref line))
+            if (!ExtensionsHelper.MatchLink(ref line, ref title, ref path) || !ExtensionsHelper.MatchInclusionEnd(ref line))
             {
                 return BlockState.None;
             }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionInline/InclusionInline.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionInline/InclusionInline.cs
@@ -5,7 +5,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 {
     using Markdig.Syntax.Inlines;
 
-    public class InclusionInline : LeafInline
+    public class InclusionInline : ContainerInline
     {
         public string Title { get; set; }
 

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionInline/InclusionInlineParser.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionInline/InclusionInlineParser.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
             string title = null, path = null;
 
-            if (!ExtensionsHelper.MatchLink(ref slice, ref title, ref path) || !ExtensionsHelper.MatchInlcusionEnd(ref slice))
+            if (!ExtensionsHelper.MatchLink(ref slice, ref title, ref path) || !ExtensionsHelper.MatchInclusionEnd(ref slice))
             {
                 return false;
             }
@@ -44,6 +44,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
                 Line = line,
                 Column = column,
                 Span = new SourceSpan(startPosition, processor.GetSourcePosition(slice.Start - 1)),
+                IsClosed = true,
             };
 
             return true;

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownExtensions.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownExtensions.cs
@@ -50,19 +50,19 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         /// </summary>
         public static MarkdownPipelineBuilder UseInlineOnly(this MarkdownPipelineBuilder pipeline)
         {
-            pipeline.Extensions.Add(new InlineOnlyExtentsion());
+            pipeline.Extensions.AddIfNotAlready(new InlineOnlyExtentsion());
             return pipeline;
         }
 
         public static MarkdownPipelineBuilder UseTabGroup(this MarkdownPipelineBuilder pipeline, MarkdownContext context)
         {
-            pipeline.Extensions.Add(new TabGroupExtension(context));
+            pipeline.Extensions.AddIfNotAlready(new TabGroupExtension(context));
             return pipeline;
         }
 
         public static MarkdownPipelineBuilder UseHeadingIdRewriter(this MarkdownPipelineBuilder pipeline)
         {
-            pipeline.Extensions.Add(new HeadingIdExtension());
+            pipeline.Extensions.AddIfNotAlready(new HeadingIdExtension());
             return pipeline;
         }
 
@@ -75,50 +75,50 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             }
             else
             {
-                pipeline.BlockParsers.Insert(0, new FencedCodeBlockParser { InfoPrefix = Constants.FencedCodePrefix });
+                pipeline.BlockParsers.AddIfNotAlready(new FencedCodeBlockParser { InfoPrefix = Constants.FencedCodePrefix });
             }
             return pipeline;
         }
 
         public static MarkdownPipelineBuilder UseQuoteSectionNote(this MarkdownPipelineBuilder pipeline, MarkdownContext context)
         {
-            pipeline.Extensions.Insert(0, new QuoteSectionNoteExtension(context));
+            pipeline.Extensions.AddIfNotAlready(new QuoteSectionNoteExtension(context));
             return pipeline;
         }
 
         public static MarkdownPipelineBuilder UseLineNumber(this MarkdownPipelineBuilder pipeline, Func<object, string> getFilePath = null)
         {
-            pipeline.Extensions.Add(new LineNumberExtension(getFilePath));
+            pipeline.Extensions.AddIfNotAlready(new LineNumberExtension(getFilePath));
             return pipeline;
         }
 
         public static MarkdownPipelineBuilder UseResolveLink(this MarkdownPipelineBuilder pipeline, MarkdownContext context)
         {
-            pipeline.Extensions.Add(new ResolveLinkExtension(context));
+            pipeline.Extensions.AddIfNotAlready(new ResolveLinkExtension(context));
             return pipeline;
         }
 
         public static MarkdownPipelineBuilder UseIncludeFile(this MarkdownPipelineBuilder pipeline, MarkdownContext context)
         {
-            pipeline.Extensions.Add(new InclusionExtension(context));
+            pipeline.Extensions.AddIfNotAlready(new InclusionExtension(context));
             return pipeline;
         }
 
         public static MarkdownPipelineBuilder UseCodeSnippet(this MarkdownPipelineBuilder pipeline, MarkdownContext context)
         {
-            pipeline.Extensions.Add(new CodeSnippetExtension(context));
+            pipeline.Extensions.AddIfNotAlready(new CodeSnippetExtension(context));
             return pipeline;
         }
 
         public static MarkdownPipelineBuilder UseInteractiveCode(this MarkdownPipelineBuilder pipeline)
         {
-            pipeline.Extensions.Add(new InteractiveCodeExtension());
+            pipeline.Extensions.AddIfNotAlready(new InteractiveCodeExtension());
             return pipeline;
         }
 
         public static MarkdownPipelineBuilder UseXref(this MarkdownPipelineBuilder pipeline)
         {
-            pipeline.Extensions.Add(new XrefInlineExtension());
+            pipeline.Extensions.AddIfNotAlready(new XrefInlineExtension());
             return pipeline;
         }
 
@@ -141,7 +141,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
         public static MarkdownPipelineBuilder UseTripleColon(this MarkdownPipelineBuilder pipeline, MarkdownContext context)
         {
-            pipeline.Extensions.Insert(0, new TripleColonExtension(context));
+            pipeline.Extensions.AddIfNotAlready(new TripleColonExtension(context));
             return pipeline;
         }
 


### PR DESCRIPTION
[AB#219787](https://dev.azure.com/ceapex/Engineering/_workitems/edit/219787)

Change `InclusionBlock` and `InclusionInline` to containers to house child nodes.

Use `AddIfNotAlready` consistently on extensions to make it easier to reason about ordering

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5912)