### PR TITLE
Display alt not text when external href is null

### DIFF
--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -1508,5 +1508,3 @@ outputs:
     {
       "conceptual": "<p>str <span class=\"xref\">SlackAPI.Block</span></p>"
     }
-  .errors.log: |
-    {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'SlackAPI.Block'.","file":"docs/a.md","line":1,"column":5}

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -1487,3 +1487,26 @@ outputs:
   .errors.log: |
     {"message_severity":"warning","code":"xref-property-conflict","message":"UID 'a' is defined with different names: 'name 1', 'name 2'."}
     {"message_severity":"warning","code":"xref-property-conflict","message":"UID 'a' is defined with different descriptions: 'test 1', 'test 2'."}
+---
+# When href doesn't exist, should display the alt but not the text.
+inputs:
+  docfx.yml: |
+    xref:
+    - xrefmap.json
+  xrefmap.json: |
+    {
+      "references":[{
+          "uid": "SlackAPI.Block",
+          "name": "Block",
+          "fullName": "SlackAPI.Block"
+      }]
+    }
+  docs/a.md: |
+    str <xref href="SlackAPI.Block?alt=SlackAPI.Block&text=Block" data-throw-if-not-resolved="True"></xref>
+outputs:
+  docs/a.json: |
+    {
+      "conceptual": "<p>str <span class=\"xref\">SlackAPI.Block</span></p>"
+    }
+  .errors.log: |
+    {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'SlackAPI.Block'.","file":"docs/a.md","line":1,"column":5}

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Docs.Build
 
             // need to url decode uid from input content
             var (xrefError, xrefSpec, resolvedHref) = ResolveXrefSpec(new SourceInfo<string>(uid, href.Source), referencingFile, inclusionRoot);
-            if (xrefError != null || xrefSpec is null || resolvedHref == null || resolvedHref.Length == 0)
+            if (xrefError != null || xrefSpec is null || string.IsNullOrEmpty(resolvedHref))
             {
                 return (xrefError, null, alt ?? "", null);
             }

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Docs.Build
 
             // need to url decode uid from input content
             var (xrefError, xrefSpec, resolvedHref) = ResolveXrefSpec(new SourceInfo<string>(uid, href.Source), referencingFile, inclusionRoot);
-            if (xrefError != null || xrefSpec is null || resolvedHref == null)
+            if (xrefError != null || xrefSpec is null || resolvedHref == null || resolvedHref?.Length == 0)
             {
                 return (xrefError, null, alt ?? "", null);
             }
@@ -210,7 +210,7 @@ namespace Microsoft.Docs.Build
             if (_externalXrefMap.Value.TryGetValue(uid, out var spec))
             {
                 var href = RemoveSharingHost(spec.Value.Href, _config.HostName);
-                return ((spec.Value.Href != null && spec.Value.Href.Length == 0) || (spec.Value.Href == null)) ? default : (spec.Value, href);
+                return (spec.Value, href);
             }
             return default;
         }

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Docs.Build
             if (_externalXrefMap.Value.TryGetValue(uid, out var spec))
             {
                 var href = RemoveSharingHost(spec.Value.Href, _config.HostName);
-                return (spec.Value, href);
+                return ((spec.Value.Href != null && spec.Value.Href.Length == 0) || (spec.Value.Href == null)) ? default : (spec.Value, href);
             }
             return default;
         }

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Docs.Build
 
             // need to url decode uid from input content
             var (xrefError, xrefSpec, resolvedHref) = ResolveXrefSpec(new SourceInfo<string>(uid, href.Source), referencingFile, inclusionRoot);
-            if (xrefError != null || xrefSpec is null || resolvedHref == null || resolvedHref?.Length == 0)
+            if (xrefError != null || xrefSpec is null || resolvedHref == null || resolvedHref.Length == 0)
             {
                 return (xrefError, null, alt ?? "", null);
             }


### PR DESCRIPTION
When the external hrefs don't defined (as the picture shows below), the spec.Value is not null but the spec.Value.Href is an empty string, **we should return null for the xrefspec at this kind of cases**. 
After this fix, when encounter the xref quote like `<xref href="SlackAPI.Block?alt=SlackAPI.Block&text=Block" data-throw-if-not-resolved="True"></xref>`, will display the "alt" part but not the "text" part.

Bug: [278744](https://ceapex.visualstudio.com/Engineering/_workitems/edit/278744)

![image](https://user-images.githubusercontent.com/67643974/89516387-f3379480-d80a-11ea-8052-afe7e4b3f829.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6372)