### PR TITLE
Add back XrefHostName to config

### DIFF
--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -144,6 +144,7 @@ repos:
         docfx.yml: |
           hostName: docs.com
           basePath: /base_path
+          xrefhostName: test.docs.com
         docs/a.md: |
           ---
           title: Title from yaml header a
@@ -165,12 +166,12 @@ outputs:
       "references":[
         {
           "uid": "a",
-          "href": "https://docs.com/base_path/docs/a",
+          "href": "https://test.docs.com/base_path/docs/a",
           "name": "Title from yaml header a"
         },
         {
           "uid": "b",
-          "href": "https://docs.com/base_path/docs/b",
+          "href": "https://test.docs.com/base_path/docs/b",
           "name": "Title from yaml header b"
         }
       ],

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Docs.Build
 
             _dependencyMapBuilder = dependencyMapBuilder;
             _fileLinkMapBuilder = fileLinkMapBuilder;
-            _xrefHostName = config.HostName;
+            _xrefHostName = string.IsNullOrEmpty(config.XrefHostName) ? config.HostName : config.XrefHostName;
         }
 
         public (Error? error, string? href, string display, Document? declaringFile) ResolveXrefByHref(

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -125,6 +125,11 @@ namespace Microsoft.Docs.Build
         public BasePath BasePath { get; private set; }
 
         /// <summary>
+        /// Gets host name used for generating .xrefmap.json
+        /// </summary>
+        public string XrefHostName { get; private set; } = "";
+
+        /// <summary>
         /// Gets whether we are running in legacy mode
         /// </summary>
         public bool Legacy { get; private set; }


### PR DESCRIPTION
`XrefHostName` was mistakenly removed, it was used by [`OpsConfigAdapter`](https://github.com/dotnet/docfx/blob/f3a0444d0db0cfa2f561f330de3e2ebd26923825/src/docfx/config/ops/OpsConfigAdapter.cs#L144)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6009)