### PR TITLE
Remove DOCFX_GLOBAL_CONFIG_PATH since stdin is used instead

### DIFF
--- a/src/docfx/config/AppData.cs
+++ b/src/docfx/config/AppData.cs
@@ -46,12 +46,6 @@ namespace Microsoft.Docs.Build
         /// </summary>
         public static bool TryGetGlobalConfigPath([NotNullWhen(true)] out string? path)
         {
-            if (EnvironmentVariable.GlobalConfigPath != null && File.Exists(EnvironmentVariable.GlobalConfigPath))
-            {
-                path = EnvironmentVariable.GlobalConfigPath;
-                return true;
-            }
-
             path = PathUtility.FindYamlOrJson(Root, "docfx");
             return path != null;
         }

--- a/src/docfx/config/AppData.cs
+++ b/src/docfx/config/AppData.cs
@@ -42,21 +42,6 @@ namespace Microsoft.Docs.Build
         }
 
         /// <summary>
-        /// Get the global configuration path, default is under <see cref="Root"/>
-        /// </summary>
-        public static bool TryGetGlobalConfigPath([NotNullWhen(true)] out string? path)
-        {
-            if (EnvironmentVariable.GlobalConfigPath != null && File.Exists(EnvironmentVariable.GlobalConfigPath))
-            {
-                path = EnvironmentVariable.GlobalConfigPath;
-                return true;
-            }
-
-            path = PathUtility.FindYamlOrJson(Root, "docfx");
-            return path != null;
-        }
-
-        /// <summary>
         /// Get the application cache root dir, default is under user profile dir.
         /// User can set the DOCFX_APPDATA_PATH environment to change the root
         /// </summary>

--- a/src/docfx/config/AppData.cs
+++ b/src/docfx/config/AppData.cs
@@ -42,6 +42,21 @@ namespace Microsoft.Docs.Build
         }
 
         /// <summary>
+        /// Get the global configuration path, default is under <see cref="Root"/>
+        /// </summary>
+        public static bool TryGetGlobalConfigPath([NotNullWhen(true)] out string? path)
+        {
+            if (EnvironmentVariable.GlobalConfigPath != null && File.Exists(EnvironmentVariable.GlobalConfigPath))
+            {
+                path = EnvironmentVariable.GlobalConfigPath;
+                return true;
+            }
+
+            path = PathUtility.FindYamlOrJson(Root, "docfx");
+            return path != null;
+        }
+
+        /// <summary>
         /// Get the application cache root dir, default is under user profile dir.
         /// User can set the DOCFX_APPDATA_PATH environment to change the root
         /// </summary>

--- a/src/docfx/config/ConfigLoader.cs
+++ b/src/docfx/config/ConfigLoader.cs
@@ -78,13 +78,10 @@ namespace Microsoft.Docs.Build
             var docfxConfig = LoadConfig(errors, Path.GetFileName(configPath), File.ReadAllText(configPath));
             var (opsConfigErrors, xrefEndpoint, xrefQueryTags, opsConfig) = OpsConfigLoader.LoadDocfxConfig(docsetPath, repository);
             errors.AddRange(opsConfigErrors);
-            var globalConfig = AppData.TryGetGlobalConfigPath(out var globalConfigPath)
-                ? LoadConfig(errors, globalConfigPath, File.ReadAllText(globalConfigPath))
-                : null;
 
             // Preload
             var preloadConfigObject = new JObject();
-            JsonUtility.Merge(unionProperties, preloadConfigObject, envConfig, globalConfig, opsConfig, docfxConfig, cliConfig);
+            JsonUtility.Merge(unionProperties, preloadConfigObject, envConfig, opsConfig, docfxConfig, cliConfig);
             var (preloadErrors, preloadConfig) = JsonUtility.ToObject<PreloadConfig>(preloadConfigObject);
             errors.AddRange(preloadErrors);
 
@@ -101,7 +98,7 @@ namespace Microsoft.Docs.Build
 
             // Create full config
             var configObject = new JObject();
-            JsonUtility.Merge(unionProperties, configObject, envConfig, globalConfig, extendConfig, opsConfig, docfxConfig, cliConfig);
+            JsonUtility.Merge(unionProperties, configObject, envConfig, extendConfig, opsConfig, docfxConfig, cliConfig);
             var (configErrors, config) = JsonUtility.ToObject<Config>(configObject);
             errors.AddRange(configErrors);
 

--- a/src/docfx/config/ConfigLoader.cs
+++ b/src/docfx/config/ConfigLoader.cs
@@ -78,10 +78,13 @@ namespace Microsoft.Docs.Build
             var docfxConfig = LoadConfig(errors, Path.GetFileName(configPath), File.ReadAllText(configPath));
             var (opsConfigErrors, xrefEndpoint, xrefQueryTags, opsConfig) = OpsConfigLoader.LoadDocfxConfig(docsetPath, repository);
             errors.AddRange(opsConfigErrors);
+            var globalConfig = AppData.TryGetGlobalConfigPath(out var globalConfigPath)
+                ? LoadConfig(errors, globalConfigPath, File.ReadAllText(globalConfigPath))
+                : null;
 
             // Preload
             var preloadConfigObject = new JObject();
-            JsonUtility.Merge(unionProperties, preloadConfigObject, envConfig, opsConfig, docfxConfig, cliConfig);
+            JsonUtility.Merge(unionProperties, preloadConfigObject, envConfig, globalConfig, opsConfig, docfxConfig, cliConfig);
             var (preloadErrors, preloadConfig) = JsonUtility.ToObject<PreloadConfig>(preloadConfigObject);
             errors.AddRange(preloadErrors);
 
@@ -98,7 +101,7 @@ namespace Microsoft.Docs.Build
 
             // Create full config
             var configObject = new JObject();
-            JsonUtility.Merge(unionProperties, configObject, envConfig, extendConfig, opsConfig, docfxConfig, cliConfig);
+            JsonUtility.Merge(unionProperties, configObject, envConfig, globalConfig, extendConfig, opsConfig, docfxConfig, cliConfig);
             var (configErrors, config) = JsonUtility.ToObject<Config>(configObject);
             errors.AddRange(configErrors);
 

--- a/src/docfx/config/EnvironmentVariable.cs
+++ b/src/docfx/config/EnvironmentVariable.cs
@@ -7,8 +7,6 @@ namespace Microsoft.Docs.Build
 {
     public static class EnvironmentVariable
     {
-        public static string? GlobalConfigPath => GetValue("DOCFX_GLOBAL_CONFIG_PATH");
-
         public static string? AppDataPath => GetValue("DOCFX_APPDATA_PATH");
 
         public static string? CachePath => GetValue("DOCFX_CACHE_PATH");

--- a/src/docfx/config/EnvironmentVariable.cs
+++ b/src/docfx/config/EnvironmentVariable.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Docs.Build
 {
     public static class EnvironmentVariable
     {
+        public static string? GlobalConfigPath => GetValue("DOCFX_GLOBAL_CONFIG_PATH");
+
         public static string? AppDataPath => GetValue("DOCFX_APPDATA_PATH");
 
         public static string? CachePath => GetValue("DOCFX_CACHE_PATH");


### PR DESCRIPTION
`DOCFX_GLOBAL_CONFIG_PATH` was removed in this [PR](https://dev.azure.com/ceapex/Engineering/_git/Docs.Build/pullrequest/24104)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6109)