### PR TITLE
Update Jint to the latest version

### DIFF
--- a/.github/actions/spell-check/dictionary/custom-dictionary.txt
+++ b/.github/actions/spell-check/dictionary/custom-dictionary.txt
@@ -518,3 +518,4 @@ MEMORYSTATUSEX
 sizeof
 IMemory
 uncomment
+Esprima

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -167,6 +167,7 @@ namespace Microsoft.Docs.Build
             RepositoryProvider.Dispose();
             GitHubAccessor.Dispose();
             MicrosoftGraphAccessor.Dispose();
+            TemplateEngine.Dispose();
         }
     }
 }

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.Experimental.Collections" Version="1.0.6-e190117-3" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Jint" Version="2.11.58" />
+    <PackageReference Include="Jint" Version="3.0.0-beta-1828" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="Stubble.Core" Version="1.9.3" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-preview2-180503-2" />

--- a/src/docfx/lib/js/ChakraCoreJsEngine.cs
+++ b/src/docfx/lib/js/ChakraCoreJsEngine.cs
@@ -35,8 +35,12 @@ namespace Microsoft.Docs.Build
 
             if (global != null)
             {
-                _global = RunInContext(() => ToJavaScriptValue(global));
-                _global.AddRef();
+                _global = RunInContext(() =>
+                {
+                    var result = ToJavaScriptValue(global);
+                    result.AddRef();
+                    return result;
+                });
             }
         }
 

--- a/src/docfx/lib/js/IJavaScriptEngine.cs
+++ b/src/docfx/lib/js/IJavaScriptEngine.cs
@@ -5,6 +5,9 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build
 {
+    /// <summary>
+    /// Represents a javascript engine for a single thread
+    /// </summary>
     internal interface IJavaScriptEngine
     {
         JToken Run(string scriptPath, string methodName, JToken arg);

--- a/src/docfx/template/TemplateEngine.cs
+++ b/src/docfx/template/TemplateEngine.cs
@@ -11,7 +11,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build
 {
-    internal class TemplateEngine
+    internal class TemplateEngine : IDisposable
     {
         private readonly string _templateDir;
         private readonly string _contentTemplateDir;
@@ -124,6 +124,11 @@ namespace Microsoft.Docs.Build
         public string? GetToken(string key)
         {
             return _global[key]?.ToString();
+        }
+
+        public void Dispose()
+        {
+            _js.Dispose();
         }
 
         private JObject LoadGlobalTokens()


### PR DESCRIPTION
Move thread handling logic outside of JavaScriptEngine, so it is easier to attach a different JavaScriptEngine per thread using `ThreadLocal`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6200)