### PR TITLE
Fix uid unescape at wrong place

### DIFF
--- a/docs/specs/escape.yml
+++ b/docs/specs/escape.yml
@@ -167,4 +167,4 @@ outputs:
     }
   .errors.log: |
     {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'a&'.","file":"html-xref.md","line":6,"column":9}
-    {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'a&'.","file":"b.json","line":3,"column":17}
+    {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'a&26b'.","file":"b.json","line":3,"column":17}

--- a/docs/specs/escape.yml
+++ b/docs/specs/escape.yml
@@ -138,7 +138,7 @@ inputs:
     Link to <xref:a&b?displayProperty=description>
     Link to @a&b?displayProperty=description
     Link to @a&c
-    Link to <xref:a%2A>
+    Link to <xref:a%26>
     Link to <xref:a%26b>
   _themes/ContentTemplate/schemas/TestData.schema.json: |
     {
@@ -161,10 +161,10 @@ outputs:
             Link to <a href='a.json'>&lt;some text &amp;&gt;\n</a>
             Link to <a href='a.json'>&lt;some text &amp;&gt;\n</a>
             Link to @a&amp;c
-            Link to &lt;xref:a%2A&gt;
+            Link to &lt;xref:a%26&gt;
             Link to <a href='a.json'>test\n</a>
           </p>"
     }
   .errors.log: |
-    {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'a*'.","file":"html-xref.md","line":6,"column":9}
-    {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'a*'.","file":"b.json","line":3,"column":17}
+    {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'a&'.","file":"html-xref.md","line":6,"column":9}
+    {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'a&'.","file":"b.json","line":3,"column":17}

--- a/docs/specs/escape.yml
+++ b/docs/specs/escape.yml
@@ -167,4 +167,4 @@ outputs:
     }
   .errors.log: |
     {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'a&'.","file":"html-xref.md","line":6,"column":9}
-    {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'a&26b'.","file":"b.json","line":3,"column":17}
+    {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'a%26b'.","file":"b.json","line":3,"column":17}

--- a/docs/specs/escape.yml
+++ b/docs/specs/escape.yml
@@ -157,4 +157,4 @@ outputs:
           </p>"
     }
   .errors.log: |
-    {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'a%2A'.","file":"html-xref.md","line":6,"column":9}
+    {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'a*'.","file":"html-xref.md","line":6,"column":9}

--- a/docs/specs/escape.yml
+++ b/docs/specs/escape.yml
@@ -127,6 +127,11 @@ inputs:
       "fullName": "test.test",
       "description": "<some text &>"
     }
+  b.json: |
+    {
+      "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TestData.json",
+      "xref": "a%26b"
+    }
   html-xref.md: |
     Link to [text](xref:a&b?displayProperty=description)
     Link to <xref href="a&b?displayProperty=description" />
@@ -134,27 +139,32 @@ inputs:
     Link to @a&b?displayProperty=description
     Link to @a&c
     Link to <xref:a%2A>
+    Link to <xref:a%26b>
   _themes/ContentTemplate/schemas/TestData.schema.json: |
     {
       "properties": {
         "uid": { "contentType": "uid" },
+        "xref": { "contentType": "xref" },
         "description": { "type": "string" }
       },
       "xrefProperties": ["name", "fullName", "description"]
     }
 outputs:
   a.json:
+  b.json:
   html-xref.json: |
     {
       "conceptual": "
           <p>
-            Link to <a href=\"a.json\">text</a>
+            Link to <a href='a.json'>text</a>
             Link to <a href='a.json'>&lt;some text &amp;&gt;\n</a>
-            Link to <a href=\"a.json\">&lt;some text &amp;&gt;\n</a>
-            Link to <a href=\"a.json\">&lt;some text &amp;&gt;\n</a>
+            Link to <a href='a.json'>&lt;some text &amp;&gt;\n</a>
+            Link to <a href='a.json'>&lt;some text &amp;&gt;\n</a>
             Link to @a&amp;c
             Link to &lt;xref:a%2A&gt;
+            Link to <a href='a.json'>test\n</a>
           </p>"
     }
   .errors.log: |
     {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'a*'.","file":"html-xref.md","line":6,"column":9}
+    {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'a*'.","file":"b.json","line":3,"column":17}

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -694,7 +694,12 @@ inputs:
 outputs:
   docs/a.json:
   docs/b.json: |
-    { "conceptual": "<p>Link to <a href=\"a\">Title from yaml header a</a>\nLink to <a href=\"a\">Title from yaml header a</a>\nLink to <a href=\"a\">Title from yaml header a</a>\nLink to <a href=\"a\">Title from yaml header a</a>\nLink to <a href=\"a\">Title from yaml header a</a></p>" }
+    { "conceptual": "<p>
+          Link to <a href=\"a\">Title from yaml header a</a>
+          Link to <a href=\"a\">Title from yaml header a</a>
+          Link to <a href=\"a\">Title from yaml header a</a>
+          Link to <a href=\"a\">Title from yaml header a</a>
+          Link to <a href=\"a\">Title from yaml header a</a></p>" }
 ---
 # Refer to uid within link
 inputs:

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -58,6 +58,9 @@ namespace Microsoft.Docs.Build
             SourceInfo<string> href, Document referencingFile, Document inclusionRoot)
         {
             var (uid, query, fragment) = UrlUtility.SplitUrl(href);
+
+            uid = Uri.UnescapeDataString(uid);
+
             string? moniker = null;
             string? text = null;
             string? alt = null;
@@ -181,11 +184,10 @@ namespace Microsoft.Docs.Build
 
         private (Error?, IXrefSpec?, string? href) Resolve(SourceInfo<string> uid, Document referencingFile, Document inclusionRoot)
         {
-            var unescapedUid = Uri.UnescapeDataString(uid);
-            var (xrefSpec, href) = ResolveInternalXrefSpec(unescapedUid, referencingFile, inclusionRoot);
+            var (xrefSpec, href) = ResolveInternalXrefSpec(uid, referencingFile, inclusionRoot);
             if (xrefSpec is null)
             {
-                (xrefSpec, href) = ResolveExternalXrefSpec(unescapedUid);
+                (xrefSpec, href) = ResolveExternalXrefSpec(uid);
             }
 
             if (xrefSpec is null)


### PR DESCRIPTION
[AB#241229](https://dev.azure.com/ceapex/Engineering/_workitems/edit/241229/)

Ensures `uid` is represented as a unescaped string, to allow faster lookup by uid.

#5013

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6167)