### PR TITLE
Fix FileResolver.ReadString race condition

### DIFF
--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Docs.Build
             var hasError = false;
             var restoreFetchOptions = options.NoCache ? FetchOptions.Latest : FetchOptions.UseCache;
             var buildFetchOptions = options.NoRestore ? FetchOptions.NoFetch : FetchOptions.UseCache;
+
             Parallel.ForEach(docsets, docset =>
             {
                 if (!options.NoRestore && Restore.RestoreDocset(docset.docsetPath, docset.outputPath, options, restoreFetchOptions))

--- a/src/docfx/restore/FileResolver.cs
+++ b/src/docfx/restore/FileResolver.cs
@@ -90,14 +90,15 @@ namespace Microsoft.Docs.Build
         private string DownloadFromUrlCore(string url)
         {
             var filePath = GetRestorePathFromUrl(url);
-            if (_fetchOptions == FetchOptions.UseCache && File.Exists(filePath))
-            {
-                return filePath;
-            }
 
-            if (_fetchOptions == FetchOptions.NoFetch)
+            switch (_fetchOptions)
             {
-                throw Errors.System.NeedRestore(url).ToException();
+                case FetchOptions.UseCache when File.Exists(filePath):
+                case FetchOptions.NoFetch when File.Exists(filePath):
+                    return filePath;
+
+                case FetchOptions.NoFetch:
+                    throw Errors.System.NeedRestore(url).ToException();
             }
 
             var etagPath = GetRestoreEtagPath(url);

--- a/src/docfx/restore/FileResolver.cs
+++ b/src/docfx/restore/FileResolver.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Docs.Build
     internal class FileResolver
     {
         // NOTE: This line assumes each build runs in a new process
-        private static readonly ConcurrentHashSet<string> s_downloadedUrls = new ConcurrentHashSet<string>();
+        private static readonly ConcurrentDictionary<string, Lazy<string>> s_downloadedUrls = new ConcurrentDictionary<string, Lazy<string>>();
 
         private static readonly HttpClient s_httpClient = new HttpClient(new HttpClientHandler()
         {
@@ -56,11 +56,6 @@ namespace Microsoft.Docs.Build
 
         public string ResolveFilePath(SourceInfo<string> file)
         {
-            if (_fetchOptions != FetchOptions.NoFetch)
-            {
-                Download(file).GetAwaiter().GetResult();
-            }
-
             if (!UrlUtility.IsHttp(file))
             {
                 var localFilePath = Path.Combine(_docsetPath, file);
@@ -76,70 +71,63 @@ namespace Microsoft.Docs.Build
                 throw Errors.Link.FileNotFound(file).ToException();
             }
 
-            var filePath = GetRestorePathFromUrl(file);
-            if (!File.Exists(filePath))
-            {
-                throw Errors.System.NeedRestore(file).ToException();
-            }
-
-            return filePath;
+            return DownloadFromUrl(file);
         }
 
-        public async Task Download(SourceInfo<string> file)
+        public void Download(SourceInfo<string> file)
         {
-            if (!UrlUtility.IsHttp(file))
+            if (UrlUtility.IsHttp(file))
             {
-                return;
+                DownloadFromUrl(file);
+            }
+        }
+
+        private string DownloadFromUrl(SourceInfo<string> url)
+        {
+            return s_downloadedUrls.GetOrAdd(url, key => new Lazy<string>(() => DownloadFromUrlCore(key))).Value;
+        }
+
+        private string DownloadFromUrlCore(string url)
+        {
+            var filePath = GetRestorePathFromUrl(url);
+            if (_fetchOptions == FetchOptions.UseCache && File.Exists(filePath))
+            {
+                return filePath;
             }
 
             if (_fetchOptions == FetchOptions.NoFetch)
             {
-                throw Errors.System.NeedRestore(file).ToException();
+                throw Errors.System.NeedRestore(url).ToException();
             }
 
-            var filePath = GetRestorePathFromUrl(file);
-            if ((_fetchOptions == FetchOptions.UseCache || s_downloadedUrls.Contains(file)) && File.Exists(filePath))
-            {
-                return;
-            }
-
-            var etagPath = GetRestoreEtagPath(file);
+            var etagPath = GetRestoreEtagPath(url);
             var existingEtag = default(EntityTagHeaderValue);
 
-            using (InterProcessMutex.Create(filePath))
+            var etagContent = File.Exists(etagPath) ? File.ReadAllText(etagPath) : null;
+            if (!string.IsNullOrEmpty(etagContent))
             {
-                var etagContent = File.Exists(etagPath) ? File.ReadAllText(etagPath) : null;
-                if (!string.IsNullOrEmpty(etagContent))
-                {
-                    existingEtag = EntityTagHeaderValue.Parse(File.ReadAllText(etagPath));
-                }
+                existingEtag = EntityTagHeaderValue.Parse(File.ReadAllText(etagPath));
             }
 
-            var (tempFile, etag) = await DownloadToTempFile(file, existingEtag);
+            var (tempFile, etag) = DownloadToTempFile(url, existingEtag).GetAwaiter().GetResult();
             if (tempFile is null)
             {
                 // no change at all
-                return;
+                return filePath;
             }
 
             using (InterProcessMutex.Create(filePath))
             {
                 Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(filePath)));
 
-                if (File.Exists(filePath))
-                {
-                    File.Delete(filePath);
-                }
-
-                File.Move(tempFile, filePath);
+                File.Move(tempFile, filePath, overwrite: true);
 
                 if (etag != null)
                 {
                     File.WriteAllText(etagPath, etag.ToString());
                 }
+                return filePath;
             }
-
-            s_downloadedUrls.TryAdd(file);
         }
 
         private static string GetRestorePathFromUrl(string url)

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Docs.Build
 
                 // download dependencies to disk
                 Parallel.Invoke(
-                    () => RestoreFiles(errorLog, config, fileResolver).GetAwaiter().GetResult(),
+                    () => RestoreFiles(errorLog, config, fileResolver),
                     () => RestorePackages(errorLog, buildOptions, config, packageResolver));
                 return errorLog.ErrorCount > 0;
             }
@@ -71,9 +71,9 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static async Task RestoreFiles(ErrorLog errorLog, Config config, FileResolver fileResolver)
+        private static void RestoreFiles(ErrorLog errorLog, Config config, FileResolver fileResolver)
         {
-            await ParallelUtility.ForEach(errorLog, config.GetFileReferences(), fileResolver.Download);
+            ParallelUtility.ForEach(errorLog, config.GetFileReferences(), fileResolver.Download);
         }
 
         private static void RestorePackages(ErrorLog errorLog, BuildOptions buildOptions, Config config, PackageResolver packageResolver)

--- a/test/docfx.Test/restore/RestoreTest.cs
+++ b/test/docfx.Test/restore/RestoreTest.cs
@@ -42,15 +42,27 @@ namespace Microsoft.Docs.Build
         {
             Assert.NotNull(
                 new FileResolver(".").ReadString(
-                    new SourceInfo<string>("https://raw.githubusercontent.com/docascode/docfx-test-dependencies-clean/master/README.md")));
+                    new SourceInfo<string>("https://raw.githubusercontent.com/docascode/docfx-test-dependencies/master/README.md")));
         }
 
         [Fact]
-        public static async Task DownloadFile_NoFetch_Should_Fail()
+        public static void DownloadFile_NoFetch_Should_Fail()
         {
-            await Assert.ThrowsAsync<DocfxException>(() =>
+            Assert.Throws<DocfxException>(() =>
                 new FileResolver(".", fetchOptions: FetchOptions.NoFetch).Download(
-                    new SourceInfo<string>("https://raw.githubusercontent.com/docascode/docfx-test-dependencies-clean/master/README.md")));
+                    new SourceInfo<string>("https://raw.githubusercontent.com/docascode/docfx-test-dependencies/master/dep.md")));
+        }
+
+        [Fact]
+        public static void Download_Read_File_In_Parallel_Should_Succeed()
+        {
+            var fileResolver = new FileResolver(".", fetchOptions: FetchOptions.Latest);
+
+            Parallel.For(0, 10, i =>
+            {
+                Assert.NotEmpty(fileResolver.ReadString(
+                    new SourceInfo<string>("https://raw.githubusercontent.com/docascode/docfx-test-dependencies/master/extend1.yml")));
+            });
         }
 
         [Fact]


### PR DESCRIPTION
[AB#268425](https://dev.azure.com/ceapex/Engineering/_workitems/edit/268425/)

This should ensure a single URL is downloaded at most once within a single process, with unit test cover the scenario.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6258)