### PR TITLE
Fix Code Style Violation of Rule MEN002 for member variables and member functions which only have one line

### DIFF
--- a/src/docfx/build/context/Input.cs
+++ b/src/docfx/build/context/Input.cs
@@ -24,8 +24,12 @@ namespace Microsoft.Docs.Build
         private readonly BuildOptions _buildOptions;
         private readonly PackageResolver _packageResolver;
         private readonly RepositoryProvider _repositoryProvider;
-        private readonly ConcurrentDictionary<FilePath, (List<Error>, JToken)> _jsonTokenCache = new ConcurrentDictionary<FilePath, (List<Error>, JToken)>();
-        private readonly ConcurrentDictionary<FilePath, (List<Error>, JToken)> _yamlTokenCache = new ConcurrentDictionary<FilePath, (List<Error>, JToken)>();
+        private readonly ConcurrentDictionary<FilePath, (List<Error>, JToken)> _jsonTokenCache =
+            new ConcurrentDictionary<FilePath, (List<Error>, JToken)>();
+
+        private readonly ConcurrentDictionary<FilePath, (List<Error>, JToken)> _yamlTokenCache =
+            new ConcurrentDictionary<FilePath, (List<Error>, JToken)>();
+
         private readonly ConcurrentDictionary<PathString, byte[]?> _gitBlobCache = new ConcurrentDictionary<PathString, byte[]?>();
         private readonly ConcurrentDictionary<FilePath, JToken> _generatedContents = new ConcurrentDictionary<FilePath, JToken>();
         private readonly PathString? _alternativeFallbackFolder;

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -15,11 +15,14 @@ namespace Microsoft.Docs.Build
         private readonly Config _config;
         private readonly GitHubAccessor _githubAccessor;
         private readonly BuildOptions _buildOptions;
-        private readonly ConcurrentDictionary<string, Lazy<CommitBuildTimeProvider>> _commitBuildTimeProviders = new ConcurrentDictionary<string, Lazy<CommitBuildTimeProvider>>(PathUtility.PathComparer);
+        private readonly ConcurrentDictionary<string, Lazy<CommitBuildTimeProvider>> _commitBuildTimeProviders =
+            new ConcurrentDictionary<string, Lazy<CommitBuildTimeProvider>>(PathUtility.PathComparer);
+
         private readonly RepositoryProvider _repositoryProvider;
         private readonly SourceMap _sourceMap;
 
-        private readonly ConcurrentDictionary<FilePath, (string?, string?, string?)> _gitUrls = new ConcurrentDictionary<FilePath, (string?, string?, string?)>();
+        private readonly ConcurrentDictionary<FilePath, (string?, string?, string?)> _gitUrls =
+            new ConcurrentDictionary<FilePath, (string?, string?, string?)>();
 
         public ContributionProvider(
             Config config, BuildOptions buildOptions, Input input, GitHubAccessor githubAccessor, RepositoryProvider repositoryProvider, SourceMap sourceMap)

--- a/src/docfx/build/redirection/RedirectionProvider.cs
+++ b/src/docfx/build/redirection/RedirectionProvider.cs
@@ -17,7 +17,8 @@ namespace Microsoft.Docs.Build
         private readonly Lazy<PublishUrlMap> _publishUrlMap;
 
         private readonly IReadOnlyDictionary<FilePath, string> _redirectUrls;
-        private readonly Lazy<(IReadOnlyDictionary<FilePath, FilePath> renameHistory, IReadOnlyDictionary<FilePath, (FilePath, SourceInfo?)> redirectionHistory)> _history;
+        private readonly Lazy<(IReadOnlyDictionary<FilePath, FilePath> renameHistory,
+            IReadOnlyDictionary<FilePath, (FilePath, SourceInfo?)> redirectionHistory)> _history;
 
         public IEnumerable<FilePath> Files => _redirectUrls.Keys;
 

--- a/src/docfx/build/toc/TableOfContentsLoader.cs
+++ b/src/docfx/build/toc/TableOfContentsLoader.cs
@@ -26,9 +26,11 @@ namespace Microsoft.Docs.Build
                      new ConcurrentDictionary<FilePath, (List<Error>, TableOfContentsNode, List<Document>, List<Document>)>();
 
         private static readonly string[] s_tocFileNames = new[] { "TOC.md", "TOC.json", "TOC.yml" };
