### PR TITLE
Service page fix

### DIFF
--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -1891,7 +1891,7 @@ outputs:
   test/a/_splitted/b/toc.json: |
     {"metadata": {"universal_conceptual_toc": "dotnet-test/learn/toc.json"}}
 ---
-# Service Page href fix
+# Service Page href fix: TopLevelTOC and ReferenceTOC in different directory hierarchy
 repos:
   https://github.com/ops/service-page2:
   - files:

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -1652,8 +1652,6 @@ repos:
               children:
               - '*'
 outputs:
-  .errors.log: |
-    {"message_severity":"warning","code":"missing-attribute","message":"Missing required attribute: 'name'.","file":"a/api/TOC.yml","line":6,"column":8}
   a/api/toc.json: |
     {
         "metadata": {"open_to_public_contributors": false},
@@ -1752,7 +1750,7 @@ repos:
       a/_themes/ContentTemplate/schemas/ReferenceContainer.schema.json: |
         {
           "type": "object",
-          "required": ["uid", "name", "pageType"],
+          "required": ["name", "pageType"],
           "properties": {
             "uid": {"contentType": "uid", "type": "string"},
             "name": {"type": "string"},
@@ -1830,9 +1828,6 @@ repos:
               children:
               - '*'
 outputs:
-  .errors.log: |
-    {"message_severity":"warning","code":"missing-attribute","message":"Missing required attribute: 'name'.","file":"a/api/TOC.yml","line":7,"column":8}
-    {"message_severity":"error","code":"missing-attribute","message":"Missing required attribute: 'uid'.","line":0,"column":0}
   a/api/a.json:
   a/api/doc.json:
   a/api/toc.json:
@@ -1895,3 +1890,52 @@ outputs:
     {"metadata": {"universal_conceptual_toc": "dotnet-test/learn/toc.json"}}
   test/a/_splitted/b/toc.json: |
     {"metadata": {"universal_conceptual_toc": "dotnet-test/learn/toc.json"}}
+---
+# Service Page href fix
+repos:
+  https://github.com/ops/service-page2:
+  - files:
+      .openpublishing.publish.config.json: |
+        {
+          "docsets_to_publish": [{  "build_source_folder": "a"}],
+          "JoinTOCPlugin": [
+            {"ReferenceTOC": "a/api/bot/TOC.yml",
+              "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml"}],
+        }
+      a/docfx.yml:
+      a/_themes/ContentTemplate/schemas/ReferenceContainer.schema.json: |
+        {
+          "type": "object",
+          "required": ["name", "pageType"],
+          "properties": {
+            "uid": {"contentType": "uid", "type": "string"},
+            "name": {"type": "string"}, "fullName": {"type": "string"},
+            "children": {
+              "items": { 
+                "type": "object", "additionalProperties": false,
+                "properties": {
+                  "href": {"contentType": "href", "type": "string"},
+                  "uid": {"contentType": "xref", "type": "string"},
+                  "name": {"type": "string"}
+                }
+              }, "type": "array", "minItems": 1},
+            "pageType": { "enum": ["root", "service"], "type": "string" }
+          }
+        }
+      a/test/doc.md:
+      a/api/bot/TOC.yml: |
+        name: TOC
+        items:
+        - name: MS.ServicePage.xxx
+          href: ../../test/doc.md
+      a/docs-ref-toc/top_level_toc.yml: |
+        items:
+        - name: API Reference
+          landingPageType: Root
+          children:
+          - 'MS.ServicePage*'
+outputs:
+  a/test/doc.json:
+  a/api/bot/toc.json:
+  a/docs-ref-toc/index.json: |
+    {"name": "API Reference", "fullName": "API Reference", "children": [{"name": "MS.ServicePage.xxx", "href": "../test/doc"}], "pageType": "root"}

--- a/src/docfx/build/toc/ServicePageGenerator.cs
+++ b/src/docfx/build/toc/ServicePageGenerator.cs
@@ -44,6 +44,9 @@ namespace Microsoft.Docs.Build
                 var topLevelTOCRelativeDir = Path.GetDirectoryName(_joinTOCConfig.TopLevelToc);
                 var baseDir = _joinTOCConfig.OutputFolder.IsDefault ? topLevelTOCRelativeDir : _joinTOCConfig.OutputFolder;
 
+                var referenceTOCRelativeDir = Path.GetDirectoryName(_joinTOCConfig.ReferenceToc) ?? ".";
+                var referenceTOCFullPath = Path.GetFullPath(Path.Combine(_docsetPath, referenceTOCRelativeDir));
+
                 var pageType = node.LandingPageType.Value;
                 FilePath servicePagePath;
                 if (pageType == LandingPageType.Root)
@@ -70,26 +73,12 @@ namespace Microsoft.Docs.Build
 
                     if (!string.IsNullOrEmpty(childHref) && UrlUtility.GetLinkType(childHref) == LinkType.RelativePath)
                     {
-                        if (topLevelTOCRelativeDir != null)
+                        if (!(childHref.StartsWith("~/") || childHref.StartsWith("~\\")))
                         {
-                            string? hrefFileFullPath;
-
-                            var topLevelTOCYmlDir = Path.GetFullPath(Path.Combine(_docsetPath, topLevelTOCRelativeDir));
-
-                            if (childHref.StartsWith("~/") || childHref.StartsWith("~\\"))
-                            {
-                                childHref = childHref.Substring(2).TrimStart('/', '\\');
-                                hrefFileFullPath = Path.GetFullPath(Path.Combine(_docsetPath, childHref));
-                            }
-                            else
-                            {
-                                hrefFileFullPath = Path.GetFullPath(Path.Combine(topLevelTOCYmlDir == null ? "" : topLevelTOCYmlDir, childHref));
-                            }
-
-                            var hrefRelativePathToDocset = Path.GetRelativePath(_docsetPath, hrefFileFullPath);
-                            var hrefFullPathOfDocset = $"~/{hrefRelativePathToDocset}";
-
-                            childHref = hrefFullPathOfDocset;
+                            var hrefFileFullPath = Path.GetFullPath(Path.Combine(referenceTOCFullPath, childHref));
+                            var servicePageFullPath = Path.GetDirectoryName(Path.GetFullPath(Path.Combine(_docsetPath, servicePagePath.Path))) ?? _docsetPath;
+                            var hrefRelativePathToReferenceTOC = Path.GetRelativePath(servicePageFullPath, hrefFileFullPath);
+                            childHref = hrefRelativePathToReferenceTOC;
                         }
 
                         child = new ServicePageItem(childName, childHref, null);

--- a/src/docfx/build/toc/ServicePageGenerator.cs
+++ b/src/docfx/build/toc/ServicePageGenerator.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Docs.Build
             if (node.LandingPageType.Value != null)
             {
                 var topLevelTOCRelativeDir = Path.GetDirectoryName(_joinTOCConfig.TopLevelToc);
-                var baseDir = string.IsNullOrEmpty(_joinTOCConfig.OutputFolder) ? topLevelTOCRelativeDir : _joinTOCConfig.OutputFolder;
+                var baseDir = _joinTOCConfig.OutputFolder.IsDefault ? topLevelTOCRelativeDir : _joinTOCConfig.OutputFolder;
 
                 var pageType = node.LandingPageType.Value;
                 FilePath servicePagePath;

--- a/src/docfx/build/toc/ServicePageGenerator.cs
+++ b/src/docfx/build/toc/ServicePageGenerator.cs
@@ -86,9 +86,10 @@ namespace Microsoft.Docs.Build
                                 hrefFileFullPath = Path.GetFullPath(Path.Combine(topLevelTOCYmlDir == null ? "" : topLevelTOCYmlDir, childHref));
                             }
 
-                            var servicePageFullPath = Path.GetDirectoryName(Path.GetFullPath(Path.Combine(_docsetPath, servicePagePath.Path))) ?? _docsetPath;
-                            var hrefRelativePath = Path.GetRelativePath(servicePageFullPath, hrefFileFullPath);
-                            childHref = hrefRelativePath;
+                            var hrefRelativePathToDocset = Path.GetRelativePath(_docsetPath, hrefFileFullPath);
+                            var hrefFullPathOfDocset = $"~/{hrefRelativePathToDocset}";
+
+                            childHref = hrefFullPathOfDocset;
                         }
 
                         child = new ServicePageItem(childName, childHref, null);

--- a/src/docfx/build/toc/TableOfContentsLoader.cs
+++ b/src/docfx/build/toc/TableOfContentsLoader.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Docs.Build
                 var servicePages = new List<FilePath>();
                 var referencedFiles = new List<FilePath>();
                 var referencedTocs = new List<FilePath>();
-                TableOfContentsNode node = new TableOfContentsNode();
+                TableOfContentsNode node;
 
                 if (_joinTOCConfigs.TryGetValue(file.Path, out var joinTOCConfig) && joinTOCConfig != null)
                 {
@@ -85,6 +85,10 @@ namespace Microsoft.Docs.Build
                         }
 
                         node.Items = LoadTocNodes(node.Items, file, file, referencedFiles, referencedTocs);
+                    }
+                    else
+                    {
+                        node = LoadTocFile(file, file, referencedFiles, referencedTocs, true);
                     }
                 }
                 else


### PR DESCRIPTION
For service-page, we need to filter items that matches with `TopLevelTOC` and add them to `TopLevelTOC`.
Then write `TopLevelTOC` back to `ReferenceTOC`.

For `TopLevelTOC` is a generated file and will be dropped finally, so all hrefs use relative path to `ReferenceTOC` unless those start with `~`. And we use `ReferenceTOC` to calculate the relative href of service pages.

[AB#299330](https://dev.azure.com/ceapex/Engineering/_boards/board/t/DocFX%20v3%20Team/Stories/?workitem=299330)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6551)