### PR TITLE
Create an ErrorBuilder abstraction to split ErrorWriter from ErrorLog

### DIFF
--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Docs.Build
             }
             catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
             {
-                errors.Write(dex);
+                errors.AddRange(dex);
                 return errors.HasError;
             }
             finally
@@ -94,7 +94,7 @@ namespace Microsoft.Docs.Build
             using (Progress.Start("Building files"))
             {
                 ParallelUtility.ForEach(
-                    context.ErrorLog,
+                    context.ErrorBuilder,
                     context.PublishUrlMap.GetAllFiles(),
                     file => BuildFile(context, file));
             }
@@ -102,11 +102,11 @@ namespace Microsoft.Docs.Build
             Parallel.Invoke(
                 () => context.BookmarkValidator.Validate(),
                 () => context.ContentValidator.PostValidate(),
-                () => context.ErrorLog.Write(context.MetadataValidator.PostValidate()),
+                () => context.ErrorBuilder.AddRange(context.MetadataValidator.PostValidate()),
                 () => context.ContributionProvider.Save(),
                 () => context.RepositoryProvider.Save(),
-                () => context.ErrorLog.Write(context.GitHubAccessor.Save()),
-                () => context.ErrorLog.Write(context.MicrosoftGraphAccessor.Save()));
+                () => context.ErrorBuilder.AddRange(context.GitHubAccessor.Save()),
+                () => context.ErrorBuilder.AddRange(context.MicrosoftGraphAccessor.Save()));
 
             // TODO: explicitly state that ToXrefMapModel produces errors
             var xrefMapModel = context.XrefResolver.ToXrefMapModel(context.BuildOptions.IsLocalizedBuild);

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Docs.Build
 
         public PackageResolver PackageResolver { get; }
 
-        public ErrorBuilder ErrorLog { get; }
+        public ErrorBuilder ErrorBuilder { get; }
 
         public Output Output { get; }
 
@@ -78,7 +78,7 @@ namespace Microsoft.Docs.Build
             DependencyMapBuilder = new DependencyMapBuilder(sourceMap);
 
             Config = config;
-            ErrorLog = errorLog;
+            ErrorBuilder = errorLog;
             BuildOptions = buildOptions;
             PackageResolver = packageResolver;
             FileResolver = fileResolver;
@@ -97,7 +97,7 @@ namespace Microsoft.Docs.Build
             RedirectionProvider = new RedirectionProvider(
                 buildOptions.DocsetPath,
                 Config.HostName,
-                ErrorLog,
+                ErrorBuilder,
                 BuildScope,
                 buildOptions.Repository,
                 DocumentProvider,
@@ -116,7 +116,7 @@ namespace Microsoft.Docs.Build
                 buildOptions.Repository,
                 DependencyMapBuilder,
                 FileLinkMapBuilder,
-                ErrorLog,
+                ErrorBuilder,
                 TemplateEngine,
                 DocumentProvider,
                 MetadataProvider,
@@ -155,8 +155,8 @@ namespace Microsoft.Docs.Build
             var tocParser = new TableOfContentsParser(Input, MarkdownEngine, DocumentProvider);
             TableOfContentsLoader = new TableOfContentsLoader(LinkResolver, XrefResolver, tocParser, MonikerProvider, DependencyMapBuilder, ContentValidator);
             TocMap = new TableOfContentsMap(
-                ErrorLog, Input, BuildScope, DependencyMapBuilder, tocParser, TableOfContentsLoader, DocumentProvider, ContentValidator);
-            PublishUrlMap = new PublishUrlMap(Config, ErrorLog, BuildScope, RedirectionProvider, DocumentProvider, MonikerProvider, TocMap);
+                ErrorBuilder, Input, BuildScope, DependencyMapBuilder, tocParser, TableOfContentsLoader, DocumentProvider, ContentValidator);
+            PublishUrlMap = new PublishUrlMap(Config, ErrorBuilder, BuildScope, RedirectionProvider, DocumentProvider, MonikerProvider, TocMap);
             PublishModelBuilder = new PublishModelBuilder(
                 config, errorLog, MonikerProvider, buildOptions, ContentValidator, PublishUrlMap, DocumentProvider, SourceMap);
             MetadataValidator = new MetadataValidator(

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Docs.Build
 
         public PackageResolver PackageResolver { get; }
 
-        public ErrorLog ErrorLog { get; }
+        public ErrorBuilder ErrorLog { get; }
 
         public Output Output { get; }
 
@@ -73,7 +73,7 @@ namespace Microsoft.Docs.Build
         public JsonSchemaTransformer JsonSchemaTransformer { get; }
 
         public Context(
-            ErrorLog errorLog, Config config, BuildOptions buildOptions, PackageResolver packageResolver, FileResolver fileResolver, SourceMap sourceMap)
+            ErrorBuilder errorLog, Config config, BuildOptions buildOptions, PackageResolver packageResolver, FileResolver fileResolver, SourceMap sourceMap)
         {
             DependencyMapBuilder = new DependencyMapBuilder(sourceMap);
 
@@ -165,7 +165,6 @@ namespace Microsoft.Docs.Build
 
         public void Dispose()
         {
-            ErrorLog.Dispose();
             PackageResolver.Dispose();
             RepositoryProvider.Dispose();
             GitHubAccessor.Dispose();

--- a/src/docfx/build/link/FileLinkMapBuilder.cs
+++ b/src/docfx/build/link/FileLinkMapBuilder.cs
@@ -9,14 +9,14 @@ namespace Microsoft.Docs.Build
 {
     internal class FileLinkMapBuilder
     {
-        private readonly ErrorLog _errorLog;
+        private readonly ErrorBuilder _errors;
         private readonly MonikerProvider _monikerProvider;
         private readonly ContributionProvider _contributionProvider;
         private readonly ConcurrentHashSet<FileLinkItem> _links = new ConcurrentHashSet<FileLinkItem>();
 
-        public FileLinkMapBuilder(ErrorLog errorLog, MonikerProvider monikerProvider, ContributionProvider contributionProvider)
+        public FileLinkMapBuilder(ErrorBuilder errors, MonikerProvider monikerProvider, ContributionProvider contributionProvider)
         {
-            _errorLog = errorLog;
+            _errors = errors;
             _monikerProvider = monikerProvider;
             _contributionProvider = contributionProvider;
         }
@@ -31,7 +31,7 @@ namespace Microsoft.Docs.Build
             var (errors, monikers) = _monikerProvider.GetFileLevelMonikers(inclusionRoot);
             var sourceGitUrl = _contributionProvider.GetGitUrl(referencingFile).originalContentGitUrl;
 
-            _errorLog.Write(errors);
+            _errors.Write(errors);
             _links.TryAdd(new FileLinkItem(inclusionRoot, sourceUrl, monikers.MonikerGroup, targetUrl, sourceGitUrl, source is null ? 1 : source.Line));
         }
 
@@ -40,7 +40,7 @@ namespace Microsoft.Docs.Build
             return new
             {
                 Links = _links
-                        .Where(x => publishFiles.Contains(x.InclusionRoot) && !_errorLog.HasError(x.InclusionRoot))
+                        .Where(x => publishFiles.Contains(x.InclusionRoot) && !_errors.FileHasError(x.InclusionRoot))
                         .OrderBy(x => x)
                         .ToArray(),
             };

--- a/src/docfx/build/link/FileLinkMapBuilder.cs
+++ b/src/docfx/build/link/FileLinkMapBuilder.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Docs.Build
             var (errors, monikers) = _monikerProvider.GetFileLevelMonikers(inclusionRoot);
             var sourceGitUrl = _contributionProvider.GetGitUrl(referencingFile).originalContentGitUrl;
 
-            _errors.Write(errors);
+            _errors.AddRange(errors);
             _links.TryAdd(new FileLinkItem(inclusionRoot, sourceUrl, monikers.MonikerGroup, targetUrl, sourceGitUrl, source is null ? 1 : source.Line));
         }
 

--- a/src/docfx/build/page/BookmarkValidator.cs
+++ b/src/docfx/build/page/BookmarkValidator.cs
@@ -8,15 +8,15 @@ namespace Microsoft.Docs.Build
 {
     internal class BookmarkValidator
     {
-        private readonly ErrorLog _errorLog;
+        private readonly ErrorBuilder _errors;
 
         private readonly DictionaryBuilder<Document, HashSet<string>> _bookmarksByFile = new DictionaryBuilder<Document, HashSet<string>>();
         private readonly ListBuilder<(Document file, Document dependency, string bookmark, bool isSelfBookmark, SourceInfo? source)>
             _references = new ListBuilder<(Document file, Document dependency, string bookmark, bool isSelfBookmark, SourceInfo? source)>();
 
-        public BookmarkValidator(ErrorLog errorLog)
+        public BookmarkValidator(ErrorBuilder errors)
         {
-            _errorLog = errorLog;
+            _errors = errors;
         }
 
         public void AddBookmarkReference(Document file, Document reference, string? fragment, bool isSelfBookmark, SourceInfo? source)
@@ -60,7 +60,7 @@ namespace Microsoft.Docs.Build
                     continue;
                 }
 
-                _errorLog.Write(Errors.Content.BookmarkNotFound(source, isSelfBookmark ? file : reference, bookmark, bookmarks));
+                _errors.Write(Errors.Content.BookmarkNotFound(source, isSelfBookmark ? file : reference, bookmark, bookmarks));
             }
         }
     }

