### PR TITLE
🛳🛳Release

### DIFF
--- a/docs/specs/learn.yml
+++ b/docs/specs/learn.yml
@@ -430,7 +430,7 @@ repos:
      docfx.yml: |
        outputType: pageJson
        http:
-         https://op-build-prod.azurewebsites.net:
+         https://docspublic.azurefd.net/api/build:
            headers:
              X-OP-BuildUserToken: {DOCS_OPS_TOKEN}
      path.yml: |

--- a/docs/specs/ops.yml
+++ b/docs/specs/ops.yml
@@ -47,7 +47,7 @@ repos:
         }
       a/docfx.yml: |
         http:
-          https://op-build-prod.azurewebsites.net:
+          https://docspublic.azurefd.net/api/build:
             headers:
               X-OP-BuildUserToken: {DOCS_OPS_TOKEN}
       a/a.md:

--- a/docs/specs/schema.yml
+++ b/docs/specs/schema.yml
@@ -485,3 +485,27 @@ outputs:
         {"asset_id": "original_b", "original_type": "Conceptual"},
       ]
     }
+---
+# Support public template
+inputs:
+  docfx.yml: |
+    template: "https://static.docs.com/ui/latest"
+  docs/a.yml: |
+    #YamlMime:TestData
+    test: b.md
+  docs/b.md:
+http:
+  https://static.docs.com/ui/latest/schemas/TestData.schema.json: |
+    {
+      "renderType": "component",
+      "type": "object",
+      "properties": {
+        "test": {"contentType": "Href"},
+      }
+    }
+outputs:
+  docs/a.json: |
+    {
+      "test": "b"
+    }
+  docs/b.json:

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -1728,9 +1728,9 @@ outputs:
   a/toc.json: |
     {"metadata": {"universal_conceptual_toc": "dotnet-test/learn/toc.json"}}
   a/_splitted/a/toc.json: |
-    {"metadata": {"universal_conceptual_toc": "dotnet-test/learn/toc.json"}}
+    {"metadata": {"universal_conceptual_toc": "dotnet-test/learn/toc.json", "universal_ref_toc": "/dotnet-test/api/toc.json"}}
   a/_splitted/b/toc.json: |
-    {"metadata": {"universal_conceptual_toc": "dotnet-test/learn/toc.json"}}
+    {"metadata": {"universal_conceptual_toc": "dotnet-test/learn/toc.json", "universal_ref_toc": "/dotnet-test/api/toc.json"}}
 ---
 # Service Page Generating
 repos:

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -1652,8 +1652,6 @@ repos:
               children:
               - '*'
 outputs:
-  .errors.log: |
-    {"message_severity":"warning","code":"missing-attribute","message":"Missing required attribute: 'name'.","file":"a/api/TOC.yml","line":6,"column":8}
   a/api/toc.json: |
     {
         "metadata": {"open_to_public_contributors": false},
@@ -1752,7 +1750,7 @@ repos:
       a/_themes/ContentTemplate/schemas/ReferenceContainer.schema.json: |
         {
           "type": "object",
-          "required": ["uid", "name", "pageType"],
+          "required": ["name", "pageType"],
           "properties": {
             "uid": {"contentType": "uid", "type": "string"},
             "name": {"type": "string"},
@@ -1830,9 +1828,6 @@ repos:
               children:
               - '*'
 outputs:
-  .errors.log: |
-    {"message_severity":"warning","code":"missing-attribute","message":"Missing required attribute: 'name'.","file":"a/api/TOC.yml","line":7,"column":8}
-    {"message_severity":"error","code":"missing-attribute","message":"Missing required attribute: 'uid'.","line":0,"column":0}
   a/api/a.json:
   a/api/doc.json:
   a/api/toc.json:
@@ -1895,3 +1890,52 @@ outputs:
     {"metadata": {"universal_conceptual_toc": "dotnet-test/learn/toc.json"}}
   test/a/_splitted/b/toc.json: |
     {"metadata": {"universal_conceptual_toc": "dotnet-test/learn/toc.json"}}
+---
+# Service Page href fix: TopLevelTOC and ReferenceTOC in different directory hierarchy
+repos:
+  https://github.com/ops/service-page2:
+  - files:
+      .openpublishing.publish.config.json: |
+        {
+          "docsets_to_publish": [{  "build_source_folder": "a"}],
+          "JoinTOCPlugin": [
+            {"ReferenceTOC": "a/api/bot/TOC.yml",
+              "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml"}],
+        }
+      a/docfx.yml:
+      a/_themes/ContentTemplate/schemas/ReferenceContainer.schema.json: |
+        {
+          "type": "object",
+          "required": ["name", "pageType"],
+          "properties": {
+            "uid": {"contentType": "uid", "type": "string"},
+            "name": {"type": "string"}, "fullName": {"type": "string"},
+            "children": {
+              "items": { 
+                "type": "object", "additionalProperties": false,
+                "properties": {
+                  "href": {"contentType": "href", "type": "string"},
+                  "uid": {"contentType": "xref", "type": "string"},
+                  "name": {"type": "string"}
+                }
+              }, "type": "array", "minItems": 1},
+            "pageType": { "enum": ["root", "service"], "type": "string" }
+          }
+        }
+      a/test/doc.md:
+      a/api/bot/TOC.yml: |
+        name: TOC
+        items:
+        - name: MS.ServicePage.xxx
+          href: ../../test/doc.md
+      a/docs-ref-toc/top_level_toc.yml: |
+        items:
+        - name: API Reference
+          landingPageType: Root
+          children:
+          - 'MS.ServicePage*'
+outputs:
+  a/test/doc.json:
+  a/api/bot/toc.json:
+  a/docs-ref-toc/index.json: |
+    {"name": "API Reference", "fullName": "API Reference", "children": [{"name": "MS.ServicePage.xxx", "href": "../test/doc"}], "pageType": "root"}

--- a/docs/specs/validations/sensitiveLanguageValidations.yml
+++ b/docs/specs/validations/sensitiveLanguageValidations.yml
@@ -74,7 +74,7 @@ outputs:
   .errors.log: |
     {"message_severity":"suggestion","code":"sensitive-language","message":"Term 'master' is sensitive and should not be used in content or code.","file":"a/b/c/file.md","line":1,"end_line":1,"column":0,"end_column":0}
     {"message_severity":"suggestion","code":"sensitive-language","message":"Term 'master' is sensitive and should not be used in content or code.","file":"file1.md","line":1,"end_line":1,"column":0,"end_column":0}
-    {"message_severity":"warning","code":"rule-override-invalid","message":"Validation rule 'sensitive-language' is not overridable, so overrides in docfx.yml/docfx.json will be ignored.","file":"docfx.yml","line":4,"end_line":4,"column":5,"end_column":5}
+    {"message_severity":"warning","code":"override-not-allowed","message":"Rule 'sensitive-language' can't be overridden in docfx.json.","file":"docfx.yml","line":4,"end_line":4,"column":5,"end_column":5}
   file1.json:
   a/b/c/file.json:
 ---

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -110,8 +110,8 @@ namespace Microsoft.Docs.Build
             /// Validation rule is not overridable in docfx config.
             /// </summary>
             /// Behavior: ✔️ Message: ✔️
-            public static Error RuleOverrideInvalid(string code, SourceInfo? source)
-                => new Error(ErrorLevel.Warning, "rule-override-invalid", $"Validation rule '{code}' is not overridable, so overrides in docfx.yml/docfx.json will be ignored.", source);
+            public static Error OverrideNotAllowed(string code, SourceInfo? source)
+                => new Error(ErrorLevel.Warning, "override-not-allowed", $"Rule '{code}' can't be overridden in docfx.json.", source);
         }
 
         public static class Json

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;

--- a/src/docfx/config/TestQuirks.cs
+++ b/src/docfx/config/TestQuirks.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Docs.Build
 
         public static Func<string, string>? GitRemoteProxy { get; set; }
 
+        public static Func<string, string?>? HttpProxy { get; set; }
+
         public static bool? Verbose { get; set; }
     }
 }