-        private static readonly string[] s_experimentalTocFileNames = new[] { "TOC.experimental.md", "TOC.experimental.json", "TOC.experimental.yml" };
+        private static readonly string[] s_experimentalTocFileNames =
+            new[] { "TOC.experimental.md", "TOC.experimental.json", "TOC.experimental.yml" };
 
-        private static AsyncLocal<ImmutableStack<Document>> t_recursionDetector = new AsyncLocal<ImmutableStack<Document>> { Value = ImmutableStack<Document>.Empty };
+        private static AsyncLocal<ImmutableStack<Document>> t_recursionDetector =
+            new AsyncLocal<ImmutableStack<Document>> { Value = ImmutableStack<Document>.Empty };
 
         public TableOfContentsLoader(
             LinkResolver linkResolver,

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -143,7 +143,8 @@ namespace Microsoft.Docs.Build
         /// Gets the file metadata added to each document.
         /// It is a map of `{metadata-name} -> {glob} -> {metadata-value}`
         /// </summary>
-        public Dictionary<string, SourceInfo<Dictionary<string, JToken>>> FileMetadata { get; } = new Dictionary<string, SourceInfo<Dictionary<string, JToken>>>();
+        public Dictionary<string, SourceInfo<Dictionary<string, JToken>>> FileMetadata { get; } =
+            new Dictionary<string, SourceInfo<Dictionary<string, JToken>>>();
 
         /// <summary>
         /// Gets a map from source folder path and output URL path.

--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Docs.Build
         private static readonly Lazy<SecretClient> s_secretClient = new Lazy<SecretClient>(()
             => new SecretClient(new Uri(s_keyVaultEndPoint), new DefaultAzureCredential()));
 
-        private static readonly Lazy<Task<Response<KeyVaultSecret>>> s_opBuildUserToken = new Lazy<Task<Response<KeyVaultSecret>>>(() => s_secretClient.Value.GetSecretAsync("opBuildUserToken"));
+        private static readonly Lazy<Task<Response<KeyVaultSecret>>> s_opBuildUserToken =
+            new Lazy<Task<Response<KeyVaultSecret>>>(() => s_secretClient.Value.GetSecretAsync("opBuildUserToken"));
 
         private readonly Action<HttpRequestMessage> _credentialProvider;
         private readonly ErrorLog _errorLog;

--- a/src/docfx/lib/HtmlUtility.cs
+++ b/src/docfx/lib/HtmlUtility.cs
@@ -23,81 +23,88 @@ namespace Microsoft.Docs.Build
         };
 
         // ref https://developer.mozilla.org/en-US/docs/Web/HTML/Element
-        private static readonly Dictionary<string, HashSet<string>?> s_allowedTagAttributeMap = new Dictionary<string, HashSet<string>?>(StringComparer.OrdinalIgnoreCase)
-        {
-            // Content sectioning
-            { "address", null },
-            { "section", null },
+        private static readonly Dictionary<string, HashSet<string>?> s_allowedTagAttributeMap =
+            new Dictionary<string, HashSet<string>?>(StringComparer.OrdinalIgnoreCase)
+            {
+                // Content sectioning
+                { "address", null },
+                { "section", null },
 
-            // Text content
-            { "blockquote", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "cite" } },
-            { "dd", null },
-            { "div", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "align" } },
-            { "dl", null },
-            { "dt", null },
-            { "figcaption", null },
-            { "figure", null },
-            { "hr", null },
-            { "li", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "value" } },
-            { "ol", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "reversed", "start", "type" } },
-            { "p", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "align" } },
-            { "pre", null },
-            { "ul", null },
+                // Text content
+                { "blockquote", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "cite" } },
+                { "dd", null },
+                { "div", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "align" } },
+                { "dl", null },
+                { "dt", null },
+                { "figcaption", null },
+                { "figure", null },
+                { "hr", null },
+                { "li", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "value" } },
+                { "ol", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "reversed", "start", "type" } },
+                { "p", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "align" } },
+                { "pre", null },
+                { "ul", null },
 