--- a/src/docfx/build/page/BookmarkValidator.cs
+++ b/src/docfx/build/page/BookmarkValidator.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Docs.Build
                     continue;
                 }
 
-                _errors.Write(Errors.Content.BookmarkNotFound(source, isSelfBookmark ? file : reference, bookmark, bookmarks));
+                _errors.Add(Errors.Content.BookmarkNotFound(source, isSelfBookmark ? file : reference, bookmark, bookmarks));
             }
         }
     }

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Docs.Build
             errors.AddRange(outputErrors);
             context.ErrorLog.Write(errors);
 
-            if (!context.ErrorLog.HasError(file.FilePath) && !context.Config.DryRun)
+            if (!context.ErrorLog.FileHasError(file.FilePath) && !context.Config.DryRun)
             {
                 if (context.Config.OutputType == OutputType.Json)
                 {

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Docs.Build
             var outputPath = context.DocumentProvider.GetOutputPath(file.FilePath);
             if (errors.Any(e => e.Level == ErrorLevel.Error))
             {
-                context.ErrorLog.Write(errors);
+                context.ErrorBuilder.AddRange(errors);
                 return;
             }
 
@@ -35,9 +35,9 @@ namespace Microsoft.Docs.Build
                 ? CreatePageOutput(context, file, sourceModel)
                 : CreateDataOutput(context, file, sourceModel);
             errors.AddRange(outputErrors);
-            context.ErrorLog.Write(errors);
+            context.ErrorBuilder.AddRange(errors);
 
-            if (!context.ErrorLog.FileHasError(file.FilePath) && !context.Config.DryRun)
+            if (!context.ErrorBuilder.FileHasError(file.FilePath) && !context.Config.DryRun)
             {
                 if (context.Config.OutputType == OutputType.Json)
                 {

--- a/src/docfx/build/redirection/BuildRedirection.cs
+++ b/src/docfx/build/redirection/BuildRedirection.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Docs.Build
                 ["canonical_url"] = file.CanonicalUrl,
             };
 
-            context.ErrorLog.Write(errors);
+            context.ErrorBuilder.AddRange(errors);
             context.PublishModelBuilder.SetPublishItem(file.FilePath, publishMetadata, null);
         }
     }

--- a/src/docfx/build/redirection/RedirectionProvider.cs
+++ b/src/docfx/build/redirection/RedirectionProvider.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Docs.Build
 
                 if (string.IsNullOrEmpty(path) || string.IsNullOrEmpty(redirectUrl))
                 {
-                    _errors.Write(Errors.Redirection.RedirectionIsNullOrEmpty(redirectUrl, path));
+                    _errors.Add(Errors.Redirection.RedirectionIsNullOrEmpty(redirectUrl, path));
                     continue;
                 }
 
@@ -109,7 +109,7 @@ namespace Microsoft.Docs.Build
                 var type = _buildScope.GetContentType(path);
                 if (type != ContentType.Page)
                 {
-                    _errors.Write(Errors.Redirection.RedirectionInvalid(redirectUrl, path));
+                    _errors.Add(Errors.Redirection.RedirectionInvalid(redirectUrl, path));
                     continue;
                 }
 
@@ -130,14 +130,14 @@ namespace Microsoft.Docs.Build
                             absoluteRedirectUrl = UrlUtility.RemoveLeadingHostName(absoluteRedirectUrl, hostName, removeLocale: true);
                             break;
                         default:
-                            _errors.Write(Errors.Redirection.RedirectionUrlNotFound(path, redirectUrl));
+                            _errors.Add(Errors.Redirection.RedirectionUrlNotFound(path, redirectUrl));
                             break;
                     }
                 }
 
                 if (!redirectUrls.TryAdd(filePath, absoluteRedirectUrl))
                 {
-                    _errors.Write(Errors.Redirection.RedirectionConflict(redirectUrl, path));
+                    _errors.Add(Errors.Redirection.RedirectionConflict(redirectUrl, path));
                 }
             }
             return redirectUrls;
@@ -217,13 +217,13 @@ namespace Microsoft.Docs.Build
                 {
                     if (item.RedirectDocumentId)
                     {
-                        _errors.Write(Errors.Redirection.RedirectionUrlNotFound(item.SourcePath, item.RedirectUrl));
+                        _errors.Add(Errors.Redirection.RedirectionUrlNotFound(item.SourcePath, item.RedirectUrl));
                     }
                     continue;
                 }
 
                 var (errors, redirectionSourceMonikers) = _monikerProvider.GetFileLevelMonikers(file);
-                _errors.Write(errors);
+                _errors.AddRange(errors);
 
                 var candidates = redirectionSourceMonikers.Count == 0
                                     ? docs.Where(doc => _monikerProvider.GetFileLevelMonikers(doc).monikers.Count == 0).ToList()
@@ -240,7 +240,7 @@ namespace Microsoft.Docs.Build
                 {
                     if (item.RedirectDocumentId && !renameHistory.TryAdd(candidate, file))
                     {
-                        _errors.Write(Errors.Redirection.RedirectionUrlConflict(item.RedirectUrl));
+                        _errors.Add(Errors.Redirection.RedirectionUrlConflict(item.RedirectUrl));
                     }
                 }
             }

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Docs.Build
 
             context.ErrorLog.Write(errors);
 
-            if (!context.ErrorLog.HasError(file.FilePath) && !context.Config.DryRun)
+            if (!context.ErrorLog.FileHasError(file.FilePath) && !context.Config.DryRun)
             {
                 if (context.Config.OutputType == OutputType.Html)
                 {

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -42,9 +42,9 @@ namespace Microsoft.Docs.Build
                         context.Config.BasePath, "opbuildpdf", monikers.MonikerGroup ?? "", LegacyUtility.ChangeExtension(file.SitePath, ".pdf"));
             }
 
-            context.ErrorLog.Write(errors);
+            context.ErrorBuilder.AddRange(errors);
 
-            if (!context.ErrorLog.FileHasError(file.FilePath) && !context.Config.DryRun)
+            if (!context.ErrorBuilder.FileHasError(file.FilePath) && !context.Config.DryRun)
             {
                 if (context.Config.OutputType == OutputType.Html)
                 {

--- a/src/docfx/build/toc/TableOfContentsMap.cs
+++ b/src/docfx/build/toc/TableOfContentsMap.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Docs.Build
                 {
                     var errors = new List<Error>();
                     var toc = _tocParser.Parse(file, errors);
-                    _errors.Write(errors);
+                    _errors.AddRange(errors);
 
                     SplitToc(file, toc, tocs);
                 });
@@ -189,7 +189,7 @@ namespace Microsoft.Docs.Build
                 {
                     var file = _documentProvider.GetDocument(path);
                     var (errors, _, referencedDocuments, referencedTocs) = _tocLoader.Load(file);
-                    _errors.Write(errors);
+                    _errors.AddRange(errors);
 
                     tocReferences.TryAdd(file, (referencedDocuments, referencedTocs));
                 });

