### PR TITLE
fix toc scrolling

### DIFF
--- a/src/docfx.website.themes/default/styles/docfx.js
+++ b/src/docfx.website.themes/default/styles/docfx.js
@@ -422,6 +422,8 @@ $(function () {
       $('#toc a.active').parents('li').each(function (i, e) {
         $(e).addClass(active).addClass(expanded);
         $(e).children('a').addClass(active);
+      })
+      $('#toc a.active').parents('li').each(function (i, e) {
         top += $(e).position().top;
       })
       $('.sidetoc').scrollTop(top - 50);


### PR DESCRIPTION
`top` calculation is invalid while parents are closed. expand all parents before performing top calculation.

closes #4470

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5915)