### PR TITLE
Link definition before h1 is treated as invisible

### DIFF
--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -170,6 +170,22 @@ outputs:
   docs/a.json: |
     { "rawTitle": "", "title": "Title from yaml header" }
 ---
+# Link definition before h1 is treated as invisible
+inputs:
+  docfx.yml:
+  a.md: |
+    ---
+    key: value
+    ---
+    [//]: # (START>DO_NOT_EDIT)
+    # h1
+outputs:
+  a.json: |
+    {
+      "conceptual": "",
+      "rawTitle": "<h1 id=\"h1\">h1</h1>"
+    }
+---
 # include another file
 inputs:
   docfx.yml:

--- a/src/docfx/lib/markdown/MarkdigUtility.cs
+++ b/src/docfx/lib/markdown/MarkdigUtility.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Docs.Build
                         visible = visible || VisibleHtml(htmlInline.Tag);
                         break;
                     case HeadingBlock headingBlock when headingBlock.Inline is null || !headingBlock.Inline.Any():
-                        // empty heading
+                    case LinkReferenceDefinition _:
                     case ThematicBreakBlock _:
                     case YamlFrontMatterBlock _:
                         break;


### PR DESCRIPTION
[AB#223940](https://dev.azure.com/ceapex/Engineering/_workitems/edit/223940/)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5950)