### PR TITLE
Splitted toc metadata

### DIFF
--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -1851,3 +1851,47 @@ outputs:
     }
   a/results/appservice/client/client.json: |
     {"name":"Client","fullName":"Client","uid":"aa","langs":["csharp"],"pageType":"service"}
+---
+# TOC split metadata supporting (with build_source_folder)
+repos:
+  https://ms.com/split:
+  - files:
+      test/docfx.yml:
+      .openpublishing.publish.config.json: |
+        {
+          "docsets_to_publish": [{  "build_source_folder": "test"}],
+          "JoinTOCPlugin": [
+            {
+              "ConceptualTOC": "test/b/TOC.yml",
+              "ReferenceTOCUrl": "/dotnet-test/api/toc.json",
+              "ConceptualTOCUrl": "dotnet-test/learn/toc.json",
+              "ReferenceTOC": "test/a/TOC.yml"
+            }
+          ]
+        }
+      test/a/TOC.yml: |
+        splitItemsBy: name
+        items:
+        - name: a
+          items:
+          - name: a-a
+        - name: b
+          items:
+          - name: b-b
+      test/b/TOC.yml: |
+        splitItemsBy: name
+        items:
+        - name: 1
+          items:
+          - name: 1-1
+outputs:
+  test/b/toc.json: |
+    {"metadata": {"universal_ref_toc": "/dotnet-test/api/toc.json"}}
+  test/b/_splitted/1/toc.json: |
+    {"metadata": {"universal_ref_toc": "/dotnet-test/api/toc.json"}}
+  test/a/toc.json: |
+    {"metadata": {"universal_conceptual_toc": "dotnet-test/learn/toc.json"}}
+  test/a/_splitted/a/toc.json: |
+    {"metadata": {"universal_conceptual_toc": "dotnet-test/learn/toc.json"}}
+  test/a/_splitted/b/toc.json: |
+    {"metadata": {"universal_conceptual_toc": "dotnet-test/learn/toc.json"}}

--- a/src/docfx/config/ops/OpsConfigLoader.cs
+++ b/src/docfx/config/ops/OpsConfigLoader.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using System.Linq;
 using ECMA2Yaml;
-using Microsoft.AspNetCore.Mvc.RazorPages;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build

--- a/src/docfx/config/ops/OpsConfigLoader.cs
+++ b/src/docfx/config/ops/OpsConfigLoader.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Linq;
 using ECMA2Yaml;
+using Microsoft.AspNetCore.Mvc.RazorPages;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build
@@ -166,9 +167,19 @@ namespace Microsoft.Docs.Build
                 {
                     refToc[buildSourceFolder.GetRelativePath(new PathString(config.ConceptualTOC))] = config.ReferenceTOCUrl;
                     refToc[Path.GetRelativePath(buildSourceFolder, config.ConceptualTOC)] = config.ReferenceTOCUrl;
-                    refToc[$"{Path.GetDirectoryName(config.ConceptualTOC)}/_splitted/**"] =
+                    var conceptualTOCDirName = Path.GetDirectoryName(config.ConceptualTOC);
+                    refToc[$"{Path.GetRelativePath(buildSourceFolder, string.IsNullOrEmpty(conceptualTOCDirName) ? "." : conceptualTOCDirName)}/_splitted/**"] =
                         config.ReferenceTOCUrl;
                 }
