### PR TITLE
Add Overview Page and use uid instead of href when encounter splitted toc in href

### DIFF
--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -1976,10 +1976,17 @@ repos:
       a/api/bot/TOC.yml: |
         splitItemsBy: name
         items:
+        - name: Test
+          items:
+          - name: T
         - name: MS.ServicePage2.xxx
           items:
           - name: MS.ServicePage.xxx
             href: ../../test/doc.md
+        - name: MS.ServicePage.yyy
+          href: _splitted/test/
+          items:
+          - name: yyy
       a/docs-ref-toc/top_level_toc.yml: |
         items:
         - name: API Reference
@@ -1990,5 +1997,8 @@ outputs:
   a/test/doc.json:
   a/api/bot/toc.json:
   a/api/bot/_splitted/ms.servicepage2.xxx/toc.json:
+  a/api/bot/_splitted/ms.servicepage.yyy/toc.json:
+  a/api/bot/_splitted/test/toc.json:
   a/docs-ref-toc/index.json: |
-    {"name": "API Reference", "fullName": "API Reference", "children": [{"name": "MS.ServicePage.xxx", "href": "../test/doc"}], "pageType": "root"}
+    {"name": "API Reference", "fullName": "API Reference", 
+    "children": [{"name": "MS.ServicePage2.xxx"},{"name": "MS.ServicePage.yyy"}], "pageType": "root"}

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -1840,7 +1840,7 @@ outputs:
     }
   a/results/appservice/client.json: |
     {
-      "name": "Client", "fullName": "Client", "href": "../api/doc.md",
+      "name": "Client", "fullName": "Client", "href": "doc.md",
       "children": [{"name": "Client","uid": "aa"},{"name": "MS.ServicePage.xxx"},{"name": "MS.ServicePage.Client.Form"}],
       "langs": ["csharp"], "pageType": "service"
     }
@@ -1976,17 +1976,10 @@ repos:
       a/api/bot/TOC.yml: |
         splitItemsBy: name
         items:
-        - name: Test
-          items:
-          - name: T
         - name: MS.ServicePage2.xxx
           items:
           - name: MS.ServicePage.xxx
             href: ../../test/doc.md
-        - name: MS.ServicePage.yyy
-          href: _splitted/test/
-          items:
-          - name: yyy
       a/docs-ref-toc/top_level_toc.yml: |
         items:
         - name: API Reference
@@ -1997,8 +1990,82 @@ outputs:
   a/test/doc.json:
   a/api/bot/toc.json:
   a/api/bot/_splitted/ms.servicepage2.xxx/toc.json:
-  a/api/bot/_splitted/ms.servicepage.yyy/toc.json:
-  a/api/bot/_splitted/test/toc.json:
   a/docs-ref-toc/index.json: |