--- a/src/docfx/build/xref/ExternalXrefMapLoader.cs
+++ b/src/docfx/build/xref/ExternalXrefMapLoader.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Docs.Build
     {
         private static readonly byte[] s_uidBytes = Encoding.UTF8.GetBytes("uid");
 
-        public static IReadOnlyDictionary<string, Lazy<ExternalXrefSpec>> Load(Config config, FileResolver fileResolver, ErrorLog errorLog)
+        public static IReadOnlyDictionary<string, Lazy<ExternalXrefSpec>> Load(Config config, FileResolver fileResolver, ErrorBuilder errorLog)
         {
             using (Progress.Start("Loading external xref map"))
             {
@@ -74,7 +74,7 @@ namespace Microsoft.Docs.Build
             return result;
         }
 
-        private static void LoadZipFile(Dictionary<string, Lazy<ExternalXrefSpec>> result, FilePath path, string physicalPath, ErrorLog errorLog)
+        private static void LoadZipFile(Dictionary<string, Lazy<ExternalXrefSpec>> result, FilePath path, string physicalPath, ErrorBuilder errorLog)
         {
             using var stream = File.OpenRead(physicalPath);
             using var archive = new ZipArchive(stream);

--- a/src/docfx/build/xref/ExternalXrefMapLoader.cs
+++ b/src/docfx/build/xref/ExternalXrefMapLoader.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Docs.Build
                     {
                         using var reader = new StreamReader(physicalPath);
                         var (errors, xrefMap) = YamlUtility.Deserialize<XrefMapModel>(reader, path);
-                        errorLog.Write(errors);
+                        errorLog.AddRange(errors);
                         foreach (var spec in xrefMap.References)
                         {
                             result.TryAdd(spec.Uid, new Lazy<ExternalXrefSpec>(() => spec));
@@ -85,7 +85,7 @@ namespace Microsoft.Docs.Build
                 {
                     using var reader = new StreamReader(entryStream);
                     var (errors, xrefMap) = YamlUtility.Deserialize<XrefMapModel>(reader, path);
-                    errorLog.Write(errors);
+                    errorLog.AddRange(errors);
                     foreach (var spec in xrefMap.References)
                     {
                         result.TryAdd(spec.Uid, new Lazy<ExternalXrefSpec>(() => spec));
@@ -95,7 +95,7 @@ namespace Microsoft.Docs.Build
                 {
                     using var reader = new StreamReader(entryStream);
                     var (errors, xrefMap) = JsonUtility.Deserialize<XrefMapModel>(reader, path);
-                    errorLog.Write(errors);
+                    errorLog.AddRange(errors);
                     foreach (var spec in xrefMap.References)
                     {
                         result.TryAdd(spec.Uid, new Lazy<ExternalXrefSpec>(() => spec));

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Docs.Build
                         break;
                     }
             }
-            _errors.Write(errors);
+            _errors.AddRange(errors);
         }
 
         private (List<Error> errors, InternalXrefSpec? spec) LoadMarkdown(UserMetadata metadata, Document file)
@@ -152,7 +152,7 @@ namespace Microsoft.Docs.Build
                 var duplicatedSources = (from spec in duplicatedSpecs where spec.Uid.Source != null select spec.Uid.Source).ToArray();
                 foreach (var spec in duplicatedSpecs)
                 {
-                    _errors.Write(Errors.Xref.DuplicateUid(spec.Uid, duplicatedSources));
+                    _errors.Add(Errors.Xref.DuplicateUid(spec.Uid, duplicatedSources));
                 }
             }
 
@@ -161,7 +161,7 @@ namespace Microsoft.Docs.Build
             var conflictsWithMoniker = specsWithSameUid.Where(x => x.Monikers.Count > 0).ToArray();
             if (CheckOverlappingMonikers(specsWithSameUid, out var overlappingMonikers))
             {
-                _errors.Write(Errors.Versioning.MonikerOverlapping(uid, specsWithSameUid.Select(spec => spec.DeclaringFile).ToList(), overlappingMonikers));
+                _errors.Add(Errors.Versioning.MonikerOverlapping(uid, specsWithSameUid.Select(spec => spec.DeclaringFile).ToList(), overlappingMonikers));
             }
 
             // uid conflicts with different values of the same xref property
@@ -172,7 +172,7 @@ namespace Microsoft.Docs.Build
                 var conflictingNames = specsWithSameUid.Select(x => x.GetXrefPropertyValueAsString(xrefProperty)).Distinct();
                 if (conflictingNames.Count() > 1)
                 {
-                    _errors.Write(Errors.Xref.XrefPropertyConflict(uid, xrefProperty, conflictingNames));
+                    _errors.Add(Errors.Xref.XrefPropertyConflict(uid, xrefProperty, conflictingNames));
                 }
             }
 

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Docs.Build
 {
     internal class InternalXrefMapBuilder
     {
-        private readonly ErrorLog _errorLog;
+        private readonly ErrorBuilder _errors;
         private readonly TemplateEngine _templateEngine;
         private readonly DocumentProvider _documentProvider;
         private readonly MetadataProvider _metadataProvider;
@@ -21,7 +21,7 @@ namespace Microsoft.Docs.Build
         private readonly JsonSchemaTransformer _jsonSchemaTransformer;
 
         public InternalXrefMapBuilder(
-            ErrorLog errorLog,
+            ErrorBuilder errors,
             TemplateEngine templateEngine,
             DocumentProvider documentProvider,
             MetadataProvider metadataProvider,
@@ -30,7 +30,7 @@ namespace Microsoft.Docs.Build
             BuildScope buildScope,
             JsonSchemaTransformer jsonSchemaTransformer)
         {
-            _errorLog = errorLog;
+            _errors = errors;
             _templateEngine = templateEngine;
             _documentProvider = documentProvider;
             _metadataProvider = metadataProvider;
@@ -47,7 +47,7 @@ namespace Microsoft.Docs.Build
             using (Progress.Start("Building Xref map"))
             {
                 ParallelUtility.ForEach(
-                    _errorLog,
+                    _errors,
                     _buildScope.GetFiles(ContentType.Page),
                     file => Load(builder, file));
             }
@@ -109,7 +109,7 @@ namespace Microsoft.Docs.Build
                         break;
                     }
             }
-            _errorLog.Write(errors);
+            _errors.Write(errors);
         }
 
         private (List<Error> errors, InternalXrefSpec? spec) LoadMarkdown(UserMetadata metadata, Document file)
@@ -152,7 +152,7 @@ namespace Microsoft.Docs.Build
                 var duplicatedSources = (from spec in duplicatedSpecs where spec.Uid.Source != null select spec.Uid.Source).ToArray();
                 foreach (var spec in duplicatedSpecs)
                 {
-                    _errorLog.Write(Errors.Xref.DuplicateUid(spec.Uid, duplicatedSources));
+                    _errors.Write(Errors.Xref.DuplicateUid(spec.Uid, duplicatedSources));
                 }
             }
 
@@ -161,7 +161,7 @@ namespace Microsoft.Docs.Build
             var conflictsWithMoniker = specsWithSameUid.Where(x => x.Monikers.Count > 0).ToArray();
             if (CheckOverlappingMonikers(specsWithSameUid, out var overlappingMonikers))
             {
-                _errorLog.Write(Errors.Versioning.MonikerOverlapping(uid, specsWithSameUid.Select(spec => spec.DeclaringFile).ToList(), overlappingMonikers));
+                _errors.Write(Errors.Versioning.MonikerOverlapping(uid, specsWithSameUid.Select(spec => spec.DeclaringFile).ToList(), overlappingMonikers));
             }
 
             // uid conflicts with different values of the same xref property
@@ -172,7 +172,7 @@ namespace Microsoft.Docs.Build
                 var conflictingNames = specsWithSameUid.Select(x => x.GetXrefPropertyValueAsString(xrefProperty)).Distinct();
                 if (conflictingNames.Count() > 1)
                 {
-                    _errorLog.Write(Errors.Xref.XrefPropertyConflict(uid, xrefProperty, conflictingNames));
+                    _errors.Write(Errors.Xref.XrefPropertyConflict(uid, xrefProperty, conflictingNames));
                 }
             }
 

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Docs.Build
             Repository? repository,
             DependencyMapBuilder dependencyMapBuilder,
             FileLinkMapBuilder fileLinkMapBuilder,
-            ErrorLog errorLog,
+            ErrorBuilder errorLog,
             TemplateEngine templateEngine,
             DocumentProvider documentProvider,
             MetadataProvider metadataProvider,

--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -31,13 +31,13 @@ namespace Microsoft.Docs.Build
 
         public static readonly DocsEnvironment DocsEnvironment = GetDocsEnvironment();
         private readonly Action<HttpRequestMessage> _credentialProvider;
-        private readonly ErrorLog _errorLog;
+        private readonly ErrorBuilder _errors;
         private readonly HttpClient _http = new HttpClient();
         private readonly (string, Func<Uri, Task<string>>)[] _apis;
 
-        public OpsConfigAdapter(ErrorLog errorLog, Action<HttpRequestMessage> credentialProvider)
+        public OpsConfigAdapter(ErrorBuilder errors, Action<HttpRequestMessage> credentialProvider)
         {
-            _errorLog = errorLog;
+            _errors = errors;
             _credentialProvider = credentialProvider;
             _apis = new (string, Func<Uri, Task<string>>)[]
             {
@@ -242,7 +242,7 @@ namespace Microsoft.Docs.Build
                            var response = await _http.SendAsync(request);
                            if (response.Headers.TryGetValues("X-Metadata-Version", out var metadataVersion))
                            {
-                               _errorLog.Write(Errors.System.MetadataValidationRuleset(string.Join(',', metadataVersion)));
+                               _errors.Write(Errors.System.MetadataValidationRuleset(string.Join(',', metadataVersion)));
                            }
                            return response;
                        });
@@ -255,7 +255,7 @@ namespace Microsoft.Docs.Build
                 // Getting validation rules failure should not block build proceeding,
                 // catch and log the exception without rethrow.
                 Log.Write(ex);
-                _errorLog.Write(Errors.System.ValidationIncomplete());
+                _errors.Write(Errors.System.ValidationIncomplete());
                 return "{}";
             }
         }

