### PR TITLE
index.html: Change from .NET to explicit languages

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@ footer{
         <i class="glyphicon glyphicon-grain"></i>
         <section>
           <h2>Generate static sites from Markdown and code files</h2>
-          <p class="lead">DocFX can produce documentation from source code (including C#, Visual Basic, REST, JavaScript, Java, Python and TypeScript) as well as raw Markdown files.</p>
+          <p class="lead">DocFX can produce documentation from source code (including C#, F#, Visual Basic, REST, JavaScript, Java, Python and TypeScript) as well as raw Markdown files.</p>
         </section>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@ footer{
         <i class="glyphicon glyphicon-grain"></i>
         <section>
           <h2>Generate static sites from Markdown and code files</h2>
-          <p class="lead">DocFX can produce documentation from source code (including .NET, REST, JavaScript, Java, Python and TypeScript) as well as raw Markdown files.</p>
+          <p class="lead">DocFX can produce documentation from source code (including C#, Visual Basic, REST, JavaScript, Java, Python and TypeScript) as well as raw Markdown files.</p>
         </section>
       </div>
     </div>


### PR DESCRIPTION
.NET is not a "programming language" per se, and even though I understand that it might be used as an umbrella term here, I think it makes more sense to explicitly mention the languages supported by DocFx in this case.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6576)