### PR TITLE
Warm up git commit history in parallel

### DIFF
--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Docs.Build
             FileResolver = fileResolver;
             SourceMap = sourceMap;
 
-            RepositoryProvider = new RepositoryProvider(buildOptions.Repository);
+            RepositoryProvider = new RepositoryProvider(buildOptions, config);
             Input = new Input(buildOptions, config, packageResolver, RepositoryProvider);
             Output = new Output(buildOptions.OutputPath, Input, Config.DryRun);
             MicrosoftGraphAccessor = new MicrosoftGraphAccessor(Config);

--- a/src/docfx/lib/git/FileCommitProvider.cs
+++ b/src/docfx/lib/git/FileCommitProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Docs.Build
 
         private readonly ConcurrentDictionary<(string, string?), GitCommit[]> _commitHistoryCache = new ConcurrentDictionary<(string, string?), GitCommit[]>();
 
-        private IntPtr _repo;
+        private readonly IntPtr _repo;
         private int _isDisposed;
         private Task? _warmup;
 

--- a/src/docfx/lib/git/FileCommitProvider.cs
+++ b/src/docfx/lib/git/FileCommitProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Docs.Build
 
         // Commit history and a lookup table from commit hash to commit.
         // Use `long` to represent SHA2 git hashes for more efficient lookup and smaller size.
-        private readonly ConcurrentDictionary<string, Lazy<(List<Commit>, Dictionary<long, Commit>)>> _commits;
+        private readonly ConcurrentDictionary<string, Lazy<(Commit[], Dictionary<long, Commit>)>> _commits = new ConcurrentDictionary<string, Lazy<(Commit[], Dictionary<long, Commit>)>>();
 
         // A giant memory cache of git tree. Key is the `long` form of SHA2 tree hash, value is a string id to git SHA2 hash.
         private readonly ConcurrentDictionary<long, Tree> _treeCache = new ConcurrentDictionary<long, Tree>();
@@ -33,6 +33,8 @@ namespace Microsoft.Docs.Build
         private readonly ConcurrentDictionary<(string, string?), GitCommit[]> _commitHistoryCache = new ConcurrentDictionary<(string, string?), GitCommit[]>();
 
         private IntPtr _repo;
+        private int _isDisposed;
+        private Task? _warmup;
 
         public FileCommitProvider(Repository repository, string cacheFilePath)
         {
@@ -40,9 +42,14 @@ namespace Microsoft.Docs.Build
             {
                 throw new ArgumentException($"Invalid git repo {repository.Path}");
             }
+
             _repository = repository;
             _commitCache = new Lazy<GitCommitCache>(() => new GitCommitCache(cacheFilePath));
-            _commits = new ConcurrentDictionary<string, Lazy<(List<Commit>, Dictionary<long, Commit>)>>();
+        }
+
+        public void WarmUp()
+        {
+            _warmup = Task.Run(() => _commits.GetOrAdd("", key => new Lazy<(Commit[], Dictionary<long, Commit>)>(() => LoadCommits(key))).Value);
         }
 
         public GitCommit[] GetCommitHistory(string file, string? committish = null)
@@ -69,9 +76,9 @@ namespace Microsoft.Docs.Build
 
             var (commits, commitsById) = _commits.GetOrAdd(
                 committish ?? "",
-                key => new Lazy<(List<Commit>, Dictionary<long, Commit>)>(() => LoadCommits(key))).Value;
+                key => new Lazy<(Commit[], Dictionary<long, Commit>)>(() => LoadCommits(key))).Value;
 
-            if (commits.Count <= 0)
+            if (commits.Length <= 0)
             {
                 return Array.Empty<GitCommit>();
             }
@@ -178,9 +185,9 @@ namespace Microsoft.Docs.Build
 
         public void Dispose()
         {
-            var repo = Interlocked.Exchange(ref _repo, IntPtr.Zero);
-            if (repo != IntPtr.Zero)
+            if (Interlocked.Exchange(ref _isDisposed, 1) == 0)
             {
+                _warmup?.GetAwaiter().GetResult();
                 git_repository_free(_repo);
                 GC.SuppressFinalize(this);
             }
@@ -191,57 +198,32 @@ namespace Microsoft.Docs.Build
             Dispose();
         }
 
