### PR TITLE
Fix service page herf when the original href starts with ~/

### DIFF
--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -1811,6 +1811,7 @@ repos:
           landingPageType: Root
           items:
           - name: App Service
+            href: ~/api/doc.md
             landingPageType: Service
             items:
             - name: Client
@@ -1836,10 +1837,10 @@ outputs:
   a/api/doc.json:
   a/api/toc.json:
   a/results/index.json: |
-    {"name": "API Reference", "fullName": "API Reference", "children": [{"name": "App Service"}], "langs": ["csharp"], "pageType": "root"}
+    {"name": "API Reference", "fullName": "API Reference", "children": [{"name": "App Service", "href": "../api/doc"}], "langs": ["csharp"], "pageType": "root"}
   a/results/appservice.json: |
     {
-      "name": "App Service", "fullName": "App Service", "children": [{"name": "Client","href": "../api/doc"},{"name": "Other"}],
+      "name": "App Service", "fullName": "App Service", "href": "~/api/doc.md", "children": [{"name": "Client","href": "../api/doc"},{"name": "Other"}],
       "langs": ["csharp"], "pageType": "service"
     }
   a/results/appservice/client.json: |

--- a/src/docfx/build/toc/ServicePageGenerator.cs
+++ b/src/docfx/build/toc/ServicePageGenerator.cs
@@ -72,8 +72,20 @@ namespace Microsoft.Docs.Build
                     {
                         if (topLevelTOCRelativeDir != null)
                         {
+                            string? hrefFileFullPath;
+
                             var topLevelTOCYmlDir = Path.GetFullPath(Path.Combine(_docsetPath, topLevelTOCRelativeDir));
-                            var hrefFileFullPath = Path.GetFullPath(Path.Combine(topLevelTOCYmlDir == null ? "" : topLevelTOCYmlDir, childHref));
+
+                            if (childHref.StartsWith("~/") || childHref.StartsWith("~\\"))
+                            {
+                                childHref = childHref.Substring(2).TrimStart('/', '\\');
+                                hrefFileFullPath = Path.GetFullPath(Path.Combine(_docsetPath, childHref));
+                            }
+                            else
+                            {
+                                hrefFileFullPath = Path.GetFullPath(Path.Combine(topLevelTOCYmlDir == null ? "" : topLevelTOCYmlDir, childHref));
+                            }
+
                             var servicePageFullPath = Path.GetDirectoryName(Path.GetFullPath(Path.Combine(_docsetPath, servicePagePath.Path))) ?? _docsetPath;
                             var hrefRelativePath = Path.GetRelativePath(servicePageFullPath, hrefFileFullPath);
                             childHref = hrefRelativePath;


### PR DESCRIPTION
Fix service page herf when the original href starts with ~/

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6494)