### PR TITLE
Content validation with monikers in consideration

### DIFF
--- a/docs/specs/validation/heading-validation.yml
+++ b/docs/specs/validation/heading-validation.yml
@@ -1057,9 +1057,8 @@ inputs:
     }
 outputs:
   .errors.log: |
-    {"message_severity":"suggestion","log_item_type":"user","code":"duplicate-h1","message":"H1 'h1' is duplicated with other articles: 'docs/v1/token1.md, docs/v1/token2.md(5,1), docs/v2/b.md'","file":"docs/v1/token1.md","line":1,"end_line":1,"column":1,"end_column":1}
-    {"message_severity":"suggestion","log_item_type":"user","code":"duplicate-h1","message":"H1 'h1' is duplicated with other articles: 'docs/v1/token1.md, docs/v1/token2.md(5,1), docs/v2/b.md'","file":"docs/v2/b.md","line":1,"end_line":1,"column":1,"end_column":1}
-    {"message_severity":"suggestion","log_item_type":"user","code":"duplicate-h1","message":"H1 'h1' is duplicated with other articles: 'docs/v1/token1.md, docs/v1/token2.md(5,1), docs/v2/b.md'","file":"docs/v1/token2.md","line":5,"end_line":5,"column":1,"end_column":1}
+    {"message_severity":"suggestion","log_item_type":"user","code":"duplicate-h1","message":"H1 'h1' is duplicated with other articles: 'docs/v1/token1.md, docs/v2/b.md'","file":"docs/v1/token1.md","line":1,"end_line":1,"column":1,"end_column":1}
+    {"message_severity":"suggestion","log_item_type":"user","code":"duplicate-h1","message":"H1 'h1' is duplicated with other articles: 'docs/v1/token1.md, docs/v2/b.md'","file":"docs/v2/b.md","line":1,"end_line":1,"column":1,"end_column":1}
     {"message_severity":"warning","log_item_type":"user","code":"moniker-zone-empty","message":"No intersection between zone and file level monikers. The result of zone level range string '< netcore-1.1' is 'netcore-1.0', while file level monikers is 'netcore-1.2', 'netcore-2.0'.","file":"docs/v1/token3.md","line":1,"end_line":1,"column":1,"end_column":1}
   9d4e15fd/docs/a.json:
   9d4e15fd/docs/b.json:

--- a/docs/specs/validation/metadata-validation.yml
+++ b/docs/specs/validation/metadata-validation.yml
@@ -247,8 +247,8 @@ outputs:
   e277e62e/docs/v1/b.json:
   8cec59bf/docs/v2/a.json:
   .errors.log: |
-    {"message_severity":"suggestion","code":"duplicate-attribute","message":"Attribute 'description' with value 'a' is duplicated in 'docs/v1/a.md(2,14)', 'docs/v1/b.md(2,14)' with moniker 'netcore-2.1'.","file":"docs/v1/b.md","line":2,"end_line":2,"column":14,"end_column":15}
-    {"message_severity":"suggestion","code":"duplicate-attribute","message":"Attribute 'description' with value 'a' is duplicated in 'docs/v1/a.md(2,14)', 'docs/v1/b.md(2,14)' with moniker 'netcore-2.1'.","file":"docs/v1/a.md","line":2,"end_line":2,"column":14,"end_column":15}
+    {"message_severity":"suggestion","code":"duplicate-attribute","message":"Attribute 'description' with value 'a' is duplicated in 'docs/v1/a.md(2,14)', 'docs/v1/b.md(2,14)'.","file":"docs/v1/b.md","line":2,"end_line":2,"column":14,"end_column":15}
+    {"message_severity":"suggestion","code":"duplicate-attribute","message":"Attribute 'description' with value 'a' is duplicated in 'docs/v1/a.md(2,14)', 'docs/v1/b.md(2,14)'.","file":"docs/v1/a.md","line":2,"end_line":2,"column":14,"end_column":15}
 ---
 # Json schema length rule: the length of string must be in range of MinLength and MaxLength
 inputs:

--- a/docs/specs/validation/title-validation.yml
+++ b/docs/specs/validation/title-validation.yml
@@ -200,7 +200,6 @@ outputs:
   9d4e15fd/docs/a.json:
   9d4e15fd/docs/b.json:
   .errors.log: |
