### PR TITLE
stop publishing to myget, now azdevops only

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ For more information see the [.NET Foundation Code of Conduct](http://www.dotnet
 
 ### Packages
 
-| Chocolatey | Nuget | Nightly Build
-| - | - | -
-| [![Chocolatey](https://img.shields.io/chocolatey/v/docfx.svg)](https://chocolatey.org/packages/docfx) | [![NuGet](https://img.shields.io/nuget/v/docfx.svg)](http://www.nuget.org/packages/docfx/) | [![MyGet](https://img.shields.io/myget/docfx-dev/v/docfx.svg?label=myget)](https://www.myget.org/feed/Packages/docfx-dev)
+| Chocolatey | Nuget
+| - | -
+| [![Chocolatey](https://img.shields.io/chocolatey/v/docfx.svg)](https://chocolatey.org/packages/docfx) | [![NuGet](https://img.shields.io/nuget/v/docfx.svg)](http://www.nuget.org/packages/docfx/)
 
 ### Running Status
 

--- a/tools/Deployment/config_gulp.json
+++ b/tools/Deployment/config_gulp.json
@@ -16,11 +16,6 @@
     "siteFolder": "../../Documentation/_site",
     "docfxJson": "../../Documentation/docfx.json"
   },
-  "myget": {
-    "testUrl": "https://www.myget.org/F/docfx-test/api/v2/package",
-    "devUrl": "https://www.myget.org/F/docfx-dev/api/v2/package",
-    "masterUrl": "https://www.myget.org/F/docfx/api/v2/package"
-  },
   "azdevops": {
     "perfUrl": "https://docfx.pkgs.visualstudio.com/docfx/_packaging/docs-build-v2-perf/nuget/v3/index.json",
     "internalUrl": "https://docfx.pkgs.visualstudio.com/docfx/_packaging/docs-build-v2-internal/nuget/v3/index.json",

--- a/tools/Deployment/gulpfile.js
+++ b/tools/Deployment/gulpfile.js
@@ -14,7 +14,7 @@ format.extend(String.prototype, {})
 
 let Common = require("./out/common").Common;
 let Guard = require("./out/common").Guard;
-let Myget = require("./out/myget").Myget;
+let Nuget = require("./out/nuget").Nuget;
 let Github = require("./out/github").Github;
 let Chocolatey = require("./out/chocolatey").Chocolatey;
 let SyncBranch = require("./out/syncBranch").SyncBranch;
@@ -93,7 +93,7 @@ gulp.task("publish:azdevops-perf-login", () => {
 
 gulp.task("publish:azdevops-perf", () => {
     let artifactsFolder = path.resolve(config.docfx["artifactsFolder"]);
-    return Myget.publishToMygetAsync(artifactsFolder, process.env.NUGETEXE, "anything", config.azdevops["perfUrl"]);
+    return Nuget.publishAsync(artifactsFolder, process.env.NUGETEXE, config.azdevops["perfUrl"]);
 });
 
 gulp.task("publish:azdevops-internal-login", () => {
@@ -102,7 +102,7 @@ gulp.task("publish:azdevops-internal-login", () => {
 
 gulp.task("publish:azdevops-internal", () => {
     let artifactsFolder = path.resolve(config.docfx["artifactsFolder"]);
-    return Myget.publishToMygetAsync(artifactsFolder, process.env.NUGETEXE, "anything", config.azdevops["internalUrl"]);
+    return Nuget.publishAsync(artifactsFolder, process.env.NUGETEXE, config.azdevops["internalUrl"]);
 });
 
 gulp.task("publish:azdevops-ppe-login", () => {
@@ -111,7 +111,7 @@ gulp.task("publish:azdevops-ppe-login", () => {
 
 gulp.task("publish:azdevops-ppe", () => {
     let artifactsFolder = path.resolve(config.docfx["artifactsFolder"]);
-    return Myget.publishToMygetAsync(artifactsFolder, process.env.NUGETEXE, "anything", config.azdevops["ppeUrl"]);
+    return Nuget.publishAsync(artifactsFolder, process.env.NUGETEXE, config.azdevops["ppeUrl"]);
 });
 
 gulp.task("publish:azdevops-prod-login", () => {
@@ -122,7 +122,7 @@ gulp.task("publish:azdevops-prod", () => {
     let releaseNotePath = path.resolve(config.docfx["releaseNotePath"]);
     let artifactsFolder = path.resolve(config.docfx["artifactsFolder"]);
 
-    return Myget.publishToMygetAsync(artifactsFolder, process.env.NUGETEXE, "anything", config.azdevops["prodUrl"], releaseNotePath);
+    return Nuget.publishAsync(artifactsFolder, process.env.NUGETEXE, config.azdevops["prodUrl"], releaseNotePath);
 });
 
 gulp.task("updateGhPage", () => {

--- a/tools/Deployment/gulpfile.js
+++ b/tools/Deployment/gulpfile.js
@@ -29,7 +29,6 @@ nconf.add("configuration", { type: "file", file: configFile });
 
 let config = {
     "docfx": nconf.get("docfx"),
-    "myget": nconf.get("myget"),
     "git": nconf.get("git"),
     "choco": nconf.get("choco"),
     "sync": nconf.get("sync"),
@@ -37,7 +36,7 @@ let config = {
 };
 
 Guard.argumentNotNull(config.docfx, "config.docfx", "Can't find docfx configuration.");
-Guard.argumentNotNull(config.myget, "config.docfx", "Can't find myget configuration.");
+Guard.argumentNotNull(config.azdevops, "config.docfx", "Can't find Azure DevOps configuration.");
 Guard.argumentNotNull(config.git, "config.docfx", "Can't find git configuration.");
 Guard.argumentNotNull(config.choco, "config.docfx", "Can't find choco configuration.");
 
@@ -88,17 +87,6 @@ gulp.task("e2eTest:buildSeed", () => {
 
 gulp.task("e2eTest", gulp.series("e2eTest:restoreSeed", "e2eTest:buildSeed"));
 
-gulp.task("publish:myget-dev", () => {
-    Guard.argumentNotNullOrEmpty(config.docfx.artifactsFolder, "config.docfx.artifactsFolder", "Can't find artifacts folder in configuration.");
-    Guard.argumentNotNullOrEmpty(config.myget.devUrl, "config.myget.devUrl", "Can't find myget url for docfx dev feed in configuration.");
-    Guard.argumentNotNullOrEmpty(process.env.MGAPIKEY, "process.env.MGAPIKEY", "Can't find myget key in Environment Variables.");
-
-    let mygetToken = process.env.MGAPIKEY;
-    let artifactsFolder = path.resolve(config.docfx["artifactsFolder"]);
-
-    return Myget.publishToMygetAsync(artifactsFolder, process.env.NUGETEXE, mygetToken, config.myget["devUrl"]);
-});
-
 gulp.task("publish:azdevops-perf-login", () => {
     return Common.execAsync(process.env.NUGETEXE, ["sources", "add", "-name", "docs-build-v2-perf", "-source", config.azdevops["perfUrl"], "-username", "anything", "-password", process.env.AZDEVOPSPAT]);
 })
@@ -124,30 +112,6 @@ gulp.task("publish:azdevops-ppe-login", () => {
 gulp.task("publish:azdevops-ppe", () => {
     let artifactsFolder = path.resolve(config.docfx["artifactsFolder"]);
     return Myget.publishToMygetAsync(artifactsFolder, process.env.NUGETEXE, "anything", config.azdevops["ppeUrl"]);
-});
-
-gulp.task("publish:myget-test", () => {
-    Guard.argumentNotNullOrEmpty(config.docfx.artifactsFolder, "config.docfx.artifactsFolder", "Can't find artifacts folder in configuration.");
-    Guard.argumentNotNullOrEmpty(config.myget.testUrl, "config.myget.testUrl", "Can't find myget url for docfx test feed in configuration.");
-    Guard.argumentNotNullOrEmpty(process.env.MGAPIKEY, "process.env.MGAPIKEY", "Can't find myget key in Environment Variables.");
-
-    let mygetToken = process.env.MGAPIKEY;
-    let artifactsFolder = path.resolve(config.docfx["artifactsFolder"]);
-
-    return Myget.publishToMygetAsync(artifactsFolder, process.env.NUGETEXE, mygetToken, config.myget["testUrl"]);
-});
-
-gulp.task("publish:myget-master", () => {
-    Guard.argumentNotNullOrEmpty(config.docfx.artifactsFolder, "config.docfx.artifactsFolder", "Can't find artifacts folder in configuration.");
-    Guard.argumentNotNullOrEmpty(config.myget.masterUrl, "config.myget.masterUrl", "Can't find myget url for docfx master feed in configuration.");
-    Guard.argumentNotNullOrEmpty(process.env.MGAPIKEY, "process.env.MGAPIKEY", "Can't find myget key in Environment Variables.");
-    Guard.argumentNotNullOrEmpty(config.docfx.releaseNotePath, "config.docfx.releaseNotePath", "Can't find RELEASENOTE.md in configuartion.");
-
-    let mygetToken = process.env.MGAPIKEY;
-    let releaseNotePath = path.resolve(config.docfx["releaseNotePath"]);
-    let artifactsFolder = path.resolve(config.docfx["artifactsFolder"]);
-
-    return Myget.publishToMygetAsync(artifactsFolder, process.env.NUGETEXE, mygetToken, config.myget["masterUrl"], releaseNotePath);
 });
 
 gulp.task("publish:azdevops-prod-login", () => {
@@ -248,13 +212,12 @@ gulp.task("syncBranchCore", () => {
     let docfxHome = path.resolve(config.docfx.home);
     return SyncBranch.runAsync(repoUrl, docfxHome, config.sync.fromBranch, config.sync.targetBranch);
 });
-gulp.task("test", gulp.series("clean", "build", "e2eTest", "pack", "publish:myget-test"));
 gulp.task("dev", gulp.series("clean", "build", "e2eTest"));
 gulp.task("dev:build", gulp.series("clean", "build", "e2eTest"));
-gulp.task("dev:release", gulp.series("pack", "publish:myget-dev", "publish:azdevops-perf-login", "publish:azdevops-perf", "publish:azdevops-internal-login", "publish:azdevops-internal", "publish:azdevops-ppe-login", "publish:azdevops-ppe"));
+gulp.task("dev:release", gulp.series("pack", "publish:azdevops-perf-login", "publish:azdevops-perf", "publish:azdevops-internal-login", "publish:azdevops-internal", "publish:azdevops-ppe-login", "publish:azdevops-ppe"));
 
 gulp.task("master:build", gulp.series("clean", "build:release", "e2eTest", "updateGhPage"));
 gulp.task("master:pack", gulp.series("pack"));
-gulp.task("master:release", gulp.series("packAssetZip", "publish:myget-master", "publish:azdevops-prod-login", "publish:azdevops-prod", "publish:gh-release", "publish:gh-asset", "publish:chocolatey"));
+gulp.task("master:release", gulp.series("packAssetZip", "publish:azdevops-prod-login", "publish:azdevops-prod", "publish:gh-release", "publish:gh-asset", "publish:chocolatey"));
 
 gulp.task("default", gulp.series("dev"));

--- a/tools/Deployment/lib/nuget.ts
+++ b/tools/Deployment/lib/nuget.ts
@@ -5,31 +5,29 @@ import * as glob from "glob";
 
 import { Common, Guard } from "./common";
 
-export class Myget {
-    static async publishToMygetAsync(
+export class Nuget {
+    static async publishAsync(
         artifactsFolder: string,
-        mygetCommand: string,
-        mygetKey: string,
-        mygetUrl: string,
+        nugetPath: string,
+        url: string,
         releaseNotePath = null): Promise<void> {
 
         Guard.argumentNotNullOrEmpty(artifactsFolder, "artifactsFolder");
-        Guard.argumentNotNullOrEmpty(mygetCommand, "mygetCommand");
-        Guard.argumentNotNullOrEmpty(mygetKey, "mygetKey");
-        Guard.argumentNotNullOrEmpty(mygetUrl, "mygetUrl");
+        Guard.argumentNotNullOrEmpty(nugetPath, "nugetPath");
+        Guard.argumentNotNullOrEmpty(url, "url");
 
         if (releaseNotePath) {
-            // Ignore to publish myget package if RELEASENOTE.md hasn't been modified.
+            // Ignore to publish nuget package if RELEASENOTE.md hasn't been modified.
             let isUpdated = await Common.isReleaseNoteVersionChangedAsync(releaseNotePath);
             if (!isUpdated) {
-                console.log(`${releaseNotePath} hasn't been changed. Ignore to publish package to myget.org.`);
+                console.log(`${releaseNotePath} hasn't been changed. Ignore to publish package.`);
                 return Promise.resolve();
             }
         }
 
         let packages = glob.sync(artifactsFolder + "/**/!(*.symbols).nupkg");
-        let promises = packages.map(p => {
-            return Common.execAsync(mygetCommand, ["push", p, mygetKey, "-Source", mygetUrl]);
+        let promises = packages.map((p: string) => {
+            return Common.execAsync(nugetPath, ["push", p, "-Source", url]);
         });
 
         await Promise.all(promises);


### PR DESCRIPTION
[AB#223303](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/223303)

I do not add new badge, as Azure DevOps only supports generating badge for release version package (not pre-release).

> A badge cannot be generated until a SemVer released version (e.g. 1.2.3, not 1.2.3-beta) of docfx.console is published to the feed.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5942)