### PR TITLE
Turn HtmlCodeSnippetRenderer laungage extractors static

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/CodeSnippet/CodeSnippetExtractor.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/CodeSnippet/CodeSnippetExtractor.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         private readonly bool IsEndLineContainsTagName;
         public const string TagNamePlaceHolder = "{tagname}";
 
-        public CodeSnippetExtractor(string startLineTemplate, string endLineTemplate, MarkdownContext context, bool isEndLineContainsTagName = true)
+        public CodeSnippetExtractor(string startLineTemplate, string endLineTemplate, bool isEndLineContainsTagName = true)
         {
             this.StartLineTemplate = startLineTemplate;
             this.EndLineTemplate = endLineTemplate;

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
@@ -111,64 +111,66 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         // Language file extensions follow https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
         // Currently only supports parts of the language names, aliases and extensions
         // Later we can move the repository's supported/custom language names, aliases, extensions and corresponding comments regexes to docfx build configuration
-        private Dictionary<string, List<CodeSnippetExtractor>> CodeLanguageExtractors = new Dictionary<string, List<CodeSnippetExtractor>>();
+        private static readonly IReadOnlyDictionary<string, List<CodeSnippetExtractor>> s_codeLanguageExtractors = BuildCodeLanguageExtractors();
 
         public HtmlCodeSnippetRenderer(MarkdownContext context)
         {
             _context = context;
-
-            BuildCodeLanguageExtractors();
         }
 
-        private void BuildCodeLanguageExtractors()
+        private static IReadOnlyDictionary<string, List<CodeSnippetExtractor>> BuildCodeLanguageExtractors()
         {
+            var result = new Dictionary<string, List<CodeSnippetExtractor>>();
+
             AddExtractorItems(new[] { "vb", "vbhtml" },
-                new CodeSnippetExtractor(BasicFamilyCodeSnippetCommentStartLineTemplate, BasicFamilyCodeSnippetCommentEndLineTemplate, _context));
+                new CodeSnippetExtractor(BasicFamilyCodeSnippetCommentStartLineTemplate, BasicFamilyCodeSnippetCommentEndLineTemplate));
             AddExtractorItems(new[] { "actionscript", "arduino", "assembly", "cpp", "csharp", "cshtml", "cuda", "d", "fsharp", "go", "java", "javascript", "pascal", "php", "processing", "rust", "scala", "smalltalk", "swift", "typescript" },
-                new CodeSnippetExtractor(CFamilyCodeSnippetCommentStartLineTemplate, CFamilyCodeSnippetCommentEndLineTemplate, _context));
+                new CodeSnippetExtractor(CFamilyCodeSnippetCommentStartLineTemplate, CFamilyCodeSnippetCommentEndLineTemplate));
             AddExtractorItems(new[] { "xml", "xaml", "html", "cshtml", "vbhtml" },
-                new CodeSnippetExtractor(MarkupLanguageFamilyCodeSnippetCommentStartLineTemplate, MarkupLanguageFamilyCodeSnippetCommentEndLineTemplate, _context));
+                new CodeSnippetExtractor(MarkupLanguageFamilyCodeSnippetCommentStartLineTemplate, MarkupLanguageFamilyCodeSnippetCommentEndLineTemplate));
             AddExtractorItems(new[] { "haskell", "lua", "sql" },
-                new CodeSnippetExtractor(SqlFamilyCodeSnippetCommentStartLineTemplate, SqlFamilyCodeSnippetCommentEndLineTemplate, _context));
+                new CodeSnippetExtractor(SqlFamilyCodeSnippetCommentStartLineTemplate, SqlFamilyCodeSnippetCommentEndLineTemplate));
             AddExtractorItems(new[] { "perl", "powershell", "python", "r", "ruby", "shell" },
-                new CodeSnippetExtractor(ScriptFamilyCodeSnippetCommentStartLineTemplate, ScriptFamilyCodeSnippetCommentEndLineTemplate, _context));
+                new CodeSnippetExtractor(ScriptFamilyCodeSnippetCommentStartLineTemplate, ScriptFamilyCodeSnippetCommentEndLineTemplate));
             AddExtractorItems(new[] { "batchfile" },
-                new CodeSnippetExtractor(BatchFileCodeSnippetRegionStartLineTemplate, BatchFileCodeSnippetRegionEndLineTemplate, _context));
+                new CodeSnippetExtractor(BatchFileCodeSnippetRegionStartLineTemplate, BatchFileCodeSnippetRegionEndLineTemplate));
             AddExtractorItems(new[] { "csharp", "cshtml" },
-                new CodeSnippetExtractor(CSharpCodeSnippetRegionStartLineTemplate, CSharpCodeSnippetRegionEndLineTemplate, _context, false));
+                new CodeSnippetExtractor(CSharpCodeSnippetRegionStartLineTemplate, CSharpCodeSnippetRegionEndLineTemplate, false));
             AddExtractorItems(new[] { "erlang", "matlab" },
-                new CodeSnippetExtractor(ErlangCodeSnippetRegionStartLineTemplate, ErlangCodeSnippetRegionEndLineTemplate, _context));
+                new CodeSnippetExtractor(ErlangCodeSnippetRegionStartLineTemplate, ErlangCodeSnippetRegionEndLineTemplate));
             AddExtractorItems(new[] { "lisp" },
-                new CodeSnippetExtractor(LispCodeSnippetRegionStartLineTemplate, LispCodeSnippetRegionEndLineTemplate, _context));
+                new CodeSnippetExtractor(LispCodeSnippetRegionStartLineTemplate, LispCodeSnippetRegionEndLineTemplate));
             AddExtractorItems(new[] { "vb", "vbhtml" },
-                new CodeSnippetExtractor(VBCodeSnippetRegionRegionStartLineTemplate, VBCodeSnippetRegionRegionEndLineTemplate, _context, false));
-        }
+                new CodeSnippetExtractor(VBCodeSnippetRegionRegionStartLineTemplate, VBCodeSnippetRegionRegionEndLineTemplate, false));
 
