### PR TITLE
Regression update cache sync for scheduled run

### DIFF
--- a/test/docfx.RegressionTest/RegressionTest.cs
+++ b/test/docfx.RegressionTest/RegressionTest.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Docs.Build
             var stderr = redirectStandardError ? process.StandardError.ReadToEnd() : default;
             process.WaitForExit();
 
-            if (allowExitCodes.Contains(process.ExitCode) && !ignoreError)
+            if (!allowExitCodes.Contains(process.ExitCode) && !ignoreError)
             {
                 throw new InvalidOperationException(
                     $"'\"{fileName}\" {sanitizedArguments}' failed in directory '{cwd}' with exit code {process.ExitCode}, message: \n {stderr}");

--- a/test/docfx.RegressionTest/RegressionTest.cs
+++ b/test/docfx.RegressionTest/RegressionTest.cs
@@ -63,11 +63,7 @@ namespace Microsoft.Docs.Build
             Environment.SetEnvironmentVariable("DOCFX_LOCALE", opts.Locale);
             Environment.SetEnvironmentVariable("DOCFX_STATE_PATH", statePath);
             Environment.SetEnvironmentVariable("DOCFX_CACHE_PATH", cachePath);
-
-            if (s_BuildReason == BuildReason.Schedule)
-            {
-                Environment.SetEnvironmentVariable("DOCFX_UPDATE_CACHE_SYNC", "true");
-            }
+            Environment.SetEnvironmentVariable("DOCFX_UPDATE_CACHE_SYNC", s_BuildReason == BuildReason.Schedule ? "true" : "false");
 
             return (baseLinePath, outputPath, workingFolder, repositoryPath, GetDocfxConfig());
 

--- a/test/docfx.RegressionTest/RegressionTest.cs
+++ b/test/docfx.RegressionTest/RegressionTest.cs
@@ -396,7 +396,7 @@ namespace Microsoft.Docs.Build
         {
             var buildReasonStr = Environment.GetEnvironmentVariable("BUILD_REASON");
 
-            // local debug should be set as PullRequest build to avoid accidentially push
+            // local debug should be set as PullRequest build to avoid accidentally push
             if (buildReasonStr == null)
             {
                 return BuildReason.PullRequest;


### PR DESCRIPTION
[AB#238565](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/238565)

For scheduled run: 
- refresh user-cache synchronously

For other run(PR, commit):
- use non-expire user cache to verify/refresh base-line

Disallow `1` for restore exit-code.
see [Build.Reason doc](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6178)