### PR TITLE
Make MonikerList a required parameter of the InternalXrefSpec's constructor

### DIFF
--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -1503,7 +1503,5 @@ outputs:
   136a42ac/docs/a.json:
   4667fedf/docs/a.json:
   .errors.log: |
-    {"message_severity":"warning","code":"duplicate-uid","message":"UID 'a' is duplicated in 'docs/v1/a.yml(5,6)', 'docs/v2/a.yml(5,6)'.","file":"docs/v1/a.yml","line":5,"column":6}
-    {"message_severity":"warning","code":"duplicate-uid","message":"UID 'a' is duplicated in 'docs/v1/a.yml(5,6)', 'docs/v2/a.yml(5,6)'.","file":"docs/v2/a.yml","line":5,"column":6}
     {"message_severity":"warning","code":"xref-property-conflict","message":"UID 'a' is defined with different names: 'name 1', 'name 2'."}
     {"message_severity":"warning","code":"xref-property-conflict","message":"UID 'a' is defined with different descriptions: 'test 1', 'test 2'."}

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Docs.Build
                 ContentValidator,
                 new Lazy<PublishUrlMap>(() => PublishUrlMap));
 
-            JsonSchemaTransformer = new JsonSchemaTransformer(MarkdownEngine, LinkResolver, XrefResolver, errorLog);
+            JsonSchemaTransformer = new JsonSchemaTransformer(MarkdownEngine, LinkResolver, XrefResolver, errorLog, MonikerProvider);
             var tocParser = new TableOfContentsParser(Input, MarkdownEngine, DocumentProvider);
             TableOfContentsLoader = new TableOfContentsLoader(LinkResolver, XrefResolver, tocParser, MonikerProvider, DependencyMapBuilder, ContentValidator);
             TocMap =

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -119,11 +119,11 @@ namespace Microsoft.Docs.Build
                 return (new List<Error>(), default);
             }
 
-            var xref = new InternalXrefSpec(metadata.Uid, file.SiteUrl, file);
+            var (errors, monikers) = _monikerProvider.GetFileLevelMonikers(file.FilePath);
+            var xref = new InternalXrefSpec(metadata.Uid, file.SiteUrl, file, monikers);
+
             xref.XrefProperties["name"] = new Lazy<JToken>(() => new JValue(string.IsNullOrEmpty(metadata.Title) ? metadata.Uid : metadata.Title.Value));
 
-            var (errors, monikers) = _monikerProvider.GetFileLevelMonikers(file.FilePath);
-            xref.Monikers = monikers;
             return (errors, xref);
         }
 

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -21,11 +21,12 @@ namespace Microsoft.Docs.Build
 
         string IXrefSpec.Uid => Uid.Value;
 
-        public InternalXrefSpec(SourceInfo<string> uid, string href, Document declaringFile)
+        public InternalXrefSpec(SourceInfo<string> uid, string href, Document declaringFile, MonikerList monikerList)
         {
             Uid = uid;
             Href = href;
             DeclaringFile = declaringFile;
+            Monikers = monikerList;
         }
 
         public string? GetXrefPropertyValueAsString(string propertyName)

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -25,7 +25,12 @@ namespace Microsoft.Docs.Build
         private static ThreadLocal<Stack<SourceInfo<string>>> t_recursionDetector
                  = new ThreadLocal<Stack<SourceInfo<string>>>(() => new Stack<SourceInfo<string>>());
 
-        public JsonSchemaTransformer(MarkdownEngine markdownEngine, LinkResolver linkResolver, XrefResolver xrefResolver, ErrorLog errorLog, MonikerProvider monikerProvider)
+        public JsonSchemaTransformer(
+            MarkdownEngine markdownEngine,
+            LinkResolver linkResolver,
+            XrefResolver xrefResolver,
+            ErrorLog errorLog,
+            MonikerProvider monikerProvider)
         {
             _markdownEngine = markdownEngine;
             _linkResolver = linkResolver;

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -105,7 +105,8 @@ namespace Microsoft.Docs.Build
             int uidCount)
         {
             var href = GetXrefHref(file, uid, uidCount, obj.Parent == null);
-            var xref = new InternalXrefSpec(uid, href, file);
+            MonikerList monikers = _monikerProvider.GetFileLevelMonikers(file.FilePath).monikers;
+            var xref = new InternalXrefSpec(uid, href, file, monikers);
 
             foreach (var xrefProperty in schema.XrefProperties)
             {
@@ -125,8 +126,6 @@ namespace Microsoft.Docs.Build
                     () => LoadXrefProperty(definitions, file, uid, value, propertySchema, uidCount),
                     LazyThreadSafetyMode.PublicationOnly);
             }
-
-            xref.Monikers = _monikerProvider.GetFileLevelMonikers(file.FilePath).monikers;
 
             return xref;
         }

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Docs.Build
         private readonly LinkResolver _linkResolver;
         private readonly XrefResolver _xrefResolver;
         private readonly ErrorLog _errorLog;
+        private readonly MonikerProvider _monikerProvider;
 
         private readonly ConcurrentDictionary<Document, int> _uidCountCache = new ConcurrentDictionary<Document, int>(ReferenceEqualsComparer.Default);
         private readonly ConcurrentDictionary<(FilePath, string), JObject> _resolvedXrefSpec = new ConcurrentDictionary<(FilePath, string), JObject>();
@@ -24,12 +25,13 @@ namespace Microsoft.Docs.Build
         private static ThreadLocal<Stack<SourceInfo<string>>> t_recursionDetector
                  = new ThreadLocal<Stack<SourceInfo<string>>>(() => new Stack<SourceInfo<string>>());
 
-        public JsonSchemaTransformer(MarkdownEngine markdownEngine, LinkResolver linkResolver, XrefResolver xrefResolver, ErrorLog errorLog)
+        public JsonSchemaTransformer(MarkdownEngine markdownEngine, LinkResolver linkResolver, XrefResolver xrefResolver, ErrorLog errorLog, MonikerProvider monikerProvider)
         {
             _markdownEngine = markdownEngine;
             _linkResolver = linkResolver;
             _xrefResolver = xrefResolver;
             _errorLog = errorLog;
+            _monikerProvider = monikerProvider;
         }
 
         public JObject? GetResolvedXrefSpec(FilePath file, string uid)
@@ -118,6 +120,8 @@ namespace Microsoft.Docs.Build
                     () => LoadXrefProperty(definitions, file, uid, value, propertySchema, uidCount),
                     LazyThreadSafetyMode.PublicationOnly);
             }
+
+            xref.Monikers = _monikerProvider.GetFileLevelMonikers(file.FilePath).monikers;
 
             return xref;
         }


### PR DESCRIPTION
Make MoniterList a required parameter of the InternalXrefSpec's constructor

[AB#263955](https://dev.azure.com/ceapex/Engineering/_workitems/edit/263955)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6226)