-        private void AddExtractorItems(string[] languages, CodeSnippetExtractor extractor)
-        {
-            foreach (var language in languages)
+            return result;
+
+            void AddExtractorItems(string[] languages, CodeSnippetExtractor extractor)
             {
-                AddExtractorItem(language, extractor);
-
-                if (LanguageAlias.ContainsKey(language))
+                foreach (var language in languages)
                 {
-                    foreach (var alias in LanguageAlias[language])
+                    AddExtractorItem(language, extractor);
+
+                    if (LanguageAlias.ContainsKey(language))
                     {
-                        AddExtractorItem(alias, extractor);
+                        foreach (var alias in LanguageAlias[language])
+                        {
+                            AddExtractorItem(alias, extractor);
+                        }
                     }
                 }
             }
-        }
 
-        private void AddExtractorItem(string language, CodeSnippetExtractor extractor)
-        {
-            if (CodeLanguageExtractors.ContainsKey(language))
+            void AddExtractorItem(string language, CodeSnippetExtractor extractor)
             {
-                CodeLanguageExtractors[language].Add(extractor);
-            }
-            else
-            {
-                CodeLanguageExtractors[language] = new List<CodeSnippetExtractor> { extractor };
+                if (result.ContainsKey(language))
+                {
+                    result[language].Add(extractor);
+                }
+                else
+                {
+                    result[language] = new List<CodeSnippetExtractor> { extractor };
+                }
             }
         }
 
@@ -245,7 +247,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
                     return GetNoteBookContent(content, obj.TagName, obj);
                 }
 
-                if (!CodeLanguageExtractors.TryGetValue(lang, out List<CodeSnippetExtractor> extractors))
+                if (!s_codeLanguageExtractors.TryGetValue(lang, out List<CodeSnippetExtractor> extractors))
                 {
                     _context.LogError(
                         "unknown-language-code",


### PR DESCRIPTION
Fix a perf bug caused by `HtmlCodeSnippetRenderer`, the language extractor list is built everytime for each h1.

[AB#226825](https://dev.azure.com/ceapex/Engineering/_workitems/edit/226825/)

![image](https://user-images.githubusercontent.com/511355/82978547-71133e80-a017-11ea-9a49-1cd4930dd42f.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/5968)