### PR TITLE
Report approximate line number for markdown contents inside YAML

### DIFF
--- a/docs/specs/learn.yml
+++ b/docs/specs/learn.yml
@@ -645,6 +645,7 @@ outputs:
     {"message_severity":"error","code":"unit-uid-missing","message":"Missing attribute: UID. A valid UID is required for each unit.","file":"unita.yml","line":2}
     {"message_severity":"error","code":"unit-duration-missing","message":"Missing attribute: durationInMinutes. DurationInMinutes is required for each unit and must be greater than 0.","file":"unita.yml","line":2}
     {"message_severity":"error","code":"unit-task-and-quiz","message":"Unit can't have both quiz and task.","file":"unitb.yml","line":2}
+---
 # validate learn included markdown
 inputs:
   docfx.yml: |

--- a/docs/specs/schema.yml
+++ b/docs/specs/schema.yml
@@ -388,9 +388,9 @@ inputs:
     <h2 id="{{heading}}"></h2>{{{description}}}
 outputs:
   .errors.log: |
-    {"message_severity":"warning","log_item_type":"user","code":"bookmark-not-found","message":"Cannot find bookmark '#heading-3' in 'b.yml', did you mean '#heading-1'?","file":"b.yml","line":4}
-    {"message_severity":"warning","log_item_type":"user","code":"bookmark-not-found","message":"Cannot find bookmark '#heading-3' in 'a.yml', did you mean '#heading-1'?","file":"c.md","line":3}
-    {"message_severity":"warning","log_item_type":"user","code":"bookmark-not-found","message":"Cannot find bookmark '#heading-3' in 'a.yml', did you mean '#heading-1'?","file":"b.yml","line":7}
+    {"message_severity":"warning","log_item_type":"user","code":"bookmark-not-found","message":"Cannot find bookmark '#heading-3' in 'b.yml', did you mean '#heading-1'?","file":"b.yml","line":6,"column":1}
+    {"message_severity":"warning","log_item_type":"user","code":"bookmark-not-found","message":"Cannot find bookmark '#heading-3' in 'a.yml', did you mean '#heading-1'?","file":"c.md","line":3,"column":1}
+    {"message_severity":"warning","log_item_type":"user","code":"bookmark-not-found","message":"Cannot find bookmark '#heading-3' in 'a.yml', did you mean '#heading-1'?","file":"b.yml","line":9,"column":1}
   a.mta.json:
   a.raw.page.json:
   b.mta.json:
@@ -511,7 +511,6 @@ outputs:
   docs/b.json:
 ---
 # Disable content fallback for loc page of ModuleUnit
-noDryRun: true
 locale: zh-cn
 repos:
   https://docs.com/page-fallback#master:
@@ -536,3 +535,24 @@ repos:
 outputs:
   .errors.log: |
     { "message_severity":"error","code":"include-not-found","message":"Invalid include link: 'includes/b.md'.","file":"unit.yml"}
+---
+# Report approximate line number for markdown contents inside YAML
+inputs:
+  docfx.yml:
+  a.yml: |
+    #YamlMime: Test
+    markdowns:
+    - '[!include[](a.md)]'
+    - '[!include[](b.md)]'
+  _themes/ContentTemplate/schemas/Test.schema.json: |
+    {
+      "properties": {
+        "markdowns": {
+          "items": { "contentType": "markdown" }
+        }
+      }
+    }
+outputs:
+  .errors.log: |
+    { "code":"include-not-found","file":"a.yml","line":3,"column":3,"end_line":3,"end_column":3 }
+    { "code":"include-not-found","file":"a.yml","line":4,"column":3,"end_line":4,"end_column":3 }

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Docs.Build
             context.MetadataValidator.ValidateMetadata(errors, userMetadata.RawJObject, file);
 
             var conceptual = new ConceptualModel { Title = userMetadata.Title };
-            var html = context.MarkdownEngine.ToHtml(errors, content, file, MarkdownPipelineType.Markdown, conceptual);
+            var html = context.MarkdownEngine.ToHtml(errors, content, new SourceInfo(file), MarkdownPipelineType.Markdown, conceptual);
 
             context.SearchIndexBuilder.SetTitle(file, conceptual.Title);
             context.ContentValidator.ValidateTitle(file, conceptual.Title, userMetadata.TitleSuffix);

