### PR TITLE
Added ability to set the path to wkhtmltopdf.exe instead of requiring it to be set in the PATH environment variable

### DIFF
--- a/Documentation/tutorial/docfx.exe_user_manual.md
+++ b/Documentation/tutorial/docfx.exe_user_manual.md
@@ -543,6 +543,7 @@ noStdin                  | Do not use `--read-args-from-stdin` for the wkhtmltop
 
 Key                      | Description
 -------------------------|-----------------------------
+filePath                 | The path and file name of a wkhtmltopdf.exe compatible executable.
 additionalArguments      | Additional arguments that should be passed to the wkhtmltopdf executable.
 
 ## 4. Supported File Mapping Format

--- a/src/Microsoft.DocAsCode.HtmlToPdf/Constants.cs
+++ b/src/Microsoft.DocAsCode.HtmlToPdf/Constants.cs
@@ -6,7 +6,7 @@ namespace Microsoft.DocAsCode.HtmlToPdf
     internal static class Constants
     {
         public const string PdfCommandName = "wkhtmltopdf";
-        public const string PdfCommandNotExistMessage = "wkhtmltopdf is a prerequisite when generating PDF. Please install it from https://wkhtmltopdf.org/downloads.html and save the executable folder to %PATH% first. Alternatively you can install it from https://chocolatey.org with `choco install wkhtmltopdf`.";
+        public const string PdfCommandNotExistMessage = "wkhtmltopdf is a prerequisite when generating PDF. Please install it from https://wkhtmltopdf.org/downloads.html and save the executable folder to %PATH% first or set the 'filePath' property. Alternatively you can install it from https://chocolatey.org with `choco install wkhtmltopdf`.";
     }
 
     internal static class BuildToolConstants

--- a/src/Microsoft.DocAsCode.HtmlToPdf/ConvertWrapper.cs
+++ b/src/Microsoft.DocAsCode.HtmlToPdf/ConvertWrapper.cs
@@ -36,9 +36,13 @@ namespace Microsoft.DocAsCode.HtmlToPdf
 
         #region Public Methods
 
-        public static void PrerequisiteCheck()
+        public static void PrerequisiteCheck(string filePath)
         {
-            if (!CommandUtility.ExistCommand(Constants.PdfCommandName))
+            if ((!string.IsNullOrEmpty(filePath)) && (!File.Exists(filePath)))
+            {
+                throw new DocfxException($"The file specified could not be found: '{filePath}'.");
+            }
+            else if (string.IsNullOrEmpty(filePath) && (!Common.CommandUtility.ExistCommand(Constants.PdfCommandName)))
             {
                 throw new DocfxException(Constants.PdfCommandNotExistMessage);
             }
@@ -333,6 +337,7 @@ namespace Microsoft.DocAsCode.HtmlToPdf
                     BasePath = basePath,
                     UserStyleSheet = _pdfOptions.CssFilePath,
                     LoadErrorHandling = _pdfOptions.LoadErrorHandling,
+                    FilePath = _pdfOptions.FilePath,
                     AdditionalArguments = _pdfOptions.AdditionalPdfCommandArgs,
                     OutlineOption = _pdfOptions.OutlineOption,
                     IsReadArgsFromStdin = !_pdfOptions.NoInputStreamArgs,

--- a/src/Microsoft.DocAsCode.HtmlToPdf/HtmlToPdfConverter.cs
+++ b/src/Microsoft.DocAsCode.HtmlToPdf/HtmlToPdfConverter.cs
@@ -127,7 +127,7 @@ namespace Microsoft.DocAsCode.HtmlToPdf
                     RedirectStandardInput = _htmlToPdfOptions.IsReadArgsFromStdin,
                     RedirectStandardOutput = _htmlToPdfOptions.IsOutputToStdout,
                     WindowStyle = ProcessWindowStyle.Hidden,
-                    FileName = Constants.PdfCommandName,
+                    FileName = _htmlToPdfOptions.FilePath ?? Constants.PdfCommandName,
                     Arguments = _htmlToPdfOptions + (_htmlToPdfOptions.IsReadArgsFromStdin ? string.Empty : (" " + arguments)),
                 }
             };

--- a/src/Microsoft.DocAsCode.HtmlToPdf/HtmlToPdfOptions.cs
+++ b/src/Microsoft.DocAsCode.HtmlToPdf/HtmlToPdfOptions.cs
@@ -72,6 +72,11 @@ namespace Microsoft.DocAsCode.HtmlToPdf
         public int MaxDegreeOfParallelism { get; set; } = 8;
 
         /// <summary>
+        /// Gets or sets the path and file name of the pdf executable.
+        /// </summary>
+        public string FilePath { get; set; }
+
+        /// <summary>
         /// Additional arguments.
         /// </summary>
         public string AdditionalArguments { get; set; }

