### PR TITLE
Fix Code Violation MEN002(Line too long)

### DIFF
--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -72,7 +72,8 @@ namespace Microsoft.Docs.Build
 
         public JsonSchemaTransformer JsonSchemaTransformer { get; }
 
-        public Context(ErrorLog errorLog, Config config, BuildOptions buildOptions, PackageResolver packageResolver, FileResolver fileResolver, SourceMap sourceMap)
+        public Context(
+            ErrorLog errorLog, Config config, BuildOptions buildOptions, PackageResolver packageResolver, FileResolver fileResolver, SourceMap sourceMap)
         {
             DependencyMapBuilder = new DependencyMapBuilder(sourceMap);
 

--- a/src/docfx/build/document/DocumentProvider.cs
+++ b/src/docfx/build/document/DocumentProvider.cs
@@ -46,7 +46,8 @@ namespace Microsoft.Docs.Build
         {
             var file = GetDocument(path);
             var outputPath = file.SitePath;
-            if ((file.ContentType == ContentType.Page && file.IsPage) || file.ContentType == ContentType.Redirection || file.ContentType == ContentType.TableOfContents)
+            if ((file.ContentType == ContentType.Page && file.IsPage) ||
+                file.ContentType == ContentType.Redirection || file.ContentType == ContentType.TableOfContents)
             {
                 var fileExtension = _config.Legacy && file.IsPage
                     ? ".raw.page.json"

--- a/src/docfx/build/legacy/LegacyAggregatedFileMap.cs
+++ b/src/docfx/build/legacy/LegacyAggregatedFileMap.cs
@@ -20,7 +20,9 @@ namespace Microsoft.Docs.Build
 
             foreach (var (path, (fileMapItem, monikers))
                 in items.GroupBy(x => x.legacyFilePathRelativeToBaseFolder)
-                        .ToDictionary(g => g.Key, g => (g.First().fileMapItem, g.SelectMany(x => x.fileMapItem.Monikers).Distinct().OrderBy(_ => _, StringComparer.Ordinal).ToList())))
+                        .ToDictionary(
+                          g => g.Key,
+                          g => (g.First().fileMapItem, g.SelectMany(x => x.fileMapItem.Monikers).Distinct().OrderBy(_ => _, StringComparer.Ordinal).ToList())))
             {
                 if (fileMapItem.Type == "Resource")
                 {

--- a/src/docfx/build/legacy/LegacyUtility.cs
+++ b/src/docfx/build/legacy/LegacyUtility.cs
@@ -32,7 +32,8 @@ namespace Microsoft.Docs.Build
                     string.IsNullOrEmpty(legacySiteUrlRelativeToBasePath) ? "." : legacySiteUrlRelativeToBasePath);
             }
 
-            if (context.Config.OutputUrlType == OutputUrlType.Docs && Path.GetFileNameWithoutExtension(doc.FilePath.Path).Equals("index", PathUtility.PathComparison) && doc.ContentType != ContentType.Resource)
+            if (context.Config.OutputUrlType == OutputUrlType.Docs &&
+                Path.GetFileNameWithoutExtension(doc.FilePath.Path).Equals("index", PathUtility.PathComparison) && doc.ContentType != ContentType.Resource)
             {
                 legacySiteUrlRelativeToBasePath = $"{legacySiteUrlRelativeToBasePath}/index";
             }

--- a/src/docfx/build/legacy/manifest/LegacyManifest.cs
+++ b/src/docfx/build/legacy/manifest/LegacyManifest.cs
@@ -54,7 +54,12 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static void ConvertDocumentToLegacyManifestItem(string docsetPath, Context context, KeyValuePair<Document, PublishItem> fileManifest, DictionaryBuilder<string, MonikerList> dictionaryBuilder, ListBuilder<(LegacyManifestItem manifestItem, Document doc, MonikerList monikers)> listBuilder)
+        private static void ConvertDocumentToLegacyManifestItem(
+            string docsetPath,
+            Context context,
+            KeyValuePair<Document, PublishItem> fileManifest,
+            DictionaryBuilder<string, MonikerList> dictionaryBuilder,
+            ListBuilder<(LegacyManifestItem manifestItem, Document doc, MonikerList monikers)> listBuilder)
         {
             var document = fileManifest.Key;
             var legacyOutputPathRelativeToBasePath = document.ToLegacyOutputPathRelativeToBasePath(context, fileManifest.Value);

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -15,11 +15,14 @@ namespace Microsoft.Docs.Build
         private readonly Config _config;
         private readonly GitHubAccessor _githubAccessor;
         private readonly BuildOptions _buildOptions;
-        private readonly ConcurrentDictionary<string, Lazy<CommitBuildTimeProvider>> _commitBuildTimeProviders = new ConcurrentDictionary<string, Lazy<CommitBuildTimeProvider>>(PathUtility.PathComparer);
+        private readonly ConcurrentDictionary<string, Lazy<CommitBuildTimeProvider>> _commitBuildTimeProviders =
+            new ConcurrentDictionary<string, Lazy<CommitBuildTimeProvider>>(PathUtility.PathComparer);
+
         private readonly RepositoryProvider _repositoryProvider;
         private readonly SourceMap _sourceMap;
 
-        private readonly ConcurrentDictionary<FilePath, (string?, string?, string?)> _gitUrls = new ConcurrentDictionary<FilePath, (string?, string?, string?)>();
+        private readonly ConcurrentDictionary<FilePath, (string?, string?, string?)> _gitUrls =
+            new ConcurrentDictionary<FilePath, (string?, string?, string?)>();
 
         public ContributionProvider(
             Config config, BuildOptions buildOptions, Input input, GitHubAccessor githubAccessor, RepositoryProvider repositoryProvider, SourceMap sourceMap)

--- a/src/docfx/build/moniker/MonikerProvider.cs
+++ b/src/docfx/build/moniker/MonikerProvider.cs
@@ -139,7 +139,8 @@ namespace Microsoft.Docs.Build
             return (errors, configMonikers);
         }
 
-        private static (Error?, MonikerList) GetMonikerIntersection(UserMetadata metadata, SourceInfo<string?> configMonikerRange, MonikerList configMonikers, MonikerList fileMonikers, bool skipMonikerValidation)
+        private static (Error?, MonikerList) GetMonikerIntersection(
+            UserMetadata metadata, SourceInfo<string?> configMonikerRange, MonikerList configMonikers, MonikerList fileMonikers, bool skipMonikerValidation)
         {
             Error? error = null;
 

--- a/src/docfx/build/redirection/RedirectionProvider.cs
+++ b/src/docfx/build/redirection/RedirectionProvider.cs
@@ -17,7 +17,8 @@ namespace Microsoft.Docs.Build
         private readonly Lazy<PublishUrlMap> _publishUrlMap;
 
         private readonly IReadOnlyDictionary<FilePath, string> _redirectUrls;
-        private readonly Lazy<(IReadOnlyDictionary<FilePath, FilePath> renameHistory, IReadOnlyDictionary<FilePath, (FilePath, SourceInfo?)> redirectionHistory)> _history;
+        private readonly Lazy<(IReadOnlyDictionary<FilePath, FilePath> renameHistory,
+            IReadOnlyDictionary<FilePath, (FilePath, SourceInfo?)> redirectionHistory)> _history;
 
         public IEnumerable<FilePath> Files => _redirectUrls.Keys;
 
@@ -223,7 +224,8 @@ namespace Microsoft.Docs.Build
 
                 var candidates = redirectionSourceMonikers.Count == 0
                                     ? docs.Where(doc => _monikerProvider.GetFileLevelMonikers(doc).monikers.Count == 0).ToList()
-                                    : docs.Where(doc => _monikerProvider.GetFileLevelMonikers(doc).monikers.Intersect(redirectionSourceMonikers).Any()).ToList();
+                                    : docs.Where(
+                                        doc => _monikerProvider.GetFileLevelMonikers(doc).monikers.Intersect(redirectionSourceMonikers).Any()).ToList();
 
                 // skip circular redirection validation for url containing query string
                 if (candidates.Count > 0 && string.IsNullOrEmpty(redirectQuery))

--- a/src/docfx/build/toc/TableOfContentsLoader.cs
+++ b/src/docfx/build/toc/TableOfContentsLoader.cs
@@ -28,7 +28,8 @@ namespace Microsoft.Docs.Build
         private static readonly string[] s_tocFileNames = new[] { "TOC.md", "TOC.json", "TOC.yml" };
         private static readonly string[] s_experimentalTocFileNames = new[] { "TOC.experimental.md", "TOC.experimental.json", "TOC.experimental.yml" };
 
-        private static AsyncLocal<ImmutableStack<Document>> t_recursionDetector = new AsyncLocal<ImmutableStack<Document>> { Value = ImmutableStack<Document>.Empty };
+        private static AsyncLocal<ImmutableStack<Document>> t_recursionDetector =
+            new AsyncLocal<ImmutableStack<Document>> { Value = ImmutableStack<Document>.Empty };
 
         public TableOfContentsLoader(
             LinkResolver linkResolver,
@@ -288,7 +289,8 @@ namespace Microsoft.Docs.Build
                 if (tocHrefType == TocHrefType.RelativeFolder)
                 {
                     var nestedTocFirstItem = GetFirstItem(nestedToc.Items);
-                    _dependencyMapBuilder.AddDependencyItem(filePath.FilePath, nestedTocFirstItem?.Document?.FilePath, DependencyType.File, filePath.ContentType);
+                    _dependencyMapBuilder.AddDependencyItem(
+                        filePath.FilePath, nestedTocFirstItem?.Document?.FilePath, DependencyType.File, filePath.ContentType);
                     return (default, default, nestedTocFirstItem, tocHrefType);
                 }
 

--- a/src/docfx/build/toc/TableOfContentsMap.cs
+++ b/src/docfx/build/toc/TableOfContentsMap.cs
@@ -27,7 +27,14 @@ namespace Microsoft.Docs.Build
         private readonly Lazy<(Dictionary<Document, Document[]> tocToTocs, Dictionary<Document, Document[]> docToTocs)> _tocs;
 
         public TableOfContentsMap(
-            ErrorLog errorLog, Input input, BuildScope buildScope, DependencyMapBuilder dependencyMapBuilder, TableOfContentsParser tocParser, TableOfContentsLoader tocLoader, DocumentProvider documentProvider, ContentValidator contentValidator)
+            ErrorLog errorLog,
+            Input input,
+            BuildScope buildScope,
+            DependencyMapBuilder dependencyMapBuilder,
+            TableOfContentsParser tocParser,
+            TableOfContentsLoader tocLoader,
+            DocumentProvider documentProvider,
+            ContentValidator contentValidator)
         {
             _errorLog = errorLog;
             _input = input;
@@ -88,7 +95,8 @@ namespace Microsoft.Docs.Build
         /// 2. parent nearest(based on file path)
         /// 3. sub-name lexicographical nearest
         /// </summary>
-        internal static (T? toc, bool hasReferencedTocs) FindNearestToc<T>(T file, IEnumerable<T> tocs, Dictionary<T, T[]> documentsToTocs, Func<T, string> getPath) where T : class, IComparable<T>
+        internal static (T? toc, bool hasReferencedTocs) FindNearestToc<T>(
+            T file, IEnumerable<T> tocs, Dictionary<T, T[]> documentsToTocs, Func<T, string> getPath) where T : class, IComparable<T>
         {
             var hasReferencedTocs = false;
             var filteredTocs = (hasReferencedTocs = documentsToTocs.TryGetValue(file, out var referencedTocFiles)) ? referencedTocFiles : tocs;

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -32,7 +32,8 @@ namespace Microsoft.Docs.Build
 
         public string? GetXrefPropertyValueAsString(string propertyName)
         {
-            return XrefProperties.TryGetValue(propertyName, out var property) && property.Value is JValue propertyValue && propertyValue.Value is string internalStr ? internalStr : null;
+            return XrefProperties.TryGetValue(propertyName, out var property) &&
+                   property.Value is JValue propertyValue && propertyValue.Value is string internalStr ? internalStr : null;
         }
 
         public ExternalXrefSpec ToExternalXrefSpec(string? overwriteHref = null)

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -148,7 +148,8 @@ namespace Microsoft.Docs.Build
         /// Gets the file metadata added to each document.
         /// It is a map of `{metadata-name} -> {glob} -> {metadata-value}`
         /// </summary>
-        public Dictionary<string, SourceInfo<Dictionary<string, JToken>>> FileMetadata { get; } = new Dictionary<string, SourceInfo<Dictionary<string, JToken>>>();
+        public Dictionary<string, SourceInfo<Dictionary<string, JToken>>> FileMetadata { get; } =
+            new Dictionary<string, SourceInfo<Dictionary<string, JToken>>>();
 
         /// <summary>
         /// Gets a map from source folder path and output URL path.

--- a/src/docfx/config/ConfigLoader.cs
+++ b/src/docfx/config/ConfigLoader.cs
@@ -56,7 +56,8 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Load the config under <paramref name="docsetPath"/>
         /// </summary>
-        public (List<Error>, Config, BuildOptions, PackageResolver, FileResolver) Load(DisposableCollector disposables, string docsetPath, string? outputPath, CommandLineOptions options, FetchOptions fetchOptions)
+        public (List<Error>, Config, BuildOptions, PackageResolver, FileResolver) Load(
+            DisposableCollector disposables, string docsetPath, string? outputPath, CommandLineOptions options, FetchOptions fetchOptions)
         {
             // load and trace entry repository
             var repository = Repository.Create(docsetPath);
@@ -133,7 +134,13 @@ namespace Microsoft.Docs.Build
         }
 
         private JObject DownloadExtendConfig(
-            List<Error> errors, string? locale, PreloadConfig config, string? xrefEndpoint, string[]? xrefQueryTags, Repository? repository, FileResolver fileResolver)
+            List<Error> errors,
+            string? locale,
+            PreloadConfig config,
+            string? xrefEndpoint,
+            string[]? xrefQueryTags,
+            Repository? repository,
+            FileResolver fileResolver)
         {
             var result = new JObject();
             var extendQuery =

--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -52,7 +52,8 @@ namespace Microsoft.Docs.Build
         private static readonly Lazy<SecretClient> s_secretClient = new Lazy<SecretClient>(()
             => new SecretClient(new Uri(s_keyVaultEndPoint), new DefaultAzureCredential()));
 
-        private static readonly Lazy<Task<Response<KeyVaultSecret>>> s_opBuildUserToken = new Lazy<Task<Response<KeyVaultSecret>>>(() => s_secretClient.Value.GetSecretAsync("opBuildUserToken"));
+        private static readonly Lazy<Task<Response<KeyVaultSecret>>> s_opBuildUserToken =
+            new Lazy<Task<Response<KeyVaultSecret>>>(() => s_secretClient.Value.GetSecretAsync("opBuildUserToken"));
 
         private readonly Action<HttpRequestMessage> _credentialProvider;
         private readonly ErrorLog _errorLog;
@@ -154,7 +155,8 @@ namespace Microsoft.Docs.Build
         private string GetXrefMapApiEndpoint(string xrefEndpoint)
         {
             var environment = s_docsEnvironment;
-            if (!string.IsNullOrEmpty(xrefEndpoint) && string.Equals(xrefEndpoint.TrimEnd('/'), "https://xref.docs.microsoft.com", StringComparison.OrdinalIgnoreCase))
+            if (!string.IsNullOrEmpty(xrefEndpoint) &&
+                string.Equals(xrefEndpoint.TrimEnd('/'), "https://xref.docs.microsoft.com", StringComparison.OrdinalIgnoreCase))
             {
                 environment = DocsEnvironment.Prod;
             }

--- a/src/docfx/config/ops/OpsConfigLoader.cs
+++ b/src/docfx/config/ops/OpsConfigLoader.cs
@@ -24,7 +24,8 @@ namespace Microsoft.Docs.Build
             return JsonUtility.Deserialize<OpsConfig>(File.ReadAllText(fullPath), filePath);
         }
 
-        public static (List<Error> errors, string? xrefEndpoint, string[]? xrefQueryTags, JObject? config) LoadDocfxConfig(string docsetPath, Repository? repository)
+        public static (List<Error> errors, string? xrefEndpoint, string[]? xrefQueryTags, JObject? config) LoadDocfxConfig(
+            string docsetPath, Repository? repository)
         {
             if (repository is null)
             {
@@ -42,7 +43,8 @@ namespace Microsoft.Docs.Build
             return (errors, xrefEndpoint, xrefQueryTags, config);
         }
 
-        private static (string? xrefEndpoint, string[]? xrefQueryTags, JObject config) ToDocfxConfig(string branch, OpsConfig opsConfig, PathString buildSourceFolder)
+        private static (string? xrefEndpoint, string[]? xrefQueryTags, JObject config) ToDocfxConfig(
+            string branch, OpsConfig opsConfig, PathString buildSourceFolder)
         {
             var result = new JObject();
             var dependencies = GetDependencies(opsConfig, branch, buildSourceFolder);

--- a/src/docfx/config/ops/OpsMetadataRuleConverter.cs
+++ b/src/docfx/config/ops/OpsMetadataRuleConverter.cs
@@ -59,7 +59,8 @@ namespace Microsoft.Docs.Build
                     maxLength = GetMaxLength(rulesInfo),
                 };
 
-                if (!string.Equals("{}", JsonConvert.SerializeObject(property, Formatting.Indented, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore })))
+                var propertyJson = JsonConvert.SerializeObject(property, Formatting.Indented, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+                if (!string.Equals("{}", propertyJson))
                 {
                     schema.properties.Add(attribute, property);
                 }
@@ -157,7 +158,8 @@ namespace Microsoft.Docs.Build
             return attributeCustomRules.Count != 0;
         }
 
-        private static bool TryGetAllowlist(string parentName, string? listId, Allowlists allowlists, int index, out Dictionary<string, EnumDependenciesSchema?> allowList)
+        private static bool TryGetAllowlist(
+            string parentName, string? listId, Allowlists allowlists, int index, out Dictionary<string, EnumDependenciesSchema?> allowList)
         {
             allowList = new Dictionary<string, EnumDependenciesSchema?>();
 

--- a/src/docfx/config/ops/OpsPreProcessor.cs
+++ b/src/docfx/config/ops/OpsPreProcessor.cs
@@ -71,7 +71,8 @@ namespace Microsoft.Docs.Build
         {
             if (!string.IsNullOrEmpty(item.Code))
             {
-                _errorLog.Write(new Error(MapLevel(item.MessageSeverity), item.Code, item.Message, item.File is null ? null : new FilePath(item.File), item.Line ?? 0));
+                _errorLog.Write(
+                    new Error(MapLevel(item.MessageSeverity), item.Code, item.Message, item.File is null ? null : new FilePath(item.File), item.Line ?? 0));
             }
 
             ErrorLevel MapLevel(MessageSeverity level)

--- a/src/docfx/lib/HtmlUtility.cs
+++ b/src/docfx/lib/HtmlUtility.cs
@@ -23,7 +23,8 @@ namespace Microsoft.Docs.Build
         };
 
         // ref https://developer.mozilla.org/en-US/docs/Web/HTML/Element
-        private static readonly Dictionary<string, HashSet<string>?> s_allowedTagAttributeMap = new Dictionary<string, HashSet<string>?>(StringComparer.OrdinalIgnoreCase)
+        private static readonly Dictionary<string, HashSet<string>?> s_allowedTagAttributeMap =
+            new Dictionary<string, HashSet<string>?>(StringComparer.OrdinalIgnoreCase)
         {
             // Content sectioning
             { "address", null },
@@ -91,7 +92,10 @@ namespace Microsoft.Docs.Build
             { "tr", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "align" } },
 
             // other
-            { "iframe", new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "frameborder", "allowtransparency", "allowfullscreen", "scrolling", "height", "src", "width" } },
+            {
+              "iframe", new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                        { "frameborder", "allowtransparency", "allowfullscreen", "scrolling", "height", "src", "width" }
+            },
             { "center", null },
             { "summary", null },
             { "details", null },
@@ -180,7 +184,11 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public static void TransformXref(ref HtmlReader reader, ref HtmlToken token, MarkdownObject? block, Func<SourceInfo<string>?, SourceInfo<string>?, bool, (string? href, string display)> resolveXref)
+        public static void TransformXref(
+            ref HtmlReader reader,
+            ref HtmlToken token,
+            MarkdownObject? block,
+            Func<SourceInfo<string>?, SourceInfo<string>?, bool, (string? href, string display)> resolveXref)
         {
             if (!token.NameIs("xref"))
             {
@@ -228,10 +236,13 @@ namespace Microsoft.Docs.Build
                 isShorthand);
 
             var resolvedNode = string.IsNullOrEmpty(resolvedHref)
-                ? rawHtml ?? rawSource ?? $"<span class=\"xref\">{(!string.IsNullOrEmpty(display) ? display : (href != null ? UrlUtility.SplitUrl(href).path : uid))}</span>"
+                ? rawHtml ?? rawSource ?? GetDefaultResolvedNode()
                 : $"<a href='{HttpUtility.HtmlEncode(resolvedHref)}'>{HttpUtility.HtmlEncode(display)}</a>";
 
             token = new HtmlToken(resolvedNode);
+
+            string GetDefaultResolvedNode()
+                => $"<span class=\"xref\">{(!string.IsNullOrEmpty(display) ? display : (href != null ? UrlUtility.SplitUrl(href).path : uid))}</span>";
         }
 
         public static string CreateHtmlMetaTags(JObject metadata, ICollection<string> htmlMetaHidden, IReadOnlyDictionary<string, string> htmlMetaNames)

--- a/src/docfx/lib/UrlUtility.cs
+++ b/src/docfx/lib/UrlUtility.cs
@@ -23,7 +23,8 @@ namespace Microsoft.Docs.Build
 
         private static readonly Regex s_azureReposUrlRegex =
             new Regex(
-                @"^(https|http):\/\/((?<account>[^\/\s]+)\.visualstudio\.com\/(?<collection>[^\/\s]+\/)?|dev\.azure\.com\/(?<account>[^\/\s]+)\/)+(?<project>[^\/\s]+)\/_git\/(?<repository>[A-Za-z0-9_.-]+)((\/)?|(#(?<branch>\S+))?)$",
+                @"^(https|http):\/\/((?<account>[^\/\s]+)\.visualstudio\.com\/(?<collection>[^\/\s]+\/)?|dev\.azure\.com\/(?<account>[^\/\s]+)\/)+" +
+                @"(?<project>[^\/\s]+)\/_git\/(?<repository>[A-Za-z0-9_.-]+)((\/)?|(#(?<branch>\S+))?)$",
                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly char[] s_queryFragmentLeadingChars = new char[] { '#', '?' };

--- a/src/docfx/lib/cache/JsonDiskCache.cs
+++ b/src/docfx/lib/cache/JsonDiskCache.cs
@@ -27,7 +27,8 @@ namespace Microsoft.Docs.Build
 
         private volatile bool _needUpdate;
 
-        public JsonDiskCache(string cachePath, TimeSpan expiration, IEqualityComparer<TKey>? comparer = null, Func<TValue, TValue, TValue>? resolveConflict = null)
+        public JsonDiskCache(
+            string cachePath, TimeSpan expiration, IEqualityComparer<TKey>? comparer = null, Func<TValue, TValue, TValue>? resolveConflict = null)
         {
             comparer ??= EqualityComparer<TKey>.Default;
             _resolveConflict = resolveConflict;

--- a/src/docfx/lib/git/FileCommitProvider.cs
+++ b/src/docfx/lib/git/FileCommitProvider.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Docs.Build
 
         // Commit history and a lookup table from commit hash to commit.
         // Use `long` to represent SHA2 git hashes for more efficient lookup and smaller size.
-        private readonly ConcurrentDictionary<string, Lazy<(Commit[], Dictionary<long, Commit>)>> _commits = new ConcurrentDictionary<string, Lazy<(Commit[], Dictionary<long, Commit>)>>();
+        private readonly ConcurrentDictionary<string, Lazy<(Commit[], Dictionary<long, Commit>)>> _commits =
+            new ConcurrentDictionary<string, Lazy<(Commit[], Dictionary<long, Commit>)>>();
 
         // A giant memory cache of git tree. Key is the `long` form of SHA2 tree hash, value is a string id to git SHA2 hash.
         private readonly ConcurrentDictionary<long, Tree> _treeCache = new ConcurrentDictionary<long, Tree>();

--- a/src/docfx/lib/git/RepositoryProvider.cs
+++ b/src/docfx/lib/git/RepositoryProvider.cs
@@ -11,7 +11,8 @@ namespace Microsoft.Docs.Build
     internal class RepositoryProvider : IDisposable
     {
         private readonly ConcurrentDictionary<string, Repository?> _repositories = new ConcurrentDictionary<string, Repository?>(PathUtility.PathComparer);
-        private readonly ConcurrentDictionary<string, FileCommitProvider> _fileCommitProvidersByRepoPath = new ConcurrentDictionary<string, FileCommitProvider>();
+        private readonly ConcurrentDictionary<string, FileCommitProvider> _fileCommitProvidersByRepoPath =
+            new ConcurrentDictionary<string, FileCommitProvider>();
 
         public Repository? Repository { get; }
 

--- a/src/docfx/lib/json/JsonContractResolver.cs
+++ b/src/docfx/lib/json/JsonContractResolver.cs
@@ -65,7 +65,8 @@ namespace Microsoft.Docs.Build
 
         private static void HandleSourceInfo(JsonProperty property)
         {
-            if (property.PropertyType != null && property.PropertyType.IsGenericType && property.PropertyType.GetGenericTypeDefinition() == typeof(SourceInfo<>))
+            if (property.PropertyType != null && property.PropertyType.IsGenericType &&
+                property.PropertyType.GetGenericTypeDefinition() == typeof(SourceInfo<>))
             {
                 // Allow source info propagation for null values
                 property.NullValueHandling = NullValueHandling.Include;

--- a/src/docfx/lib/log/Error.cs
+++ b/src/docfx/lib/log/Error.cs
@@ -32,7 +32,16 @@ namespace Microsoft.Docs.Build
             : this(level, code, message, source?.File, source?.Line ?? 0, source?.Column ?? 0, source?.EndLine ?? 0, source?.EndColumn ?? 0, name)
         { }
 
-        public Error(ErrorLevel level, string code, string message, FilePath? file = null, int line = 0, int column = 0, int endLine = 0, int endColumn = 0, string? name = null)
+        public Error(
+            ErrorLevel level,
+            string code,
+            string message,
+            FilePath? file = null,
+            int line = 0,
+            int column = 0,
+            int endLine = 0,
+            int endColumn = 0,
+            string? name = null)
         {
             Level = level;
             Code = code;

--- a/src/docfx/lib/log/Telemetry.cs
+++ b/src/docfx/lib/log/Telemetry.cs
@@ -18,18 +18,36 @@ namespace Microsoft.Docs.Build
     internal static class Telemetry
     {
         private static readonly TelemetryClient s_telemetryClient = new TelemetryClient(TelemetryConfiguration.CreateDefault());
-        private static readonly ConcurrentDictionary<FilePath, (string, string, string)> s_fileTypeCache = new ConcurrentDictionary<FilePath, (string, string, string)>();
+        private static readonly ConcurrentDictionary<FilePath, (string, string, string)> s_fileTypeCache =
+            new ConcurrentDictionary<FilePath, (string, string, string)>();
 
         // Set value per dimension limit to int.MaxValue
         // https://github.com/microsoft/ApplicationInsights-dotnet/issues/1496
-        private static readonly MetricConfiguration s_metricConfiguration = new MetricConfiguration(1000, int.MaxValue, new MetricSeriesConfigurationForMeasurement(false));
+        private static readonly MetricConfiguration s_metricConfiguration =
+            new MetricConfiguration(1000, int.MaxValue, new MetricSeriesConfigurationForMeasurement(false));
 
-        private static readonly Metric s_operationTimeMetric = s_telemetryClient.GetMetric(new MetricIdentifier(null, $"Time", "Name", "OS", "Version", "Repo", "Branch", "CorrelationId"), s_metricConfiguration);
-        private static readonly Metric s_errorCountMetric = s_telemetryClient.GetMetric(new MetricIdentifier(null, $"BuildLog", "Code", "Level", "Name", "Type", "OS", "Version", "Repo", "Branch", "CorrelationId"), s_metricConfiguration);
-        private static readonly Metric s_buildFileTypeCountMetric = s_telemetryClient.GetMetric(new MetricIdentifier(null, "BuildFileType", "FileExtension", "DocumentType", "MimeType", "OS", "Version", "Repo", "Branch", "CorrelationId"), s_metricConfiguration);
-        private static readonly Metric s_markdownElementCountMetric = s_telemetryClient.GetMetric(new MetricIdentifier(null, "MarkdownElement", "ElementType", "FileExtension", "DocumentType", "MimeType", "OS", "Version", "Repo", "Branch", "CorrelationId"), s_metricConfiguration);
+        private static readonly Metric s_operationTimeMetric =
+            s_telemetryClient.GetMetric(new MetricIdentifier(null, $"Time", "Name", "OS", "Version", "Repo", "Branch", "CorrelationId"), s_metricConfiguration);
 
-        private static readonly string s_version = typeof(Telemetry).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "<null>";
+        private static readonly Metric s_errorCountMetric =
+            s_telemetryClient.GetMetric(
+                new MetricIdentifier(
+                    null, $"BuildLog", "Code", "Level", "Name", "Type", "OS", "Version", "Repo", "Branch", "CorrelationId"), s_metricConfiguration);
+
+        private static readonly Metric s_buildFileTypeCountMetric =
+            s_telemetryClient.GetMetric(
+                new MetricIdentifier(null, "BuildFileType", "FileExtension", "DocumentType", "MimeType", "OS", "Version", "Repo", "Branch", "CorrelationId"),
+                s_metricConfiguration);
+
+        private static readonly Metric s_markdownElementCountMetric =
+            s_telemetryClient.GetMetric(
+                new MetricIdentifier(
+                    null, "MarkdownElement", "ElementType", "FileExtension", "DocumentType", "MimeType", "OS", "Version", "Repo", "Branch", "CorrelationId"),
+                s_metricConfiguration);
+
+        private static readonly string s_version =
+            typeof(Telemetry).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "<null>";
+
         private static readonly string s_os = RuntimeInformation.OSDescription ?? "<null>";
 
         private static string s_repo = "<null>";
@@ -73,7 +91,8 @@ namespace Microsoft.Docs.Build
             var (fileExtension, documentType, mimeType) = GetFileType(file.FilePath, file.ContentType, file.Mime.Value);
             foreach (var (elementType, value) in elementCount)
             {
-                s_markdownElementCountMetric.TrackValue(value, CoalesceEmpty(elementType), fileExtension, documentType, mimeType, s_os, s_version, s_repo, s_branch, s_correlationId);
+                s_markdownElementCountMetric.TrackValue(
+                    value, CoalesceEmpty(elementType), fileExtension, documentType, mimeType, s_os, s_version, s_repo, s_branch, s_correlationId);
             }
         }
 

--- a/src/docfx/lib/markdown/ExtractTitleExtension.cs
+++ b/src/docfx/lib/markdown/ExtractTitleExtension.cs
@@ -10,7 +10,8 @@ namespace Microsoft.Docs.Build
 {
     internal static class ExtractTitleExtension
     {
-        public static MarkdownPipelineBuilder UseExtractTitle(this MarkdownPipelineBuilder builder, MarkdownEngine markdownEngine, Func<ConceptualModel?> getConceptual)
+        public static MarkdownPipelineBuilder UseExtractTitle(
+            this MarkdownPipelineBuilder builder, MarkdownEngine markdownEngine, Func<ConceptualModel?> getConceptual)
         {
             return builder.Use(document =>
             {

--- a/src/docfx/lib/markdown/IncludeExtension.cs
+++ b/src/docfx/lib/markdown/IncludeExtension.cs
@@ -36,7 +36,8 @@ namespace Microsoft.Docs.Build
             renderer.ObjectRenderers.RemoveAll(r => r is HtmlInclusionInlineRenderer);
         }
 
-        private static void ExpandInclude(MarkdownContext context, MarkdownObject document, MarkdownPipeline pipeline, MarkdownPipeline inlinePipeline, List<Error> errors)
+        private static void ExpandInclude(
+            MarkdownContext context, MarkdownObject document, MarkdownPipeline pipeline, MarkdownPipeline inlinePipeline, List<Error> errors)
         {
             document.Visit(obj =>
             {
@@ -56,7 +57,8 @@ namespace Microsoft.Docs.Build
             });
         }
 
-        private static void ExpandInclusionBlock(MarkdownContext context, InclusionBlock inclusionBlock, MarkdownPipeline pipeline, MarkdownPipeline inlinePipeline, List<Error> errors)
+        private static void ExpandInclusionBlock(
+            MarkdownContext context, InclusionBlock inclusionBlock, MarkdownPipeline pipeline, MarkdownPipeline inlinePipeline, List<Error> errors)
         {
             var (content, file) = context.ReadFile(inclusionBlock.IncludedFilePath, inclusionBlock);
             if (content is null)
@@ -79,7 +81,8 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static void ExpandInclusionInline(MarkdownContext context, InclusionInline inclusionInline, MarkdownPipeline pipeline, MarkdownPipeline inlinePipeline, List<Error> errors)
+        private static void ExpandInclusionInline(
+            MarkdownContext context, InclusionInline inclusionInline, MarkdownPipeline pipeline, MarkdownPipeline inlinePipeline, List<Error> errors)
         {
             var (content, file) = context.ReadFile(inclusionInline.IncludedFilePath, inclusionInline);
             if (content is null)

--- a/src/docfx/lib/moniker/EvaluatorWithMonikersVisitor.cs
+++ b/src/docfx/lib/moniker/EvaluatorWithMonikersVisitor.cs
@@ -26,7 +26,8 @@ namespace Microsoft.Docs.Build
         {
             if (!MonikerOrder.TryGetValue(expression.Operand, out var moniker))
             {
-                return (Errors.Versioning.MonikerRangeInvalid(monikerRange, $"Invalid moniker range '{monikerRange}': Moniker '{expression.Operand}' is not defined."), Array.Empty<Moniker>());
+                var message = $"Invalid moniker range '{monikerRange}': Moniker '{expression.Operand}' is not defined.";
+                return (Errors.Versioning.MonikerRangeInvalid(monikerRange, message), Array.Empty<Moniker>());
             }
 
             return expression.Operator switch

--- a/src/docfx/lib/moniker/MonikerRangeParser.cs
+++ b/src/docfx/lib/moniker/MonikerRangeParser.cs
@@ -10,7 +10,9 @@ namespace Microsoft.Docs.Build
 {
     internal class MonikerRangeParser
     {
-        private readonly ConcurrentDictionary<string, (List<Error>, MonikerList)> _cache = new ConcurrentDictionary<string, (List<Error>, MonikerList)>(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, (List<Error>, MonikerList)> _cache =
+            new ConcurrentDictionary<string, (List<Error>, MonikerList)>(StringComparer.OrdinalIgnoreCase);
+
         private readonly EvaluatorWithMonikersVisitor _monikersEvaluator;
 
         public MonikerRangeParser(MonikerDefinitionModel monikerDefinition)

--- a/src/docfx/lib/process/ProcessUtility.cs
+++ b/src/docfx/lib/process/ProcessUtility.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -18,7 +19,7 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Start a new process and wait for its execution to complete
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "MemoryStream properly disposed")]
+        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "MemoryStream properly disposed")]
         public static string Execute(string fileName, string commandLineArgs, string? cwd = null, bool stdout = true, string[]? secrets = null)
         {
             var sanitizedCommandLineArgs = secrets != null ? secrets.Aggregate(commandLineArgs, HideSecrets) : commandLineArgs;

--- a/src/docfx/lib/schema/JsonSchemaValidator.cs
+++ b/src/docfx/lib/schema/JsonSchemaValidator.cs
@@ -268,7 +268,8 @@ namespace Microsoft.Docs.Build
 
                 if (schema.MinLength.HasValue && unicodeLength < schema.MinLength.Value)
                 {
-                    errors.Add(Errors.JsonSchema.StringLengthInvalid(JsonUtility.GetSourceInfo(scalar), name, "short", unicodeLength, $">= {schema.MinLength}"));
+                    errors.Add(
+                        Errors.JsonSchema.StringLengthInvalid(JsonUtility.GetSourceInfo(scalar), name, "short", unicodeLength, $">= {schema.MinLength}"));
                 }
             }
 

--- a/src/docfx/publish/PublishModelBuilder.cs
+++ b/src/docfx/publish/PublishModelBuilder.cs
@@ -19,7 +19,8 @@ namespace Microsoft.Docs.Build
         private readonly DocumentProvider _documentProvider;
         private readonly SourceMap _sourceMap;
 
-        private ConcurrentDictionary<FilePath, (JObject? metadata, string? outputPath)> _buildOutput = new ConcurrentDictionary<FilePath, (JObject? metadata, string? outputPath)>();
+        private ConcurrentDictionary<FilePath, (JObject? metadata, string? outputPath)> _buildOutput =
+            new ConcurrentDictionary<FilePath, (JObject? metadata, string? outputPath)>();
 
         public PublishModelBuilder(
             Config config,

--- a/src/docfx/restore/PackageResolver.cs
+++ b/src/docfx/restore/PackageResolver.cs
@@ -214,7 +214,8 @@ namespace Microsoft.Docs.Build
                 else
                 {
                     (var repoOrg, var repoName) = ParseRepoInfo(url);
-                    throw Errors.DependencyRepository.RepositoryOwnerPermissionInsufficient(_config.DocsRepositoryOwnerName, repoOrg, repoName, url).ToException(ex);
+                    throw Errors.DependencyRepository.RepositoryOwnerPermissionInsufficient(
+                        _config.DocsRepositoryOwnerName, repoOrg, repoName, url).ToException(ex);
                 }
             }
         }
@@ -224,7 +225,8 @@ namespace Microsoft.Docs.Build
             return ex.Message.Contains("fatal: Authentication fail", StringComparison.OrdinalIgnoreCase)
                             || ex.Message.Contains("remote: Not Found", StringComparison.OrdinalIgnoreCase)
                             || ex.Message.Contains("remote: Repository not found.", StringComparison.OrdinalIgnoreCase)
-                            || ex.Message.Contains("does not exist or you do not have permissions for the operation you are attempting", StringComparison.OrdinalIgnoreCase)
+                            || ex.Message.Contains(
+                                "does not exist or you do not have permissions for the operation you are attempting", StringComparison.OrdinalIgnoreCase)
                             || ex.Message.Contains("fatal: could not read Username", StringComparison.OrdinalIgnoreCase);
         }
 

--- a/src/docfx/template/MustacheTemplate.cs
+++ b/src/docfx/template/MustacheTemplate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -22,7 +22,8 @@ namespace Microsoft.Docs.Build
         private readonly JObject? _global;
         private readonly string _templateDir;
         private readonly ParserPipeline _parserPipeline;
-        private readonly ConcurrentDictionary<string, Lazy<BlockToken>> _templates = new ConcurrentDictionary<string, Lazy<BlockToken>>(PathUtility.PathComparer);
+        private readonly ConcurrentDictionary<string, Lazy<BlockToken>> _templates =
+            new ConcurrentDictionary<string, Lazy<BlockToken>>(PathUtility.PathComparer);
 
         public MustacheTemplate(string templateDir, JObject? global = null)
         {

--- a/src/docfx/validation/MetadataValidator.cs
+++ b/src/docfx/validation/MetadataValidator.cs
@@ -74,7 +74,8 @@ namespace Microsoft.Docs.Build
             {
                 // Only validate conceptual files
                 if (contentType == ContentType.Page && mime == "Conceptual" &&
-                    (!metadata.ContainsKey("layout") || string.Equals(metadata.GetValue("layout")?.ToString(), "conceptual", StringComparison.OrdinalIgnoreCase)))
+                    (!metadata.ContainsKey("layout") ||
+                     string.Equals(metadata.GetValue("layout")?.ToString(), "conceptual", StringComparison.OrdinalIgnoreCase)))
                 {
                     errors.AddRange(schemaValidator.Validate(metadata, isCanonicalVersion));
                 }


### PR DESCRIPTION
[AB#107202](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/107202)

Fix MEN002 for:
- Method Definition:
  - If it is long parameter, try put parameters to a new line, if it is still too long, break each parameter into its own line
- Member Variable Declarations:
  - For long member variable declarations with initialization, try put the default initializer to a new line
  - If it is long parameter, try put parameters to a new line, if it is still too long, break each parameter into its own line 
- Long return:
  - If the return value is a tuple and the tuple definition is long, try put the return value definition in its own line
- Long if conditions and other expressions

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6165)