### PR TITLE
Remove unused expansive read file code when building xrefmap

### DIFF
--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -42,9 +42,6 @@ namespace Microsoft.Docs.Build
             }
 
             var errors = new List<Error>();
-            var content = context.Input.ReadString(file.FilePath);
-            var callStack = new List<Document> { file };
-
             switch (file.FilePath.Format)
             {
                 case FileFormat.Markdown:


### PR DESCRIPTION
[AB#221431](https://dev.azure.com/ceapex/Engineering/_workitems/edit/221431/)

It is too slow to build xref map for `blogs-archive-pr`. Due to a `@username`, xref map build is triggered and this `ReadString` is hell slow as it reads all the markdown files. Usually we only peek the YAML header.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5966)