### PR TITLE
Normalize unstable yaml-syntax-error

### DIFF
--- a/.github/actions/spell-check/dictionary/custom-dictionary.txt
+++ b/.github/actions/spell-check/dictionary/custom-dictionary.txt
@@ -505,3 +505,4 @@ nobr
 allowtransparency
 addbuildtag
 ecma
+Idx

--- a/test/docfx.RegressionTest/Normalizer.cs
+++ b/test/docfx.RegressionTest/Normalizer.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Docs.Build
                 switch (Path.GetExtension(path).ToLowerInvariant())
                 {
                     case ".json":
-                        File.WriteAllText(path, NormlizeJsonFile(path));
+                        File.WriteAllText(path, NormalizeJsonFile(path));
                         break;
 
                     case ".log":
@@ -38,7 +38,7 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static string NormlizeJsonFile(string path) => NormalizeNewLine(NormalizeJson(File.ReadAllText(path)));
+        private static string NormalizeJsonFile(string path) => NormalizeNewLine(NormalizeJson(File.ReadAllText(path)));
 
         private static string NormalizeJson(string json) => JToken.Parse(json).ToString();
 

--- a/test/docfx.RegressionTest/Normalizer.cs
+++ b/test/docfx.RegressionTest/Normalizer.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Docs.Build
+{
+    internal static class Normalizer
+    {
+        internal static void Normalize(string outputPath)
+        {
+            // remove docfx.yml to ignore the diff caused by xref url for now
+            // the logic can be removed while docfx.yml not generated anymore
+            foreach (var configPath in Directory.GetFiles(outputPath, "docfx.yml", SearchOption.AllDirectories))
+            {
+                File.Delete(configPath);
+            }
+
+            Parallel.ForEach(Directory.GetFiles(outputPath, "*.*", SearchOption.AllDirectories), PrettifyFile);
+
+            static void PrettifyFile(string path)
+            {
+                switch (Path.GetExtension(path).ToLowerInvariant())
+                {
+                    case ".json":
+                        File.WriteAllText(path, NormlizeJsonFile(path));
+                        break;
+
+                    case ".log":
+                    case ".txt":
+                        File.WriteAllLines(path, File.ReadAllLines(path).OrderBy(line => line).Select(NormalizeJsonLog));
+                        break;
+                }
+            }
+        }
+
+        private static string NormlizeJsonFile(string path) => NormalizeNewLine(NormalizeJson(File.ReadAllText(path)));
+
+        private static string NormalizeJson(string json) => JToken.Parse(json).ToString();
+
+        private static string NormalizeNewLine(string text) => text.Replace("\r", "").Replace("\\n\\n", "⬇\n").Replace("\\n", "⬇\n");
+
+        private static string NormalizeJsonLog(string json)
+        {
+            var obj = JObject.Parse(json);
+            obj.Remove("date_time");
+
+            if (obj.ContainsKey("code")
+                && obj["code"]!.Value<string>() == "yaml-syntax-error"
+                && obj.ContainsKey("message"))
+            {
+                obj["message"] = JValue.CreateString(Regex.Replace(obj["message"]!.Value<string>(), @"Idx: \d+", ""));
+            }
+
+            return NormalizeNewLine(obj.ToString());
+        }
+    }
+}

--- a/test/docfx.RegressionTest/RegressionTest.cs
+++ b/test/docfx.RegressionTest/RegressionTest.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Docs.Build
             Clean(outputPath);
 
             var buildTime = Build(repositoryPath, outputPath, docfxConfig);
-            Prettify(outputPath);
+            Normalizer.Normalize(outputPath);
             Compare(outputPath, opts.Repository, baseLinePath, buildTime, opts.Timeout, workingFolder);
 
             Console.BackgroundColor = ConsoleColor.DarkMagenta;
@@ -302,50 +302,6 @@ namespace Microsoft.Docs.Build
         private static string BasicAuth(string? token)
         {
             return Convert.ToBase64String(Encoding.UTF8.GetBytes($"user:{token}"));
-        }
-
-        private static void Prettify(string outputPath)
-        {
-            // remove docfx.yml to ignore the diff caused by xref url for now
-            // the logic can be removed while docfx.yml not generated anymore
-            foreach (var configPath in Directory.GetFiles(outputPath, "docfx.yml", SearchOption.AllDirectories))
-            {
-                File.Delete(configPath);
-            }
-
-            Parallel.ForEach(Directory.GetFiles(outputPath, "*.*", SearchOption.AllDirectories), PrettifyFile);
-
-            static void PrettifyFile(string path)
-            {
-                switch (Path.GetExtension(path).ToLowerInvariant())
-                {
-                    case ".json":
-                        File.WriteAllText(path, PrettifyJson(File.ReadAllText(path)));
-                        break;
-
-                    case ".log":
-                    case ".txt":
-                        File.WriteAllLines(path, File.ReadAllLines(path).OrderBy(line => line).Select(PrettifyLogJson));
-                        break;
-                }
-            }
-
-            static string PrettifyJson(string json)
-            {
-                return PrettifyNewLine(JToken.Parse(json).ToString());
-            }
-
-            static string PrettifyLogJson(string json)
-            {
-                var obj = JObject.Parse(json);
-                obj.Remove("date_time");
-                return PrettifyNewLine(obj.ToString());
-            }
-
-            static string PrettifyNewLine(string text)
-            {
-                return text.Replace("\r", "").Replace("\\n\\n", "⬇\n").Replace("\\n", "⬇\n");
-            }
         }
 
         private static Task SendPullRequestComments()


### PR DESCRIPTION
[AB#234659](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/234659)

`yaml-syntax-error` reported by Yaml.DotNet for `AnchorAlias` syntax is unstable

e.g.
devsandbox\reference\com.microsoft.azure.batch.auth.BatchSharedKeyCredentials.yml
```
  type: Method
  source:
    remote: *o0
    path: src/main/java/com/microsoft/azure/batch/auth/BatchSharedKeyCredentials.java
    startLine: 26
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6050)