### PR TITLE
Default allow fallbacking to public data when the credential is not sufficient to get the required data

### DIFF
--- a/src/docfx/config/ops/OpsAccessor.cs
+++ b/src/docfx/config/ops/OpsAccessor.cs
@@ -214,6 +214,9 @@ namespace Microsoft.Docs.Build
         {
             using (PerfScope.Start($"[{nameof(OpsConfigAdapter)}] Executing request '{request.Method} {request.RequestUri}'"))
             {
+                // Default header which allow fallbacking to public data when credential is not provided.
+                request.Headers.TryAddWithoutValidation("X-OP-FallbackToPublicData", true.ToString());
+
                 _credentialProvider?.Invoke(request);
 
                 await FillOpsToken(request.RequestUri.AbsoluteUri, request, environment);


### PR DESCRIPTION
[AB#303461](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/303461)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6569)