### PR TITLE
Legacy file map original_type respects MimeType

### DIFF
--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -275,7 +275,7 @@ inputs:
 outputs:
   docs/a.json:
   .manifest.json: |
-    {"files":[{"asset_id":"docs/a.json","original":"docs/a.yml","source_relative_path":"docs/a.yml","original_type":"Conceptual","type":"Toc"}]}
+    {"files":[{"asset_id":"docs/a.json","original":"docs/a.yml","source_relative_path":"docs/a.yml","original_type":"ContextObject","type":"Toc"}]}
 ---
 # Do not copy resource when the copyResources is false
 legacy: true

--- a/docs/specs/schema.yml
+++ b/docs/specs/schema.yml
@@ -459,3 +459,32 @@ outputs:
     {"message_severity":"error","code":"missing-attribute","message":"Missing required attribute: 'authors'.","file":"a.yml","line":2,"column":1}
   .publish.json: |
     {"files":[{"url":"/a/","source_path":"a.yml","has_error":true}]}
+---
+# .manifest.json original_type uses mime name
+inputs:
+  docfx.yml: 
+  a.yml: |
+    #YamlMime:TestPage
+    key: value
+  b.yml: |
+    #YamlMime:TestData
+  redirections.yml: |
+    redirections:
+      original_b.md: /b
+  _themes/ContentTemplate/schemas/TestData.schema.json: '{}'
+  _themes/ContentTemplate/schemas/TestPage.schema.json: '{}'
+  _themes/ContentTemplate/TestPage.html.primary.js: |
+    exports.transform = function (model) {
+      return model;
+    }
+outputs:
+  a.json:
+  b.json:
+  .manifest.json: |
+    {
+      "files": [
+        {"asset_id": "a", "original_type": "TestPage"},
+        {"asset_id": "b.json", "original_type": "TestData"},
+        {"asset_id": "original_b", "original_type": "Conceptual"},
+      ]
+    }

--- a/src/docfx/build/legacy/manifest/LegacyManifest.cs
+++ b/src/docfx/build/legacy/manifest/LegacyManifest.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Docs.Build
                 AssetId = legacySiteUrlRelativeToBasePath,
                 Original = fileManifest.Value.SourcePath,
                 SourceRelativePath = context.SourceMap.GetOriginalFilePath(document.FilePath) ?? document.FilePath.Path,
-                OriginalType = GetOriginalType(document.ContentType),
+                OriginalType = GetOriginalType(document.ContentType, document.Mime),
                 Type = GetType(context, document.ContentType, document),
                 Output = output,
                 SkipNormalization = !(document.ContentType == ContentType.Resource),
@@ -152,13 +152,13 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static string GetOriginalType(ContentType type)
+        private static string GetOriginalType(ContentType type, string? mime)
         {
             switch (type)
             {
                 case ContentType.Page:
                 case ContentType.Redirection: // todo: support reference redirection
-                    return "Conceptual";
+                    return mime ?? "Conceptual";
                 case ContentType.Resource:
                     return "Resource";
                 case ContentType.TableOfContents:

--- a/src/docfx/build/legacy/manifest/LegacyManifest.cs
+++ b/src/docfx/build/legacy/manifest/LegacyManifest.cs
@@ -152,21 +152,14 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static string GetOriginalType(ContentType type, string? mime)
+        private static string GetOriginalType(ContentType type, string? mime) => type switch
         {
-            switch (type)
-            {
-                case ContentType.Page:
-                case ContentType.Redirection: // todo: support reference redirection
-                    return mime ?? "Conceptual";
-                case ContentType.Resource:
-                    return "Resource";
-                case ContentType.TableOfContents:
-                    return "Toc";
-                default:
-                    return string.Empty;
-            }
-        }
+            ContentType.Page => mime ?? "Conceptual",
+            ContentType.Redirection => "Conceptual", // todo: support reference redirection
+            ContentType.Resource => "Resource",
+            ContentType.TableOfContents => "Toc",
+            _ => string.Empty,
+        };
 
         private static string GetType(Context context, ContentType type, Document doc)
         {


### PR DESCRIPTION
[AB#267683](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/267683)

LearnValidation plugin uses [`original_type`](https://github.com/dotnet/docfx/blob/v3/src/Microsoft.Docs.LearnValidation/Validator.cs#L28) to extract output items it concerns.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6288)