### PR TITLE
Use dictionary lookup to get language code

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
@@ -187,6 +187,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
                     {
                         foreach (var alias in aliases)
                         {
+                            AddExtractorItem(alias, extractor);
                             AddExtractorItem($".{alias}", extractor);
                         }
                     }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
@@ -5,6 +5,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Text;
@@ -17,181 +18,208 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
     public class HtmlCodeSnippetRenderer : HtmlObjectRenderer<CodeSnippet>
     {
-        private readonly MarkdownContext _context;
-        private const string tagPrefix = "snippet";
-        private const string warningMessageId = "codeIncludeNotFound";
-        private const string defaultWarningMessage = "It looks like the sample you are looking for does not exist.";
-        private const string warningTitleId = "warning";
-        private const string defaultWarningTitle = "<h5>WARNING</h5>";
-
-        public static readonly IReadOnlyDictionary<string, List<string>> LanguageAlias = new Dictionary<string, List<string>>
-        {
-            { "actionscript", new List<string>{"as" } },
-            { "arduino", new List<string>{"ino" } },
-            { "assembly", new List<string>{"nasm", "asm" } },
-            { "batchfile", new List<string>{"bat", "cmd" } },
-            { "css", new List<string>{ } },
-            { "cpp", new List<string>{"c", "c++", "objective-c", "obj-c", "objc", "objectivec", "h", "hpp", "cc", "m" } },
-            { "csharp", new List<string>{"cs"} },
-            { "cuda", new List<string>{"cu", "cuh" } },
-            { "d", new List<string>{"dlang"} },
-            { "everything", new List<string>{"example" } }, //this is the catch all to try and process unforseen languages
-            { "erlang", new List<string>{"erl" } },
-            { "fsharp", new List<string>{"fs", "fsi", "fsx" } },
-            { "go", new List<string>{"golang" } },
-            { "handlebars", new List<string>{"hbs" } },
-            { "haskell", new List<string>{"hs" } },
-            { "html", new List<string>{ "jsp", "asp", "aspx", "ascx" } },
-            { "cshtml", new List<string>{"aspx-cs", "aspx-csharp" } },
-            { "vbhtml", new List<string>{"aspx-vb" } },
-            { "java", new List<string>{"gradle" } },
-            { "javascript", new List<string>{"js", "node", "json" } },
-            { "lisp", new List<string>{".lsp" } },
-            { "lua", new List<string>{ } },
-            { "matlab", new List<string>{ } },
-            { "pascal", new List<string>{"pas" } },
-            { "perl", new List<string>{"pl" } },
-            { "php", new List<string>{"php" } },
-            { "powershell", new List<string>{"posh", "ps1" } },
-            { "processing", new List<string>{"pde" } },
-            { "python", new List<string>{"py" } },
-            { "r", new List<string>{ } },
-            { "react", new List<string>{"tsx" } },
-            { "ruby", new List<string>{"ru", "ruby", "", "erb", "rb" } },
-            { "rust", new List<string>{"rs" } },
-            { "scala", new List<string>{ } },
-            { "shell", new List<string>{"sh", "bash" } },
-            { "smalltalk", new List<string>{"st" } },
-            { "sql", new List<string>{ } },
-            { "swift", new List<string>{ } },
-            { "typescript", new List<string>{"ts" } },
-            { "xaml", new List<string>{ } },
-            { "xml", new List<string>{"xsl", "xslt", "xsd", "wsdl", "csdl", "edmx" } },
-            { "vb", new List<string>{"vbnet", "vbscript", "bas", "vbs", "vba" } }
-        };
-
+        private const string TagPrefix = "snippet";
+        private const string WarningMessageId = "codeIncludeNotFound";
+        private const string DefaultWarningMessage = "It looks like the sample you are looking for does not exist.";
+        private const string WarningTitleId = "warning";
+        private const string DefaultWarningTitle = "<h5>WARNING</h5>";
 
         // C# code snippet comment block: // <[/]snippetname>
-        private static readonly string CFamilyCodeSnippetCommentStartLineTemplate = "//<{tagname}>";
-        private static readonly string CFamilyCodeSnippetCommentEndLineTemplate = "//</{tagname}>";
+        private const string CFamilyCodeSnippetCommentStartLineTemplate = "//<{tagname}>";
+        private const string CFamilyCodeSnippetCommentEndLineTemplate = "//</{tagname}>";
 
         // C# code snippet region block: start -> #region snippetname, end -> #endregion
-        private static readonly string CSharpCodeSnippetRegionStartLineTemplate = "#region{tagname}";
-        private static readonly string CSharpCodeSnippetRegionEndLineTemplate = "#endregion";
+        private const string CSharpCodeSnippetRegionStartLineTemplate = "#region{tagname}";
+        private const string CSharpCodeSnippetRegionEndLineTemplate = "#endregion";
 
         // VB code snippet comment block: ' <[/]snippetname>
-        private static readonly string BasicFamilyCodeSnippetCommentStartLineTemplate = "'<{tagname}>";
-        private static readonly string BasicFamilyCodeSnippetCommentEndLineTemplate = "'</{tagname}>";
+        private const string BasicFamilyCodeSnippetCommentStartLineTemplate = "'<{tagname}>";
+        private const string BasicFamilyCodeSnippetCommentEndLineTemplate = "'</{tagname}>";
 
         // VB code snippet Region block: start -> # Region "snippetname", end -> # End Region
-        private static readonly string VBCodeSnippetRegionRegionStartLineTemplate = "#region{tagname}";
-        private static readonly string VBCodeSnippetRegionRegionEndLineTemplate = "#endregion";
+        private const string VBCodeSnippetRegionRegionStartLineTemplate = "#region{tagname}";
+        private const string VBCodeSnippetRegionRegionEndLineTemplate = "#endregion";
 
         // XML code snippet block: <!-- <[/]snippetname> -->
-        private static readonly string MarkupLanguageFamilyCodeSnippetCommentStartLineTemplate = "<!--<{tagname}>-->";
-        private static readonly string MarkupLanguageFamilyCodeSnippetCommentEndLineTemplate = "<!--</{tagname}>-->";
+        private const string MarkupLanguageFamilyCodeSnippetCommentStartLineTemplate = "<!--<{tagname}>-->";
+        private const string MarkupLanguageFamilyCodeSnippetCommentEndLineTemplate = "<!--</{tagname}>-->";
 
         // Sql code snippet block: -- <[/]snippetname>
-        private static readonly string SqlFamilyCodeSnippetCommentStartLineTemplate = "--<{tagname}>";
-        private static readonly string SqlFamilyCodeSnippetCommentEndLineTemplate = "--</{tagname}>";
+        private const string SqlFamilyCodeSnippetCommentStartLineTemplate = "--<{tagname}>";
+        private const string SqlFamilyCodeSnippetCommentEndLineTemplate = "--</{tagname}>";
 
         // Python code snippet comment block: # <[/]snippetname>
-        private static readonly string ScriptFamilyCodeSnippetCommentStartLineTemplate = "#<{tagname}>";
-        private static readonly string ScriptFamilyCodeSnippetCommentEndLineTemplate = "#</{tagname}>";
+        private const string ScriptFamilyCodeSnippetCommentStartLineTemplate = "#<{tagname}>";
+        private const string ScriptFamilyCodeSnippetCommentEndLineTemplate = "#</{tagname}>";
 
         // Batch code snippet comment block: rem <[/]snippetname>
-        private static readonly string BatchFileCodeSnippetRegionStartLineTemplate = "rem<{tagname}>";
-        private static readonly string BatchFileCodeSnippetRegionEndLineTemplate = "rem</{tagname}>";
+        private const string BatchFileCodeSnippetRegionStartLineTemplate = "rem<{tagname}>";
+        private const string BatchFileCodeSnippetRegionEndLineTemplate = "rem</{tagname}>";
 
         // Erlang code snippet comment block: % <[/]snippetname>
-        private static readonly string ErlangCodeSnippetRegionStartLineTemplate = "%<{tagname}>";
-        private static readonly string ErlangCodeSnippetRegionEndLineTemplate = "%</{tagname}>";
+        private const string ErlangCodeSnippetRegionStartLineTemplate = "%<{tagname}>";
+        private const string ErlangCodeSnippetRegionEndLineTemplate = "%</{tagname}>";
 
         // Lisp code snippet comment block: ; <[/]snippetname>
-        private static readonly string LispCodeSnippetRegionStartLineTemplate = ";<{tagname}>";
-        private static readonly string LispCodeSnippetRegionEndLineTemplate = ";</{tagname}>";
+        private const string LispCodeSnippetRegionStartLineTemplate = ";<{tagname}>";
+        private const string LispCodeSnippetRegionEndLineTemplate = ";</{tagname}>";
 
         // css code snippet comment block: ; <[/]snippetname>
-        private static readonly string CSSCodeSnippetRegionStartLineTemplate = "/*<{tagname}>*/";
-        private static readonly string CSSCodeSnippetRegionEndLineTemplate = "/*</{tagname}>*/";
+        private const string CSSCodeSnippetRegionStartLineTemplate = "/*<{tagname}>*/";
+        private const string CSSCodeSnippetRegionEndLineTemplate = "/*</{tagname}>*/";
+
+        private static readonly IReadOnlyDictionary<string, string[]> s_languageAlias = new Dictionary<string, string[]>
+        {
+            { "actionscript", new string[] {"as" } },
+            { "arduino", new string[] {"ino" } },
+            { "assembly", new string[] {"nasm", "asm" } },
+            { "batchfile", new string[] {"bat", "cmd" } },
+            { "css", Array.Empty<string>() },
+            { "cpp", new string[] {"c", "c++", "objective-c", "obj-c", "objc", "objectivec", "h", "hpp", "cc", "m" } },
+            { "csharp", new string[] {"cs"} },
+            { "cuda", new string[] {"cu", "cuh" } },
+            { "d", new string[] {"dlang"} },
+            { "everything", new string[] {"example" } }, //this is the catch all to try and process unforseen languages
+            { "erlang", new string[] {"erl" } },
+            { "fsharp", new string[] {"fs", "fsi", "fsx" } },
+            { "go", new string[] {"golang" } },
+            { "handlebars", new string[] {"hbs" } },
+            { "haskell", new string[] {"hs" } },
+            { "html", new string[] { "jsp", "asp", "aspx", "ascx" } },
+            { "cshtml", new string[] {"aspx-cs", "aspx-csharp" } },
+            { "vbhtml", new string[] {"aspx-vb" } },
+            { "java", new string[] {"gradle" } },
+            { "javascript", new string[] {"js", "node", "json" } },
+            { "lisp", new string[] {"lsp" } },
+            { "lua", Array.Empty<string>() },
+            { "matlab", Array.Empty<string>() },
+            { "pascal", new string[] {"pas" } },
+            { "perl", new string[] {"pl" } },
+            { "php", Array.Empty<string>() },
+            { "powershell", new string[] {"posh", "ps1" } },
+            { "processing", new string[] {"pde" } },
+            { "python", new string[] {"py" } },
+            { "r", Array.Empty<string>() },
+            { "react", new string[] {"tsx" } },
+            { "ruby", new string[] {"ru", "erb", "rb", "" } },
+            { "rust", new string[] {"rs" } },
+            { "scala", Array.Empty<string>() },
+            { "shell", new string[] {"sh", "bash" } },
+            { "smalltalk", new string[] {"st" } },
+            { "sql", Array.Empty<string>() },
+            { "swift", Array.Empty<string>() },
+            { "typescript", new string[] {"ts" } },
+            { "xaml", Array.Empty<string>() },
+            { "xml", new string[] {"xsl", "xslt", "xsd", "wsdl", "csdl", "edmx" } },
+            { "vb", new string[] {"vbnet", "vbscript", "bas", "vbs", "vba" } }
+        };
+
+        private static readonly Dictionary<string, string> s_languageByFileExtension = new Dictionary<string, string>();
 
         // If we ever come across a language that has not been defined above, we shouldn't break the build.
         // We can at least try it with a default language, "C#" for now, and try and resolve the code snippet.
-        private static readonly string DefaultSnippetLanguage = ".everything";
+        private static readonly HashSet<CodeSnippetExtractor> s_defaultExtractors = new HashSet<CodeSnippetExtractor>();
 
         // Language names and aliases follow http://highlightjs.readthedocs.org/en/latest/css-classes-reference.html#language-names-and-aliases
         // Language file extensions follow https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
         // Currently only supports parts of the language names, aliases and extensions
         // Later we can move the repository's supported/custom language names, aliases, extensions and corresponding comments regexes to docfx build configuration
-        private static readonly IReadOnlyDictionary<string, List<CodeSnippetExtractor>> s_codeLanguageExtractors = BuildCodeLanguageExtractors();
+        private static readonly Dictionary<string, HashSet<CodeSnippetExtractor>> s_languageExtractors = new Dictionary<string, HashSet<CodeSnippetExtractor>>();
+
+        private readonly MarkdownContext _context;
+
+        static HtmlCodeSnippetRenderer()
+        {
+            BuildFileExtensionLanguageMap();
+
+            AddExtractorItems(new[] { "vb", "vbhtml" },
+                new CodeSnippetExtractor(BasicFamilyCodeSnippetCommentStartLineTemplate, BasicFamilyCodeSnippetCommentEndLineTemplate));
+            AddExtractorItems(new[] { "actionscript", "arduino", "assembly", "cpp", "csharp", "cshtml", "cuda", "d", "fsharp", "go", "java", "javascript", "objectivec", "pascal", "php", "processing", "react", "rust", "scala", "smalltalk", "swift", "typescript" },
+                new CodeSnippetExtractor(CFamilyCodeSnippetCommentStartLineTemplate, CFamilyCodeSnippetCommentEndLineTemplate));
+            AddExtractorItems(new[] { "xml", "xaml", "handlebars", "html", "cshtml", "php", "react", "ruby", "vbhtml" },
+                new CodeSnippetExtractor(MarkupLanguageFamilyCodeSnippetCommentStartLineTemplate, MarkupLanguageFamilyCodeSnippetCommentEndLineTemplate));
+            AddExtractorItems(new[] { "haskell", "lua", "sql" },
+                new CodeSnippetExtractor(SqlFamilyCodeSnippetCommentStartLineTemplate, SqlFamilyCodeSnippetCommentEndLineTemplate));
+            AddExtractorItems(new[] { "perl", "powershell", "python", "r", "ruby", "shell" },
+                new CodeSnippetExtractor(ScriptFamilyCodeSnippetCommentStartLineTemplate, ScriptFamilyCodeSnippetCommentEndLineTemplate));
+            AddExtractorItems(new[] { "batchfile" },
+                new CodeSnippetExtractor(BatchFileCodeSnippetRegionStartLineTemplate, BatchFileCodeSnippetRegionEndLineTemplate));
+            AddExtractorItems(new[] { "csharp", "cshtml" },
+                new CodeSnippetExtractor(CSharpCodeSnippetRegionStartLineTemplate, CSharpCodeSnippetRegionEndLineTemplate, false));
+            AddExtractorItems(new[] { "erlang", "matlab" },
+                new CodeSnippetExtractor(ErlangCodeSnippetRegionStartLineTemplate, ErlangCodeSnippetRegionEndLineTemplate));
+            AddExtractorItems(new[] { "lisp" },
+                new CodeSnippetExtractor(LispCodeSnippetRegionStartLineTemplate, LispCodeSnippetRegionEndLineTemplate));
+            AddExtractorItems(new[] { "vb", "vbhtml" },
+                new CodeSnippetExtractor(VBCodeSnippetRegionRegionStartLineTemplate, VBCodeSnippetRegionRegionEndLineTemplate, false));
+            AddExtractorItems(new[] { "css" },
+                new CodeSnippetExtractor(CSSCodeSnippetRegionStartLineTemplate, CSSCodeSnippetRegionEndLineTemplate, false));
+
+            static void BuildFileExtensionLanguageMap()
+            {
+                foreach (var (language, aliases) in s_languageAlias)
+                {
+                    Debug.Assert(!language.StartsWith('.'));
+
+                    s_languageByFileExtension.Add(language, language);
+                    s_languageByFileExtension.Add($".{language}", language);
+
+                    foreach (var alias in aliases)
+                    {
+                        Debug.Assert(!alias.StartsWith('.'));
+
+                        s_languageByFileExtension.Add(alias, language);
+                        s_languageByFileExtension.Add($".{alias}", language);
+                    }
+                }
+            }
+
+            static void AddExtractorItems(string[] languages, CodeSnippetExtractor extractor)
+            {
+                s_defaultExtractors.Add(extractor);
+
+                foreach (var language in languages)
+                {
+                    AddExtractorItem(language, extractor);
+                    AddExtractorItem($".{language}", extractor);
+
+                    if (s_languageAlias.TryGetValue(language, out var aliases))
+                    {
+                        foreach (var alias in aliases)
+                        {
+                            AddExtractorItem($".{alias}", extractor);
+                        }
+                    }
+                }
+            }
+
+            static void AddExtractorItem(string language, CodeSnippetExtractor extractor)
+            {
+                if (s_languageExtractors.TryGetValue(language, out var extractors))
+                {
+                    extractors.Add(extractor);
+                }
+                else
+                {
+                    s_languageExtractors[language] = new HashSet<CodeSnippetExtractor> { extractor };
+                }
+            }
+        }
 
         public HtmlCodeSnippetRenderer(MarkdownContext context)
         {
             _context = context;
         }
 
-        private static IReadOnlyDictionary<string, List<CodeSnippetExtractor>> BuildCodeLanguageExtractors()
+        public static string GetLanguageByFileExtension(string extension)
         {
-            var result = new Dictionary<string, List<CodeSnippetExtractor>>();
-
-            AddExtractorItems(new[] { "vb", "vbhtml", "everything" },
-                new CodeSnippetExtractor(BasicFamilyCodeSnippetCommentStartLineTemplate, BasicFamilyCodeSnippetCommentEndLineTemplate));
-            AddExtractorItems(new[] { "actionscript", "arduino", "assembly", "cpp", "csharp", "cshtml", "cuda", "d", "fsharp", "go", "java", "javascript", "objectivec", "pascal", "php", "processing", "react", "rust", "scala", "smalltalk", "swift", "typescript", "everything" },
-                new CodeSnippetExtractor(CFamilyCodeSnippetCommentStartLineTemplate, CFamilyCodeSnippetCommentEndLineTemplate));
-            AddExtractorItems(new[] { "xml", "xaml", "handlebars", "html", "cshtml", "php", "react", "ruby", "vbhtml", "everything" },
-                new CodeSnippetExtractor(MarkupLanguageFamilyCodeSnippetCommentStartLineTemplate, MarkupLanguageFamilyCodeSnippetCommentEndLineTemplate));
-            AddExtractorItems(new[] { "haskell", "lua", "sql", "everything" },
-                new CodeSnippetExtractor(SqlFamilyCodeSnippetCommentStartLineTemplate, SqlFamilyCodeSnippetCommentEndLineTemplate));
-            AddExtractorItems(new[] { "perl", "powershell", "python", "r", "ruby", "shell", "everything" },
-                new CodeSnippetExtractor(ScriptFamilyCodeSnippetCommentStartLineTemplate, ScriptFamilyCodeSnippetCommentEndLineTemplate));
-            AddExtractorItems(new[] { "batchfile", "everything" },
-                new CodeSnippetExtractor(BatchFileCodeSnippetRegionStartLineTemplate, BatchFileCodeSnippetRegionEndLineTemplate));
-            AddExtractorItems(new[] { "csharp", "cshtml", "everything" },
-                new CodeSnippetExtractor(CSharpCodeSnippetRegionStartLineTemplate, CSharpCodeSnippetRegionEndLineTemplate, false));
-            AddExtractorItems(new[] { "erlang", "matlab", "everything" },
-                new CodeSnippetExtractor(ErlangCodeSnippetRegionStartLineTemplate, ErlangCodeSnippetRegionEndLineTemplate));
-            AddExtractorItems(new[] { "lisp", "everything" },
-                new CodeSnippetExtractor(LispCodeSnippetRegionStartLineTemplate, LispCodeSnippetRegionEndLineTemplate));
-            AddExtractorItems(new[] { "vb", "vbhtml", "everything" },
-                new CodeSnippetExtractor(VBCodeSnippetRegionRegionStartLineTemplate, VBCodeSnippetRegionRegionEndLineTemplate, false));
-            AddExtractorItems(new[] { "css", "everything" },
-                new CodeSnippetExtractor(CSSCodeSnippetRegionStartLineTemplate, CSSCodeSnippetRegionEndLineTemplate, false));
-
-            return result;
-
-            void AddExtractorItems(string[] languages, CodeSnippetExtractor extractor)
-            {
-                foreach (var language in languages)
-                {
-                    AddExtractorItem(language, extractor);
-
-                    if (LanguageAlias.ContainsKey(language))
-                    {
-                        foreach (var alias in LanguageAlias[language])
-                        {
-                            AddExtractorItem(alias, extractor);
-                        }
-                    }
-                }
-            }
-
-            void AddExtractorItem(string language, CodeSnippetExtractor extractor)
-            {
-                if (result.ContainsKey(language))
-                {
-                    result[language].Add(extractor);
-                }
-                else
-                {
-                    result[language] = new List<CodeSnippetExtractor> { extractor };
-                }
-            }
+            return s_languageByFileExtension.TryGetValue(extension, out var result) ? result : null;
         }
 
         protected override void Write(HtmlRenderer renderer, CodeSnippet codeSnippet)
         {
             var (content, codeSnippetPath) = _context.ReadFile(codeSnippet.CodePath, codeSnippet);
-            
+
             if (content == null)
             {
                 _context.LogWarning("codesnippet-not-found", $"Invalid code snippet link: '{codeSnippet.CodePath}'.", codeSnippet);
@@ -261,11 +289,9 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
                     return GetNoteBookContent(content, obj.TagName, obj);
                 }
 
-                List<CodeSnippetExtractor> extractors;
-                if (!s_codeLanguageExtractors.TryGetValue(lang, out extractors)
-                    && !s_codeLanguageExtractors.TryGetValue(lang.Remove(0, 1), out extractors))
+                if (!s_languageExtractors.TryGetValue(lang, out var extractors))
                 {
-                    s_codeLanguageExtractors.TryGetValue(DefaultSnippetLanguage, out extractors);
+                    extractors = s_defaultExtractors;
 
                     _context.LogWarning(
                         "unknown-language-code",
@@ -273,18 +299,15 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
                         obj);
                 }
 
-                if (extractors != null)
+                var tagWithPrefix = TagPrefix + obj.TagName;
+                foreach (var extractor in extractors)
                 {
-                    var tagWithPrefix = tagPrefix + obj.TagName;
-                    foreach (var extractor in extractors)
+                    HashSet<int> tagLines = new HashSet<int>();
+                    var tagToCoderangeMapping = extractor.GetAllTags(allLines, ref tagLines);
+                    if (tagToCoderangeMapping.TryGetValue(obj.TagName, out var cr)
+                        || tagToCoderangeMapping.TryGetValue(tagWithPrefix, out cr))
                     {
-                        HashSet<int> tagLines = new HashSet<int>();
-                        var tagToCoderangeMapping = extractor.GetAllTags(allLines, ref tagLines);
-                        if (tagToCoderangeMapping.TryGetValue(obj.TagName, out var cr)
-                            || tagToCoderangeMapping.TryGetValue(tagWithPrefix, out cr))
-                        {
-                            return GetCodeLines(allLines, obj, new List<CodeRange> { cr }, tagLines);
-                        }
+                        return GetCodeLines(allLines, obj, new List<CodeRange> { cr }, tagLines);
                     }
                 }
             }
@@ -444,8 +467,8 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
         private string GetWarning()
         {
-            var warningTitle = _context.GetToken(warningTitleId) ?? defaultWarningTitle;
-            var warningMessage = _context.GetToken(warningMessageId) ?? defaultWarningMessage;
+            var warningTitle = _context.GetToken(WarningTitleId) ?? DefaultWarningTitle;
+            var warningMessage = _context.GetToken(WarningMessageId) ?? DefaultWarningMessage;
 
             return $@"<div class=""WARNING"">
 {warningTitle}

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/CodeExtension.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/CodeExtension.cs
@@ -132,16 +132,12 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             {
                 logError("Language is not set, and your source has no file type. Cannot infer language.");
             }
-            var language = HtmlCodeSnippetRenderer.LanguageAlias.Where(oo =>
-                oo.Key.Equals(fileExtension)
-                || oo.Key.Equals(fileExtension.Remove(0, 1))
-                || oo.Value.Contains(fileExtension)
-                || oo.Value.Contains(fileExtension.Remove(0,1))).FirstOrDefault();
-            if(string.IsNullOrEmpty(language.Key))
+            var language = HtmlCodeSnippetRenderer.GetLanguageByFileExtension(fileExtension);
+            if(string.IsNullOrEmpty(language))
             {
                 logError("Language is not set, and we could not infer language from the file type.");
             }
-            return language.Key;
+            return language;
         }
 
         public bool TryValidateAncestry(ContainerBlock container, Action<string> logError)


### PR DESCRIPTION
@adunndevster This eliminate an expensive compare [here](https://github.com/dotnet/docfx/pull/6210/files#diff-731659c44c7df577cd866c6342b8eed2L135) , remove the need to trim `.` for each language and also remove the magic `everything` string.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6210)