### PR TITLE
only skip bookmark validation of SDP file when the public template is used

### DIFF
--- a/docs/specs/schema.yml
+++ b/docs/specs/schema.yml
@@ -355,7 +355,6 @@ outputs:
     {"message_severity":"error","code":"unexpected-type","message":"Expected type 'Object' but got 'Array'.","file":"a.yml","line":1,"column":1}
 ---
 # Validate bookmark against content HTML after applying template for SDP 
-noDryRun: true
 inputs:
   docfx.yml: |
     outputType: pageJson

--- a/src/docfx/build/page/BuildPage.cs
+++ b/src/docfx/build/page/BuildPage.cs
@@ -62,8 +62,9 @@ namespace Microsoft.Docs.Build
             var systemMetadata = CreateSystemMetadata(errors, context, file, userMetadata);
 
             // Mandatory metadata are metadata that are required by template to successfully ran to completion.
-            // The bookmark validation for SDP is out of scope in dry-run mode, so we can skip creating template model for SDP as well
-            if (context.Config.DryRun)
+            // The bookmark validation for SDP can be skipped when the public template is used since the mustache is not accessable for public template
+            if (context.Config.DryRun
+                && (TemplateEngine.IsConceptual(mime) || context.Config.Template.Type == PackageType.PublicTemplate))
             {
                 return (new JObject(), new JObject());
             }


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6593)