-    {"name": "API Reference", "fullName": "API Reference", 
-    "children": [{"name": "MS.ServicePage2.xxx"},{"name": "MS.ServicePage.yyy"}], "pageType": "root"}
+    {"name": "API Reference", "fullName": "API Reference", "children": [{"name": "MS.ServicePage2.xxx"}], "pageType": "root"}
+---
+# make overview page for service pages
+repos:
+  https://github.com/ops/service-page-overview:
+  - files:
+      .openpublishing.publish.config.json: |
+        {
+          "docsets_to_publish": [{  "build_source_folder": "a"}],
+          "JoinTOCPlugin": [
+            {"ReferenceTOC": "a/api/bot/TOC.yml",
+              "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml"}],
+        }
+      a/docfx.yml:
+      a/_themes/ContentTemplate/schemas/ReferenceContainer.schema.json: |
+        {
+          "type": "object",
+          "required": ["name", "pageType"],
+          "properties": {
+            "uid": {"contentType": "uid", "type": "string"},
+            "name": {"type": "string"}, "fullName": {"type": "string"},
+            "children": {
+              "items": { 
+                "type": "object", "additionalProperties": false,
+                "properties": {
+                  "href": {"contentType": "href", "type": "string"},
+                  "uid": {"contentType": "xref", "type": "string"},
+                  "name": {"type": "string"}
+                }
+              }, "type": "array", "minItems": 1},
+            "pageType": { "enum": ["root", "service"], "type": "string" }
+          }
+        }
+      a/test/doc.md:
+      a/api/bot/TOC.yml: |
+        splitItemsBy: name
+        items:
+        - name: MS.ServicePage2.xxx
+          items:
+          - name: MS.ServicePage.xxx
+            href: ../../test/doc.md
+      a/docs-ref-toc/top_level_toc.yml: |
+        items:
+        - name: API Reference
+          landingPageType: Root
+          items:
+          - name: API Test
+            href: ../test/doc.md
+            children:
+            - 'MS.ServicePage*'
+outputs:
+  a/test/doc.json:
+  a/api/bot/toc.json: |
+    {
+      "items": [
+        {
+          "name": "API Reference",
+          "items": [
+            {
+              "name": "API Test",
+              "items": [
+                {
+                  "name": "Overview",
+                  "href": "../../test/doc",
+                  "items": [
+                    { "name": "MS.ServicePage2.xxx", "href": "../../test/doc" }
+                  ]
+                },
+                { "name": "MS.ServicePage2.xxx", "href": "../../test/doc" }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  a/api/bot/_splitted/ms.servicepage2.xxx/toc.json:
+  a/docs-ref-toc/index.json: |
+    {"name": "API Reference", "fullName": "API Reference", "children": [{"name": "API Test"}], "pageType": "root"}

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -2053,11 +2053,7 @@ outputs:
               "name": "API Test",
               "items": [
                 {
-                  "name": "Overview",
-                  "href": "../../test/doc",
-                  "items": [
-                    { "name": "MS.ServicePage2.xxx", "href": "../../test/doc" }
-                  ]
+                  "name": "Overview"
                 },
                 { "name": "MS.ServicePage2.xxx", "href": "../../test/doc" }
               ]

--- a/docs/specs/toc.yml
+++ b/docs/specs/toc.yml
@@ -1939,3 +1939,56 @@ outputs:
   a/api/bot/toc.json:
   a/docs-ref-toc/index.json: |
     {"name": "API Reference", "fullName": "API Reference", "children": [{"name": "MS.ServicePage.xxx", "href": "../test/doc"}], "pageType": "root"}
+---
+# item-href in service-page linking to a splitted toc
+# Service Page href fix: TopLevelTOC and ReferenceTOC in different directory hierarchy
+repos:
+  https://github.com/ops/service-page-splitted-toc:
+  - files:
+      .openpublishing.publish.config.json: |
+        {
+          "docsets_to_publish": [{  "build_source_folder": "a"}],
+          "JoinTOCPlugin": [
+            {"ReferenceTOC": "a/api/bot/TOC.yml",
+              "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml"}],
+        }
+      a/docfx.yml:
+      a/_themes/ContentTemplate/schemas/ReferenceContainer.schema.json: |
+        {
+          "type": "object",
+          "required": ["name", "pageType"],
+          "properties": {
+            "uid": {"contentType": "uid", "type": "string"},
+            "name": {"type": "string"}, "fullName": {"type": "string"},
+            "children": {
+              "items": { 
+                "type": "object", "additionalProperties": false,
+                "properties": {
+                  "href": {"contentType": "href", "type": "string"},
+                  "uid": {"contentType": "xref", "type": "string"},
+                  "name": {"type": "string"}
+                }
+              }, "type": "array", "minItems": 1},
+            "pageType": { "enum": ["root", "service"], "type": "string" }
+          }
+        }
+      a/test/doc.md:
+      a/api/bot/TOC.yml: |
+        splitItemsBy: name
+        items:
+        - name: MS.ServicePage2.xxx
+          items:
+          - name: MS.ServicePage.xxx
+            href: ../../test/doc.md
+      a/docs-ref-toc/top_level_toc.yml: |
+        items:
+        - name: API Reference
+          landingPageType: Root
+          children:
+          - 'MS.ServicePage*'
+outputs:
+  a/test/doc.json:
+  a/api/bot/toc.json:
+  a/api/bot/_splitted/ms.servicepage2.xxx/toc.json:
+  a/docs-ref-toc/index.json: |
+    {"name": "API Reference", "fullName": "API Reference", "children": [{"name": "MS.ServicePage.xxx", "href": "../test/doc"}], "pageType": "root"}

--- a/src/docfx/build/toc/ServicePageGenerator.cs
+++ b/src/docfx/build/toc/ServicePageGenerator.cs
@@ -71,20 +71,18 @@ namespace Microsoft.Docs.Build
                     var childHref = item.Value.Href.Value;
                     var childUid = item.Value.Uid.Value;
 
-                    if (!string.IsNullOrEmpty(childHref) && childHref.EndsWith('/'))
+                    if (!string.IsNullOrEmpty(childHref) &&
+                        TableOfContentsLoader.GetHrefType(childHref) == TableOfContentsLoader.TocHrefType.RelativeFolder)
                     {
                         childHref = null;
                     }
 
-                    if (!string.IsNullOrEmpty(childHref) && UrlUtility.GetLinkType(childHref) == LinkType.RelativePath)
+                    if (!string.IsNullOrEmpty(childHref) && !(childHref.StartsWith("~/") || childHref.StartsWith("~\\")))
                     {
-                        if (!(childHref.StartsWith("~/") || childHref.StartsWith("~\\")))
-                        {
-                            var hrefFileFullPath = Path.GetFullPath(Path.Combine(referenceTOCFullPath, childHref));
-                            var servicePageFullPath = Path.GetDirectoryName(Path.GetFullPath(Path.Combine(_docsetPath, servicePagePath.Path))) ?? _docsetPath;
-                            var hrefRelativePathToReferenceTOC = Path.GetRelativePath(servicePageFullPath, hrefFileFullPath);
-                            childHref = hrefRelativePathToReferenceTOC;
-                        }
+                        var hrefFileFullPath = Path.GetFullPath(Path.Combine(referenceTOCFullPath, childHref));
+                        var servicePageFullPath = Path.GetDirectoryName(Path.GetFullPath(Path.Combine(_docsetPath, servicePagePath.Path))) ?? _docsetPath;
+                        var hrefRelativePathToReferenceTOC = Path.GetRelativePath(servicePageFullPath, hrefFileFullPath);
+                        childHref = hrefRelativePathToReferenceTOC;
 
                         child = new ServicePageItem(childName, childHref, null);
                     }

--- a/src/docfx/build/toc/ServicePageGenerator.cs
+++ b/src/docfx/build/toc/ServicePageGenerator.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Docs.Build
                     var childUid = item.Value.Uid.Value;
 
                     if (!string.IsNullOrEmpty(childHref) &&
-                        TableOfContentsLoader.GetHrefType(childHref) == TableOfContentsLoader.TocHrefType.RelativeFolder)
+                        TableOfContentsLoader.GetHrefType(childHref) == TocHrefType.RelativeFolder)
                     {
                         childHref = null;
                     }

--- a/src/docfx/build/toc/ServicePageGenerator.cs
+++ b/src/docfx/build/toc/ServicePageGenerator.cs
@@ -77,12 +77,15 @@ namespace Microsoft.Docs.Build
                         childHref = null;
                     }
 
-                    if (!string.IsNullOrEmpty(childHref) && !(childHref.StartsWith("~/") || childHref.StartsWith("~\\")))
+                    if (!string.IsNullOrEmpty(childHref))
                     {
-                        var hrefFileFullPath = Path.GetFullPath(Path.Combine(referenceTOCFullPath, childHref));
-                        var servicePageFullPath = Path.GetDirectoryName(Path.GetFullPath(Path.Combine(_docsetPath, servicePagePath.Path))) ?? _docsetPath;
-                        var hrefRelativePathToReferenceTOC = Path.GetRelativePath(servicePageFullPath, hrefFileFullPath);
-                        childHref = hrefRelativePathToReferenceTOC;
+                        if (!(childHref.StartsWith("~/") || childHref.StartsWith("~\\")))
+                        {
+                            var hrefFileFullPath = Path.GetFullPath(Path.Combine(referenceTOCFullPath, childHref));
+                            var servicePageFullPath = Path.GetDirectoryName(Path.GetFullPath(Path.Combine(_docsetPath, servicePagePath.Path))) ?? _docsetPath;
+                            var hrefRelativePathToReferenceTOC = Path.GetRelativePath(servicePageFullPath, hrefFileFullPath);
+                            childHref = hrefRelativePathToReferenceTOC;
+                        }
 
                         child = new ServicePageItem(childName, childHref, null);
                     }

--- a/src/docfx/build/toc/ServicePageGenerator.cs
+++ b/src/docfx/build/toc/ServicePageGenerator.cs
@@ -71,6 +71,11 @@ namespace Microsoft.Docs.Build
                     var childHref = item.Value.Href.Value;
                     var childUid = item.Value.Uid.Value;
 
+                    if (!string.IsNullOrEmpty(childHref) && childHref.EndsWith('/'))
+                    {
+                        childHref = null;
+                    }
+
                     if (!string.IsNullOrEmpty(childHref) && UrlUtility.GetLinkType(childHref) == LinkType.RelativePath)
                     {
                         if (!(childHref.StartsWith("~/") || childHref.StartsWith("~\\")))

--- a/src/docfx/build/toc/TableOfContentsLoader.cs
+++ b/src/docfx/build/toc/TableOfContentsLoader.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Docs.Build
 
                 var hrefRelativeToReferenceTOC = Path.GetRelativePath(referenceTOCFullPath, hrefFullPath);
 
-                node.Href.With(hrefRelativeToReferenceTOC);
+                node.Href = node.Href.With(hrefRelativeToReferenceTOC);
             }
             foreach (var item in node.Items)
             {
@@ -161,6 +161,8 @@ namespace Microsoft.Docs.Build
                         {
                             servicePage.GenerateServicePageFromTopLevelTOC(item, servicePages);
                         }
+
+                        TableOfContentsNode.SeperatedExpandableClickableNode(node);
                     }
                 }
 

--- a/src/docfx/build/toc/TableOfContentsLoader.cs
+++ b/src/docfx/build/toc/TableOfContentsLoader.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Docs.Build
                             servicePage.GenerateServicePageFromTopLevelTOC(item, servicePages);
                         }
 
-                        TableOfContentsNode.SeperatedExpandableClickableNode(node);
+                        AddOverviewPage(node);
                     }
                 }
 
