### PR TITLE
overwrite target file during copy

### DIFF
--- a/src/docfx/build/context/Output.cs
+++ b/src/docfx/build/context/Output.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Docs.Build
                     File.WriteAllLines(GetDestinationPath(destRelativePaths[0]), lines);
                     for (var i = 1; i < destRelativePaths.Length; i++)
                     {
-                        File.Copy(GetDestinationPath(destRelativePaths[0]), GetDestinationPath(destRelativePaths[i]));
+                        File.Copy(GetDestinationPath(destRelativePaths[0]), GetDestinationPath(destRelativePaths[i]), overwrite: true);
                     }
                 });
             }


### PR DESCRIPTION
Fixes https://dev.azure.com/ceapex/Engineering/_build/results?buildId=178483&view=logs&j=ca395085-040a-526b-2ce8-bdc85f692774&t=2ae53c0f-5c60-565e-5788-130ce3e94790


```
System.IO.IOException: The file 'D:\Docs.Build.TestData\test-azure-docs-pr\.temp\server-side-dependent-list.txt' already exists.
   at System.IO.FileSystem.CopyFile(String sourceFullPath, String destFullPath, Boolean overwrite)
   at System.IO.File.Copy(String sourceFileName, String destFileName, Boolean overwrite)
   at Microsoft.Docs.Build.Output.<>c__DisplayClass9_0.<WriteLines>b__0() in D:\work\2\docfx\src\docfx\build\context\Output.cs:line 71
   at System.Threading.Tasks.Dataflow.ActionBlock`1.ProcessMessage(Action`1 action, KeyValuePair`2 messageWithId)
   at System.Threading.Tasks.Dataflow.ActionBlock`1.<>c__DisplayClass6_0.<.ctor>b__0(KeyValuePair`2 messageWithId)
   at System.Threading.Tasks.Dataflow.Internal.TargetCore`1.ProcessMessagesLoopCore()
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6351)