--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -242,7 +242,7 @@ namespace Microsoft.Docs.Build
                            var response = await _http.SendAsync(request);
                            if (response.Headers.TryGetValues("X-Metadata-Version", out var metadataVersion))
                            {
-                               _errors.Write(Errors.System.MetadataValidationRuleset(string.Join(',', metadataVersion)));
+                               _errors.Add(Errors.System.MetadataValidationRuleset(string.Join(',', metadataVersion)));
                            }
                            return response;
                        });
@@ -255,7 +255,7 @@ namespace Microsoft.Docs.Build
                 // Getting validation rules failure should not block build proceeding,
                 // catch and log the exception without rethrow.
                 Log.Write(ex);
-                _errors.Write(Errors.System.ValidationIncomplete());
+                _errors.Add(Errors.System.ValidationIncomplete());
                 return "{}";
             }
         }

--- a/src/docfx/config/ops/OpsPostProcessor.cs
+++ b/src/docfx/config/ops/OpsPostProcessor.cs
@@ -12,12 +12,12 @@ namespace Microsoft.Docs.Build
 
         private readonly Config _config;
         private readonly BuildOptions _buildOptions;
-        private readonly ErrorLog _errorLog;
+        private readonly ErrorBuilder _errors;
 
-        public OpsPostProcessor(Config config, ErrorLog errorLog, BuildOptions buildOptions)
+        public OpsPostProcessor(Config config, ErrorBuilder errors, BuildOptions buildOptions)
         {
             _config = config;
-            _errorLog = errorLog;
+            _errors = errors;
             _buildOptions = buildOptions;
         }
 
