### PR TITLE
Support versioning heading

### DIFF
--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -223,17 +223,13 @@ inputs:
     files: docs/a.md
   docs/a.md: |
     [!INCLUDE[B](b.md)]
-    [!INCLUDE[C](c.md)]
   docs/b.md: |
     Hello
-  docs/c.md: |
-    # Heading from C
 outputs:
   docs/a.json: |
     {
-      "conceptual": "<p>Hello</p><h1 id=\"heading-from-c\">Heading from C</h1>",
-      "rawTitle": "",
-      "title": "Heading from C"
+      "conceptual": "<p>Hello</p>",
+      "rawTitle": ""
     }
 ---
 # Include in h1

--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -206,6 +206,8 @@ inputs:
     [!INCLUDE[C](c.md)]
   docs/b.md: |
     [!INCLUDE[D](d.md)]
+
+    content
   docs/c.md: |
     # Heading from C
   docs/d.md: |
@@ -213,7 +215,7 @@ inputs:
 outputs:
   docs/a.json: |
     {
-      "conceptual": "<h1 id=\"heading-from-c\">Heading from C</h1>",
+      "conceptual": "<p>content</p><h1 id=\"heading-from-c\">Heading from C</h1>",
       "rawTitle": "<h1 id=\"heading-from-d\">Heading from D</h1>"
     }
 ---

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -126,6 +126,7 @@ outputs:
 # Header in moniker zone should be extracted properly
 inputs:
   docfx.yml: |
+    exclude: "**/includes/**"
     monikerRange:
       'docs/**': '<= netcore-1.2'
     monikerDefinition: monikerDefinition.json
@@ -144,6 +145,23 @@ inputs:
     ::: moniker range=">=netcore-1.2"
     # Header for netcore-1.2
     ::: moniker-end
+  docs/b.md: |
+    [!INCLUDE [Include](includes/token-1.md)]
+    [!INCLUDE [Include](includes/token-2.md)]
+  docs/includes/token-1.md: |
+    ::: moniker range="<=netcore-1.0"
+    # Header for netcore-1.0
+    
+    content netcore-1.0
+    ::: moniker-end
+    
+    ::: moniker range="netcore-1.1"
+    content netcore-1.1
+    ::: moniker-end
+  docs/includes/token-2.md: |
+    ::: moniker range=">=netcore-1.2"
+    # Header for netcore-1.2
+    ::: moniker-end
   monikerDefinition.json: |
     {
       "monikers": [
@@ -154,6 +172,13 @@ inputs:
     }
 outputs:
   2420f88b/docs/a.json: |
+    {
+      "conceptual": "<div data-moniker=\"netcore-1.0\"><p>content netcore-1.0</p></div><div data-moniker=\"netcore-1.1\"><p>content netcore-1.1</p></div><div data-moniker=\"netcore-1.2\"></div>",
+      "title": "Header for netcore-1.0",
+      "rawTitle": "<div data-moniker=\"netcore-1.0\"><h1 id=\"header-for-netcore-10\">Header for netcore-1.0</h1></div><div data-moniker=\"netcore-1.2\"><h1 id=\"header-for-netcore-12\">Header for netcore-1.2</h1></div>",
+      "monikers": ["netcore-1.0", "netcore-1.1", "netcore-1.2"],
+    }
+  2420f88b/docs/b.json: |
     {
       "conceptual": "<div data-moniker=\"netcore-1.0\"><p>content netcore-1.0</p></div><div data-moniker=\"netcore-1.1\"><p>content netcore-1.1</p></div><div data-moniker=\"netcore-1.2\"></div>",
       "title": "Header for netcore-1.0",

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -123,6 +123,44 @@ outputs:
       }
     }
 ---
+# Header in moniker zone should be extracted properly
+inputs:
+  docfx.yml: |
+    monikerRange:
+      'docs/**': '<= netcore-1.2'
+    monikerDefinition: monikerDefinition.json
+  docs/a.md: |
+    ::: moniker range="<=netcore-1.0"
+    # Header for netcore-1.0
+    
+    content netcore-1.0
+    ::: moniker-end
+    
+    ::: moniker range="netcore-1.1"
+    content netcore-1.1
+    ::: moniker-end
+    
+    <!-- This is comment -->
+    ::: moniker range=">=netcore-1.2"
+    # Header for netcore-1.2
+    ::: moniker-end
+  monikerDefinition.json: |
+    {
+      "monikers": [
+        { "moniker_name": "netcore-1.0", "product_name": ".NET Core" },
+        { "moniker_name": "netcore-1.1", "product_name": ".NET Core" },
+        { "moniker_name": "netcore-1.2", "product_name": ".NET Core" }
+      ]
+    }
+outputs:
+  2420f88b/docs/a.json: |
+    {
+      "conceptual": "<div data-moniker=\"netcore-1.0\"><p>content netcore-1.0</p></div><div data-moniker=\"netcore-1.1\"><p>content netcore-1.1</p></div><div data-moniker=\"netcore-1.2\"></div>",
+      "title": "Header for netcore-1.0",
+      "rawTitle": "<div data-moniker=\"netcore-1.0\"><h1 id=\"header-for-netcore-10\">Header for netcore-1.0</h1></div><div data-moniker=\"netcore-1.2\"><h1 id=\"header-for-netcore-12\">Header for netcore-1.2</h1></div>",
+      "monikers": ["netcore-1.0", "netcore-1.1", "netcore-1.2"],
+    }
+---
 # Moniker Zone syntax
 inputs:
   docfx.yml: |

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -145,9 +145,13 @@ inputs:
     ::: moniker range=">=netcore-1.2"
     # Header for netcore-1.2
     ::: moniker-end