@@ -178,6 +178,28 @@ namespace Microsoft.Docs.Build
             finally
             {
                 t_recursionDetector.Value = recursionDetector.Pop();
+            }
+        }
+
+        private void AddOverviewPage(TableOfContentsNode toc)
+        {
+            if (toc == null || toc.Items == null || toc.Items.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var child in toc.Items)
+            {
+                AddOverviewPage(child);
+            }
+
+            if (!string.IsNullOrEmpty(toc.Uid) || !string.IsNullOrEmpty(toc.Href))
+            {
+                var overview = toc.CloneWithoutItems();
+                overview.Name = overview.Name.With("Overview");
+                toc.Items.Insert(0, new SourceInfo<TableOfContentsNode>(overview));
+                toc.Uid = toc.Uid.With(null);
+                toc.Href = toc.Href.With(null);
             }
         }
 

--- a/src/docfx/build/toc/TableOfContentsLoader.cs
+++ b/src/docfx/build/toc/TableOfContentsLoader.cs
@@ -59,15 +59,6 @@ namespace Microsoft.Docs.Build
             _joinTOCConfigs = config.JoinTOC.Where(x => x.ReferenceToc != null).ToDictionary(x => PathUtility.Normalize(x.ReferenceToc!));
         }
 
-        public enum TocHrefType
-        {
-            None,
-            AbsolutePath,
-            RelativeFile,
-            RelativeFolder,
-            TocFile,
-        }
-
         public static TocHrefType GetHrefType(string? href)
         {
             var linkType = UrlUtility.GetLinkType(href);

--- a/src/docfx/build/toc/TableOfContentsNode.cs
+++ b/src/docfx/build/toc/TableOfContentsNode.cs
@@ -90,6 +90,7 @@ namespace Microsoft.Docs.Build
             {
                 var overview = toc.Clone();
                 overview.Name = overview.Name.With("Overview");
+                overview.Items = new List<SourceInfo<TableOfContentsNode>>();
                 toc.Items.Insert(0, new SourceInfo<TableOfContentsNode>(overview));
                 toc.Uid = toc.Uid.With(null);
                 toc.Href = toc.Href.With(null);

--- a/src/docfx/build/toc/TableOfContentsNode.cs
+++ b/src/docfx/build/toc/TableOfContentsNode.cs
@@ -74,52 +74,11 @@ namespace Microsoft.Docs.Build
             LandingPageType = item.LandingPageType;
         }
 
-        public static void SeperatedExpandableClickableNode(TableOfContentsNode toc)
-        {
-            if (toc == null || toc.Items == null || toc.Items.Count == 0)
-            {
-                return;
-            }
-
-            foreach (var child in toc.Items)
-            {
-                SeperatedExpandableClickableNode(child);
-            }
-
-            if (!string.IsNullOrEmpty(toc.Uid) || !string.IsNullOrEmpty(toc.Href))
-            {
-                var overview = toc.Clone();
-                overview.Name = overview.Name.With("Overview");
-                overview.Items = new List<SourceInfo<TableOfContentsNode>>();
-                toc.Items.Insert(0, new SourceInfo<TableOfContentsNode>(overview));
-                toc.Uid = toc.Uid.With(null);
-                toc.Href = toc.Href.With(null);
-            }
-        }
-
-        public TableOfContentsNode Clone()
+        public TableOfContentsNode CloneWithoutItems()
         {
             var cloned = (TableOfContentsNode)this.MemberwiseClone();
-            if (cloned.Items != null && cloned.Items.Count > 0)
-            {
-                cloned.Items = CloneItems();
-            }
+            cloned.Items = new List<SourceInfo<TableOfContentsNode>>();
             return cloned;
-        }
-
-        private List<SourceInfo<TableOfContentsNode>> CloneItems()
-        {
-            var items = this.Items;
-            var clonedItems = new List<SourceInfo<TableOfContentsNode>>();
-            if (items != null && items.Count > 0)
-            {
-                foreach (var item in items)
-                {
-                    var newItem = new SourceInfo<TableOfContentsNode>(item.Value.Clone(), item.Source);
-                    clonedItems.Add(newItem);
-                }
-            }
-            return clonedItems;
         }
     }
 }

