### PR TITLE
Check internal xref property conflict after map built

### DIFF
--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -1484,6 +1484,14 @@ inputs:
     uid: a
     name: name 1
     description: test 1
+  docs/v1/b.yml: |
+    ### YamlMime:TestData
+    metadata:
+      monikers: 
+      - netcore-1.0
+    uid: b
+    name: name b
+    description: test b
   docs/v2/a.yml: |
     ### YamlMime:TestData
     metadata:
@@ -1491,7 +1499,7 @@ inputs:
       - netcore-2.0
     uid: a
     name: name 2
-    description: test 2
+    description: test 2 <xref:b>
   _themes/ContentTemplate/schemas/TestData.schema.json: |
     {
       "xrefProperties": ["name", "description"],
@@ -1501,15 +1509,17 @@ inputs:
             "monikers": { "type": "array" }
           }
         },
-        "uid": { "contentType": "uid" } 
+        "uid": { "contentType": "uid" },
+        "description": { "contentType": "Markdown" }
       }
     }
 outputs:
   136a42ac/docs/a.json:
+  136a42ac/docs/b.json:
   4667fedf/docs/a.json:
   .errors.log: |
     {"message_severity":"warning","code":"xref-property-conflict","message":"UID 'a' is defined with different names: 'name 1', 'name 2'."}
-    {"message_severity":"warning","code":"xref-property-conflict","message":"UID 'a' is defined with different descriptions: 'test 1', 'test 2'."}
+    {"message_severity":"warning","code":"xref-property-conflict","message":"UID 'a' is defined with different descriptions: '<p>test 1</p>\n', '<p>test 2 <a href=\"b.json\">name b</a></p>\n'."}
 ---
 # referencing multiple version, using uid with intersection for toc & SDP
 inputs:

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -146,18 +146,6 @@ namespace Microsoft.Docs.Build
                 _errors.Add(Errors.Versioning.MonikerOverlapping(uid, specsWithSameUid.Select(spec => spec.DeclaringFile).ToList(), overlappingMonikers));
             }
 
-            // uid conflicts with different values of the same xref property
-            // log an warning and take the first one order by the declaring file
-            var xrefProperties = specsWithSameUid.SelectMany(x => x.XrefProperties.Keys).Distinct();
-            foreach (var xrefProperty in xrefProperties)
-            {
-                var conflictingNames = specsWithSameUid.Select(x => x.GetXrefPropertyValueAsString(xrefProperty)).Distinct();
-                if (conflictingNames.Count() > 1)
-                {
-                    _errors.Add(Errors.Xref.XrefPropertyConflict(uid, xrefProperty, conflictingNames));
-                }
-            }
-
             return specsWithSameUid
                    .OrderByDescending(spec => spec.Monikers.HasMonikers
                         ? spec.Monikers.Select(moniker => _monikerProvider.GetMonikerOrder(moniker)).Max()

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -150,6 +150,7 @@ namespace Microsoft.Docs.Build
                     .Select(xrefs =>
                     {
                         var xref = xrefs.First();
+
                         // validate xref properties
                         // uid conflicts with different values of the same xref property
                         // log an warning and take the first one order by the declaring file

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
+using System.Threading;
 using System.Web;
 
 namespace Microsoft.Docs.Build
@@ -20,6 +21,7 @@ namespace Microsoft.Docs.Build
         private readonly FileLinkMapBuilder _fileLinkMapBuilder;
         private readonly Repository? _repository;
         private readonly string _xrefHostName;
+        private int internalXrefPropertiesValidated;
 
         public XrefResolver(
             Config config,
@@ -254,8 +256,13 @@ namespace Microsoft.Docs.Build
             if (!_internalXrefMap.IsValueCreated)
             {
                 _ = _internalXrefMap.Value;
+            }
+
+            if (Interlocked.Exchange(ref internalXrefPropertiesValidated, 1) == 0)
+            {
                 ValidateInternalXrefProperties();
             }
+
             return _internalXrefMap.Value;
         }
 


### PR DESCRIPTION
Fixing [lazy crashed](https://opbuildstorageprod.blob.core.windows.net/report/2020%5C9%5C7%5C5de83821-f44b-0e93-473e-c19393f102fe%5CCommit%5C202009070424567676-javaSDP%5Crawlog.txt?sv=2016-05-31&sr=b&sig=NOgy0OAZMo3C9Rbi4ZJTzaTCbVdM2k8ILinQJQlpg8w%3D&st=2020-09-07T04%3A25%3A37Z&se=2020-10-08T04%3A30%3A37Z&sp=r)

Checking xref property conflict requires evaluate xref property value, and if the value also tries to resolve xref, 💥
![image](https://user-images.githubusercontent.com/42199316/92353444-eca28280-f112-11ea-8882-191da7cdac85.png)

Validate internal xref properties only once after it's initialized.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6515)