### PR TITLE
Fix powershell config path

### DIFF
--- a/docs/specs/maml2Yaml.yml
+++ b/docs/specs/maml2Yaml.yml
@@ -8,16 +8,17 @@ repos:
         {
           "docsets_to_publish": [
           { 
-            "build_source_folder": ".",
+            "build_source_folder": "docs",
             "monikerPath": [
               "mapping/monikerMapping.json"
             ]
           }]
         }
-      docfx.yml: |
+      docs/docfx.yml: |
         files: '**/*.yml'
-      docs-conceptual/toc.yml:
-      mapping/monikerMapping.json: |
+        template: ../_themes
+      docs/docs-conceptual/toc.yml:
+      docs/mapping/monikerMapping.json: |
         {
           "v1.0": {
             "packageRoot": "samples-v1.0",
@@ -27,11 +28,11 @@ repos:
             "serviceMap": "mapping/serviceMapping.json"
           }
         }
-      mapping/serviceMapping.json: |
+      docs/mapping/serviceMapping.json: |
         {
           "Add-History": "Microsoft.PowerShell.Core"
         }
-      samples-v1.0/Microsoft.PowerShell.Core/Microsoft.PowerShell.Core.md: |
+      docs/samples-v1.0/Microsoft.PowerShell.Core/Microsoft.PowerShell.Core.md: |
         ---
         Download Help Link: https://aka.ms/powershell71-help
         Help Version: 7.1.0.0
@@ -55,7 +56,7 @@ repos:
 
         ### [Add-History](Add-History.md)
         Appends entries to the session history.
-      samples-v1.0/Microsoft.PowerShell.Core/Add-History.md: |
+      docs/samples-v1.0/Microsoft.PowerShell.Core/Add-History.md: |
         ---
         external help file: System.Management.Automation.dll-Help.xml
         keywords: powershell,cmdlet
@@ -277,10 +278,10 @@ repos:
         {"properties":{"uid":{"contentType":"uid"}}}
       _themes/ContentTemplate/schemas/PowershellModule.schema.json: '{}'
 outputs:
-  samples-v1.0/toc.json:
-  docs-conceptual/toc.json:
-  samples-v1.0/microsoft.powershell.core/add-history.json:
-  samples-v1.0/microsoft.powershell.core/index.json:
+  docs/samples-v1.0/toc.json:
+  docs/docs-conceptual/toc.json:
+  docs/samples-v1.0/microsoft.powershell.core/add-history.json:
+  docs/samples-v1.0/microsoft.powershell.core/index.json:
   .errors.log: |
     {"message_severity":"info","code":"MAML2Yaml_Info","message":"Generated reference toc with service mapping."}
     {"message_severity":"info","code":"MAML2Yaml_Info","message":"Dumped toc at *toc.yml"}

--- a/src/docfx/config/ops/OpsConfigLoader.cs
+++ b/src/docfx/config/ops/OpsConfigLoader.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Docs.Build
                 sourceMaps.AddRange(monodoc.Select((_, index) => $".sourcemap-ecma-{index}.json"));
             }
 
-            var maml2YamlMonikerPath = GetMAML2YamlMonikerPath(docsetConfig, opsConfig, buildSourceFolder);
+            var maml2YamlMonikerPath = GetMAML2YamlMonikerPath(docsetConfig, opsConfig);
             if (maml2YamlMonikerPath != null)
             {
                 result["mamlMonikerPath"] = maml2YamlMonikerPath;
@@ -138,18 +138,12 @@ namespace Microsoft.Docs.Build
             return result.Count == 0 ? null : result;
         }
 
-        private static JArray? GetMAML2YamlMonikerPath(OpsDocsetConfig? docsetConfig, OpsConfig opsConfig, string buildSourceFolder)
+        private static JArray? GetMAML2YamlMonikerPath(OpsDocsetConfig? docsetConfig, OpsConfig opsConfig)
         {
-            var result = new JArray();
             var maml2YamlMonikerPath = docsetConfig?.MonikerPath ?? opsConfig.MonikerPath;
-            if (maml2YamlMonikerPath != null)
-            {
-                foreach (var monikerPath in maml2YamlMonikerPath)
-                {
-                    result.Add(Path.GetRelativePath(buildSourceFolder, monikerPath));
-                }
-            }
-            return result.Count == 0 ? null : result;
+            return maml2YamlMonikerPath == null || maml2YamlMonikerPath.Length == 0
+                ? null
+                : new JArray(maml2YamlMonikerPath);
         }
 
         private static bool NeedRunLearnValidation(OpsDocsetConfig? docsetConfig)


### PR DESCRIPTION
[AB#279561](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/279561)
the `monikerMapping` is always considered relative to docset root.

see [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs) for example:
the [`monikerMapping`](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/staging/.openpublishing.publish.config.json#L40) is relative to [docset root](https://github.com/MicrosoftDocs/PowerShell-Docs/tree/staging/reference)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6390)