### PR TITLE
🧹 Some validation related cleanups

### DIFF
--- a/src/docfx/build/Build.cs
+++ b/src/docfx/build/Build.cs
@@ -128,6 +128,10 @@ namespace Microsoft.Docs.Build
         private static void BuildFile(Context context, FilePath path)
         {
             var file = context.DocumentProvider.GetDocument(path);
+
+            Telemetry.TrackBuildFileTypeCount(file);
+            context.ContentValidator.ValidateManifest(file.FilePath, file.SiteUrl);
+
             switch (file.ContentType)
             {
                 case ContentType.TableOfContents:

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -108,7 +108,8 @@ namespace Microsoft.Docs.Build
                 new Lazy<PublishUrlMap>(() => PublishUrlMap));
 
             ContentValidator = new ContentValidator(
-                config, FileResolver, errorLog, MonikerProvider, MetadataProvider, new Lazy<PublishUrlMap>(() => PublishUrlMap));
+                config, FileResolver, errorLog, DocumentProvider, MonikerProvider, new Lazy<PublishUrlMap>(() => PublishUrlMap));
+
             GitHubAccessor = new GitHubAccessor(Config);
             BookmarkValidator = new BookmarkValidator(errorLog);
             ContributionProvider = new ContributionProvider(config, buildOptions, Input, GitHubAccessor, RepositoryProvider, sourceMap);
@@ -168,9 +169,11 @@ namespace Microsoft.Docs.Build
                 DocumentProvider);
             TocMap = new TableOfContentsMap(
                 ErrorBuilder, Input, BuildScope, DependencyMapBuilder, tocParser, TableOfContentsLoader, DocumentProvider, ContentValidator);
-            PublishUrlMap = new PublishUrlMap(Config, ErrorBuilder, BuildScope, RedirectionProvider, DocumentProvider, MonikerProvider, TocMap);
+            PublishUrlMap = new PublishUrlMap(
+                Config, ErrorBuilder, BuildScope, RedirectionProvider, DocumentProvider, MonikerProvider, TocMap);
+
             PublishModelBuilder = new PublishModelBuilder(
-                config, errorLog, MonikerProvider, buildOptions, ContentValidator, PublishUrlMap, DocumentProvider, SourceMap);
+                config, errorLog, MonikerProvider, buildOptions, PublishUrlMap, DocumentProvider, SourceMap);
 
             var validatorExtension = new JsonSchemaValidatorExtension(DocumentProvider, PublishUrlMap, MonikerProvider, errorLog);
             MetadataValidator = new MetadataValidator(Config, MicrosoftGraphAccessor, FileResolver, validatorExtension);

--- a/src/docfx/build/document/Document.cs
+++ b/src/docfx/build/document/Document.cs
@@ -15,11 +15,6 @@ namespace Microsoft.Docs.Build
         public ContentType ContentType { get; }
 
         /// <summary>
-        /// Gets the page type of this document.
-        /// </summary>
-        public string? PageType { get; }
-
-        /// <summary>
         /// Gets the MIME type specified in YAML header or JSON $schema.
         /// </summary>
         public SourceInfo<string?> Mime { get; }
@@ -85,7 +80,6 @@ namespace Microsoft.Docs.Build
             string siteUrl,
             string canonicalUrl,
             ContentType contentType,
-            string? pageType,
             SourceInfo<string?> mime,
             bool isExperimental,
             bool isHtml = true)
@@ -97,7 +91,6 @@ namespace Microsoft.Docs.Build
             SiteUrl = siteUrl;
             CanonicalUrl = canonicalUrl;
             ContentType = contentType;
-            PageType = pageType;
             Mime = mime;
             IsExperimental = isExperimental;
             IsHtml = isHtml;

--- a/src/docfx/build/document/DocumentProvider.cs
+++ b/src/docfx/build/document/DocumentProvider.cs
@@ -124,6 +124,24 @@ namespace Microsoft.Docs.Build
             return PathToAbsoluteUrl(Path.Combine(_config.BasePath, sitePath), file.ContentType, OutputUrlType.Docs, file.IsHtml);
         }
 
