### PR TITLE
duplicated uid in the same file

### DIFF
--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -1748,3 +1748,27 @@ outputs:
     {
       "conceptual": "<p>str <span class=\"xref\">SlackAPI.Block</span></p>"
     }
+---
+# multiple duplicated uids within a file
+inputs:
+  docfx.json: |
+    {"build": {"content": [{"files": ["**/*.yml"], "version": "latest"}], "monikerDefinition": "monikerDefinition.json"}}
+  _themes/ContentTemplate/schemas/test.schema.json: |
+    {
+      "type": "object",
+      "required": ["members", "uid"],
+      "properties": {
+        "uid": {"contentType": "uid","type": "string"},
+        "members": {"items":{"properties": {"uid": {"contentType": "uid","type": "string"}}}}
+      }
+    }
+  monikerDefinition.json: |
+    {"monikers": [{ "moniker_name": "latest" }]}
+  test.yml: |
+    ### YamlMime:test
+    uid: "a"
+    members:
+    - uid: "a"
+outputs: 
+  .errors.log: |
+    {"message_severity":"error","code":"duplicate-uid","message":"UID 'a' is duplicated.","file":"test.yml","line":4,"column":8}

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -1749,7 +1749,7 @@ outputs:
       "conceptual": "<p>str <span class=\"xref\">SlackAPI.Block</span></p>"
     }
 ---
-# multiple duplicated uids within a file
+# multiple duplicated uids with the same MonkerList
 inputs:
   docfx.json: |
     {"build": {"content": [{"files": ["**/*.yml"], "version": "latest"}], "monikerDefinition": "monikerDefinition.json"}}
@@ -1770,5 +1770,7 @@ inputs:
     members:
     - uid: "a"
 outputs: 
+  71ccb7a3/test.json:
   .errors.log: |
-    {"message_severity":"error","code":"duplicate-uid","message":"UID 'a' is duplicated.","file":"test.yml","line":4,"column":8}
+    {"message_severity":"warning","code":"duplicate-uid","message":"UID 'a' is duplicated in 'test.yml(2,6)', 'test.yml(4,8)'.","file":"test.yml","line":4,"column":8}
+    {"message_severity":"warning","code":"duplicate-uid","message":"UID 'a' is duplicated in 'test.yml(2,6)', 'test.yml(4,8)'.","file":"test.yml","line":2,"column":6}

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -401,6 +401,9 @@ namespace Microsoft.Docs.Build
             public static Error DuplicateUid(SourceInfo<string> uid, IEnumerable<SourceInfo> conflicts)
                 => new Error(ErrorLevel.Warning, "duplicate-uid", $"UID '{uid}' is duplicated in {StringUtility.Join(conflicts)}.", uid);
 
+            public static Error DuplicateUid(SourceInfo<string> uid)
+                => new Error(ErrorLevel.Error, "duplicate-uid", $"UID '{uid}' is duplicated.", uid);
+
             /// <summary>
             /// Same uid defined within different versions with different values of the same xref property.
             /// Examples:

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -401,9 +401,6 @@ namespace Microsoft.Docs.Build
             public static Error DuplicateUid(SourceInfo<string> uid, IEnumerable<SourceInfo> conflicts)
                 => new Error(ErrorLevel.Warning, "duplicate-uid", $"UID '{uid}' is duplicated in {StringUtility.Join(conflicts)}.", uid);
 
-            public static Error DuplicateUid(SourceInfo<string> uid)
-                => new Error(ErrorLevel.Error, "duplicate-uid", $"UID '{uid}' is duplicated.", uid);
-
             /// <summary>
             /// Same uid defined within different versions with different values of the same xref property.
             /// Examples:

--- a/src/docfx/build/toc/ServicePageGenerator.cs
+++ b/src/docfx/build/toc/ServicePageGenerator.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Docs.Build
 {

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -181,8 +181,6 @@ namespace Microsoft.Docs.Build
                     {
                         if (!monikerFileDic[moniker].Add(path))
                         {
-                            var a = spec.Uid;
-
                             // duplicate uids in the same file.
                             error.Add(Errors.Xref.DuplicateUid(spec.Uid));
                             continue;


### PR DESCRIPTION
[AB#297742](https://dev.azure.com/ceapex/Engineering/_workitems/edit/297742)

As shown of the following example, a file contains 2 duplicate uids. Previously, docfx v3 give `moniker overlapping` error message, but it's not appropriate. So fix it.

![image](https://user-images.githubusercontent.com/67643974/94247344-91b0be00-ff4f-11ea-89dd-1756cecd0663.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6599)