### PR TITLE
Fix for duplicate-uids of multiple versioning SDP

### DIFF
--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -1503,7 +1503,5 @@ outputs:
   136a42ac/docs/a.json:
   4667fedf/docs/a.json:
   .errors.log: |
-    {"message_severity":"warning","code":"duplicate-uid","message":"UID 'a' is duplicated in 'docs/v1/a.yml(5,6)', 'docs/v2/a.yml(5,6)'.","file":"docs/v1/a.yml","line":5,"column":6}
-    {"message_severity":"warning","code":"duplicate-uid","message":"UID 'a' is duplicated in 'docs/v1/a.yml(5,6)', 'docs/v2/a.yml(5,6)'.","file":"docs/v2/a.yml","line":5,"column":6}
     {"message_severity":"warning","code":"xref-property-conflict","message":"UID 'a' is defined with different names: 'name 1', 'name 2'."}
     {"message_severity":"warning","code":"xref-property-conflict","message":"UID 'a' is defined with different descriptions: 'test 1', 'test 2'."}

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Docs.Build
                 ContentValidator,
                 new Lazy<PublishUrlMap>(() => PublishUrlMap));
 
-            JsonSchemaTransformer = new JsonSchemaTransformer(MarkdownEngine, LinkResolver, XrefResolver, errorLog);
+            JsonSchemaTransformer = new JsonSchemaTransformer(MarkdownEngine, LinkResolver, XrefResolver, errorLog, MonikerProvider);
             var tocParser = new TableOfContentsParser(Input, MarkdownEngine, DocumentProvider);
             TableOfContentsLoader = new TableOfContentsLoader(LinkResolver, XrefResolver, tocParser, MonikerProvider, DependencyMapBuilder, ContentValidator);
             TocMap =

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -25,7 +25,12 @@ namespace Microsoft.Docs.Build
         private static ThreadLocal<Stack<SourceInfo<string>>> t_recursionDetector
                  = new ThreadLocal<Stack<SourceInfo<string>>>(() => new Stack<SourceInfo<string>>());
 
-        public JsonSchemaTransformer(MarkdownEngine markdownEngine, LinkResolver linkResolver, XrefResolver xrefResolver, ErrorLog errorLog, MonikerProvider monikerProvider)
+        public JsonSchemaTransformer(
+            MarkdownEngine markdownEngine,
+            LinkResolver linkResolver,
+            XrefResolver xrefResolver,
+            ErrorLog errorLog,
+            MonikerProvider monikerProvider)
         {
             _markdownEngine = markdownEngine;
             _linkResolver = linkResolver;

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Docs.Build
         private readonly LinkResolver _linkResolver;
         private readonly XrefResolver _xrefResolver;
         private readonly ErrorLog _errorLog;
+        private readonly MonikerProvider _monikerProvider;
 
         private readonly ConcurrentDictionary<Document, int> _uidCountCache = new ConcurrentDictionary<Document, int>(ReferenceEqualsComparer.Default);
         private readonly ConcurrentDictionary<(FilePath, string), JObject> _resolvedXrefSpec = new ConcurrentDictionary<(FilePath, string), JObject>();
@@ -24,12 +25,13 @@ namespace Microsoft.Docs.Build
         private static ThreadLocal<Stack<SourceInfo<string>>> t_recursionDetector
                  = new ThreadLocal<Stack<SourceInfo<string>>>(() => new Stack<SourceInfo<string>>());
 
-        public JsonSchemaTransformer(MarkdownEngine markdownEngine, LinkResolver linkResolver, XrefResolver xrefResolver, ErrorLog errorLog)
+        public JsonSchemaTransformer(MarkdownEngine markdownEngine, LinkResolver linkResolver, XrefResolver xrefResolver, ErrorLog errorLog, MonikerProvider monikerProvider)
         {
             _markdownEngine = markdownEngine;
             _linkResolver = linkResolver;
             _xrefResolver = xrefResolver;
             _errorLog = errorLog;
+            _monikerProvider = monikerProvider;
         }
 
         public JObject? GetResolvedXrefSpec(FilePath file, string uid)
@@ -118,6 +120,8 @@ namespace Microsoft.Docs.Build
                     () => LoadXrefProperty(definitions, file, uid, value, propertySchema, uidCount),
                     LazyThreadSafetyMode.PublicationOnly);
             }
+
+            xref.Monikers = _monikerProvider.GetFileLevelMonikers(file.FilePath).monikers;
 
             return xref;
         }


### PR DESCRIPTION
Fix the duplicate-uid warnings by adding monikers for specs (which is used to determin whether same uids have different monikers) of each file.

[AB#263955](https://dev.azure.com/ceapex/Engineering/_workitems/edit/263955)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6224)