+
+    ## header should not be extracted
   docs/b.md: |
     [!INCLUDE [Include](includes/token-1.md)]
     [!INCLUDE [Include](includes/token-2.md)]
+
+    ## header should not be extracted
   docs/includes/token-1.md: |
     ::: moniker range="<=netcore-1.0"
     # Header for netcore-1.0
@@ -173,14 +177,14 @@ inputs:
 outputs:
   2420f88b/docs/a.json: |
     {
-      "conceptual": "<div data-moniker=\"netcore-1.0\"><p>content netcore-1.0</p></div><div data-moniker=\"netcore-1.1\"><p>content netcore-1.1</p></div><div data-moniker=\"netcore-1.2\"></div>",
+      "conceptual": "<div data-moniker=\"netcore-1.0\"><p>content netcore-1.0</p></div><div data-moniker=\"netcore-1.1\"><p>content netcore-1.1</p></div><div data-moniker=\"netcore-1.2\"></div><h2 id=\"header-should-not-be-extracted\">header should not be extracted</h2>",
       "title": "Header for netcore-1.0",
       "rawTitle": "<div data-moniker=\"netcore-1.0\"><h1 id=\"header-for-netcore-10\">Header for netcore-1.0</h1></div><div data-moniker=\"netcore-1.2\"><h1 id=\"header-for-netcore-12\">Header for netcore-1.2</h1></div>",
       "monikers": ["netcore-1.0", "netcore-1.1", "netcore-1.2"],
     }
   2420f88b/docs/b.json: |
     {
-      "conceptual": "<div data-moniker=\"netcore-1.0\"><p>content netcore-1.0</p></div><div data-moniker=\"netcore-1.1\"><p>content netcore-1.1</p></div><div data-moniker=\"netcore-1.2\"></div>",
+      "conceptual": "<div data-moniker=\"netcore-1.0\"><p>content netcore-1.0</p></div><div data-moniker=\"netcore-1.1\"><p>content netcore-1.1</p></div><div data-moniker=\"netcore-1.2\"></div><h2 id=\"header-should-not-be-extracted\">header should not be extracted</h2>",
       "title": "Header for netcore-1.0",
       "rawTitle": "<div data-moniker=\"netcore-1.0\"><h1 id=\"header-for-netcore-10\">Header for netcore-1.0</h1></div><div data-moniker=\"netcore-1.2\"><h1 id=\"header-for-netcore-12\">Header for netcore-1.2</h1></div>",
       "monikers": ["netcore-1.0", "netcore-1.1", "netcore-1.2"],

--- a/src/docfx/lib/markdown/ExtractTitleExtension.cs
+++ b/src/docfx/lib/markdown/ExtractTitleExtension.cs
@@ -76,8 +76,8 @@ namespace Microsoft.Docs.Build
                     case MonikerRangeBlock _:
                         return (i, token);
                     case InclusionBlock inclusionBlock:
-                        var (_, candidata) = GetFirstHeadingCandidate((MarkdownDocument)inclusionBlock[0]);
-                        return (i, candidata);
+                        var (_, candidate) = GetFirstHeadingCandidate((MarkdownDocument)inclusionBlock[0]);
+                        return (i, candidate);
                     default:
                         return default;
                 }

--- a/src/docfx/lib/markdown/ExtractTitleExtension.cs
+++ b/src/docfx/lib/markdown/ExtractTitleExtension.cs
@@ -1,3 +1,4 @@
+
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
@@ -32,6 +33,7 @@ namespace Microsoft.Docs.Build
                     if (candidate is HeadingBlock headingBlock && headingBlock.Level <= 3)
                     {
                         heading = headingBlock;
+                        document.Remove(headingBlock);
                     }
                     else if (candidate is MonikerRangeBlock)
                     {
@@ -75,7 +77,6 @@ namespace Microsoft.Docs.Build
                     switch (token)
                     {
                         case HeadingBlock heading when heading.Level <= 3:
-                            document.RemoveAt(i);
                             candidate = token;
                             break;
                         case MonikerRangeBlock _:


### PR DESCRIPTION
[AB#278610](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/278610)
Another minor behavior change:
- before
    - raw title: if the first visible token is heading(level <= 3), take it, or it will be empty string
    - title: if the `title` metadata exists, take it, or take the first heading(level<=3).
- after 
    - raw title: if the first visible token is heading(level <= 3), take it, or it will be empty string
    - title: if the `title` metadata exists, take it, or use the same heading token with raw title.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6350)