--- a/src/docfx/config/ops/OpsAccessor.cs
+++ b/src/docfx/config/ops/OpsAccessor.cs
@@ -202,10 +202,10 @@ namespace Microsoft.Docs.Build
         {
             return (environment ?? DocsEnvironment) switch
             {
-                DocsEnvironment.Prod => "https://op-build-prod.azurewebsites.net",
-                DocsEnvironment.PPE => "https://op-build-sandbox2.azurewebsites.net",
-                DocsEnvironment.Internal => "https://op-build-internal.azurewebsites.net",
-                DocsEnvironment.Perf => "https://op-build-perf.azurewebsites.net",
+                DocsEnvironment.Prod => "https://docspublic.azurefd.net/api/build",
+                DocsEnvironment.PPE => "https://docspubdev.azurefd.net/api/build",
+                DocsEnvironment.Internal => "https://docspubdev.azurefd.net/api/build",
+                DocsEnvironment.Perf => "https://docspubdev.azurefd.net/api/build",
                 _ => throw new NotSupportedException(),
             };
         }

--- a/src/docfx/config/ops/OpsAccessor.cs
+++ b/src/docfx/config/ops/OpsAccessor.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -22,6 +23,18 @@ namespace Microsoft.Docs.Build
     {
         public static readonly DocsEnvironment DocsEnvironment = GetDocsEnvironment();
 
+        private static readonly string DocsProdServiceEndpoint =
+            Environment.GetEnvironmentVariable("DOCS_PROD_SERVICE_ENDPOINT") ?? "https://docspublic.azurefd.net/api/build";
+
+        private static readonly string DocsPPEServiceEndpoint =
+            Environment.GetEnvironmentVariable("DOCS_PPE_SERVICE_ENDPOINT") ?? "https://docspubdev.azurefd.net/api/build";
+
+        private static readonly string DocsInternalServiceEndpoint =
+            Environment.GetEnvironmentVariable("DOCS_INTERNAL_SERVICE_ENDPOINT") ?? "https://docspubdev.azurefd.net/api/build";
+
+        private static readonly string DocsPerfServiceEndpoint =
+            Environment.GetEnvironmentVariable("DOCS_PERF_SERVICE_ENDPOINT") ?? "https://docspubdev.azurefd.net/api/build";
+
         private static readonly SecretClient s_secretClient = new SecretClient(new Uri("https://docfx.vault.azure.net"), new DefaultAzureCredential());
         private static readonly Lazy<Task<string>> s_opsTokenProd = new Lazy<Task<string>>(() => GetSecret("OpsBuildTokenProd"));
         private static readonly Lazy<Task<string>> s_opsTokenSandbox = new Lazy<Task<string>>(() => GetSecret("OpsBuildTokenSandbox"));
@@ -38,41 +51,43 @@ namespace Microsoft.Docs.Build
 
         public async Task<string> GetDocsetInfo(string repositoryUrl)
         {
-            var fetchUrl = $"{BuildServiceEndpoint()}/v2/Queries/Docsets?git_repo_url={repositoryUrl}&docset_query_status=Created";
+            var fetchUrl = $"/v2/Queries/Docsets?git_repo_url={repositoryUrl}&docset_query_status=Created";
             return await Fetch(fetchUrl, value404: "[]");
         }
 
         public Task<string> GetMonikerDefinition()
         {
-            return Fetch($"{BuildServiceEndpoint()}/v2/monikertrees/allfamiliesproductsmonikers");
+            return Fetch("/v2/monikertrees/allfamiliesproductsmonikers");
         }
 
-        public async Task<string[]> GetXrefMaps(string tag, string xrefMapQueryParams, DocsEnvironment? xrefMapBuildServiceEndpoint)
+        public async Task<string[]> GetXrefMaps(string tag, string xrefEndpoint, string xrefMapQueryParams)
         {
-            var response = await Fetch($"{BuildServiceEndpoint(xrefMapBuildServiceEndpoint)}/v1/xrefmap{tag}{xrefMapQueryParams}", value404: "{}");
+            var xrefMapDocsEnvironment = GetXrefMapEnvironment(xrefEndpoint);
+            var response = await Fetch(
+                $"/v1/xrefmap{tag}{xrefMapQueryParams}", value404: "{}", environment: xrefMapDocsEnvironment);
             return JsonConvert.DeserializeAnonymousType(response, new { links = new[] { "" } }).links
                 ?? Array.Empty<string>();
         }
 
         public async Task<string> GetMarkdownValidationRules((string repositoryUrl, string branch) tuple)
         {
-            return await FetchValidationRules($"{BuildServiceEndpoint()}/route/validationmgt/rulesets/contentrules", tuple.repositoryUrl, tuple.branch);
+            return await FetchValidationRules($"/route/validationmgt/rulesets/contentrules", tuple.repositoryUrl, tuple.branch);
         }
 
         public async Task<string> GetAllowlists((string repositoryUrl, string branch) tuple)
         {
-            return await FetchValidationRules($"{BuildServiceEndpoint()}/route/validationmgt/validation/allowlists", tuple.repositoryUrl, tuple.branch);
+            return await FetchValidationRules($"/route/validationmgt/validation/allowlists", tuple.repositoryUrl, tuple.branch);
         }
 
         public async Task<string> GetDisallowlists((string repositoryUrl, string branch) tuple)
         {
-            return await FetchValidationRules($"{BuildServiceEndpoint()}/route/validationmgt/validation/disallowlists", tuple.repositoryUrl, tuple.branch);
+            return await FetchValidationRules($"/route/validationmgt/validation/disallowlists", tuple.repositoryUrl, tuple.branch);
         }
 
         public async Task<string> GetMetadataSchema((string repositoryUrl, string branch) tuple)
         {
-            var metadataRules = FetchValidationRules($"{BuildServiceEndpoint()}/route/validationmgt/rulesets/metadatarules", tuple.repositoryUrl, tuple.branch);
-            var allowlists = FetchValidationRules($"{BuildServiceEndpoint()}/route/validationmgt/validation/allowlists", tuple.repositoryUrl, tuple.branch);
+            var metadataRules = FetchValidationRules($"/route/validationmgt/rulesets/metadatarules", tuple.repositoryUrl, tuple.branch);
+            var allowlists = FetchValidationRules($"/route/validationmgt/validation/allowlists", tuple.repositoryUrl, tuple.branch);
 
             return OpsMetadataRuleConverter.GenerateJsonSchema(await metadataRules, await allowlists);
         }
@@ -80,17 +95,18 @@ namespace Microsoft.Docs.Build
         public async Task<string> GetRegressionAllContentRules()
         {
             return await FetchValidationRules(
-                $"{BuildServiceEndpoint(DocsEnvironment.PPE)}/route/validationmgt/rulesets/contentrules?name=_regression_all_",
+                "/route/validationmgt/rulesets/contentrules?name=_regression_all_",
                 environment: DocsEnvironment.PPE);
         }
 
         public async Task<string> GetRegressionAllMetadataSchema()
         {
             var metadataRules = FetchValidationRules(
-                $"{BuildServiceEndpoint(DocsEnvironment.PPE)}/route/validationmgt/rulesets/metadatarules?name=_regression_all_",
+                "/route/validationmgt/rulesets/metadatarules?name=_regression_all_",
                 environment: DocsEnvironment.PPE);
             var allowlists = FetchValidationRules(
-                $"{BuildServiceEndpoint(DocsEnvironment.PPE)}/route/validationmgt/validation/allowlists", environment: DocsEnvironment.PPE);
+                "/route/validationmgt/validation/allowlists",
+                environment: DocsEnvironment.PPE);
 
             return OpsMetadataRuleConverter.GenerateJsonSchema(await metadataRules, await allowlists);
         }