--- a/src/docfx/build/toc/TableOfContentsNode.cs
+++ b/src/docfx/build/toc/TableOfContentsNode.cs
@@ -73,5 +73,52 @@ namespace Microsoft.Docs.Build
             Children = item.Children;
             LandingPageType = item.LandingPageType;
         }
+
+        public static void SeperatedExpandableClickableNode(TableOfContentsNode toc)
+        {
+            if (toc == null || toc.Items == null || toc.Items.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var child in toc.Items)
+            {
+                SeperatedExpandableClickableNode(child);
+            }
+
+            if (!string.IsNullOrEmpty(toc.Uid) || !string.IsNullOrEmpty(toc.Href))
+            {
+                var overview = toc.Clone();
+                overview.Name = overview.Name.With("Overview");
+                toc.Items.Insert(0, new SourceInfo<TableOfContentsNode>(overview));
+                toc.Uid = toc.Uid.With(null);
+                toc.Href = toc.Href.With(null);
+            }
+        }
+
+        public TableOfContentsNode Clone()
+        {
+            var cloned = (TableOfContentsNode)this.MemberwiseClone();
+            if (cloned.Items != null && cloned.Items.Count > 0)
+            {
+                cloned.Items = CloneItems();
+            }
+            return cloned;
+        }
+
+        private List<SourceInfo<TableOfContentsNode>> CloneItems()
+        {
+            var items = this.Items;
+            var clonedItems = new List<SourceInfo<TableOfContentsNode>>();
+            if (items != null && items.Count > 0)
+            {
+                foreach (var item in items)
+                {
+                    var newItem = new SourceInfo<TableOfContentsNode>(item.Value.Clone(), item.Source);
+                    clonedItems.Add(newItem);
+                }
+            }
+            return clonedItems;
+        }
     }
 }

--- a/src/docfx/build/toc/TocHrefType.cs
+++ b/src/docfx/build/toc/TocHrefType.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Docs.Build
+{
+    public enum TocHrefType
+    {
+        None,
+        AbsolutePath,
+        RelativeFile,
+        RelativeFolder,
+        TocFile,
+    }
+}


### PR DESCRIPTION
- Add missing overview page.
- use uid but not href in service pages when the href is a splitted toc directory.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6571)