--- a/src/docfx/build/toc/TableOfContentsParser.cs
+++ b/src/docfx/build/toc/TableOfContentsParser.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Docs.Build
         private TableOfContentsNode ParseMarkdown(string content, FilePath file, ErrorBuilder errors)
         {
             var headingBlocks = new List<HeadingBlock>();
-            var ast = _markdownEngine.Parse(errors, content, file, MarkdownPipelineType.TocMarkdown);
+            var ast = _markdownEngine.Parse(errors, content, new SourceInfo(file), MarkdownPipelineType.TocMarkdown);
 
             foreach (var block in ast)
             {

--- a/src/docfx/lib/log/SourceInfo.cs
+++ b/src/docfx/lib/log/SourceInfo.cs
@@ -123,6 +123,10 @@ namespace Microsoft.Docs.Build
 
         public override string ToString()
         {
+            if (ApexValidationExtension.ForceSourceInfoToStringFilePathOnly)
+            {
+                return File.ToString();
+            }
             return Line <= 1 && Column <= 1 ? File.ToString() : $"{File}({Line},{Column})";
         }
 

--- a/src/docfx/lib/log/SourceInfo.cs
+++ b/src/docfx/lib/log/SourceInfo.cs
@@ -13,22 +13,22 @@ namespace Microsoft.Docs.Build
         public FilePath File { get; }
 
         /// <summary>
-        /// A one based start line value.
+        /// A one based start line value, or zero if there is no line info.
         /// </summary>
         public int Line { get; }
 
         /// <summary>
-        /// A one based start column value.
+        /// A one based start column value, or zero if there is no line info.
         /// </summary>
         public int Column { get; }
 
         /// <summary>
-        /// A one based end line value.
+        /// A one based end line value, or zero if there is no line info.
         /// </summary>
         public int EndLine { get; }
 
         /// <summary>
-        /// A one based end column value.
+        /// A one based end column value, or zero if there is no line info.
         /// </summary>
         public int EndColumn { get; }
 
@@ -65,6 +65,36 @@ namespace Microsoft.Docs.Build
         public SourceInfo WithKeySourceInfo(SourceInfo? keySourceInfo)
         {
             return new SourceInfo(File, Line, Column, EndLine, EndColumn, keySourceInfo);
+        }
+
+        public SourceInfo WithOffset(SourceInfo? offset)
+        {
+            if (offset is null)
+            {
+                return this;
+            }
+
+            if (offset.File != File)
+            {
+                return offset;
+            }
+
+            return WithOffset(offset.Line, offset.Column, offset.EndLine, offset.EndColumn);
+        }
+
+        public SourceInfo WithOffset(int line, int column)
+        {
+            var start = OffSet(Line, Column, line, column);
+
+            return new SourceInfo(File, start.line, start.column, start.line, start.column);
+        }
+
+        public SourceInfo WithOffset(int line, int column, int endLine, int endColumn)
+        {
+            var start = OffSet(Line, Column, line, column);
+            var end = OffSet(Line, Column, endLine, endColumn);
+
+            return new SourceInfo(File, start.line, start.column, end.line, end.column);
         }
 
         public static bool operator ==(SourceInfo? a, SourceInfo? b) => Equals(a, b);
@@ -125,6 +155,16 @@ namespace Microsoft.Docs.Build
             }
 
             return result;
+        }
+
+        private static (int line, int column) OffSet(int line1, int column1, int line2, int column2)
+        {
+            line1 = line1 <= 0 ? 1 : line1;
+            column1 = column1 <= 0 ? 1 : column1;
+            line2 = line2 <= 0 ? 1 : line2;
+            column2 = column2 <= 0 ? 1 : column2;
+
+            return line2 == 1 ? (line1, column1 + column2 - 1) : (line1 + line2 - 1, column2);
         }
     }
 }

