### PR TITLE
Regression test refresh user cache only in schedule build

### DIFF
--- a/test/docfx.RegressionTest/RegressionTest.cs
+++ b/test/docfx.RegressionTest/RegressionTest.cs
@@ -165,7 +165,8 @@ namespace Microsoft.Docs.Build
                 Path.Combine(AppContext.BaseDirectory, "docfx.exe"),
                 arguments: $"restore --legacy --verbose --stdin",
                 stdin: noExpireDocfxConfig,
-                cwd: repositoryPath);
+                cwd: repositoryPath,
+                allowExitCodes: new int[] { 0 });
 
             if (s_ciType == CIType.Schedule)
             {
@@ -174,15 +175,13 @@ namespace Microsoft.Docs.Build
                     Path.Combine(AppContext.BaseDirectory, "docfx.exe"),
                     arguments: $"build -o \"{outputPath}\" --legacy --verbose --no-restore --stdin",
                     stdin: expireDocfxConfig,
-                    cwd: repositoryPath,
-                    allowExitCodes: new int[] { 0, 1 });
+                    cwd: repositoryPath);
             }
             return Exec(
                     Path.Combine(AppContext.BaseDirectory, "docfx.exe"),
                     arguments: $"build -o \"{outputPath}\" --legacy --verbose --no-restore --stdin",
                     stdin: noExpireDocfxConfig,
-                    cwd: repositoryPath,
-                    allowExitCodes: new int[] { 0, 1 });
+                    cwd: repositoryPath);
         }
 
         private static void Compare(string outputPath, string repository, string existingOutputPath, TimeSpan buildTime, int? timeout, string testWorkingFolder)
@@ -259,7 +258,7 @@ namespace Microsoft.Docs.Build
         {
             var stopwatch = Stopwatch.StartNew();
             var sanitizedArguments = secrets.Aggregate(arguments, (arg, secret) => string.IsNullOrEmpty(secret) ? arg : arg.Replace(secret, "***"));
-            allowExitCodes ??= new int[] { 0 };
+            allowExitCodes ??= new int[] { 0, 1 };
 
             Console.ForegroundColor = ConsoleColor.DarkCyan;
             Console.WriteLine($"{fileName} {sanitizedArguments}");

--- a/test/docfx.RegressionTest/RegressionTest.cs
+++ b/test/docfx.RegressionTest/RegressionTest.cs
@@ -280,7 +280,7 @@ namespace Microsoft.Docs.Build
             var stderr = redirectStandardError ? process.StandardError.ReadToEnd() : default;
             process.WaitForExit();
 
-            if (allowExitCodes.Contains(process.ExitCode) && !ignoreError)
+            if (!allowExitCodes.Contains(process.ExitCode) && !ignoreError)
             {
                 throw new InvalidOperationException(
                     $"'\"{fileName}\" {sanitizedArguments}' failed in directory '{cwd}' with exit code {process.ExitCode}, message: \n {stderr}");

--- a/test/docfx.RegressionTest/RegressionTest.cs
+++ b/test/docfx.RegressionTest/RegressionTest.cs
@@ -81,8 +81,8 @@ namespace Microsoft.Docs.Build
                 updateTimeAsCommitBuildTime = true,
                 githubToken = s_githubToken,
                 githubUserCacheExpirationInHours = noUserCacheExpire ? 24 * 365 : 24 * 30,
-
             };
+
             return JsonUtility.Serialize(docfxConfig);
         }
 


### PR DESCRIPTION
[AB#238565](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/238565) 

For scheduled run: 
- refresh user-cache
- use non-expire user cache to refresh base-line

For other run(PR, commit):
- use non-expire user cache to verify/refresh base-line

Disallow `1` for restore exit-code.
see [Build.Reason doc](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6172)