+
+                if (!string.IsNullOrEmpty(config.ReferenceTOC) && !string.IsNullOrEmpty(config.ConceptualTOCUrl))
+                {
+                    conceptualToc[Path.GetRelativePath(buildSourceFolder, config.ReferenceTOC)] = config.ConceptualTOCUrl;
+                    var refTOCDirName = Path.GetDirectoryName(config.ReferenceTOC);
+                    conceptualToc[$"{Path.GetRelativePath(buildSourceFolder, string.IsNullOrEmpty(refTOCDirName) ? "." : refTOCDirName)}/_splitted/**"] =
+                        config.ConceptualTOCUrl;
+                }
+
                 if (!string.IsNullOrEmpty(config.ReferenceTOC) && !string.IsNullOrEmpty(config.ConceptualTOCUrl))
                 {
                     conceptualToc[buildSourceFolder.GetRelativePath(new PathString(config.ReferenceTOC))] = config.ConceptualTOCUrl;
@@ -191,12 +202,7 @@ namespace Microsoft.Docs.Build
                 {
                     item["topLevelToc"] = buildSourceFolder.GetRelativePath(new PathString(config.TopLevelTOC));
                 }
-                if (!string.IsNullOrEmpty(config.ReferenceTOC) && !string.IsNullOrEmpty(config.ConceptualTOCUrl))
-                {
-                    conceptualToc[Path.GetRelativePath(buildSourceFolder, config.ReferenceTOC)] = config.ConceptualTOCUrl;
-                    conceptualToc[$"{Path.GetDirectoryName(config.ReferenceTOC)}/_splitted/**"] =
-                        config.ConceptualTOCUrl;
-                }
+
                 joinTocConfig.Add(item);
             }
 

--- a/src/docfx/config/ops/OpsConfigLoader.cs
+++ b/src/docfx/config/ops/OpsConfigLoader.cs
@@ -166,21 +166,17 @@ namespace Microsoft.Docs.Build
                 {
                     refToc[buildSourceFolder.GetRelativePath(new PathString(config.ConceptualTOC))] = config.ReferenceTOCUrl;
                     refToc[Path.GetRelativePath(buildSourceFolder, config.ConceptualTOC)] = config.ReferenceTOCUrl;
-                    var conceptualTOCDirName = Path.GetDirectoryName(config.ConceptualTOC);
-                    refToc[$"{Path.GetRelativePath(buildSourceFolder, string.IsNullOrEmpty(conceptualTOCDirName) ? "." : conceptualTOCDirName)}/_splitted/**"] =
-                        config.ReferenceTOCUrl;
+                    var conceptualTOCDir = Path.GetDirectoryName(config.ConceptualTOC);
+                    var conceptualTOCRelativeDir = Path.GetRelativePath(buildSourceFolder, string.IsNullOrEmpty(conceptualTOCDir) ? "." : conceptualTOCDir);
+                    refToc[Path.Combine(conceptualTOCRelativeDir, "_splitted/**")] = config.ReferenceTOCUrl;
                 }
 
                 if (!string.IsNullOrEmpty(config.ReferenceTOC) && !string.IsNullOrEmpty(config.ConceptualTOCUrl))
                 {
                     conceptualToc[Path.GetRelativePath(buildSourceFolder, config.ReferenceTOC)] = config.ConceptualTOCUrl;
-                    var refTOCDirName = Path.GetDirectoryName(config.ReferenceTOC);
-                    conceptualToc[$"{Path.GetRelativePath(buildSourceFolder, string.IsNullOrEmpty(refTOCDirName) ? "." : refTOCDirName)}/_splitted/**"] =
-                        config.ConceptualTOCUrl;
-                }
-
-                if (!string.IsNullOrEmpty(config.ReferenceTOC) && !string.IsNullOrEmpty(config.ConceptualTOCUrl))
-                {
+                    var refTOCDir = Path.GetDirectoryName(config.ReferenceTOC);
+                    var refTOCRelativeDir = Path.GetRelativePath(buildSourceFolder, string.IsNullOrEmpty(refTOCDir) ? "." : refTOCDir);
+                    conceptualToc[Path.Combine(refTOCRelativeDir, "_splitted/**")] = config.ConceptualTOCUrl;
                     conceptualToc[buildSourceFolder.GetRelativePath(new PathString(config.ReferenceTOC))] = config.ConceptualTOCUrl;
                 }
 


### PR DESCRIPTION
Bug.

Use path relative to docset to get the `ConceptualTOC` and `refToc` metadata.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6497)