### PR TITLE
fix bug that the altTextDuplicate check is not stable

### DIFF
--- a/docs/specs/validations/metadataContentValidations.yml
+++ b/docs/specs/validations/metadataContentValidations.yml
@@ -1975,6 +1975,62 @@ outputs:
     {"message_severity":"suggestion","log_item_type":"user","code":"image-alt-text-duplicated","message":"Alt text 'test alt text3' is duplicated. Within an article, alt text must be unique.","file":"a.md","line":18,"end_line":18,"column":11,"end_column":19}
     {"message_severity":"suggestion","log_item_type":"user","code":"image-alt-text-duplicated","message":"Alt text 'test alt text3' is duplicated. Within an article, alt text must be unique.","file":"a.md","line":19,"end_line":19,"column":11,"end_column":19}
 ---
+# Content Validation - alt text duplicated in includes
+inputs:
+  docfx.yml: |
+    markdownValidationRules: rules.json
+    exclude:
+      - b.md
+  rules.json: |
+    {
+      "images": {
+        "rules": [
+          {
+            "name": "Images",
+            "type": "ImageAltTextDuplicated",
+            "message": "Alt text '{0}' is duplicated. Within an article, alt text must be unique.",
+            "code": "image-alt-text-duplicated",
+            "severity": "SUGGESTION",
+            "exclusions": [
+              "includes",
+              "landingPage",
+              "hubPage",
+              "toc"
+            ],
+            "excludedDocfxVersions": [
+              "v2"
+            ]
+          }
+        ]
+      }
+    }
+  pig1.jpg:
+  pig2.jpg:
+  a.md: |
+    hello
+    ![alt text](pig1.jpg)
+    include b
+    [!include[](b.md)]
+  b.md: |
+    hello
+    ![alt text](pig2.jpg)
+  c.md: |
+    hello
+    [!include[](b.md)]
+  d.md: |
+    hello
+    [!include[](b.md)]
+outputs:
+  a.json:
+  c.json:
+  d.json:
+  pig1.jpg:
+  pig2.jpg:
+  .errors.log: |
+    {"message_severity":"suggestion","log_item_type":"user","code":"image-alt-text-duplicated","message":"Alt text 'alt text' is duplicated. Within an article, alt text must be unique.","file":"a.md","line":2,"end_line":2,"column":1,"end_column":1}
+    {"message_severity":"suggestion","log_item_type":"user","code":"image-alt-text-duplicated","message":"Alt text 'alt text' is duplicated. Within an article, alt text must be unique.","file":"b.md","line":2,"end_line":2,"column":1,"end_column":1}
+    
+---
 # Content Validation - image alt text missing
 inputs:
   docfx.yml: |

--- a/src/docfx/validation/ContentValidator.cs
+++ b/src/docfx/validation/ContentValidator.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Docs.Build
         private readonly MonikerProvider _monikerProvider;
         private readonly MetadataProvider _metadataProvider;
         private readonly Lazy<PublishUrlMap> _publishUrlMap;
-        private readonly ConcurrentHashSet<SourceInfo<string>> _links;
+        private readonly ConcurrentHashSet<(FilePath, SourceInfo<string>)> _links;
 
         public ContentValidator(
             Config config,
@@ -32,13 +32,13 @@ namespace Microsoft.Docs.Build
             _monikerProvider = monikerProvider;
             _metadataProvider = metadataProvider;
             _publishUrlMap = publishUrlMap;
-            _links = new ConcurrentHashSet<SourceInfo<string>>();
+            _links = new ConcurrentHashSet<(FilePath, SourceInfo<string>)>();
         }
 
         public void ValidateImageLink(Document file, SourceInfo<string> link, string? altText)
         {
             // validate image link and altText here
-            if (_links.TryAdd(link) && TryGetValidationDocumentType(file, file.Mime.Value, false, out var documentType))
+            if (_links.TryAdd((file.FilePath, link)) && TryGetValidationDocumentType(file, file.Mime.Value, false, out var documentType))
             {
                 var validationContext = new ValidationContext { DocumentType = documentType, File = file.FilePath.Path };
                 Write(_validator.ValidateLink(


### PR DESCRIPTION
the alt text in the included files are filtered out incorrectly, this fix should be able to help stable the diff in PR.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6334)