### PR TITLE
Using ordinal comparer to sorting .errors.log

### DIFF
--- a/test/docfx.RegressionTest/Normalizer.cs
+++ b/test/docfx.RegressionTest/Normalizer.cs
@@ -86,6 +86,7 @@ namespace Microsoft.Docs.Build
             foreach (var log in logs)
             {
                 var obj = JObject.Parse(log);
+                obj.Remove("date_time");
 
                 if (obj.ContainsKey("code")
                     && obj["code"]!.Value<string>() == "yaml-syntax-error"

--- a/test/docfx.RegressionTest/Normalizer.cs
+++ b/test/docfx.RegressionTest/Normalizer.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Docs.Build
 
         private static void PrettifyJsonLog(string logPath)
         {
-            var logs = File.ReadAllLines(logPath).Select(line => Regex.Replace(line, ",\"date_time\":.*?Z\"", "")).OrderBy(line => line);
+            var logs = File.ReadAllLines(logPath).OrderBy(line => line, StringComparer.Ordinal);
 
             using var sw = new StreamWriter(File.OpenWrite(logPath));
             foreach (var log in logs)

--- a/test/docfx.RegressionTest/Normalizer.cs
+++ b/test/docfx.RegressionTest/Normalizer.cs
@@ -80,13 +80,12 @@ namespace Microsoft.Docs.Build
 
         private static void PrettifyJsonLog(string logPath)
         {
-            var logs = File.ReadAllLines(logPath).OrderBy(line => line);
+            var logs = File.ReadAllLines(logPath).Select(line => Regex.Replace(line, ",\"date_time\":.*?Z\"", "")).OrderBy(line => line);
 
             using var sw = new StreamWriter(File.OpenWrite(logPath));
             foreach (var log in logs)
             {
                 var obj = JObject.Parse(log);
-                obj.Remove("date_time");
 
                 if (obj.ContainsKey("code")
                     && obj["code"]!.Value<string>() == "yaml-syntax-error"


### PR DESCRIPTION
following #6188
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6195)