### PR TITLE
Turn git-clone-incomplete into a warning

### DIFF
--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Docs.Build
             /// Failed to compute specific info of a commit.
             /// </summary>
             public static Error GitCloneIncomplete(string repoPath)
-                => new Error(ErrorLevel.Error, "git-clone-incomplete", $"Git repository '{repoPath}' is an incomplete clone, GitHub contributor list may not be accurate.");
+                => new Error(ErrorLevel.Warning, "git-clone-incomplete", $"Git repository '{repoPath}' is an incomplete clone, GitHub contributor list may not be accurate.");
 
             /// <summary>
             /// Git.exe isn't installed.

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Docs.Build
             FileResolver = fileResolver;
             SourceMap = sourceMap;
 
-            RepositoryProvider = new RepositoryProvider(buildOptions, config);
+            RepositoryProvider = new RepositoryProvider(errorLog, buildOptions, config);
             Input = new Input(buildOptions, config, packageResolver, RepositoryProvider);
             Output = new Output(buildOptions.OutputPath, Input, Config.DryRun);
             MicrosoftGraphAccessor = new MicrosoftGraphAccessor(Config);
@@ -103,6 +103,7 @@ namespace Microsoft.Docs.Build
                 DocumentProvider,
                 MonikerProvider,
                 new Lazy<PublishUrlMap>(() => PublishUrlMap));
+
             ContentValidator = new ContentValidator(config, FileResolver, errorLog, MonikerProvider, new Lazy<PublishUrlMap>(() => PublishUrlMap));
             GitHubAccessor = new GitHubAccessor(Config);
             BookmarkValidator = new BookmarkValidator(errorLog);
@@ -151,13 +152,13 @@ namespace Microsoft.Docs.Build
             JsonSchemaTransformer = new JsonSchemaTransformer(MarkdownEngine, LinkResolver, XrefResolver, errorLog, MonikerProvider);
             var tocParser = new TableOfContentsParser(Input, MarkdownEngine, DocumentProvider);
             TableOfContentsLoader = new TableOfContentsLoader(LinkResolver, XrefResolver, tocParser, MonikerProvider, DependencyMapBuilder, ContentValidator);
-            TocMap =
-                new TableOfContentsMap(ErrorLog, Input, BuildScope, DependencyMapBuilder, tocParser, TableOfContentsLoader, DocumentProvider, ContentValidator);
+            TocMap = new TableOfContentsMap(
+                ErrorLog, Input, BuildScope, DependencyMapBuilder, tocParser, TableOfContentsLoader, DocumentProvider, ContentValidator);
             PublishUrlMap = new PublishUrlMap(Config, ErrorLog, BuildScope, RedirectionProvider, DocumentProvider, MonikerProvider, TocMap);
-            PublishModelBuilder =
-                new PublishModelBuilder(config, errorLog, MonikerProvider, buildOptions, ContentValidator, PublishUrlMap, DocumentProvider, SourceMap);
-            MetadataValidator =
-                new MetadataValidator(Config, MicrosoftGraphAccessor, FileResolver, BuildScope, DocumentProvider, MonikerProvider, PublishUrlMap);
+            PublishModelBuilder = new PublishModelBuilder(
+                config, errorLog, MonikerProvider, buildOptions, ContentValidator, PublishUrlMap, DocumentProvider, SourceMap);
+            MetadataValidator = new MetadataValidator(
+                Config, MicrosoftGraphAccessor, FileResolver, BuildScope, DocumentProvider, MonikerProvider, PublishUrlMap);
         }
 
         public void Dispose()

--- a/src/docfx/lib/git/RepositoryProvider.cs
+++ b/src/docfx/lib/git/RepositoryProvider.cs
@@ -10,14 +10,17 @@ namespace Microsoft.Docs.Build
 {
     internal class RepositoryProvider : IDisposable
     {
+        private readonly ErrorLog _errorLog;
+
         private readonly ConcurrentDictionary<string, Repository?> _repositories = new ConcurrentDictionary<string, Repository?>(PathUtility.PathComparer);
         private readonly ConcurrentDictionary<string, FileCommitProvider> _fileCommitProvidersByRepoPath =
             new ConcurrentDictionary<string, FileCommitProvider>();
 
         public Repository? Repository { get; }
 
-        public RepositoryProvider(BuildOptions buildOptions, Config config)
+        public RepositoryProvider(ErrorLog errorLog, BuildOptions buildOptions, Config config)
         {
+            _errorLog = errorLog;
             Repository = buildOptions.Repository;
 
             if (Repository != null && !config.DryRun && !buildOptions.IsLocalizedBuild)
@@ -92,7 +95,7 @@ namespace Microsoft.Docs.Build
         {
             return _fileCommitProvidersByRepoPath.GetOrAdd(
                 repo.Path,
-                _ => new FileCommitProvider(repo, AppData.GetCommitCachePath(repo.Remote)));
+                _ => new FileCommitProvider(_errorLog, repo, AppData.GetCommitCachePath(repo.Remote)));
         }
     }
 }

--- a/src/docfx/lib/process/InterProcessReaderWriterLock.cs
+++ b/src/docfx/lib/process/InterProcessReaderWriterLock.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Docs.Build
         private static FileStream WaitFile(string name, string lockHash, FileAccess access, FileShare fileShare)
         {
             var path = Path.Combine(AppData.MutexRoot, lockHash);
-            var start = DateTime.UtcNow;
+            var lastPrintTime = DateTime.UtcNow;
 
             while (true)
             {
@@ -51,8 +51,10 @@ namespace Microsoft.Docs.Build
                 }
                 catch
                 {
-                    if (DateTime.UtcNow - start > TimeSpan.FromSeconds(30))
+                    var now = DateTime.UtcNow;
+                    if (now - lastPrintTime > TimeSpan.FromSeconds(30))
                     {
+                        lastPrintTime = now;
                         Log.Important($"Waiting for another process to access '{name}'", ConsoleColor.Yellow);
                     }
 

--- a/test/docfx.Test/lib/GitUtilityTest.cs
+++ b/test/docfx.Test/lib/GitUtilityTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Docs.Build
             var repo = Repository.Create(Path.GetFullPath(file), branch: null);
             Assert.NotNull(repo);
 
-            using var gitCommitProvider = new FileCommitProvider(repo, "git-commit-test-cache");
+            using var gitCommitProvider = new FileCommitProvider(new ErrorLog(), repo, "git-commit-test-cache");
             var pathToRepo = PathUtility.NormalizeFile(file);
 
             // current branch


### PR DESCRIPTION
This is more on local build, if building a repo clone using `--depth 1`, `git-clone-incomplete` will almost always throw. This PR turns it into a warning and tweak the behavior to match what the warning message says.

![image](https://user-images.githubusercontent.com/511355/87267895-837c0580-c4fb-11ea-8626-03981f18b574.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6230)