--- a/src/Microsoft.DocAsCode.HtmlToPdf/PdfOptions.cs
+++ b/src/Microsoft.DocAsCode.HtmlToPdf/PdfOptions.cs
@@ -34,6 +34,11 @@ namespace Microsoft.DocAsCode.HtmlToPdf
         public string ExternalLinkFormat => $"{Normalize(Host)}{Normalize(Locale)}{Normalize(BasePath)}{{0}}";
 
         /// <summary>
+        /// Gets or sets the path and file name of the pdf executable.
+        /// </summary>
+        public string FilePath { get; set; }
+
+        /// <summary>
         /// Specify additional command line arguments that should be passed to the pdf command.
         /// </summary>
         public string AdditionalPdfCommandArgs { get; set; }
@@ -72,5 +77,5 @@ namespace Microsoft.DocAsCode.HtmlToPdf
         /// Are input arguments set using command line
         /// </summary>
         public bool NoInputStreamArgs { get; set; }
-	}
+    }
 }

--- a/src/docfx/Models/WkhtmltopdfJsonConfig.cs
+++ b/src/docfx/Models/WkhtmltopdfJsonConfig.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.DocAsCode
 {
     using System;
+    using System.IO;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -13,9 +14,25 @@ namespace Microsoft.DocAsCode
     public class WkhtmltopdfJsonConfig
     {
         /// <summary>
+        /// Gets or sets the path and file name of a wkhtmltopdf.exe compatible executable.
+        /// </summary>
+        [JsonProperty("filePath")]
+        public string FilePath { get; set; }
+
+        /// <summary>
         /// Specify additional command line arguments that should be passed to the wkhtmltopdf executable.
         /// </summary>
         [JsonProperty("additionalArguments")]
         public string AdditionalArguments { get; set; }
+
+        internal string GetFullFilePath(string baseDirectory)
+        {
+            if (string.IsNullOrEmpty(FilePath) || Path.IsPathRooted(FilePath))
+            {
+                return FilePath;
+            }
+
+            return Path.Combine(baseDirectory, FilePath);
+        }
     }
 }

--- a/src/docfx/SubCommands/DocumentBuilderWrapper.cs
+++ b/src/docfx/SubCommands/DocumentBuilderWrapper.cs
@@ -95,7 +95,7 @@ namespace Microsoft.DocAsCode.SubCommands
                 {
                     throw new DocfxException(e.Message);
                 }
-                catch (DocumentException e)
+                catch (DocumentException)
                 {
                     throw;
                 }

--- a/src/docfx/SubCommands/PdfCommand.cs
+++ b/src/docfx/SubCommands/PdfCommand.cs
@@ -19,14 +19,17 @@ namespace Microsoft.DocAsCode.SubCommands
     {
         private readonly BuildCommand _innerBuildCommand;
         private readonly PdfJsonConfig _config;
+        private readonly string _wkhtmltopdfFilePath;
 
         public string Name { get; } = nameof(PdfCommand);
         public bool AllowReplay => true;
 
         public PdfCommand(PdfCommandOptions options)
         {
-            ConvertWrapper.PrerequisiteCheck();
             _config = ParseOptions(options);
+            _wkhtmltopdfFilePath = _config.Wkhtmltopdf?.GetFullFilePath(_config.BaseDirectory);
+            ConvertWrapper.PrerequisiteCheck(_wkhtmltopdfFilePath);
+
             if (_config.Serve == true)
             {
                 Logger.LogWarning("--serve is not supported in pdf command, ignored");
@@ -63,6 +66,7 @@ namespace Microsoft.DocAsCode.SubCommands
                 ExcludeTocs = _config.ExcludedTocs?.ToArray(),
                 KeepRawFiles = _config.KeepRawFiles,
                 LoadErrorHandling = _config.LoadErrorHandling,
+                FilePath = _wkhtmltopdfFilePath,
                 AdditionalPdfCommandArgs = _config.Wkhtmltopdf?.AdditionalArguments,
                 TocTitle = _config.TocTitle,
                 OutlineOption = _config.OutlineOption,

--- a/test/docfx.Tests/JsonConverterTest.cs
+++ b/test/docfx.Tests/JsonConverterTest.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DocAsCode.Tests
 
             BuildJsonConfig buildOptions = JsonConvert.DeserializeObject<BuildJsonConfig>(jsonString);
 
-            Assert.Equal(buildOptions.GlobalMetadata.Count(), 7);
+            Assert.Equal(7, buildOptions.GlobalMetadata.Count());
 
             JsonSerializerSettings settings = new JsonSerializerSettings
             {


### PR DESCRIPTION
Fixes #4422

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5916)