### PR TITLE
Learn achievement dependency

### DIFF
--- a/docs/specs/learn.yml
+++ b/docs/specs/learn.yml
@@ -91,6 +91,7 @@ outputs:
     }
 ---
 # Can produce proper dependency type
+# basic path->module; module->unit; path|module->achievement;
 inputs:
   docfx.yml:
   path.yml: |
@@ -232,6 +233,150 @@ outputs:
         },
         "unit1a.yml": {},
         "unit1b.yml": {},
+        "unit2.yml": {}
+      }
+    }
+---
+# Can produce proper dependency type
+# fallback patha->pathb.achievement;modulea->moduleb.achievement;
+inputs:
+  docfx.yml:
+  path.yml: |
+    ### YamlMime:LearningPath
+    uid: path
+    modules: ['module1']
+    achievement: trophy
+    trophy:
+      uid: trophy
+  patha.yml: |
+    ### YamlMime:LearningPath
+    uid: patha
+    modules: ['module1']
+    achievement: trophy
+  module1.yml: |
+    ### YamlMime:Module
+    uid: module1
+    units: ['unit1']
+    achievement: badge
+    badge:
+      uid: badge
+  module2.yml: |
+    ### YamlMime:Module
+    uid: module2
+    units: ['unit2']
+    achievement: badge
+  unit1.yml: |
+    ### YamlMime:ModuleUnit
+    uid: unit1
+  unit2.yml: |
+    ### YamlMime:ModuleUnit
+    uid: unit2
+  _themes/ContentTemplate/schemas/LearningPath.schema.json: |
+    {
+      "properties": {
+        "uid" : {"contentType": "uid"},
+        "modules": {"items": {"contentType": "xref"}},
+        "achievement": {"contentType": "xref"},
+        "trophy": {
+          "properties": {"uid" : {"contentType": "uid"}}
+        }
+      }
+    }
+  _themes/ContentTemplate/LearningPath.html.primary.tmpl:
+  _themes/ContentTemplate/schemas/Module.schema.json: |
+    {
+      "properties": {
+        "uid" : {"contentType": "uid"},
+        "units": {"items": {"contentType": "xref" }},
+        "achievement": {"contentType": "xref"},
+        "badge": {
+          "properties": {"uid" : {"contentType": "uid"}}
+        }
+      }
+    }
+  _themes/ContentTemplate/Module.html.primary.tmpl:
+  _themes/ContentTemplate/schemas/ModuleUnit.schema.json: |
+    {
+      "properties": {
+        "uid" : {"contentType": "uid"}
+      }
+    }
+  _themes/ContentTemplate/ModuleUnit.html.primary.tmpl:
+  _themes/ContentTemplate/schemas/Achievement.schema.json: |
+    {
+      "properties": {
+        "achievements": { 
+          "items": { 
+            "properties": {"uid" : {"contentType": "uid"}}
+          }
+        }
+      }
+    }
+outputs:
+  path.json:
+  patha.json:
+  module1.json:
+  module2.json:
+  unit1.json:
+  unit2.json:
+  full-dependent-list.txt: |
+    {"dependency_type":"achievement","from_file_path":"*module2.yml*","to_file_path":"*module1.yml*"}
+    {"dependency_type":"achievement","from_file_path":"*patha.yml*","to_file_path":"*path.yml*"}
+    {"dependency_type":"hierarchy","from_file_path":"*module1.yml*","to_file_path":"*unit1.yml*"}
+    {"dependency_type":"hierarchy","from_file_path":"*module2.yml*","to_file_path":"*unit2.yml*"}
+    {"dependency_type":"hierarchy","from_file_path":"*path.yml*","to_file_path":"*module1.yml*"}
+    {"dependency_type":"hierarchy","from_file_path":"*patha.yml*","to_file_path":"*module1.yml*"}
+
+  op_aggregated_file_map_info.json: |
+    {
+      "aggregated_file_map_items": {
+        "module1.yml": {
+          "dependencies": [
+            {
+              "from_file_path": "module1.yml",
+              "to_file_path": "unit1.yml",
+              "dependency_type": "hierarchy"
+            }
+          ]
+        },
+        "module2.yml": {
+          "dependencies": [
+            {
+              "from_file_path": "module2.yml",
+              "to_file_path": "module1.yml",
+              "dependency_type": "achievement"
+            },
+            {
+              "from_file_path": "module2.yml",
+              "to_file_path": "unit2.yml",
+              "dependency_type": "hierarchy"
+            }
+          ]
+        },
+        "path.yml": {
+          "dependencies": [
+            {
+              "from_file_path": "path.yml",
+              "to_file_path": "module1.yml",
+              "dependency_type": "hierarchy"
+            }
+          ]
+        },
+        "patha.yml": {
+          "dependencies": [
+            {
+              "from_file_path": "patha.yml",
+              "to_file_path": "module1.yml",
+              "dependency_type": "hierarchy"
+            },
+            {
+              "from_file_path": "patha.yml",
+              "to_file_path": "path.yml",
+              "dependency_type": "achievement"
+            }
+          ]
+        },
+        "unit1.yml": {},
         "unit2.yml": {}
       }
     }

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build
@@ -21,12 +22,17 @@ namespace Microsoft.Docs.Build
 
         string IXrefSpec.Uid => Uid.Value;
 