-        private unsafe (List<Commit>, Dictionary<long, Commit>) LoadCommits(string? committish = null)
+        private unsafe (Commit[], Dictionary<long, Commit>) LoadCommits(string? committish = null)
         {
             using (Progress.Start("Loading git commits"))
             {
-                if (string.IsNullOrEmpty(committish))
+                var commitIds = LoadCommitIds(committish);
+                var commits = new Commit[commitIds.Count];
+
+                // Stop warm up if build completes before warm up finished
+                if (_isDisposed == 1)
                 {
-                    committish = _repository.Commit;
+                    return (Array.Empty<Commit>(), new Dictionary<long, Commit>());
                 }
 
-                var commits = new List<Commit>();
-                var commitsById = new Dictionary<long, Commit>();
-
-                // walk commit list
-                git_revwalk_new(out var walk, _repo);
-                git_revwalk_sorting(walk, 1 << 0 | 1 << 1 /* GIT_SORT_TOPOLOGICAL | GIT_SORT_TIME */);
-
-                if (git_revparse_single(out var headCommit, _repo, committish) != 0)
+                // Build commit tree
+                Parallel.For(0, commits.Length, i =>
                 {
-                    git_object_free(walk);
-                    throw Errors.Config.CommittishNotFound(_repository.Remote, committish).ToException();
-                }
-
-                var lastCommitId = *git_object_id(headCommit);
-                git_revwalk_push(walk, &lastCommitId);
-                git_object_free(headCommit);
-
-                while (true)
-                {
-                    var error = git_revwalk_next(out var commitId, walk);
-                    if (error == -31 /* GIT_ITEROVER */)
-                    {
-                        break;
-                    }
-
-                    // https://github.com/libgit2/libgit2sharp/issues/1351
-                    if (error != 0 /* GIT_ENOTFOUND */)
-                    {
-                        git_revwalk_free(walk);
-
-                        Log.Write($"Load git commit failed: {error} {lastCommitId}");
-                        throw Errors.System.GitCloneIncomplete(_repository.Path).ToException();
-                    }
-
-                    lastCommitId = commitId;
+                    var commitId = commitIds[i];
                     git_object_lookup(out var commit, _repo, &commitId, 1 /* GIT_OBJ_COMMIT */);
+
                     var author = git_commit_author(commit);
                     var parentCount = git_commit_parentcount(commit);
                     var parents = new git_oid[parentCount];
-                    for (var i = 0; i < parentCount; i++)
+
+                    for (var n = 0; n < parentCount; n++)
                     {
-                        parents[i] = *git_commit_parent_id(commit, i);
+                        parents[n] = *git_commit_parent_id(commit, n);
                     }
 
                     var gitCommit = new GitCommit(
@@ -253,12 +235,12 @@ namespace Microsoft.Docs.Build
                     var treeId = *git_commit_tree_id(commit);
                     var tree = new Tree { Id = treeId };
                     var item = new Commit(commitId, parents, tree, gitCommit);
-
-                    commitsById.Add(commitId.a, item);
-                    commits.Add(item);
                     git_object_free(commit);
-                }
-                git_revwalk_free(walk);
+
+                    commits[i] = item;
+                });
+
+                var commitsById = commits.ToDictionary(c => c.Id.a);
 
                 // build parent indices
                 Parallel.ForEach(commits, commit =>
@@ -272,6 +254,61 @@ namespace Microsoft.Docs.Build
 
                 return (commits, commitsById);
             }
+        }
+
+        private unsafe List<git_oid> LoadCommitIds(string? committish)
+        {
+            if (string.IsNullOrEmpty(committish))
+            {
+                committish = _repository.Commit;
+            }
+
+            var commitIds = new List<git_oid>();
+
+            // walk commit list
+            git_revwalk_new(out var walk, _repo);
+            git_revwalk_sorting(walk, 1 << 0 | 1 << 1 /* GIT_SORT_TOPOLOGICAL | GIT_SORT_TIME */);
+
+            if (git_revparse_single(out var headCommit, _repo, committish) != 0)
+            {
+                git_object_free(walk);
+                throw Errors.Config.CommittishNotFound(_repository.Remote, committish).ToException();
+            }
+
+            var lastCommitId = *git_object_id(headCommit);
+            git_revwalk_push(walk, &lastCommitId);
+            git_object_free(headCommit);
+
+            while (true)
+            {
+                // Stop warm up if build completes before warm up finished
+                if (_isDisposed == 1)
+                {
+                    break;
+                }
+
+                var error = git_revwalk_next(out var commitId, walk);
+                if (error == -31 /* GIT_ITEROVER */)
+                {
+                    break;
+                }
+
+                // https://github.com/libgit2/libgit2sharp/issues/1351
+                if (error != 0 /* GIT_ENOTFOUND */)
+                {
+                    git_revwalk_free(walk);
+
+                    Log.Write($"Load git commit failed: {error} {lastCommitId}");
+                    throw Errors.System.GitCloneIncomplete(_repository.Path).ToException();
+                }
+
+                commitIds.Add(commitId);
+                lastCommitId = commitId;
+            }
+
+            git_revwalk_free(walk);
+
+            return commitIds;
         }
 
         private long GetBlob(Tree tree, uint[] pathSegments)

--- a/src/docfx/lib/git/RepositoryProvider.cs
+++ b/src/docfx/lib/git/RepositoryProvider.cs
@@ -15,9 +15,14 @@ namespace Microsoft.Docs.Build
 
         public Repository? Repository { get; }
 
-        public RepositoryProvider(Repository? repository)
+        public RepositoryProvider(BuildOptions buildOptions, Config config)
         {
-            Repository = repository;
+            Repository = buildOptions.Repository;
+
+            if (Repository != null && !config.DryRun && !buildOptions.IsLocalizedBuild)
+            {
+                GetCommitProvider(Repository).WarmUp();
+            }
         }
 
         public (Repository? repository, PathString? pathToRepository) GetRepository(PathString fullPath)

--- a/test/docfx.Test/docfx.Test.csproj
+++ b/test/docfx.Test/docfx.Test.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0034" />
     <PackageReference Include="Fody" Version="6.2.0" />
-    <PackageReference Include="ModuleInit.Fody" Version="2.1.0" />
+    <PackageReference Include="ModuleInit.Fody" Version="2.1.0" PrivateAssets="All" />
     <PackageReference Include="coverlet.msbuild" Version="2.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="yunit" Version="1.0.0-preview-0026-g48bfd5b1eb" />


### PR DESCRIPTION
[AB#240717](https://dev.azure.com/ceapex/Engineering/_workitems/edit/240717/)

Parallelize `LoadCommitHistory`, reduces `azure-docs-pr` commit history load time from ~7s -> ~6s.

Pre warm up `LoadCommitHistory`, so that load commit history and other pre loading tasks (like build TOC map) run at the same time, reduces `azure-docs-pr` build time to < 50s.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6130)