### PR TITLE
Deprecate GetDocsSiteUrl

### DIFF
--- a/src/docfx/build/document/DocumentProvider.cs
+++ b/src/docfx/build/document/DocumentProvider.cs
@@ -87,6 +87,12 @@ namespace Microsoft.Docs.Build
             return UrlUtility.Combine(_config.BasePath, outputPath);
         }
 
+        public string GetSiteUrl(FilePath path)
+        {
+            return GetDocument(path).SiteUrl;
+        }
+
+        [Obsolete("To workaround a docs pdf build image fallback issue. Use GetSiteUrl instead.")]
         public string GetDocsSiteUrl(FilePath path)
         {
             var file = GetDocument(path);
@@ -94,6 +100,7 @@ namespace Microsoft.Docs.Build
             {
                 return file.SiteUrl;
             }
+
             var sitePath = FilePathToSitePath(path, file.ContentType, OutputUrlType.Docs, file.IsHtml);
             return PathToAbsoluteUrl(Path.Combine(_config.BasePath, sitePath), file.ContentType, OutputUrlType.Docs, file.IsHtml);
         }

--- a/src/docfx/build/link/LinkResolver.cs
+++ b/src/docfx/build/link/LinkResolver.cs
@@ -144,10 +144,11 @@ namespace Microsoft.Docs.Build
                 return (Errors.Link.LinkOutOfScope(href, file), href, fragment, linkType, null, false);
             }
 
-            // For static hosting, reference file in fallback repo should be resolved to docs site URL
             if (file.FilePath.Origin == FileOrigin.Fallback && file.ContentType == ContentType.Page && _config.OutputUrlType != OutputUrlType.Docs)
             {
+#pragma warning disable CS0618 // Docs pdf build uses static url, but images in fallback repo should be resolved to docs site URL
                 var siteUrl = _documentProvider.GetDocsSiteUrl(file.FilePath);
+#pragma warning restore CS0618
                 return (error, UrlUtility.MergeUrl($"https://{_config.HostName}{siteUrl}", query, fragment), fragment, linkType, file, false);
             }
 

--- a/src/docfx/validation/MetadataValidator.cs
+++ b/src/docfx/validation/MetadataValidator.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Docs.Build
 
             var contentType = _buildScope.GetContentType(filePath);
             var mime = _buildScope.GetMime(contentType, filePath);
-            var siteUrl = _documentProvider.GetDocsSiteUrl(filePath);
+            var siteUrl = _documentProvider.GetSiteUrl(filePath);
             var canonicalVersion = _publishUrlMap.GetCanonicalVersion(siteUrl);
             var isCanonicalVersion = _monikerProvider.GetFileLevelMonikers(errors, filePath).IsCanonicalVersion(canonicalVersion);
 


### PR DESCRIPTION
The `GetDocsSiteUrl` method is used to workaround a problem in docs pdf build. It should not be broadly used. This PR changes the signature of this method so people won't misuse it.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6436)