### PR TITLE
add support to exclude glob paths from sensitive languate validations

### DIFF
--- a/docs/designs/local-build.md
+++ b/docs/designs/local-build.md
@@ -63,7 +63,7 @@ _Example Response:_
 {
    "monikerDefinition": "https://api.docs.com/config/monikerDefinition",
    "metadataSchema": "https://api.docs.com/config/metadataSchema",
-   "customRules": {
+   "rules": {
      "h1-missing": {
        "severity": "error"
      }

--- a/docs/specs/config.yml
+++ b/docs/specs/config.yml
@@ -341,7 +341,7 @@ outputs:
 # Adjust error level using custom errors
 inputs:
   docfx.yml: |
-    customRules:
+    rules:
       file-not-found: off
   docs/a.md: |
     [b](b.md)
@@ -352,7 +352,7 @@ outputs:
 # Adjust error message using custom errors
 inputs:
   docfx.yml: |
-    customRules:
+    rules:
       file-not-found:
         severity: error
         additionalMessage: 'NOTE:'

--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -413,7 +413,7 @@ outputs:
 # do not output file if bookmark-not-found is treated as error
 inputs:
   docfx.yml: |
-    customRules:
+    rules:
       bookmark-not-found: error
   docs/a.md: |
     [link to b](b.md#bookmark)

--- a/docs/specs/output.yml
+++ b/docs/specs/output.yml
@@ -250,7 +250,7 @@ outputs:
 # Manifest includes files with errors
 inputs:
   docfx.yml: |
-    customRules:
+    rules:
       file-not-found: error
   docs/a.md: |
     a [](b)

--- a/docs/specs/schema.yml
+++ b/docs/specs/schema.yml
@@ -198,7 +198,7 @@ outputs:
 # Support schema documents with inline markdown content
 inputs:
   docfx.yml: |
-    customRules:
+    rules:
       heading-not-found: error
   docs/a.yml: |
     #YamlMime:TestPage

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -1415,7 +1415,7 @@ outputs:
 # turn skip-level toc error to warning
 inputs:
   docfx.yml: |
-    customRules:
+    rules:
       invalid-toc-level: warning
   docs/TOC.md: |
     # level 1

--- a/docs/specs/validations/metadataContentValidations.yml
+++ b/docs/specs/validations/metadataContentValidations.yml
@@ -1792,7 +1792,7 @@ inputs:
               "maxLength": 10
           }
       },
-      "customRules": {
+      "rules": {
           "title": {
               "duplicate-attribute": {
                   "severity": "suggestion",
@@ -2250,7 +2250,7 @@ inputs:
   docfx.yml: |
     markdownValidationRules: rules.json
     metadataSchema: schema.json
-    customRules:
+    rules:
       h1-missing: warning
       heading-empty: warning
   schema.json: |
@@ -2274,7 +2274,7 @@ inputs:
               "maxLength": 10
           }
       },
-      "customRules": {
+      "rules": {
           "title": {
               "string-length-invalid": {
                   "severity": "suggestion",

--- a/docs/specs/validations/sensitiveLanguageValidations.yml
+++ b/docs/specs/validations/sensitiveLanguageValidations.yml
@@ -3,6 +3,8 @@
 inputs:
   docfx.yml: |
     markdownValidationRules: rules.json
+    sensitiveLanguageValidationExcludes:
+      - a/b/**/*.md
   rules.json: |
     {
       "text": {
@@ -22,14 +24,19 @@ inputs:
   file2.md: There is#whitelist-with-special chars in the content, this will error
   file3.md: This is no sensitive language in this file, something like masterclass is ok.
   file4.md: Blacklist at the start, ends with Master
+  a/b/c/file.md: skipped bad language check for master due to exclusion
+  a/x/y/file.md: not skipped bad language check for master due to exclusion
 outputs:
   .errors.log: |
     {"message_severity":"suggestion","code":"sensitive-language","message":"Term 'master' is sensitive and should not be used in content or code.","file":"file1.md","line":1,"end_line":1,"column":0,"end_column":0}
     {"message_severity":"suggestion","code":"sensitive-language","message":"Term 'whitelist' is sensitive and should not be used in content or code.","file":"file2.md","line":1,"end_line":1,"column":0,"end_column":0}
     {"message_severity":"suggestion","code":"sensitive-language","message":"Term 'blacklist' is sensitive and should not be used in content or code.","file":"file4.md","line":1,"end_line":1,"column":0,"end_column":0}
     {"message_severity":"suggestion","code":"sensitive-language","message":"Term 'master' is sensitive and should not be used in content or code.","file":"file4.md","line":1,"end_line":1,"column":0,"end_column":0}
+    {"message_severity":"suggestion","code":"sensitive-language","message":"Term 'master' is sensitive and should not be used in content or code.","file":"a/x/y/file.md","line":1,"end_line":1,"column":0,"end_column":0}
   file1.json:
   file2.json:
   file3.json:
   file4.json:
+  a/b/c/file.json:
+  a/x/y/file.json:
 ---

--- a/docs/specs/validations/sensitiveLanguageValidations.yml
+++ b/docs/specs/validations/sensitiveLanguageValidations.yml
@@ -3,7 +3,7 @@
 inputs:
   docfx.yml: |
     markdownValidationRules: rules.json
-    customRules:
+    rules:
       sensitive-language:
         exclude:
           - x/y/**/*.md

--- a/docs/specs/validations/sensitiveLanguageValidations.yml
+++ b/docs/specs/validations/sensitiveLanguageValidations.yml
@@ -3,8 +3,11 @@
 inputs:
   docfx.yml: |
     markdownValidationRules: rules.json
-    sensitiveLanguageValidationExcludes:
-      - a/b/**/*.md
+    customRules:
+      sensitive-language:
+        exclude:
+          - x/y/**/*.md
+          - a/b/**/*.md
   rules.json: |
     {
       "text": {
@@ -25,18 +28,18 @@ inputs:
   file3.md: This is no sensitive language in this file, something like masterclass is ok.
   file4.md: Blacklist at the start, ends with Master
   a/b/c/file.md: skipped bad language check for master due to exclusion
-  a/x/y/file.md: not skipped bad language check for master due to exclusion
+  n/m/o/file.md: not skipped bad language check for master due to exclusion
 outputs:
   .errors.log: |
     {"message_severity":"suggestion","code":"sensitive-language","message":"Term 'master' is sensitive and should not be used in content or code.","file":"file1.md","line":1,"end_line":1,"column":0,"end_column":0}
     {"message_severity":"suggestion","code":"sensitive-language","message":"Term 'whitelist' is sensitive and should not be used in content or code.","file":"file2.md","line":1,"end_line":1,"column":0,"end_column":0}
     {"message_severity":"suggestion","code":"sensitive-language","message":"Term 'blacklist' is sensitive and should not be used in content or code.","file":"file4.md","line":1,"end_line":1,"column":0,"end_column":0}
     {"message_severity":"suggestion","code":"sensitive-language","message":"Term 'master' is sensitive and should not be used in content or code.","file":"file4.md","line":1,"end_line":1,"column":0,"end_column":0}
-    {"message_severity":"suggestion","code":"sensitive-language","message":"Term 'master' is sensitive and should not be used in content or code.","file":"a/x/y/file.md","line":1,"end_line":1,"column":0,"end_column":0}
+    {"message_severity":"suggestion","code":"sensitive-language","message":"Term 'master' is sensitive and should not be used in content or code.","file":"n/m/o/file.md","line":1,"end_line":1,"column":0,"end_column":0}
   file1.json:
   file2.json:
   file3.json:
   file4.json:
   a/b/c/file.json:
-  a/x/y/file.json:
+  n/m/o/file.json:
 ---

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Gets allow custom error code, severity and message.
         /// </summary>
-        public Dictionary<string, CustomRule> CustomRules { get; } = new Dictionary<string, CustomRule>();
+        public Dictionary<string, CustomRule> Rules { get; } = new Dictionary<string, CustomRule>();
 
         /// <summary>
         /// Gets whether warnings should be treated as errors.

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -305,12 +305,6 @@ namespace Microsoft.Docs.Build
         [JsonConverter(typeof(OneOrManyConverter))]
         public ECMA2YamlRepoConfig[]? Monodoc { get; private set; }
 
-        /// <summary>
-        /// Paths to exclude for sensitive language validations
-        /// </summary>
-        [JsonConverter(typeof(OneOrManyConverter))]
-        public string[] SensitiveLanguageValidationExcludes { get; private set; } = Array.Empty<string>();
-
         public IEnumerable<SourceInfo<string>> GetFileReferences()
         {
             foreach (var url in Xref)

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -305,6 +305,12 @@ namespace Microsoft.Docs.Build
         [JsonConverter(typeof(OneOrManyConverter))]
         public ECMA2YamlRepoConfig[]? Monodoc { get; private set; }
 
+        /// <summary>
+        /// Paths to exclude for sensitive language validations
+        /// </summary>
+        [JsonConverter(typeof(OneOrManyConverter))]
+        public string[] SensitiveLanguageValidationExcludes { get; private set; } = Array.Empty<string>();
+
         public IEnumerable<SourceInfo<string>> GetFileReferences()
         {
             foreach (var url in Xref)

--- a/src/docfx/config/ops/OpsMetadataRuleConverter.cs
+++ b/src/docfx/config/ops/OpsMetadataRuleConverter.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Docs.Build
                 either = new List<List<string>>(),
                 precludes = new List<List<string>>(),
                 enumDependencies = new EnumDependenciesSchema(),
-                customRules = new Dictionary<string, Dictionary<string, dynamic>>(),
+                rules = new Dictionary<string, Dictionary<string, dynamic>>(),
             };
 
             foreach (var (attribute, attributeRules) in rules)
@@ -84,7 +84,7 @@ namespace Microsoft.Docs.Build
 
                 if (TryGetAttributeCustomRules(rulesInfo, out var attributeCustomRules))
                 {
-                    schema.customRules.Add(attribute, attributeCustomRules);
+                    schema.rules.Add(attribute, attributeCustomRules);
                 }
 
                 if (rulesInfo.ContainsKey("Uniqueness"))

--- a/src/docfx/lib/log/CustomRule.cs
+++ b/src/docfx/lib/log/CustomRule.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Newtonsoft.Json;
 
 namespace Microsoft.Docs.Build
@@ -17,6 +18,9 @@ namespace Microsoft.Docs.Build
         public bool CanonicalVersionOnly { get; private set; }
 
         public bool PullRequestOnly { get; private set; }
+
+        [JsonConverter(typeof(OneOrManyConverter))]
+        public string[] Exclude { get; private set; } = Array.Empty<string>();
 
         public CustomRule() { }
 

--- a/src/docfx/lib/log/Error.cs
+++ b/src/docfx/lib/log/Error.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Docs.Build
 {
@@ -48,6 +49,19 @@ namespace Microsoft.Docs.Build
             level = isCanonicalVersion != null && customRule.CanonicalVersionOnly
                 ? (isCanonicalVersion.Value ? level : ErrorLevel.Off)
                 : level;
+
+            if (level != ErrorLevel.Off && customRule.Exclude.Any())
+            {
+                foreach (var exclusion in customRule.Exclude)
+                {
+                    var matcher = GlobUtility.CreateGlobMatcher(exclusion);
+                    if (matcher(OriginalPath ?? Source?.File?.Path ?? string.Empty))
+                    {
+                        level = ErrorLevel.Off;
+                        break;
+                    }
+                }
+            }
 
             return new Error(
                 level,

--- a/src/docfx/lib/log/ErrorLog.cs
+++ b/src/docfx/lib/log/ErrorLog.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Docs.Build
 
         private Dictionary<string, CustomRule> MergeCustomRules(Config? config, Dictionary<string, ValidationRules>? validationRules)
         {
-            var customRules = config != null ? new Dictionary<string, CustomRule>(_config.CustomRules) : new Dictionary<string, CustomRule>();
+            var customRules = config != null ? new Dictionary<string, CustomRule>(_config.Rules) : new Dictionary<string, CustomRule>();
 
             if (validationRules == null)
             {

--- a/src/docfx/lib/schema/JsonSchema.cs
+++ b/src/docfx/lib/schema/JsonSchema.cs
@@ -263,6 +263,6 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// This field is used to provide additional error information and only can be set in root level of schema
         /// </summary>
-        public Dictionary<string, Dictionary<string, CustomRule>> CustomRules { get; } = new Dictionary<string, Dictionary<string, CustomRule>>();
+        public Dictionary<string, Dictionary<string, CustomRule>> Rules { get; } = new Dictionary<string, Dictionary<string, CustomRule>>();
     }
 }

--- a/src/docfx/lib/schema/JsonSchemaValidator.cs
+++ b/src/docfx/lib/schema/JsonSchemaValidator.cs
@@ -648,7 +648,7 @@ namespace Microsoft.Docs.Build
             }
 
             if (!string.IsNullOrEmpty(error.Name) &&
-                schema.CustomRules.TryGetValue(error.Name, out var attributeCustomRules) &&
+                schema.Rules.TryGetValue(error.Name, out var attributeCustomRules) &&
                 attributeCustomRules.TryGetValue(error.Code, out var customRule))
             {
                 return error.WithCustomRule(customRule, isCanonicalVersion);
@@ -682,7 +682,7 @@ namespace Microsoft.Docs.Build
 
         private bool CanonicalVersionOnly(string key, string code)
         {
-            return _schema.CustomRules.TryGetValue(key, out var customRules) &&
+            return _schema.Rules.TryGetValue(key, out var customRules) &&
                 customRules.TryGetValue(code, out var customRule) &&
                 customRule.CanonicalVersionOnly;
         }

--- a/src/docfx/validation/ContentValidator.cs
+++ b/src/docfx/validation/ContentValidator.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Docs.Build
         private readonly MetadataProvider _metadataProvider;
         private readonly Lazy<PublishUrlMap> _publishUrlMap;
         private readonly ConcurrentHashSet<(FilePath, SourceInfo<string>)> _links;
-        private readonly List<Func<string, bool>> _sensitiveLanguageValidationExcludeRules = new List<Func<string, bool>>();
 
         public ContentValidator(
             Config config,
@@ -37,11 +36,6 @@ namespace Microsoft.Docs.Build
             _metadataProvider = metadataProvider;
             _publishUrlMap = publishUrlMap;
             _links = new ConcurrentHashSet<(FilePath, SourceInfo<string>)>();
-
-            foreach (var exclusion in config.SensitiveLanguageValidationExcludes)
-            {
-                _sensitiveLanguageValidationExcludeRules.Add(GlobUtility.CreateGlobMatcher(exclusion));
-            }
         }
 
         public void ValidateImageLink(Document file, SourceInfo<string> link, string? altText)
@@ -111,11 +105,6 @@ namespace Microsoft.Docs.Build
 
         public void ValidateSensitiveLanguage(string content, Document document)
         {
-            if (_sensitiveLanguageValidationExcludeRules.Any(glob => glob(document.FilePath.Path)))
-            {
-                return;
-            }
-
             if (TryGetValidationDocumentType(document, document.Mime.Value, false, out var documentType))
             {
                 var validationContext = new ValidationContext { DocumentType = documentType };

--- a/test/docfx.Test/data/validation/schema.json
+++ b/test/docfx.Test/data/validation/schema.json
@@ -5080,7 +5080,7 @@
       "tutorial": null
     }
   },
-  "customRules": {
+  "rules": {
     "author": {
       "unexpected-type": {
         "severity": "suggestion",

--- a/test/docfx.Test/lib/JsonSchemaTest.cs
+++ b/test/docfx.Test/lib/JsonSchemaTest.cs
@@ -350,17 +350,17 @@ namespace Microsoft.Docs.Build
             "{'message_severity':'warning','code':'invalid-value','message':'Invalid value for 'key1[0]': 'yyy'.','file':'file','line':1,'end_line':1,'column':15,'end_column':15}")]
 
         // custom errors
-        [InlineData("{'required': ['author'], 'customRules': {'author': {'missing-attribute': {'severity': 'suggestion', 'code': 'author-missing', 'additionalMessage': 'Add a valid GitHub ID.'}}}}", "{'b': 1}",
+        [InlineData("{'required': ['author'], 'rules': {'author': {'missing-attribute': {'severity': 'suggestion', 'code': 'author-missing', 'additionalMessage': 'Add a valid GitHub ID.'}}}}", "{'b': 1}",
             "{'message_severity':'suggestion','code':'author-missing','message':'Missing required attribute: 'author'. Add a valid GitHub ID.','file':'file','line':1,'end_line':1,'column':1,'end_column':1}")]
-        [InlineData("{'required': ['author'], 'customRules': {'author': {'missing-attribute': {'code': 'author-missing', 'additionalMessage': 'Add a valid GitHub ID.'}}}}", "{'b': 1}",
+        [InlineData("{'required': ['author'], 'rules': {'author': {'missing-attribute': {'code': 'author-missing', 'additionalMessage': 'Add a valid GitHub ID.'}}}}", "{'b': 1}",
             "{'message_severity':'warning','code':'author-missing','message':'Missing required attribute: 'author'. Add a valid GitHub ID.','file':'file','line':1,'end_line':1,'column':1,'end_column':1}")]
-        [InlineData("{'properties': {'key1': {'replacedBy': 'key2'}}, 'customRules': {'key1': {'attribute-deprecated': {'severity': 'suggestion', 'code': 'key1-attribute-deprecated'}}}}", "{'key1': 1}",
+        [InlineData("{'properties': {'key1': {'replacedBy': 'key2'}}, 'rules': {'key1': {'attribute-deprecated': {'severity': 'suggestion', 'code': 'key1-attribute-deprecated'}}}}", "{'key1': 1}",
             "{'message_severity':'suggestion','code':'key1-attribute-deprecated','message':'Deprecated attribute: 'key1', use 'key2' instead.','file':'file','line':1,'end_line':1,'column':10,'end_column':10}")]
-        [InlineData("{'properties': {'keys': {'precludes': [['key1', 'key2']]}}, 'customRules': {'key1': {'precluded-attributes': {'severity': 'error'}}}}", "{'keys' : {'key1': 1, 'key2': 2}}",
+        [InlineData("{'properties': {'keys': {'precludes': [['key1', 'key2']]}}, 'rules': {'key1': {'precluded-attributes': {'severity': 'error'}}}}", "{'keys' : {'key1': 1, 'key2': 2}}",
             "{'message_severity':'error','code':'precluded-attributes','message':'Only one of the following attributes can exist: 'key1', 'key2'.','file':'file','line':1,'end_line':1,'column':11,'end_column':11}")]
-        [InlineData("{'dependencies': {'key1': ['key2']}, 'customRules': {'key1': {'missing-paired-attribute': {'code': 'key2-missing'}}}}", "{'key1' : 1}",
+        [InlineData("{'dependencies': {'key1': ['key2']}, 'rules': {'key1': {'missing-paired-attribute': {'code': 'key2-missing'}}}}", "{'key1' : 1}",
             "{'message_severity':'warning','code':'key2-missing','message':'Missing attribute: 'key2'. If you specify 'key1', you must also specify 'key2'.','file':'file','line':1,'end_line':1,'column':1,'end_column':1}")]
-        [InlineData("{'required': ['author'], 'customRules': {'author': {'missing-attribute': {'severity': 'suggestion', 'code': 'author-missing', 'additionalMessage': 'Add a valid GitHub ID.', 'pullRequestOnly': true}}}}", "{'b': 1}",
+        [InlineData("{'required': ['author'], 'rules': {'author': {'missing-attribute': {'severity': 'suggestion', 'code': 'author-missing', 'additionalMessage': 'Add a valid GitHub ID.', 'pullRequestOnly': true}}}}", "{'b': 1}",
             "{'message_severity':'suggestion','code':'author-missing','message':'Missing required attribute: 'author'. Add a valid GitHub ID.','file':'file','line':1,'end_line':1,'column':1,'end_column':1,'pull_request_only':true}")]
 
         // strict required validation
@@ -419,15 +419,15 @@ namespace Microsoft.Docs.Build
         }
 
         [Theory]
-        [InlineData("{'required': ['author'], 'customRules': {'author': {'missing-attribute': {'canonicalVersionOnly': true}}}}",
+        [InlineData("{'required': ['author'], 'rules': {'author': {'missing-attribute': {'canonicalVersionOnly': true}}}}",
             new[] { "{'key1': 'a'}" }, new[] { "" }, new[] { "missing-attribute:Warning" })]
-        [InlineData("{'required': ['author'], 'customRules': {'author': {'missing-attribute': {'canonicalVersionOnly': true}}}}",
+        [InlineData("{'required': ['author'], 'rules': {'author': {'missing-attribute': {'canonicalVersionOnly': true}}}}",
             new[] { "{'key1': 'a'}" }, new[] { "t" }, new[] { "missing-attribute:Warning" })]
-        [InlineData("{'required': ['author'], 'customRules': {'author': {'missing-attribute': {'canonicalVersionOnly': true}}}}",
+        [InlineData("{'required': ['author'], 'rules': {'author': {'missing-attribute': {'canonicalVersionOnly': true}}}}",
             new[] { "{'key1': 'a'}" }, new[] { "f" }, new[] { "missing-attribute:Off" })]
-        [InlineData("{'required': ['author'], 'customRules': {'author': {'missing-attribute': {'canonicalVersionOnly': true}}}}",
+        [InlineData("{'required': ['author'], 'rules': {'author': {'missing-attribute': {'canonicalVersionOnly': true}}}}",
             new[] { "{'key1': 'a'}", "{'key1': 'a'}" }, new[] { "", "f" }, new[] { "missing-attribute:Warning", "missing-attribute:Off" })]
-        [InlineData("{'required': ['author'], 'customRules': {'author': {'missing-attribute': {'canonicalVersionOnly': true}}}}",
+        [InlineData("{'required': ['author'], 'rules': {'author': {'missing-attribute': {'canonicalVersionOnly': true}}}}",
             new[] { "{'key1': 'a'}", "{'key1': 'a'}" }, new[] { "t", "f" }, new[] { "missing-attribute:Warning", "missing-attribute:Off" })]
         [InlineData("{'required': ['author']}",
             new[] { "{'key1': 'a'}" }, new[] { "" }, new[] { "missing-attribute:Warning" })]
@@ -436,12 +436,12 @@ namespace Microsoft.Docs.Build
         [InlineData("{'required': ['author']}",
             new[] { "{'key1': 'a'}" }, new[] { "f" }, new[] { "missing-attribute:Warning" })]
 
-        [InlineData("{'docsetUnique': ['key1'], 'customRules': {'key1': {'duplicate-attribute': {'canonicalVersionOnly': true}}}}", new[] { "{'key1': 'a'}", "{'key1': 'a'}" }, new[] { "", "" }, new[] { "duplicate-attribute:Suggestion", "duplicate-attribute:Suggestion" })]
-        [InlineData("{'docsetUnique': ['key1'], 'customRules': {'key1': {'duplicate-attribute': {'canonicalVersionOnly': true}}}}", new[] { "{'key1': 'a'}", "{'key1': 'a'}" }, new[] { "", "t" }, new[] { "duplicate-attribute:Suggestion", "duplicate-attribute:Suggestion" })]
-        [InlineData("{'docsetUnique': ['key1'], 'customRules': {'key1': {'duplicate-attribute': {'canonicalVersionOnly': true}}}}", new[] { "{'key1': 'a'}", "{'key1': 'a'}" }, new[] { "t", "t" }, new[] { "duplicate-attribute:Suggestion", "duplicate-attribute:Suggestion" })]
-        [InlineData("{'docsetUnique': ['key1'], 'customRules': {'key1': {'duplicate-attribute': {'canonicalVersionOnly': true}}}}", new[] { "{'key1': 'a'}", "{'key1': 'a'}" }, new[] { "t", "f" }, new string[] { })]
-        [InlineData("{'docsetUnique': ['key1'], 'customRules': {'key1': {'duplicate-attribute': {'canonicalVersionOnly': true}}}}", new[] { "{'key1': 'a'}", "{'key1': 'a'}" }, new[] { "f", "f" }, new string[] { })]
-        [InlineData("{'docsetUnique': ['key1'], 'customRules': {'key1': {'duplicate-attribute': {'canonicalVersionOnly': true}}}}", new[] { "{'key1': 'a'}", "{'key1': 'a'}" }, new[] { "", "f" }, new string[] { })]
+        [InlineData("{'docsetUnique': ['key1'], 'rules': {'key1': {'duplicate-attribute': {'canonicalVersionOnly': true}}}}", new[] { "{'key1': 'a'}", "{'key1': 'a'}" }, new[] { "", "" }, new[] { "duplicate-attribute:Suggestion", "duplicate-attribute:Suggestion" })]
+        [InlineData("{'docsetUnique': ['key1'], 'rules': {'key1': {'duplicate-attribute': {'canonicalVersionOnly': true}}}}", new[] { "{'key1': 'a'}", "{'key1': 'a'}" }, new[] { "", "t" }, new[] { "duplicate-attribute:Suggestion", "duplicate-attribute:Suggestion" })]
+        [InlineData("{'docsetUnique': ['key1'], 'rules': {'key1': {'duplicate-attribute': {'canonicalVersionOnly': true}}}}", new[] { "{'key1': 'a'}", "{'key1': 'a'}" }, new[] { "t", "t" }, new[] { "duplicate-attribute:Suggestion", "duplicate-attribute:Suggestion" })]
+        [InlineData("{'docsetUnique': ['key1'], 'rules': {'key1': {'duplicate-attribute': {'canonicalVersionOnly': true}}}}", new[] { "{'key1': 'a'}", "{'key1': 'a'}" }, new[] { "t", "f" }, new string[] { })]
+        [InlineData("{'docsetUnique': ['key1'], 'rules': {'key1': {'duplicate-attribute': {'canonicalVersionOnly': true}}}}", new[] { "{'key1': 'a'}", "{'key1': 'a'}" }, new[] { "f", "f" }, new string[] { })]
+        [InlineData("{'docsetUnique': ['key1'], 'rules': {'key1': {'duplicate-attribute': {'canonicalVersionOnly': true}}}}", new[] { "{'key1': 'a'}", "{'key1': 'a'}" }, new[] { "", "f" }, new string[] { })]
 
         [InlineData("{'docsetUnique': ['key1']}", new[] { "{'key1': 'a'}", "{'key1': 'a'}" }, new[] { "", "" }, new[] { "duplicate-attribute:Suggestion", "duplicate-attribute:Suggestion" })]
         [InlineData("{'docsetUnique': ['key1']}", new[] { "{'key1': 'a'}", "{'key1': 'a'}" }, new[] { "", "t" }, new[] { "duplicate-attribute:Suggestion", "duplicate-attribute:Suggestion" })]


### PR DESCRIPTION
To add excludes for sensitive language validations, glob patterns can be added to docfx.json:

Updated to use customRules:

```
"customRules": {
      "sensitive-language": {
        "exclude": [
          "articles/path1/**/*.md",
          "articles/path2/**/*.md"
        ]
      }
    }
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6357)