@@ -56,7 +56,7 @@ namespace Microsoft.Docs.Build
         private void LogError(LearnLogItem item)
         {
             var source = item.File is null ? null : new SourceInfo(new FilePath(item.File));
-            _errorLog.Write(new Error(MapLevel(item.ErrorLevel), item.ErrorCode.ToString(), item.Message, source));
+            _errors.Write(new Error(MapLevel(item.ErrorLevel), item.ErrorCode.ToString(), item.Message, source));
 
             static ErrorLevel MapLevel(LearnErrorLevel level) => level switch
             {

--- a/src/docfx/config/ops/OpsPostProcessor.cs
+++ b/src/docfx/config/ops/OpsPostProcessor.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Docs.Build
         private void LogError(LearnLogItem item)
         {
             var source = item.File is null ? null : new SourceInfo(new FilePath(item.File));
-            _errors.Write(new Error(MapLevel(item.ErrorLevel), item.ErrorCode.ToString(), item.Message, source));
+            _errors.Add(new Error(MapLevel(item.ErrorLevel), item.ErrorCode.ToString(), item.Message, source));
 
             static ErrorLevel MapLevel(LearnErrorLevel level) => level switch
             {

--- a/src/docfx/config/ops/OpsPreProcessor.cs
+++ b/src/docfx/config/ops/OpsPreProcessor.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Docs.Build
             if (!string.IsNullOrEmpty(item.Code))
             {
                 var source = item.File is null ? null : new SourceInfo(new FilePath(item.File), item.Line ?? 0, 0);
-                _errors.Write(new Error(MapLevel(item.MessageSeverity), item.Code, item.Message, source));
+                _errors.Add(new Error(MapLevel(item.MessageSeverity), item.Code, item.Message, source));
             }
 
             static ErrorLevel MapLevel(MessageSeverity level) => level switch

--- a/src/docfx/config/ops/OpsPreProcessor.cs
+++ b/src/docfx/config/ops/OpsPreProcessor.cs
@@ -12,12 +12,12 @@ namespace Microsoft.Docs.Build
 
         private readonly Config _config;
         private readonly BuildOptions _buildOptions;
-        private readonly ErrorLog _errorLog;
+        private readonly ErrorBuilder _errors;
 
-        public OpsPreProcessor(Config config, ErrorLog errorLog, BuildOptions buildOptions)
+        public OpsPreProcessor(Config config, ErrorBuilder errors, BuildOptions buildOptions)
         {
             _config = config;
-            _errorLog = errorLog;
+            _errors = errors;
             _buildOptions = buildOptions;
         }
 
@@ -72,7 +72,7 @@ namespace Microsoft.Docs.Build
             if (!string.IsNullOrEmpty(item.Code))
             {
                 var source = item.File is null ? null : new SourceInfo(new FilePath(item.File), item.Line ?? 0, 0);
-                _errorLog.Write(new Error(MapLevel(item.MessageSeverity), item.Code, item.Message, source));
+                _errors.Write(new Error(MapLevel(item.MessageSeverity), item.Code, item.Message, source));
             }
 
             static ErrorLevel MapLevel(MessageSeverity level) => level switch

--- a/src/docfx/lib/ParallelUtility.cs
+++ b/src/docfx/lib/ParallelUtility.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Docs.Build
                 }
                 catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
                 {
-                    errors.Write(dex);
+                    errors.AddRange(dex);
                 }
                 catch
                 {
@@ -92,7 +92,7 @@ namespace Microsoft.Docs.Build
                 }
                 catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
                 {
-                    errorLog.Write(dex);
+                    errorLog.AddRange(dex);
                 }
                 catch (OperationCanceledException oce)
                 {

--- a/src/docfx/lib/ParallelUtility.cs
+++ b/src/docfx/lib/ParallelUtility.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Docs.Build
             EnsureOrdered = false,
         };
 
-        public static void ForEach<T>(ErrorLog errorLog, IEnumerable<T> source, Action<T> action)
+        public static void ForEach<T>(ErrorBuilder errors, IEnumerable<T> source, Action<T> action)
         {
             var done = 0;
             var total = source.Count();
@@ -41,7 +41,7 @@ namespace Microsoft.Docs.Build
                 }
                 catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
                 {
-                    errorLog.Write(dex);
+                    errors.Write(dex);
                 }
                 catch
                 {

--- a/src/docfx/lib/git/FileCommitProvider.cs
+++ b/src/docfx/lib/git/FileCommitProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Docs.Build
     {
         private static readonly DictionarySlim<uint, Tree> s_emptyTree = new DictionarySlim<uint, Tree>();
 
-        private readonly ErrorLog _errorLog;
+        private readonly ErrorBuilder _errors;
         private readonly Repository _repository;
         private readonly Lazy<GitCommitCache> _commitCache;
 
@@ -38,14 +38,14 @@ namespace Microsoft.Docs.Build
         private int _isDisposed;
         private Task? _warmup;
 
-        public FileCommitProvider(ErrorLog errorLog, Repository repository, string cacheFilePath)
+        public FileCommitProvider(ErrorBuilder errors, Repository repository, string cacheFilePath)
         {
             if (git_repository_open(out _repo, repository.Path) != 0)
             {
                 throw new ArgumentException($"Invalid git repo {repository.Path}");
             }
 
-            _errorLog = errorLog;
+            _errors = errors;
             _repository = repository;
             _commitCache = new Lazy<GitCommitCache>(() => new GitCommitCache(cacheFilePath));
         }
@@ -299,7 +299,7 @@ namespace Microsoft.Docs.Build
                 // https://github.com/libgit2/libgit2sharp/issues/1351
                 if (error != 0 /* GIT_ENOTFOUND */)
                 {
-                    _errorLog.Write(Errors.System.GitCloneIncomplete(_repository.Path));
+                    _errors.Write(Errors.System.GitCloneIncomplete(_repository.Path));
                     break;
                 }
 

--- a/src/docfx/lib/git/FileCommitProvider.cs
+++ b/src/docfx/lib/git/FileCommitProvider.cs
@@ -299,7 +299,7 @@ namespace Microsoft.Docs.Build
                 // https://github.com/libgit2/libgit2sharp/issues/1351
                 if (error != 0 /* GIT_ENOTFOUND */)
                 {
-                    _errors.Write(Errors.System.GitCloneIncomplete(_repository.Path));
+                    _errors.Add(Errors.System.GitCloneIncomplete(_repository.Path));
                     break;
                 }
 

--- a/src/docfx/lib/git/RepositoryProvider.cs
+++ b/src/docfx/lib/git/RepositoryProvider.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Docs.Build
 {
     internal class RepositoryProvider : IDisposable
     {
-        private readonly ErrorLog _errorLog;
+        private readonly ErrorBuilder _errors;
 
         private readonly ConcurrentDictionary<string, Repository?> _repositories = new ConcurrentDictionary<string, Repository?>(PathUtility.PathComparer);
         private readonly ConcurrentDictionary<string, FileCommitProvider> _fileCommitProvidersByRepoPath =
@@ -18,9 +18,9 @@ namespace Microsoft.Docs.Build
 
         public Repository? Repository { get; }
 
-        public RepositoryProvider(ErrorLog errorLog, BuildOptions buildOptions, Config config)
+        public RepositoryProvider(ErrorBuilder errors, BuildOptions buildOptions, Config config)
         {
-            _errorLog = errorLog;
+            _errors = errors;
             Repository = buildOptions.Repository;
 
             if (Repository != null && !config.DryRun && !buildOptions.IsLocalizedBuild)
@@ -95,7 +95,7 @@ namespace Microsoft.Docs.Build
         {
             return _fileCommitProvidersByRepoPath.GetOrAdd(
                 repo.Path,
-                _ => new FileCommitProvider(_errorLog, repo, AppData.GetCommitCachePath(repo.Remote)));
+                _ => new FileCommitProvider(_errors, repo, AppData.GetCommitCachePath(repo.Remote)));
         }
     }
 }

--- a/src/docfx/lib/log/ErrorBuilder.cs
+++ b/src/docfx/lib/log/ErrorBuilder.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Docs.Build
+{
+    internal abstract class ErrorBuilder
+    {
+        public abstract bool HasError { get; }
+
+        public abstract void Add(Error error);
+
+        public virtual bool FileHasError(FilePath file) => throw new NotSupportedException();
+
+        public void Write(Error error)
+        {
+            Add(error);
+        }
+
+        public void AddRange(IEnumerable<Error> errors)
+        {
+            foreach (var error in errors)
+            {
+                Add(error);
+            }
+        }
+
+        public void Write(IEnumerable<Error> errors)
+        {
+            foreach (var error in errors)
+            {
+                Add(error);
+            }
+        }
+
+        public void Write(IEnumerable<DocfxException> exceptions)
+        {
+            foreach (var exception in exceptions)
+            {
+                Log.Write(exception);
+                Add(exception.Error);
+            }
+        }
+    }
+}

--- a/src/docfx/lib/log/ErrorBuilder.cs
+++ b/src/docfx/lib/log/ErrorBuilder.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Docs.Build
@@ -12,7 +11,7 @@ namespace Microsoft.Docs.Build
 
         public abstract void Add(Error error);
 
-        public virtual bool FileHasError(FilePath file) => throw new NotSupportedException();
+        public abstract bool FileHasError(FilePath file);
 
         public void AddRange(IEnumerable<Error> errors)
         {

--- a/src/docfx/lib/log/ErrorBuilder.cs
+++ b/src/docfx/lib/log/ErrorBuilder.cs
@@ -14,11 +14,6 @@ namespace Microsoft.Docs.Build
 
         public virtual bool FileHasError(FilePath file) => throw new NotSupportedException();
 
-        public void Write(Error error)
-        {
-            Add(error);
-        }
-
         public void AddRange(IEnumerable<Error> errors)
         {
             foreach (var error in errors)
@@ -27,15 +22,7 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public void Write(IEnumerable<Error> errors)
-        {
-            foreach (var error in errors)
-            {
-                Add(error);
-            }
-        }
-
-        public void Write(IEnumerable<DocfxException> exceptions)
+        public void AddRange(IEnumerable<DocfxException> exceptions)
         {
             foreach (var exception in exceptions)
             {

--- a/src/docfx/lib/log/ErrorLog.cs
+++ b/src/docfx/lib/log/ErrorLog.cs
@@ -1,110 +1,59 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
 using System.Linq;
 using Microsoft.Docs.Validation;
 
 namespace Microsoft.Docs.Build
 {
-    internal sealed class ErrorLog : IDisposable
+    internal class ErrorLog : ErrorBuilder
     {
-        private readonly object _outputLock = new object();
+        private readonly ErrorBuilder _errors;
+        private readonly Config _config;
+        private readonly SourceMap? _sourceMap;
+        private readonly Dictionary<string, CustomRule> _customRules = new Dictionary<string, CustomRule>();
 
-        private Lazy<TextWriter> _output;
-        private Config? _config;
-        private SourceMap? _sourceMap;
-        private Dictionary<string, CustomRule> _customRules = new Dictionary<string, CustomRule>();
+        private readonly ErrorSink _errorSink = new ErrorSink();
+        private readonly ConcurrentDictionary<FilePath, ErrorSink> _fileSink = new ConcurrentDictionary<FilePath, ErrorSink>();
 
-        private ErrorSink _errorSink = new ErrorSink();
-        private ConcurrentDictionary<FilePath, ErrorSink> _fileSink = new ConcurrentDictionary<FilePath, ErrorSink>();
+        public override bool HasError => _errors.HasError;
 
-        public int ErrorCount => _errorSink.ErrorCount + _fileSink.Values.Sum(sink => sink.ErrorCount);
+        public override bool FileHasError(FilePath file) => _fileSink.TryGetValue(file, out var sink) && sink.ErrorCount > 0;
 
-        public int WarningCount => _errorSink.WarningCount + _fileSink.Values.Sum(sink => sink.WarningCount);
-
-        public int SuggestionCount => _errorSink.SuggestionCount + _fileSink.Values.Sum(sink => sink.SuggestionCount);
-
-        public bool HasError(FilePath file) => _fileSink.TryGetValue(file, out var sink) && sink.ErrorCount > 0;
-
-        public ErrorLog(string? outputPath = null)
+        public ErrorLog(ErrorBuilder errors, Config config, SourceMap? sourceMap = null, Dictionary<string, ValidationRules>? contentValidationRules = null)
         {
-            _output = new Lazy<TextWriter>(() => outputPath is null ? TextWriter.Null : CreateOutput(outputPath));
-        }
-
-        public void Configure(Config config, string outputPath, SourceMap? sourceMap, Dictionary<string, ValidationRules>? contentValidationRules = null)
-        {
+            _errors = errors;
             _config = config;
             _sourceMap = sourceMap;
             _customRules = MergeCustomRules(config, contentValidationRules);
-
-            lock (_outputLock)
-            {
-                if (_output.IsValueCreated)
-                {
-                    _output.Value.Flush();
-                    _output.Value.Dispose();
-                }
-                _output = new Lazy<TextWriter>(() => CreateOutput(outputPath));
-            }
         }
 
-        public bool Write(IEnumerable<Error> errors)
+        public override void Add(Error error)
         {
-            var hasErrors = false;
-            foreach (var error in errors)
-            {
-                if (Write(error))
-                {
-                    hasErrors = true;
-                }
-            }
-            return hasErrors;
-        }
-
-        public bool Write(IEnumerable<DocfxException> exceptions)
-        {
-            var hasErrors = false;
-            foreach (var exception in exceptions)
-            {
-                Log.Write(exception);
-                if (Write(exception.Error))
-                {
-                    hasErrors = true;
-                }
-            }
-            return hasErrors;
-        }
-
-        public bool Write(Error error)
-        {
-            var config = _config;
-            if (config != null && _customRules.TryGetValue(error.Code, out var customRule))
+            if (_customRules.TryGetValue(error.Code, out var customRule))
             {
                 error = error.WithCustomRule(customRule);
             }
 
             if (error.Level == ErrorLevel.Off)
             {
-                return false;
+                return;
             }
 
-            if (config != null && config.WarningsAsErrors && error.Level == ErrorLevel.Warning)
+            if (_config.WarningsAsErrors && error.Level == ErrorLevel.Warning)
             {
                 error = error.WithLevel(ErrorLevel.Error);
             }
 
-            if (config != null && error.Source?.File != null && error.Source?.File.Origin == FileOrigin.Fallback)
+            if (error.Source?.File != null && error.Source?.File.Origin == FileOrigin.Fallback)
             {
                 if (error.Level == ErrorLevel.Error)
                 {
-                    return Write(Errors.Logging.FallbackError(config.DefaultLocale));
+                    _errors.Add(Errors.Logging.FallbackError(_config.DefaultLocale));
                 }
-                return false;
+                return;
             }
 
             if (error.Source != null)
@@ -114,126 +63,29 @@ namespace Microsoft.Docs.Build
 
             var errorSink = error.Source?.File is null ? _errorSink : _fileSink.GetOrAdd(error.Source.File, _ => new ErrorSink());
 
-            switch (errorSink.Add(error.Source?.File is null ? null : config, error))
+            switch (errorSink.Add(error.Source?.File is null ? null : _config, error))
             {
                 case ErrorSinkResult.Ok:
-                    WriteCore(error);
+                    _errors.Add(error);
                     break;
 
-                case ErrorSinkResult.Exceed when error.Source?.File != null && config != null:
+                case ErrorSinkResult.Exceed when error.Source?.File != null:
                     var maxAllowed = error.Level switch
                     {
-                        ErrorLevel.Error => config.MaxFileErrors,
-                        ErrorLevel.Warning => config.MaxFileWarnings,
-                        ErrorLevel.Suggestion => config.MaxFileSuggestions,
-                        ErrorLevel.Info => config.MaxFileInfos,
+                        ErrorLevel.Error => _config.MaxFileErrors,
+                        ErrorLevel.Warning => _config.MaxFileWarnings,
+                        ErrorLevel.Suggestion => _config.MaxFileSuggestions,
+                        ErrorLevel.Info => _config.MaxFileInfos,
                         _ => 0,
                     };
-                    WriteCore(Errors.Logging.ExceedMaxFileErrors(maxAllowed, error.Level, error.Source.File));
+                    _errors.Add(Errors.Logging.ExceedMaxFileErrors(maxAllowed, error.Level, error.Source.File));
                     break;
             }
-
-            return error.Level == ErrorLevel.Error;
-        }
-
-        [SuppressMessage("Reliability", "CA2002", Justification = "Lock Console.Out")]
-        public void PrintSummary()
-        {
-            lock (Console.Out)
-            {
-                if (ErrorCount > 0 || WarningCount > 0 || SuggestionCount > 0)
-                {
-                    Console.ForegroundColor = ErrorCount > 0 ? ConsoleColor.Red
-                                            : WarningCount > 0 ? ConsoleColor.Yellow
-                                            : ConsoleColor.Magenta;
-                    Console.WriteLine();
-                    Console.WriteLine($"  {ErrorCount} Error(s), {WarningCount} Warning(s), {SuggestionCount} Suggestion(s)");
-                }
-
-                Console.ResetColor();
-            }
-        }
-
-        [SuppressMessage("Reliability", "CA2002", Justification = "Lock Console.Out")]
-        public static void PrintError(Error error)
-        {
-            lock (Console.Out)
-            {
-                var output = error.Level == ErrorLevel.Error ? Console.Error : Console.Out;
-                Console.ForegroundColor = GetColor(error.Level);
-                output.Write(error.Code + " ");
-                Console.ResetColor();
-
-                if (error.Source != null)
-                {
-                    output.WriteLine($"./{error.Source.File}({error.Source.Line},{error.Source.Column}): {error.Message}");
-                }
-                else
-                {
-                    output.WriteLine(error.Message);
-                }
-            }
-        }
-
-        public static void PrintErrors(List<Error> errors)
-        {
-            foreach (var error in errors)
-            {
-                PrintError(error);
-            }
-        }
-
-        public void Dispose()
-        {
-            lock (_outputLock)
-            {
-                if (_output.IsValueCreated)
-                {
-                    _output.Value.Dispose();
-                }
-            }
-        }
-
-        private void WriteCore(Error error)
-        {
-            Telemetry.TrackErrorCount(error.Code, error.Level, error.Name);
-
-            if (_output != null)
-            {
-                lock (_outputLock)
-                {
-                    _output.Value.WriteLine(error.ToString());
-                }
-            }
-
-            PrintError(error);
-        }
-
-        private TextWriter CreateOutput(string outputPath)
-        {
-            // add default build log file output path
-            var outputFilePath = Path.GetFullPath(Path.Combine(outputPath, ".errors.log"));
-
-            Directory.CreateDirectory(Path.GetDirectoryName(outputFilePath));
-
-            return File.AppendText(outputFilePath);
-        }
-
-        private static ConsoleColor GetColor(ErrorLevel level)
-        {
-            return level switch
-            {
-                ErrorLevel.Error => ConsoleColor.Red,
-                ErrorLevel.Warning => ConsoleColor.Yellow,
-                ErrorLevel.Suggestion => ConsoleColor.Magenta,
-                ErrorLevel.Info => ConsoleColor.DarkGray,
-                _ => ConsoleColor.DarkGray,
-            };
         }
 
         private Dictionary<string, CustomRule> MergeCustomRules(Config? config, Dictionary<string, ValidationRules>? validationRules)
         {
-            var customRules = config != null ? new Dictionary<string, CustomRule>(config.CustomRules) : new Dictionary<string, CustomRule>();
+            var customRules = config != null ? new Dictionary<string, CustomRule>(_config.CustomRules) : new Dictionary<string, CustomRule>();
 
             if (validationRules == null)
             {
@@ -242,7 +94,7 @@ namespace Microsoft.Docs.Build
 
             foreach (var validationRule in validationRules.SelectMany(rules => rules.Value.Rules).Where(rule => rule.PullRequestOnly))
             {
-                if (config != null && customRules.TryGetValue(validationRule.Code, out var customRule))
+                if (customRules.TryGetValue(validationRule.Code, out var customRule))
                 {
                     customRules[validationRule.Code] = new CustomRule(
                             customRule.Severity,

--- a/src/docfx/lib/log/ErrorWriter.cs
+++ b/src/docfx/lib/log/ErrorWriter.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading;
+
+namespace Microsoft.Docs.Build
+{
+    internal class ErrorWriter : ErrorBuilder, IDisposable
+    {
+        private readonly object _outputLock = new object();
+        private readonly Lazy<TextWriter> _output;
+
+        private int _errorCount;
+        private int _warningCount;
+        private int _suggestionCount;
+
+        public int ErrorCount => _errorCount;
+
+        public int WarningCount => _warningCount;
+
+        public int SuggestionCount => _suggestionCount;
+
+        public override bool HasError => Volatile.Read(ref _errorCount) > 0;
+
+        public ErrorWriter(string? outputPath = null)
+        {
+            _output = new Lazy<TextWriter>(() => outputPath is null ? TextWriter.Null : CreateOutput(outputPath));
+        }
+
+        public override void Add(Error error)
+        {
+            var count = error.Level switch
+            {
+                ErrorLevel.Error => Interlocked.Increment(ref _errorCount),
+                ErrorLevel.Warning => Interlocked.Increment(ref _warningCount),
+                ErrorLevel.Suggestion => Interlocked.Increment(ref _suggestionCount),
+                _ => 0,
+            };
+
+            Telemetry.TrackErrorCount(error.Code, error.Level, error.Name);
+
+            if (_output != null)
+            {
+                lock (_outputLock)
+                {
+                    _output.Value.WriteLine(error.ToString());
+                }
+            }
+
+            PrintError(error);
+        }
+
+        [SuppressMessage("Reliability", "CA2002", Justification = "Lock Console.Out")]
+        public void PrintSummary()
+        {
+            lock (Console.Out)
+            {
+                if (_errorCount > 0 || _warningCount > 0 || _suggestionCount > 0)
+                {
+                    Console.ForegroundColor = _errorCount > 0 ? ConsoleColor.Red
+                                            : _warningCount > 0 ? ConsoleColor.Yellow
+                                            : ConsoleColor.Magenta;
+                    Console.WriteLine();
+                    Console.WriteLine($"  {_errorCount} Error(s), {_warningCount} Warning(s), {_suggestionCount} Suggestion(s)");
+                }
+
+                Console.ResetColor();
+            }
+        }
+
+        [SuppressMessage("Reliability", "CA2002", Justification = "Lock Console.Out")]
+        public static void PrintError(Error error)
+        {
+            lock (Console.Out)
+            {
+                var output = error.Level == ErrorLevel.Error ? Console.Error : Console.Out;
+                Console.ForegroundColor = GetColor(error.Level);
+                output.Write(error.Code + " ");
+                Console.ResetColor();
+
+                if (error.Source != null)
+                {
+                    output.WriteLine($"./{error.Source.File}({error.Source.Line},{error.Source.Column}): {error.Message}");
+                }
+                else
+                {
+                    output.WriteLine(error.Message);
+                }
+            }
+        }
+
+        public static void PrintErrors(List<Error> errors)
+        {
+            foreach (var error in errors)
+            {
+                PrintError(error);
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_outputLock)
+            {
+                if (_output.IsValueCreated)
+                {
+                    _output.Value.Dispose();
+                }
+            }
+        }
+
+        private TextWriter CreateOutput(string outputPath)
+        {
+            // add default build log file output path
+            var outputFilePath = Path.GetFullPath(Path.Combine(outputPath, ".errors.log"));
+
+            Directory.CreateDirectory(Path.GetDirectoryName(outputFilePath));
+
+            return File.AppendText(outputFilePath);
+        }
+
+        private static ConsoleColor GetColor(ErrorLevel level)
+        {
+            return level switch
+            {
+                ErrorLevel.Error => ConsoleColor.Red,
+                ErrorLevel.Warning => ConsoleColor.Yellow,
+                ErrorLevel.Suggestion => ConsoleColor.Magenta,
+                ErrorLevel.Info => ConsoleColor.DarkGray,
+                _ => ConsoleColor.DarkGray,
+            };
+        }
+    }
+}

--- a/src/docfx/lib/log/ErrorWriter.cs
+++ b/src/docfx/lib/log/ErrorWriter.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Docs.Build
 
         public override bool HasError => Volatile.Read(ref _errorCount) > 0;
 
+        public override bool FileHasError(FilePath file) => throw new NotSupportedException();
+
         public ErrorWriter(string? outputPath = null)
         {
             _output = new Lazy<TextWriter>(() => outputPath is null ? TextWriter.Null : CreateOutput(outputPath));

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Docs.Build
         private readonly MarkdownEngine _markdownEngine;
         private readonly LinkResolver _linkResolver;
         private readonly XrefResolver _xrefResolver;
-        private readonly ErrorLog _errorLog;
+        private readonly ErrorBuilder _errors;
         private readonly MonikerProvider _monikerProvider;
 
         private readonly ConcurrentDictionary<Document, int> _uidCountCache = new ConcurrentDictionary<Document, int>(ReferenceEqualsComparer.Default);
@@ -29,13 +29,13 @@ namespace Microsoft.Docs.Build
             MarkdownEngine markdownEngine,
             LinkResolver linkResolver,
             XrefResolver xrefResolver,
-            ErrorLog errorLog,
+            ErrorBuilder errors,
             MonikerProvider monikerProvider)
         {
             _markdownEngine = markdownEngine;
             _linkResolver = linkResolver;
             _xrefResolver = xrefResolver;
-            _errorLog = errorLog;
+            _errors = errors;
             _monikerProvider = monikerProvider;
         }
 
@@ -203,7 +203,7 @@ namespace Microsoft.Docs.Build
             {
                 recursionDetector.Push(uid);
                 var (transformErrors, transformedToken) = TransformContentCore(definitions, file, schema, value, uidCount);
-                _errorLog.Write(transformErrors);
+                _errors.Write(transformErrors);
                 return transformedToken;
             }
             finally

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Docs.Build
             {
                 recursionDetector.Push(uid);
                 var (transformErrors, transformedToken) = TransformContentCore(definitions, file, schema, value, uidCount);
-                _errors.Write(transformErrors);
+                _errors.AddRange(transformErrors);
                 return transformedToken;
             }
             finally

--- a/src/docfx/publish/PublishModelBuilder.cs
+++ b/src/docfx/publish/PublishModelBuilder.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Docs.Build
     internal class PublishModelBuilder
     {
         private readonly Config _config;
-        private readonly ErrorLog _errorLog;
+        private readonly ErrorBuilder _errors;
         private readonly MonikerProvider _monikerProvider;
         private readonly string _locale;
         private readonly ContentValidator _contentValidator;
@@ -24,7 +24,7 @@ namespace Microsoft.Docs.Build
 
         public PublishModelBuilder(
             Config config,
-            ErrorLog errorLog,
+            ErrorBuilder errors,
             MonikerProvider monikerProvider,
             BuildOptions buildOptions,
             ContentValidator contentValidator,
@@ -33,7 +33,7 @@ namespace Microsoft.Docs.Build
             SourceMap sourceMap)
         {
             _config = config;
-            _errorLog = errorLog;
+            _errors = errors;
             _monikerProvider = monikerProvider;
             _locale = buildOptions.Locale;
             _contentValidator = contentValidator;
@@ -63,7 +63,7 @@ namespace Microsoft.Docs.Build
                     _monikerProvider.GetConfigMonikerRange(sourcePath),
                     document.ContentType,
                     document.Mime,
-                    _errorLog.HasError(sourcePath),
+                    _errors.FileHasError(sourcePath),
                     buildOutput ? RemoveComplexValue(result.metadata) : null);
                 publishItems.Add(sourcePath, publishItem);
             }

--- a/src/docfx/publish/PublishUrlMap.cs
+++ b/src/docfx/publish/PublishUrlMap.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Docs.Build
                 return conflicts.First();
             }
 
-            _errors.Write(Errors.UrlPath.OutputPathConflict(conflicts.First().OutputPath, conflicts.Select(x => x.SourcePath)));
+            _errors.Add(Errors.UrlPath.OutputPathConflict(conflicts.First().OutputPath, conflicts.Select(x => x.SourcePath)));
 
             // redirection file is preferred than source file
             // otherwise, prefer the one based on FilePath
@@ -143,7 +143,7 @@ namespace Microsoft.Docs.Build
                 .Select(group => group.Key)
                 .ToList();
             var conflictingFiles = conflicts.ToDictionary(x => x.SourcePath, x => x.Monikers);
-            _errors.Write(Errors.UrlPath.PublishUrlConflict(conflicts.First().Url, conflictingFiles, conflictMonikers));
+            _errors.Add(Errors.UrlPath.PublishUrlConflict(conflicts.First().Url, conflictingFiles, conflictMonikers));
 
             return conflicts.OrderBy(x => x).Last();
         }
@@ -152,7 +152,7 @@ namespace Microsoft.Docs.Build
         {
             var file = _documentProvider.GetDocument(path);
             var (monikerErrors, monikers) = _monikerProvider.GetFileLevelMonikers(path);
-            _errors.Write(monikerErrors);
+            _errors.AddRange(monikerErrors);
             var outputPath = _documentProvider.GetOutputPath(path);
             outputMapping.Add(new PublishUrlMapItem(file.SiteUrl, outputPath, monikers, path));
         }

--- a/src/docfx/publish/PublishUrlMap.cs
+++ b/src/docfx/publish/PublishUrlMap.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Docs.Build
     internal class PublishUrlMap
     {
         private readonly Config _config;
-        private readonly ErrorLog _errorLog;
+        private readonly ErrorBuilder _errors;
         private readonly BuildScope _buildScope;
         private readonly RedirectionProvider _redirectionProvider;
         private readonly DocumentProvider _documentProvider;
@@ -25,7 +25,7 @@ namespace Microsoft.Docs.Build
 
         public PublishUrlMap(
             Config config,
-            ErrorLog errorLog,
+            ErrorBuilder errors,
             BuildScope buildScope,
             RedirectionProvider redirectionProvider,
             DocumentProvider documentProvider,
@@ -33,7 +33,7 @@ namespace Microsoft.Docs.Build
             TableOfContentsMap tocMap)
         {
             _config = config;
-            _errorLog = errorLog;
+            _errors = errors;
             _buildScope = buildScope;
             _redirectionProvider = redirectionProvider;
             _documentProvider = documentProvider;
@@ -92,14 +92,14 @@ namespace Microsoft.Docs.Build
             {
                 Parallel.Invoke(
                     () => ParallelUtility.ForEach(
-                        _errorLog, _redirectionProvider.Files.Where(x => x.Origin != FileOrigin.Fallback), file => AddItem(builder, file)),
+                        _errors, _redirectionProvider.Files.Where(x => x.Origin != FileOrigin.Fallback), file => AddItem(builder, file)),
                     () => ParallelUtility.ForEach(
-                        _errorLog,
+                        _errors,
                         _buildScope.GetFiles(ContentType.Resource).Where(x => x.Origin != FileOrigin.Fallback || _config.OutputType == OutputType.Html),
                         file => AddItem(builder, file)),
                     () => ParallelUtility.ForEach(
-                        _errorLog, _buildScope.GetFiles(ContentType.Page).Where(x => x.Origin != FileOrigin.Fallback), file => AddItem(builder, file)),
-                    () => ParallelUtility.ForEach(_errorLog, _tocMap.GetFiles(), file => AddItem(builder, file)));
+                        _errors, _buildScope.GetFiles(ContentType.Page).Where(x => x.Origin != FileOrigin.Fallback), file => AddItem(builder, file)),
+                    () => ParallelUtility.ForEach(_errors, _tocMap.GetFiles(), file => AddItem(builder, file)));
             }
 
             // resolve output path conflicts
@@ -121,7 +121,7 @@ namespace Microsoft.Docs.Build
                 return conflicts.First();
             }
 
-            _errorLog.Write(Errors.UrlPath.OutputPathConflict(conflicts.First().OutputPath, conflicts.Select(x => x.SourcePath)));
+            _errors.Write(Errors.UrlPath.OutputPathConflict(conflicts.First().OutputPath, conflicts.Select(x => x.SourcePath)));
 
             // redirection file is preferred than source file
             // otherwise, prefer the one based on FilePath
@@ -143,7 +143,7 @@ namespace Microsoft.Docs.Build
                 .Select(group => group.Key)
                 .ToList();
             var conflictingFiles = conflicts.ToDictionary(x => x.SourcePath, x => x.Monikers);
-            _errorLog.Write(Errors.UrlPath.PublishUrlConflict(conflicts.First().Url, conflictingFiles, conflictMonikers));
+            _errors.Write(Errors.UrlPath.PublishUrlConflict(conflicts.First().Url, conflictingFiles, conflictMonikers));
 
             return conflicts.OrderBy(x => x).Last();
         }
@@ -152,7 +152,7 @@ namespace Microsoft.Docs.Build
         {
             var file = _documentProvider.GetDocument(path);
             var (monikerErrors, monikers) = _monikerProvider.GetFileLevelMonikers(path);
-            _errorLog.Write(monikerErrors);
+            _errors.Write(monikerErrors);
             var outputPath = _documentProvider.GetOutputPath(path);
             outputMapping.Add(new PublishUrlMapItem(file.SiteUrl, outputPath, monikers, path));
         }

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Docs.Build
             }
             catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
             {
-                errors.Write(dex);
+                errors.AddRange(dex);
                 return errors.HasError;
             }
             finally

--- a/src/docfx/validation/ContentValidator.cs
+++ b/src/docfx/validation/ContentValidator.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Docs.Build
     internal class ContentValidator
     {
         private Validator _validator;
-        private ErrorLog _errorLog;
+        private ErrorBuilder _errors;
         private MonikerProvider _monikerProvider;
         private MetadataProvider _metadataProvider;
         private Lazy<PublishUrlMap> _publishUrlMap;
@@ -22,13 +22,13 @@ namespace Microsoft.Docs.Build
         public ContentValidator(
             Config config,
             FileResolver fileResolver,
-            ErrorLog log,
+            ErrorBuilder errors,
             MonikerProvider monikerProvider,
             MetadataProvider metadataProvider,
             Lazy<PublishUrlMap> publishUrlMap)
         {
             _validator = new Validator(GetValidationPhysicalFilePath(fileResolver, config.MarkdownValidationRules));
-            _errorLog = log;
+            _errors = errors;
             _monikerProvider = monikerProvider;
             _metadataProvider = metadataProvider;
             _publishUrlMap = publishUrlMap;
@@ -106,19 +106,17 @@ namespace Microsoft.Docs.Build
             {
                 var validationContext = new ValidationContext { DocumentType = documentType };
 
-                using (StringReader reader = new StringReader(content))
+                using var reader = new StringReader(content);
+                var lineCount = 1;
+                string? line = null;
+                while ((line = reader.ReadLine()) != null)
                 {
-                    var lineCount = 1;
-                    string? line = null;
-                    while ((line = reader.ReadLine()) != null)
+                    var item = new TextItem()
                     {
-                        var item = new TextItem()
-                        {
-                            Content = line,
-                            SourceInfo = new SourceInfo(document.FilePath, lineCount++, 0),
-                        };
-                        Write(_validator.ValidateText(item, validationContext).GetAwaiter().GetResult());
-                    }
+                        Content = line,
+                        SourceInfo = new SourceInfo(document.FilePath, lineCount++, 0),
+                    };
+                    Write(_validator.ValidateText(item, validationContext).GetAwaiter().GetResult());
                 }
             }
         }
@@ -221,9 +219,9 @@ namespace Microsoft.Docs.Build
             return filePath;
         }
 
-        private bool Write(IEnumerable<ValidationError> validationErrors)
+        private void Write(IEnumerable<ValidationError> validationErrors)
         {
-            return _errorLog.Write(validationErrors.Select(e => new Error(GetLevel(e.Severity), e.Code, e.Message, (SourceInfo?)e.SourceInfo)));
+            _errors.Write(validationErrors.Select(e => new Error(GetLevel(e.Severity), e.Code, e.Message, (SourceInfo?)e.SourceInfo)));
 
             static ErrorLevel GetLevel(ValidationSeverity severity) =>
                 severity switch

--- a/src/docfx/validation/ContentValidator.cs
+++ b/src/docfx/validation/ContentValidator.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Docs.Build
 
         private void Write(IEnumerable<ValidationError> validationErrors)
         {
-            _errors.Write(validationErrors.Select(e => new Error(GetLevel(e.Severity), e.Code, e.Message, (SourceInfo?)e.SourceInfo)));
+            _errors.AddRange(validationErrors.Select(e => new Error(GetLevel(e.Severity), e.Code, e.Message, (SourceInfo?)e.SourceInfo)));
 
             static ErrorLevel GetLevel(ValidationSeverity severity) =>
                 severity switch

--- a/test/docfx.Test/lib/ErrorLogTest.cs
+++ b/test/docfx.Test/lib/ErrorLogTest.cs
@@ -11,22 +11,22 @@ namespace Microsoft.Docs.Build
         [Fact]
         public void DedupErrors()
         {
-            using var errorLog = new ErrorLog("DedupErrors");
-            errorLog.Configure(new Config(), ".", null);
+            using var errors = new ErrorWriter();
+            var errorLog = new ErrorLog(errors, new Config());
             errorLog.Write(new Error(ErrorLevel.Error, "an-error-code", "message 1"));
             errorLog.Write(new Error(ErrorLevel.Error, "an-error-code", "message 1"));
             errorLog.Write(new Error(ErrorLevel.Warning, "an-error-code", "message 2"));
 
-            Assert.Equal(1, errorLog.ErrorCount);
-            Assert.Equal(1, errorLog.WarningCount);
+            Assert.Equal(1, errors.ErrorCount);
+            Assert.Equal(1, errors.WarningCount);
         }
 
         [Fact]
         public void MaxErrors()
         {
-            using var errorLog = new ErrorLog("MaxErrors");
+            using var errors = new ErrorWriter();
             var config = new Config();
-            errorLog.Configure(config, ".", null);
+            var errorLog = new ErrorLog(errors, config);
 
             var testFiles = 100;
             var testErrors = new List<Error>();
@@ -48,7 +48,7 @@ namespace Microsoft.Docs.Build
 
             ParallelUtility.ForEach(errorLog, testErrors, testError => errorLog.Write(testError));
 
-            Assert.Equal(config.MaxFileErrors * testFiles + testEmptyFileErrors, errorLog.ErrorCount);
+            Assert.Equal(config.MaxFileErrors * testFiles + testEmptyFileErrors, errors.ErrorCount);
         }
     }
 }

--- a/test/docfx.Test/lib/ErrorLogTest.cs
+++ b/test/docfx.Test/lib/ErrorLogTest.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Docs.Build
         {
             using var errors = new ErrorWriter();
             var errorLog = new ErrorLog(errors, new Config());
-            errorLog.Write(new Error(ErrorLevel.Error, "an-error-code", "message 1"));
-            errorLog.Write(new Error(ErrorLevel.Error, "an-error-code", "message 1"));
-            errorLog.Write(new Error(ErrorLevel.Warning, "an-error-code", "message 2"));
+            errorLog.Add(new Error(ErrorLevel.Error, "an-error-code", "message 1"));
+            errorLog.Add(new Error(ErrorLevel.Error, "an-error-code", "message 1"));
+            errorLog.Add(new Error(ErrorLevel.Warning, "an-error-code", "message 2"));
 
             Assert.Equal(1, errors.ErrorCount);
             Assert.Equal(1, errors.WarningCount);
@@ -46,7 +46,7 @@ namespace Microsoft.Docs.Build
                 testErrors.Add(new Error(ErrorLevel.Error, "an-error-code", i.ToString()));
             }
 
-            ParallelUtility.ForEach(errorLog, testErrors, testError => errorLog.Write(testError));
+            ParallelUtility.ForEach(errorLog, testErrors, testError => errorLog.Add(testError));
 
             Assert.Equal(config.MaxFileErrors * testFiles + testEmptyFileErrors, errors.ErrorCount);
         }

--- a/test/docfx.Test/lib/GitUtilityTest.cs
+++ b/test/docfx.Test/lib/GitUtilityTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Docs.Build
             var repo = Repository.Create(Path.GetFullPath(file), branch: null);
             Assert.NotNull(repo);
 
-            using var gitCommitProvider = new FileCommitProvider(new ErrorLog(), repo, "git-commit-test-cache");
+            using var gitCommitProvider = new FileCommitProvider(new ErrorWriter(), repo, "git-commit-test-cache");
             var pathToRepo = PathUtility.NormalizeFile(file);
 
             // current branch


### PR DESCRIPTION
[AB#268450](https://dev.azure.com/ceapex/Engineering/_workitems/edit/268450/)

Split `ErrorLog` into `ErrorLog` and `ErrorWriter`, where `ErrorLog` depends on `Config` and `ErrorWriter` is pure output. Created an `ErrorBuilder` to abstract them.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6297)