-            // Inline text semantics
-            { "a", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "href", "target", "rel" } },
-            { "abbr", null },
-            { "b", null },
-            { "bdi", null },
-            { "bdo", null },
-            { "br", null },
-            { "cite", null },
-            { "code", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "name" } },
-            { "dfn", null },
-            { "em", null },
-            { "i", null },
-            { "kbd", null },
-            { "mark", null },
-            { "q", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "cite" } },
-            { "s", null },
-            { "samp", null },
-            { "small", null },
-            { "span", null },
-            { "strong", null },
-            { "sub", null },
-            { "sup", null },
-            { "time", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "datetime" } },
-            { "u", null },
-            { "var", null },
+                // Inline text semantics
+                { "a", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "href", "target", "rel" } },
+                { "abbr", null },
+                { "b", null },
+                { "bdi", null },
+                { "bdo", null },
+                { "br", null },
+                { "cite", null },
+                { "code", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "name" } },
+                { "dfn", null },
+                { "em", null },
+                { "i", null },
+                { "kbd", null },
+                { "mark", null },
+                { "q", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "cite" } },
+                { "s", null },
+                { "samp", null },
+                { "small", null },
+                { "span", null },
+                { "strong", null },
+                { "sub", null },
+                { "sup", null },
+                { "time", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "datetime" } },
+                { "u", null },
+                { "var", null },
 
-            // Image and multimedia
-            { "img", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "alt", "height", "src", "width", "align" } },
-            { "image", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "alt", "height", "src", "width" } },
+                // Image and multimedia
+                { "img", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "alt", "height", "src", "width", "align" } },
+                { "image", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "alt", "height", "src", "width" } },
 
-            // Demarcating edits
-            { "del", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "cite", "datetime" } },
-            { "ins", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "cite", "datetime" } },
+                // Demarcating edits
+                { "del", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "cite", "datetime" } },
+                { "ins", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "cite", "datetime" } },
 
-            // table
-            { "caption", null },
-            { "col", null },
-            { "colgroup", null },
-            { "table", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "align", "width", "border" } },
-            { "tbody", null },
-            { "td", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "rowspan", "colspan", "align", "width" } },
-            { "tfoot", null },
-            { "th", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "rowspan", "colspan", "align", "width" } },
-            { "thead", null },
-            { "tr", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "align" } },
+                // table
+                { "caption", null },
+                { "col", null },
+                { "colgroup", null },
+                { "table", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "align", "width", "border" } },
+                { "tbody", null },
+                { "td", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "rowspan", "colspan", "align", "width" } },
+                { "tfoot", null },
+                { "th", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "rowspan", "colspan", "align", "width" } },
+                { "thead", null },
+                { "tr", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "align" } },
 
-            // other
-            { "iframe", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "frameborder", "allowtransparency", "allowfullscreen", "scrolling", "height", "src", "width" } },
-            { "center", null },
-            { "summary", null },
-            { "details", null },
-            { "nobr", null },
-            { "strike", null },
-        };
+                // other
+                {
+                    "iframe",
+                    new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        "frameborder", "allowtransparency", "allowfullscreen", "scrolling", "height", "src", "width",
+                    }
+                },
+                { "center", null },
+                { "summary", null },
+                { "details", null },
+                { "nobr", null },
+                { "strike", null },
+            };
 
         public static string TransformHtml(string html, TransformHtmlDelegate transform)
         {

--- a/src/docfx/lib/LocalizationUtility.cs
+++ b/src/docfx/lib/LocalizationUtility.cs
@@ -23,8 +23,11 @@ namespace Microsoft.Docs.Build
                     new[] { "zh-cn", "zh-tw", "zh-hk", "zh-sg", "zh-mo" }),
             StringComparer.OrdinalIgnoreCase);
 