@@ -127,8 +143,14 @@ namespace Microsoft.Docs.Build
             _http.Dispose();
         }
 
-        private async Task<string> Fetch(string url, IReadOnlyDictionary<string, string>? headers = null, string? value404 = null)
+        private async Task<string> Fetch(
+            string routePath,
+            IReadOnlyDictionary<string, string>? headers = null,
+            string? value404 = null,
+            DocsEnvironment? environment = null)
         {
+            Debug.Assert(routePath.StartsWith("/"));
+            var url = BuildServiceEndpoint(environment) + routePath;
             using var request = new HttpRequestMessage(HttpMethod.Get, url);
             if (headers != null)
             {
@@ -137,7 +159,7 @@ namespace Microsoft.Docs.Build
                     request.Headers.TryAddWithoutValidation(key, value);
                 }
             }
-            var response = await SendRequest(request);
+            var response = await SendRequest(request, environment);
 
             if (value404 != null && response.StatusCode == HttpStatusCode.NotFound)
             {
@@ -146,22 +168,12 @@ namespace Microsoft.Docs.Build
             return await response.EnsureSuccessStatusCode().Content.ReadAsStringAsync();
         }
 
-        private async Task<HttpResponseMessage> SendRequest(HttpRequestMessage request)
-        {
-            using (PerfScope.Start($"[{nameof(OpsConfigAdapter)}] Executing request '{request.Method} {request.RequestUri}'"))
-            {
-                _credentialProvider?.Invoke(request);
-
-                await FillOpsToken(request.RequestUri.AbsoluteUri, request);
-
-                return await _http.SendAsync(request);
-            }
-        }
-
-        private async Task<string> FetchValidationRules(string url, string repositoryUrl = "", string branch = "", DocsEnvironment? environment = null)
+        private async Task<string> FetchValidationRules(string routePath, string repositoryUrl = "", string branch = "", DocsEnvironment? environment = null)
         {
             try
             {
+                Debug.Assert(routePath.StartsWith("/"));
+                var url = BuildServiceEndpoint(environment) + routePath;
                 using (PerfScope.Start($"[{nameof(OpsConfigAdapter)}] Fetching '{url}'"))
                 {
                     using var response = await HttpPolicyExtensions
@@ -172,13 +184,11 @@ namespace Microsoft.Docs.Build
                        .ExecuteAsync(async () =>
                        {
                            using var request = new HttpRequestMessage(HttpMethod.Get, url);
-                           _credentialProvider?.Invoke(request);
 
                            request.Headers.TryAddWithoutValidation("X-Metadata-RepositoryUrl", repositoryUrl);
                            request.Headers.TryAddWithoutValidation("X-Metadata-RepositoryBranch", branch);
 
-                           await FillOpsToken(url, request, environment);
-                           var response = await _http.SendAsync(request);
+                           var response = await SendRequest(request, environment);
                            if (response.Headers.TryGetValues("X-Metadata-Version", out var metadataVersion))
                            {
                                _errors.Add(Errors.System.MetadataValidationRuleset(string.Join(',', metadataVersion)));
@@ -199,16 +209,38 @@ namespace Microsoft.Docs.Build
             }
         }
 
+        private async Task<HttpResponseMessage> SendRequest(HttpRequestMessage request, DocsEnvironment? environment = null)
+        {
+            using (PerfScope.Start($"[{nameof(OpsConfigAdapter)}] Executing request '{request.Method} {request.RequestUri}'"))
+            {
+                _credentialProvider?.Invoke(request);
+
+                await FillOpsToken(request.RequestUri.AbsoluteUri, request, environment);
+
+                return await _http.SendAsync(request);
+            }
+        }
+
         private static string BuildServiceEndpoint(DocsEnvironment? environment = null)
         {
             return (environment ?? DocsEnvironment) switch
             {
-                DocsEnvironment.Prod => "https://docspublic.azurefd.net/api/build",
-                DocsEnvironment.PPE => "https://docspubdev.azurefd.net/api/build",
-                DocsEnvironment.Internal => "https://docspubdev.azurefd.net/api/build",
-                DocsEnvironment.Perf => "https://docspubdev.azurefd.net/api/build",
+                DocsEnvironment.Prod => DocsProdServiceEndpoint,
+                DocsEnvironment.PPE => DocsPPEServiceEndpoint,
+                DocsEnvironment.Internal => DocsInternalServiceEndpoint,
+                DocsEnvironment.Perf => DocsPerfServiceEndpoint,
                 _ => throw new NotSupportedException(),
             };
+        }
+
+        private static DocsEnvironment GetXrefMapEnvironment(string xrefEndpoint)
+        {
+            if (!string.IsNullOrEmpty(xrefEndpoint) &&
+                string.Equals(xrefEndpoint.TrimEnd('/'), "https://xref.docs.microsoft.com", StringComparison.OrdinalIgnoreCase))
+            {
+                return DocsEnvironment.Prod;
+            }
+            return DocsEnvironment;
         }
 
         private static async Task<string> GetSecret(string secret)

--- a/src/docfx/config/ops/OpsAccessor.cs
+++ b/src/docfx/config/ops/OpsAccessor.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Azure.Identity;
@@ -230,7 +231,11 @@ namespace Microsoft.Docs.Build
 
         private static async Task FillOpsToken(string url, HttpRequestMessage request, DocsEnvironment? environment = null)
         {
-            if (url.StartsWith(BuildServiceEndpoint(environment)) && !request.Headers.Contains("X-OP-BuildUserToken"))
+            // don't access key vault for osx since azure-cli will crash in osx
+            // https://github.com/Azure/azure-cli/issues/7519
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                && url.StartsWith(BuildServiceEndpoint(environment))
+                && !request.Headers.Contains("X-OP-BuildUserToken"))
             {
                 // For development usage
                 try

--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -85,7 +85,6 @@ namespace Microsoft.Docs.Build
             var metadataServiceQueryParams = $"?repository_url={HttpUtility.UrlEncode(repository)}&branch={HttpUtility.UrlEncode(branch)}";
 
             var xrefMapQueryParams = $"?site_name={docset.site_name}&branch_name={branch}&exclude_depot_name={docset.product_name}.{name}";
-            var xrefMapBuildServiceEndpoint = GetXrefMapBuildServiceEndpoint(xrefEndpoint);
             if (!string.IsNullOrEmpty(docset.base_path))
             {
                 xrefQueryTags.Add(docset.base_path.ValueWithLeadingSlash);
@@ -93,7 +92,7 @@ namespace Microsoft.Docs.Build
             var xrefMaps = new List<string>();
             foreach (var tag in xrefQueryTags)
             {
-                var links = await _opsAccessor.GetXrefMaps(tag, xrefMapQueryParams, xrefMapBuildServiceEndpoint);
+                var links = await _opsAccessor.GetXrefMaps(tag, xrefEndpoint, xrefMapQueryParams);
                 xrefMaps.AddRange(links);
             }
 
@@ -116,16 +115,6 @@ namespace Microsoft.Docs.Build
                 disallowlists = DisallowlistsApi,
                 xref = xrefMaps,
             });
-        }
-
-        private static DocsEnvironment? GetXrefMapBuildServiceEndpoint(string xrefEndpoint)
-        {
-            if (!string.IsNullOrEmpty(xrefEndpoint) &&
-                string.Equals(xrefEndpoint.TrimEnd('/'), "https://xref.docs.microsoft.com", StringComparison.OrdinalIgnoreCase))
-            {
-                return DocsEnvironment.Prod;
-            }
-            return null;
         }
 
         private static Task<string> GetOpsMetadata()

--- a/src/docfx/config/ops/OpsConfigLoader.cs
+++ b/src/docfx/config/ops/OpsConfigLoader.cs
@@ -178,6 +178,11 @@ namespace Microsoft.Docs.Build
                     var refTOCDir = Path.GetDirectoryName(config.ReferenceTOC);
                     var refTOCRelativeDir = Path.GetRelativePath(buildSourceFolder, string.IsNullOrEmpty(refTOCDir) ? "." : refTOCDir);
                     conceptualToc[Path.Combine(refTOCRelativeDir, "_splitted/**")] = config.ConceptualTOCUrl;
+
+                    if (!string.IsNullOrEmpty(config.ReferenceTOCUrl))
+                    {
+                        refToc[Path.Combine(refTOCRelativeDir, "_splitted/**")] = config.ReferenceTOCUrl;
+                    }
                     conceptualToc[buildSourceFolder.GetRelativePath(new PathString(config.ReferenceTOC))] = config.ConceptualTOCUrl;
                 }
 

--- a/src/docfx/lib/log/ErrorLog.cs
+++ b/src/docfx/lib/log/ErrorLog.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Docs.Build
             {
                 if (customRules.ContainsKey(validationRule.Code))
                 {
-                    Add(Errors.Logging.RuleOverrideInvalid(validationRule.Code, customRules[validationRule.Code].Source));
+                    Add(Errors.Logging.OverrideNotAllowed(validationRule.Code, customRules[validationRule.Code].Source));
                     customRules.Remove(validationRule.Code);
                 }
             }

--- a/src/docfx/lib/path/PackagePath.cs
+++ b/src/docfx/lib/path/PackagePath.cs
@@ -35,8 +35,16 @@ namespace Microsoft.Docs.Build
         {
             if (UrlUtility.IsHttp(value))
             {
-                Type = PackageType.Git;
-                (Url, Branch) = SplitGitUrl(value);
+                if (value.StartsWith("https://static.docs.com/ui/"))
+                {
+                    Type = PackageType.PublicTemplate;
+                    Url = value;
+                }
+                else
+                {
+                    Type = PackageType.Git;
+                    (Url, Branch) = SplitGitUrl(value);
+                }
             }
             else
             {

--- a/src/docfx/lib/path/PackageType.cs
+++ b/src/docfx/lib/path/PackageType.cs
@@ -8,5 +8,6 @@ namespace Microsoft.Docs.Build
         None,
         Folder,
         Git,
+        PublicTemplate,
     }
 }

--- a/src/docfx/restore/FileResolver.cs
+++ b/src/docfx/restore/FileResolver.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
 using System.Threading.Tasks;
 using Polly;
 using Polly.Extensions.Http;
@@ -25,14 +26,14 @@ namespace Microsoft.Docs.Build
         });
 
         private readonly string _docsetPath;
