### PR TITLE
Support public template definition file

### DIFF
--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Docs.Build
             Input = new Input(buildOptions, config, packageResolver, RepositoryProvider);
             Output = new Output(buildOptions.OutputPath, Input, Config.DryRun);
             MicrosoftGraphAccessor = new MicrosoftGraphAccessor(Config);
-            TemplateEngine = new TemplateEngine(config, buildOptions, PackageResolver, new Lazy<JsonSchemaTransformer>(() => JsonSchemaTransformer));
+            TemplateEngine = new TemplateEngine(config, buildOptions, PackageResolver, FileResolver, errorLog, new Lazy<JsonSchemaTransformer>(() => JsonSchemaTransformer));
 
             BuildScope = new BuildScope(Config, Input, buildOptions);
             MetadataProvider = new MetadataProvider(Config, Input, FileResolver, BuildScope);

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -66,7 +66,8 @@ namespace Microsoft.Docs.Build
             // Mandatory metadata are metadata that are required by template to successfully ran to completion.
             // The current bookmark validation for SDP validates against HTML produced from mustache,
             // so we need to run the full template for SDP even in --dry-run mode.
-            if (context.Config.DryRun && TemplateEngine.IsConceptual(file.Mime) && context.Config.OutputType != OutputType.Html)
+            // TODO: For the SDP, we can let the scheme to tell whether the property will be generated as a bookmark
+            if (context.Config.DryRun)
             {
                 return (new JObject(), new JObject());
             }

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -227,7 +227,7 @@ namespace Microsoft.Docs.Build
         public SourceInfo<string>[] MetadataSchema { get; private set; } = Array.Empty<SourceInfo<string>>();
 
         /// <summary>
-        /// Get the template folder or git repository url (like https://github.com/docs/theme#master)
+        /// Get the template folder or git repository url (like https://github.com/docs/theme#master) or public template definition file (like https://static.docs.com/ui/latest/schemas/schema_config.json)
         /// </summary>
         public PackagePath Template { get; private set; } = new PackagePath();
 