+        public string? GetPageType(FilePath file)
+        {
+            var document = GetDocument(file);
+            var mime = document.Mime.Value;
+
+            return document.ContentType switch
+            {
+                ContentType.Page when mime is null => null,
+                ContentType.Page when file.Format == FileFormat.Markdown
+                    => (_metadataProvider.GetMetadata(_errors, file).Layout ?? mime).ToLowerInvariant(),
+                ContentType.Page
+                    => s_pageTypeMapping.TryGetValue(mime, out var type) ? type : mime.ToLowerInvariant(),
+                ContentType.Redirection => "redirection",
+                ContentType.TableOfContents => "toc",
+                _ => null,
+            };
+        }
+
         public (string documentId, string versionIndependentId) GetDocumentId(FilePath path)
         {
             var file = GetDocument(path);
@@ -181,28 +199,13 @@ namespace Microsoft.Docs.Build
         {
             var contentType = _buildScope.GetContentType(path);
             var mime = _buildScope.GetMime(contentType, path);
-            var pageType = GetPageType(contentType, path, mime);
             var isHtml = _templateEngine.IsHtml(contentType, mime.Value);
             var isExperimental = Path.GetFileNameWithoutExtension(path.Path).EndsWith(".experimental", PathUtility.PathComparison);
             var sitePath = FilePathToSitePath(path, contentType, _config.OutputUrlType, isHtml);
             var siteUrl = PathToAbsoluteUrl(Path.Combine(_config.BasePath, sitePath), contentType, _config.OutputUrlType, isHtml);
             var canonicalUrl = GetCanonicalUrl(siteUrl, sitePath, isExperimental, contentType, isHtml);
 
-            return new Document(path, sitePath, siteUrl, canonicalUrl, contentType, pageType, mime, isExperimental, isHtml);
-        }
-
-        private string? GetPageType(ContentType contentType, FilePath path, string? mime)
-        {
-            return contentType switch
-            {
-                ContentType.Page when mime != null && path.Format == FileFormat.Markdown
-                    => (_metadataProvider.GetMetadata(_errors, path).Layout ?? mime).ToLowerInvariant(),
-                ContentType.Page when mime != null
-                    => s_pageTypeMapping.TryGetValue(mime, out var type) ? type : mime.ToLowerInvariant(),
-                ContentType.Redirection => "redirection",
-                ContentType.TableOfContents => "toc",
-                _ => null,
-            };
+            return new Document(path, sitePath, siteUrl, canonicalUrl, contentType, mime, isExperimental, isHtml);
         }
 
         private string FilePathToSitePath(FilePath filePath, ContentType contentType, OutputUrlType outputUrlType, bool isHtml)

--- a/src/docfx/build/moniker/MonikerProvider.cs
+++ b/src/docfx/build/moniker/MonikerProvider.cs
@@ -40,7 +40,10 @@ namespace Microsoft.Docs.Build
             _monikerOrder = GetMonikerOrder(monikerDefinition);
         }
 
-        public MonikerList Validate(ErrorBuilder errors, SourceInfo<string>[] monikers) => _rangeParser.Validate(errors, monikers);
+        public MonikerList Validate(ErrorBuilder errors, SourceInfo<string>[] monikers)
+        {
+            return _rangeParser.Validate(errors, monikers);
+        }
 
         public int GetMonikerOrder(string moniker)
         {

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Docs.Build
             var content = context.Input.ReadString(file.FilePath);
             errors.AddIfNotNull(MergeConflict.CheckMergeConflictMarker(content, file.FilePath));
 
-            context.ContentValidator.ValidateSensitiveLanguage(content, file);
+            context.ContentValidator.ValidateSensitiveLanguage(file.FilePath, content);
 
             var userMetadata = context.MetadataProvider.GetMetadata(errors, file.FilePath);
 
@@ -214,7 +214,7 @@ namespace Microsoft.Docs.Build
             var html = context.MarkdownEngine.ToHtml(errors, content, file, MarkdownPipelineType.Markdown, conceptual);
 
             context.SearchIndexBuilder.SetTitle(file, conceptual.Title);
-            context.ContentValidator.ValidateTitle(file, conceptual.Title, userMetadata.TitleSuffix);
+            context.ContentValidator.ValidateTitle(file.FilePath, conceptual.Title, userMetadata.TitleSuffix);
 
             ProcessConceptualHtml(conceptual, context, file, html);
 

--- a/src/docfx/build/toc/BuildTableOfContents.cs
+++ b/src/docfx/build/toc/BuildTableOfContents.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Docs.Build
             // load toc tree
             var (node, _, _) = context.TableOfContentsLoader.Load(file);
 
-            context.ContentValidator.ValidateTocDeprecated(file);
+            context.ContentValidator.ValidateTocDeprecated(file.FilePath);
 
             var metadata = context.MetadataProvider.GetMetadata(errors, file.FilePath);
             context.MetadataValidator.ValidateMetadata(errors, metadata.RawJObject, file);

--- a/src/docfx/build/toc/TableOfContentsLoader.cs
+++ b/src/docfx/build/toc/TableOfContentsLoader.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Docs.Build
 
                 if (file == rootPath)
                 {
-                    _contentValidator.ValidateTocEntryDuplicated(file, referencedFiles);
+                    _contentValidator.ValidateTocEntryDuplicated(file.FilePath, referencedFiles);
                 }
                 return node;
             }
