### PR TITLE
Fix Code Style Violation of Rule MEN002 for Method Definitions

### DIFF
--- a/azure-pipelines-v3.yml
+++ b/azure-pipelines-v3.yml
@@ -104,17 +104,6 @@ jobs:
       nugetFeedType: external
       allowPackageConflicts: true
 
-  # Publish binary packages to sandbox
-  - task: AzureFileCopy@3
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/v3'))
-    displayName: Publish Binary Packages To Sandbox
-    inputs:
-      azureSubscription: Open Publishing - Build Sandbox
-      sourcePath: drop/docfx-bin/staging
-      destination: AzureBlob
-      storage: opbuildstoragesandbox
-      containerName: docfx-bin
-
   # Publish binary packages to production
   - task: AzureFileCopy@3
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/v3-release'))

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -72,7 +72,13 @@ namespace Microsoft.Docs.Build
 
         public JsonSchemaTransformer JsonSchemaTransformer { get; }
 
-        public Context(ErrorLog errorLog, Config config, BuildOptions buildOptions, PackageResolver packageResolver, FileResolver fileResolver, SourceMap sourceMap)
+        public Context(
+            ErrorLog errorLog,
+            Config config,
+            BuildOptions buildOptions,
+            PackageResolver packageResolver,
+            FileResolver fileResolver,
+            SourceMap sourceMap)
         {
             DependencyMapBuilder = new DependencyMapBuilder(sourceMap);
 

--- a/src/docfx/build/context/Input.cs
+++ b/src/docfx/build/context/Input.cs
@@ -24,8 +24,12 @@ namespace Microsoft.Docs.Build
         private readonly BuildOptions _buildOptions;
         private readonly PackageResolver _packageResolver;
         private readonly RepositoryProvider _repositoryProvider;
-        private readonly ConcurrentDictionary<FilePath, (List<Error>, JToken)> _jsonTokenCache = new ConcurrentDictionary<FilePath, (List<Error>, JToken)>();
-        private readonly ConcurrentDictionary<FilePath, (List<Error>, JToken)> _yamlTokenCache = new ConcurrentDictionary<FilePath, (List<Error>, JToken)>();
+        private readonly ConcurrentDictionary<FilePath, (List<Error>, JToken)> _jsonTokenCache =
+            new ConcurrentDictionary<FilePath, (List<Error>, JToken)>();
+
+        private readonly ConcurrentDictionary<FilePath, (List<Error>, JToken)> _yamlTokenCache =
+            new ConcurrentDictionary<FilePath, (List<Error>, JToken)>();
+
         private readonly ConcurrentDictionary<PathString, byte[]?> _gitBlobCache = new ConcurrentDictionary<PathString, byte[]?>();
         private readonly ConcurrentDictionary<FilePath, JToken> _generatedContents = new ConcurrentDictionary<FilePath, JToken>();
         private readonly PathString? _alternativeFallbackFolder;

--- a/src/docfx/build/context/Output.cs
+++ b/src/docfx/build/context/Output.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Docs.Build
             _queue.Completion.Wait();
         }
 
-        private string GetDestinationPath(string destRelativePath)
+        public string GetDestinationPath(string destRelativePath)
         {
             Debug.Assert(!Path.IsPathRooted(destRelativePath));
 

--- a/src/docfx/build/legacy/LegacyDependencyMap.cs
+++ b/src/docfx/build/legacy/LegacyDependencyMap.cs
@@ -48,10 +48,13 @@ namespace Microsoft.Docs.Build
                         version = dep.Version,
                     });
 
-                var dependencyListText = string.Join('\n', dependencyList);
-
-                context.Output.WriteText("full-dependent-list.txt", dependencyListText);
-                context.Output.WriteText("server-side-dependent-list.txt", dependencyListText);
+                using var dependentListWriter = File.AppendText(context.Output.GetDestinationPath("full-dependent-list.txt"));
+                using var serverDependentListWriter = File.AppendText(context.Output.GetDestinationPath("server-side-dependent-list.txt"));
+                foreach (var dependency in dependencyList)
+                {
+                    dependentListWriter.WriteLine(dependency);
+                    serverDependentListWriter.WriteLine(dependency);
+                }
 
                 return sorted.Select(x => new LegacyDependencyMapItem(x.From.Substring(2), x.To.Substring(2), x.Version, x.Type))
                              .GroupBy(x => x.From)

--- a/src/docfx/build/legacy/manifest/LegacyManifest.cs
+++ b/src/docfx/build/legacy/manifest/LegacyManifest.cs
@@ -54,7 +54,12 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static void ConvertDocumentToLegacyManifestItem(string docsetPath, Context context, KeyValuePair<Document, PublishItem> fileManifest, DictionaryBuilder<string, MonikerList> dictionaryBuilder, ListBuilder<(LegacyManifestItem manifestItem, Document doc, MonikerList monikers)> listBuilder)
+        private static void ConvertDocumentToLegacyManifestItem(
+            string docsetPath,
+            Context context,
+            KeyValuePair<Document, PublishItem> fileManifest,
+            DictionaryBuilder<string, MonikerList> dictionaryBuilder,
+            ListBuilder<(LegacyManifestItem manifestItem, Document doc, MonikerList monikers)> listBuilder)
         {
             var document = fileManifest.Key;
             var legacyOutputPathRelativeToBasePath = document.ToLegacyOutputPathRelativeToBasePath(context, fileManifest.Value);

--- a/src/docfx/build/link/LinkResolver.cs
+++ b/src/docfx/build/link/LinkResolver.cs
@@ -61,7 +61,8 @@ namespace Microsoft.Docs.Build
             return (error, file);
         }
 
