### PR TITLE
By default taking highest version xref

### DIFF
--- a/docs/designs/xref.md
+++ b/docs/designs/xref.md
@@ -357,7 +357,7 @@ resolving uid `a` should take the one with the highest version and also respect 
       folder-3:
           - b.md(<a href="url">A1</a>)
   ```
-- multiple versioning with different product names, take the one with highest product name alphabetically
+- multiple versioning with different product names, take the one with highest moniker version defined in moniker definition file
   ```
   inputs:
       folder-1(a-1.0, a-2.0):

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -731,13 +731,13 @@ inputs:
 outputs:
   afb33dd2/docs/a.json:
   docs/c.json: |
-    {"conceptual":"<p>Link to <a href=\"a\" data-linktype=\"relative-path\">netcore-1.1, netcore-2.0</a></p>"}
+    {"conceptual":"<p>Link to <a href=\"a\" data-linktype=\"relative-path\">netcore-2.0, netcore-2.1</a></p>"}
   .errors.log: |
     {"message_severity":"error","code":"moniker-overlapping","message":"Two or more documents with the same uid `a`('docs/v1/a.md', 'docs/v2/a.md') have defined overlapping moniker: 'netcore-2.0'."}
     {"message_severity":"warning","code":"xref-property-conflict","message":"UID 'a' is defined with different names: 'netcore-1.1, netcore-2.0', 'netcore-2.0, netcore-2.1'."}
     {"message_severity":"warning","code":"publish-url-conflict","message":"Two or more files of the same version('netcore-2.0') publish to the same url '/docs/a': 'docs/v1/a.md<'netcore-1.1', 'netcore-2.0'>', 'docs/v2/a.md<'netcore-2.0', 'netcore-2.1'>'."}
   .xrefmap.json: | 
-    {"references":[{"uid":"a","name":"netcore-1.1, netcore-2.0"}]}
+    {"references":[{"uid":"a","name":"netcore-2.0, netcore-2.1"}]}
   .publish.json: |
     {
       "files": 

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -1626,6 +1626,59 @@ outputs:
     {"content": "<a href=\"../v1/a.json\" data-linktype=\"relative-path\"> name 1.0 </a>"}
   4667fedf/v2/b.mta.json:
 ---
+# can cross version reference, using highest version
+legacy: true
+inputs:
+  docfx.yml: |
+    monikerDefinition: monikerDefinition.json
+  monikerDefinition.json: |
+    {
+      "monikers": [
+        { "moniker_name": "netcore-1.0", "product_name": ".NET Core" },
+        { "moniker_name": "netcore-2.0", "product_name": ".NET Core" },
+        { "moniker_name": "netcore-3.0", "product_name": ".NET Core" }
+      ]
+    }
+  v1/a.yml: |
+    ### YamlMime:TestData
+    metadata:
+      monikers: netcore-1.0
+    uid: a
+    name: name 1.0
+  v2/a.yml: |
+    ### YamlMime:TestData
+    metadata:
+      monikers: netcore-2.0
+    uid: a
+    name: name 2.0
+  v3/b.yml: |
+    ### YamlMime:TestPage
+    metadata:
+      monikers: netcore-3.0
+    xref: a
+  _themes/ContentTemplate/schemas/TestData.schema.json: |
+    {
+      "xrefProperties": ["name"],
+      "properties": { "uid": { "contentType": "uid" }}
+    }
+  _themes/ContentTemplate/schemas/TestPage.schema.json: |
+    {
+      "properties": { 
+        "xref": { "contentType": "xref" }
+      }
+    }
+  _themes/ContentTemplate/TestPage.html.primary.tmpl: |
+    <xref uid="xref"/>
+
+outputs:
+  136a42ac/v1/a.json:
+  4667fedf/v2/a.json:
+  439a76d0/v3/b.raw.page.json: |
+    {"content": "<a href=\"../v2/a.json\" data-linktype=\"relative-path\"> name 2.0 </a>"}
+  439a76d0/v3/b.mta.json:
+  .errors.log: |
+    {"message_severity":"warning","code":"xref-property-conflict","message":"UID 'a' is defined with different names: 'name 1.0', 'name 2.0'."}
+---
 # When href doesn't exist, should display the alt but not the text.
 inputs:
   docfx.yml: |

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -158,7 +158,11 @@ namespace Microsoft.Docs.Build
                 }
             }
 
-            return specsWithSameUid.OrderBy(spec => spec.DeclaringFile).ToArray();
+            return specsWithSameUid
+                   .OrderByDescending(spec => spec.Monikers.HasMonikers
+                        ? spec.Monikers.Select(moniker => _monikerProvider.GetMonikerOrder(moniker)).Max()
+                        : 0)
+                   .ToArray();
         }
 
         private static bool CheckOverlappingMonikers(IXrefSpec[] specsWithSameUid, out HashSet<string> overlappingMonikers)

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Docs.Build
             return specsWithSameUid
                    .OrderByDescending(spec => spec.Monikers.HasMonikers
                         ? spec.Monikers.Select(moniker => _monikerProvider.GetMonikerOrder(moniker)).Max()
-                        : 0)
+                        : int.MaxValue)
                    .ThenBy(spec => spec.DeclaringFile)
                    .ToArray();
         }

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -162,6 +162,7 @@ namespace Microsoft.Docs.Build
                    .OrderByDescending(spec => spec.Monikers.HasMonikers
                         ? spec.Monikers.Select(moniker => _monikerProvider.GetMonikerOrder(moniker)).Max()
                         : 0)
+                   .ThenBy(spec => spec.DeclaringFile)
                    .ToArray();
         }
 

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -238,11 +238,7 @@ namespace Microsoft.Docs.Build
                 }
                 else
                 {
-                    spec = specs.FirstOrDefault(s => s.Monikers.Intersects(monikers.Value));
-                    if (spec == null)
-                    {
-                        return default;
-                    }
+                    spec = specs.FirstOrDefault(s => s.Monikers.Intersects(monikers.Value)) ?? specs[0];
                 }
 
                 var dependencyType = GetDependencyType(referencingFile, spec);


### PR DESCRIPTION
[AB#293823](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/293823)

By default taking highest versioned uid when:
- multiple-versioned uid defined.
- no version intersection between referencing file & referenced uid

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6501)