-    {"message_severity":"suggestion","log_item_type":"user","code":"duplicate-titles","message":"Title 'title 1 - Product' is duplicated with other articles: 'docs/v1/a.md(2,8), docs/v2/b.md(2,8), docs/v2/c.md(2,8)'","file":"docs/v2/b.md","line":2,"end_line":2,"column":8,"end_column":15}
-    {"message_severity":"suggestion","log_item_type":"user","code":"duplicate-titles","message":"Title 'title 1 - Product' is duplicated with other articles: 'docs/v1/a.md(2,8), docs/v2/b.md(2,8), docs/v2/c.md(2,8)'","file":"docs/v2/c.md","line":2,"end_line":2,"column":8,"end_column":15}
-    {"message_severity":"suggestion","log_item_type":"user","code":"duplicate-titles","message":"Title 'title 1 - Product' is duplicated with other articles: 'docs/v1/a.md(2,8), docs/v2/b.md(2,8), docs/v2/c.md(2,8)'","file":"docs/v1/a.md","line":2,"end_line":2,"column":8,"end_column":15}
+    {"message_severity":"suggestion","log_item_type":"user","code":"duplicate-titles","message":"Title 'title 1 - Product' is duplicated with other articles: 'docs/v2/b.md(2,8), docs/v2/c.md(2,8)'","file":"docs/v2/b.md","line":2,"end_line":2,"column":8,"end_column":15}
+    {"message_severity":"suggestion","log_item_type":"user","code":"duplicate-titles","message":"Title 'title 1 - Product' is duplicated with other articles: 'docs/v2/b.md(2,8), docs/v2/c.md(2,8)'","file":"docs/v2/c.md","line":2,"end_line":2,"column":8,"end_column":15}
 ---

--- a/docs/specs/validation/validation-rules.yml
+++ b/docs/specs/validation/validation-rules.yml
@@ -153,8 +153,8 @@ outputs:
     {"message_severity":"suggestion","code":"title-bad-length","message":"String 'title' is too short: 1 characters. Length should be >= 2.","file":"docs/v2/b.md","line":2,"end_line":2,"column":8,"end_column":9}
     {"message_severity":"suggestion","code":"description-bad-length","message":"String 'description' is too short: 1 characters. Length should be >= 2.","file":"docs/v2/a.md","line":3,"end_line":3,"column":14,"end_column":15}
     {"message_severity":"suggestion","code":"description-bad-length","message":"String 'description' is too short: 1 characters. Length should be >= 2.","file":"docs/v2/b.md","line":3,"end_line":3,"column":14,"end_column":15}
-    {"message_severity":"suggestion","code":"duplicate-title-within-docset","message":"Attribute 'title' with value 't' is duplicated in 'docs/v2/a.md(2,8)', 'docs/v2/b.md(2,8)' with moniker 'netcore-2.0'. Title must be unique within a docset.","file":"docs/v2/b.md","line":2,"end_line":2,"column":8,"end_column":9}
-    {"message_severity":"suggestion","code":"duplicate-title-within-docset","message":"Attribute 'title' with value 't' is duplicated in 'docs/v2/a.md(2,8)', 'docs/v2/b.md(2,8)' with moniker 'netcore-2.0'. Title must be unique within a docset.","file":"docs/v2/a.md","line":2,"end_line":2,"column":8,"end_column":9}
+    {"message_severity":"suggestion","code":"duplicate-title-within-docset","message":"Attribute 'title' with value 't' is duplicated in 'docs/v2/a.md(2,8)', 'docs/v2/b.md(2,8)'. Title must be unique within a docset.","file":"docs/v2/b.md","line":2,"end_line":2,"column":8,"end_column":9}
+    {"message_severity":"suggestion","code":"duplicate-title-within-docset","message":"Attribute 'title' with value 't' is duplicated in 'docs/v2/a.md(2,8)', 'docs/v2/b.md(2,8)'. Title must be unique within a docset.","file":"docs/v2/a.md","line":2,"end_line":2,"column":8,"end_column":9}
   9d4e15fd/docs/a.json:
   9d4e15fd/docs/b.json:
   976da3a9/docs/a.json:

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -608,11 +608,11 @@ namespace Microsoft.Docs.Build
             /// Behavior: ✔️ Message: ✔️
             public const string DuplicateAttributeCode = "duplicate-attribute";
 
