### PR TITLE
updated Validations.Docfx.Adapter to 1.2.27

### DIFF
--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="Stubble.Core" Version="1.9.3" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180503-2" />
-    <PackageReference Include="Validations.DocFx.Adapter" Version="1.2.27-beta005" />
+    <PackageReference Include="Validations.DocFx.Adapter" Version="1.2.27" />
     <PackageReference Include="YamlDotNet" Version="8.1.2" />
   </ItemGroup>
 


### PR DESCRIPTION
updated Validations.Docfx.Adapter to production release version 1.2.27

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6182)