### PR TITLE
Fix wrong path to OpsMetadata.json

### DIFF
--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Docs.Build
     {
         public const string BuildConfigApi = "https://ops/buildconfig/";
         private const string MonikerDefinitionApi = "https://ops/monikerDefinition/";
+        private const string OpsMetadataApi = "https://ops/opsmetadatas/";
         private const string MetadataSchemaApi = "https://ops/metadataschema/";
         private const string MarkdownValidationRulesApi = "https://ops/markdownvalidationrules/";
         private const string AllowlistsApi = "https://ops/allowlists/";
@@ -47,6 +48,7 @@ namespace Microsoft.Docs.Build
             {
                 (BuildConfigApi, GetBuildConfig),
                 (MonikerDefinitionApi, GetMonikerDefinition),
+                (OpsMetadataApi, GetOpsMetadata),
                 (MetadataSchemaApi, GetMetadataSchema),
                 (MarkdownValidationRulesApi, GetMarkdownValidationRules),
                 (AllowlistsApi, GetAllowlists),
@@ -122,7 +124,7 @@ namespace Microsoft.Docs.Build
                 markdownValidationRules = $"{MarkdownValidationRulesApi}{metadataServiceQueryParams}",
                 metadataSchema = new[]
                 {
-                    Path.Combine(AppContext.BaseDirectory, "data/schemas/OpsMetadata.json"),
+                    OpsMetadataApi,
                     $"{MetadataSchemaApi}{metadataServiceQueryParams}",
                 },
                 allowlists = AllowlistsApi,
@@ -160,6 +162,11 @@ namespace Microsoft.Docs.Build
         private Task<string> GetMonikerDefinition(Uri url)
         {
             return Fetch($"{BuildServiceEndpoint()}/v2/monikertrees/allfamiliesproductsmonikers");
+        }
+
+        private Task<string> GetOpsMetadata(Uri url)
+        {
+            return File.ReadAllTextAsync(Path.Combine(AppContext.BaseDirectory, "data/schemas/OpsMetadata.json"));
         }
 
         private async Task<string> GetMarkdownValidationRules(Uri url)


### PR DESCRIPTION
Fixes:

![image](https://user-images.githubusercontent.com/511355/91407152-176c1b80-e875-11ea-86fb-850cad637b17.png)
![image](https://user-images.githubusercontent.com/511355/91407871-7df13980-e875-11ea-808b-58b0ca6df860.png)

----

Root cause:

Building an OPS docset locally the first time using `docfx version 1`, the full path `Path.Combine(AppContext.BaseDirectory, "data/schemas/OpsMetadata.json")` is cached on disk. This full path contains version info. When a newer version of docfx is installed (by global tool), this cached path does not exist and causes the above error.




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6467)