-        public (Error? error, string link, Document? file) ResolveLink(SourceInfo<string> href, Document referencingFile, Document inclusionRoot)
+        public (Error? error, string link, Document? file) ResolveLink(
+            SourceInfo<string> href, Document referencingFile, Document inclusionRoot)
         {
             if (href.Value.StartsWith("xref:"))
             {
@@ -100,8 +101,8 @@ namespace Microsoft.Docs.Build
             return (error, link, file);
         }
 
-        private (Error? error, string href, string? fragment, LinkType linkType, Document? file, bool isCrossReference) TryResolveAbsoluteLink(
-            SourceInfo<string> href, Document hrefRelativeTo)
+        private (Error? error, string href, string? fragment, LinkType linkType, Document? file, bool isCrossReference)
+            TryResolveAbsoluteLink(SourceInfo<string> href, Document hrefRelativeTo)
         {
             var decodedHref = new SourceInfo<string>(Uri.UnescapeDataString(href), href);
             var (error, file, query, fragment, linkType) = TryResolveFile(hrefRelativeTo, decodedHref);

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -22,7 +22,12 @@ namespace Microsoft.Docs.Build
         private readonly ConcurrentDictionary<FilePath, (string?, string?, string?)> _gitUrls = new ConcurrentDictionary<FilePath, (string?, string?, string?)>();
 
         public ContributionProvider(
-            Config config, BuildOptions buildOptions, Input input, GitHubAccessor githubAccessor, RepositoryProvider repositoryProvider, SourceMap sourceMap)
+            Config config,
+            BuildOptions buildOptions,
+            Input input,
+            GitHubAccessor githubAccessor,
+            RepositoryProvider repositoryProvider,
+            SourceMap sourceMap)
         {
             _input = input;
             _config = config;

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -15,11 +15,14 @@ namespace Microsoft.Docs.Build
         private readonly Config _config;
         private readonly GitHubAccessor _githubAccessor;
         private readonly BuildOptions _buildOptions;
-        private readonly ConcurrentDictionary<string, Lazy<CommitBuildTimeProvider>> _commitBuildTimeProviders = new ConcurrentDictionary<string, Lazy<CommitBuildTimeProvider>>(PathUtility.PathComparer);
+        private readonly ConcurrentDictionary<string, Lazy<CommitBuildTimeProvider>> _commitBuildTimeProviders =
+            new ConcurrentDictionary<string, Lazy<CommitBuildTimeProvider>>(PathUtility.PathComparer);
+
         private readonly RepositoryProvider _repositoryProvider;
         private readonly SourceMap _sourceMap;
 
-        private readonly ConcurrentDictionary<FilePath, (string?, string?, string?)> _gitUrls = new ConcurrentDictionary<FilePath, (string?, string?, string?)>();
+        private readonly ConcurrentDictionary<FilePath, (string?, string?, string?)> _gitUrls =
+            new ConcurrentDictionary<FilePath, (string?, string?, string?)>();
 
         public ContributionProvider(
             Config config,

--- a/src/docfx/build/moniker/MonikerProvider.cs
+++ b/src/docfx/build/moniker/MonikerProvider.cs
@@ -139,7 +139,12 @@ namespace Microsoft.Docs.Build
             return (errors, configMonikers);
         }
 
-        private static (Error?, MonikerList) GetMonikerIntersection(UserMetadata metadata, SourceInfo<string?> configMonikerRange, MonikerList configMonikers, MonikerList fileMonikers, bool skipMonikerValidation)
+        private static (Error?, MonikerList) GetMonikerIntersection(
+            UserMetadata metadata,
+            SourceInfo<string?> configMonikerRange,
+            MonikerList configMonikers,
+            MonikerList fileMonikers,
+            bool skipMonikerValidation)
         {
             Error? error = null;
 

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -122,7 +122,8 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static (List<Error> errors, object output, JObject metadata) CreateDataOutput(Context context, Document file, JObject sourceModel)
+        private static (List<Error> errors, object output, JObject metadata) CreateDataOutput(
+            Context context, Document file, JObject sourceModel)
         {
             if (context.Config.DryRun)
             {
@@ -246,7 +247,8 @@ namespace Microsoft.Docs.Build
             return LoadSchemaDocument(context, errors, token, file);
         }
 
-        private static (List<Error> errors, JObject model) LoadSchemaDocument(Context context, List<Error> errors, JToken token, Document file)
+        private static (List<Error> errors, JObject model) LoadSchemaDocument(
+            Context context, List<Error> errors, JToken token, Document file)
         {
             var schemaTemplate = context.TemplateEngine.GetSchema(file.Mime);
 

--- a/src/docfx/build/redirection/RedirectionProvider.cs
+++ b/src/docfx/build/redirection/RedirectionProvider.cs
@@ -17,7 +17,8 @@ namespace Microsoft.Docs.Build
         private readonly Lazy<PublishUrlMap> _publishUrlMap;
 
         private readonly IReadOnlyDictionary<FilePath, string> _redirectUrls;
-        private readonly Lazy<(IReadOnlyDictionary<FilePath, FilePath> renameHistory, IReadOnlyDictionary<FilePath, (FilePath, SourceInfo?)> redirectionHistory)> _history;
+        private readonly Lazy<(IReadOnlyDictionary<FilePath, FilePath> renameHistory,
+            IReadOnlyDictionary<FilePath, (FilePath, SourceInfo?)> redirectionHistory)> _history;
 
         public IEnumerable<FilePath> Files => _redirectUrls.Keys;
 

--- a/src/docfx/build/redirection/RedirectionProvider.cs
+++ b/src/docfx/build/redirection/RedirectionProvider.cs
@@ -192,8 +192,8 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private (IReadOnlyDictionary<FilePath, FilePath>, IReadOnlyDictionary<FilePath, (FilePath, SourceInfo?)>) GetRenameAndRedirectionHistory(
-            RedirectionItem[] redirections, IReadOnlyDictionary<FilePath, string> redirectUrls)
+        private (IReadOnlyDictionary<FilePath, FilePath>, IReadOnlyDictionary<FilePath, (FilePath, SourceInfo?)>)
+            GetRenameAndRedirectionHistory(RedirectionItem[] redirections, IReadOnlyDictionary<FilePath, string> redirectUrls)
         {
             // Convert the redirection target from redirect url to file path according to the version of redirect source
             var renameHistory = new Dictionary<FilePath, FilePath>();

--- a/src/docfx/build/toc/TableOfContentsLoader.cs
+++ b/src/docfx/build/toc/TableOfContentsLoader.cs
@@ -252,7 +252,10 @@ namespace Microsoft.Docs.Build
             return default;
         }
 
-        private (SourceInfo<string?> resolvedTocHref, TableOfContentsNode? subChildren, TableOfContentsNode? subChildrenFirstItem, TocHrefType tocHrefType)
+        private (SourceInfo<string?> resolvedTocHref,
+            TableOfContentsNode? subChildren,
+            TableOfContentsNode? subChildrenFirstItem,
+            TocHrefType tocHrefType)
             ProcessTocHref(
                 Document filePath,
                 Document rootPath,

--- a/src/docfx/build/toc/TableOfContentsLoader.cs
+++ b/src/docfx/build/toc/TableOfContentsLoader.cs
@@ -26,9 +26,11 @@ namespace Microsoft.Docs.Build
                      new ConcurrentDictionary<FilePath, (List<Error>, TableOfContentsNode, List<Document>, List<Document>)>();
 
         private static readonly string[] s_tocFileNames = new[] { "TOC.md", "TOC.json", "TOC.yml" };
-        private static readonly string[] s_experimentalTocFileNames = new[] { "TOC.experimental.md", "TOC.experimental.json", "TOC.experimental.yml" };
+        private static readonly string[] s_experimentalTocFileNames =
+            new[] { "TOC.experimental.md", "TOC.experimental.json", "TOC.experimental.yml" };
 
-        private static AsyncLocal<ImmutableStack<Document>> t_recursionDetector = new AsyncLocal<ImmutableStack<Document>> { Value = ImmutableStack<Document>.Empty };
+        private static AsyncLocal<ImmutableStack<Document>> t_recursionDetector =
+            new AsyncLocal<ImmutableStack<Document>> { Value = ImmutableStack<Document>.Empty };
 
         public TableOfContentsLoader(
             LinkResolver linkResolver,

--- a/src/docfx/build/toc/TableOfContentsMap.cs
+++ b/src/docfx/build/toc/TableOfContentsMap.cs
@@ -27,7 +27,14 @@ namespace Microsoft.Docs.Build
         private readonly Lazy<(Dictionary<Document, Document[]> tocToTocs, Dictionary<Document, Document[]> docToTocs)> _tocs;
 
         public TableOfContentsMap(
-            ErrorLog errorLog, Input input, BuildScope buildScope, DependencyMapBuilder dependencyMapBuilder, TableOfContentsParser tocParser, TableOfContentsLoader tocLoader, DocumentProvider documentProvider, ContentValidator contentValidator)
+            ErrorLog errorLog,
+            Input input,
+            BuildScope buildScope,
+            DependencyMapBuilder dependencyMapBuilder,
+            TableOfContentsParser tocParser,
+            TableOfContentsLoader tocLoader,
+            DocumentProvider documentProvider,
+            ContentValidator contentValidator)
         {
             _errorLog = errorLog;
             _input = input;
@@ -88,7 +95,8 @@ namespace Microsoft.Docs.Build
         /// 2. parent nearest(based on file path)
         /// 3. sub-name lexicographical nearest
         /// </summary>
-        internal static (T? toc, bool hasReferencedTocs) FindNearestToc<T>(T file, IEnumerable<T> tocs, Dictionary<T, T[]> documentsToTocs, Func<T, string> getPath) where T : class, IComparable<T>
+        internal static (T? toc, bool hasReferencedTocs) FindNearestToc<T>(
+            T file, IEnumerable<T> tocs, Dictionary<T, T[]> documentsToTocs, Func<T, string> getPath) where T : class, IComparable<T>
         {
             var hasReferencedTocs = false;
             var filteredTocs = (hasReferencedTocs = documentsToTocs.TryGetValue(file, out var referencedTocFiles)) ? referencedTocFiles : tocs;

--- a/src/docfx/build/xref/ExternalXrefMapLoader.cs
+++ b/src/docfx/build/xref/ExternalXrefMapLoader.cs
@@ -74,7 +74,8 @@ namespace Microsoft.Docs.Build
             return result;
         }
 
-        private static void LoadZipFile(Dictionary<string, Lazy<ExternalXrefSpec>> result, FilePath path, string physicalPath, ErrorLog errorLog)
+        private static void LoadZipFile(
+            Dictionary<string, Lazy<ExternalXrefSpec>> result, FilePath path, string physicalPath, ErrorLog errorLog)
         {
             using var stream = File.OpenRead(physicalPath);
             using var archive = new ZipArchive(stream);

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -143,7 +143,8 @@ namespace Microsoft.Docs.Build
         /// Gets the file metadata added to each document.
         /// It is a map of `{metadata-name} -> {glob} -> {metadata-value}`
         /// </summary>
-        public Dictionary<string, SourceInfo<Dictionary<string, JToken>>> FileMetadata { get; } = new Dictionary<string, SourceInfo<Dictionary<string, JToken>>>();
+        public Dictionary<string, SourceInfo<Dictionary<string, JToken>>> FileMetadata { get; } =
+            new Dictionary<string, SourceInfo<Dictionary<string, JToken>>>();
 
         /// <summary>
         /// Gets a map from source folder path and output URL path.

--- a/src/docfx/config/ConfigLoader.cs
+++ b/src/docfx/config/ConfigLoader.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Docs.Build
             _errorLog = errorLog;
         }
 
-        public static (List<Error> errors, (string docsetPath, string? outputPath)[]) FindDocsets(string workingDirectory, CommandLineOptions options)
+        public static (List<Error> errors, (string docsetPath, string? outputPath)[]) FindDocsets(
+            string workingDirectory, CommandLineOptions options)
         {
             var (errors, glob) = FindDocsetsGlob(workingDirectory);
             if (glob is null)
@@ -56,7 +57,8 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Load the config under <paramref name="docsetPath"/>
         /// </summary>
-        public (List<Error>, Config, BuildOptions, PackageResolver, FileResolver) Load(DisposableCollector disposables, string docsetPath, string? outputPath, CommandLineOptions options, FetchOptions fetchOptions)
+        public (List<Error>, Config, BuildOptions, PackageResolver, FileResolver) Load(
+            DisposableCollector disposables, string docsetPath, string? outputPath, CommandLineOptions options, FetchOptions fetchOptions)
         {
             // load and trace entry repository
             var repository = Repository.Create(docsetPath);
@@ -133,7 +135,13 @@ namespace Microsoft.Docs.Build
         }
 
         private JObject DownloadExtendConfig(
-            List<Error> errors, string? locale, PreloadConfig config, string? xrefEndpoint, string[]? xrefQueryTags, Repository? repository, FileResolver fileResolver)
+            List<Error> errors,
+            string? locale,
+            PreloadConfig config,
+            string? xrefEndpoint,
+            string[]? xrefQueryTags,
+            Repository? repository,
+            FileResolver fileResolver)
         {
             var result = new JObject();
             var extendQuery =

--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Docs.Build
         private static readonly Lazy<SecretClient> s_secretClient = new Lazy<SecretClient>(()
             => new SecretClient(new Uri(s_keyVaultEndPoint), new DefaultAzureCredential()));
 
-        private static readonly Lazy<Task<Response<KeyVaultSecret>>> s_opBuildUserToken = new Lazy<Task<Response<KeyVaultSecret>>>(() => s_secretClient.Value.GetSecretAsync("opBuildUserToken"));
+        private static readonly Lazy<Task<Response<KeyVaultSecret>>> s_opBuildUserToken =
+            new Lazy<Task<Response<KeyVaultSecret>>>(() => s_secretClient.Value.GetSecretAsync("opBuildUserToken"));
 
         private readonly Action<HttpRequestMessage> _credentialProvider;
         private readonly ErrorLog _errorLog;
@@ -355,9 +356,9 @@ namespace Microsoft.Docs.Build
         private static string ValidationServiceEndpoint => s_docsEnvironment switch
         {
             DocsEnvironment.Prod => "https://op-build-prod.azurewebsites.net/route/validationmgt",
-            DocsEnvironment.Internal => "https://op-build-sandbox2.azurewebsites.net/route/validationmgt",
+            DocsEnvironment.Internal => "https://op-build-internal.azurewebsites.net/route/validationmgt",
             DocsEnvironment.PPE => "https://op-build-sandbox2.azurewebsites.net/route/validationmgt",
-            DocsEnvironment.Perf => "https://op-build-sandbox2.azurewebsites.net/route/validationmgt",
+            DocsEnvironment.Perf => "https://op-build-perf.azurewebsites.net/route/validationmgt",
             _ => throw new NotSupportedException(),
         };
     }

--- a/src/docfx/config/ops/OpsConfigLoader.cs
+++ b/src/docfx/config/ops/OpsConfigLoader.cs
@@ -24,7 +24,8 @@ namespace Microsoft.Docs.Build
             return JsonUtility.Deserialize<OpsConfig>(File.ReadAllText(fullPath), filePath);
         }
 
-        public static (List<Error> errors, string? xrefEndpoint, string[]? xrefQueryTags, JObject? config) LoadDocfxConfig(string docsetPath, Repository? repository)
+        public static (List<Error> errors, string? xrefEndpoint, string[]? xrefQueryTags, JObject? config) LoadDocfxConfig(
+            string docsetPath, Repository? repository)
         {
             if (repository is null)
             {
@@ -42,7 +43,8 @@ namespace Microsoft.Docs.Build
             return (errors, xrefEndpoint, xrefQueryTags, config);
         }
 
-        private static (string? xrefEndpoint, string[]? xrefQueryTags, JObject config) ToDocfxConfig(string branch, OpsConfig opsConfig, PathString buildSourceFolder)
+        private static (string? xrefEndpoint, string[]? xrefQueryTags, JObject config) ToDocfxConfig(
+            string branch, OpsConfig opsConfig, PathString buildSourceFolder)
         {
             var result = new JObject();
             var dependencies = GetDependencies(opsConfig, branch, buildSourceFolder);

--- a/src/docfx/config/ops/OpsMetadataRuleConverter.cs
+++ b/src/docfx/config/ops/OpsMetadataRuleConverter.cs
@@ -114,7 +114,8 @@ namespace Microsoft.Docs.Build
             return jsonSchema;
         }
 
-        private static bool TryGetAttributeCustomRules(Dictionary<string, OpsMetadataRule> rulesInfo, out Dictionary<string, dynamic> attributeCustomRules)
+        private static bool TryGetAttributeCustomRules(
+            Dictionary<string, OpsMetadataRule> rulesInfo, out Dictionary<string, dynamic> attributeCustomRules)
         {
             attributeCustomRules = new Dictionary<string, dynamic>();
 
@@ -157,7 +158,8 @@ namespace Microsoft.Docs.Build
             return attributeCustomRules.Count != 0;
         }
 
-        private static bool TryGetAllowlist(string parentName, string? listId, Allowlists allowlists, int index, out Dictionary<string, EnumDependenciesSchema?> allowList)
+        private static bool TryGetAllowlist(
+            string parentName, string? listId, Allowlists allowlists, int index, out Dictionary<string, EnumDependenciesSchema?> allowList)
         {
             allowList = new Dictionary<string, EnumDependenciesSchema?>();
 

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Azure.Identity" Version="1.2.0-preview.1" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.3" />
     <PackageReference Include="docs.validation" Version="1.0.0-beta-00141-21b1204" />
-    <PackageReference Include="DotLiquid" Version="2.0.358" />
+    <PackageReference Include="DotLiquid" Version="2.0.361" />
     <PackageReference Include="Glob" Version="1.1.6" />
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.298" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.14.0" />

--- a/src/docfx/lib/HtmlUtility.cs
+++ b/src/docfx/lib/HtmlUtility.cs
@@ -180,7 +180,11 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public static void TransformXref(ref HtmlReader reader, ref HtmlToken token, MarkdownObject? block, Func<SourceInfo<string>?, SourceInfo<string>?, bool, (string? href, string display)> resolveXref)
+        public static void TransformXref(
+            ref HtmlReader reader,
+            ref HtmlToken token,
+            MarkdownObject? block,
+            Func<SourceInfo<string>?, SourceInfo<string>?, bool, (string? href, string display)> resolveXref)
         {
             if (!token.NameIs("xref"))
             {
@@ -234,7 +238,8 @@ namespace Microsoft.Docs.Build
             token = new HtmlToken(resolvedNode);
         }
 
-        public static string CreateHtmlMetaTags(JObject metadata, ICollection<string> htmlMetaHidden, IReadOnlyDictionary<string, string> htmlMetaNames)
+        public static string CreateHtmlMetaTags(
+            JObject metadata, ICollection<string> htmlMetaHidden, IReadOnlyDictionary<string, string> htmlMetaNames)
         {
             var result = new StringBuilder();
 

--- a/src/docfx/lib/HtmlUtility.cs
+++ b/src/docfx/lib/HtmlUtility.cs
@@ -23,81 +23,88 @@ namespace Microsoft.Docs.Build
         };
 
         // ref https://developer.mozilla.org/en-US/docs/Web/HTML/Element
-        private static readonly Dictionary<string, HashSet<string>?> s_allowedTagAttributeMap = new Dictionary<string, HashSet<string>?>(StringComparer.OrdinalIgnoreCase)
-        {
-            // Content sectioning
-            { "address", null },
-            { "section", null },
+        private static readonly Dictionary<string, HashSet<string>?> s_allowedTagAttributeMap =
+            new Dictionary<string, HashSet<string>?>(StringComparer.OrdinalIgnoreCase)
+            {
+                // Content sectioning
+                { "address", null },
+                { "section", null },
 
-            // Text content
-            { "blockquote", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "cite" } },
-            { "dd", null },
-            { "div", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "align" } },
-            { "dl", null },
-            { "dt", null },
-            { "figcaption", null },
-            { "figure", null },
-            { "hr", null },
-            { "li", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "value" } },
-            { "ol", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "reversed", "start", "type" } },
-            { "p", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "align" } },
-            { "pre", null },
-            { "ul", null },
+                // Text content
+                { "blockquote", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "cite" } },
+                { "dd", null },
+                { "div", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "align" } },
+                { "dl", null },
+                { "dt", null },
+                { "figcaption", null },
+                { "figure", null },
+                { "hr", null },
+                { "li", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "value" } },
+                { "ol", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "reversed", "start", "type" } },
+                { "p", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "align" } },
+                { "pre", null },
+                { "ul", null },
 
-            // Inline text semantics
-            { "a", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "href", "target", "rel" } },
-            { "abbr", null },
-            { "b", null },
-            { "bdi", null },
-            { "bdo", null },
-            { "br", null },
-            { "cite", null },
-            { "code", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "name" } },
-            { "dfn", null },
-            { "em", null },
-            { "i", null },
-            { "kbd", null },
-            { "mark", null },
-            { "q", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "cite" } },
-            { "s", null },
-            { "samp", null },
-            { "small", null },
-            { "span", null },
-            { "strong", null },
-            { "sub", null },
-            { "sup", null },
-            { "time", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "datetime" } },
-            { "u", null },
-            { "var", null },
+                // Inline text semantics
+                { "a", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "href", "target", "rel" } },
+                { "abbr", null },
+                { "b", null },
+                { "bdi", null },
+                { "bdo", null },
+                { "br", null },
+                { "cite", null },
+                { "code", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "name" } },
+                { "dfn", null },
+                { "em", null },
+                { "i", null },
+                { "kbd", null },
+                { "mark", null },
+                { "q", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "cite" } },
+                { "s", null },
+                { "samp", null },
+                { "small", null },
+                { "span", null },
+                { "strong", null },
+                { "sub", null },
+                { "sup", null },
+                { "time", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "datetime" } },
+                { "u", null },
+                { "var", null },
 
