### PR TITLE
document --enable-local-file-access option

### DIFF
--- a/Documentation/tutorial/docfx.exe_user_manual.md
+++ b/Documentation/tutorial/docfx.exe_user_manual.md
@@ -544,7 +544,7 @@ noStdin                  | Do not use `--read-args-from-stdin` for the wkhtmltop
 Key                      | Description
 -------------------------|-----------------------------
 filePath                 | The path and file name of a wkhtmltopdf.exe compatible executable.
-additionalArguments      | Additional arguments that should be passed to the wkhtmltopdf executable.
+additionalArguments      | Additional arguments that should be passed to the wkhtmltopdf executable. For example, pass `--enable-local-file-access` if you are building on a local file system. This will ensure that the supporting *.js and *.css files are loaded when rendering the HTML being converted to PDF.
 
 ## 4. Supported File Mapping Format
 

--- a/Documentation/tutorial/walkthrough/walkthrough_generate_pdf.md
+++ b/Documentation/tutorial/walkthrough/walkthrough_generate_pdf.md
@@ -95,6 +95,9 @@ Parameters are similar to `build` section, definitely it is using a different te
         ]
       }
     ],
+    "wkhtmltopdf": {
+      "additionalArguments": "--enable-local-file-access"
+    },
     "dest": "_site_pdf"
   }
 ```


### PR DESCRIPTION
Starting with version 0.12.6, wkhtmlpdf blocks local file access by default. This means that when generating PDF, if you are running on a local file system then the JS and CSS files will be blocked (probably among other files) and the output will look bare bones. Passing "--enable-local-file-access" as an additional option corrects this. This PR documents this in a couple of places.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6072)