### PR TITLE
refactor: Decouple Document from XrefResolver

### DIFF
--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -657,7 +657,7 @@ namespace Microsoft.Docs.Build
             /// Defined reference with by #bookmark fragment within articles, which doesn't exist.
             /// </summary>
             /// Behavior: ✔️ Message: ❌
-            public static Error BookmarkNotFound(SourceInfo? source, Document reference, string bookmark, IEnumerable<string> candidateBookmarks)
+            public static Error BookmarkNotFound(SourceInfo? source, FilePath reference, string bookmark, IEnumerable<string> candidateBookmarks)
                 => new Error(ErrorLevel.Warning, "bookmark-not-found", $"Cannot find bookmark '#{bookmark}' in '{reference}'{(StringUtility.FindBestMatch(bookmark, candidateBookmarks, out var matchedBookmark) ? $", did you mean '#{matchedBookmark}'?" : ".")}", source);
 
             /// <summary>

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Docs.Build
             GitHubAccessor = new GitHubAccessor(Config);
             BookmarkValidator = new BookmarkValidator(errorLog);
             ContributionProvider = new ContributionProvider(config, buildOptions, Input, GitHubAccessor, RepositoryProvider, sourceMap);
-            FileLinkMapBuilder = new FileLinkMapBuilder(errorLog, MonikerProvider, ContributionProvider);
+            FileLinkMapBuilder = new FileLinkMapBuilder(errorLog, DocumentProvider, MonikerProvider, ContributionProvider);
             XrefResolver = new XrefResolver(
                 config,
                 FileResolver,

--- a/src/docfx/build/dependency/DependencyItem.cs
+++ b/src/docfx/build/dependency/DependencyItem.cs
@@ -11,16 +11,16 @@ namespace Microsoft.Docs.Build
         public FilePath From { get; }
 
         [JsonIgnore]
-        public ContentType FromContentType { get; }
+        public bool Transitive { get; }
 
         public FilePath To { get; }
 
         public DependencyType Type { get; }
 
-        public DependencyItem(FilePath from, FilePath to, DependencyType type, ContentType fromContentType)
+        public DependencyItem(FilePath from, FilePath to, DependencyType type, bool transitive)
         {
             From = from;
-            FromContentType = fromContentType;
+            Transitive = transitive;
             To = to;
             Type = type;
         }

--- a/src/docfx/build/link/FileLinkMapBuilder.cs
+++ b/src/docfx/build/link/FileLinkMapBuilder.cs
@@ -10,19 +10,24 @@ namespace Microsoft.Docs.Build
     internal class FileLinkMapBuilder
     {
         private readonly ErrorBuilder _errors;
+        private readonly DocumentProvider _documentProvider;
         private readonly MonikerProvider _monikerProvider;
         private readonly ContributionProvider _contributionProvider;
         private readonly ConcurrentHashSet<FileLinkItem> _links = new ConcurrentHashSet<FileLinkItem>();
 
-        public FileLinkMapBuilder(ErrorBuilder errors, MonikerProvider monikerProvider, ContributionProvider contributionProvider)
+        public FileLinkMapBuilder(
+            ErrorBuilder errors, DocumentProvider documentProvider, MonikerProvider monikerProvider, ContributionProvider contributionProvider)
         {
             _errors = errors;
+            _documentProvider = documentProvider;
             _monikerProvider = monikerProvider;
             _contributionProvider = contributionProvider;
         }
 
-        public void AddFileLink(FilePath inclusionRoot, FilePath referencingFile, string sourceUrl, string targetUrl, SourceInfo? source)
+        public void AddFileLink(FilePath inclusionRoot, FilePath referencingFile, string targetUrl, SourceInfo? source)
         {
+            var sourceUrl = _documentProvider.GetSiteUrl(inclusionRoot);
+
             if (string.IsNullOrEmpty(targetUrl) || sourceUrl == targetUrl)
             {
                 return;

--- a/src/docfx/build/page/BookmarkValidator.cs
+++ b/src/docfx/build/page/BookmarkValidator.cs
@@ -10,18 +10,18 @@ namespace Microsoft.Docs.Build
     {
         private readonly ErrorBuilder _errors;
 
-        private readonly DictionaryBuilder<Document, HashSet<string>> _bookmarksByFile = new DictionaryBuilder<Document, HashSet<string>>();
-        private readonly ListBuilder<(Document file, Document dependency, string bookmark, bool isSelfBookmark, SourceInfo? source)>
-            _references = new ListBuilder<(Document file, Document dependency, string bookmark, bool isSelfBookmark, SourceInfo? source)>();
+        private readonly DictionaryBuilder<FilePath, HashSet<string>> _bookmarksByFile = new DictionaryBuilder<FilePath, HashSet<string>>();
+        private readonly ListBuilder<(FilePath file, FilePath dependency, string bookmark, bool isSelfBookmark, SourceInfo? source)> _references
+                   = new ListBuilder<(FilePath file, FilePath dependency, string bookmark, bool isSelfBookmark, SourceInfo? source)>();
 
         public BookmarkValidator(ErrorBuilder errors)
         {
             _errors = errors;
         }
 
-        public void AddBookmarkReference(Document file, Document reference, string? fragment, bool isSelfBookmark, SourceInfo? source)
+        public void AddBookmarkReference(FilePath file, FilePath reference, string? fragment, bool isSelfBookmark, SourceInfo? source)
         {
-            if (reference.ContentType == ContentType.Page && !string.IsNullOrEmpty(fragment))
+            if (!string.IsNullOrEmpty(fragment))
             {
                 var bookmark = fragment.Substring(1).Trim();
                 if (!string.IsNullOrEmpty(bookmark))
@@ -31,7 +31,7 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public void AddBookmarks(Document file, HashSet<string> bookmarks)
+        public void AddBookmarks(FilePath file, HashSet<string> bookmarks)
         {
             _bookmarksByFile.TryAdd(file, bookmarks);
         }

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -345,7 +345,7 @@ namespace Microsoft.Docs.Build
                 }
             });
 
-            context.BookmarkValidator.AddBookmarks(file, bookmarks);
+            context.BookmarkValidator.AddBookmarks(file.FilePath, bookmarks);
             context.SearchIndexBuilder.SetBody(file, searchText.ToString());
 
             return LocalizationUtility.AddLeftToRightMarker(context.BuildOptions.Culture, result);
@@ -383,7 +383,7 @@ namespace Microsoft.Docs.Build
                 }
             }
 
-            context.BookmarkValidator.AddBookmarks(file, bookmarks);
+            context.BookmarkValidator.AddBookmarks(file.FilePath, bookmarks);
             context.SearchIndexBuilder.SetBody(file, searchText.ToString());
 
             conceptual.Conceptual = LocalizationUtility.AddLeftToRightMarker(context.BuildOptions.Culture, result);

--- a/src/docfx/build/toc/TableOfContentsMap.cs
+++ b/src/docfx/build/toc/TableOfContentsMap.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Docs.Build
                 return null;
             }
 
-            _dependencyMapBuilder.AddDependencyItem(file.FilePath, nearestToc.FilePath, DependencyType.Metadata, file.ContentType);
+            _dependencyMapBuilder.AddDependencyItem(file.FilePath, nearestToc.FilePath, DependencyType.Metadata);
             return PathUtility.NormalizeFile(PathUtility.GetRelativePathToFile(file.SitePath, nearestToc.SitePath));
         }
 

