### PR TITLE
Displaying all levels in PDF TOC in default PDF template

### DIFF
--- a/src/docfx.website.themes/pdf.default/partials/toc.li.tmpl.partial
+++ b/src/docfx.website.themes/pdf.default/partials/toc.li.tmpl.partial
@@ -1,0 +1,19 @@
+{{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
+
+{{#items}}
+<li>
+{{# href }}
+<a class="normal" href="{{ href }}">{{ name }}</a>
+{{/ href }}
+{{^ href }}
+<a class="normal slidedown" href="javascript:void(0)">{{ name }}</a>
+{{/ href }}
+{{# items.0 }}
+<ul class="tocLevel{{level}}">
+{{/ items.0 }}
+{{>partials/toc.li}}    
+{{# items.0 }}
+</ul>
+{{/ items.0 }}
+</li>
+{{/items}}

--- a/src/docfx.website.themes/pdf.default/toc.html.tmpl
+++ b/src/docfx.website.themes/pdf.default/toc.html.tmpl
@@ -65,32 +65,6 @@ full license information.}} {{!master(layout/_master.tmpl)}}
 </div>
 <div class="TocNavigationVertical" id="toc">
   <ul class="tocBase tocLevel1">
-    {{#items}}
-    <li>
-      {{# href }}
-      <a class="normal" href="{{ href }}">{{ name }}</a> {{/ href }} {{^ href }}
-      <a class="normal slidedown" href="javascript:void(0)">{{ name }}</a> {{/ href }} {{# items.0 }}
-      <ul class="tocLevel{{level}}">
-        {{/ items.0 }} {{#items}}
-        <li>
-          {{# href }}
-          <a class="normal" href="{{ href }}">{{ name }}</a> {{/ href }} {{^ href }}
-          <a class="normal slidedown" href="javascript:void(0)">{{ name }}</a> {{/ href }} {{# items.0 }}
-          <ul class="tocLevel{{level}}">
-            {{/ items.0 }} {{#items}}
-            <li>
-              {{# href }}
-              <a class="normal" href="{{ href }}">{{ name }}</a> {{/ href }} {{^ href }}
-              <a class="normal slidedown" href="javascript:void(0)">{{ name }}</a> {{/ href }}
-            </li>
-            {{/items}} {{# items.0 }}
-          </ul>
-          {{/ items.0 }}
-        </li>
-        {{/items}} {{# items.0 }}
-      </ul>
-      {{/ items.0 }}
-    </li>
-    {{/items}}
+    {{>partials/toc.li}}
   </ul>
 </div>


### PR DESCRIPTION
Fixes #3015

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6378)