### PR TITLE
Remove required 'children' in ReferenceContainer.schema.json

### DIFF
--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -1752,7 +1752,7 @@ repos:
       a/_themes/ContentTemplate/schemas/ReferenceContainer.schema.json: |
         {
           "type": "object",
-          "required": ["uid", "name", "children", "pageType"],
+          "required": ["uid", "name", "pageType"],
           "properties": {
             "uid": {"contentType": "uid", "type": "string"},
             "name": {"type": "string"},
@@ -1832,7 +1832,6 @@ outputs:
   .errors.log: |
     {"message_severity":"warning","code":"missing-attribute","message":"Missing required attribute: 'name'.","file":"a/api/TOC.yml","line":7,"column":8}
     {"message_severity":"error","code":"missing-attribute","message":"Missing required attribute: 'uid'.","line":0,"column":0}
-    {"message_severity":"error","code":"missing-attribute","message":"Missing required attribute: 'children'.","line":0,"column":0}
   a/api/a.json:
   a/api/doc.json:
   a/api/toc.json:


### PR DESCRIPTION
Considering the build results of v2, the children can be empty. When this happens, "children" should be null and not be displayed in generated service pages. So **remove "children" from the required list**.

```yml
### YamlMime:ManagedReference
items:
- uid: azure.java.sdk.landingpage.services.mediaservices
  id: azure.java.sdk.landingpage.services.mediaservices
  children: []
  langs:
  - java
  name: Media Services
  nameWithType: Media Services
  fullName: Media Services
  type: Container
  open_to_public_contributors: false
references: []
landingPageType: Service
open_to_public_contributors: false
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6491)