@@ -171,7 +171,7 @@ namespace Microsoft.Docs.Build
             var topicHref = GetTopicHref(node);
             var topicUid = node.Value.Uid;
 
-            _contentValidator.ValidateTocBreadcrumbLinkExternal(filePath, node);
+            _contentValidator.ValidateTocBreadcrumbLinkExternal(filePath.FilePath, node);
 
             var (resolvedTocHref, subChildren, subChildrenFirstItem, tocHrefType) = ProcessTocHref(
                 filePath, rootPath, referencedFiles, referencedTocs, tocHref);

--- a/src/docfx/build/toc/TableOfContentsMap.cs
+++ b/src/docfx/build/toc/TableOfContentsMap.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Docs.Build
                 _tocs.Value.docToTocs,
                 file => file.FilePath.Path);
 
-            _contentValidator.ValidateTocMissing(file, result.hasReferencedTocs);
+            _contentValidator.ValidateTocMissing(file.FilePath, result.hasReferencedTocs);
             return result.toc;
         }
 

--- a/src/docfx/lib/markdown/MarkdownEngine.cs
+++ b/src/docfx/lib/markdown/MarkdownEngine.cs
@@ -326,7 +326,7 @@ namespace Microsoft.Docs.Build
 
         private string GetImageLink(SourceInfo<string> href, MarkdownObject origin, string? altText)
         {
-            _contentValidator.ValidateImageLink((Document)InclusionContext.RootFile, href, origin, altText);
+            _contentValidator.ValidateImageLink(((Document)InclusionContext.RootFile).FilePath, href, origin, altText);
             var link = GetLink(href);
             return link;
         }
@@ -375,7 +375,7 @@ namespace Microsoft.Docs.Build
 
         private string? GetCanonicalVersion()
         {
-            return _publishUrlMap.Value.GetCanonicalVersion(((Document)InclusionContext.RootFile).SiteUrl);
+            return _publishUrlMap.Value.GetCanonicalVersion(((Document)InclusionContext.RootFile).FilePath);
         }
 
         private class Status

--- a/src/docfx/lib/markdown/validation/DocsValidationExtension.cs
+++ b/src/docfx/lib/markdown/validation/DocsValidationExtension.cs
@@ -58,15 +58,15 @@ namespace Microsoft.Docs.Build
                     return false;
                 });
 
-                contentValidator.ValidateHeadings(currentFile, documentNodes, false);
+                contentValidator.ValidateHeadings(currentFile.FilePath, documentNodes, false);
                 foreach (var (inclusion, inclusionNodes) in inclusionDocumentNodes)
                 {
-                    contentValidator.ValidateHeadings(inclusion, inclusionNodes, true);
+                    contentValidator.ValidateHeadings(inclusion.FilePath, inclusionNodes, true);
                 }
 
                 foreach (var (isInclude, codeBlockItem) in codeBlockNodes)
                 {
-                    contentValidator.ValidateCodeBlock(currentFile, codeBlockItem, isInclude);
+                    contentValidator.ValidateCodeBlock(currentFile.FilePath, codeBlockItem, isInclude);
                 }
             });
         }

--- a/src/docfx/publish/PublishItem.cs
+++ b/src/docfx/publish/PublishItem.cs
@@ -35,15 +35,6 @@ namespace Microsoft.Docs.Build
         [JsonExtensionData]
         public JObject? ExtensionData { get; }
 
-        [JsonIgnore]
-        public ContentType ContentType { get; }
-
-        [JsonIgnore]
-        public string? PageType { get; }
-
-        [JsonIgnore]
-        public string? Mime { get; }
-
         public PublishItem(
             string url,
             string? path,
@@ -51,9 +42,6 @@ namespace Microsoft.Docs.Build
             string locale,
             MonikerList monikers,
             string? configMonikerRange,
-            ContentType contentType,
-            string? pageType,
-            string? mime,
             bool hasError,
             JObject? extensionData)
         {
@@ -63,9 +51,6 @@ namespace Microsoft.Docs.Build
             Locale = locale;
             Monikers = monikers;
             ConfigMonikerRange = configMonikerRange;
-            ContentType = contentType;
-            PageType = pageType;
-            Mime = mime;
             HasError = hasError;
             ExtensionData = extensionData;
         }

