### PR TITLE
Copy assets in template definition to output directory

### DIFF
--- a/docs/specs/static.yml
+++ b/docs/specs/static.yml
@@ -14,6 +14,18 @@ outputs:
   styles/main.css: css
   scripts/main.js: js
 ---
+# Copy assets in template definition to output directory only when output is HTML
+inputs:
+  docfx.yml: |
+    template: _themes
+  _themes/template.yml: |
+    assets:
+    - styles/**
+    - scripts/**
+  _themes/styles/main.css: css
+  _themes/scripts/main.js: js
+outputs:
+---
 # Liquid template file missing should not crash
 inputs: 
   docfx.yml: |

--- a/docs/specs/static.yml
+++ b/docs/specs/static.yml
@@ -1,3 +1,18 @@
+# Copy assets in template definition to output directory
+inputs:
+  docfx.yml: |
+    outputType: html
+    outputUrlType: pretty
+    template: _themes
+  _themes/template.yml: |
+    assets:
+    - styles/**
+    - scripts/**
+  _themes/styles/main.css: css
+  _themes/scripts/main.js: js
+outputs:
+  styles/main.css: css
+  scripts/main.js: js
 ---
 # Liquid template file missing should not crash
 inputs: 

--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -111,6 +111,7 @@ namespace Microsoft.Docs.Build
             MemoryCache.Clear();
 
             Parallel.Invoke(
+                () => context.TemplateEngine.CopyAssetsToOutput(),
                 () => context.Output.WriteJson(".xrefmap.json", xrefMapModel),
                 () => context.Output.WriteJson(".publish.json", publishModel),
                 () => context.Output.WriteJson(".dependencymap.json", dependencyMap.ToDependencyMapModel()),

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -88,7 +88,8 @@ namespace Microsoft.Docs.Build
             Input = new Input(buildOptions, config, packageResolver, RepositoryProvider);
             Output = new Output(buildOptions.OutputPath, Input, Config.DryRun);
             MicrosoftGraphAccessor = new MicrosoftGraphAccessor(Config);
-            TemplateEngine = new TemplateEngine(config, buildOptions, PackageResolver, new Lazy<JsonSchemaTransformer>(() => JsonSchemaTransformer));
+            TemplateEngine = new TemplateEngine(
+                errorLog, config, buildOptions, Output, PackageResolver, new Lazy<JsonSchemaTransformer>(() => JsonSchemaTransformer));
 
             BuildScope = new BuildScope(Config, Input, buildOptions);
             MetadataProvider = new MetadataProvider(Config, Input, FileResolver, BuildScope);

--- a/src/docfx/config/AppData.cs
+++ b/src/docfx/config/AppData.cs
@@ -42,15 +42,6 @@ namespace Microsoft.Docs.Build
         }
 
         /// <summary>
-        /// Get the global configuration path, default is under <see cref="Root"/>
-        /// </summary>
-        public static bool TryGetGlobalConfigPath([NotNullWhen(true)] out string? path)
-        {
-            path = PathUtility.FindYamlOrJson(Root, "docfx");
-            return path != null;
-        }
-
-        /// <summary>
         /// Get the application cache root dir, default is under user profile dir.
         /// User can set the DOCFX_APPDATA_PATH environment to change the root
         /// </summary>

--- a/src/docfx/lib/GlobUtility.cs
+++ b/src/docfx/lib/GlobUtility.cs
@@ -16,10 +16,10 @@ namespace Microsoft.Docs.Build
             return path => !IsFileStartingWithDot(path) && glob.IsMatch(path);
         }
 
-        public static Func<string, bool> CreateGlobMatcher(string[] includePatterns, string[] excludePatterns)
+        public static Func<string, bool> CreateGlobMatcher(string[] includePatterns, string[]? excludePatterns = null)
         {
             var includeGlobs = Array.ConvertAll(includePatterns, CreateGlob);
-            var excludeGlobs = Array.ConvertAll(excludePatterns, CreateGlob);
+            var excludeGlobs = Array.ConvertAll(excludePatterns ?? Array.Empty<string>(), CreateGlob);
 
             return IsMatch;
 

--- a/src/docfx/lib/log/CustomRule.cs
+++ b/src/docfx/lib/log/CustomRule.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Docs.Build
 
         public bool ExcludeMatches(string file)
         {
-            var match = LazyInitializer.EnsureInitialized(ref _globMatcherCache, () => GlobUtility.CreateGlobMatcher(Exclude, Array.Empty<string>()));
+            var match = LazyInitializer.EnsureInitialized(ref _globMatcherCache, () => GlobUtility.CreateGlobMatcher(Exclude));
 
             return match(file);
         }

--- a/src/docfx/template/TemplateDefinition.cs
+++ b/src/docfx/template/TemplateDefinition.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Docs.Build
+{
+    /// <summary>
+    /// Data model for an optional `template.json` file that describes the docfx template.
+    /// </summary>
+    internal class TemplateDefinition
+    {
+        /// <summary>
+        /// Gets the file glob patterns to copy as static assets.
+        /// </summary>
+        [JsonConverter(typeof(OneOrManyConverter))]
+        public string[] Assets { get; private set; } = Array.Empty<string>();
+    }
+}

--- a/src/docfx/template/TemplateEngine.cs
+++ b/src/docfx/template/TemplateEngine.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Docs.Build
         private readonly string _templateDir;
         private readonly string _schemaDir;
         private readonly string _contentTemplateDir;
+        private readonly Config _config;
         private readonly Output _output;
         private readonly TemplateDefinition _templateDefinition;
         private readonly JObject _global;
@@ -34,6 +35,7 @@ namespace Microsoft.Docs.Build
             PackageResolver packageResolver,
             Lazy<JsonSchemaTransformer> jsonSchemaTransformer)
         {
+            _config = config;
             _output = output;
 
             _templateDir = config.Template.Type switch
@@ -140,7 +142,7 @@ namespace Microsoft.Docs.Build
 
         public void CopyAssetsToOutput()
         {
-            if (_templateDefinition.Assets.Length <= 0)
+            if (_config.OutputType != OutputType.Html || _templateDefinition.Assets.Length <= 0)
             {
                 return;
             }


### PR DESCRIPTION
The default docfx public template https://github.com/docascode/template requires to copy some static asserts to output directory. This PR adds the capability for template to describe which files should be copied to output when building a static page.

Docfx template can define a `template.json` or `template.yml` file at template root folder describing specific requirement about this template. The `assets` property specifies which files should be copied to output folder for the page to be fully functional. Typically these are css files, javascript files, static images, etc.

This PR extracts two methods `PathUtility.LoadYamlOrJson` and `PathUtility.GetFiles` to help with code sharing.

Somewhat related to #6371

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6415)