### PR TITLE
Increase git commit cache hit rate

### DIFF
--- a/src/docfx/lib/git/FileCommitProvider.cs
+++ b/src/docfx/lib/git/FileCommitProvider.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Docs.Build
                 return Array.Empty<GitCommit>();
             }
 
+            var searchSteps = 0;
             var updateCache = true;
             var result = new List<Commit>();
             var parentBlobs = new long[MaxParentBlob];
@@ -95,6 +96,8 @@ namespace Microsoft.Docs.Build
                 {
                     continue;
                 }
+
+                searchSteps++;
 
                 // Lookup and use cached commit history ONLY if there are no other commits to follow
                 if (commitsToFollow.Count == 0 && commitCache.TryGetCommits(commit.Id.a, blob, out var commitIds))
@@ -140,12 +143,10 @@ namespace Microsoft.Docs.Build
                 }
             }
 
-            if (updateCache)
+            // Only update commit cache if the search takes significant amount of effort
+            if (updateCache && searchSteps > 100)
             {
-                lock (commitCache)
-                {
-                    commitCache.SetCommits(headCommit.Id.a, headBlob, result.Select(c => c.Id.a).ToArray());
-                }
+                commitCache.SetCommits(headCommit.Id.a, headBlob, result.Select(c => c.Id.a).ToArray());
             }
 
             return result.Select(c => c.GitCommit).ToArray();

--- a/src/docfx/lib/git/GitCommitCache.cs
+++ b/src/docfx/lib/git/GitCommitCache.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Docs.Build
 {
     internal class GitCommitCache
     {
-        private const int MaxCommitCacheCountPerFile = 10;
+        private const int MaxCommitCacheCountPerFile = 20;
 
         private readonly string _cacheFilePath;
 


### PR DESCRIPTION
[AB#240717](https://dev.azure.com/ceapex/Engineering/_workitems/edit/240717)

_Depends on_ #6124

This PR adjusts git commit history cache to be not as aggressive, to increase cache hit rate.

Today the cache creates a new entry for each new commit, and we have a total of 10 commits per file. the approx. cache size is 4MB for azure-docs-pr.

With repo level cache on server, the cache is synced across branches, but if the commit count diff between two builds are bigger than 10, it is very likely to have cache miss. (As seen in azure-docs-pr) where there might be >100 small checkins a day).

This PR calculates the complexity to compute a commit history and only cache it if above certain threshold. It does adds a tiny overhead for the happies case, but with #6124, that overhead is negatable.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6126)