-            // Image and multimedia
-            { "img", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "alt", "height", "src", "width", "align" } },
-            { "image", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "alt", "height", "src", "width" } },
+                // Image and multimedia
+                { "img", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "alt", "height", "src", "width", "align" } },
+                { "image", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "alt", "height", "src", "width" } },
 
-            // Demarcating edits
-            { "del", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "cite", "datetime" } },
-            { "ins", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "cite", "datetime" } },
+                // Demarcating edits
+                { "del", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "cite", "datetime" } },
+                { "ins", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "cite", "datetime" } },
 
-            // table
-            { "caption", null },
-            { "col", null },
-            { "colgroup", null },
-            { "table", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "align", "width", "border" } },
-            { "tbody", null },
-            { "td", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "rowspan", "colspan", "align", "width" } },
-            { "tfoot", null },
-            { "th", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "rowspan", "colspan", "align", "width" } },
-            { "thead", null },
-            { "tr", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "align" } },
+                // table
+                { "caption", null },
+                { "col", null },
+                { "colgroup", null },
+                { "table", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "align", "width", "border" } },
+                { "tbody", null },
+                { "td", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "rowspan", "colspan", "align", "width" } },
+                { "tfoot", null },
+                { "th", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "rowspan", "colspan", "align", "width" } },
+                { "thead", null },
+                { "tr", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "align" } },
 