-        private readonly string? _fallbackDocsetPath;
+        private readonly Lazy<string?>? _fallbackDocsetPath;
         private readonly Action<HttpRequestMessage>? _credentialProvider;
         private readonly OpsConfigAdapter? _opsConfigAdapter;
         private readonly FetchOptions _fetchOptions;
 
         public FileResolver(
             string docsetPath,
-            string? fallbackDocsetPath = null,
+            Lazy<string?>? fallbackDocsetPath = null,
             Action<HttpRequestMessage>? credentialProvider = null,
             OpsConfigAdapter? opsConfigAdapter = null,
             FetchOptions fetchOptions = default)
@@ -52,7 +53,30 @@ namespace Microsoft.Docs.Build
 
         public Stream ReadStream(SourceInfo<string> file)
         {
+            if (UrlUtility.IsHttp(file))
+            {
+                var content = TestQuirks.HttpProxy?.Invoke(file);
+                if (content != null)
+                {
+                    byte[] byteArray = Encoding.ASCII.GetBytes(content);
+                    return new MemoryStream(byteArray);
+                }
+            }
             return File.OpenRead(ResolveFilePath(file));
+        }
+
+        public bool TryResolveFilePath(SourceInfo<string> file, out string? result)
+        {
+            try
+            {
+                result = ResolveFilePath(file);
+                return true;
+            }
+            catch (DocfxException ex) when (ex.Error.Code == "file-not-found" || ex.Error.Code == "download-failed")
+            {
+                result = default;
+                return false;
+            }
         }
 
         public string ResolveFilePath(SourceInfo<string> file)
