### PR TITLE
Regression timeout error to warning

### DIFF
--- a/test/docfx.RegressionTest/RegressionTest.cs
+++ b/test/docfx.RegressionTest/RegressionTest.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Docs.Build
 
             if (buildTime.TotalSeconds > opts.Timeout)
             {
-                Console.WriteLine($"##vso[task.complete result=Failed]Test failed, build timeout. Repo: ${s_repositoryName}");
+                Console.WriteLine($"##vso[task.complete result=SucceededWithIssues]Test failed, build timeout. Repo: {s_repositoryName}; Expected Runtime: {opts.Timeout}s");
                 Console.WriteLine($"Test failed, build timeout: {buildTime.TotalSeconds} Repo: ${s_repositoryName}");
             }
 


### PR DESCRIPTION
Currently commit build can also fail due to timeout. (mostly caused by github api call)
![image](https://user-images.githubusercontent.com/42199316/95946321-e775d900-0e1e-11eb-821f-da39382ee800.png)

This will stop proceeding docs-build & PPE deploy.

This PR tries to turn state from "failed" to "SucceededWithIssues".
Need further testing to prove if this can continue the deploy pipeline.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6642)