### PR TITLE
Loc consume _repo.en-us in op-config

### DIFF
--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -765,3 +765,30 @@ repos:
 outputs:
   docs/toc.json: |
     {"items":[{"href":"a"}]}
+---
+# loc repo consume _repo.en-us repo in op config
+locale: zh-cn
+repos:
+  https://docs.com/org-en-us/page-fallback#master:
+    - files:
+        docfx.yml:
+        docs/b.md: |
+          [link in a](a.md)
+  https://docs.com/org-loc/page-fallback.zh-cn#master:
+    - files:
+        .openpublishing.publish.config.json: |
+          {
+            "docsets_to_publish": [{ "build_source_folder": "docs" }],
+            "dependent_repositories": [{
+                "path_to_root": "_repo.en-us",
+                "url": "https://docs.com/org-en-us/page-fallback",
+                "branch": "unexist"
+              }]
+          }
+        docs/docfx.yml: |
+        docs/a.md: |
+          [link in b](b.md)
+          [!include[](b.md)]
+outputs:
+  docs/a.json: |
+    { "conceptual":"<p><a href=\"b\">link in b</a></p>\n<p><a href=\"a\">link in a</a></p>\n"}

--- a/src/docfx/config/ConfigLoader.cs
+++ b/src/docfx/config/ConfigLoader.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Docs.Build
             var packageResolver = new PackageResolver(docsetPath, preloadConfig, fetchOptions, repository);
             disposables.Add(packageResolver);
 
-            var fallbackDocsetPath = LocalizationUtility.GetFallbackDocsetPath(docsetPath, repository, packageResolver);
+            var fallbackDocsetPath = LocalizationUtility.GetFallbackDocsetPath(docsetPath, repository, preloadConfig.FallbackRepository, packageResolver);
             var fileResolver = new FileResolver(docsetPath, fallbackDocsetPath, credentialProvider, configAdapter, fetchOptions);
             var buildOptions = new BuildOptions(docsetPath, fallbackDocsetPath, outputPath, repository, preloadConfig);
             var extendConfig = DownloadExtendConfig(errors, buildOptions.Locale, preloadConfig, xrefEndpoint, xrefQueryTags, repository, fileResolver);

--- a/src/docfx/config/PreloadConfig.cs
+++ b/src/docfx/config/PreloadConfig.cs
@@ -30,6 +30,12 @@ namespace Microsoft.Docs.Build
         public string DefaultLocale { get; private set; } = "en-us";
 
         /// <summary>
+        /// Specify the fallback repository url.
+        /// For localization build, it takes precedence over convention-calculated url.
+        /// </summary>
+        public PackagePath? FallbackRepository { get; private set; }
+
+        /// <summary>
         /// The extend file addresses
         /// The addresses can be absolute url or relative path
         /// </summary>

--- a/src/docfx/config/ops/OpsConfigLoader.cs
+++ b/src/docfx/config/ops/OpsConfigLoader.cs
@@ -62,6 +62,8 @@ namespace Microsoft.Docs.Build
 
             result["editRepositoryUrl"] = opsConfig.GitRepositoryUrlOpenToPublicContributors;
             result["editRepositoryBranch"] = opsConfig.GitRepositoryBranchOpenToPublicContributors;
+            result["fallbackRepository"] = dependencies.FirstOrDefault(
+                dep => dep.name.Equals("_repo.en-us", StringComparison.OrdinalIgnoreCase)).obj;
 
             var docsetConfig = opsConfig.DocsetsToPublish.FirstOrDefault(
                 config => config.BuildSourceFolder.FolderEquals(buildSourceFolder));

--- a/src/docfx/lib/LocalizationUtility.cs
+++ b/src/docfx/lib/LocalizationUtility.cs
@@ -43,19 +43,24 @@ namespace Microsoft.Docs.Build
             return s_lrmAdjustment.Replace(text, me => $"{me.Groups[1]}{me.Groups[2]}&lrm;{me.Groups[3]}{me.Groups[4]}");
         }
 
