### PR TITLE
[BREAKING]: Replace --legacy command line switch with --output-type

### DIFF
--- a/docs/designs/output.md
+++ b/docs/designs/output.md
@@ -2,8 +2,6 @@
 
 This document specifies docfx output file layout. It is designed to satisfy these requirements:
 
-- **Backward compatible with legacy system**: the output files should contain all the information needed to transform to whatever the *legacy system* desires. With an *undocumented* command line switch `--legacy`, `docfx` converts the output files to the legacy format.
-
 - **Dynamic build output maps directly to hosting server**: the build output for dynamic rendering should map directly to what the hosting layer expects, without permutation.
   > *Hosting server* here is a fictional server using `documentdb`
 

--- a/docs/specs/landingData.yml
+++ b/docs/specs/landingData.yml
@@ -1,8 +1,8 @@
 ---
 # Tags and comments in the sections item with cardsM className should be remove
-legacy: true
 inputs:
-  docfx.yml:
+  docfx.yml: |
+    outputType: pageJson
   docs/index.yml: |
     ### YamlMime:YamlDocument
     documentType: LandingData
@@ -23,9 +23,9 @@ outputs:
     { "content": "<ul class=\"cardsM cols cols1\"><li><a class=\"card\" href=\"/en-us/a\" data-linktype=\"absolute-path\"><img class=\"cardImage\" role=\"presentation\" src=\"./a.png\" data-linktype=\"relative-path\"><div class=\"cardText\"><h3></h3><p>Test html</p></div></a></li></ul>" }
 ---
 # Support grid type
-legacy: true
 inputs:
-  docfx.yml:
+  docfx.yml: |
+    outputType: pageJson
   docs/index.yml: |
     ### YamlMime:YamlDocument
     documentType: landingData

--- a/docs/specs/learn.yml
+++ b/docs/specs/learn.yml
@@ -1,11 +1,10 @@
 ---
 # Draft run learn post validation
 noDryRun: true
-legacy: true
 repos:
   https://github.com/learn/learn-pr:
   - files:
-     .openpublishing.publish.config.json: |
+      .openpublishing.publish.config.json: |
         {
           "docsets_to_publish": [
           { 
@@ -17,7 +16,8 @@ repos:
             }
           }]
         }
-     learn-pr/docfx.json: '{}'
+      learn-pr/docfx.yml: |
+        outputType: pageJson
 outputs:
   learn-pr/hierarchy.json: |
     {
@@ -47,12 +47,11 @@ repos:
 outputs:
 ---
 # Can generate hierarchy
-legacy: true
 noDryRun: true
 repos:
   https://github.com/learn/learn-pr:
   - files:
-     .openpublishing.publish.config.json: |
+      .openpublishing.publish.config.json: |
         {
           "docsets_to_publish": [
           { 
@@ -64,29 +63,30 @@ repos:
             }
           }]
         }
-     docfx.json: '{}'
-     # NOTICE: these input data are created based on real output data, for not to write too much template logic in test case
-     path.yml: |
-       ### YamlMime:LearningPath
-       serviceData: "{\"uid\": \"learning-path\",\"achievement\":{\"uid\":\"achievement1\",\"type\":\"trophy\"},\"modules\":[\"module\"]}"
-     module.yml: |
-       ### YamlMime:Module
-       serviceData: "{\"uid\": \"module\",\"achievement\":{\"uid\":\"achievement2\",\"type\":\"badge\"},\"units\":[\"unit\"]}"
-     unit.yml: |
-       ### YamlMime:ModuleUnit
-       metadata:
-         uid: unit
-       serviceData: "{\"uid\": \"unit\",\"durationInMinutes\":3}"
-     achievement.yml: |
-       ### YamlMime:Achievement
-         uid: achievement
-     _themes/ContentTemplate/schemas/LearningPath.schema.json: '{}'
-     _themes/ContentTemplate/LearningPath.html.primary.tmpl:
-     _themes/ContentTemplate/schemas/Module.schema.json: '{}'
-     _themes/ContentTemplate/Module.html.primary.tmpl:
-     _themes/ContentTemplate/schemas/ModuleUnit.schema.json: '{}'
-     _themes/ContentTemplate/ModuleUnit.html.primary.tmpl:
-     _themes/ContentTemplate/schemas/Achievement.schema.json:
+      docfx.yml: |
+        outputType: pageJson
+      # NOTICE: these input data are created based on real output data, for not to write too much template logic in test case
+      path.yml: |
+        ### YamlMime:LearningPath
+        serviceData: "{\"uid\": \"learning-path\",\"achievement\":{\"uid\":\"achievement1\",\"type\":\"trophy\"},\"modules\":[\"module\"]}"
+      module.yml: |
+        ### YamlMime:Module
+        serviceData: "{\"uid\": \"module\",\"achievement\":{\"uid\":\"achievement2\",\"type\":\"badge\"},\"units\":[\"unit\"]}"
+      unit.yml: |
+        ### YamlMime:ModuleUnit
+        metadata:
+          uid: unit
+        serviceData: "{\"uid\": \"unit\",\"durationInMinutes\":3}"
+      achievement.yml: |
+        ### YamlMime:Achievement
+        uid: achievement
+      _themes/ContentTemplate/schemas/LearningPath.schema.json: '{}'
+      _themes/ContentTemplate/LearningPath.html.primary.tmpl:
+      _themes/ContentTemplate/schemas/Module.schema.json: '{}'
+      _themes/ContentTemplate/Module.html.primary.tmpl:
+      _themes/ContentTemplate/schemas/ModuleUnit.schema.json: '{}'
+      _themes/ContentTemplate/ModuleUnit.html.primary.tmpl:
+      _themes/ContentTemplate/schemas/Achievement.schema.json:
 outputs:
   achievement.json:
   path.mta.json:
@@ -403,7 +403,6 @@ outputs:
     }
 ---
 # Loc-build remote invalid items from .publish.json
-legacy: true
 noDryRun: true
 locale: zh-CN
 environments:
@@ -427,6 +426,7 @@ repos:
           }]
         }
      docfx.yml: |
+       outputType: pageJson
        http:
          https://op-build-prod.azurewebsites.net:
            headers:

--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -1,11 +1,11 @@
 # Build with --legacy
-legacy: true
 repos:
   https://github.com/legacy/test:
   - author: Charlie
     email: charlie@contoso.com
     files:
       docfx.yml: |
+        outputType: pageJson
         template: https://docs.com/theme
         metadataSchema: schema.json
         updateTimeAsCommitBuildTime: true
@@ -70,7 +70,7 @@ outputs:
         <meta name=\"depot_name\" content=\".\" />
         <meta name=\"document_id\" content=\"fdb5a0d7-b68e-c465-9c5e-54a5cda94902\" />
         <meta name=\"document_version_independent_id\" content=\"92a5a770-f05f-b8bb-81c9-a8d786a9e608\" />
-        <meta name=\"gitcommit\" content=\"https://github.com/legacy/test/blob/882f998f63d445aeaae7362eea74195ce5e3c333/c.md\" />
+        <meta name=\"gitcommit\" content=\"https://github.com/legacy/test/blob/e88185569e9862b31cce708c78de92c3be696df6/c.md\" />
         <meta name=\"locale\" content=\"en-us\" />
         <meta name=\"ms.author\" content=\"yufeih\" />
         <meta name=\"original_content_git_url\" content=\"https://github.com/legacy/test/blob/main/c.md\" />
@@ -83,6 +83,7 @@ outputs:
         <meta name=\"updated_at\" content=\"2020-04-01 08:08 AM\" />
         <meta name=\"wordCount\" content=\"1\" />"
     }
+  d.png:
   c.mta.json: |
     { "locale": "en-us", "ms.author": "yufeih", "is_dynamic_rendering": true }
   toc.json:
@@ -233,7 +234,6 @@ outputs:
     { "message_severity": "warning", "code": "output-path-conflict" }
 ---
 # Redirection file href shouldn't have extension
-legacy: true
 inputs:
   docfx.yml:
   redirections.yml: |
@@ -242,9 +242,8 @@ inputs:
   a.md: |
     [link](redirect.md)
 outputs:
-  a.mta.json:
-  a.raw.page.json: |
-    { "content": "<p>\n<a data-linktype=\"relative-path\" href=\"redirect\">link</a></p>" }
+  a.json: |
+    { "conceptual": "<p>\n<a data-linktype=\"relative-path\" href=\"redirect\">link</a></p>" }
 ---
 # Legacy metadata black list
 inputs:
@@ -266,7 +265,6 @@ outputs:
     {"message_severity":"warning","code":"attribute-reserved","message":"Attribute ms.contentlang is reserved for use by Docs.","file":"docs/a.md","line":2,"column":1}
 ---
 # Context object type is TOC
-legacy: true
 inputs:
   docfx.yml: |
   docs/a.yml: |
@@ -278,7 +276,6 @@ outputs:
     {"files":[{"asset_id":"docs/a.json","original":"docs/a.yml","source_relative_path":"docs/a.yml","original_type":"ContextObject","type":"Toc"}]}
 ---
 # Do not copy resource when the selfContained is false
-legacy: true
 inputs:
   docfx.yml: |
     files: a.png
@@ -291,9 +288,9 @@ outputs:
     {"files":[{"asset_id":"a.png","output":{"resource":{"is_raw_page":false,"relative_path":"a.png"}}}]}
 ---
 # Build versioning repository
-legacy: true
 inputs:
   docfx.yml: |
+    outputType: pageJson
     monikerRange:
       'docs/v1/**': '< netcore-2.0'
       'docs/v2/**': 'netcore-2.0'
@@ -354,7 +351,6 @@ outputs:
     }
 ---
 # Orphan file, with multiple toc of same site path, look up by file path(sub then parent)
-legacy: true # only legacy has toc dependency for orphan file
 inputs:
   docfx.yml: |
     monikerRange:
@@ -380,18 +376,15 @@ inputs:
     }
 outputs:
   docs/136a42ac/toc.json:
-  docs/136a42ac/f1/a.mta.json:
-  docs/136a42ac/f1/a.raw.page.json: |
-    {"rawMetadata":{"_tocRel": "../toc.json"}}
+  docs/136a42ac/f1/a.json: |
+    {"_tocRel": "../toc.json"}
   docs/4667fedf/toc.json:
-  docs/4667fedf/f1/a.mta.json:
-  docs/4667fedf/f1/a.raw.page.json: |
-    {"rawMetadata":{"_tocRel": "../toc.json"}}
+  docs/4667fedf/f1/a.json: |
+    {"_tocRel": "../toc.json"}
   docs/filemap.json:
 ---
-# legacy errors from source repo [repo mapping]
+# Errors from source repo [repo mapping]
 locale: zh-cn
-legacy: true
 repos:
   https://docs.com/error-from-source-legacy#test:
     - files:
@@ -406,15 +399,14 @@ repos:
         docs/a.md: |
           @a
 outputs:
-  docs/a.mta.json:
-  docs/a.raw.page.json:
+  docs/a.json:
   .errors.log: |
     {"message_severity":"error","code":"fallback-error","message":"Error(s) from 'en-us' repository caused this build failure, please check 'en-us' build report."}
 ---
 # Replace empty content with <div></div>
-legacy: true
 inputs:
-  docfx.yml:
+  docfx.yml: |
+    outputType: pageJson
   a.md:
   b.yml: '#YamlMime:TestPage'
   _themes/ContentTemplate/schemas/TestPage.schema.json: '{}'
@@ -426,9 +418,9 @@ outputs:
   b.raw.page.json: '{"content": "<div></div>"}'
 ---
 # Add data-linktype to urls
-legacy: true
 inputs:
-  docfx.yml:
+  docfx.yml: |
+    outputType: pageJson
   a.md: '[](https://github.com)'
   b.yml: |
     #YamlMime:TestPage
@@ -456,9 +448,9 @@ outputs:
         <p><a data-linktype='relative-path' href='a'></a></p>" }
 ---
 # The site base path is empty.
-legacy: true
 inputs:
-  docfx.yml:
+  docfx.yml: |
+    outputType: pageJson
   index.md:
 outputs:
   index.mta.json:
@@ -467,9 +459,9 @@ outputs:
     {"files":[{"asset_id":"index","original":"index.md","source_relative_path":"index.md","original_type":"Conceptual","type":"Content"}]}
 ---
 # Verify output path
-legacy: true
 inputs:
-  docfx.yml:
+  docfx.yml: |
+    outputType: pageJson
   offboarding-mailbox-fails-homemdb-homemta.md:
   a.b.md:
 outputs:

--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -1,4 +1,4 @@
-# Build with --legacy
+# Build output as page json
 repos:
   https://github.com/legacy/test:
   - author: Charlie

--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -356,7 +356,7 @@ outputs:
 ---
 # validate internal/external bookmarks in markdown documents
 inputs:
