### PR TITLE
docfx_getting_started: Mention mono-devel

### DIFF
--- a/tutorial/docfx_getting_started.html
+++ b/tutorial/docfx_getting_started.html
@@ -116,7 +116,7 @@ For a detailed description about DFM, please refer to <a href="../spec/docfx_fla
 <p>Now you can view the generated website on http://localhost:8080.</p>
 <div class="IMPORTANT">
 <h5>Important</h5>
-<p>For macOS/Linux users: Use <a href="https://www.mono-project.com/">Mono</a> version &gt;= 5.10.</p>
+<p>For macOS/Linux users: Use <a href="https://www.mono-project.com/">Mono</a> version &gt;= 5.10. The following command line can be used on Debian/Ubuntu: <tt>sudo apt-get install mono-runtime mono-devel</tt></p>
 <p>For macOS users: <strong>DO NOT</strong> Install Mono from Homebrew, but rather from the <a href="https://www.mono-project.com/download/stable/#download-mac">Mono download page</a>.</p>
 </div>
 <h2 id="3-use-docfx-integrated-with-visual-studio">3. Use <em>DocFX</em> integrated with Visual Studio</h2>


### PR DESCRIPTION
The primary aim here is to ensure that `mono-devel` is mentioned, since it's not enough in this case to just have the runtime package installed. Feel free to edit the exact text being used if needed.

Closes #5082.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6581)