@@ -69,7 +93,7 @@ namespace Microsoft.Docs.Build
                 {
                     return localFilePath;
                 }
-                else if (_fallbackDocsetPath != null && File.Exists(localFilePath = Path.Combine(_fallbackDocsetPath, file)))
+                else if (_fallbackDocsetPath?.Value != null && File.Exists(localFilePath = Path.Combine(_fallbackDocsetPath.Value, file)))
                 {
                     return localFilePath;
                 }
@@ -77,6 +101,11 @@ namespace Microsoft.Docs.Build
                 throw Errors.Link.FileNotFound(file).ToException();
             }
 
+            var content = TestQuirks.HttpProxy?.Invoke(file);
+            if (content != null)
+            {
+                return file;
+            }
             return DownloadFromUrl(file);
         }
 

--- a/src/docfx/restore/PublicTemplatePackage.cs
+++ b/src/docfx/restore/PublicTemplatePackage.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.Docs.Build
+{
+    internal class PublicTemplatePackage : Package
+    {
+        private readonly Uri _baseUrl;
+        private readonly FileResolver _fileResolver;
+
+        public PublicTemplatePackage(string baseUrl, FileResolver fileResolver)
+        {
+            _baseUrl = new Uri($"{baseUrl.TrimEnd('/')}/");
+            _fileResolver = fileResolver;
+        }
+
+        public override bool Exists(PathString path)
+        {
+            return _fileResolver.TryResolveFilePath(GetPath(path), out _);
+        }
+
+        public override IEnumerable<PathString> GetFiles() => throw new NotSupportedException();
+
+        public override Stream ReadStream(PathString path) => _fileResolver.ReadStream(GetPath(path));
+
+        public override PathString? TryGetPhysicalPath(PathString path) => throw new NotSupportedException();
+
+        private SourceInfo<string> GetPath(PathString path)
+        {
+            if (path.StartsWithPath(new PathString("ContentTemplate"), out var remainingPath))
+            {
+                path = remainingPath;
+            }
+            return new SourceInfo<string>(new Uri(_baseUrl, path.Value).AbsoluteUri);
+        }
+    }
+}