-            public static Error DuplicateAttribute(SourceInfo? source, string name, string moniker, object value, IEnumerable<SourceInfo> duplicatedSources)
+            public static Error DuplicateAttribute(SourceInfo? source, string name, object value, IEnumerable<SourceInfo> duplicatedSources)
                 => new Error(
                     ErrorLevel.Suggestion,
                     DuplicateAttributeCode,
-                    $"Attribute '{name}' with value '{value}' is duplicated in {StringUtility.Join(duplicatedSources)}{(string.IsNullOrEmpty(moniker) ? "" : $" with moniker '{moniker}'")}.",
+                    $"Attribute '{name}' with value '{value}' is duplicated in {StringUtility.Join(duplicatedSources)}.",
                     source,
                     name);
         }

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.2.3" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
-    <PackageReference Include="docs.validation" Version="1.0.0-beta-00266-ea94a98" />
+    <PackageReference Include="docs.validation" Version="1.0.0-beta-00267-c950d99" />
     <PackageReference Include="DotLiquid" Version="2.0.361" />
     <PackageReference Include="Glob" Version="1.1.8" />
     <PackageReference Include="HtmlReaderWriter" Version="1.0.0-preview-0001-gcf3636c5d9" />

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.2.3" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
-    <PackageReference Include="docs.validation" Version="1.0.0-beta-00267-c950d99" />
+    <PackageReference Include="docs.validation" Version="1.0.0-beta-00268-3522755" />
     <PackageReference Include="DotLiquid" Version="2.0.361" />
     <PackageReference Include="Glob" Version="1.1.8" />
     <PackageReference Include="HtmlReaderWriter" Version="1.0.0-preview-0001-gcf3636c5d9" />

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.2.3" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
-    <PackageReference Include="docs.validation" Version="1.0.0-beta-00261-3af877b" />
+    <PackageReference Include="docs.validation" Version="1.0.0-beta-00266-ea94a98" />
     <PackageReference Include="DotLiquid" Version="2.0.361" />
     <PackageReference Include="Glob" Version="1.1.8" />
     <PackageReference Include="HtmlReaderWriter" Version="1.0.0-preview-0001-gcf3636c5d9" />

--- a/src/docfx/lib/markdown/validation/DocsValidationExtension.cs
+++ b/src/docfx/lib/markdown/validation/DocsValidationExtension.cs
@@ -59,9 +59,9 @@ namespace Microsoft.Docs.Build
 
                 contentValidator.ValidateHeadings(currentFile, documentNodes);
 
-                foreach (var (isInclude, codeBlockItem) in codeBlockNodes)
+                foreach (var (_, codeBlockItem) in codeBlockNodes)
                 {
-                    contentValidator.ValidateCodeBlock(currentFile, codeBlockItem, isInclude);
+                    contentValidator.ValidateCodeBlock(currentFile, codeBlockItem);
                 }
             });
         }

--- a/src/docfx/lib/markdown/validation/DocsValidationExtension.cs
+++ b/src/docfx/lib/markdown/validation/DocsValidationExtension.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Docs.Build
                     return false;
                 });
 
-                contentValidator.ValidateHeadings(currentFile, documentNodes, false);
+                contentValidator.ValidateHeadings(currentFile, documentNodes);
 
                 foreach (var (isInclude, codeBlockItem) in codeBlockNodes)
                 {

--- a/src/docfx/lib/markdown/validation/DocsValidationExtension.cs
+++ b/src/docfx/lib/markdown/validation/DocsValidationExtension.cs
@@ -32,7 +32,6 @@ namespace Microsoft.Docs.Build
                 }
 
                 var documentNodes = new List<ContentNode>();
-                var inclusionDocumentNodes = new Dictionary<FilePath, List<ContentNode>>();
                 var codeBlockNodes = new List<(bool isInclude, CodeBlockItem codeBlockItem)>();
 
                 var canonicalVersion = getCanonicalVersion();
@@ -51,7 +50,7 @@ namespace Microsoft.Docs.Build
 
                     var isCanonicalVersion = IsCanonicalVersion(canonicalVersion, fileLevelMoniker, node.GetZoneLevelMonikers());
 
-                    BuildHeadingNodes(node, markdownEngine, documentNodes, inclusionDocumentNodes, isCanonicalVersion);
+                    BuildHeadingNodes(node, markdownEngine, documentNodes, isCanonicalVersion);
 
                     BuildCodeBlockNodes(node, codeBlockNodes, isCanonicalVersion);
 
