### PR TITLE
Make writing output files async

### DIFF
--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -110,6 +110,11 @@ namespace Microsoft.Docs.Build
                 () => context.Output.WriteJson(".dependencymap.json", dependencyMap.ToDependencyMapModel()),
                 () => context.Output.WriteJson(".links.json", context.FileLinkMapBuilder.Build(context.PublishUrlMap.GetFiles())),
                 () => Legacy.ConvertToLegacyModel(context.BuildOptions.DocsetPath, context, fileManifests, dependencyMap));
+
+            using (Progress.Start("Waiting for pending outputs..."))
+            {
+                context.Output.WaitForCompletion();
+            }
         }
 
         private static void BuildFile(Context context, FilePath path)


### PR DESCRIPTION
Now that there is no `Output.Delete`, async output just got way simpler.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6056)