### PR TITLE
Mustache <xref> with inner template content

### DIFF
--- a/src/docfx/template/MustacheXrefTagParser.cs
+++ b/src/docfx/template/MustacheXrefTagParser.cs
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Text.RegularExpressions;
+using System;
+using System.Text;
 
 namespace Microsoft.Docs.Build
 {
@@ -15,47 +16,91 @@ namespace Microsoft.Docs.Build
             "  @resolvedTag" +
             "{{/href}}" +
             "{{^href}}" +
-            "  <span> {{name}} </span>" +
+            "  @unresolvedTag" +
             "{{/href}}";
 
         private static readonly char[] s_trimChars = new[] { '{', ' ', '}' };
 
-        private static readonly Regex s_xrefTagMatcher = new Regex(@"<xref(.*?)\/>", RegexOptions.IgnoreCase);
-
         public static string ProcessXrefTag(string templateStr)
-            => s_xrefTagMatcher.Replace(templateStr, ReplaceXrefTag);
-
-        private static string ReplaceXrefTag(Match match)
         {
-            var uidName = "uid";
-            var partialName = default(string);
-            var reader = new HtmlReader(match.Value);
+            if (!templateStr.Contains("<xref", StringComparison.OrdinalIgnoreCase))
+            {
+                return templateStr;
+            }
+            var reader = new HtmlReader(templateStr);
+            var result = new StringBuilder();
+            var innerTemplate = new StringBuilder();
+            var resolvedTag = new StringBuilder();
+            var unresolvedTag = new StringBuilder();
+
             while (reader.Read(out var token))
             {
-                if (token.NameIs("xref"))
+                if (token.NameIs("xref") && token.Type == HtmlTokenType.StartTag)
                 {
+                    var uidName = default(string);
+                    var partialName = default(string);
+                    var titleName = default(string);
+                    innerTemplate.Length = 0;
+                    resolvedTag.Length = 0;
+                    unresolvedTag.Length = 0;
                     foreach (ref readonly var attribute in token.Attributes.Span)
                     {
-                        // TODO: uid may fallback to href in ProfileList
                         if (attribute.NameIs("uid"))
                         {
                             uidName = attribute.Value.ToString().Trim(s_trimChars);
+                        }
+                        else if (attribute.NameIs("href"))
+                        {
+                            uidName = uidName ?? attribute.Value.ToString().Trim(s_trimChars);
                         }
                         else if (attribute.NameIs("template"))
                         {
                             partialName = attribute.Value.ToString().Trim(s_trimChars);
                         }
+                        else if (attribute.NameIs("title"))
+                        {
+                            titleName = attribute.Value.ToString().Trim(s_trimChars);
+                        }
                     }
+
+                    var openAnchor = $"<a href=\"{{{{href}}}}\" {(titleName == null ? "" : $"title=\"{{{{{titleName}}}}}\"")}";
+                    if (token.IsSelfClosing)
+                    {
+                        resolvedTag.Append(partialName == null ? $"{openAnchor}> {{{{name}}}} </a>" : "{{> " + partialName + "}}");
+                        unresolvedTag.Append("<span> {{name}} </span>");
+                    }
+                    else
+                    {
+                        resolvedTag.Append($"{openAnchor}>");
+                        unresolvedTag.Append("<span>");
+
+                        while (reader.Read(out var innerToken))
+                        {
+                            if (innerToken.NameIs("xref") && innerToken.Type == HtmlTokenType.EndTag)
+                            {
+                                resolvedTag.Append(innerTemplate).Append("</a>");
+                                unresolvedTag.Append(innerTemplate).Append("</span>");
+                                break;
+                            }
+                            else
+                            {
+                                innerTemplate.Append(innerToken.RawText);
+                            }
+                        }
+                    }
+
+                    var resultTemplate = XrefTagTemplate
+                        .Replace("@resolvedTag", resolvedTag.ToString())
+                        .Replace("@unresolvedTag", unresolvedTag.ToString());
+                    result.Append((uidName ??= "uid") == "." ? resultTemplate : $"{{{{#{uidName}}}}}{resultTemplate}{{{{/{uidName}}}}}");
+                }
+                else
+                {
+                    result.Append(token.RawText);
                 }
             }
 
-            var resolvedTag = partialName == null
-                ? "<a href=\"{{href}}\"> {{name}} </a>"
-                : "{{> " + partialName + "}}";
-
-            var resultTemplate = XrefTagTemplate.Replace("@resolvedTag", resolvedTag);
-
-            return uidName == "." ? resultTemplate : $"{{{{#{uidName}}}}}{resultTemplate}{{{{/{uidName}}}}}";
+            return result.ToString();
         }
     }
 }

--- a/src/docfx/template/MustacheXrefTagParser.cs
+++ b/src/docfx/template/MustacheXrefTagParser.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Docs.Build
                             result.Append(OpeningClause.Replace("@openTag", openAnchor));
                         }
                     }