@@ -59,10 +58,6 @@ namespace Microsoft.Docs.Build
                 });
 
                 contentValidator.ValidateHeadings(currentFile, documentNodes, false);
-                foreach (var (inclusion, inclusionNodes) in inclusionDocumentNodes)
-                {
-                    contentValidator.ValidateHeadings(inclusion, inclusionNodes, true);
-                }
 
                 foreach (var (isInclude, codeBlockItem) in codeBlockNodes)
                 {
@@ -75,7 +70,6 @@ namespace Microsoft.Docs.Build
             MarkdownObject node,
             MarkdownEngine markdownEngine,
             List<ContentNode> documentNodes,
-            Dictionary<FilePath, List<ContentNode>> inclusionDocumentNodes,
             bool isCanonicalVersion)
         {
             ContentNode? documentNode = null;
@@ -104,16 +98,6 @@ namespace Microsoft.Docs.Build
             if (documentNode != null)
             {
                 documentNodes.Add(documentNode);
-                if (node.IsInclude())
-                {
-                    var file = node.GetFilePath();
-                    if (!inclusionDocumentNodes.TryGetValue(file, out var inclusionNodes))
-                    {
-                        inclusionDocumentNodes[file] = inclusionNodes = new List<ContentNode>();
-                    }
-
-                    inclusionNodes.Add(documentNode);
-                }
             }
         }
 

--- a/src/docfx/lib/moniker/MonikerList.cs
+++ b/src/docfx/lib/moniker/MonikerList.cs
@@ -11,7 +11,7 @@ using Newtonsoft.Json;
 namespace Microsoft.Docs.Build
 {
     [JsonConverter(typeof(MonikerListJsonConverter))]
-    internal readonly struct MonikerList : IEquatable<MonikerList>, IEnumerable<string>, IComparable<MonikerList>
+    internal readonly struct MonikerList : IEquatable<MonikerList>, IReadOnlyCollection<string>, IComparable<MonikerList>
     {
         private static readonly ConcurrentDictionary<MonikerList, string> s_monikerGroupCache = new ConcurrentDictionary<MonikerList, string>();
 

--- a/src/docfx/lib/schema/JsonSchemaValidator.cs
+++ b/src/docfx/lib/schema/JsonSchemaValidator.cs
@@ -583,7 +583,7 @@ namespace Microsoft.Docs.Build
                     var metadataSources = (from g in items where g.source != null select g.source).ToArray();
                     foreach (var file in items)
                     {
-                        errors.Add(Errors.JsonSchema.DuplicateAttribute(file.source, metadataKey, moniker, metadataValue, metadataSources));
+                        errors.Add(Errors.JsonSchema.DuplicateAttribute(file.source, metadataKey, metadataValue, metadataSources));
                     }
                 }
             }

--- a/src/docfx/validation/ContentValidator.cs
+++ b/src/docfx/validation/ContentValidator.cs
@@ -49,7 +49,12 @@ namespace Microsoft.Docs.Build
             // validate image link and altText here
             if (_links.TryAdd((file, link)) && TryGetValidationDocumentType(file, out var documentType))
             {
-                var validationContext = new ValidationContext { DocumentType = documentType, File = file.Path };
+                var validationContext = new ValidationContext
+                {
+                    DocumentType = documentType,
+                    FileSourceInfo = new SourceInfo(file),
+                    Monikers = _monikerProvider.GetFileLevelMonikers(_errors, file).ToList(),
+                };
                 Write(_validator.ValidateLink(
                     new Link
                     {
@@ -59,6 +64,7 @@ namespace Microsoft.Docs.Build
                         IsInlineImage = origin.IsInlineImage(imageIndex),
                         SourceInfo = link.Source,
                         ParentSourceInfoList = origin.GetInclusionStack(),
+                        Monikers = origin.GetZoneLevelMonikers().ToList(),
                     }, validationContext).GetAwaiter().GetResult());
             }
         }
@@ -67,7 +73,12 @@ namespace Microsoft.Docs.Build
         {
             if (TryGetValidationDocumentType(file, isInclude, out var documentType))
             {
-                var validationContext = new ValidationContext { DocumentType = documentType };
+                var validationContext = new ValidationContext
+                {
+                    DocumentType = documentType,
+                    FileSourceInfo = new SourceInfo(file),
+                    Monikers = _monikerProvider.GetFileLevelMonikers(_errors, file).ToList(),
+                };
                 Write(_validator.ValidateCodeBlock(codeBlockItem, validationContext).GetAwaiter().GetResult());
             }
         }