--- a/src/docfx/publish/PublishModelBuilder.cs
+++ b/src/docfx/publish/PublishModelBuilder.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Docs.Build
         private readonly ErrorBuilder _errors;
         private readonly MonikerProvider _monikerProvider;
         private readonly string _locale;
-        private readonly ContentValidator _contentValidator;
         private readonly PublishUrlMap _publishUrlMapBuilder;
         private readonly DocumentProvider _documentProvider;
         private readonly SourceMap _sourceMap;
@@ -27,7 +26,6 @@ namespace Microsoft.Docs.Build
             ErrorBuilder errors,
             MonikerProvider monikerProvider,
             BuildOptions buildOptions,
-            ContentValidator contentValidator,
             PublishUrlMap publishUrlMapBuilder,
             DocumentProvider documentProvider,
             SourceMap sourceMap)
@@ -36,7 +34,6 @@ namespace Microsoft.Docs.Build
             _errors = errors;
             _monikerProvider = monikerProvider;
             _locale = buildOptions.Locale;
-            _contentValidator = contentValidator;
             _publishUrlMapBuilder = publishUrlMapBuilder;
             _documentProvider = documentProvider;
             _sourceMap = sourceMap;
@@ -61,21 +58,9 @@ namespace Microsoft.Docs.Build
                     _locale,
                     monikers,
                     _monikerProvider.GetConfigMonikerRange(sourcePath),
-                    document.ContentType,
-                    document.PageType,
-                    document.Mime,
                     _errors.FileHasError(sourcePath),
                     buildOutput ? RemoveComplexValue(result.metadata) : null);
                 publishItems.Add(sourcePath, publishItem);
-            }
-
-            foreach (var (filePath, publishItem) in publishItems)
-            {
-                if (!publishItem.HasError)
-                {
-                    Telemetry.TrackBuildFileTypeCount(filePath, publishItem);
-                    _contentValidator.ValidateManifest(filePath, publishItem);
-                }
             }
 
             var items = (

--- a/src/docfx/publish/PublishUrlMap.cs
+++ b/src/docfx/publish/PublishUrlMap.cs
@@ -43,8 +43,9 @@ namespace Microsoft.Docs.Build
             _files = _publishUrlMap.Values.SelectMany(x => x).Select(x => x.SourcePath).ToHashSet();
         }
 
-        public string? GetCanonicalVersion(string url)
+        public string? GetCanonicalVersion(FilePath file)
         {
+            var url = _documentProvider.GetSiteUrl(file);
             return _canonicalVersionMap.GetOrAdd(url, GetCanonicalVersionCore);
         }
 

--- a/src/docfx/validation/JsonSchemaValidatorExtension.cs
+++ b/src/docfx/validation/JsonSchemaValidatorExtension.cs
@@ -26,21 +26,16 @@ namespace Microsoft.Docs.Build
 
         public bool IsEnable(FilePath filePath, CustomRule customRule)
         {
-            var siteUrl = _documentProvider.GetSiteUrl(filePath);
-            var canonicalVersion = _publishUrlMap.GetCanonicalVersion(siteUrl);
+            var canonicalVersion = _publishUrlMap.GetCanonicalVersion(filePath);
             var isCanonicalVersion = _monikerProvider.GetFileLevelMonikers(_errorLog, filePath).IsCanonicalVersion(canonicalVersion);
             if (customRule.CanonicalVersionOnly && !isCanonicalVersion)
             {
                 return false;
             }
 
-            var file = _documentProvider.GetDocument(filePath);
-            if (file.PageType is null)
-            {
-                return false;
-            }
+            var pageType = _documentProvider.GetPageType(filePath);
 
-            return customRule.ContentTypes is null || customRule.ContentTypes.Contains(file.PageType);
+            return customRule.ContentTypes is null || customRule.ContentTypes.Contains(pageType);
         }
     }
 }

--- a/src/docfx/validation/MetadataValidator.cs
+++ b/src/docfx/validation/MetadataValidator.cs
@@ -52,10 +52,7 @@ namespace Microsoft.Docs.Build
 
             foreach (var schemaValidator in _schemaValidators)
             {
-                if (file.PageType != null)
-                {
-                    errors.AddRange(schemaValidator.Validate(metadata, file.FilePath));
-                }
+                errors.AddRange(schemaValidator.Validate(metadata, file.FilePath));
             }
         }
 


### PR DESCRIPTION
- Remove content type related fields from `PublishItem` by calling `ValidateManifest` in a different place.
- `Document.PageType` --> `DocumentProvider.GetPageType`.
- Make `ContentValidator` takes `FilePath` as input.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6446)