### PR TITLE
Copy fonts (glyph) folder to PDF output

### DIFF
--- a/src/docfx.website.themes/pdf.default/gulpfile.js
+++ b/src/docfx.website.themes/pdf.default/gulpfile.js
@@ -35,6 +35,4 @@ gulp.task('copy:font', function () {
         .pipe(copy('./fonts/'));
 });
 
-gulp.task('copy', ['copy:font']);
-
-gulp.task('default', ['concat']);
+gulp.task('default', gulp.parallel('concat', 'copy:font'));

--- a/src/docfx.website.themes/pdf.default/gulpfile.js
+++ b/src/docfx.website.themes/pdf.default/gulpfile.js
@@ -30,4 +30,11 @@ gulp.task('concat', function () {
   ;
 });
 
+gulp.task('copy:font', function () {
+    return gulp.src(vendor.font.src, { cwd: vendor.font.cwd })
+        .pipe(copy('./fonts/'));
+});
+
+gulp.task('copy', ['copy:font']);
+
 gulp.task('default', ['concat']);


### PR DESCRIPTION
Copy the "fonts" folder to intermediate PDF output folder, which is needed for glyphs in NOTEs sections.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6211)