@@ -76,7 +87,12 @@ namespace Microsoft.Docs.Build
         {
             if (TryGetValidationDocumentType(file, isInclude, out var documentType))
             {
-                var validationContext = new ValidationContext { DocumentType = documentType, FileSourceInfo = new SourceInfo(file) };
+                var validationContext = new ValidationContext
+                {
+                    DocumentType = documentType,
+                    FileSourceInfo = new SourceInfo(file),
+                    Monikers = isInclude ? null : _monikerProvider.GetFileLevelMonikers(_errors, file).ToList(),
+                };
                 Write(_validator.ValidateHeadings(nodes, validationContext).GetAwaiter().GetResult());
             }
         }
@@ -99,7 +115,12 @@ namespace Microsoft.Docs.Build
                     Title = GetOgTitle(title.Value, titleSuffix),
                     SourceInfo = title.Source,
                 };
-                var validationContext = new ValidationContext { DocumentType = documentType };
+                var validationContext = new ValidationContext
+                {
+                    DocumentType = documentType,
+                    FileSourceInfo = new SourceInfo(file),
+                    Monikers = monikers.ToList(),
+                };
                 Write(_validator.ValidateTitle(titleItem, validationContext).GetAwaiter().GetResult());
             }
 
@@ -124,7 +145,11 @@ namespace Microsoft.Docs.Build
         {
             if (TryGetValidationDocumentType(file, out var documentType))
             {
-                var validationContext = new ValidationContext { DocumentType = documentType };
+                var validationContext = new ValidationContext
+                {
+                    DocumentType = documentType,
+                    FileSourceInfo = new SourceInfo(file),
+                };
 
                 using var reader = new StringReader(content);
                 var lineCount = 1;
@@ -151,7 +176,11 @@ namespace Microsoft.Docs.Build
                     SourceInfo = new SourceInfo(file, 0, 0),
                 };
 
-                var validationContext = new ValidationContext { DocumentType = documentType };
+                var validationContext = new ValidationContext
+                {
+                    DocumentType = documentType,
+                    FileSourceInfo = new SourceInfo(file),
+                };
                 Write(_validator.ValidateManifest(manifestItem, validationContext).GetAwaiter().GetResult());
             }
         }
