### PR TITLE
copyResources --> selfContained

### DIFF
--- a/docs/specs/config.yml
+++ b/docs/specs/config.yml
@@ -398,7 +398,7 @@ outputs:
 inputs:
   docfx.yml: |
     files: '**'
-    copyResources: false
+    selfContained: false
     routes:
       docs/: .
   a.png:

--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -277,12 +277,12 @@ outputs:
   .manifest.json: |
     {"files":[{"asset_id":"docs/a.json","original":"docs/a.yml","source_relative_path":"docs/a.yml","original_type":"ContextObject","type":"Toc"}]}
 ---
-# Do not copy resource when the copyResources is false
+# Do not copy resource when the selfContained is false
 legacy: true
 inputs:
   docfx.yml: |
     files: a.png
-    copyResources: false
+    selfContained: false
   a.png:
 outputs:
   .publish.json: |

--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -682,7 +682,7 @@ inputs:
   docsets.yml: |
     docsets: new-hope/new-hope/*
   new-hope/new-hope/docfx.yml: |
-    copyResources: false
+    selfContained: false
   new-hope/new-hope/specs/unify-version/unify-version.md: |
     ![ready-for-review](../../../new-hope/specs/gauntlet/media/ready-for-review.png)
   new-hope/new-hope/specs/international-content/docs-vscode-validation.md: |

--- a/docs/specs/output.yml
+++ b/docs/specs/output.yml
@@ -34,11 +34,11 @@ outputs:
       "base_path": "/"
     }
 ---
-# Publish manifest path is source relative path when copyResources is set to false
+# Publish manifest path is source relative path when selfContained is set to false
 inputs:
   docfx.yml: |
     files: '**'
-    copyResources: false
+    selfContained: false
   a.png:
 outputs:
   .publish.json: |

--- a/docs/specs/static.yml
+++ b/docs/specs/static.yml
@@ -1,9 +1,12 @@
-# Copy assets in template definition to output directory
+# Copy assets in template definition to output directory for self contained build
 inputs:
-  docfx.yml: |
-    outputType: html
-    urlType: pretty
-    template: _themes
+  docsets.yml:
+  a/docfx.yml: |
+    selfContained: true
+    template: ../_themes
+  b/docfx.yml: |
+    selfContained: false
+    template: ../_themes
   _themes/template.yml: |
     assets:
     - styles/**
@@ -11,20 +14,8 @@ inputs:
   _themes/styles/main.css: css
   _themes/scripts/main.js: js
 outputs:
-  styles/main.css: css
-  scripts/main.js: js
----
-# Copy assets in template definition to output directory only when output is HTML
-inputs:
-  docfx.yml: |
-    template: _themes
-  _themes/template.yml: |
-    assets:
-    - styles/**
-    - scripts/**
-  _themes/styles/main.css: css
-  _themes/scripts/main.js: js
-outputs:
+  a/styles/main.css: css
+  a/scripts/main.js: js
 ---
 # Liquid template file missing should not crash
 inputs: 

--- a/src/Microsoft.Docs.LearnValidation/Models/LegacyManifestOutputItem.cs
+++ b/src/Microsoft.Docs.LearnValidation/Models/LegacyManifestOutputItem.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Docs.LearnValidation
 
         /// <summary>
         /// Gets or sets output absolute path, used when output not within build output directory
-        /// e.g. resource's output when <see cref="OutputConfig.CopyResources"/> = false
+        /// e.g. resource's output when <see cref="OutputConfig.SelfContained"/> = false
         /// </summary>
         [JsonProperty("link_to_path")]
         public string LinkToPath { get; set; }

--- a/src/docfx/build/legacy/LegacyUtility.cs
+++ b/src/docfx/build/legacy/LegacyUtility.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Docs.Build
         public static string ToLegacyOutputPathRelativeToBasePath(this FilePath doc, Context context, PublishItem manifestItem)
         {
             var outputPath = manifestItem.Path;
-            if (outputPath is null || (context.DocumentProvider.GetContentType(doc) == ContentType.Resource && !context.Config.CopyResources))
+            if (outputPath is null || (context.DocumentProvider.GetContentType(doc) == ContentType.Resource && !context.Config.SelfContained))
             {
                 outputPath = context.DocumentProvider.GetOutputPath(doc);
             }

--- a/src/docfx/build/legacy/manifest/LegacyManifest.cs
+++ b/src/docfx/build/legacy/manifest/LegacyManifest.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Docs.Build
                     RelativePath = legacyOutputPathRelativeToBasePath,
                     IsRawPage = false,
                 };
-                if (!context.Config.CopyResources)
+                if (!context.Config.SelfContained)
                 {
                     resourceOutput.LinkToPath = Path.GetFullPath(Path.Combine(docsetPath, document.Path));
                 }

--- a/src/docfx/build/legacy/manifest/LegacyManifestOutputItem.cs
+++ b/src/docfx/build/legacy/manifest/LegacyManifestOutputItem.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Docs.Build
 
         /// <summary>
         /// Gets or sets output absolute path, used when output not within build output directory
-        /// e.g. resource's output when <see cref="OutputConfig.CopyResources"/> = false
+        /// e.g. resource's output when <see cref="OutputConfig.SelfContained"/> = false
         /// </summary>
         [JsonProperty("link_to_path")]
         public string? LinkToPath { get; set; }

--- a/src/docfx/build/resource/BuildResource.cs
+++ b/src/docfx/build/resource/BuildResource.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Docs.Build
             // Output path is source file path relative to output folder when copy resource is disabled
             var copy = true;
 
-            if (!context.Config.CopyResources &&
+            if (!context.Config.SelfContained &&
                 context.Input.TryGetPhysicalPath(file, out var physicalPath))
             {
                 outputPath = PathUtility.NormalizeFile(Path.GetRelativePath(context.Output.OutputPath, physicalPath));

--- a/src/docfx/cli/CommandLineOptions.cs
+++ b/src/docfx/cli/CommandLineOptions.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Docs.Build
             {
                 config["outputType"] = "Json";
                 config["urlType"] = "Docs";
-                config["copyResources"] = false;
+                config["selfContained"] = false;
             }
 
             if (Template != null)

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -83,9 +83,10 @@ namespace Microsoft.Docs.Build
         public bool LowerCaseUrl { get; private set; } = true;
 
         /// <summary>
-        /// Gets whether resources are copied to output.
+        /// Gets whether dependencies such as images and template styles
+        /// are copied to output so the output folder can be deployed as a self-contained website.
         /// </summary>
-        public bool CopyResources { get; private set; } = true;
+        public bool SelfContained { get; private set; } = true;
 
         /// <summary>
         /// Gets the maximum errors of each file to output.

--- a/src/docfx/template/TemplateEngine.cs
+++ b/src/docfx/template/TemplateEngine.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Docs.Build
 
         public void CopyAssetsToOutput()
         {
-            if (_config.OutputType != OutputType.Html || !_config.SelfContained || _templateDefinition.Assets.Length <= 0)
+            if (!_config.SelfContained || _templateDefinition.Assets.Length <= 0)
             {
                 return;
             }

--- a/src/docfx/template/TemplateEngine.cs
+++ b/src/docfx/template/TemplateEngine.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Docs.Build
 
         public void CopyAssetsToOutput()
         {
-            if (_config.OutputType != OutputType.Html || _templateDefinition.Assets.Length <= 0)
+            if (_config.OutputType != OutputType.Html || !_config.SelfContained || _templateDefinition.Assets.Length <= 0)
             {
                 return;
             }

--- a/test/docfx.Test/ModuleInitializer.cs
+++ b/test/docfx.Test/ModuleInitializer.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Docs.Build
             Environment.SetEnvironmentVariable("DOCFX_HOST_NAME", "docs.com");
             Environment.SetEnvironmentVariable("DOCFX_OUTPUT_TYPE", "Json");
             Environment.SetEnvironmentVariable("DOCFX_URL_TYPE", "Docs");
-            Environment.SetEnvironmentVariable("DOCFX_COPY_RESOURCES", "true");
 
             TestQuirks.Verbose = true;
             TestUtility.MakeDebugAssertThrowException();


### PR DESCRIPTION
[AB#295823](https://dev.azure.com/ceapex/Engineering/_workitems/edit/295823/)

This flag should now also affects whether to copy static template assets to output, so self-contained is a better name because it represents whether the output is a self-contained website that is xcopy deployable.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6500)