-        private static readonly Regex s_nameWithLocale = new Regex(@"^.+?(\.[a-z]{2,4}-[a-z]{2,4}(-[a-z]{2,4})?|\.loc)?$", RegexOptions.IgnoreCase);
-        private static readonly Regex s_lrmAdjustment = new Regex(@"(^|\s|\>)(C#|F#|C\+\+)(\s*|[.!?;:]*)(\<|[\n\r]|$)", RegexOptions.IgnoreCase);
+        private static readonly Regex s_nameWithLocale =
+            new Regex(@"^.+?(\.[a-z]{2,4}-[a-z]{2,4}(-[a-z]{2,4})?|\.loc)?$", RegexOptions.IgnoreCase);
+
+        private static readonly Regex s_lrmAdjustment =
+            new Regex(@"(^|\s|\>)(C#|F#|C\+\+)(\s*|[.!?;:]*)(\<|[\n\r]|$)", RegexOptions.IgnoreCase);
 
         public static bool IsValidLocale(string locale) => s_locales.Contains(locale);
 

--- a/src/docfx/lib/UrlUtility.cs
+++ b/src/docfx/lib/UrlUtility.cs
@@ -23,7 +23,9 @@ namespace Microsoft.Docs.Build
 
         private static readonly Regex s_azureReposUrlRegex =
             new Regex(
-                @"^(https|http):\/\/((?<account1>[^\/\s]+)\.visualstudio\.com\/(?<collection>[^\/\s]+\/)?|dev\.azure\.com\/(?<account2>[^\/\s]+)\/)+(?<project>[^\/\s]+)\/_git\/(?<repository>[A-Za-z0-9_.-]+)((\/)?|(#(?<branch>\S+))?)$",
+                @"^(https|http):\/\/" +
+                @"((?<account1>[^\/\s]+)\.visualstudio\.com\/(?<collection>[^\/\s]+\/)?|dev\.azure\.com\/(?<account2>[^\/\s]+)\/)+" +
+                @"(?<project>[^\/\s]+)\/_git\/(?<repository>[A-Za-z0-9_.-]+)((\/)?|(#(?<branch>\S+))?)$",
                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly char[] s_queryFragmentLeadingChars = new char[] { '#', '?' };

--- a/src/docfx/lib/git/FileCommitProvider.cs
+++ b/src/docfx/lib/git/FileCommitProvider.cs
@@ -30,7 +30,8 @@ namespace Microsoft.Docs.Build
         // A giant memory cache of git tree. Key is the `long` form of SHA2 tree hash, value is a string id to git SHA2 hash.
         private readonly ConcurrentDictionary<long, Tree> _treeCache = new ConcurrentDictionary<long, Tree>();
 
-        private readonly ConcurrentDictionary<(string, string?), GitCommit[]> _commitHistoryCache = new ConcurrentDictionary<(string, string?), GitCommit[]>();
+        private readonly ConcurrentDictionary<(string, string?), GitCommit[]> _commitHistoryCache =
+            new ConcurrentDictionary<(string, string?), GitCommit[]>();
 
         private IntPtr _repo;
 

--- a/src/docfx/lib/git/GitCommitCache.cs
+++ b/src/docfx/lib/git/GitCommitCache.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Docs.Build
 
         // Commit history LRU cache per file (or empty for whole repo). Key is the file path relative to repository root.
         // Value is a dictionary of git commit history for a particular commit hash and file blob hash.
-        // Only the last N = MaxCommitCacheCountPerFile commit histories are cached for a file, they are selected by least recently used order (lruOrder).
+        // Only the last N = MaxCommitCacheCountPerFile commit histories are cached for a file,
+        // they are selected by least recently used order (lruOrder).
         private readonly ConcurrentDictionary<string, FileCommitCache> _commitCache;
 
         private bool _cacheUpdated;

--- a/src/docfx/lib/git/RepositoryProvider.cs
+++ b/src/docfx/lib/git/RepositoryProvider.cs
@@ -10,8 +10,11 @@ namespace Microsoft.Docs.Build
 {
     internal class RepositoryProvider : IDisposable
     {
-        private readonly ConcurrentDictionary<string, Repository?> _repositories = new ConcurrentDictionary<string, Repository?>(PathUtility.PathComparer);
-        private readonly ConcurrentDictionary<string, FileCommitProvider> _fileCommitProvidersByRepoPath = new ConcurrentDictionary<string, FileCommitProvider>();
+        private readonly ConcurrentDictionary<string, Repository?> _repositories =
+            new ConcurrentDictionary<string, Repository?>(PathUtility.PathComparer);
+
+        private readonly ConcurrentDictionary<string, FileCommitProvider> _fileCommitProvidersByRepoPath =
+            new ConcurrentDictionary<string, FileCommitProvider>();
 
         public Repository? Repository { get; }
 

--- a/src/docfx/lib/github/GitHubAccessor.cs
+++ b/src/docfx/lib/github/GitHubAccessor.cs
@@ -25,7 +25,9 @@ namespace Microsoft.Docs.Build
 
         private readonly HttpClient? _httpClient;
         private readonly SemaphoreSlim _syncRoot = new SemaphoreSlim(1, 1);
-        private readonly ConcurrentHashSet<(string owner, string name)> _unknownRepos = new ConcurrentHashSet<(string owner, string name)>();
+        private readonly ConcurrentHashSet<(string owner, string name)> _unknownRepos =
+            new ConcurrentHashSet<(string owner, string name)>();
+
         private readonly JsonDiskCache<Error, string, GitHubUser> _userCache;
 
         private volatile Error? _fatalError;

--- a/src/docfx/lib/js/ChakraCoreJsEngine.cs
+++ b/src/docfx/lib/js/ChakraCoreJsEngine.cs
@@ -22,7 +22,8 @@ namespace Microsoft.Docs.Build
         private static readonly ConcurrentBag<JavaScriptContext> s_contextPool = new ConcurrentBag<JavaScriptContext>();
 
         // Limit the maximum ChakraCore runtimes to current processor count.
-        private static readonly SemaphoreSlim s_contextThrottler = new SemaphoreSlim(Environment.ProcessorCount, Environment.ProcessorCount);
+        private static readonly SemaphoreSlim s_contextThrottler =
+            new SemaphoreSlim(Environment.ProcessorCount, Environment.ProcessorCount);
 
         private static readonly ConcurrentDictionary<(JavaScriptContext, string scriptPath), JavaScriptValue> s_scriptExports
                           = new ConcurrentDictionary<(JavaScriptContext, string scriptPath), JavaScriptValue>();
@@ -31,11 +32,13 @@ namespace Microsoft.Docs.Build
 
         private static readonly ThreadLocal<Stack<string>> t_dirnames = new ThreadLocal<Stack<string>>(() => new Stack<string>());
 
-        private static readonly ThreadLocal<Dictionary<string, JavaScriptValue>?> t_modules = new ThreadLocal<Dictionary<string, JavaScriptValue>?>();
+        private static readonly ThreadLocal<Dictionary<string, JavaScriptValue>?> t_modules =
+            new ThreadLocal<Dictionary<string, JavaScriptValue>?>();
 
         private static int s_currentSourceContext;
 
-        private readonly ConcurrentDictionary<JavaScriptContext, JavaScriptValue> _globals = new ConcurrentDictionary<JavaScriptContext, JavaScriptValue>();
+        private readonly ConcurrentDictionary<JavaScriptContext, JavaScriptValue> _globals =
+            new ConcurrentDictionary<JavaScriptContext, JavaScriptValue>();
 
         private readonly string _scriptDir;
         private readonly JObject? _global;

--- a/src/docfx/lib/json/OneOrManyConverter.cs
+++ b/src/docfx/lib/json/OneOrManyConverter.cs
@@ -12,7 +12,8 @@ namespace Microsoft.Docs.Build
 
         public override bool CanConvert(Type objectType) => objectType.IsArray;
 
-        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer) => throw new InvalidOperationException();
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+            => throw new InvalidOperationException();
 
         public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {

--- a/src/docfx/lib/json/ShortHandConverter.cs
+++ b/src/docfx/lib/json/ShortHandConverter.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Docs.Build
 
         public override bool CanConvert(Type objectType) => GetShortHandType(objectType) != null;
 
-        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer) => throw new InvalidOperationException();
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+            => throw new InvalidOperationException();
 
         public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {

--- a/src/docfx/lib/json/UnionTypeConverter.cs
+++ b/src/docfx/lib/json/UnionTypeConverter.cs
@@ -14,7 +14,8 @@ namespace Microsoft.Docs.Build
     {
         public override bool CanWrite => false;
 
-        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer) => throw new InvalidOperationException();
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+            => throw new InvalidOperationException();
 
         public override bool CanConvert(Type objectType) => typeof(ITuple).IsAssignableFrom(objectType);
 

--- a/src/docfx/lib/log/Telemetry.cs
+++ b/src/docfx/lib/log/Telemetry.cs
@@ -18,18 +18,66 @@ namespace Microsoft.Docs.Build
     internal static class Telemetry
     {
         private static readonly TelemetryClient s_telemetryClient = new TelemetryClient(TelemetryConfiguration.CreateDefault());
-        private static readonly ConcurrentDictionary<FilePath, (string, string, string)> s_fileTypeCache = new ConcurrentDictionary<FilePath, (string, string, string)>();
+        private static readonly ConcurrentDictionary<FilePath, (string, string, string)> s_fileTypeCache =
+            new ConcurrentDictionary<FilePath, (string, string, string)>();
 
         // Set value per dimension limit to int.MaxValue
         // https://github.com/microsoft/ApplicationInsights-dotnet/issues/1496
-        private static readonly MetricConfiguration s_metricConfiguration = new MetricConfiguration(1000, int.MaxValue, new MetricSeriesConfigurationForMeasurement(false));
+        private static readonly MetricConfiguration s_metricConfiguration =
+            new MetricConfiguration(1000, int.MaxValue, new MetricSeriesConfigurationForMeasurement(false));
 
-        private static readonly Metric s_operationTimeMetric = s_telemetryClient.GetMetric(new MetricIdentifier(null, $"Time", "Name", "OS", "Version", "Repo", "Branch", "CorrelationId"), s_metricConfiguration);
-        private static readonly Metric s_errorCountMetric = s_telemetryClient.GetMetric(new MetricIdentifier(null, $"BuildLog", "Code", "Level", "Name", "Type", "OS", "Version", "Repo", "Branch", "CorrelationId"), s_metricConfiguration);
-        private static readonly Metric s_buildFileTypeCountMetric = s_telemetryClient.GetMetric(new MetricIdentifier(null, "BuildFileType", "FileExtension", "DocumentType", "MimeType", "OS", "Version", "Repo", "Branch", "CorrelationId"), s_metricConfiguration);
-        private static readonly Metric s_markdownElementCountMetric = s_telemetryClient.GetMetric(new MetricIdentifier(null, "MarkdownElement", "ElementType", "FileExtension", "DocumentType", "MimeType", "OS", "Version", "Repo", "Branch", "CorrelationId"), s_metricConfiguration);
+        private static readonly Metric s_operationTimeMetric =
+            s_telemetryClient.GetMetric(
+                new MetricIdentifier(null, $"Time", "Name", "OS", "Version", "Repo", "Branch", "CorrelationId"),
+                s_metricConfiguration);
 
-        private static readonly string s_version = typeof(Telemetry).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "<null>";
+        private static readonly Metric s_errorCountMetric =
+            s_telemetryClient.GetMetric(
+                new MetricIdentifier(
+                    null,
+                    $"BuildLog",
+                    "Code",
+                    "Level",
+                    "Name",
+                    "Type",
+                    "OS",
+                    "Version",
+                    "Repo",
+                    "Branch",
+                    "CorrelationId"), s_metricConfiguration);
+
+        private static readonly Metric s_buildFileTypeCountMetric =
+            s_telemetryClient.GetMetric(
+                new MetricIdentifier(
+                    null,
+                    "BuildFileType",
+                    "FileExtension",
+                    "DocumentType",
+                    "MimeType",
+                    "OS",
+                    "Version",
+                    "Repo",
+                    "Branch",
+                    "CorrelationId"), s_metricConfiguration);
+
+        private static readonly Metric s_markdownElementCountMetric =
+            s_telemetryClient.GetMetric(
+                new MetricIdentifier(
+                    null,
+                    "MarkdownElement",
+                    "ElementType",
+                    "FileExtension",
+                    "DocumentType",
+                    "MimeType",
+                    "OS",
+                    "Version",
+                    "Repo",
+                    "Branch",
+                    "CorrelationId"), s_metricConfiguration);
+
+        private static readonly string s_version =
+            typeof(Telemetry).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "<null>";
+
         private static readonly string s_os = RuntimeInformation.OSDescription ?? "<null>";
 
         private static string s_repo = "<null>";

--- a/src/docfx/lib/moniker/MonikerList.cs
+++ b/src/docfx/lib/moniker/MonikerList.cs
@@ -14,7 +14,8 @@ namespace Microsoft.Docs.Build
     [JsonConverter(typeof(MonikerListJsonConverter))]
     internal readonly struct MonikerList : IEquatable<MonikerList>, IEnumerable<string>, IComparable<MonikerList>
     {
-        private static readonly ConcurrentDictionary<MonikerList, string> s_monikerGroupCache = new ConcurrentDictionary<MonikerList, string>();
+        private static readonly ConcurrentDictionary<MonikerList, string> s_monikerGroupCache =
+            new ConcurrentDictionary<MonikerList, string>();
 
         private readonly string[]? _monikers;
 

--- a/src/docfx/lib/moniker/MonikerRangeParser.cs
+++ b/src/docfx/lib/moniker/MonikerRangeParser.cs
@@ -10,7 +10,9 @@ namespace Microsoft.Docs.Build
 {
     internal class MonikerRangeParser
     {
-        private readonly ConcurrentDictionary<string, (List<Error>, MonikerList)> _cache = new ConcurrentDictionary<string, (List<Error>, MonikerList)>(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, (List<Error>, MonikerList)> _cache =
+            new ConcurrentDictionary<string, (List<Error>, MonikerList)>(StringComparer.OrdinalIgnoreCase);
+
         private readonly EvaluatorWithMonikersVisitor _monikersEvaluator;
 
         public MonikerRangeParser(MonikerDefinitionModel monikerDefinition)

--- a/src/docfx/lib/path/PathUtility.cs
+++ b/src/docfx/lib/path/PathUtility.cs
@@ -22,9 +22,11 @@ namespace Microsoft.Docs.Build
 
         public static readonly StringComparer PathComparer = IsCaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
 
-        public static readonly StringComparison PathComparison = IsCaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+        public static readonly StringComparison PathComparison =
+            IsCaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
 
-        private static readonly HashSet<char> s_invalidPathChars = Path.GetInvalidPathChars().Concat(Path.GetInvalidFileNameChars()).Distinct().ToHashSet();
+        private static readonly HashSet<char> s_invalidPathChars =
+            Path.GetInvalidPathChars().Concat(Path.GetInvalidFileNameChars()).Distinct().ToHashSet();
 
         /// <summary>
         /// Finds a yaml or json file under the specified location

--- a/src/docfx/lib/schema/JsonSchema.cs
+++ b/src/docfx/lib/schema/JsonSchema.cs
@@ -177,7 +177,8 @@ namespace Microsoft.Docs.Build
         //-------------------------------------------
 
         /// <summary>
-        /// Alternative name used in output HTML <meta> tag. If not set, the original metadata name is used. Does not have effect in sub schemas.
+        /// Alternative name used in output HTML <meta> tag.
+        /// If not set, the original metadata name is used. Does not have effect in sub schemas.
         /// </summary>
         public string? HtmlMetaName { get; set; }
 
@@ -208,7 +209,8 @@ namespace Microsoft.Docs.Build
         //-------------------------------------------
 
         /// <summary>
-        /// Properties that are used to indicate some attitudes are required and the value of them can't be null or white space for string type
+        /// Properties that are used to indicate some attitudes are required,
+        /// and the value of them can't be null or white space for string type
         /// </summary>
         public string[] StrictRequired { get; set; } = Array.Empty<string>();
 
@@ -263,6 +265,7 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// This field is used to provide additional error information and only can be set in root level of schema
         /// </summary>
-        public Dictionary<string, Dictionary<string, CustomRule>> CustomRules { get; } = new Dictionary<string, Dictionary<string, CustomRule>>();
+        public Dictionary<string, Dictionary<string, CustomRule>> CustomRules { get; } =
+            new Dictionary<string, Dictionary<string, CustomRule>>();
     }
 }

--- a/src/docfx/lib/schema/JsonSchemaValidator.cs
+++ b/src/docfx/lib/schema/JsonSchemaValidator.cs
@@ -18,7 +18,9 @@ namespace Microsoft.Docs.Build
         private readonly JsonSchema _schema;
         private readonly JsonSchemaDefinition _definitions;
         private readonly MicrosoftGraphAccessor? _microsoftGraphAccessor;
-        private readonly ListBuilder<(JsonSchema schema, string key, JToken value, SourceInfo? source, bool? isCanonicalVersion)> _metadataBuilder;
+        private readonly ListBuilder<(JsonSchema schema, string key, JToken value, SourceInfo? source, bool? isCanonicalVersion)>
+            _metadataBuilder;
+
         private static readonly ThreadLocal<bool?> t_isCanonicalVersion = new ThreadLocal<bool?>();
 
         public JsonSchemaValidator(JsonSchema schema, MicrosoftGraphAccessor? microsoftGraphAccessor = null, bool forceError = false)

--- a/src/docfx/publish/PublishModelBuilder.cs
+++ b/src/docfx/publish/PublishModelBuilder.cs
@@ -19,7 +19,8 @@ namespace Microsoft.Docs.Build
         private readonly DocumentProvider _documentProvider;
         private readonly SourceMap _sourceMap;
 
-        private ConcurrentDictionary<FilePath, (JObject? metadata, string? outputPath)> _buildOutput = new ConcurrentDictionary<FilePath, (JObject? metadata, string? outputPath)>();
+        private ConcurrentDictionary<FilePath, (JObject? metadata, string? outputPath)> _buildOutput =
+            new ConcurrentDictionary<FilePath, (JObject? metadata, string? outputPath)>();
 
         public PublishModelBuilder(
             Config config,

--- a/src/docfx/restore/PackageResolver.cs
+++ b/src/docfx/restore/PackageResolver.cs
@@ -18,8 +18,11 @@ namespace Microsoft.Docs.Build
         private readonly PreloadConfig _config;
         private readonly FetchOptions _fetchOptions;
 
-        private readonly ConcurrentDictionary<PackagePath, Lazy<string>> _packagePath = new ConcurrentDictionary<PackagePath, Lazy<string>>();
-        private readonly Dictionary<PathString, InterProcessReaderWriterLock> _gitReaderLocks = new Dictionary<PathString, InterProcessReaderWriterLock>();
+        private readonly ConcurrentDictionary<PackagePath, Lazy<string>> _packagePath =
+            new ConcurrentDictionary<PackagePath, Lazy<string>>();
+
+        private readonly Dictionary<PathString, InterProcessReaderWriterLock> _gitReaderLocks =
+            new Dictionary<PathString, InterProcessReaderWriterLock>();
 
         public PackageResolver(string docsetPath, PreloadConfig config, FetchOptions fetchOptions)
         {

--- a/src/docfx/template/MustacheTemplate.cs
+++ b/src/docfx/template/MustacheTemplate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -22,7 +22,8 @@ namespace Microsoft.Docs.Build
         private readonly JObject? _global;
         private readonly string _templateDir;
         private readonly ParserPipeline _parserPipeline;
-        private readonly ConcurrentDictionary<string, Lazy<BlockToken>> _templates = new ConcurrentDictionary<string, Lazy<BlockToken>>(PathUtility.PathComparer);
+        private readonly ConcurrentDictionary<string, Lazy<BlockToken>> _templates =
+            new ConcurrentDictionary<string, Lazy<BlockToken>>(PathUtility.PathComparer);
 
         public MustacheTemplate(string templateDir, JObject? global = null)
         {


### PR DESCRIPTION
[AB#107202](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/107202)

Changes:
- Fix Code Style Violation of Rule MEN002 for member variables and member functions which only have one line: 
  - for long member variable declarations with initialization, try put the default initializer to a new line

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6144)