### PR TITLE
ImageExtensionBlock --> ImageExtension

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/ImageExtension.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/ImageExtension.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 {
@@ -9,7 +9,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
     using System;
     using System.Collections.Generic;
 
-    public class ImageExtensionBlock : ITripleColonExtensionInfo
+    public class ImageExtension : ITripleColonExtensionInfo
     {
         private readonly MarkdownContext _context;
 
@@ -17,7 +17,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         public bool SelfClosing => true;
         public Func<HtmlRenderer, TripleColonBlock, bool> RenderDelegate { get; private set; }
 
-        public ImageExtensionBlock(MarkdownContext context)
+        public ImageExtension(MarkdownContext context)
         {
             _context = context;
         }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/TripleColonExtension.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/TripleColonExtension.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             {
                 new ZoneExtension(),
                 new ChromelessFormExtension(),
-                new ImageExtensionBlock(context),
+                new ImageExtension(context),
                 new CodeExtension(context),
                 // todo: moniker range, row, etc...
             }).ToDictionary(x => x.Name);

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/TripleColonParser.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/TripleColonParser.cs
@@ -76,7 +76,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
             processor.NewBlocks.Push(block);
 
-            if (extension.GetType() == typeof(ImageExtensionBlock)
+            if (extension.GetType() == typeof(ImageExtension)
                 && htmlAttributes != null
                 && ImageExtensionInline.RequiresClosingTripleColon(attributes))
             {

--- a/test/docfx.Test/lib/MarkdownElementTelemetryExtensionTest.cs
+++ b/test/docfx.Test/lib/MarkdownElementTelemetryExtensionTest.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Docs.Build
                 new object[] { new NestedColumnBlock (null), "NestedColumn" },
                 new object[] { new TripleColonBlock (null) { Extension = new ZoneExtension () }, "TripleColonZone" },
                 new object[] { new TripleColonBlock (null) { Extension = new ChromelessFormExtension () }, "TripleColonForm" },
-                new object[] { new TripleColonBlock (null) { Extension = new ImageExtensionBlock (null) }, "TripleColonImage" },
+                new object[] { new TripleColonBlock (null) { Extension = new ImageExtension (null) }, "TripleColonImage" },
                 new object[] { new TripleColonInline (null) { Extension = new ImageExtensionInline (null) }, "TripleColonInline" },
                 new object[] { new TripleColonBlock (null) { Extension = new CodeExtension (null) }, "TripleColonCode" },
                 new object[] { new YamlFrontMatterBlock (null), "YamlHeader" },


### PR DESCRIPTION
[AB#231712](https://ceapex.visualstudio.com/Engineering/_workitems/edit/231712)

@adunndevster , I had to rename `ImageExtensionBlock` back to `ImageExtension` because this is a public interface breaking change. Downstream dependencies like `ApexValidationLibrary` still compiles against the old version.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6028)