### PR TITLE
Sensitive language validation integration

### DIFF
--- a/docs/specs/validations/sensitiveLanguageValidations.yml
+++ b/docs/specs/validations/sensitiveLanguageValidations.yml
@@ -1,0 +1,35 @@
+
+# SensitiveLanguage - sensitive-language
+inputs:
+  docfx.yml: |
+    markdownValidationRules: rules.json
+  rules.json: |
+    {
+      "text": {
+        "rules": [
+          {
+            "type": "SensitiveLanguage",
+            "message": "Term '{0}' is sensitive and should not be used in content or code.",
+            "code": "sensitive-language",
+            "severity": "SUGGESTION",
+            "disallowed": ["master", "blacklist", "whitelist"],
+            "exclusions": ["includes"]
+          }
+        ]
+      }
+    }
+  file1.md: There is master in the content, this will error
+  file2.md: There is#whitelist-with-special chars in the content, this will error
+  file3.md: This is no sensitive language in this file, something like masterclass is ok.
+  file4.md: Blacklist at the start, ends with Master
+outputs:
+  .errors.log: |
+    {"message_severity":"suggestion","code":"sensitive-language","message":"Term 'master' is sensitive and should not be used in content or code.","file":"file1.md","line":1,"end_line":1,"column":0,"end_column":0}
+    {"message_severity":"suggestion","code":"sensitive-language","message":"Term 'whitelist' is sensitive and should not be used in content or code.","file":"file2.md","line":1,"end_line":1,"column":0,"end_column":0}
+    {"message_severity":"suggestion","code":"sensitive-language","message":"Term 'blacklist' is sensitive and should not be used in content or code.","file":"file4.md","line":1,"end_line":1,"column":0,"end_column":0}
+    {"message_severity":"suggestion","code":"sensitive-language","message":"Term 'master' is sensitive and should not be used in content or code.","file":"file4.md","line":1,"end_line":1,"column":0,"end_column":0}
+  file1.json:
+  file2.json:
+  file3.json:
+  file4.json:
+---

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -218,6 +218,8 @@ namespace Microsoft.Docs.Build
             var content = context.Input.ReadString(file.FilePath);
             errors.AddIfNotNull(MergeConflict.CheckMergeConflictMarker(content, file.FilePath));
 
+            context.ContentValidator.ValidateSensitiveLanguage(content, file);
+
             var (metadataErrors, userMetadata) = context.MetadataProvider.GetMetadata(file.FilePath);
             errors.AddRange(metadataErrors);
 

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.2.0-preview.4" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.3" />
-    <PackageReference Include="docs.validation" Version="1.0.0-beta-00192-815d5cd" />
+    <PackageReference Include="docs.validation" Version="1.0.0-beta-00208-a32d80f" />
     <PackageReference Include="DotLiquid" Version="2.0.361" />
     <PackageReference Include="Glob" Version="1.1.7" />
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.298" />

--- a/src/docfx/validation/ContentValidator.cs
+++ b/src/docfx/validation/ContentValidator.cs
@@ -72,6 +72,29 @@ namespace Microsoft.Docs.Build
             }
         }
 
+        public void ValidateSensitiveLanguage(string content, Document document)
+        {
+            if (TryGetValidationDocumentType(document.ContentType, document.Mime.Value, false, out var documentType))
+            {
+                var validationContext = new ValidationContext { DocumentType = documentType };
+
+                using (StringReader reader = new StringReader(content))
+                {
+                    var lineCount = 1;
+                    string? line = null;
+                    while ((line = reader.ReadLine()) != null)
+                    {
+                        var item = new TextItem()
+                        {
+                            Content = line,
+                            SourceInfo = new SourceInfo(document.FilePath, lineCount++, 0),
+                        };
+                        Write(_validator.ValidateText(item, validationContext).GetAwaiter().GetResult());
+                    }
+                }
+            }
+        }
+
         public void ValidateManifest(FilePath filePath, PublishItem publishItem)
         {
             if (TryGetValidationDocumentType(publishItem.ContentType, publishItem.Mime, false, out var documentType))


### PR DESCRIPTION
* Add `ValidateSensitiveLanguage` in ContentValidator
* Add validator call for `ValidateSensitiveLanguage` within `LoadMarkdown`
* Add SensitiveLanguage tests

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6245)