### PR TITLE
Bump Microsoft.DocAsCode.ECMAHelper from 1.1.737 to 1.1.738

### DIFF
--- a/docs/specs/ecma2Yaml.yml
+++ b/docs/specs/ecma2Yaml.yml
@@ -100,7 +100,6 @@ repos:
         {}
 outputs:
   .errors.log: |
-    {"message_severity":"warning","code":"ECMA2Yaml_ExceptionTypeNotFound","message":"Referenced exception type not found: None.Existing.Ex", "file":"cat/xml/CatLibrary/Cat`2.xml"}
     {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'CatLibrary'."}
     {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'CatLibrary.Cat`2'."}
     {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'CatLibrary.Cat`2.#ctor*'."}
@@ -215,7 +214,6 @@ repos:
       
 outputs:
   .errors.log: |
-    {"message_severity":"warning","code":"ECMA2Yaml_ExceptionTypeNotFound","message":"Referenced exception type not found: None.Existing.Ex", "file":"cat/CatLibrary/Cat`2.xml"}
     {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'CatLibrary'."}
     {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'CatLibrary.Cat`2'."}
     {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'CatLibrary.Cat`2.#ctor*'."}
@@ -403,8 +401,6 @@ repos:
         {}
 outputs:
   .errors.log: |
-    {"message_severity":"warning","code":"ECMA2Yaml_ExceptionTypeNotFound","message":"Referenced exception type not found: None.Existing.Ex", "file":"cat/xml/CatLibrary/Cat`2.xml"}
-    {"message_severity":"warning","code":"ECMA2Yaml_ExceptionTypeNotFound","message":"Referenced exception type not found: None.Existing.Ex", "file":"cat/mouse/xml/CatLibrary/Cat`2.xml"}
     {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'CatLibrary'."}
     {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'CatLibrary.Cat`2'."}
     {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'CatLibrary.Cat`2.#ctor*'."}

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.14.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.6" />
     <PackageReference Include="Microsoft.ChakraCore" Version="1.11.20" />
-    <PackageReference Include="Microsoft.DocAsCode.ECMAHelper" Version="1.1.737" />
+    <PackageReference Include="Microsoft.DocAsCode.ECMAHelper" Version="1.1.738" />
     <PackageReference Include="Microsoft.Graph" Version="3.8.0" />
     <PackageReference Include="Microsoft.Experimental.Collections" Version="1.0.6-e190117-3" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.16.1" />


### PR DESCRIPTION
Not generating `ECMA2Yaml_ExceptionTypeNotFound`
[AB#271822](https://dev.azure.com/ceapex/Engineering/_workitems/edit/271822)
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6307)