--- a/src/docfx/lib/markdown/HtmlExtension.cs
+++ b/src/docfx/lib/markdown/HtmlExtension.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Docs.Build
             return builder.Use(document =>
             {
                 var errors = getErrors();
-                var file = (FilePath)InclusionContext.File;
+                var file = ((SourceInfo)InclusionContext.File).File;
                 var scanTags = TemplateEngine.IsConceptual(documentProvider.GetMime(file)) &&
                     !metadataProvider.GetMetadata(errors, file).IsArchived;
 

--- a/src/docfx/lib/markdown/IncludeExtension.cs
+++ b/src/docfx/lib/markdown/IncludeExtension.cs
@@ -67,13 +67,13 @@ namespace Microsoft.Docs.Build
 
             if (InclusionContext.IsCircularReference(file, out var dependencyChain))
             {
-                throw Errors.Link.CircularReference(new SourceInfo((FilePath)file), file, dependencyChain.Reverse()).ToException();
+                throw Errors.Link.CircularReference((SourceInfo)file, file, dependencyChain.Reverse()).ToException();
             }
 
             using (InclusionContext.PushInclusion(file))
             {
                 var child = Markdown.Parse(content, pipeline);
-                child.SetFilePath((FilePath)file);
+                child.SetSourceInfo((SourceInfo)file);
                 ExpandInclude(context, child, pipeline, inlinePipeline, errors);
                 inclusionBlock.Add(child);
             }
@@ -91,7 +91,7 @@ namespace Microsoft.Docs.Build
 
             if (InclusionContext.IsCircularReference(file, out var dependencyChain))
             {
-                throw Errors.Link.CircularReference(new SourceInfo((FilePath)file), file, dependencyChain.Reverse()).ToException();
+                throw Errors.Link.CircularReference((SourceInfo)file, file, dependencyChain.Reverse()).ToException();
             }
 
             using (InclusionContext.PushInclusion(file))
@@ -103,7 +103,7 @@ namespace Microsoft.Docs.Build
                 {
                     if (block is LeafBlock leaf && leaf.Inline != null)
                     {
-                        leaf.Inline.SetFilePath((FilePath)file);
+                        leaf.Inline.SetSourceInfo((SourceInfo)file);
                         inclusionInline.AppendChild(leaf.Inline);
                     }
                 }

--- a/src/docfx/lib/markdown/MarkdownEngine.cs
+++ b/src/docfx/lib/markdown/MarkdownEngine.cs
@@ -81,9 +81,9 @@ namespace Microsoft.Docs.Build
             };
         }
 
