### PR TITLE
File reference in fallback origin should also be resolved to docs site URL in static output mode

### DIFF
--- a/docs/specs/static.yml
+++ b/docs/specs/static.yml
@@ -305,3 +305,36 @@ outputs:
         { "url": "/docs/b.png" }
       ]
     }
+---
+# File reference in fallback origin should also be resolved to  in static output mode
+locale: zh-cn
+repos: 
+  https://github.com/c/image1#master:
+    - files:
+        docfx.yml:
+        docs/index.md:
+  https://github.com/c/image1.zh-cn#master:
+    - files:
+        docfx.yml: |
+          outputType: html
+          outputUrlType: ugly
+        _themes/ContentTemplate/Conceptual.mta.json.js: |
+          exports.transform = function (model) {
+            model.layout = "Conceptual";
+            return {
+              content: JSON.stringify(model)
+            };
+          }
+        _themes/Conceptual.html.liquid: |
+          {{content}}
+        docs/a.md: |
+          [引用](index.md)
+outputs:
+  docs/a.html: |
+    <p><a data-linktype="external" href="https://docs.com/docs/">引用</a></p>
+  .publish.json: |
+    {
+      "files": [
+        { "url": "/docs/a.html" }
+      ]
+    }

--- a/src/docfx/build/link/LinkResolver.cs
+++ b/src/docfx/build/link/LinkResolver.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Docs.Build
             }
 
             // For static hosting, reference file in fallback repo should be resolved to docs site URL
-            if (file.FilePath.Origin == FileOrigin.Fallback && file.ContentType != ContentType.Resource && _config.OutputUrlType != OutputUrlType.Docs)
+            if (file.FilePath.Origin == FileOrigin.Fallback && file.ContentType == ContentType.Page && _config.OutputUrlType != OutputUrlType.Docs)
             {
                 var siteUrl = _documentProvider.GetDocsSiteUrl(file.FilePath);
                 return (error, UrlUtility.MergeUrl($"https://{_config.HostName}{siteUrl}", query, fragment), fragment, linkType, file, false);

--- a/src/docfx/build/link/LinkResolver.cs
+++ b/src/docfx/build/link/LinkResolver.cs
@@ -145,6 +145,13 @@ namespace Microsoft.Docs.Build
                 return (Errors.Link.LinkOutOfScope(href, file), href, fragment, linkType, null, false);
             }
 
+            // For static hosting, reference file in fallback repo should be resolved to docs site URL
+            if (file.FilePath.Origin == FileOrigin.Fallback && file.ContentType != ContentType.Resource && _config.OutputUrlType != OutputUrlType.Docs)
+            {
+                var siteUrl = _documentProvider.GetDocsSiteUrl(file.FilePath);
+                return (error, UrlUtility.MergeUrl($"https://{_config.HostName}{siteUrl}", query, fragment), fragment, linkType, file, false);
+            }
+
             return (error, UrlUtility.MergeUrl(file.SiteUrl, query, fragment), fragment, linkType, file, false);
         }
 


### PR DESCRIPTION
[AB#220907](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/220907)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5922)