--- a/test/docfx.Test/DocfxTestSpec.cs
+++ b/test/docfx.Test/DocfxTestSpec.cs
@@ -37,6 +37,6 @@ namespace Microsoft.Docs.Build
 
         public Dictionary<string, string> Outputs { get; set; } = new Dictionary<string, string>();
 
-        public Dictionary<string, JToken> Http { get; set; } = new Dictionary<string, JToken>();
+        public Dictionary<string, string> Http { get; set; } = new Dictionary<string, string>();
     }
 }


### PR DESCRIPTION
- @928PJY  [BREAKING] Update op API endpoint (#6523) + Support DOCS_SERVICE_ENDPOINT (#6553)
   - Azure Dev task: [AB#288435](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/288435)
   - Impact: no impact for the service build

- @928PJY Disable key vault access in osx (#6555)
   - Azure Dev task: [AB#288444](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/288444)
   - Impact: no impact for the service build

- @928PJY Support public template (#6550)
   - Azure Dev task: [AB#288440](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/288440)
   - Impact: no impact for the service build
- @AngryBerryMS  Service-page Fix(#6551 )
  - Bug: [AB#299330](https://dev.azure.com/ceapex/Engineering/_boards/board/t/DocFX%20v3%20Team/Stories/?workitem=299330)
  - Impact: No impact for current v3 repos. This is for migration in process.
- @AngryBerryMS Splitted Toc Metadata(#6556 )
  - Bug: [AB#299969](https://dev.azure.com/ceapex/Engineering/_boards/board/t/DocFX%20v3%20Team/Stories/?workitem=299969)
  - Impact: split tocs' metadata (add a metadata)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6557)