-        public InternalXrefSpec(SourceInfo<string> uid, string href, Document declaringFile, MonikerList monikerList)
+        // TODO: change to use xrefSpec type to express what kind of xref spec it is: e.g. achievement, module
+        [JsonIgnore]
+        internal string? DeclaringPropertyName { get; }
+
+        public InternalXrefSpec(SourceInfo<string> uid, string href, Document declaringFile, MonikerList monikerList, string? declaringPropertyName = null)
         {
             Uid = uid;
             Href = href;
             DeclaringFile = declaringFile;
             Monikers = monikerList;
+            DeclaringPropertyName = declaringPropertyName;
         }
 
         public string? GetXrefPropertyValueAsString(string propertyName)

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Docs.Build
         {
             if (_internalXrefMap.Value.TryGetValue(uid, out var spec))
             {
-                var dependencyType = GetDependencyType(referencingFile.Mime, spec.DeclaringFile.Mime);
+                var dependencyType = GetDependencyType(referencingFile, spec);
                 _dependencyMapBuilder.AddDependencyItem(referencingFile.FilePath, spec.DeclaringFile.FilePath, dependencyType, referencingFile.ContentType);
                 var href = UrlUtility.GetRelativeUrl((inclusionRoot ?? referencingFile).SiteUrl, spec.Href);
                 return (spec, href);
@@ -227,14 +227,26 @@ namespace Microsoft.Docs.Build
             return default;
         }
 
-        private static DependencyType GetDependencyType(string? fromMime, string? toMime)
-            => (fromMime, toMime) switch
+        private static DependencyType GetDependencyType(Document referencingFile, InternalXrefSpec xref)
+        {
+            if (!string.Equals(referencingFile.Mime, "LearningPath", StringComparison.Ordinal)
+                && !string.Equals(referencingFile.Mime, "Module", StringComparison.Ordinal))
             {
-                ("LearningPath", "Module") => DependencyType.Hierarchy,
-                ("Module", "ModuleUnit") => DependencyType.Hierarchy,
-                ("LearningPath", "Achievement") => DependencyType.Achievement,
-                ("Module", "Achievement") => DependencyType.Achievement,
-                _ => DependencyType.Uid,
-            };
+                return DependencyType.Uid;
+            }
+
+            switch ((referencingFile.Mime.Value, xref.DeclaringFile.Mime.Value))
+            {
+                case ("LearningPath", "Module"):
+                case ("Module", "ModuleUnit"):
+                    return DependencyType.Hierarchy;
+                case ("LearningPath", "Achievement"):
+                case ("Module", "Achievement"):
+                case ("LearningPath", "LearningPath") when string.Equals(xref.DeclaringPropertyName, "trophy", StringComparison.OrdinalIgnoreCase):
+                case ("Module", "Module") when string.Equals(xref.DeclaringPropertyName, "badge", StringComparison.OrdinalIgnoreCase):
+                    return DependencyType.Achievement;
+            }
+            return DependencyType.Uid;
+        }
     }
 }

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Docs.Build
         {
             var href = GetXrefHref(file, uid, uidCount, obj.Parent == null);
             var monikers = _monikerProvider.GetFileLevelMonikers(errors, file.FilePath);
-            var xref = new InternalXrefSpec(uid, href, file, monikers);
+            var xref = new InternalXrefSpec(uid, href, file, monikers, obj.Parent?.Path);
 
             foreach (var xrefProperty in schema.XrefProperties)
             {


### PR DESCRIPTION
when `LearningPath1.achievement` refers to `LearningPath.trophy`, dependency type should be `achievement`.
[AB#280867](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/280867)

Using transient declaring property name to distinguish the referenced xref spec's type

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6370)