--- a/src/docfx/build/toc/TableOfContentsNode.cs
+++ b/src/docfx/build/toc/TableOfContentsNode.cs
@@ -71,6 +71,7 @@ namespace Microsoft.Docs.Build
             Items = item.Items;
             Document = item.Document;
             Children = item.Children;
+            LandingPageType = item.LandingPageType;
         }
     }
 }

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Docs.Build
     internal class XrefResolver
     {
         private readonly Config _config;
+        private readonly DocumentProvider _documentProvider;
         private readonly Lazy<IReadOnlyDictionary<string, Lazy<ExternalXrefSpec>>> _externalXrefMap;
         private readonly Lazy<IReadOnlyDictionary<string, InternalXrefSpec[]>> _internalXrefMap;
         private readonly DependencyMapBuilder _dependencyMapBuilder;
@@ -36,6 +37,7 @@ namespace Microsoft.Docs.Build
         {
             _config = config;
             _repository = repository;
+            _documentProvider = documentProvider;
             _internalXrefMap = new Lazy<IReadOnlyDictionary<string, InternalXrefSpec[]>>(
                 () => new InternalXrefMapBuilder(
                             errorLog,
@@ -55,7 +57,7 @@ namespace Microsoft.Docs.Build
         }
 
         public (Error? error, string? href, string display, Document? declaringFile) ResolveXrefByHref(
-            SourceInfo<string> href, Document referencingFile, Document inclusionRoot)
+            SourceInfo<string> href, FilePath referencingFile, FilePath inclusionRoot)
         {
             var (uid, query, fragment) = UrlUtility.SplitUrl(href);
 
@@ -98,14 +100,14 @@ namespace Microsoft.Docs.Build
 
             query = queries.AllKeys.Length == 0 ? "" : "?" + string.Join('&', queries);
             var fileLink = UrlUtility.MergeUrl(xrefSpec.Href, query, fragment);
-            _fileLinkMapBuilder.AddFileLink(inclusionRoot.FilePath, referencingFile.FilePath, inclusionRoot.SiteUrl, fileLink, href.Source);
+            _fileLinkMapBuilder.AddFileLink(inclusionRoot, referencingFile, fileLink, href.Source);
 
             resolvedHref = UrlUtility.MergeUrl(resolvedHref, query, fragment);
             return (null, resolvedHref, display, xrefSpec?.DeclaringFile);
         }
 
         public (Error? error, string? href, string display, Document? declaringFile) ResolveXrefByUid(
-            SourceInfo<string> uid, Document referencingFile, Document inclusionRoot, MonikerList? monikers = null)
+            SourceInfo<string> uid, FilePath referencingFile, FilePath inclusionRoot, MonikerList? monikers = null)
         {
             if (string.IsNullOrEmpty(uid))
             {
@@ -118,12 +120,12 @@ namespace Microsoft.Docs.Build
             {
                 return (error, null, "", null);
             }
-            _fileLinkMapBuilder.AddFileLink(inclusionRoot.FilePath, referencingFile.FilePath, inclusionRoot.SiteUrl, xrefSpec.Href, uid.Source);
+            _fileLinkMapBuilder.AddFileLink(inclusionRoot, referencingFile, xrefSpec.Href, uid.Source);
             return (null, href, xrefSpec.GetName() ?? xrefSpec.Uid, xrefSpec.DeclaringFile);
         }
 
         public (Error?, IXrefSpec?, string? href) ResolveXrefSpec(
-            SourceInfo<string> uid, Document referencingFile, Document inclusionRoot, MonikerList? monikers = null)
+            SourceInfo<string> uid, FilePath referencingFile, FilePath inclusionRoot, MonikerList? monikers = null)
         {
             var (error, xrefSpec, href) = Resolve(uid, referencingFile, inclusionRoot, monikers);
             if (xrefSpec == null)
@@ -198,7 +200,7 @@ namespace Microsoft.Docs.Build
         }
 
         private (Error?, IXrefSpec?, string? href) Resolve(
-            SourceInfo<string> uid, Document referencingFile, Document inclusionRoot, MonikerList? monikers = null)
+            SourceInfo<string> uid, FilePath referencingFile, FilePath inclusionRoot, MonikerList? monikers = null)
         {
             var (xrefSpec, href) = ResolveInternalXrefSpec(uid, referencingFile, inclusionRoot, monikers);
             if (xrefSpec is null)
@@ -225,7 +227,7 @@ namespace Microsoft.Docs.Build
         }
 
         private (IXrefSpec?, string? href) ResolveInternalXrefSpec(
-            string uid, Document referencingFile, Document inclusionRoot, MonikerList? monikers = null)
+            string uid, FilePath referencingFile, FilePath inclusionRoot, MonikerList? monikers = null)
         {
             if (_internalXrefMap.Value.TryGetValue(uid, out var specs))
             {
@@ -244,22 +246,25 @@ namespace Microsoft.Docs.Build
                 }
 
                 var dependencyType = GetDependencyType(referencingFile, spec);
-                _dependencyMapBuilder.AddDependencyItem(referencingFile.FilePath, spec.DeclaringFile.FilePath, dependencyType, referencingFile.ContentType);
-                var href = UrlUtility.GetRelativeUrl((inclusionRoot ?? referencingFile).SiteUrl, spec.Href);
+                _dependencyMapBuilder.AddDependencyItem(referencingFile, spec.DeclaringFile.FilePath, dependencyType);
+
+                var href = UrlUtility.GetRelativeUrl(_documentProvider.GetSiteUrl(inclusionRoot), spec.Href);
                 return (spec, href);
             }
             return default;
         }
 
