### PR TITLE
Regression test failed only on PR.

### DIFF
--- a/test/docfx.RegressionTest/RegressionTest.cs
+++ b/test/docfx.RegressionTest/RegressionTest.cs
@@ -227,10 +227,10 @@ namespace Microsoft.Docs.Build
             // For temporary normalize: use 'NormalizeJsonFiles' for output files
             Normalizer.Normalize(outputPath, NormalizeStage.PrettifyJsonFiles | NormalizeStage.PrettifyLogFiles, errorLevel: opts.ErrorLevel);
 
-            if (buildTime.TotalSeconds > opts.Timeout)
+            if (buildTime.TotalSeconds > opts.Timeout && s_isPullRequest)
             {
-                Console.WriteLine($"##vso[task.complete result=SucceededWithIssues]Test failed, build timeout. Repo: {s_repositoryName}; Expected Runtime: {opts.Timeout}s");
-                Console.WriteLine($"Test failed, build timeout: {buildTime.TotalSeconds} Repo: ${s_repositoryName}");
+                Console.WriteLine($"##vso[task.complete result=Failed]Test failed, build timeout. Repo: {s_repositoryName}; Expected Runtime: {opts.Timeout}s");
+                Console.WriteLine($"Test failed, build timeout. Repo: {s_repositoryName}; Expected Runtime: {opts.Timeout}s");
             }
 
             if (s_isPullRequest)


### PR DESCRIPTION
[Build completion](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/pipeline-triggers?view=azure-devops&tabs=yaml) trigger only happens when build succeeds.

Makes regression test timeout an error ONLY in PR build.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6653)