### PR TITLE
🐛Should not always output name in xref map

### DIFF
--- a/docs/specs/template.yml
+++ b/docs/specs/template.yml
@@ -171,6 +171,22 @@ inputs:
         href: https://docfx.com/uid2
       - uid: uid-non-href
         name: uni-non-href-name-use-span
+  a.json: |
+    {
+      "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TestData.json",
+      "uid": "a",
+      "name": "test.test",
+      "description": "a.description"
+    }
+  _themes/ContentTemplate/schemas/TestData.schema.json: |
+    {
+      "properties": {
+        "uid": { "contentType": "uid" },
+        "name": { "type": "string" },
+        "description": { "type": "string" }
+      },
+      "xrefProperties": ["description"]
+    }
     
   _themes/ContentTemplate/schemas/TestPage.schema.json: |
     {
@@ -221,6 +237,9 @@ inputs:
   # normal partial include syntax, with <xref /> in partial template
   _themes/ContentTemplate/partials/uid-partial.tmpl.partial: |
     <xref uid="{{uidPartial}}"/>
+  internal-uid.yml: |
+    ### YamlMime: TestPage
+    uid: a
   uid-resolve.yml: |
     ### YamlMime: TestPage
     uid: uid1
@@ -252,6 +271,10 @@ inputs:
       - unresolve
       - uid2
 outputs:
+  a.json:
+  internal-uid.mta.json:
+  internal-uid.raw.page.json: |
+    {"content": "<p> <a href=\"a.json\" data-linktype=\"relative-path\"> a </a> </p> "}
   uid-resolve.mta.json:
   uid-resolve.raw.page.json: |
     {"content": "<p> <a href=\"/en-us/uid1\" data-linktype=\"absolute-path\"> uid1-name </a> </p> "}

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -315,6 +315,30 @@ outputs:
       }
     }
 ---
+# Define uid in SDP without name as xref property
+inputs:
+  docfx.yml: |
+  docs/a.json: |
+    {
+      "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TestData.json",
+      "uid": "a",
+      "fullName": "test.test",
+      "description": "a.description"
+    }
+  _themes/ContentTemplate/schemas/TestData.schema.json: |
+    {
+      "properties": {
+        "uid": { "contentType": "uid" },
+        "fullName": { "type": "string" },
+        "name": { "type": "string" }
+      },
+      "xrefProperties": ["fullName", "description"]
+    }
+outputs:
+  docs/a.json:
+  .xrefmap.json: | 
+    {"references":[{"uid":"a", "name": undefined}]}
+---
 # Define duplicate uid in conceptual and SDP 
 # should output error and uid cannot be resolved
 repos:

--- a/src/docfx/build/xref/ExternalXrefSpec.cs
+++ b/src/docfx/build/xref/ExternalXrefSpec.cs
@@ -49,8 +49,8 @@ namespace Microsoft.Docs.Build
             return null;
         }
 
-        public ExternalXrefSpec ToExternalXrefSpec(string? overwriteHref = null) =>
-            new ExternalXrefSpec(Name, Uid, overwriteHref ?? Href, Monikers, _shouldSerializeName)
+        public ExternalXrefSpec ToExternalXrefSpec(string? overwriteHref, bool shouldSerializeName) =>
+            new ExternalXrefSpec(Name, Uid, overwriteHref ?? Href, Monikers, shouldSerializeName)
             {
                 ExtensionData = ExtensionData,
             };

--- a/src/docfx/build/xref/ExternalXrefSpec.cs
+++ b/src/docfx/build/xref/ExternalXrefSpec.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Docs.Build
 {
     internal class ExternalXrefSpec : IXrefSpec
     {
+        private readonly bool _shouldSerializeName;
         private string? _name;
 
         public string Uid { get; private set; } = "";
@@ -30,9 +31,10 @@ namespace Microsoft.Docs.Build
 
         public ExternalXrefSpec() { }
 
-        public ExternalXrefSpec(string? name, string uid, string href, MonikerList monikers)
+        public ExternalXrefSpec(string? name, string uid, string href, MonikerList monikers, bool shouldSerializeName)
         {
             _name = name;
+            _shouldSerializeName = shouldSerializeName;
             Uid = uid;
             Href = href;
             Monikers = monikers;
@@ -48,9 +50,11 @@ namespace Microsoft.Docs.Build
         }
 
         public ExternalXrefSpec ToExternalXrefSpec(string? overwriteHref = null) =>
-            new ExternalXrefSpec(Name, Uid, overwriteHref ?? Href, Monikers)
+            new ExternalXrefSpec(Name, Uid, overwriteHref ?? Href, Monikers, _shouldSerializeName)
             {
                 ExtensionData = ExtensionData,
             };
+
+        public bool ShouldSerializeName() => _shouldSerializeName;
     }
 }