@@ -160,7 +189,11 @@ namespace Microsoft.Docs.Build
         {
             if (TryGetValidationDocumentType(file, out var documentType))
             {
-                var validationContext = new ValidationContext { DocumentType = documentType };
+                var validationContext = new ValidationContext
+                {
+                    DocumentType = documentType,
+                    FileSourceInfo = new SourceInfo(file),
+                };
                 var tocItem = new DeprecatedTocItem()
                 {
                     FilePath = file.Path.Value,
@@ -174,7 +207,11 @@ namespace Microsoft.Docs.Build
         {
             if (TryGetValidationDocumentType(file, out var documentType))
             {
-                var validationContext = new ValidationContext { DocumentType = documentType };
+                var validationContext = new ValidationContext
+                {
+                    DocumentType = documentType,
+                    FileSourceInfo = new SourceInfo(file),
+                };
                 var tocItem = new MissingTocItem()
                 {
                     FilePath = file.Path.Value,
@@ -190,7 +227,12 @@ namespace Microsoft.Docs.Build
             if (!string.IsNullOrEmpty(node.Value?.Href)
                 && TryGetValidationDocumentType(file, out var documentType))
             {
-                var validationContext = new ValidationContext { DocumentType = documentType };
+                var validationContext = new ValidationContext
+                {
+                    DocumentType = documentType,
+                    FileSourceInfo = new SourceInfo(file),
+                    Monikers = _monikerProvider.GetFileLevelMonikers(_errors, file).ToList(),
+                };
                 var tocItem = new ExternalBreadcrumbTocItem()
                 {
                     FilePath = node.Value.Href!,
@@ -209,7 +251,12 @@ namespace Microsoft.Docs.Build
                     .Select(item => item.Path.Value)
                     .ToList();
 
-                var validationContext = new ValidationContext { DocumentType = documentType };
+                var validationContext = new ValidationContext
+                {
+                    DocumentType = documentType,
+                    FileSourceInfo = new SourceInfo(file),
+                    Monikers = _monikerProvider.GetFileLevelMonikers(_errors, file).ToList(),
+                };
                 var tocItem = new DuplicatedTocItem()
                 {
                     FilePaths = filePaths,

--- a/src/docfx/validation/ContentValidator.cs
+++ b/src/docfx/validation/ContentValidator.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Docs.Build
                 {
                     DocumentType = documentType,
                     FileSourceInfo = new SourceInfo(file),
-                    Monikers = _monikerProvider.GetFileLevelMonikers(_errors, file).ToList(),
+                    Monikers = _monikerProvider.GetFileLevelMonikers(_errors, file),
                 };
                 Write(_validator.ValidateLink(
                     new Link
@@ -64,7 +64,7 @@ namespace Microsoft.Docs.Build
                         IsInlineImage = origin.IsInlineImage(imageIndex),
                         SourceInfo = link.Source,
                         ParentSourceInfoList = origin.GetInclusionStack(),
-                        Monikers = origin.GetZoneLevelMonikers().ToList(),
+                        Monikers = origin.GetZoneLevelMonikers(),
                     }, validationContext).GetAwaiter().GetResult());
             }
         }
@@ -77,21 +77,21 @@ namespace Microsoft.Docs.Build
                 {
                     DocumentType = documentType,
                     FileSourceInfo = new SourceInfo(file),
-                    Monikers = _monikerProvider.GetFileLevelMonikers(_errors, file).ToList(),
+                    Monikers = _monikerProvider.GetFileLevelMonikers(_errors, file),
                 };
                 Write(_validator.ValidateCodeBlock(codeBlockItem, validationContext).GetAwaiter().GetResult());
             }
         }
 
-        public void ValidateHeadings(FilePath file, List<ContentNode> nodes, bool isInclude)
+        public void ValidateHeadings(FilePath file, List<ContentNode> nodes)
         {
-            if (TryGetValidationDocumentType(file, isInclude, out var documentType))
+            if (TryGetValidationDocumentType(file, out var documentType))
             {
                 var validationContext = new ValidationContext
                 {
                     DocumentType = documentType,
                     FileSourceInfo = new SourceInfo(file),
-                    Monikers = isInclude ? null : _monikerProvider.GetFileLevelMonikers(_errors, file).ToList(),
+                    Monikers = _monikerProvider.GetFileLevelMonikers(_errors, file),
                 };
                 Write(_validator.ValidateHeadings(nodes, validationContext).GetAwaiter().GetResult());
             }
@@ -119,7 +119,7 @@ namespace Microsoft.Docs.Build
                 {
                     DocumentType = documentType,
                     FileSourceInfo = new SourceInfo(file),
-                    Monikers = monikers.ToList(),
+                    Monikers = monikers,
                 };
                 Write(_validator.ValidateTitle(titleItem, validationContext).GetAwaiter().GetResult());
             }
@@ -231,7 +231,7 @@ namespace Microsoft.Docs.Build
                 {
                     DocumentType = documentType,
                     FileSourceInfo = new SourceInfo(file),
-                    Monikers = _monikerProvider.GetFileLevelMonikers(_errors, file).ToList(),
+                    Monikers = _monikerProvider.GetFileLevelMonikers(_errors, file),
                 };
                 var tocItem = new ExternalBreadcrumbTocItem()
                 {
@@ -255,7 +255,7 @@ namespace Microsoft.Docs.Build
                 {
                     DocumentType = documentType,
                     FileSourceInfo = new SourceInfo(file),
-                    Monikers = _monikerProvider.GetFileLevelMonikers(_errors, file).ToList(),
+                    Monikers = _monikerProvider.GetFileLevelMonikers(_errors, file),
                 };
                 var tocItem = new DuplicatedTocItem()
                 {

--- a/src/docfx/validation/ContentValidator.cs
+++ b/src/docfx/validation/ContentValidator.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public void ValidateCodeBlock(FilePath file, CodeBlockItem codeBlockItem, bool isInclude)
+        public void ValidateCodeBlock(FilePath file, CodeBlockItem codeBlockItem)
         {
             if (TryCreateValidationContext(file, out var validationContext))
             {


### PR DESCRIPTION
- Remove `File` from and add `Monikers` into `ValidationContext`
- Update `ContentValidator` and other related code to pass file-level and zone-level monikers to Docs Validation
- Remove moniker info from metadata `docsetUnique` validation error message
- Update Docs Validation version to apply new validators
- Cleanup explicit heading validations on included files

[AB#308802](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/308802)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6596)