### PR TITLE
Print docfx version when publishing binary package

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -33,6 +33,7 @@ function publishBinaryPackages() {
         exec "dotnet publish src\docfx\docfx.csproj -c release -r $rid -o $packagesBasePath/$rid /p:PackAsTool=false"
         if ($rid -eq "win7-x64") {
             $version = Invoke-Expression "$packagesBasePath/win7-x64/docfx.exe --version"
+            Write-Host "##[debug]package version: $version"
         }
         $packageName = "docfx-$rid-$version"
         Compress-Archive -Path "$packagesBasePath/$rid/*" -DestinationPath "$stagingPath/$packageName.zip" -Update


### PR DESCRIPTION
[AB#230992](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/230992)
sample: 
![image](https://user-images.githubusercontent.com/42199316/86105724-41fa5c00-baf2-11ea-80fd-081565c9d48c.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6113)