### PR TITLE
Allocate chakra call arguments on stack

### DIFF
--- a/src/docfx/lib/js/ChakraCoreJsEngine.cs
+++ b/src/docfx/lib/js/ChakraCoreJsEngine.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Docs.Build
                     input.SetProperty(JavaScriptPropertyId.FromString("__global"), _global, useStrictRules: true);
                 }
 
-                var output = method.CallFunction(JavaScriptValue.Undefined, input);
+                var output = method.CallFunction(stackalloc JavaScriptValue[] { JavaScriptValue.Undefined, input });
 
                 return ToJToken(output);
             });
@@ -138,13 +138,16 @@ namespace Microsoft.Docs.Build
             {
                 var sourceContext = JavaScriptSourceContext.FromIntPtr((IntPtr)Interlocked.Increment(ref s_currentSourceContext));
 
-                JavaScriptContext.RunScript(script, sourceContext, scriptPath).CallFunction(
-                    JavaScriptValue.Undefined, // this pointer
-                    module,
-                    exports,
-                    JavaScriptValue.FromString(dirname),
-                    JavaScriptValue.CreateFunction(s_requireFunction),
-                    JavaScriptValue.CreateObject());
+                JavaScriptContext.RunScript(script, sourceContext, scriptPath)
+                    .CallFunction(stackalloc JavaScriptValue[]
+                    {
+                        JavaScriptValue.Undefined, // this pointer
+                        module,
+                        exports,
+                        JavaScriptValue.FromString(dirname),
+                        JavaScriptValue.CreateFunction(s_requireFunction),
+                        JavaScriptValue.CreateObject(),
+                    });
 
                 return modules[scriptPath] = module.GetProperty(exportsProperty);
             }

--- a/src/docfx/lib/js/chakra/JavaScriptValue.cs
+++ b/src/docfx/lib/js/chakra/JavaScriptValue.cs
@@ -841,7 +841,7 @@ namespace ChakraHost.Hosting
         /// </remarks>
         /// <param name="arguments">The arguments to the call.</param>
         /// <returns>The <c>Value</c> returned from the function invocation, if any.</returns>
-        public JavaScriptValue CallFunction(params JavaScriptValue[] arguments)
+        public unsafe JavaScriptValue CallFunction(ReadOnlySpan<JavaScriptValue> arguments)
         {
             JavaScriptValue returnReference;
 
@@ -850,7 +850,10 @@ namespace ChakraHost.Hosting
                 throw new ArgumentOutOfRangeException("arguments");
             }
 
-            Native.ThrowIfError(Native.JsCallFunction(this, arguments, (ushort)arguments.Length, out returnReference));
+            fixed (JavaScriptValue* p = arguments)
+            {
+                Native.ThrowIfError(Native.JsCallFunction(this, (IntPtr)p, (ushort)arguments.Length, out returnReference));
+            }
             return returnReference;
         }
 

--- a/src/docfx/lib/js/chakra/Native.cs
+++ b/src/docfx/lib/js/chakra/Native.cs
@@ -317,7 +317,7 @@ namespace ChakraHost.Hosting
         internal static extern JavaScriptErrorCode JsCreateArray(uint length, out JavaScriptValue result);
 
         [DllImport(DllName)]
-        internal static extern JavaScriptErrorCode JsCallFunction(JavaScriptValue function, JavaScriptValue[] arguments, ushort argumentCount, out JavaScriptValue result);
+        internal static extern JavaScriptErrorCode JsCallFunction(JavaScriptValue function, IntPtr arguments, ushort argumentCount, out JavaScriptValue result);
 
         [DllImport(DllName)]
         internal static extern JavaScriptErrorCode JsConstructObject(JavaScriptValue function, JavaScriptValue[] arguments, ushort argumentCount, out JavaScriptValue result);


### PR DESCRIPTION
[AB#275080](https://dev.azure.com/ceapex/Engineering/_workitems/edit/275080/)

The chakra crash minidump shows that `JsCallFunction` method crashed at validating the 3rd argument, (`JavaScriptValue.FromString(dirname)`). This suggests the pointers at `args[0]`, `args[1]`, and `args[2]` are valid, but `args[3]` isn't.

The root cause is that the JavaScript object referenced by `args[3]` is immediately garbage collected after creation. The old `CallFunction` method takes a `JavaScriptValue[]`, which is allocated on the .NET heap. and doesn't appear on the call stack. When the chakra garbage collector kicks in and looks for object roots, `args[3]` is not considered a root and thus be reclaimed. (Notice `module` and `exports` has stack pointers, so they are kept alive).

The fix is to use `stackalloc` to allocate the arguments array on stack, to avoid Chakra garbage collector collect these `JavaScriptValue` arguments before the `Run` function returns.

![image](https://user-images.githubusercontent.com/511355/90598895-7fdc4c80-e226-11ea-941f-0883b41899c2.png)




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6427)