### PR TITLE
Print timeout info in regression-test

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -33,7 +33,7 @@ function publishBinaryPackages() {
         exec "dotnet publish src\docfx\docfx.csproj -c release -r $rid -o $packagesBasePath/$rid /p:PackAsTool=false"
         if ($rid -eq "win7-x64") {
             $version = Invoke-Expression "$packagesBasePath/win7-x64/docfx.exe --version"
-            Write-Host "##[debug]package version: $version"
+            Write-Host "package version: $version"
         }
         $packageName = "docfx-$rid-$version"
         Compress-Archive -Path "$packagesBasePath/$rid/*" -DestinationPath "$stagingPath/$packageName.zip" -Update

--- a/test/docfx.RegressionTest/RegressionTest.cs
+++ b/test/docfx.RegressionTest/RegressionTest.cs
@@ -192,6 +192,7 @@ namespace Microsoft.Docs.Build
             if (buildTime.TotalSeconds > timeout)
             {
                 Console.WriteLine($"##vso[task.complete result=Failed]Test failed, build timeout. Repo: ${testRepositoryName}");
+                Console.WriteLine($"Test failed, build timeout: {buildTime.TotalSeconds} Repo: ${testRepositoryName}");
             }
 
             if (s_isPullRequest)


### PR DESCRIPTION
azure-pipeline logging command is buggy

Pipeline is marked as failed, bug no error message displayed.
e.g. [build](https://ceapex.visualstudio.com/Engineering/_build/results?buildId=167073&view=logs&j=43d08477-5396-50a3-fedd-32f526c9defc&t=7f91c047-fae8-5c9e-afc1-f6b0f36191b6)

![image](https://user-images.githubusercontent.com/42199316/86864810-6a8ce200-c100-11ea-8ef6-f80a8342a847.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6203)