-        public MarkdownDocument Parse(ErrorBuilder errors, string content, FilePath file, MarkdownPipelineType pipelineType)
+        public MarkdownDocument Parse(ErrorBuilder errors, string content, SourceInfo sourceInfo, MarkdownPipelineType pipelineType)
         {
-            using (InclusionContext.PushFile(file))
+            using (InclusionContext.PushFile(sourceInfo))
             {
                 try
                 {
@@ -103,12 +103,12 @@ namespace Microsoft.Docs.Build
         public string ToHtml(
             ErrorBuilder errors,
             string markdown,
-            FilePath file,
+            SourceInfo sourceInfo,
             MarkdownPipelineType pipelineType,
             ConceptualModel? conceptual = null,
             bool contentFallback = true)
         {
-            using (InclusionContext.PushFile(file))
+            using (InclusionContext.PushFile(sourceInfo))
             {
                 try
                 {
@@ -273,12 +273,7 @@ namespace Microsoft.Docs.Build
         {
             // At parser stage, we are unable to reliably access GetPathToRoot method,
             // use InclusionContext to report syntax diagnostics.
-            var source = new SourceInfo(
-                (FilePath)InclusionContext.File,
-                line is null ? (origin?.Line + 1) ?? 0 : (line.Value + 1),
-                line is null ? (origin?.Column + 1) ?? 0 : 0);
-
-            t_status.Value!.Peek().Errors.Add(new Error(level, code, $"{message}", source));
+            t_status.Value!.Peek().Errors.Add(new Error(level, code, $"{message}", ((SourceInfo)InclusionContext.File).WithOffset(origin, line)));
         }
 
         private static ErrorBuilder GetErrors()
@@ -296,11 +291,6 @@ namespace Microsoft.Docs.Build
             return _metadataProvider.GetMetadata(GetErrors(), path).Layout;
         }
 
-        private bool IsArchived(FilePath path)
-        {
-            return _metadataProvider.GetMetadata(GetErrors(), path).IsArchived;
-        }
-
         private (string? content, object? file) ReadFile(string path, MarkdownObject origin)
         {
             var status = t_status.Value!.Peek();
@@ -310,14 +300,14 @@ namespace Microsoft.Docs.Build
                 status.ContentFallback);
             status.Errors.AddIfNotNull(error);
 
-            return file is null ? default : (_input.ReadString(file).Replace("\r", ""), file);
+            return file is null ? default : (_input.ReadString(file).Replace("\r", ""), new SourceInfo(file));
         }
 
         private string GetLink(string path, MarkdownObject origin)
         {
             var status = t_status.Value!.Peek();
             var (error, link, _) = _linkResolver.ResolveLink(
-                new SourceInfo<string>(path, origin.GetSourceInfo()), origin.GetFilePath(), (FilePath)InclusionContext.RootFile);
+                new SourceInfo<string>(path, origin.GetSourceInfo()), origin.GetFilePath(), GetRootFilePath());
             status.Errors.AddIfNotNull(error);
 
             return link;
@@ -335,7 +325,7 @@ namespace Microsoft.Docs.Build
 
         private string GetImageLink(SourceInfo<string> href, MarkdownObject origin, string? altText, int imageIndex)
         {
-            _contentValidator.ValidateImageLink((FilePath)InclusionContext.RootFile, href, origin, altText, imageIndex);
+            _contentValidator.ValidateImageLink(GetRootFilePath(), href, origin, altText, imageIndex);
             var link = GetLink(href);
             return link;
         }
@@ -343,7 +333,7 @@ namespace Microsoft.Docs.Build
         private string GetLink(SourceInfo<string> href)
         {
             var status = t_status.Value!.Peek();
-            var (error, link, _) = _linkResolver.ResolveLink(href, GetFilePath(href), (FilePath)InclusionContext.RootFile);
+            var (error, link, _) = _linkResolver.ResolveLink(href, GetFilePath(href), GetRootFilePath());
             status.Errors.AddIfNotNull(error);
 
             return link;
@@ -355,9 +345,9 @@ namespace Microsoft.Docs.Build
             var status = t_status.Value!.Peek();
 
             var (error, link, display, _) = href.HasValue
-                ? _xrefResolver.ResolveXrefByHref(href.Value, GetFilePath(href.Value), (FilePath)InclusionContext.RootFile)
+                ? _xrefResolver.ResolveXrefByHref(href.Value, GetFilePath(href.Value), GetRootFilePath())
                 : uid.HasValue
-                    ? _xrefResolver.ResolveXrefByUid(uid.Value, GetFilePath(uid.Value), (FilePath)InclusionContext.RootFile)
+                    ? _xrefResolver.ResolveXrefByUid(uid.Value, GetFilePath(uid.Value), GetRootFilePath())
                     : default;
 
             if (!suppressXrefNotFound)
@@ -369,22 +359,27 @@ namespace Microsoft.Docs.Build
 
         private static FilePath GetFilePath<T>(SourceInfo<T> sourceInfo)
         {
-            return sourceInfo.Source?.File ?? (FilePath)InclusionContext.File;
+            return sourceInfo.Source?.File ?? ((SourceInfo)InclusionContext.File).File;
+        }
+
+        private static FilePath GetRootFilePath()
+        {
+            return ((SourceInfo)InclusionContext.RootFile).File;
         }
 
         private MonikerList ParseMonikerRange(SourceInfo<string?> monikerRange)
         {
-            return _monikerProvider.GetZoneLevelMonikers(GetErrors(), (FilePath)InclusionContext.RootFile, monikerRange);
+            return _monikerProvider.GetZoneLevelMonikers(GetErrors(), GetRootFilePath(), monikerRange);
         }
 
         private MonikerList GetFileLevelMonikers()
         {
-            return _monikerProvider.GetFileLevelMonikers(GetErrors(), (FilePath)InclusionContext.RootFile);
+            return _monikerProvider.GetFileLevelMonikers(GetErrors(), GetRootFilePath());
         }
 
         private string? GetCanonicalVersion()
         {
-            return _publishUrlMap.Value.GetCanonicalVersion((FilePath)InclusionContext.RootFile);
+            return _publishUrlMap.Value.GetCanonicalVersion(GetRootFilePath());
         }
 
         private class Status

--- a/src/docfx/lib/markdown/MarkdownTelemetryExtension.cs
+++ b/src/docfx/lib/markdown/MarkdownTelemetryExtension.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Docs.Build
         {
             return builder.Use(document =>
             {
-                var file = (FilePath)InclusionContext.File;
+                var file = ((SourceInfo)InclusionContext.File).File;
                 var elementCount = new Dictionary<string, int>();
 
                 document.Visit(node =>

--- a/src/docfx/lib/markdown/validation/ApexValidationExtension.cs
+++ b/src/docfx/lib/markdown/validation/ApexValidationExtension.cs
@@ -10,6 +10,13 @@ namespace Microsoft.Docs.Build
 {
     internal static class ApexValidationExtension
     {
+        // An internal HACK to workaround the `SourceInfo.ToString` behavior dependency.
+        // TODO: remove this after we retire apex validation.
+        [ThreadStatic]
+        private static bool t_forceSourceInfoToStringFilePathOnly;
+
+        public static bool ForceSourceInfoToStringFilePathOnly => t_forceSourceInfoToStringFilePathOnly;
+
         public static MarkdownPipelineBuilder UseApexValidation(
             this MarkdownPipelineBuilder builder,
             OnlineServiceMarkdownValidatorProvider? validatorProvider,
@@ -29,9 +36,18 @@ namespace Microsoft.Docs.Build
                     var layout = getLayout(filePath);
                     if (layout != "HubPage" && layout != "LandingPage")
                     {
-                        foreach (var validator in validators)
+                        try
                         {
-                            validator.Validate(document);
+                            t_forceSourceInfoToStringFilePathOnly = true;
+
+                            foreach (var validator in validators)
+                            {
+                                validator.Validate(document);
+                            }
+                        }
+                        finally
+                        {
+                            t_forceSourceInfoToStringFilePathOnly = false;
                         }
                     }
                 }

--- a/src/docfx/lib/markdown/validation/ApexValidationExtension.cs
+++ b/src/docfx/lib/markdown/validation/ApexValidationExtension.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Docs.Build
 
             return builder.Use(document =>
             {
-                var filePath = (FilePath)InclusionContext.File;
+                var filePath = ((SourceInfo)InclusionContext.File).File;
                 if (filePath.Format == FileFormat.Markdown)
                 {
                     var layout = getLayout(filePath);

--- a/src/docfx/lib/markdown/validation/DocsValidationExtension.cs
+++ b/src/docfx/lib/markdown/validation/DocsValidationExtension.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Docs.Build
         {
             return builder.Use(document =>
             {
-                var currentFile = (FilePath)InclusionContext.File;
+                var currentFile = ((SourceInfo)InclusionContext.File).File;
                 if (currentFile.Format != FileFormat.Markdown)
                 {
                     return;

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -330,7 +330,7 @@ namespace Microsoft.Docs.Build
                 return value;
             }
 
-            var sourceInfo = JsonUtility.GetSourceInfo(value);
+            var sourceInfo = JsonUtility.GetSourceInfo(value) ?? new SourceInfo(file);
             var content = new SourceInfo<string>(value.Value<string>(), sourceInfo);
 
             switch (schema.ContentType)
@@ -343,12 +343,12 @@ namespace Microsoft.Docs.Build
                 case JsonSchemaContentType.Markdown:
 
                     // todo: use BuildPage.CreateHtmlContent() when we only validate markdown properties' bookmarks
-                    return _markdownEngine.ToHtml(errors, content, file, MarkdownPipelineType.Markdown, null, rootSchema.ContentFallback);
+                    return _markdownEngine.ToHtml(errors, content, sourceInfo, MarkdownPipelineType.Markdown, null, rootSchema.ContentFallback);
 
                 case JsonSchemaContentType.InlineMarkdown:
 
                     // todo: use BuildPage.CreateHtmlContent() when we only validate markdown properties' bookmarks
-                    return _markdownEngine.ToHtml(errors, content, file, MarkdownPipelineType.InlineMarkdown, null, rootSchema.ContentFallback);
+                    return _markdownEngine.ToHtml(errors, content, sourceInfo, MarkdownPipelineType.InlineMarkdown, null, rootSchema.ContentFallback);
 
                 // TODO: remove JsonSchemaContentType.Html after LandingData is migrated
                 case JsonSchemaContentType.Html:
@@ -357,7 +357,8 @@ namespace Microsoft.Docs.Build
                     {
                         HtmlUtility.TransformLink(ref token, null, href =>
                         {
-                            var (htmlError, htmlLink, _) = _linkResolver.ResolveLink(new SourceInfo<string>(href, content), file, file);
+                            var source = new SourceInfo<string>(href, content.Source?.WithOffset(href.Source));
+                            var (htmlError, htmlLink, _) = _linkResolver.ResolveLink(source, file, file);
                             errors.AddIfNotNull(htmlError);
                             return htmlLink;
                         });

--- a/src/docfx/validation/ContentValidator.cs
+++ b/src/docfx/validation/ContentValidator.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Docs.Build
                 var manifestItem = new ManifestItem()
                 {
                     PublishUrl = _documentProvider.GetSiteUrl(file),
-                    SourceInfo = new SourceInfo(file, 0, 0),
+                    SourceInfo = new SourceInfo(file),
                 };
 
                 var validationContext = new ValidationContext { DocumentType = documentType };
@@ -164,7 +164,7 @@ namespace Microsoft.Docs.Build
                 var tocItem = new DeprecatedTocItem()
                 {
                     FilePath = file.Path.Value,
-                    SourceInfo = new SourceInfo(file, 0, 0),
+                    SourceInfo = new SourceInfo(file),
                 };
                 Write(_validator.ValidateToc(tocItem, validationContext).GetAwaiter().GetResult());
             }
@@ -179,7 +179,7 @@ namespace Microsoft.Docs.Build
                 {
                     FilePath = file.Path.Value,
                     HasReferencedTocs = hasReferencedTocs,
-                    SourceInfo = new SourceInfo(file, 0, 0),
+                    SourceInfo = new SourceInfo(file),
                 };
                 Write(_validator.ValidateToc(tocItem, validationContext).GetAwaiter().GetResult());
             }
@@ -213,7 +213,7 @@ namespace Microsoft.Docs.Build
                 var tocItem = new DuplicatedTocItem()
                 {
                     FilePaths = filePaths,
-                    SourceInfo = new SourceInfo(file, 0, 0),
+                    SourceInfo = new SourceInfo(file),
                 };
                 Write(_validator.ValidateToc(tocItem, validationContext).GetAwaiter().GetResult());
             }

--- a/test/docfx.Test/lib/JsonUtilityTest.cs
+++ b/test/docfx.Test/lib/JsonUtilityTest.cs
@@ -400,9 +400,9 @@ namespace Microsoft.Docs.Build
             var basic = new BasicClass
             {
                 B = 1,
-                Property = new SourceInfo<string>(null, new SourceInfo(new FilePath(""), 0, 0)),
-                Array = new SourceInfo<string[]>(Array.Empty<string>(), new SourceInfo(new FilePath(""), 0, 0)),
-                GenericArray = new SourceInfo<List<string>>(new List<string>(), new SourceInfo(new FilePath(""), 0, 0)),
+                Property = new SourceInfo<string>(null, new SourceInfo(new FilePath(""))),
+                Array = new SourceInfo<string[]>(Array.Empty<string>(), new SourceInfo(new FilePath(""))),
+                GenericArray = new SourceInfo<List<string>>(new List<string>(), new SourceInfo(new FilePath(""))),
             };
             var result = JsonUtility.Serialize(basic);
             Assert.Equal("{\"b\":1,\"d\":false}", result);


### PR DESCRIPTION
Mitigate #3357 as seen in #6541

This fix does not account for different string formatting options in YAML/JSON and new line escape mechanisms, it is a simple approximation not an accurate result. Doing an accurate source map does not seem achievable at the moment (or too complex to do) because it requires carry over source map out of YAML/JSON strings.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6587)