-        private static DependencyType GetDependencyType(Document referencingFile, InternalXrefSpec xref)
+        private DependencyType GetDependencyType(FilePath referencingFile, InternalXrefSpec xref)
         {
-            if (!string.Equals(referencingFile.Mime, "LearningPath", StringComparison.Ordinal)
-                && !string.Equals(referencingFile.Mime, "Module", StringComparison.Ordinal))
+            var mime = _documentProvider.GetDocument(referencingFile).Mime.Value;
+
+            if (!string.Equals(mime, "LearningPath", StringComparison.Ordinal) &&
+                !string.Equals(mime, "Module", StringComparison.Ordinal))
             {
                 return DependencyType.Uid;
             }
 
-            switch ((referencingFile.Mime.Value, xref.DeclaringFile.Mime.Value))
+            switch ((mime, xref.DeclaringFile.Mime.Value))
             {
                 case ("LearningPath", "Module"):
                 case ("Module", "ModuleUnit"):

--- a/src/docfx/lib/markdown/MarkdownEngine.cs
+++ b/src/docfx/lib/markdown/MarkdownEngine.cs
@@ -346,9 +346,9 @@ namespace Microsoft.Docs.Build
             var status = t_status.Value!.Peek();
 
             var (error, link, display, _) = href.HasValue
-                ? _xrefResolver.ResolveXrefByHref(href.Value, GetDocument(href.Value), (Document)InclusionContext.RootFile)
+                ? _xrefResolver.ResolveXrefByHref(href.Value, GetDocument(href.Value).FilePath, ((Document)InclusionContext.RootFile).FilePath)
                 : uid.HasValue
-                    ? _xrefResolver.ResolveXrefByUid(uid.Value, GetDocument(uid.Value), (Document)InclusionContext.RootFile)
+                    ? _xrefResolver.ResolveXrefByUid(uid.Value, GetDocument(uid.Value).FilePath, ((Document)InclusionContext.RootFile).FilePath)
                     : default;
 
             if (!suppressXrefNotFound)

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -305,7 +305,7 @@ namespace Microsoft.Docs.Build
                     {
                         // the content here must be an UID, not href
                         var (xrefError, xrefSpec, href) = _xrefResolver.ResolveXrefSpec(
-                            content, file, file, _monikerProvider.GetFileLevelMonikers(ErrorBuilder.Null, file.FilePath));
+                            content, file.FilePath, file.FilePath, _monikerProvider.GetFileLevelMonikers(ErrorBuilder.Null, file.FilePath));
                         errors.AddIfNotNull(xrefError);
 
                         var xrefSpecObj = xrefSpec is null ? null : JsonUtility.ToJObject(xrefSpec.ToExternalXrefSpec(href));


### PR DESCRIPTION
`XrefResolver` now takes `FilePath` as input

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6475)