-                    else
+                    else if (token.Type == HtmlTokenType.EndTag)
                     {
                         result.Append(ClosingClause)
                               .Append((uidName ??= "uid") != "." ? $"{{{{/{uidName}}}}}" : default);

--- a/test/docfx.Test/template/MustacheXrefTagParserTest.cs
+++ b/test/docfx.Test/template/MustacheXrefTagParserTest.cs
@@ -71,10 +71,17 @@ namespace Microsoft.Docs.Build
             "</xref>",
             "{{#uid-from-href}}" +
             "  {{#href}}" +
-            "    <a href='{{href}}' title='{{name}}'> <h3>{{name}}</h3> </a>" +
+            "    <a href='{{href}}' title='{{name}}'>" +
             "  {{/href}}" +
             "  {{^href}}" +
-            "    <span> <h3>{{name}}</h3> </span>" +
+            "    <span>" +
+            "  {{/href}}" +
+            "  <h3>{{name}}</h3>" +
+            "  {{#href}}" +
+            "    </a>" +
+            "  {{/href}}" +
+            "  {{^href}}" +
+            "    </span>" +
             "  {{/href}}" +
             "{{/uid-from-href}}"
             )]
@@ -84,10 +91,17 @@ namespace Microsoft.Docs.Build
             "</xref>",
             "{{#uid-higher-priority}}" +
             "  {{#href}}" +
-            "    <a href='{{href}}' title='{{name}}'> <h3>{{name}}</h3> </a>" +
+            "    <a href='{{href}}' title='{{name}}'>" +
             "  {{/href}}" +
             "  {{^href}}" +
-            "    <span> <h3>{{name}}</h3> </span>" +
+            "    <span>" +
+            "  {{/href}}" +
+            "  <h3>{{name}}</h3>" +
+            "  {{#href}}" +
+            "    </a>" +
+            "  {{/href}}" +
+            "  {{^href}}" +
+            "    </span>" +
             "  {{/href}}" +
             "{{/uid-higher-priority}}"
             )]

--- a/test/docfx.Test/template/MustacheXrefTagParserTest.cs
+++ b/test/docfx.Test/template/MustacheXrefTagParserTest.cs
@@ -8,10 +8,11 @@ namespace Microsoft.Docs.Build
     public class MustacheXrefTagParserTest
     {
         [Theory]
+        [InlineData("<no xref>", "<no xref>")]
         [InlineData("<xref/>",
             "{{#uid}}" +
             "  {{#href}}" +
-            "    <a href=\"{{href}}\"> {{name}} </a>" +
+            "    <a href='{{href}}'> {{name}} </a>" +
             "  {{/href}}" +
             "  {{^href}}" +
             "    <span> {{name}} </span>" +
@@ -21,7 +22,7 @@ namespace Microsoft.Docs.Build
         [InlineData("<xref uid='{{uid}}'/>",
             "{{#uid}}" +
             "  {{#href}}" +
-            "    <a href=\"{{href}}\"> {{name}} </a>" +
+            "    <a href='{{href}}'> {{name}} </a>" +
             "  {{/href}}" +
             "  {{^href}}" +
             "    <span> {{name}} </span>" +
@@ -50,11 +51,45 @@ namespace Microsoft.Docs.Build
             )]
         [InlineData("<xref uid='{{ . }}'/>",
             "{{#href}}" +
-            "  <a href=\"{{href}}\"> {{name}} </a>" +
+            "  <a href='{{href}}'> {{name}} </a>" +
             "{{/href}}" +
             "{{^href}}" +
             "  <span> {{name}} </span>" +
             "{{/href}}"
+            )]
+        [InlineData("<xref uid='{{ . }}' title='{{title}}'/>",
+            "{{#href}}" +
+            "  <a href='{{href}}' title='{{title}}'> {{name}} </a>" +
+            "{{/href}}" +
+            "{{^href}}" +
+            "  <span> {{name}} </span>" +
+            "{{/href}}"
+            )]
+        [InlineData(
+            "<xref href='{{uid-from-href}}' title='{{name}}'>" +
+            "  <h3>{{name}}</h3>" +
+            "</xref>",
+            "{{#uid-from-href}}" +
+            "  {{#href}}" +
+            "    <a href='{{href}}' title='{{name}}'> <h3>{{name}}</h3> </a>" +
+            "  {{/href}}" +
+            "  {{^href}}" +
+            "    <span> <h3>{{name}}</h3> </span>" +
+            "  {{/href}}" +
+            "{{/uid-from-href}}"
+            )]
+        [InlineData(
+            "<xref uid='{{uid-higher-priority}}' href='{{uid}}' title='{{name}}'>" +
+            "  <h3>{{name}}</h3>" +
+            "</xref>",
+            "{{#uid-higher-priority}}" +
+            "  {{#href}}" +
+            "    <a href='{{href}}' title='{{name}}'> <h3>{{name}}</h3> </a>" +
+            "  {{/href}}" +
+            "  {{^href}}" +
+            "    <span> <h3>{{name}}</h3> </span>" +
+            "  {{/href}}" +
+            "{{/uid-higher-priority}}"
             )]
         public void ProcessXrefTag(string template, string expected)
         {


### PR DESCRIPTION
Another solution for [AB#233985](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/233985)

See #6081
using condition to control opening/closing `<a>` `<span>`, instead of copy the whole middle-stuff.

Keeping self-closing `<xref/>` logic as before for better readability.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6083)