### PR TITLE
Skip GitHub API call on empty email or login

### DIFF
--- a/src/docfx/lib/github/GitHubAccessor.cs
+++ b/src/docfx/lib/github/GitHubAccessor.cs
@@ -48,6 +48,11 @@ namespace Microsoft.Docs.Build
 
         public (Error?, GitHubUser?) GetUserByLogin(SourceInfo<string> login)
         {
+            if (string.IsNullOrEmpty(login))
+            {
+                return default;
+            }
+
             var (error, user) = _userCache.GetOrAdd(login.Value, GetUserByLoginCore);
             if (user != null && !user.IsValid())
             {
@@ -59,6 +64,11 @@ namespace Microsoft.Docs.Build
 
         public (Error?, GitHubUser?) GetUserByEmail(string email, string owner, string name, string commit)
         {
+            if (string.IsNullOrEmpty(email) || string.IsNullOrEmpty(owner) || string.IsNullOrEmpty(name) || string.IsNullOrEmpty(commit))
+            {
+                return default;
+            }
+
             var (error, user) = _userCache.GetOrAdd(email, _ => GetUserByEmailCore(email, owner, name, commit));
             return (error, user != null && user.IsValid() ? user : null);
         }
@@ -113,11 +123,6 @@ namespace Microsoft.Docs.Build
 
         private async Task<(Error?, IEnumerable<GitHubUser>)> GetUserByEmailCore(string email, string owner, string name, string commit)
         {
-            if (string.IsNullOrEmpty(owner) || string.IsNullOrEmpty(name) || string.IsNullOrEmpty(commit))
-            {
-                return default;
-            }
-
             if (_unknownRepos.Contains((owner, name)))
             {
                 return default;


### PR DESCRIPTION
```
Building files:  97% (69256/71119), 00:00:37 
disallowed-html ./articles/azure-sql/includes/appliesto-sqlvm.md(1,2): HTML tag 'Token' isn't allowed. Disallowed HTML poses a security risk and must be replaced with approved Docs Markdown syntax.
disallowed-html ./articles/virtual-machines/windows/using-visual-studio-vm.md(92,107): HTML attribute 'style' on tag 'img' isn't allowed. Disallowed HTML poses a security risk and must be replaced with approved Docs Markdown syntax.
disallowed-html ./articles/azure-sql/database/saas-standaloneapp-get-started-deploy.md(41,75): HTML attribute 'style' on tag 'img' isn't allowed. Disallowed HTML poses a security risk and must be replaced with approved Docs Markdown syntax.
disallowed-html ./articles/azure-sql/database/saas-standaloneapp-get-started-deploy.md(43,75): HTML attribute 'style' on tag 'img' isn't allowed. Disallowed HTML poses a security risk and must be replaced with approved Docs Markdown syntax.
disallowed-html ./articles/azure-sql/database/saas-standaloneapp-get-started-deploy.md(45,76): HTML attribute 'style' on tag 'img' isn't allowed. Disallowed HTML poses a security risk and must be replaced with approved Docs Markdown syntax.
Calling GitHub API: ...

column-header-missing ./articles/cognitive-services/LUIS/luis-reference-prebuilt-entities.md(42,0): Column headers are required for tables. Add appropriate header text. NOTE: This Suggestion will become a Warning in late September, 2020.
column-header-missing ./articles/cognitive-services/LUIS/luis-reference-prebuilt-entities.md(64,0): Column headers are required for tables. Add appropriate header text. NOTE: This Suggestion will become a Warning in late September, 2020.
column-header-missing ./articles/cognitive-services/LUIS/luis-reference-prebuilt-entities.md(86,0): Column headers are required for tables. Add appropriate header text. NOTE: This Suggestion will become a Warning in late September, 2020.
column-header-missing ./articles/cognitive-services/LUIS/luis-reference-prebuilt-entities.md(108,0): Column headers are required for tables. Add appropriate header text. NOTE: This Suggestion will become a Warning in late September, 2020.
column-header-missing ./articles/cognitive-services/LUIS/luis-reference-prebuilt-entities.md(130,0): Column headers are required for tables. Add appropriate header text. NOTE: This Suggestion will become a Warning in late September, 2020.
column-header-missing ./articles/cognitive-services/LUIS/luis-reference-prebuilt-entities.md(152,0): Column headers are required for tables. Add appropriate header text. NOTE: This Suggestion will become a Warning in late September, 2020.
column-header-missing ./articles/cognitive-services/LUIS/luis-reference-prebuilt-entities.md(176,0): Column headers are required for tables. Add appropriate header text. NOTE: This Suggestion will become a Warning in late September, 2020.
column-header-missing ./articles/cognitive-services/LUIS/luis-reference-prebuilt-entities.md(198,0): Column headers are required for tables. Add appropriate header text. NOTE: This Suggestion will become a Warning in late September, 2020.
column-header-missing ./articles/cognitive-services/LUIS/luis-reference-prebuilt-entities.md(220,0): Column headers are required for tables. Add appropriate header text. NOTE: This Suggestion will become a Warning in late September, 2020.
column-header-missing ./articles/cognitive-services/LUIS/luis-reference-prebuilt-entities.md(242,0): Column headers are required for tables. Add appropriate header text. NOTE: This Suggestion will become a Warning in late September, 2020.
column-header-missing ./articles/cognitive-services/LUIS/luis-reference-prebuilt-entities.md(264,0): Column headers are required for tables. Add appropriate header text. NOTE: This Suggestion will become a Warning in late September, 2020.
column-header-missing ./articles/cognitive-services/LUIS/luis-reference-prebuilt-entities.md(286,0): Column headers are required for tables. Add appropriate header text. NOTE: This Suggestion will become a Warning in late September, 2020.
column-header-missing ./articles/hdinsight/hadoop/apache-hadoop-on-premises-migration-best-practices-data-migration.md(34,0): Column headers are required for tables. Add appropriate header text. NOTE: This Suggestion will become a Warning in late September, 2020.
disallowed-html ./articles/azure-monitor/platform/workbooks-resources.md(101,66): HTML tag 'sub-id' isn't allowed. Disallowed HTML poses a security risk and must be replaced with approved Docs Markdown syntax.
disallowed-html ./articles/virtual-machines/workloads/sap/sap-hana-scale-out-standby-netapp-files-rhel.md(566,61): HTML tag 'assign' isn't allowed. Disallowed HTML poses a security risk and must be replaced with approved Docs Markdown syntax.
disallowed-html ./articles/azure-monitor/platform/workbooks-resources.md(101,90): HTML tag 'resource-group' isn't allowed. Disallowed HTML poses a security risk and must be replaced with approved Docs Markdown syntax.
disallowed-html ./articles/azure-monitor/platform/workbooks-resources.md(101,117): HTML tag 'resource-type' isn't allowed. Disallowed HTML poses a security risk and must be replaced with approved Docs Markdown syntax.
disallowed-html ./articles/azure-monitor/platform/workbooks-resources.md(103,83): HTML tag 'sub-id' isn't allowed. Disallowed HTML poses a security risk and must be replaced with approved Docs Markdown syntax.
disallowed-html ./articles/azure-monitor/platform/workbooks-resources.md(103,107): HTML tag 'resource-group' isn't allowed. Disallowed HTML poses a security risk and must be replaced with approved Docs Markdown syntax.
disallowed-html ./articles/azure-monitor/platform/workbooks-resources.md(103,134): HTML tag 'resource-type' isn't allowed. Disallowed HTML poses a security risk and must be replaced with approved Docs Markdown syntax.
Building files:  98% (69771/71119), 00:00:38 
disallowed-html ./articles/virtual-machines/workloads/sap/sap-hana-scale-out-standby-netapp-files-suse.md(564,61): HTML tag 'assign' isn't allowed. Disallowed HTML poses a security risk and must be replaced with approved Docs Markdown syntax.
disallowed-html ./articles/virtual-machines/workloads/sap/high-availability-guide.md(1609,49): HTML tag 'SID' isn't allowed. Disallowed HTML poses a security risk and must be replaced with approved Docs Markdown syntax.
disallowed-html ./articles/virtual-machines/workloads/sap/high-availability-guide.md(1638,55): HTML tag 'SID' isn't allowed. Disallowed HTML poses a security risk and must be replaced with approved Docs Markdown syntax.
column-header-missing ./articles/hdinsight/hadoop/apache-hadoop-on-premises-migration-motivation.md(161,0): Column headers are required for tables. Add appropriate header text. NOTE: This Suggestion will become a Warning in late September, 2020.
Calling GitHub API:  done in 683.21ms
disallowed-html ./articles/virtual-machines/wor
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6251)