### PR TITLE
Prevent NOTE, TIP, etc. sections from being split by a page break in PDF

### DIFF
--- a/src/docfx.website.themes/pdf.default/styles/default.css
+++ b/src/docfx.website.themes/pdf.default/styles/default.css
@@ -923,6 +923,14 @@ table th {
     font-weight: normal;
 }
 
+/* prevent NOTE sections from being split by a page break.*/
+@media print {
+   .NOTE, .TIP, .IMPORTANT, .CAUTION, .WARNING{
+       break-inside: avoid-page;
+       page-break-inside: avoid;
+    }
+}
+
 .inheritance ul {
     margin: 0;
     padding: 0;


### PR DESCRIPTION
NOTE sections can sometimes be cut in half by page break in PDF output. This will help avoid that.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6271)