### PR TITLE
Fix lazy not lazy when retrieving ops user token

### DIFF
--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -9,7 +9,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Web;
-using Azure;
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
 using Newtonsoft.Json;
@@ -30,6 +29,11 @@ namespace Microsoft.Docs.Build
         private const string RegressionAllMetadataSchemaApi = "https://ops/regressionallmetadataschema/";
 
         public static readonly DocsEnvironment DocsEnvironment = GetDocsEnvironment();
+
+        private static readonly SecretClient s_secretClient = new SecretClient(new Uri("https://docfx.vault.azure.net"), new DefaultAzureCredential());
+        private static readonly Lazy<Task<string>> s_opsTokenProd = new Lazy<Task<string>>(GetSecret("OpsBuildTokenProd"));
+        private static readonly Lazy<Task<string>> s_opsTokenSandbox = new Lazy<Task<string>>(GetSecret("OpsBuildTokenSandbox"));
+
         private readonly Action<HttpRequestMessage> _credentialProvider;
         private readonly ErrorBuilder _errors;
         private readonly HttpClient _http = new HttpClient();
@@ -287,7 +291,8 @@ namespace Microsoft.Docs.Build
         }
 
         private static string BuildServiceEndpoint(DocsEnvironment? environment = null)
-            => (environment ?? DocsEnvironment) switch
+        {
+            return (environment ?? DocsEnvironment) switch
             {
                 DocsEnvironment.Prod => "https://op-build-prod.azurewebsites.net",
                 DocsEnvironment.PPE => "https://op-build-sandbox2.azurewebsites.net",
@@ -295,19 +300,23 @@ namespace Microsoft.Docs.Build
                 DocsEnvironment.Perf => "https://op-build-perf.azurewebsites.net",
                 _ => throw new NotSupportedException(),
             };
+        }
 
-        private static string ValidationServiceEndpoint(DocsEnvironment? environment = null) =>
-            $"{BuildServiceEndpoint(environment)}/route/validationmgt";
+        private static string ValidationServiceEndpoint(DocsEnvironment? environment = null)
+        {
+            return $"{BuildServiceEndpoint(environment)}/route/validationmgt";
+        }
 
-        private static Lazy<Task<Response<KeyVaultSecret>>> OpBuildUserToken(DocsEnvironment? environment = null)
-            => new Lazy<Task<Response<KeyVaultSecret>>>(
-            () => new SecretClient(new Uri("https://docfx.vault.azure.net"), new DefaultAzureCredential()).GetSecretAsync(
-            (environment ?? DocsEnvironment) switch
+        private static async Task<string> GetSecret(string secret)
+        {
+            var response = await s_secretClient.GetSecretAsync(secret);
+            if (response.Value is null)
             {
-                DocsEnvironment.Prod => "OpsBuildTokenProd",
-                DocsEnvironment.PPE => "OpsBuildTokenSandbox",
-                _ => throw new NotSupportedException(),
-            }));
+                throw new HttpRequestException(response.GetRawResponse().ToString());
+            }
+
+            return response.Value.Value;
+        }
 
         private static string GetHostName(string siteName)
         {
@@ -369,7 +378,14 @@ namespace Microsoft.Docs.Build
                 // For development usage
                 try
                 {
-                    request.Headers.Add("X-OP-BuildUserToken", (await OpBuildUserToken(environment).Value).Value.Value);
+                    var token = (environment ?? DocsEnvironment) switch
+                    {
+                        DocsEnvironment.Prod => s_opsTokenProd,
+                        DocsEnvironment.PPE => s_opsTokenSandbox,
+                        _ => throw new InvalidOperationException(),
+                    };
+
+                    request.Headers.Add("X-OP-BuildUserToken", await token.Value);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
https://dev.azure.com/ceapex/Engineering/_build/results?buildId=186480&view=logs&jobId=73369bf2-6897-51f4-4549-2cc8453877a2&j=743bc1cd-037d-5150-fc69-2953b556a708

```
Cannot get 'OPBuildUserToken' from azure key vault, please make sure you have been granted the permission to access: DefaultAzureCredential authentication failed: Object reference not set to an instance of an object.
```

This PR:

- Improves the exception handling
- Fix the wrong lazy


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6447)