### PR TITLE
Avoid mutating command line options when running in parallel

### DIFF
--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -20,16 +20,17 @@ namespace Microsoft.Docs.Build
             }
 
             var hasError = false;
-            var fetchOptions = options.NoCache ? FetchOptions.Latest : FetchOptions.UseCache;
+            var restoreFetchOptions = options.NoCache ? FetchOptions.Latest : FetchOptions.UseCache;
+            var buildFetchOptions = options.NoRestore ? FetchOptions.NoFetch : FetchOptions.UseCache;
             Parallel.ForEach(docsets, docset =>
             {
-                if (!options.NoRestore && Restore.RestoreDocset(docset.docsetPath, docset.outputPath, options, fetchOptions))
+                if (!options.NoRestore && Restore.RestoreDocset(docset.docsetPath, docset.outputPath, options, restoreFetchOptions))
                 {
                     hasError = true;
                     return;
                 }
 
-                if (BuildDocset(docset.docsetPath, docset.outputPath, options, FetchOptions.NoFetch))
+                if (BuildDocset(docset.docsetPath, docset.outputPath, options, buildFetchOptions))
                 {
                     hasError = true;
                 }

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -20,16 +20,16 @@ namespace Microsoft.Docs.Build
             }
 
             var hasError = false;
+            var fetchOptions = options.NoCache ? FetchOptions.Latest : FetchOptions.UseCache;
             Parallel.ForEach(docsets, docset =>
             {
-                if (!options.NoRestore && Restore.RestoreDocset(docset.docsetPath, docset.outputPath, options))
+                if (!options.NoRestore && Restore.RestoreDocset(docset.docsetPath, docset.outputPath, options, fetchOptions))
                 {
                     hasError = true;
                     return;
                 }
 
-                options.NoCache = false;
-                if (BuildDocset(docset.docsetPath, docset.outputPath, options))
+                if (BuildDocset(docset.docsetPath, docset.outputPath, options, FetchOptions.NoFetch))
                 {
                     hasError = true;
                 }
@@ -37,7 +37,7 @@ namespace Microsoft.Docs.Build
             return hasError ? 1 : 0;
         }
 
-        private static bool BuildDocset(string docsetPath, string? outputPath, CommandLineOptions options)
+        private static bool BuildDocset(string docsetPath, string? outputPath, CommandLineOptions options, FetchOptions fetchOptions)
         {
             using var errorLog = new ErrorLog(outputPath, options.Legacy);
             var stopwatch = Stopwatch.StartNew();
@@ -45,7 +45,7 @@ namespace Microsoft.Docs.Build
             try
             {
                 var configLoader = new ConfigLoader(errorLog);
-                var (errors, config, buildOptions, packageResolver, fileResolver) = configLoader.Load(docsetPath, outputPath, options);
+                var (errors, config, buildOptions, packageResolver, fileResolver) = configLoader.Load(docsetPath, outputPath, options, fetchOptions);
                 if (errorLog.Write(errors))
                 {
                     return true;

--- a/src/docfx/cli/CommandLineOptions.cs
+++ b/src/docfx/cli/CommandLineOptions.cs
@@ -20,10 +20,6 @@ namespace Microsoft.Docs.Build
 
         public JObject? StdinConfig;
 
-        public FetchOptions FetchOptions => NoRestore
-            ? FetchOptions.NoFetch
-            : (NoCache ? FetchOptions.Latest : FetchOptions.UseCache);
-
         public JObject ToJObject()
         {
             var config = new JObject

--- a/src/docfx/config/ConfigLoader.cs
+++ b/src/docfx/config/ConfigLoader.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Load the config under <paramref name="docsetPath"/>
         /// </summary>
-        public (List<Error>, Config, BuildOptions, PackageResolver, FileResolver) Load(string docsetPath, string? outputPath, CommandLineOptions options)
+        public (List<Error>, Config, BuildOptions, PackageResolver, FileResolver) Load(string docsetPath, string? outputPath, CommandLineOptions options, FetchOptions fetchOptions)
         {
             // load and trace entry repository
             var repository = Repository.Create(docsetPath);
@@ -79,9 +79,9 @@ namespace Microsoft.Docs.Build
             // Download dependencies
             var credentialProvider = preloadConfig.GetCredentialProvider();
             var configAdapter = new OpsConfigAdapter(_errorLog, credentialProvider);
-            var packageResolver = new PackageResolver(docsetPath, preloadConfig, options.FetchOptions);
+            var packageResolver = new PackageResolver(docsetPath, preloadConfig, fetchOptions);
             var fallbackDocsetPath = LocalizationUtility.GetFallbackDocsetPath(docsetPath, repository, packageResolver);
-            var fileResolver = new FileResolver(docsetPath, fallbackDocsetPath, credentialProvider, configAdapter, options.FetchOptions);
+            var fileResolver = new FileResolver(docsetPath, fallbackDocsetPath, credentialProvider, configAdapter, fetchOptions);
             var buildOptions = new BuildOptions(docsetPath, fallbackDocsetPath, outputPath, repository, preloadConfig);
             var extendConfig = DownloadExtendConfig(errors, buildOptions.Locale, preloadConfig, xrefEndpoint, xrefQueryTags, repository, fileResolver);
 

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Docs.Build
     {
         public static int Run(string workingDirectory, CommandLineOptions options)
         {
-            options.NoCache = true;
             var docsets = ConfigLoader.FindDocsets(workingDirectory, options);
             if (docsets.Length == 0)
             {
@@ -24,7 +23,7 @@ namespace Microsoft.Docs.Build
             var hasError = false;
             Parallel.ForEach(docsets, docset =>
             {
-                if (RestoreDocset(docset.docsetPath, docset.outputPath, options))
+                if (RestoreDocset(docset.docsetPath, docset.outputPath, options, FetchOptions.Latest))
                 {
                     hasError = true;
                 }
@@ -32,7 +31,7 @@ namespace Microsoft.Docs.Build
             return hasError ? 1 : 0;
         }
 
-        public static bool RestoreDocset(string docsetPath, string? outputPath, CommandLineOptions options)
+        public static bool RestoreDocset(string docsetPath, string? outputPath, CommandLineOptions options, FetchOptions fetchOptions)
         {
             // Restore has to use Config directly, it cannot depend on Docset,
             // because Docset assumes the repo to physically exist on disk.
@@ -45,7 +44,7 @@ namespace Microsoft.Docs.Build
                 {
                     // load configuration from current entry or fallback repository
                     var configLoader = new ConfigLoader(errorLog);
-                    var (errors, config, buildOptions, packageResolver, fileResolver) = configLoader.Load(docsetPath, outputPath, options);
+                    var (errors, config, buildOptions, packageResolver, fileResolver) = configLoader.Load(docsetPath, outputPath, options, fetchOptions);
                     if (errorLog.Write(errors))
                     {
                         return true;


### PR DESCRIPTION
Fix a parallel bug

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5934)