--- a/src/docfx/lib/path/PackagePath.cs
+++ b/src/docfx/lib/path/PackagePath.cs
@@ -35,8 +35,16 @@ namespace Microsoft.Docs.Build
         {
             if (UrlUtility.IsHttp(value))
             {
-                Type = PackageType.Git;
-                (Url, Branch) = SplitGitUrl(value);
+                if (value.EndsWith(".json"))
+                {
+                    Type = PackageType.File;
+                    Url = value;
+                }
+                else
+                {
+                    Type = PackageType.Git;
+                    (Url, Branch) = SplitGitUrl(value);
+                }
             }
             else
             {
@@ -56,6 +64,7 @@ namespace Microsoft.Docs.Build
         {
             PackageType.Folder => Path,
             PackageType.Git => $"{Url}#{Branch}",
+            PackageType.File => Url,
             _ => $"{Url}, (type: {Type.ToString()})",
         };
 

--- a/src/docfx/template/TemplateDefinition.cs
+++ b/src/docfx/template/TemplateDefinition.cs
@@ -1,13 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
 namespace Microsoft.Docs.Build
 {
-    public enum PackageType
+    internal class TemplateDefinition
     {
-        None,
-        File,
-        Folder,
-        Git,
+        public Dictionary<string, string> Definitions { get; set; } = new Dictionary<string, string>();
     }
 }

--- a/src/docfx/template/TemplateEngine.cs
+++ b/src/docfx/template/TemplateEngine.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -12,47 +13,79 @@ namespace Microsoft.Docs.Build
 {
     internal class TemplateEngine : IDisposable
     {
-        private readonly string _templateDir;
-        private readonly string _schemaDir;
-        private readonly string _contentTemplateDir;
-        private readonly JObject _global;
-        private readonly LiquidTemplate _liquid;
-        private readonly ThreadLocal<IJavaScriptEngine> _js;
-        private readonly MustacheTemplate _mustacheTemplate;
+        private readonly string? _templateDir;
+        private readonly string? _schemaDir;
+        private readonly string? _contentTemplateDir;
+        private readonly JObject? _global;
+        private readonly LiquidTemplate? _liquid;
+        private readonly ThreadLocal<IJavaScriptEngine>? _js;
+        private readonly MustacheTemplate? _mustacheTemplate;
+        private readonly TemplateDefinition? _templateDefinition;
+        private readonly FileResolver _fileResolver;
 
         private readonly ConcurrentDictionary<string, JsonSchemaValidator?> _schemas
                    = new ConcurrentDictionary<string, JsonSchemaValidator?>(StringComparer.OrdinalIgnoreCase);
 
-        public TemplateEngine(Config config, BuildOptions buildOptions, PackageResolver packageResolver, Lazy<JsonSchemaTransformer> jsonSchemaTransformer)
+        public TemplateEngine(
+            Config config,
+            BuildOptions buildOptions,
+            PackageResolver packageResolver,
+            FileResolver fileResolver,
+            ErrorBuilder errors,
+            Lazy<JsonSchemaTransformer> jsonSchemaTransformer)
         {
-            _templateDir = config.Template.Type switch
+            _fileResolver = fileResolver;
+
+            if (config.Template.Type == PackageType.File)
             {
-                PackageType.None => Path.Combine(buildOptions.DocsetPath, "_themes"),
-                _ => packageResolver.ResolvePackage(config.Template, PackageFetchOptions.DepthOne),
-            };
+                _templateDefinition = JsonUtility.Deserialize<TemplateDefinition>(
+                    errors,
+                    fileResolver.ReadString(new SourceInfo<string>(config.Template.Url)),
+                    new FilePath("--stdin"));
+            }
+            else
+            {
+                _templateDir = config.Template.Type switch
+                {
+                    PackageType.None => Path.Combine(buildOptions.DocsetPath, "_themes"),
+                    _ => packageResolver.ResolvePackage(config.Template, PackageFetchOptions.DepthOne),
+                };
 
-            _contentTemplateDir = Path.Combine(_templateDir, "ContentTemplate");
-            _schemaDir = Path.Combine(_contentTemplateDir, "schemas");
+                _contentTemplateDir = Path.Combine(_templateDir, "ContentTemplate");
+                _schemaDir = Path.Combine(_contentTemplateDir, "schemas");
 
-            _global = LoadGlobalTokens();
-            _liquid = new LiquidTemplate(_templateDir);
+                _global = LoadGlobalTokens();
+                _liquid = new LiquidTemplate(_templateDir);
 
-            // TODO: remove JINT after Microsoft.CharkraCore NuGet package
-            // supports linux and macOS: https://github.com/microsoft/ChakraCore/issues/2578
-            _js = new ThreadLocal<IJavaScriptEngine>(() => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                ? (IJavaScriptEngine)new ChakraCoreJsEngine(_contentTemplateDir, _global)
-                : new JintJsEngine(_contentTemplateDir, _global));
+                // TODO: remove JINT after Microsoft.CharkraCore NuGet package
+                // supports linux and macOS: https://github.com/microsoft/ChakraCore/issues/2578
+                _js = new ThreadLocal<IJavaScriptEngine>(() => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    ? (IJavaScriptEngine)new ChakraCoreJsEngine(_contentTemplateDir, _global)
+                    : new JintJsEngine(_contentTemplateDir, _global));
 
-            _mustacheTemplate = new MustacheTemplate(_contentTemplateDir, _global, jsonSchemaTransformer);
+                _mustacheTemplate = new MustacheTemplate(_contentTemplateDir, _global, jsonSchemaTransformer);
+            }
         }
 
         public bool IsHtml(ContentType contentType, string? mime)
         {
+            if (_templateDefinition != null)
+            {
+                // TODO: For the page, we need the schema to tell whether it is a Data type page.
+                return contentType switch
+                {
+                    ContentType.Redirection => true,
+                    ContentType.Page => true,
+                    ContentType.TableOfContents => true,
+                    _ => false,
+                };
+            }
+            Debug.Assert(_mustacheTemplate != null);
             return contentType switch
             {
                 ContentType.Redirection => true,
-                ContentType.Page => IsConceptual(mime) || IsLandingData(mime) || _mustacheTemplate.HasTemplate($"{mime}.html"),
-                ContentType.TableOfContents => _mustacheTemplate.HasTemplate($"toc.html"),
+                ContentType.Page => IsConceptual(mime) || IsLandingData(mime) || _mustacheTemplate!.HasTemplate($"{mime}.html"),
+                ContentType.TableOfContents => _mustacheTemplate!.HasTemplate($"toc.html"),
                 _ => false,
             };
         }
@@ -82,6 +115,7 @@ namespace Microsoft.Docs.Build
 
         public string RunLiquid(Document file, TemplateModel model)
         {
+            Debug.Assert(_liquid != null);
             var layout = model.RawMetadata?.Value<string>("layout") ?? "";
             var themeRelativePath = _templateDir;
 
@@ -98,11 +132,13 @@ namespace Microsoft.Docs.Build
 
         public string RunMustache(string templateName, JToken pageModel, FilePath file)
         {
+            Debug.Assert(_mustacheTemplate != null);
             return _mustacheTemplate.Render(templateName, pageModel, file);
         }
 
         public JToken RunJavaScript(string scriptName, JObject model, string methodName = "transform")
         {
+            Debug.Assert(_contentTemplateDir != null);
             var scriptPath = Path.Combine(_contentTemplateDir, scriptName);
             if (!File.Exists(scriptPath))
             {
@@ -127,25 +163,41 @@ namespace Microsoft.Docs.Build
 
         public string? GetToken(string key)
         {
-            return _global[key]?.ToString();
+            return _global?[key]?.ToString();
         }
 
         public void Dispose()
         {
-            _js.Dispose();
+            _js?.Dispose();
         }
 
         private JObject LoadGlobalTokens()
         {
+            Debug.Assert(_contentTemplateDir != null);
             var path = Path.Combine(_contentTemplateDir, "token.json");
             return File.Exists(path) ? JObject.Parse(File.ReadAllText(path)) : new JObject();
         }
 
         private JsonSchemaValidator? GetSchemaCore(string schemaName)
         {
-            var schemaFilePath = IsLandingData(schemaName)
-                ? Path.Combine(AppContext.BaseDirectory, "data/schemas/LandingData.json")
-                : Path.Combine(_schemaDir, $"{schemaName}.schema.json");
+            string schemaFilePath;
+            if (IsLandingData(schemaName))
+            {
+                schemaFilePath = Path.Combine(AppContext.BaseDirectory, "data/schemas/LandingData.json");
+            }
+            else if (_templateDefinition != null)
+            {
+                if (!_templateDefinition.Definitions.TryGetValue(schemaName, out var schemaDefinition))
+                {
+                    return null;
+                }
+                schemaFilePath = _fileResolver.ResolveFilePath(new SourceInfo<string>(schemaDefinition));
+            }
+            else
+            {
+                Debug.Assert(_schemaDir != null);
+                schemaFilePath = Path.Combine(_schemaDir, $"{schemaName}.schema.json");
+            }
 
             if (!File.Exists(schemaFilePath))
             {


### PR DESCRIPTION
For now, to run the local validation, we still need to clone the template repository, but it is private, so it is not accessible for the public contributors. but the schemas are already public and organized by this definition file: https://static.docs.com/ui/latest/schemas/schema_config.json.

With this change, in `dry-run` mode and after resolving the following dependencies, a private template repository is no longer needed.

# Dependency
- For SDP, some bookmarks are imported by mustache, but if we support another contentType `bookmark` in schema, and let the schema tell whether the property will be exported as a bookmark, then we will not need the `*.js` and `*.html.tmpl` anymore.
- For SDP, some page are data type and will go through a different flow, for now, we detect that by search whether there is a `{mime}.html.tmpl`. but if we can let the schema/definition file to tell whether it is a data type, we can get rid of this detection.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6371)