### PR TITLE
Update validation version to 1.2.26-beta004

### DIFF
--- a/docs/specs/validation.yml
+++ b/docs/specs/validation.yml
@@ -1258,3 +1258,176 @@ outputs:
     {"message_severity":"suggestion","log_item_type":"user","code":"h1-missing","message":"H1 is required. Use a single hash (#) followed by a space to create your top-level heading","file":"c.md","line":1,"end_line":1,"column":0,"end_column":0}
     {"message_severity":"suggestion","log_item_type":"user","code":"h1-missing","message":"H1 is required. Use a single hash (#) followed by a space to create your top-level heading","file":"e.md","line":1,"end_line":1,"column":0,"end_column":0}
 ---
+#Content validation - h1 in zone
+inputs:
+  docfx.yml: |
+    markdownValidationRules: rules.json
+  rules.json: |
+    {
+      "headings": {
+        "name": "Headings",
+        "description": "Validates H1 and other heading content",
+        "aliases": null,
+        "rules": [
+          {
+            "type": "H1InZone",
+            "message": "H1 in zone '{0}'. H1 is only allowed in Docs zones.",
+            "code": "h1-in-zone",
+            "severity": "SUGGESTION",
+            "exclusions": [
+              "includes",
+              "landingpage",
+              "hubpage",
+              "toc"
+            ],
+            "excludedDocfxVersions": [
+              "v2"
+            ]
+          }
+        ]
+      }
+    }
+  a.md: |
+    ::: zone target= "docs"
+    # Tutorial: Copy data to Azure Data Box via SMB
+    ::: zone-end
+
+    ::: zone target = "chromeless"
+    # Copy data to Azure Data Box
+    ::: zone-end
+
+    ::: zone target = "pdf"
+    # Copy data to Azure Data Box
+    ::: zone-end
+
+    ::: zone pivot = "test"
+    # Copy data to Azure Data Box
+    ::: zone-end
+
+    ::: zone target = "docs"
+    #Tutorial: Copy data to Azure Data Box via SMB
+    ::: zone-end
+
+    ::: zone target = "chromeless"
+    #Copy data to Azure Data Box
+    ::: zone-end
+
+    ::: zone target = "chromeless"
+    ::: zone-end
+
+    ::: zone target = "chromeless"
+    ## This is h2
+    ::: zone-end
+
+    ::: zone target = "chromeless"
+    # This is h1
+    #This is h1
+    ::: zone-end
+outputs:
+  a.json:
+  .errors.log: |
+    {"message_severity":"suggestion","log_item_type":"user","code":"h1-in-zone","message":"H1 in zone 'target=chromeless'. H1 is only allowed in Docs zones.","file":"a.md","line":6,"end_line":6,"column":0,"end_column":0}
+    {"message_severity":"suggestion","log_item_type":"user","code":"h1-in-zone","message":"H1 in zone 'target=pdf'. H1 is only allowed in Docs zones.","file":"a.md","line":10,"end_line":10,"column":0,"end_column":0}
+    {"message_severity":"suggestion","log_item_type":"user","code":"h1-in-zone","message":"H1 in zone 'pivot'. H1 is only allowed in Docs zones.","file":"a.md","line":14,"end_line":14,"column":0,"end_column":0}
+    {"message_severity":"suggestion","log_item_type":"user","code":"h1-in-zone","message":"H1 in zone 'target=chromeless'. H1 is only allowed in Docs zones.","file":"a.md","line":22,"end_line":22,"column":0,"end_column":0}
+    {"message_severity":"suggestion","log_item_type":"user","code":"h1-in-zone","message":"H1 in zone 'target=chromeless'. H1 is only allowed in Docs zones.","file":"a.md","line":33,"end_line":33,"column":0,"end_column":0}
+    {"message_severity":"suggestion","log_item_type":"user","code":"h1-in-zone","message":"H1 in zone 'target=chromeless'. H1 is only allowed in Docs zones.","file":"a.md","line":34,"end_line":34,"column":0,"end_column":0}
+---
+#Content validation - multiple-h1s in docs zone
+inputs:
+  docfx.yml: |
+    markdownValidationRules: rules.json
+  rules.json: |
+    {
+      "headings": {
+        "name": "Headings",
+        "description": "Validates H1 and other heading content",
+        "aliases": null,
+        "rules": [
+          {
+            "type": "H1Multiples",
+            "message": "Multiple H1s are not allowed. You can only have one top-level heading",
+            "code": "multiple-h1s",
+            "severity": "SUGGESTION",
+            "exclusions": [
+              "includes",
+              "landingpage",
+              "hubpage",
+              "toc"
+            ],
+            "excludedDocfxVersions": [
+              "v2"
+            ]
+          }
+        ]
+      }
+    }
+  a.md: |
+    a.md: |
+    ::: zone target="docs"
+    # H1 heading text
+    ::: zone-end
+  b.md: |
+    ::: zone target="docs"
+    # H1 heading text
+    #H1 heading text dup
+    ::: zone-end
+  c.md: |
+    ::: zone target="chromeless"
+    # H1 heading text
+    #H1 heading dup
+    ::: zone-end
+  d.md: |
+    ::: zone pivot = "test"
+    # H1 Heading text
+    # H1 heading text 2
+    ::: zone-end
+  e.md: |
+    ::: zone target="docs"
+    # H1 heading text
+    # H1 heading dup
+    ::: zone-end
+  f.md: |
+    ::: zone target="docs"
+    # H1 heading text
+    ::: zone-end
+    ::: zone target="chromeless"
+    # H1 heading text
+    ::: zone-end
+  g.md: |
+    # H1 heading
+    ::: zone target="docs"
+    # H1 heading text
+    ::: zone-end
+  h.md: |
+    #H1 heading
+    ::: zone target="docs"
+    # H1 heading text
+    ::: zone-end
+  i.md: |
+    # H1 heading
+    ::: zone target="chromeless"
+    # H1 heading text
+    ::: zone-end
+  j.md: |
+    # H1 heading
+    ::: zone pivot="test"
+    # H1 heading text
+    ::: zone-end
+outputs:
+  a.json:
+  b.json:
+  c.json:
+  d.json:
+  e.json:
+  f.json:
+  g.json:
+  h.json:
+  i.json:
+  j.json:
+  .errors.log: |
+    {"message_severity":"suggestion","log_item_type":"user","code":"multiple-h1s","message":"Multiple H1s are not allowed. You can only have one top-level heading","file":"b.md","line":3,"end_line":3,"column":0,"end_column":0}
+    {"message_severity":"suggestion","log_item_type":"user","code":"multiple-h1s","message":"Multiple H1s are not allowed. You can only have one top-level heading","file":"h.md","line":3,"end_line":3,"column":0,"end_column":0}
+    {"message_severity":"suggestion","log_item_type":"user","code":"multiple-h1s","message":"Multiple H1s are not allowed. You can only have one top-level heading","file":"g.md","line":3,"end_line":3,"column":0,"end_column":0}
+    {"message_severity":"suggestion","log_item_type":"user","code":"multiple-h1s","message":"Multiple H1s are not allowed. You can only have one top-level heading","file":"e.md","line":3,"end_line":3,"column":0,"end_column":0}
+---

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="Stubble.Core" Version="1.7.2" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180503-2" />
-    <PackageReference Include="Validations.DocFx.Adapter" Version="1.2.26-beta002" />
+    <PackageReference Include="Validations.DocFx.Adapter" Version="1.2.26-beta003" />
     <PackageReference Include="YamlDotNet" Version="8.1.0" />
   </ItemGroup>
 

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="Stubble.Core" Version="1.7.2" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180503-2" />
-    <PackageReference Include="Validations.DocFx.Adapter" Version="1.2.26-beta003" />
+    <PackageReference Include="Validations.DocFx.Adapter" Version="1.2.26-beta004" />
     <PackageReference Include="YamlDotNet" Version="8.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
1. Update validation version to 1.2.26-beta004
2. Add unit test for case h1-in-zone
3. Add unit test for supporting multiple-h1s in triple colon zone

[AB#220832](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/220832)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5955)