--- a/src/docfx/build/xref/IXrefSpec.cs
+++ b/src/docfx/build/xref/IXrefSpec.cs
@@ -17,6 +17,6 @@ namespace Microsoft.Docs.Build
 
         string? GetXrefPropertyValueAsString(string propertyName);
 
-        ExternalXrefSpec ToExternalXrefSpec(string? overwriteHref = null);
+        ExternalXrefSpec ToExternalXrefSpec(string? overwriteHref, bool shouldSerializeName);
     }
 }

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Docs.Build
 
         public ExternalXrefSpec ToExternalXrefSpec(string? overwriteHref = null)
         {
-            var spec = new ExternalXrefSpec(Name, Uid, overwriteHref ?? Href, Monikers);
+            var spec = new ExternalXrefSpec(Name, Uid, overwriteHref ?? Href, Monikers, XrefProperties.ContainsKey("name"));
 
             foreach (var (key, value) in XrefProperties)
             {

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Docs.Build
               : null;
         }
 
-        public ExternalXrefSpec ToExternalXrefSpec(string? overwriteHref = null)
+        public ExternalXrefSpec ToExternalXrefSpec(string? overwriteHref, bool shouldSerializeName)
         {
             var spec = new ExternalXrefSpec(Name, Uid, overwriteHref ?? Href, Monikers, XrefProperties.ContainsKey("name"));
 

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Docs.Build
 
         public ExternalXrefSpec ToExternalXrefSpec(string? overwriteHref, bool shouldSerializeName)
         {
-            var spec = new ExternalXrefSpec(Name, Uid, overwriteHref ?? Href, Monikers, XrefProperties.ContainsKey("name"));
+            var spec = new ExternalXrefSpec(Name, Uid, overwriteHref ?? Href, Monikers, shouldSerializeName | XrefProperties.ContainsKey("name"));
 
             foreach (var (key, value) in XrefProperties)
             {

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Docs.Build
 
         public ExternalXrefSpec ToExternalXrefSpec(string? overwriteHref, bool shouldSerializeName)
         {
-            var spec = new ExternalXrefSpec(Name, Uid, overwriteHref ?? Href, Monikers, shouldSerializeName | XrefProperties.ContainsKey("name"));
+            var spec = new ExternalXrefSpec(Name, Uid, overwriteHref ?? Href, Monikers, shouldSerializeName || XrefProperties.ContainsKey("name"));
 
             foreach (var (key, value) in XrefProperties)
             {

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Docs.Build
                     var query = repositoryBranch == "master" ? "?branch=master" : "";
                     var href = UrlUtility.MergeUrl($"https://{_xrefHostName}{xref.Href}", query);
 
-                    var xrefSpec = xref.ToExternalXrefSpec(href);
+                    var xrefSpec = xref.ToExternalXrefSpec(href, false);
                     return xrefSpec;
                 })
                 .OrderBy(xref => xref.Uid).ToArray();

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -311,7 +311,7 @@ namespace Microsoft.Docs.Build
 
                     var xrefSpecObj = xrefSpec is null
                         ? new JObject { ["name"] = value, ["href"] = null }
-                        : JsonUtility.ToJObject(xrefSpec.ToExternalXrefSpec(href));
+                        : JsonUtility.ToJObject(xrefSpec.ToExternalXrefSpec(href, true));
 
                     _resolvedXrefSpec.TryAdd((file.FilePath, content), xrefSpecObj);
 


### PR DESCRIPTION
[AB#246680](https://dev.azure.com/ceapex/Engineering/_workitems/edit/246680)

- for mustache template, always serialize `name`
- for `.xrefmap.json`, only serialize `name` when it's part of xref property

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6197)