-            // other
-            { "iframe", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "frameborder", "allowtransparency", "allowfullscreen", "scrolling", "height", "src", "width" } },
-            { "center", null },
-            { "summary", null },
-            { "details", null },
-            { "nobr", null },
-            { "strike", null },
-        };
+                // other
+                {
+                    "iframe",
+                    new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        "frameborder", "allowtransparency", "allowfullscreen", "scrolling", "height", "src", "width",
+                    }
+                },
+                { "center", null },
+                { "summary", null },
+                { "details", null },
+                { "nobr", null },
+                { "strike", null },
+            };
 
         public static string TransformHtml(string html, TransformHtmlDelegate transform)
         {

--- a/src/docfx/lib/LocalizationUtility.cs
+++ b/src/docfx/lib/LocalizationUtility.cs
@@ -23,8 +23,11 @@ namespace Microsoft.Docs.Build
                     new[] { "zh-cn", "zh-tw", "zh-hk", "zh-sg", "zh-mo" }),
             StringComparer.OrdinalIgnoreCase);
 
-        private static readonly Regex s_nameWithLocale = new Regex(@"^.+?(\.[a-z]{2,4}-[a-z]{2,4}(-[a-z]{2,4})?|\.loc)?$", RegexOptions.IgnoreCase);
-        private static readonly Regex s_lrmAdjustment = new Regex(@"(^|\s|\>)(C#|F#|C\+\+)(\s*|[.!?;:]*)(\<|[\n\r]|$)", RegexOptions.IgnoreCase);
+        private static readonly Regex s_nameWithLocale =
+            new Regex(@"^.+?(\.[a-z]{2,4}-[a-z]{2,4}(-[a-z]{2,4})?|\.loc)?$", RegexOptions.IgnoreCase);
+
+        private static readonly Regex s_lrmAdjustment =
+            new Regex(@"(^|\s|\>)(C#|F#|C\+\+)(\s*|[.!?;:]*)(\<|[\n\r]|$)", RegexOptions.IgnoreCase);
 
         public static bool IsValidLocale(string locale) => s_locales.Contains(locale);
 

--- a/src/docfx/lib/LocalizationUtility.cs
+++ b/src/docfx/lib/LocalizationUtility.cs
@@ -145,7 +145,8 @@ namespace Microsoft.Docs.Build
             return false;
         }
 
