### PR TITLE
Ecma2Yaml logItem.Path can be null

### DIFF
--- a/src/docfx/config/ops/OpsPreProcessor.cs
+++ b/src/docfx/config/ops/OpsPreProcessor.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Docs.Build
         {
             if (!string.IsNullOrEmpty(item.Code))
             {
-                _errorLog.Write(new Error(MapLevel(item.MessageSeverity), item.Code, item.Message, new FilePath(item.File ?? ""), item.Line ?? 0));
+                _errorLog.Write(new Error(MapLevel(item.MessageSeverity), item.Code, item.Message, item.File is null ? null : new FilePath(item.File), item.Line ?? 0));
             }
 
             ErrorLevel MapLevel(MessageSeverity level)

--- a/src/docfx/config/ops/OpsPreProcessor.cs
+++ b/src/docfx/config/ops/OpsPreProcessor.cs
@@ -49,10 +49,10 @@ namespace Microsoft.Docs.Build
 
                         var fallbackXmlPath = _buildOptions.FallbackDocsetPath is null
                             ? null
-                            : Path.Combine(_buildOptions.FallbackDocsetPath.Value, monodocConfig.SourceXmlFolder);
+                            : PathUtility.Normalize(Path.Combine(_buildOptions.FallbackDocsetPath.Value, monodocConfig.SourceXmlFolder));
                         var fallbackOutputDirectory = _buildOptions.FallbackDocsetPath is null
                             ? null
-                            : Path.Combine(_buildOptions.DocsetPath, ".fallback", monodocConfig.OutputYamlFolder);
+                            : PathUtility.Normalize(Path.Combine(_buildOptions.DocsetPath, ".fallback", monodocConfig.OutputYamlFolder));
                         ECMA2YamlConverter.Run(
                             xmlDirectory: Path.Combine(_buildOptions.DocsetPath, monodocConfig.SourceXmlFolder),
                             outputDirectory: Path.Combine(_buildOptions.DocsetPath, monodocConfig.OutputYamlFolder),

--- a/src/docfx/config/ops/OpsPreProcessor.cs
+++ b/src/docfx/config/ops/OpsPreProcessor.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Docs.Build
         {
             if (!string.IsNullOrEmpty(item.Code))
             {
-                _errorLog.Write(new Error(MapLevel(item.MessageSeverity), item.Code, item.Message, new FilePath(item.File), item.Line ?? 0));
+                _errorLog.Write(new Error(MapLevel(item.MessageSeverity), item.Code, item.Message, new FilePath(item.File ?? ""), item.Line ?? 0));
             }
 
             ErrorLevel MapLevel(MessageSeverity level)

--- a/src/docfx/config/ops/OpsPreProcessor.cs
+++ b/src/docfx/config/ops/OpsPreProcessor.cs
@@ -49,10 +49,10 @@ namespace Microsoft.Docs.Build
 
                         var fallbackXmlPath = _buildOptions.FallbackDocsetPath is null
                             ? null
-                            : PathUtility.Normalize(Path.Combine(_buildOptions.FallbackDocsetPath.Value, monodocConfig.SourceXmlFolder));
+                            : Path.GetFullPath(Path.Combine(_buildOptions.FallbackDocsetPath.Value, monodocConfig.SourceXmlFolder));
                         var fallbackOutputDirectory = _buildOptions.FallbackDocsetPath is null
                             ? null
-                            : PathUtility.Normalize(Path.Combine(_buildOptions.DocsetPath, ".fallback", monodocConfig.OutputYamlFolder));
+                            : Path.GetFullPath(Path.Combine(_buildOptions.DocsetPath, ".fallback", monodocConfig.OutputYamlFolder));
                         ECMA2YamlConverter.Run(
                             xmlDirectory: Path.Combine(_buildOptions.DocsetPath, monodocConfig.SourceXmlFolder),
                             outputDirectory: Path.Combine(_buildOptions.DocsetPath, monodocConfig.OutputYamlFolder),


### PR DESCRIPTION
1. Nullable ref check is only enabled in docfx.
It regards Ecma2Yaml.LogItem.Path(string type) to be non-nullable too by mistake, which leads to [Crash report](https://opbuildstoragesandbox2.blob.core.windows.net/report/2020%5C6%5C10%5Cabba77f9-81b0-4978-3ce6-30195711911c%5CCommit%5C202006100253309488-docs-build-v3-loc-sxs%5Crawlog.txt?sv=2016-05-31&sr=b&sig=MDmfO2tu1ehK3BTzJQSZylpVX9nA%2FKIs%2FvvTPwG6ZNQ%3D&st=2020-06-10T02%3A49%3A09Z&se=2020-07-11T02%3A54%3A09Z&sp=r)

2. normalize fallbackXmlPath, cause it may contain `..`, and Ecma2Yaml uses it to trim log filepath
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6051)