### PR TITLE
fix bug of invalid monikers

### DIFF
--- a/docs/specs/validation.yml
+++ b/docs/specs/validation.yml
@@ -1657,10 +1657,9 @@ inputs:
     }
 outputs:
   .errors.log: |
-    {"message_severity":"suggestion","log_item_type":"user","code":"duplicate-h1","message":"H1 'h1' is duplicated with other articles: 'docs/v1/token1.md, docs/v1/token2.md(5,1), docs/v1/token3.md(2,1), docs/v2/b.md'","file":"docs/v1/token1.md","line":1,"end_line":1,"column":1,"end_column":1}
-    {"message_severity":"suggestion","log_item_type":"user","code":"duplicate-h1","message":"H1 'h1' is duplicated with other articles: 'docs/v1/token1.md, docs/v1/token2.md(5,1), docs/v1/token3.md(2,1), docs/v2/b.md'","file":"docs/v2/b.md","line":1,"end_line":1,"column":1,"end_column":1}
-    {"message_severity":"suggestion","log_item_type":"user","code":"duplicate-h1","message":"H1 'h1' is duplicated with other articles: 'docs/v1/token1.md, docs/v1/token2.md(5,1), docs/v1/token3.md(2,1), docs/v2/b.md'","file":"docs/v1/token2.md","line":5,"end_line":5,"column":1,"end_column":1}
-    {"message_severity":"suggestion","log_item_type":"user","code":"duplicate-h1","message":"H1 'h1' is duplicated with other articles: 'docs/v1/token1.md, docs/v1/token2.md(5,1), docs/v1/token3.md(2,1), docs/v2/b.md'","file":"docs/v1/token3.md","line":2,"end_line":2,"column":1,"end_column":1}
+    {"message_severity":"suggestion","log_item_type":"user","code":"duplicate-h1","message":"H1 'h1' is duplicated with other articles: 'docs/v1/token1.md, docs/v1/token2.md(5,1), docs/v2/b.md'","file":"docs/v1/token1.md","line":1,"end_line":1,"column":1,"end_column":1}
+    {"message_severity":"suggestion","log_item_type":"user","code":"duplicate-h1","message":"H1 'h1' is duplicated with other articles: 'docs/v1/token1.md, docs/v1/token2.md(5,1), docs/v2/b.md'","file":"docs/v2/b.md","line":1,"end_line":1,"column":1,"end_column":1}
+    {"message_severity":"suggestion","log_item_type":"user","code":"duplicate-h1","message":"H1 'h1' is duplicated with other articles: 'docs/v1/token1.md, docs/v1/token2.md(5,1), docs/v2/b.md'","file":"docs/v1/token2.md","line":5,"end_line":5,"column":1,"end_column":1}
     {"message_severity":"error","log_item_type":"user","code":"moniker-range-out-of-scope","message":"No intersection between zone and file level monikers. The result of zone level range string '< netcore-1.1' is 'netcore-1.0', while file level monikers is 'netcore-1.2', 'netcore-2.0'.","file":"docs/v1/token3.md","line":1,"end_line":1,"column":1,"end_column":1}
   9d4e15fd/docs/a.json:
   9d4e15fd/docs/b.json:

--- a/src/docfx/lib/markdown/MarkdigUtility.cs
+++ b/src/docfx/lib/markdown/MarkdigUtility.cs
@@ -136,12 +136,14 @@ namespace Microsoft.Docs.Build
             {
                 case MonikerRangeBlock monikerRangeBlock:
                     var monikers = monikerRangeBlock.GetAttributes().Properties.First(p => p.Key == "data-moniker").Value.Split(" ", StringSplitOptions.RemoveEmptyEntries);
-                    context.ZoneMonikerStack.Push(new MonikerList(monikers));
+                    context.MonikerStack.Push((new MonikerList(monikers), monikers.Length >= 1));
+
                     foreach (var child in monikerRangeBlock)
                     {
                         Visit(child, context, action);
                     }
-                    context.ZoneMonikerStack.Pop();
+
+                    context.MonikerStack.Pop();
                     break;
 
                 case InclusionBlock inclusionBlock:

--- a/src/docfx/lib/markdown/MarkdownVisitContext.cs
+++ b/src/docfx/lib/markdown/MarkdownVisitContext.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Docs.Build
 
         public bool IsInclude => FileStack.Count >= 2;
 
-        public (MonikerList monikers, bool valid) Monikers => MonikerStack.TryPeek(out var moniker) ? moniker : default;
+        public (MonikerList monikers, bool valid) Monikers => MonikerStack.TryPeek(out var monikers) ? monikers : default;
 
         public MarkdownVisitContext(Document document, MonikerList monikerList)
         {

--- a/src/docfx/lib/markdown/MarkdownVisitContext.cs
+++ b/src/docfx/lib/markdown/MarkdownVisitContext.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Docs.Build
 {
     internal class MarkdownVisitContext
     {
-        public Stack<MonikerList> ZoneMonikerStack { get; private set; }
+        public Stack<(MonikerList, bool)> MonikerStack { get; private set; }
 
         public Stack<SourceInfo<Document>> FileStack { get; private set; }
 
@@ -18,13 +18,14 @@ namespace Microsoft.Docs.Build
 
         public bool IsInclude => FileStack.Count >= 2;
 
-        public MonikerList ZoneMoniker => ZoneMonikerStack.TryPeek(out var zoneMoniker) ? zoneMoniker : default;
+        public (MonikerList monikers, bool valid) Monikers => MonikerStack.TryPeek(out var moniker) ? moniker : default;
 
-        public MarkdownVisitContext(Document document)
+        public MarkdownVisitContext(Document document, MonikerList monikerList)
         {
             FileStack = new Stack<SourceInfo<Document>>();
-            ZoneMonikerStack = new Stack<MonikerList>();
+            MonikerStack = new Stack<(MonikerList, bool)>();
             FileStack.Push(new SourceInfo<Document>(document));
+            MonikerStack.Push((monikerList, true));
         }
     }
 }

--- a/src/docfx/lib/markdown/validation/DocsValidationExtension.cs
+++ b/src/docfx/lib/markdown/validation/DocsValidationExtension.cs
@@ -8,7 +8,6 @@ using System.Text;
 using Markdig;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
-using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.DocAsCode.MarkdigEngine.Extensions;
 using Microsoft.Docs.Validation;
 
@@ -35,9 +34,9 @@ namespace Microsoft.Docs.Build
                 var inclusionDocumentNodes = new Dictionary<Document, List<ContentNode>>();
                 var canonicalVersion = getCanonicalVersion();
                 var fileLevelMoniker = getFileLevelMonikers();
-                MarkdigUtility.Visit(document, new MarkdownVisitContext(currentFile), (node, context) =>
+                MarkdigUtility.Visit(document, new MarkdownVisitContext(currentFile, fileLevelMoniker), (node, context) =>
                 {
-                    var isCanonicalVersion = IsCanonicalVersion(canonicalVersion, fileLevelMoniker, context.ZoneMoniker);
+                    var isCanonicalVersion = !context.Monikers.valid ? false : MonikerList.IsCanonicalVersion(canonicalVersion, context.Monikers.monikers);
                     ContentNode? documentNode = null;
                     if (node is HeadingBlock headingBlock)
                     {
@@ -86,16 +85,6 @@ namespace Microsoft.Docs.Build
                     contentValidator.ValidateHeadings(inclusion, inclusionNodes, true);
                 }
             });
-        }
-
-        private static bool? IsCanonicalVersion(string? canonicalVersion, MonikerList fileLevelMonikerList, MonikerList zoneLevelMonikerList)
-        {
-            if (zoneLevelMonikerList.HasMonikers)
-            {
-                return MonikerList.IsCanonicalVersion(canonicalVersion, zoneLevelMonikerList);
-            }
-
-            return MonikerList.IsCanonicalVersion(canonicalVersion, fileLevelMonikerList);
         }
 
         private static string GetHeadingContent(HeadingBlock headingBlock)


### PR DESCRIPTION
invalid moniker should be considered as `isCanonicalVersion = false`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6059)