### PR TITLE
fix: update endpoint for internal and perf of validation service

### DIFF
--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -355,9 +355,9 @@ namespace Microsoft.Docs.Build
         private static string ValidationServiceEndpoint => s_docsEnvironment switch
         {
             DocsEnvironment.Prod => "https://op-build-prod.azurewebsites.net/route/validationmgt",
-            DocsEnvironment.Internal => "https://op-build-sandbox2.azurewebsites.net/route/validationmgt",
+            DocsEnvironment.Internal => "https://op-build-internal.azurewebsites.net/route/validationmgt",
             DocsEnvironment.PPE => "https://op-build-sandbox2.azurewebsites.net/route/validationmgt",
-            DocsEnvironment.Perf => "https://op-build-sandbox2.azurewebsites.net/route/validationmgt",
+            DocsEnvironment.Perf => "https://op-build-perf.azurewebsites.net/route/validationmgt",
             _ => throw new NotSupportedException(),
         };
     }


### PR DESCRIPTION
Docfx should always respect Docs.Build service environment and endpoint. The route of validation service endpoint to PPE/Internal/Perf will be handle by service side route controller.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6141)