### PR TITLE
docfx output is now readable in white background

### DIFF
--- a/src/Microsoft.DocAsCode.Common/ConsoleUtility.cs
+++ b/src/Microsoft.DocAsCode.Common/ConsoleUtility.cs
@@ -9,29 +9,35 @@ namespace Microsoft.DocAsCode.Common
     {
         public static void Write(string message, ConsoleColor color)
         {
-            var originalColor = Console.ForegroundColor;
             try
             {
-                Console.ForegroundColor = color;
+                if (color == ConsoleColor.White)
+                    Console.ResetColor();
+                else
+                    Console.ForegroundColor = color;
                 Console.Write(message);
             }
             finally
             {
-                Console.ForegroundColor = originalColor;
+                Console.ResetColor();
             }
         }
 
         public static void WriteLine(string message, ConsoleColor color)
         {
-            var originalColor = Console.ForegroundColor;
+            
             try
             {
-                Console.ForegroundColor = color;
+                if (color == ConsoleColor.White)
+                    Console.ResetColor();
+                else
+                    Console.ForegroundColor = color;
+
                 Console.WriteLine(message);
             }
             finally
             {
-                Console.ForegroundColor = originalColor;
+                Console.ResetColor();
             }
         }
     }

--- a/src/Microsoft.DocAsCode.Common/Loggers/ConsoleLogListener.cs
+++ b/src/Microsoft.DocAsCode.Common/Loggers/ConsoleLogListener.cs
@@ -41,16 +41,8 @@ namespace Microsoft.DocAsCode.Common
 
             formatter += message;
 
-            var foregroundColor = Console.ForegroundColor;
-            try
-            {
-                ChangeConsoleColor(level);
-                Console.WriteLine(formatter);
-            }
-            finally
-            {
-                Console.ForegroundColor = foregroundColor;
-            }
+            var consoleColor = GetConsoleColor(level);
+            ConsoleUtility.WriteLine(formatter, consoleColor);
         }
 
         public void Dispose()
@@ -61,25 +53,20 @@ namespace Microsoft.DocAsCode.Common
         {
         }
 
-        private void ChangeConsoleColor(LogLevel level)
+        private ConsoleColor GetConsoleColor(LogLevel level)
         {
             switch (level)
             {
                 case LogLevel.Verbose:
-                    Console.ForegroundColor = ConsoleColor.Gray;
-                    break;
+                    return ConsoleColor.Gray;
                 case LogLevel.Info:
-                    Console.ForegroundColor = ConsoleColor.White;
-                    break;
+                    return ConsoleColor.White;
                 case LogLevel.Suggestion:
-                    Console.ForegroundColor = ConsoleColor.Blue;
-                    break;
+                    return ConsoleColor.Blue;
                 case LogLevel.Warning:
-                    Console.ForegroundColor = ConsoleColor.Yellow;
-                    break;
+                    return ConsoleColor.Yellow;
                 case LogLevel.Error:
-                    Console.ForegroundColor = ConsoleColor.Red;
-                    break;
+                    return ConsoleColor.Red;
                 default:
                     throw new NotSupportedException(level.ToString());
             }


### PR DESCRIPTION
Fix the font color to use the system default color for regular text
instead of hardcoding it to white

With this change, now the output is legible when the terminal is set
to white background.

fixes #5309 

![Screen Shot 2020-05-25 at 11 40 06 AM](https://user-images.githubusercontent.com/466007/82831089-147c1c00-9e7d-11ea-901d-68e80a1bdbd3.png)
![Screen Shot 2020-05-25 at 11 41 02 AM](https://user-images.githubusercontent.com/466007/82831093-16de7600-9e7d-11ea-821b-2dd5a5e42806.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5962)