-        public static string? GetFallbackDocsetPath(string docsetPath, Repository? repository, PackageResolver packageResolver)
+        public static string? GetFallbackDocsetPath(string docsetPath, Repository? repository, PackagePath? fallbackRepository, PackageResolver packageResolver)
         {
-            if (repository != null)
+            var docsetSourceFolder = repository == null
+                ? docsetPath.Split('/').Last()
+                : Path.GetRelativePath(repository.Path, docsetPath);
+            var fallbackRemote = fallbackRepository?.Url;
+            var fallbackBranch = fallbackRepository?.Branch;
+            if (fallbackRemote == null && repository != null)
             {
-                var docsetSourceFolder = Path.GetRelativePath(repository.Path, docsetPath);
-                if (TryGetFallbackRepository(repository?.Remote, repository?.Branch, out var fallbackRemote, out var fallbackBranch))
+                (fallbackRemote, fallbackBranch) = GetFallbackRepository(repository.Remote, repository.Branch);
+            }
+            if (fallbackRemote != null)
+            {
+                foreach (var branch in new[] { fallbackBranch, "master" })
                 {
-                    foreach (var branch in new[] { fallbackBranch, "master" })
+                    if (packageResolver.TryResolvePackage(new PackagePath(fallbackRemote, branch), PackageFetchOptions.None, out var fallbackRepoPath))
                     {
-                        if (packageResolver.TryResolvePackage(new PackagePath(fallbackRemote, branch), PackageFetchOptions.None, out var fallbackRepoPath))
-                        {
-                            return Path.Combine(fallbackRepoPath, docsetSourceFolder);
-                        }
+                        return Path.Combine(fallbackRepoPath, docsetSourceFolder);
                     }
                 }
             }
@@ -107,23 +112,16 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        internal static bool TryGetFallbackRepository(
-            string? remote,
-            string? branch,
-            [NotNullWhen(true)] out string? fallbackRemote,
-            [NotNullWhen(true)] out string? fallbackBranch)
+        internal static (string? fallbackRemote, string? fallbackBranch) GetFallbackRepository(string? remote, string? branch)
         {
-            fallbackRemote = null;
-            fallbackBranch = null;
-
             if (string.IsNullOrEmpty(remote) || string.IsNullOrEmpty(branch))
             {
-                return false;
+                return default;
             }
 
-            if (TryRemoveLocale(remote, out fallbackRemote, out _))
+            if (TryRemoveLocale(remote, out var fallbackRemote, out _))
             {
-                fallbackBranch = branch;
+                var fallbackBranch = branch;
                 if (TryRemoveLocale(branch, out var branchWithoutLocale, out _))
                 {
                     fallbackBranch = branchWithoutLocale;
@@ -134,10 +132,10 @@ namespace Microsoft.Docs.Build
                     fallbackBranch = contributionBranch;
                 }
 
-                return true;
+                return (fallbackRemote, fallbackBranch);
             }
 
-            return false;
+            return default;
         }
 
         private static bool TryRemoveLocale(string name, [NotNullWhen(true)] out string? nameWithoutLocale, [NotNullWhen(true)] out string? locale)

--- a/src/docfx/lib/LocalizationUtility.cs
+++ b/src/docfx/lib/LocalizationUtility.cs
@@ -45,17 +45,17 @@ namespace Microsoft.Docs.Build
 
         public static string? GetFallbackDocsetPath(string docsetPath, Repository? repository, PackagePath? fallbackRepository, PackageResolver packageResolver)
         {
-            var docsetSourceFolder = repository == null
-                ? docsetPath.Split('/').Last()
-                : Path.GetRelativePath(repository.Path, docsetPath);
-            var fallbackRemote = fallbackRepository?.Url;
-            var fallbackBranch = fallbackRepository?.Branch;
-            if (fallbackRemote == null && repository != null)
+            if (repository == null)
             {
-                (fallbackRemote, fallbackBranch) = GetFallbackRepository(repository.Remote, repository.Branch);
+                return null;
             }
+
+            var (fallbackRemote, fallbackBranch) = fallbackRepository?.Type == PackageType.Git
+                ? (fallbackRepository?.Url, fallbackRepository?.Branch)
+                : GetFallbackRepository(repository!.Remote, repository.Branch);
             if (fallbackRemote != null)
             {
+                var docsetSourceFolder = Path.GetRelativePath(repository.Path, docsetPath);
                 foreach (var branch in new[] { fallbackBranch, "master" })
                 {
                     if (packageResolver.TryResolvePackage(new PackagePath(fallbackRemote, branch), PackageFetchOptions.None, out var fallbackRepoPath))

--- a/test/docfx.Test/build/ConfigTest.cs
+++ b/test/docfx.Test/build/ConfigTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Docs.Build
         [InlineData("https://github.com/docs.loc", "master-sxs.zh-cn", "https://github.com/docs", "master")]
         public static void LocConfigConventionSourceRepo(string remote, string branch, string expectedSourceRemote, string expectedSourceBranch)
         {
-            LocalizationUtility.TryGetFallbackRepository(remote, branch, out var sourceRemote, out var sourceBranch);
+            var (sourceRemote, sourceBranch) = LocalizationUtility.GetFallbackRepository(remote, branch);
 
             Assert.Equal(expectedSourceRemote, sourceRemote);
             Assert.Equal(expectedSourceBranch, sourceBranch);


### PR DESCRIPTION
[AB#274997](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/274997)

added a `FallbackRepository` in `PreLoadConfig` for restoring fallback repository, which is converted from `_repo.en-us`
Priority: `_repo.en-us` > `conventional`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6323)