### PR TITLE
set PrivateAssets for FSharp.Compiler.Service.MSBuild.v12

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.fsproj
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp/Microsoft.DocAsCode.Metadata.ManagedReference.FSharp.fsproj
@@ -28,7 +28,9 @@
   <ItemGroup>
     <PackageReference Include="Dotnet.ProjInfo" Version="0.9.0" />
     <PackageReference Include="FSharp.Compiler.Service" Version="34.1.1" />
-    <PackageReference Include="FSharp.Compiler.Service.MSBuild.v12" Version="34.1.1" />
+    <PackageReference Include="FSharp.Compiler.Service.MSBuild.v12" Version="34.1.1">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn.csproj
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.5.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="NuGet.ProjectModel" Version="4.5.0" />
-    <PackageReference Include="NuGet.Packaging.Core" Version="4.5.0" />
+    <PackageReference Include="NuGet.Packaging.Core" Version="5.7.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.5.24" />
     <PackageReference Include="Microsoft.VisualStudio.RemoteControl" Version="14.0.262-masterA5CACE98" />
   </ItemGroup>

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="1.9.71" />
-    <PackageReference Include="NuGet.Common" Version="4.8.0" />
+    <PackageReference Include="NuGet.Common" Version="5.7.0" />
     <PackageReference Include="Owin" Version="1.0.0" />
     <PackageReference Include="Microsoft.Owin" Version="3.0.1" />
     <PackageReference Include="Microsoft.Owin.FileSystems" Version="3.0.1" />


### PR DESCRIPTION
This pull request is to resolve issue #5785:
- Set [`<PrivateAssets>all</PrivateAssets>`](https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#controlling-dependency-assets) for `FSharp.Compiler.Service.MSBuild.v12` to resolve the error `cannot find GetSystemInfo..`:
   - Both `FSharp.Compiler.Service.MSBuild.v12` and `Microsoft.CodeAnalysis.Workspaces.MSBuild` are using `Microsoft.Build.*.dll`. Docfx doesn't directly include the `Microsoft.Build.*.dll` in nuget package, it uses [`Microsoft.Build.Locator`](https://docs.microsoft.com/en-us/visualstudio/msbuild/updating-an-existing-application?view=vs-2019#use-microsoftbuildlocator) to resolve `Microsoft.Build.*.dll`. However, `FSharp.Compiler.Service.MSBuild.v12` included the `Microsoft.Build.*.dll` in its nuget package with this [change](https://github.com/fsharp/FSharp.Compiler.Service/commit/e2ce51eab89211acb140b5d22c70ad21e3827dc8#diff-63af3b5620cdc8762f4682130dc4805d17fd3b105922b6961a7af9cf5b1a52b6), which causing the error in docfx.
-  Use version 5.7.0 for `Nuget.Packaging.Core` and `Nuget.Common` to resolve warning `The "GetReferenceNearestTargetFrameworkTask" task failed`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6647)