-  docfx.yml: |
+  docfx.yml:
   docs/a.md: |
     # title 1
     [link to title 1](#title-1)

--- a/docs/specs/output.yml
+++ b/docs/specs/output.yml
@@ -746,7 +746,6 @@ outputs:
     {"dependencies":undefined}
 ---
 # verify legacy output with source map
-legacy: true
 repos:
   https://github.com/relocate/source-file:
     - files:
@@ -770,10 +769,8 @@ repos:
 outputs:
   .errors.log: |
     {"message_severity":"error","code":"schema-not-found","message":"Unknown schema ''.","file":"a/original.xml"}
-  b.mta.json:
-  b.raw.page.json:
-  c.mta.json:
-  c.raw.page.json:
+  b.json:
+  c.json:
   op_aggregated_file_map_info.json: |
     {
       "aggregated_file_map_items": 
@@ -818,7 +815,6 @@ outputs:
     }
 ---
 # Expose all toc reference to aggregated file map
-legacy: true
 inputs:
   docfx.yml:
   docs/a.md:
@@ -827,8 +823,7 @@ inputs:
   docs/a/TOC.md: |
     # [file reference](../a.md)
 outputs:
-  docs/a.mta.json:
-  docs/a.raw.page.json:
+  docs/a.json:
   docs/toc.json:
   docs/a/toc.json:
   op_aggregated_file_map_info.json: |

--- a/docs/specs/restore.yml
+++ b/docs/specs/restore.yml
@@ -299,7 +299,6 @@ outputs:
     {"files": [{"url": "/crrb/folder/b", "monikers":["netcore-1.1"]}, {"url": "/docs/b", "monikers":["netcore-1.0","netcore-1.1"]}]}
 ---
 # crr files have same name but in different crr
-legacy: true
 repos:
   https://docs.com/crrsame/a:
     - files:
@@ -331,18 +330,12 @@ repos:
           [link to b](b.md)
         b.md:
 outputs:
-  docs/a.mta.json:
-  docs/a.raw.page.json:
-  docs/b.mta.json:
-  docs/b.raw.page.json:
-  crrb/a.mta.json:
-  crrb/a.raw.page.json:
-  crrb/b.mta.json:
-  crrb/b.raw.page.json:
-  crrc/a.mta.json:
-  crrc/a.raw.page.json:
-  crrc/b.mta.json:
-  crrc/b.raw.page.json:
+  docs/a.json:
+  docs/b.json:
+  crrb/a.json:
+  crrb/b.json:
+  crrc/a.json:
+  crrc/b.json:
   filemap.json: |
     {
       "file_mapping": {

--- a/docs/specs/schema.yml
+++ b/docs/specs/schema.yml
@@ -353,9 +353,9 @@ outputs:
     {"message_severity":"error","code":"unexpected-type","message":"Expected type 'Object' but got 'Array'.","file":"a.yml","line":1,"column":1}
 ---
 # Validate bookmark against content HTML after applying template for SDP 
-legacy: true
 inputs:
-  docfx.yml:
+  docfx.yml: |
+    outputType: pageJson
   a.yml: |
     #YamlMime:TestPage
     heading: heading-1

--- a/docs/specs/template.yml
+++ b/docs/specs/template.yml
@@ -47,8 +47,7 @@ outputs:
   b.json: |
     ['p1', 'p2']
 ---
-# Run data-transform if provided in legacy mode, by default return {"content": "serialized json"}
-legacy: true
+# Run data-transform if provided, by default return {"content": "serialized json"}
 inputs:
   docfx.yml:
   a.yml: |
@@ -172,10 +171,10 @@ outputs:
   a.json:
 ---
 # Support <xref> tag in mustache template
-legacy: true
 inputs:
   docfx.yml: |
     xref: xrefmap.yml
+    outputType: pageJson
   xrefmap.yml: |
     references:
       - uid: uid1
@@ -299,9 +298,9 @@ outputs:
 ---
 # Leave xref-properties empty if not explicitly defined by author,
 # to avoid unintentional inheritance from parent context
-legacy: true
 inputs:
-  docfx.yml:
+  docfx.yml: |
+    outputType: pageJson
   _themes/ContentTemplate/schemas/XrefDeclaration.schema.json: |
     {
       "type": "object",
@@ -353,10 +352,10 @@ outputs:
         </p>"
     }
 ---
-# Uid self reference 
-legacy: true
+# Uid self reference
 inputs:
-  docfx.yml:
+  docfx.yml: |
+    outputType: pageJson
   _themes/ContentTemplate/schemas/TestPage.schema.json: |
     {
       "properties": {
@@ -405,9 +404,9 @@ outputs:
     }
 ---
 # Known variables in <xref> tag does not fallback to parent scope.
-legacy: true
 inputs:
-  docfx.yml:
+  docfx.yml: |
+    outputType: pageJson
   _themes/ContentTemplate/schemas/TestPage.schema.json: |
     {
       "properties": {
@@ -455,9 +454,9 @@ outputs:
     {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'unresolved2'.","file":"a.yml","line":7,"end_line":7,"column":10,"end_column":21}
 ---
 # Known variables in <xref> tag for external xref spec does not fallback to parent scope.
-legacy: true
 inputs:
   docfx.yml: |
+    outputType: pageJson
     xref: xref.yml
   xref.yml: |
     references:

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -1512,9 +1512,9 @@ outputs:
     {"message_severity":"warning","code":"xref-property-conflict","message":"UID 'a' is defined with different descriptions: 'test 1', 'test 2'."}
 ---
 # referencing multiple version, using uid with intersection for toc & SDP
-legacy: true
 inputs:
   docfx.yml: |
+    outputType: pageJson
     monikerRange:
       'docs/v1/**': 'netcore-1.0'
       'docs/v2/**': 'netcore-2.0'
@@ -1584,9 +1584,9 @@ outputs:
     {"message_severity":"warning","code":"xref-property-conflict","message":"UID 'a' is defined with different names: 'name 1.0', 'name 2.0'."}
 ---
 # can cross version referencing single-version uid
-legacy: true
 inputs:
   docfx.yml: |
+    outputType: pageJson
     monikerDefinition: monikerDefinition.json
   monikerDefinition.json: |
     {
@@ -1627,9 +1627,9 @@ outputs:
   4667fedf/v2/b.mta.json:
 ---
 # can cross version reference, using highest version
-legacy: true
 inputs:
   docfx.yml: |
+    outputType: pageJson
     monikerDefinition: monikerDefinition.json
   monikerDefinition.json: |
     {

--- a/src/docfx/build/document/DocumentProvider.cs
+++ b/src/docfx/build/document/DocumentProvider.cs
@@ -88,7 +88,8 @@ namespace Microsoft.Docs.Build
                     var fileExtension = _config.OutputType switch
                     {
                         OutputType.Html => file.IsHtml ? ".html" : ".json",
-                        OutputType.Json => _config.Legacy && file.IsHtml ? ".raw.page.json" : ".json",
+                        OutputType.Json => ".json",
+                        OutputType.PageJson => file.IsHtml ? ".raw.page.json" : ".json",
                         _ => throw new NotSupportedException(),
                     };
                     outputPath = Path.ChangeExtension(outputPath, fileExtension);
@@ -99,6 +100,7 @@ namespace Microsoft.Docs.Build
                     {
                         OutputType.Html => file.IsHtml ? ".html" : ".json",
                         OutputType.Json => ".json",
+                        OutputType.PageJson => ".json",
                         _ => throw new NotSupportedException(),
                     };
                     outputPath = Path.ChangeExtension(outputPath, tocExtension);

--- a/src/docfx/build/legacy/manifest/LegacyManifest.cs
+++ b/src/docfx/build/legacy/manifest/LegacyManifest.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Docs.Build
                 Original = fileManifest.Value.SourcePath,
                 SourceRelativePath = context.SourceMap.GetOriginalFilePath(document) ?? document.Path,
                 OriginalType = GetOriginalType(contentType, context.DocumentProvider.GetMime(document)),
-                Type = GetType(context, contentType, isHtml),
+                Type = GetType(contentType, isHtml),
                 Output = output,
                 SkipNormalization = !(contentType == ContentType.Resource),
                 SkipSchemaCheck = !(contentType == ContentType.Resource),
@@ -163,9 +163,9 @@ namespace Microsoft.Docs.Build
             _ => string.Empty,
         };
 
-        private static string GetType(Context context, ContentType type, bool isHtml)
+        private static string GetType(ContentType type, bool isHtml)
         {
-            if (context.Config.OutputType == OutputType.Json && type == ContentType.Page && !isHtml)
+            if (type == ContentType.Page && !isHtml)
             {
                 return "Toc";
             }

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Docs.Build
                     context.Output.WriteJson(Path.ChangeExtension(outputPath, ".json"), output);
                 }
 
-                if (context.Config.Legacy && isHtml)
+                if (context.Config.OutputType == OutputType.PageJson && isHtml)
                 {
                     var metadataPath = outputPath.Substring(0, outputPath.Length - ".raw.page.json".Length) + ".mta.json";
                     context.Output.WriteJson(metadataPath, metadata);
@@ -91,13 +91,14 @@ namespace Microsoft.Docs.Build
                 JsonUtility.Merge(outputModel, sourceModel, new JObject { ["metadata"] = outputMetadata });
             }
 
-            if (context.Config.OutputType == OutputType.Json && !context.Config.Legacy)
+            if (context.Config.OutputType == OutputType.Json)
             {
                 return (outputModel, JsonUtility.SortProperties(outputMetadata));
             }
 
             var (templateModel, templateMetadata) = CreateTemplateModel(context, file, mime, JsonUtility.SortProperties(outputModel));
-            if (context.Config.OutputType == OutputType.Json)
+
+            if (context.Config.OutputType == OutputType.PageJson)
             {
                 return (templateModel, JsonUtility.SortProperties(templateMetadata));
             }
@@ -265,7 +266,7 @@ namespace Microsoft.Docs.Build
             var schema = context.TemplateEngine.GetSchema(mime);
             var pageModel = (JObject)context.JsonSchemaTransformer.TransformContent(errors, schema, file, validatedObj);
 
-            if (context.Config.Legacy && TemplateEngine.IsLandingData(mime))
+            if (context.Config.OutputType == OutputType.PageJson && TemplateEngine.IsLandingData(mime))
             {
                 var landingData = JsonUtility.ToObject<LandingData>(errors, pageModel);
                 var razorHtml = RazorTemplate.Render(mime, landingData).GetAwaiter().GetResult();

--- a/src/docfx/cli/CommandLineOptions.cs
+++ b/src/docfx/cli/CommandLineOptions.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Docs.Build
     {
         public string? Output;
         public string? Log;
-        public bool Legacy;
         public bool Verbose;
+        public OutputType? OutputType;
         public bool DryRun;
         public bool NoDrySync;
         public bool Stdin;
@@ -26,7 +26,6 @@ namespace Microsoft.Docs.Build
         {
             var config = new JObject
             {
-                ["legacy"] = Legacy,
                 ["dryRun"] = DryRun,
                 ["noDrySync"] = NoDrySync,
             };
@@ -36,11 +35,9 @@ namespace Microsoft.Docs.Build
                 config["outputPath"] = Output;
             }
 
-            if (Legacy)
+            if (OutputType != null)
             {
-                config["outputType"] = "Json";
-                config["urlType"] = "Docs";
-                config["selfContained"] = false;
+                config["outputType"] = OutputType.Value.ToString();
             }
 
             if (Template != null)

--- a/src/docfx/cli/Docfx.cs
+++ b/src/docfx/cli/Docfx.cs
@@ -111,6 +111,13 @@ namespace Microsoft.Docs.Build
                     // Build command
                     syntax.DefineCommand("build", ref command, "Builds a docset.");
                     syntax.DefineOption("o|output", ref options.Output, "Output directory in which to place built artifacts.");
+
+                    syntax.DefineOption(
+                        "output-type",
+                        ref options.OutputType,
+                        value => Enum.TryParse<OutputType>(value, ignoreCase: true, out var result) ? result : default,
+                        "Output directory in which to place built artifacts.");
+
                     syntax.DefineOption("dry-run", ref options.DryRun, "Do not produce build artifact and only produce validation result.");
                     syntax.DefineOption("no-dry-sync", ref options.NoDrySync, "Do not run dry sync for learn validation.");
                     syntax.DefineOption("no-restore", ref options.NoRestore, "Do not restore dependencies before build.");
@@ -137,7 +144,6 @@ namespace Microsoft.Docs.Build
             syntax.DefineOption("v|verbose", ref options.Verbose, "Enable diagnostics console output.");
             syntax.DefineOption("log", ref options.Log, "Enable logging to the specified file path.");
             syntax.DefineOption("stdin", ref options.Stdin, "Enable additional config in JSON one liner using standard input.");
-            syntax.DefineOption("legacy", ref options.Legacy, "Enable legacy output for backward compatibility.");
             syntax.DefineOption("template", ref options.Template, "The directory or git repository that contains website template.");
             syntax.DefineParameter("directory", ref workingDirectory, "A directory that contains docfx.yml/docfx.json.");
         }

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -129,11 +129,6 @@ namespace Microsoft.Docs.Build
         public string XrefHostName { get; private set; } = "";
 
         /// <summary>
-        /// Gets whether we are running in legacy mode
-        /// </summary>
-        public bool Legacy { get; private set; }
-
-        /// <summary>
         /// Gets whether we are running in dry run mode
         /// </summary>
         public bool DryRun { get; private set; }

--- a/src/docfx/config/OutputType.cs
+++ b/src/docfx/config/OutputType.cs
@@ -6,13 +6,18 @@ namespace Microsoft.Docs.Build
     internal enum OutputType
     {
         /// <summary>
-        /// Output json file
+        /// HTML file after applying liquid template, including both content and the chrome.
+        /// </summary>
+        Html,
+
+        /// <summary>
+        /// The default JSON file before applying any templates.
         /// </summary>
         Json,
 
         /// <summary>
-        /// Output Html file with liquid applied
+        /// Liquid JSON input format, same content as stored in docs document hosting service.
         /// </summary>
-        Html,
+        PageJson,
     }
 }

--- a/src/docfx/config/ops/OpsConfigLoader.cs
+++ b/src/docfx/config/ops/OpsConfigLoader.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Docs.Build
             var result = new JObject();
             var dependencies = GetDependencies(opsConfig, branch, buildSourceFolder);
 
+            result["urlType"] = "docs";
             result["dependencies"] = new JObject(
                 from dep in dependencies
                 where !dep.name.Equals("_themes", StringComparison.OrdinalIgnoreCase) &&

--- a/src/docfx/config/ops/OpsPostProcessor.cs
+++ b/src/docfx/config/ops/OpsPostProcessor.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Docs.Build
 
         private void PostProcessLearnValidation()
         {
-            if (!_config.RunLearnValidation || !_config.Legacy || _config.DryRun)
+            if (!_config.RunLearnValidation || _config.OutputType != OutputType.PageJson || _config.DryRun)
             {
                 return;
             }

--- a/src/docfx/lib/log/Progress.cs
+++ b/src/docfx/lib/log/Progress.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Docs.Build
             var percent = ((int)(100 * Math.Min(1.0, done / Math.Max(1.0, total)))).ToString();
             var duration = TimeSpan.FromSeconds(elapsedMs / 1000);
 
-            Console.Write($"{scope.Name}: {percent.PadLeft(3)}% ({done}/{total}), {duration} {eol}");
+            Console.Write($"{scope.Name}: {percent,3}% ({done}/{total}), {duration} {eol}");
         }
 
         public static string FormatTimeSpan(TimeSpan value)

--- a/src/docfx/lib/path/PackagePath.cs
+++ b/src/docfx/lib/path/PackagePath.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Docs.Build
         {
             PackageType.Folder => Path,
             PackageType.Git => $"{Url}#{Branch}",
-            _ => $"{Url}, (type: {Type.ToString()})",
+            _ => $"{Url}, (type: {Type})",
         };
 
         public override int GetHashCode()

--- a/test/docfx.RegressionTest/RegressionTest.cs
+++ b/test/docfx.RegressionTest/RegressionTest.cs
@@ -110,6 +110,10 @@ namespace Microsoft.Docs.Build
                     docfxConfig["urlType"] = "ugly";
                     docfxConfig["template"] = "https://github.com/Microsoft/templates.docs.msft.pdf#master";
                 }
+                else
+                {
+                    docfxConfig["outputType"] = "pageJson";
+                }
 
                 if (opts.RegressionMarkdownRule)
                 {

--- a/test/docfx.RegressionTest/RegressionTest.cs
+++ b/test/docfx.RegressionTest/RegressionTest.cs
@@ -113,6 +113,7 @@ namespace Microsoft.Docs.Build
                 else
                 {
                     docfxConfig["outputType"] = "pageJson";
+                    docfxConfig["selfContained"] = false;
                 }
 
                 if (opts.RegressionMarkdownRule)

--- a/test/docfx.RegressionTest/RegressionTest.cs
+++ b/test/docfx.RegressionTest/RegressionTest.cs
@@ -199,21 +199,20 @@ namespace Microsoft.Docs.Build
 
         private static TimeSpan Build(string repositoryPath, string outputPath, Options opts, string docfxConfig)
         {
-            var legacyOption = !opts.OutputHtml ? "--legacy" : "";
             var dryRunOption = opts.DryRun ? "--dry-run" : "";
             var noDrySyncOption = opts.NoDrySync ? "--no-dry-sync" : "";
             var logOption = $"--log \"{Path.Combine(outputPath, ".errors.log")}\"";
 
             Exec(
                 Path.Combine(AppContext.BaseDirectory, "docfx.exe"),
-                arguments: $"restore {logOption} {legacyOption} --verbose --stdin",
+                arguments: $"restore {logOption} --verbose --stdin",
                 stdin: docfxConfig,
                 cwd: repositoryPath,
                 allowExitCodes: new int[] { 0 });
 
             return Exec(
                 Path.Combine(AppContext.BaseDirectory, "docfx.exe"),
-                arguments: $"build -o \"{outputPath}\" {logOption} {legacyOption} {dryRunOption} {noDrySyncOption} --verbose --no-restore --stdin",
+                arguments: $"build -o \"{outputPath}\" {logOption} {dryRunOption} {noDrySyncOption} --verbose --no-restore --stdin",
                 stdin: docfxConfig,
                 cwd: repositoryPath);
         }

--- a/test/docfx.Test/DocfxTest.cs
+++ b/test/docfx.Test/DocfxTest.cs
@@ -178,7 +178,6 @@ namespace Microsoft.Docs.Build
                     "--output", randomOutputPath,
                     "--log", Path.Combine(randomOutputPath, ".errors.log"),
                     dryRun ? "--dry-run" : null,
-                    spec.Legacy ? "--legacy" : null,
                     spec.NoRestore ? "--no-restore" : null,
                     spec.NoDrySync ? "--no-dry-sync" : null,
                 };

--- a/test/docfx.Test/DocfxTestSpec.cs
+++ b/test/docfx.Test/DocfxTestSpec.cs
@@ -19,8 +19,6 @@ namespace Microsoft.Docs.Build
 
         public bool NoRestore { get; set; }
 
-        public bool Legacy { get; set; }
-
         public bool Temp { get; set; }
 
         public string Locale { get; set; }

--- a/test/docfx.Test/lib/GitUtilityTest.cs
+++ b/test/docfx.Test/lib/GitUtilityTest.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Docs.Build
 
             Assert.Equal(
                 exe.Replace("\r", ""),
-                string.Join("\n", lib.Select(c => $"{c.Sha}|{c.Time.ToString("s")}{c.Time.ToString("zzz")}|{c.AuthorName}|{c.AuthorEmail}")));
+                string.Join("\n", lib.Select(c => $"{c.Sha}|{c.Time:s}{c.Time:zzz}|{c.AuthorName}|{c.AuthorEmail}")));
 
             // another branch
             exe = Exec("git", $"--no-pager log --format=\"%H|%cI|%an|%ae\" a050eaf -- \"{pathToRepo}\"", repo.Path);
@@ -48,7 +48,7 @@ namespace Microsoft.Docs.Build
 
             Assert.Equal(
                 exe.Replace("\r", ""),
-                string.Join("\n", lib.Select(c => $"{c.Sha}|{c.Time.ToString("s")}{c.Time.ToString("zzz")}|{c.AuthorName}|{c.AuthorEmail}")));
+                string.Join("\n", lib.Select(c => $"{c.Sha}|{c.Time:s}{c.Time:zzz}|{c.AuthorName}|{c.AuthorEmail}")));
 
             gitCommitProvider.Save();
         }


### PR DESCRIPTION
[AB#295823](https://dev.azure.com/ceapex/Engineering/_workitems/edit/295823/)

Remove `--legacy` command line switch in favor of `--output-type`:

For docs:
```
docfx build --output-type pagejson
```

output type | summary
---|---
html | The default output type, generates static HTML pages
json | The JSON model without applying any templates (mustache/jint/liquid), this is used in most of the test cases
pagejson | The JSON model stored in DHS. Applied mustache and jint but not liquid.

Currently `--legacy` affects 3 options:

- `outputType`: this is replaced by a command line switch
- `urlType`: this is automatically set to `docs` for docs repos
- `selfContained`: this will be set to false on docs server build.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6507)