### PR TITLE
Loc's uid override fallback's when path different

### DIFF
--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -257,6 +257,33 @@ outputs:
   a.json: |
     { "conceptual":"<p><a href=\"b\" data-linktype=\"relative-path\">uid from fallback</a></p>\n"}
 ---
+# uid in loc has higher priority than in fallback(path can be different)
+# and report no error
+locale: zh-cn
+repos:
+  https://docs.com/xref-fallback#master:
+    - files:
+        docfx.yml:
+        dir/b.md: |
+          ---
+          title: uid in fallback
+          uid: b
+          ---
+  https://docs.com/xref-fallback.zh-cn#master:
+    - files:
+        docfx.yml:
+        b.md: |
+          ---
+          title: uid in loc
+          uid: b
+          ---
+        a.md: |
+          @b
+outputs:
+  a.json: |
+    { "conceptual":"<p><a href=\"b\" data-linktype=\"relative-path\">uid in loc</a></p>\n"}
+  b.json:
+---
 # Define uid in SDP
 # Resolve xref with display property in conceptual document
 # Resolve xref with non-existing display property, display name

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -126,6 +126,13 @@ namespace Microsoft.Docs.Build
                 return specsWithSameUid;
             }
 
+            // loc override fallback uid
+            if (specsWithSameUid.Length == 2 &&
+                 (specsWithSameUid[0].DeclaringFile.Origin ^ specsWithSameUid[1].DeclaringFile.Origin ^ FileOrigin.Main ^ FileOrigin.Fallback) == 0)
+            {
+                return new[] { specsWithSameUid[0].DeclaringFile.Origin == FileOrigin.Main ? specsWithSameUid[0] : specsWithSameUid[1] };
+            }
+
             // multiple uid conflicts without moniker range definition
             // log an warning and take the first one order by the declaring file
             var duplicatedSpecs = specsWithSameUid.Where(item => item.Monikers.Count == 0).ToArray();

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -127,10 +127,9 @@ namespace Microsoft.Docs.Build
             }
 
             // loc override fallback uid
-            if (specsWithSameUid.Length == 2 &&
-                 (specsWithSameUid[0].DeclaringFile.Origin ^ specsWithSameUid[1].DeclaringFile.Origin ^ FileOrigin.Main ^ FileOrigin.Fallback) == 0)
+            if (specsWithSameUid.Any(spec => spec.DeclaringFile.Origin == FileOrigin.Main))
             {
-                return new[] { specsWithSameUid[0].DeclaringFile.Origin == FileOrigin.Main ? specsWithSameUid[0] : specsWithSameUid[1] };
+                specsWithSameUid = specsWithSameUid.Where(spec => spec.DeclaringFile.Origin != FileOrigin.Fallback).ToArray();
             }
 
             // multiple uid conflicts without moniker range definition


### PR DESCRIPTION
[AB#296459](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/296459)

Loc's file path can be different with fallback's, and loc's should take higher priority.
e.g.
```
en-us: a.yml
loc: trans/a.yml
```
And hence if `a.yml` declares a uid `a`, `duplicate-uid` can be reported, which isn't the desired behavior.
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6513)