### PR TITLE
Use main branch as default branch when retrieving op resources

### DIFF
--- a/src/docfx/config/ConfigLoader.cs
+++ b/src/docfx/config/ConfigLoader.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Docs.Build
                 $"name={WebUtility.UrlEncode(config.Name)}" +
                 $"&locale={WebUtility.UrlEncode(locale)}" +
                 $"&repository_url={WebUtility.UrlEncode(repository?.Remote)}" +
-                $"&branch={WebUtility.UrlEncode(repository?.Branch)}" +
+                $"&branch={WebUtility.UrlEncode(repository?.Branch ?? "main")}" +
                 $"&xref_endpoint={WebUtility.UrlEncode(xrefEndpoint)}" +
                 $"&xref_query_tags={WebUtility.UrlEncode(xrefQueryTags is null ? null : string.Join(',', xrefQueryTags))}";
 


### PR DESCRIPTION
For the repository which is in a  detached head, the branch will be null, but the branch is required when retrieving op resources

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6488)