-        private static bool TryRemoveLocale(string name, [NotNullWhen(true)] out string? nameWithoutLocale, [NotNullWhen(true)] out string? locale)
+        private static bool TryRemoveLocale(
+            string name, [NotNullWhen(true)] out string? nameWithoutLocale, [NotNullWhen(true)] out string? locale)
         {
             var match = s_nameWithLocale.Match(name);
             if (match.Success && match.Groups.Count >= 2 && !string.IsNullOrEmpty(match.Groups[1].Value))

--- a/src/docfx/lib/StringUtility.cs
+++ b/src/docfx/lib/StringUtility.cs
@@ -54,7 +54,8 @@ namespace Microsoft.Docs.Build
         /// <returns>
         ///     if a match is found, return true and assign it to <paramref name="bestMatch"/>, otherwise return false.
         /// </returns>
-        public static bool FindBestMatch(string target, IEnumerable<string> candidates, [NotNullWhen(true)] out string? bestMatch, int threshold = 5)
+        public static bool FindBestMatch(
+            string target, IEnumerable<string> candidates, [NotNullWhen(true)] out string? bestMatch, int threshold = 5)
         {
             bestMatch = candidates != null ?
                     (from candidate in candidates

--- a/src/docfx/lib/UrlUtility.cs
+++ b/src/docfx/lib/UrlUtility.cs
@@ -23,7 +23,9 @@ namespace Microsoft.Docs.Build
 
         private static readonly Regex s_azureReposUrlRegex =
             new Regex(
-                @"^(https|http):\/\/((?<account1>[^\/\s]+)\.visualstudio\.com\/(?<collection>[^\/\s]+\/)?|dev\.azure\.com\/(?<account2>[^\/\s]+)\/)+(?<project>[^\/\s]+)\/_git\/(?<repository>[A-Za-z0-9_.-]+)((\/)?|(#(?<branch>\S+))?)$",
+                @"^(https|http):\/\/" +
+                @"((?<account1>[^\/\s]+)\.visualstudio\.com\/(?<collection>[^\/\s]+\/)?|dev\.azure\.com\/(?<account2>[^\/\s]+)\/)+" +
+                @"(?<project>[^\/\s]+)\/_git\/(?<repository>[A-Za-z0-9_.-]+)((\/)?|(#(?<branch>\S+))?)$",
                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly char[] s_queryFragmentLeadingChars = new char[] { '#', '?' };

--- a/src/docfx/lib/cache/JsonDiskCache.cs
+++ b/src/docfx/lib/cache/JsonDiskCache.cs
@@ -27,7 +27,11 @@ namespace Microsoft.Docs.Build
 
         private volatile bool _needUpdate;
 
-        public JsonDiskCache(string cachePath, TimeSpan expiration, IEqualityComparer<TKey>? comparer = null, Func<TValue, TValue, TValue>? resolveConflict = null)
+        public JsonDiskCache(
+            string cachePath,
+            TimeSpan expiration,
+            IEqualityComparer<TKey>? comparer = null,
+            Func<TValue, TValue, TValue>? resolveConflict = null)
         {
             comparer ??= EqualityComparer<TKey>.Default;
             _resolveConflict = resolveConflict;

--- a/src/docfx/lib/collections/CollectionUtility.cs
+++ b/src/docfx/lib/collections/CollectionUtility.cs
@@ -15,7 +15,8 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public static void AddRange<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, IDictionary<TKey, TValue> range) where TKey : notnull
+        public static void AddRange<TKey, TValue>(
+            this IDictionary<TKey, TValue> dictionary, IDictionary<TKey, TValue> range) where TKey : notnull
         {
             foreach (var (key, value) in range)
             {

--- a/src/docfx/lib/git/FileCommitProvider.cs
+++ b/src/docfx/lib/git/FileCommitProvider.cs
@@ -30,7 +30,8 @@ namespace Microsoft.Docs.Build
         // A giant memory cache of git tree. Key is the `long` form of SHA2 tree hash, value is a string id to git SHA2 hash.
         private readonly ConcurrentDictionary<long, Tree> _treeCache = new ConcurrentDictionary<long, Tree>();
 
-        private readonly ConcurrentDictionary<(string, string?), GitCommit[]> _commitHistoryCache = new ConcurrentDictionary<(string, string?), GitCommit[]>();
+        private readonly ConcurrentDictionary<(string, string?), GitCommit[]> _commitHistoryCache =
+            new ConcurrentDictionary<(string, string?), GitCommit[]>();
 
         private IntPtr _repo;
 

--- a/src/docfx/lib/git/GitCommitCache.cs
+++ b/src/docfx/lib/git/GitCommitCache.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Docs.Build
 
         // Commit history LRU cache per file (or empty for whole repo). Key is the file path relative to repository root.
         // Value is a dictionary of git commit history for a particular commit hash and file blob hash.
-        // Only the last N = MaxCommitCacheCountPerFile commit histories are cached for a file, they are selected by least recently used order (lruOrder).
+        // Only the last N = MaxCommitCacheCountPerFile commit histories are cached for a file,
+        // they are selected by least recently used order (lruOrder).
         private readonly ConcurrentDictionary<string, FileCommitCache> _commitCache;
 
         private bool _cacheUpdated;

--- a/src/docfx/lib/git/RepositoryProvider.cs
+++ b/src/docfx/lib/git/RepositoryProvider.cs
@@ -39,7 +39,8 @@ namespace Microsoft.Docs.Build
             return (repository, new PathString(Path.GetRelativePath(repository.Path, fullPath)));
         }
 
-        public (Repository? repo, PathString? pathToRepo, GitCommit[] commits) GetCommitHistory(PathString fullPath, string? committish = null)
+        public (Repository? repo, PathString? pathToRepo, GitCommit[] commits) GetCommitHistory(
+            PathString fullPath, string? committish = null)
         {
             var (repo, pathToRepo) = GetRepository(fullPath);
             if (repo is null || pathToRepo is null)

--- a/src/docfx/lib/git/RepositoryProvider.cs
+++ b/src/docfx/lib/git/RepositoryProvider.cs
@@ -10,8 +10,11 @@ namespace Microsoft.Docs.Build
 {
     internal class RepositoryProvider : IDisposable
     {
-        private readonly ConcurrentDictionary<string, Repository?> _repositories = new ConcurrentDictionary<string, Repository?>(PathUtility.PathComparer);
-        private readonly ConcurrentDictionary<string, FileCommitProvider> _fileCommitProvidersByRepoPath = new ConcurrentDictionary<string, FileCommitProvider>();
+        private readonly ConcurrentDictionary<string, Repository?> _repositories =
+            new ConcurrentDictionary<string, Repository?>(PathUtility.PathComparer);
+
+        private readonly ConcurrentDictionary<string, FileCommitProvider> _fileCommitProvidersByRepoPath =
+            new ConcurrentDictionary<string, FileCommitProvider>();
 
         public Repository? Repository { get; }
 

--- a/src/docfx/lib/github/GitHubAccessor.cs
+++ b/src/docfx/lib/github/GitHubAccessor.cs
@@ -25,7 +25,9 @@ namespace Microsoft.Docs.Build
 
         private readonly HttpClient? _httpClient;
         private readonly SemaphoreSlim _syncRoot = new SemaphoreSlim(1, 1);
-        private readonly ConcurrentHashSet<(string owner, string name)> _unknownRepos = new ConcurrentHashSet<(string owner, string name)>();
+        private readonly ConcurrentHashSet<(string owner, string name)> _unknownRepos =
+            new ConcurrentHashSet<(string owner, string name)>();
+
         private readonly JsonDiskCache<Error, string, GitHubUser> _userCache;
 
         private volatile Error? _fatalError;

--- a/src/docfx/lib/js/ChakraCoreJsEngine.cs
+++ b/src/docfx/lib/js/ChakraCoreJsEngine.cs
@@ -22,7 +22,8 @@ namespace Microsoft.Docs.Build
         private static readonly ConcurrentBag<JavaScriptContext> s_contextPool = new ConcurrentBag<JavaScriptContext>();
 
         // Limit the maximum ChakraCore runtimes to current processor count.
-        private static readonly SemaphoreSlim s_contextThrottler = new SemaphoreSlim(Environment.ProcessorCount, Environment.ProcessorCount);
+        private static readonly SemaphoreSlim s_contextThrottler =
+            new SemaphoreSlim(Environment.ProcessorCount, Environment.ProcessorCount);
 
         private static readonly ConcurrentDictionary<(JavaScriptContext, string scriptPath), JavaScriptValue> s_scriptExports
                           = new ConcurrentDictionary<(JavaScriptContext, string scriptPath), JavaScriptValue>();
@@ -31,11 +32,13 @@ namespace Microsoft.Docs.Build
 
         private static readonly ThreadLocal<Stack<string>> t_dirnames = new ThreadLocal<Stack<string>>(() => new Stack<string>());
 
-        private static readonly ThreadLocal<Dictionary<string, JavaScriptValue>?> t_modules = new ThreadLocal<Dictionary<string, JavaScriptValue>?>();
+        private static readonly ThreadLocal<Dictionary<string, JavaScriptValue>?> t_modules =
+            new ThreadLocal<Dictionary<string, JavaScriptValue>?>();
 
         private static int s_currentSourceContext;
 
-        private readonly ConcurrentDictionary<JavaScriptContext, JavaScriptValue> _globals = new ConcurrentDictionary<JavaScriptContext, JavaScriptValue>();
+        private readonly ConcurrentDictionary<JavaScriptContext, JavaScriptValue> _globals =
+            new ConcurrentDictionary<JavaScriptContext, JavaScriptValue>();
 
         private readonly string _scriptDir;
         private readonly JObject? _global;

--- a/src/docfx/lib/json/OneOrManyConverter.cs
+++ b/src/docfx/lib/json/OneOrManyConverter.cs
@@ -12,7 +12,8 @@ namespace Microsoft.Docs.Build
 
         public override bool CanConvert(Type objectType) => objectType.IsArray;
 
-        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer) => throw new InvalidOperationException();
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+            => throw new InvalidOperationException();
 
         public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {

--- a/src/docfx/lib/json/ShortHandConverter.cs
+++ b/src/docfx/lib/json/ShortHandConverter.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Docs.Build
 
         public override bool CanConvert(Type objectType) => GetShortHandType(objectType) != null;
 
-        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer) => throw new InvalidOperationException();
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+            => throw new InvalidOperationException();
 
         public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {

--- a/src/docfx/lib/json/UnionTypeConverter.cs
+++ b/src/docfx/lib/json/UnionTypeConverter.cs
@@ -14,7 +14,8 @@ namespace Microsoft.Docs.Build
     {
         public override bool CanWrite => false;
 
-        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer) => throw new InvalidOperationException();
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+            => throw new InvalidOperationException();
 
         public override bool CanConvert(Type objectType) => typeof(ITuple).IsAssignableFrom(objectType);
 

--- a/src/docfx/lib/log/Error.cs
+++ b/src/docfx/lib/log/Error.cs
@@ -29,10 +29,28 @@ namespace Microsoft.Docs.Build
         public int EndColumn { get; }
 
         public Error(ErrorLevel level, string code, string message, SourceInfo? source, string? name = null)
-            : this(level, code, message, source?.File, source?.Line ?? 0, source?.Column ?? 0, source?.EndLine ?? 0, source?.EndColumn ?? 0, name)
+            : this(
+                  level,
+                  code,
+                  message,
+                  source?.File,
+                  source?.Line ?? 0,
+                  source?.Column ?? 0,
+                  source?.EndLine ?? 0,
+                  source?.EndColumn ?? 0,
+                  name)
         { }
 
-        public Error(ErrorLevel level, string code, string message, FilePath? file = null, int line = 0, int column = 0, int endLine = 0, int endColumn = 0, string? name = null)
+        public Error(
+            ErrorLevel level,
+            string code,
+            string message,
+            FilePath? file = null,
+            int line = 0,
+            int column = 0,
+            int endLine = 0,
+            int endColumn = 0,
+            string? name = null)
         {
             Level = level;
             Code = code;

--- a/src/docfx/lib/log/Telemetry.cs
+++ b/src/docfx/lib/log/Telemetry.cs
@@ -18,18 +18,66 @@ namespace Microsoft.Docs.Build
     internal static class Telemetry
     {
         private static readonly TelemetryClient s_telemetryClient = new TelemetryClient(TelemetryConfiguration.CreateDefault());
-        private static readonly ConcurrentDictionary<FilePath, (string, string, string)> s_fileTypeCache = new ConcurrentDictionary<FilePath, (string, string, string)>();
+        private static readonly ConcurrentDictionary<FilePath, (string, string, string)> s_fileTypeCache =
+            new ConcurrentDictionary<FilePath, (string, string, string)>();
 
         // Set value per dimension limit to int.MaxValue
         // https://github.com/microsoft/ApplicationInsights-dotnet/issues/1496
-        private static readonly MetricConfiguration s_metricConfiguration = new MetricConfiguration(1000, int.MaxValue, new MetricSeriesConfigurationForMeasurement(false));
+        private static readonly MetricConfiguration s_metricConfiguration =
+            new MetricConfiguration(1000, int.MaxValue, new MetricSeriesConfigurationForMeasurement(false));
 
-        private static readonly Metric s_operationTimeMetric = s_telemetryClient.GetMetric(new MetricIdentifier(null, $"Time", "Name", "OS", "Version", "Repo", "Branch", "CorrelationId"), s_metricConfiguration);
-        private static readonly Metric s_errorCountMetric = s_telemetryClient.GetMetric(new MetricIdentifier(null, $"BuildLog", "Code", "Level", "Name", "Type", "OS", "Version", "Repo", "Branch", "CorrelationId"), s_metricConfiguration);
-        private static readonly Metric s_buildFileTypeCountMetric = s_telemetryClient.GetMetric(new MetricIdentifier(null, "BuildFileType", "FileExtension", "DocumentType", "MimeType", "OS", "Version", "Repo", "Branch", "CorrelationId"), s_metricConfiguration);
-        private static readonly Metric s_markdownElementCountMetric = s_telemetryClient.GetMetric(new MetricIdentifier(null, "MarkdownElement", "ElementType", "FileExtension", "DocumentType", "MimeType", "OS", "Version", "Repo", "Branch", "CorrelationId"), s_metricConfiguration);
+        private static readonly Metric s_operationTimeMetric =
+            s_telemetryClient.GetMetric(
+                new MetricIdentifier(null, $"Time", "Name", "OS", "Version", "Repo", "Branch", "CorrelationId"),
+                s_metricConfiguration);
 
-        private static readonly string s_version = typeof(Telemetry).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "<null>";
+        private static readonly Metric s_errorCountMetric =
+            s_telemetryClient.GetMetric(
+                new MetricIdentifier(
+                    null,
+                    $"BuildLog",
+                    "Code",
+                    "Level",
+                    "Name",
+                    "Type",
+                    "OS",
+                    "Version",
+                    "Repo",
+                    "Branch",
+                    "CorrelationId"), s_metricConfiguration);
+
+        private static readonly Metric s_buildFileTypeCountMetric =
+            s_telemetryClient.GetMetric(
+                new MetricIdentifier(
+                    null,
+                    "BuildFileType",
+                    "FileExtension",
+                    "DocumentType",
+                    "MimeType",
+                    "OS",
+                    "Version",
+                    "Repo",
+                    "Branch",
+                    "CorrelationId"), s_metricConfiguration);
+
+        private static readonly Metric s_markdownElementCountMetric =
+            s_telemetryClient.GetMetric(
+                new MetricIdentifier(
+                    null,
+                    "MarkdownElement",
+                    "ElementType",
+                    "FileExtension",
+                    "DocumentType",
+                    "MimeType",
+                    "OS",
+                    "Version",
+                    "Repo",
+                    "Branch",
+                    "CorrelationId"), s_metricConfiguration);
+
+        private static readonly string s_version =
+            typeof(Telemetry).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "<null>";
+
         private static readonly string s_os = RuntimeInformation.OSDescription ?? "<null>";
 
         private static string s_repo = "<null>";

--- a/src/docfx/lib/log/Telemetry.cs
+++ b/src/docfx/lib/log/Telemetry.cs
@@ -106,7 +106,8 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static (string fileExtension, string documentType, string mimeType) GetFileType(FilePath filePath, ContentType contentType, string? mime)
+        private static (string fileExtension, string documentType, string mimeType) GetFileType(
+            FilePath filePath, ContentType contentType, string? mime)
         {
             return s_fileTypeCache.GetOrAdd(filePath, filePath =>
             {

--- a/src/docfx/lib/markdown/ExtractTitleExtension.cs
+++ b/src/docfx/lib/markdown/ExtractTitleExtension.cs
@@ -10,7 +10,8 @@ namespace Microsoft.Docs.Build
 {
     internal static class ExtractTitleExtension
     {
-        public static MarkdownPipelineBuilder UseExtractTitle(this MarkdownPipelineBuilder builder, MarkdownEngine markdownEngine, Func<ConceptualModel?> getConceptual)
+        public static MarkdownPipelineBuilder UseExtractTitle(
+            this MarkdownPipelineBuilder builder, MarkdownEngine markdownEngine, Func<ConceptualModel?> getConceptual)
         {
             return builder.Use(document =>
             {

--- a/src/docfx/lib/markdown/IncludeExtension.cs
+++ b/src/docfx/lib/markdown/IncludeExtension.cs
@@ -16,7 +16,8 @@ namespace Microsoft.Docs.Build
 {
     internal static class IncludeExtension
     {
-        public static MarkdownPipelineBuilder UseExpandInclude(this MarkdownPipelineBuilder builder, MarkdownContext context, Func<List<Error>> getErrors)
+        public static MarkdownPipelineBuilder UseExpandInclude(
+            this MarkdownPipelineBuilder builder, MarkdownContext context, Func<List<Error>> getErrors)
         {
             var pipeline = CreateMarkdownPipeline(builder);
             var inlinePipeline = CreateMarkdownPipeline(builder, inlineOnly: true);
@@ -38,7 +39,12 @@ namespace Microsoft.Docs.Build
             renderer.ObjectRenderers.RemoveAll(r => r is HtmlInclusionInlineRenderer);
         }
 
-        private static void ExpandInclude(MarkdownContext context, MarkdownObject document, MarkdownPipeline pipeline, MarkdownPipeline inlinePipeline, List<Error> errors)
+        private static void ExpandInclude(
+            MarkdownContext context,
+            MarkdownObject document,
+            MarkdownPipeline pipeline,
+            MarkdownPipeline inlinePipeline,
+            List<Error> errors)
         {
             document.Visit(obj =>
             {
@@ -58,7 +64,12 @@ namespace Microsoft.Docs.Build
             });
         }
 
-        private static void ExpandInclusionBlock(MarkdownContext context, InclusionBlock inclusionBlock, MarkdownPipeline pipeline, MarkdownPipeline inlinePipeline, List<Error> errors)
+        private static void ExpandInclusionBlock(
+            MarkdownContext context,
+            InclusionBlock inclusionBlock,
+            MarkdownPipeline pipeline,
+            MarkdownPipeline inlinePipeline,
+            List<Error> errors)
         {
             var (content, file) = context.ReadFile(inclusionBlock.IncludedFilePath, inclusionBlock);
             if (content is null)
@@ -81,7 +92,12 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static void ExpandInclusionInline(MarkdownContext context, InclusionInline inclusionInline, MarkdownPipeline pipeline, MarkdownPipeline inlinePipeline, List<Error> errors)
+        private static void ExpandInclusionInline(
+            MarkdownContext context,
+            InclusionInline inclusionInline,
+            MarkdownPipeline pipeline,
+            MarkdownPipeline inlinePipeline,
+            List<Error> errors)
         {
             var (content, file) = context.ReadFile(inclusionInline.IncludedFilePath, inclusionInline);
             if (content is null)

--- a/src/docfx/lib/markdown/MarkdigUtility.cs
+++ b/src/docfx/lib/markdown/MarkdigUtility.cs
@@ -120,7 +120,8 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Traverse the markdown object graph, returns true to skip the current node.
         /// </summary>
-        public static void Visit(this MarkdownObject? obj, MarkdownVisitContext context, Func<MarkdownObject, MarkdownVisitContext, bool> action)
+        public static void Visit(
+            this MarkdownObject? obj, MarkdownVisitContext context, Func<MarkdownObject, MarkdownVisitContext, bool> action)
         {
             if (obj is null)
             {

--- a/src/docfx/lib/markdown/MarkdownEngine.cs
+++ b/src/docfx/lib/markdown/MarkdownEngine.cs
@@ -103,7 +103,8 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public (List<Error> errors, string html) ToHtml(string markdown, Document file, MarkdownPipelineType pipelineType, ConceptualModel? conceptual = null)
+        public (List<Error> errors, string html) ToHtml(
+            string markdown, Document file, MarkdownPipelineType pipelineType, ConceptualModel? conceptual = null)
         {
             using (InclusionContext.PushFile(file))
             {

--- a/src/docfx/lib/markdown/MonikerZoneExtension.cs
+++ b/src/docfx/lib/markdown/MonikerZoneExtension.cs
@@ -11,7 +11,8 @@ namespace Microsoft.Docs.Build
 {
     internal static class MonikerZoneExtension
     {
-        public static MarkdownPipelineBuilder UseMonikerZone(this MarkdownPipelineBuilder builder, Func<SourceInfo<string?>, MonikerList> parseMonikerRange)
+        public static MarkdownPipelineBuilder UseMonikerZone(
+            this MarkdownPipelineBuilder builder, Func<SourceInfo<string?>, MonikerList> parseMonikerRange)
         {
             return builder.Use(document =>
             {

--- a/src/docfx/lib/markdown/validation/DocsValidationExtension.cs
+++ b/src/docfx/lib/markdown/validation/DocsValidationExtension.cs
@@ -87,7 +87,8 @@ namespace Microsoft.Docs.Build
             });
         }
 
-        private static bool? IsCanonicalVersion(string? canonicalVersion, MonikerList fileLevelMonikerList, MonikerList zoneLevelMonikerList)
+        private static bool? IsCanonicalVersion(
+            string? canonicalVersion, MonikerList fileLevelMonikerList, MonikerList zoneLevelMonikerList)
         {
             if (zoneLevelMonikerList.HasMonikers)
             {

--- a/src/docfx/lib/moniker/MonikerList.cs
+++ b/src/docfx/lib/moniker/MonikerList.cs
@@ -14,7 +14,8 @@ namespace Microsoft.Docs.Build
     [JsonConverter(typeof(MonikerListJsonConverter))]
     internal readonly struct MonikerList : IEquatable<MonikerList>, IEnumerable<string>, IComparable<MonikerList>
     {
-        private static readonly ConcurrentDictionary<MonikerList, string> s_monikerGroupCache = new ConcurrentDictionary<MonikerList, string>();
+        private static readonly ConcurrentDictionary<MonikerList, string> s_monikerGroupCache =
+            new ConcurrentDictionary<MonikerList, string>();
 
         private readonly string[]? _monikers;
 

--- a/src/docfx/lib/moniker/MonikerRangeParser.cs
+++ b/src/docfx/lib/moniker/MonikerRangeParser.cs
@@ -10,7 +10,9 @@ namespace Microsoft.Docs.Build
 {
     internal class MonikerRangeParser
     {
-        private readonly ConcurrentDictionary<string, (List<Error>, MonikerList)> _cache = new ConcurrentDictionary<string, (List<Error>, MonikerList)>(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, (List<Error>, MonikerList)> _cache =
+            new ConcurrentDictionary<string, (List<Error>, MonikerList)>(StringComparer.OrdinalIgnoreCase);
+
         private readonly EvaluatorWithMonikersVisitor _monikersEvaluator;
 
         public MonikerRangeParser(MonikerDefinitionModel monikerDefinition)

--- a/src/docfx/lib/path/PathUtility.cs
+++ b/src/docfx/lib/path/PathUtility.cs
@@ -22,9 +22,11 @@ namespace Microsoft.Docs.Build
 
         public static readonly StringComparer PathComparer = IsCaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
 
-        public static readonly StringComparison PathComparison = IsCaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+        public static readonly StringComparison PathComparison =
+            IsCaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
 
-        private static readonly HashSet<char> s_invalidPathChars = Path.GetInvalidPathChars().Concat(Path.GetInvalidFileNameChars()).Distinct().ToHashSet();
+        private static readonly HashSet<char> s_invalidPathChars =
+            Path.GetInvalidPathChars().Concat(Path.GetInvalidFileNameChars()).Distinct().ToHashSet();
 
         /// <summary>
         /// Finds a yaml or json file under the specified location

--- a/src/docfx/lib/process/ProcessUtility.cs
+++ b/src/docfx/lib/process/ProcessUtility.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Start a new process and wait for its execution to complete
         /// </summary>
-        public static string Execute(string fileName, string commandLineArgs, string? cwd = null, bool stdout = true, string[]? secrets = null)
+        public static string Execute(
+            string fileName, string commandLineArgs, string? cwd = null, bool stdout = true, string[]? secrets = null)
         {
             var sanitizedCommandLineArgs = secrets != null ? secrets.Aggregate(commandLineArgs, HideSecrets) : commandLineArgs;
 

--- a/src/docfx/lib/schema/JsonSchema.cs
+++ b/src/docfx/lib/schema/JsonSchema.cs
@@ -177,7 +177,8 @@ namespace Microsoft.Docs.Build
         //-------------------------------------------
 
         /// <summary>
-        /// Alternative name used in output HTML <meta> tag. If not set, the original metadata name is used. Does not have effect in sub schemas.
+        /// Alternative name used in output HTML <meta> tag.
+        /// If not set, the original metadata name is used. Does not have effect in sub schemas.
         /// </summary>
         public string? HtmlMetaName { get; set; }
 
@@ -208,7 +209,8 @@ namespace Microsoft.Docs.Build
         //-------------------------------------------
 
         /// <summary>
-        /// Properties that are used to indicate some attitudes are required and the value of them can't be null or white space for string type
+        /// Properties that are used to indicate some attitudes are required,
+        /// and the value of them can't be null or white space for string type
         /// </summary>
         public string[] StrictRequired { get; set; } = Array.Empty<string>();
 
@@ -263,6 +265,7 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// This field is used to provide additional error information and only can be set in root level of schema
         /// </summary>
-        public Dictionary<string, Dictionary<string, CustomRule>> CustomRules { get; } = new Dictionary<string, Dictionary<string, CustomRule>>();
+        public Dictionary<string, Dictionary<string, CustomRule>> CustomRules { get; } =
+            new Dictionary<string, Dictionary<string, CustomRule>>();
     }
 }

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -192,7 +192,8 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private (List<Error>, JToken) TransformContentCore(JsonSchemaDefinition definitions, Document file, JsonSchema schema, JToken token, int uidCount)
+        private (List<Error>, JToken) TransformContentCore(
+            JsonSchemaDefinition definitions, Document file, JsonSchema schema, JToken token, int uidCount)
         {
             var errors = new List<Error>();
             schema = definitions.GetDefinition(schema);

--- a/src/docfx/lib/schema/JsonSchemaValidator.cs
+++ b/src/docfx/lib/schema/JsonSchemaValidator.cs
@@ -18,7 +18,9 @@ namespace Microsoft.Docs.Build
         private readonly JsonSchema _schema;
         private readonly JsonSchemaDefinition _definitions;
         private readonly MicrosoftGraphAccessor? _microsoftGraphAccessor;
-        private readonly ListBuilder<(JsonSchema schema, string key, JToken value, SourceInfo? source, bool? isCanonicalVersion)> _metadataBuilder;
+        private readonly ListBuilder<(JsonSchema schema, string key, JToken value, SourceInfo? source, bool? isCanonicalVersion)>
+            _metadataBuilder;
+
         private static readonly ThreadLocal<bool?> t_isCanonicalVersion = new ThreadLocal<bool?>();
 
         public JsonSchemaValidator(JsonSchema schema, MicrosoftGraphAccessor? microsoftGraphAccessor = null, bool forceError = false)

--- a/src/docfx/publish/PublishModelBuilder.cs
+++ b/src/docfx/publish/PublishModelBuilder.cs
@@ -19,7 +19,8 @@ namespace Microsoft.Docs.Build
         private readonly DocumentProvider _documentProvider;
         private readonly SourceMap _sourceMap;
 
-        private ConcurrentDictionary<FilePath, (JObject? metadata, string? outputPath)> _buildOutput = new ConcurrentDictionary<FilePath, (JObject? metadata, string? outputPath)>();
+        private ConcurrentDictionary<FilePath, (JObject? metadata, string? outputPath)> _buildOutput =
+            new ConcurrentDictionary<FilePath, (JObject? metadata, string? outputPath)>();
 
         public PublishModelBuilder(
             Config config,

--- a/src/docfx/restore/PackageResolver.cs
+++ b/src/docfx/restore/PackageResolver.cs
@@ -18,8 +18,11 @@ namespace Microsoft.Docs.Build
         private readonly PreloadConfig _config;
         private readonly FetchOptions _fetchOptions;
 
-        private readonly ConcurrentDictionary<PackagePath, Lazy<string>> _packagePath = new ConcurrentDictionary<PackagePath, Lazy<string>>();
-        private readonly Dictionary<PathString, InterProcessReaderWriterLock> _gitReaderLocks = new Dictionary<PathString, InterProcessReaderWriterLock>();
+        private readonly ConcurrentDictionary<PackagePath, Lazy<string>> _packagePath =
+            new ConcurrentDictionary<PackagePath, Lazy<string>>();
+
+        private readonly Dictionary<PathString, InterProcessReaderWriterLock> _gitReaderLocks =
+            new Dictionary<PathString, InterProcessReaderWriterLock>();
 
         public PackageResolver(string docsetPath, PreloadConfig config, FetchOptions fetchOptions)
         {

--- a/src/docfx/template/MustacheTemplate.cs
+++ b/src/docfx/template/MustacheTemplate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -22,7 +22,8 @@ namespace Microsoft.Docs.Build
         private readonly JObject? _global;
         private readonly string _templateDir;
         private readonly ParserPipeline _parserPipeline;
-        private readonly ConcurrentDictionary<string, Lazy<BlockToken>> _templates = new ConcurrentDictionary<string, Lazy<BlockToken>>(PathUtility.PathComparer);
+        private readonly ConcurrentDictionary<string, Lazy<BlockToken>> _templates =
+            new ConcurrentDictionary<string, Lazy<BlockToken>>(PathUtility.PathComparer);
 
         public MustacheTemplate(string templateDir, JObject? global = null)
         {


### PR DESCRIPTION
[AB#107202](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/107202)

Changes:
- Fix MEN002 violation for Method Definitions that have long parameters:
  - If it is long parameter, try put parameters to a new line, if it is still too long, break each parameter into its own line

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6145)