### PR TITLE
Service page fix

### DIFF
--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -1836,18 +1836,18 @@ outputs:
   a/api/a.json:
   a/api/doc.json:
   a/api/toc.json:
-  a/results/apireference.json: |
+  a/results/index.json: |
     {"name": "API Reference", "fullName": "API Reference", "children": [{"name": "App Service"}], "langs": ["csharp"], "pageType": "root"}
-  a/results/apireference/appservice.json: |
+  a/results/appservice.json: |
     {
-      "name": "App Service", "fullName": "App Service", "children": [{"name": "Client","href": "../../api/doc"},{"name": "Other"}],
+      "name": "App Service", "fullName": "App Service", "children": [{"name": "Client","href": "../api/doc"},{"name": "Other"}],
       "langs": ["csharp"], "pageType": "service"
     }
-  a/results/apireference/appservice/client.json: |
+  a/results/appservice/client.json: |
     {
       "name": "Client", "fullName": "Client", "href": "../api/doc.md",
       "children": [{"name": "Client","uid": "aa"},{"name": "MS.ServicePage.xxx"},{"name": "MS.ServicePage.Client.Form"}],
       "langs": ["csharp"], "pageType": "service"
     }
-  a/results/apireference/appservice/client/client.json: |
+  a/results/appservice/client/client.json: |
     {"name":"Client","fullName":"Client","uid":"aa","langs":["csharp"],"pageType":"service"}

--- a/src/docfx/build/toc/ServicePageGenerator.cs
+++ b/src/docfx/build/toc/ServicePageGenerator.cs
@@ -43,7 +43,17 @@ namespace Microsoft.Docs.Build
             {
                 var topLevelTOCRelativeDir = Path.GetDirectoryName(_joinTOCConfig.TopLevelToc);
                 var baseDir = string.IsNullOrEmpty(_joinTOCConfig.OutputFolder) ? topLevelTOCRelativeDir : _joinTOCConfig.OutputFolder;
-                var servicePagePath = FilePath.Generated(new PathString($"./{baseDir}/{directoryName}/{filename}.yml"));
+
+                var pageType = node.LandingPageType.Value;
+                FilePath servicePagePath;
+                if (pageType == LandingPageType.Root)
+                {
+                    servicePagePath = FilePath.Generated(new PathString($"./{baseDir}/{directoryName}/index.yml"));
+                }
+                else
+                {
+                    servicePagePath = FilePath.Generated(new PathString($"./{baseDir}/{directoryName}/{filename}.yml"));
+                }
 
                 var name = node.Name;
                 var fullName = node.Name;
@@ -86,7 +96,6 @@ namespace Microsoft.Docs.Build
                     langs = lang?.ToObject<List<string?>>();
                 }
 
-                var pageType = node.LandingPageType.Value;
                 results.Add(servicePagePath);
                 var servicePageToken = new ServicePageModel(name, fullName, href, uid, children, langs, pageType);
                 _input.AddGeneratedContent(servicePagePath, JsonUtility.ToJObject(servicePageToken), "ReferenceContainer");
@@ -94,7 +103,14 @@ namespace Microsoft.Docs.Build
 
             foreach (var item in node.Items)
             {
-                GenerateServicePageFromTopLevelTOC(item, results, $"{directoryName}/{filename}");
+                if (!string.IsNullOrEmpty(node.LandingPageType.ToString()) && node.LandingPageType == LandingPageType.Root)
+                {
+                    GenerateServicePageFromTopLevelTOC(item, results, $"{directoryName}");
+                }
+                else
+                {
+                    GenerateServicePageFromTopLevelTOC(item, results, $"{directoryName}/{filename}");
+                }
             }
         }
     }

--- a/src/docfx/build/toc/ServicePageGenerator.cs
+++ b/src/docfx/build/toc/ServicePageGenerator.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Docs.Build
 
             var filename = Regex.Replace(node.Name, @"\s+", "");
 
-            if (!string.IsNullOrEmpty(node.LandingPageType.ToString()))
+            if (node.LandingPageType.Value != null)
             {
                 var topLevelTOCRelativeDir = Path.GetDirectoryName(_joinTOCConfig.TopLevelToc);
                 var baseDir = string.IsNullOrEmpty(_joinTOCConfig.OutputFolder) ? topLevelTOCRelativeDir : _joinTOCConfig.OutputFolder;
@@ -103,7 +103,7 @@ namespace Microsoft.Docs.Build
 
             foreach (var item in node.Items)
             {
-                if (!string.IsNullOrEmpty(node.LandingPageType.ToString()) && node.LandingPageType == LandingPageType.Root)
+                if (node.LandingPageType == LandingPageType.Root)
                 {
                     GenerateServicePageFromTopLevelTOC(item, results, $"{directoryName}");
                 }


### PR DESCRIPTION
Discussed with Tianqi, when the "LandingPageType" is `Root`, the generated service page's name should be "index.yml"，and we shouldn't create a folder/directory, either. (Only create folder/directory when the "LandingPageType" is `Service`)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6484)