### PR TITLE
Split toc default by name

### DIFF
--- a/docs/specs/ecma2Yaml.yml
+++ b/docs/specs/ecma2Yaml.yml
@@ -9,6 +9,7 @@ repos:
           "docsets_to_publish": [
           { 
             "build_source_folder": "cat",
+            "SplitTOC": ["api/toc.yml"]
           }],
           "ECMA2Yaml": {
             "SourceXmlFolder": "cat/xml",
@@ -119,6 +120,7 @@ repos:
           "docsets_to_publish": [
           { 
             "build_source_folder": "cat",
+            "SplitTOC": ["api/toc.yml"],
             "ECMA2Yaml": {
               "SourceXmlFolder": "cat/xml",
               "OutputYamlFolder": "cat/api",
@@ -233,6 +235,7 @@ repos:
           "docsets_to_publish": [
           { 
             "build_source_folder": "cat",
+            "SplitTOC": ["api/toc.yml", "api/copied-mouse/toc.yml"]
           }],
           "ECMA2Yaml": [
             {

--- a/docs/specs/toc/service-page.yml
+++ b/docs/specs/toc/service-page.yml
@@ -191,7 +191,6 @@ repos:
         }
       a/test/doc.md:
       a/api/bot/TOC.yml: |
-        splitItemsBy: name
         items:
         - name: MS.ServicePage2.xxx
           items:
@@ -243,7 +242,6 @@ repos:
         }
       a/test/doc.md:
       a/api/bot/TOC.yml: |
-        splitItemsBy: name
         items:
         - name: MS.ServicePage2.xxx
           items:
@@ -362,7 +360,6 @@ repos:
         }
       a/test/doc.md:
       a/api/bot/TOC.yml: |
-        splitItemsBy: name
         items:
         - name: MS.ServicePage2.xxx
           items:

--- a/docs/specs/toc/service-page.yml
+++ b/docs/specs/toc/service-page.yml
@@ -164,7 +164,7 @@ repos:
   - files:
       .openpublishing.publish.config.json: |
         {
-          "docsets_to_publish": [{  "build_source_folder": "a"}],
+          "docsets_to_publish": [{  "build_source_folder": "a", "SplitTOC": ["api/bot/TOC.yml"]}],
           "JoinTOCPlugin": [
             {"ReferenceTOC": "a/api/bot/TOC.yml",
               "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml"}],
@@ -216,7 +216,7 @@ repos:
   - files:
       .openpublishing.publish.config.json: |
         {
-          "docsets_to_publish": [{  "build_source_folder": "a"}],
+          "docsets_to_publish": [{  "build_source_folder": "a", "SplitTOC": ["api/bot/TOC.yml"]}],
           "JoinTOCPlugin": [
             {"ReferenceTOC": "a/api/bot/TOC.yml",
               "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml"}],
@@ -335,7 +335,7 @@ repos:
   - files:
       .openpublishing.publish.config.json: |
         {
-          "docsets_to_publish": [{  "build_source_folder": "a"}],
+          "docsets_to_publish": [{  "build_source_folder": "a", "SplitTOC": ["api/bot/TOC.yml"]}],
           "JoinTOCPlugin": [
             {"ReferenceTOC": "a/api/bot/TOC.yml",
               "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml"}],

--- a/docs/specs/toc/split-toc.yml
+++ b/docs/specs/toc/split-toc.yml
@@ -1,19 +1,29 @@
 # TOC splitItemsBy produces multiple output TOCs with correct link and _tocRel
-inputs:
-  docfx.yml:
-  TOC.yml: |
-    splitItemsBy: name
-    items:
-    - name: 1
-      href: a.md
-      items:
-      - name: 1-1
-        href: b.md
-    - name: 2
-      href: c.md
-  a.md:
-  b.md:
-  c.md:
+repos:
+  https://github.com/ops/split-toc-default-by-name:
+  - files:
+      .openpublishing.publish.config.json: |
+        {
+          "docsets_to_publish": [
+            {
+              "build_source_folder": ".", 
+              "SplitTOC": ["TOC.yml"]
+            }
+          ]
+        }
+      docfx.yml:
+      TOC.yml: |
+        items:
+        - name: 1
+          href: a.md
+          items:
+          - name: 1-1
+            href: b.md
+        - name: 2
+          href: c.md
+      a.md:
+      b.md:
+      c.md:
 outputs:
   a.json: '{ "_tocRel": "_splitted/1/toc.json" }'
   b.json: '{ "_tocRel": "_splitted/1/toc.json" }'

--- a/docs/specs/toc/split-toc.yml
+++ b/docs/specs/toc/split-toc.yml
@@ -71,7 +71,6 @@ repos:
           key:
             _splitted/**/TOC.yml: value
       TOC.yml: |
-        splitItemsBy: name
         items:
         - name: 1
           items:
@@ -106,7 +105,6 @@ repos:
         }
     
       TOC.yml: |
-        splitItemsBy: name
         items:
         - name: 1
           items:
@@ -214,7 +212,6 @@ repos:
           ]
         }
       a/TOC.yml: |
-        splitItemsBy: name
         items:
         - name: a
           items:
@@ -223,7 +220,6 @@ repos:
           items:
           - name: b-b
       b/TOC.yml: |
-        splitItemsBy: name
         items:
         - name: 1
           items:
@@ -258,7 +254,6 @@ repos:
           ]
         }
       test/a/TOC.yml: |
-        splitItemsBy: name
         items:
         - name: a
           items:
@@ -267,7 +262,6 @@ repos:
           items:
           - name: b-b
       test/b/TOC.yml: |
-        splitItemsBy: name
         items:
         - name: 1
           items:

--- a/docs/specs/toc/split-toc.yml
+++ b/docs/specs/toc/split-toc.yml
@@ -54,41 +54,63 @@ outputs:
     }
 ---
 # TOC splitItemsBy respect metadata config
-inputs:
-  docfx.yml: |
-    fileMetadata:
-      key:
-        _splitted/**/TOC.yml: value
-  TOC.yml: |
-    splitItemsBy: name
-    items:
-    - name: 1
-      items:
-      - name: 1-1
+repos:
+  https://github.com/ops/split-toc-respect-metadata-config:
+  - files:
+      .openpublishing.publish.config.json: |
+        {
+          "docsets_to_publish": [
+            {
+              "build_source_folder": ".", 
+              "SplitTOC": ["TOC.yml"]
+            }
+          ]
+        }
+      docfx.yml: |
+        fileMetadata:
+          key:
+            _splitted/**/TOC.yml: value
+      TOC.yml: |
+        splitItemsBy: name
+        items:
+        - name: 1
+          items:
+          - name: 1-1
 outputs:
   toc.json:
   _splitted/1/toc.json: |
     { "metadata": { "key": "value" } }
 ---
 # TOC splitItemsBy respect content route config
-inputs:
-  docfx.json: |
-    {
-      "content":[
+repos:
+  https://github.com/ops/split-toc-respect-content-route-config:
+  - files:
+      .openpublishing.publish.config.json: |
         {
-          "files": ["**/TOC.yml"],
-          "src": ".",
-          "dest": "toc-dest"
+          "docsets_to_publish": [
+            {
+              "build_source_folder": ".", 
+              "SplitTOC": ["TOC.yml"]
+            }
+          ]
         }
-      ]
-    }
+      docfx.json: |
+        {
+          "content":[
+            {
+              "files": ["**/TOC.yml"],
+              "src": ".",
+              "dest": "toc-dest"
+            }
+          ]
+        }
     
-  TOC.yml: |
-    splitItemsBy: name
-    items:
-    - name: 1
-      items:
-      - name: 1-1
+      TOC.yml: |
+        splitItemsBy: name
+        items:
+        - name: 1
+          items:
+          - name: 1-1
 outputs:
   toc-dest/toc.json:
   toc-dest/_splitted/1/toc.json:
@@ -181,6 +203,7 @@ repos:
       docfx.yml:
       .openpublishing.publish.config.json: |
         {
+          "docsets_to_publish": [{  "build_source_folder": ".", "SplitTOC": ["a/TOC.yml", "b/TOC.yml"]}],
           "JoinTOCPlugin": [
             {
               "ConceptualTOC": "b/TOC.yml",
@@ -224,7 +247,7 @@ repos:
       test/docfx.yml:
       .openpublishing.publish.config.json: |
         {
-          "docsets_to_publish": [{  "build_source_folder": "test"}],
+          "docsets_to_publish": [{  "build_source_folder": "test", "SplitTOC": ["a/TOC.yml", "b/TOC.yml"]}],
           "JoinTOCPlugin": [
             {
               "ConceptualTOC": "test/b/TOC.yml",

--- a/docs/specs/validation/toc-breadcrumb-validation.yml
+++ b/docs/specs/validation/toc-breadcrumb-validation.yml
@@ -165,7 +165,6 @@ inputs:
     }
     }
   TOC.yml: |
-    splitItemsBy: name
     items:
     - name: 1
       href: a.md

--- a/src/docfx/build/context/Context.cs
+++ b/src/docfx/build/context/Context.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Docs.Build
                 config,
                 errorLog);
             TocMap = new TableOfContentsMap(
-                ErrorBuilder, Input, BuildScope, DependencyMapBuilder, tocParser, TableOfContentsLoader, DocumentProvider, ContentValidator);
+                Config, ErrorBuilder, Input, BuildScope, DependencyMapBuilder, tocParser, TableOfContentsLoader, DocumentProvider, ContentValidator);
             PublishUrlMap = new PublishUrlMap(
                 Config, ErrorBuilder, BuildScope, RedirectionProvider, DocumentProvider, MonikerProvider, TocMap);
 

--- a/src/docfx/build/toc/TableOfContentsMap.cs
+++ b/src/docfx/build/toc/TableOfContentsMap.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Docs.Build
 
         private void SplitToc(FilePath file, TableOfContentsNode toc, ConcurrentBag<FilePath> result)
         {
-            if (Array.Exists<string>(_config.SplitTOC, e => e.Equals(file.Path.Value)) || toc.Items.Count <= 0)
+            if (!Array.Exists(_config.SplitTOC, e => e.Equals(file.Path.Value)) || toc.Items.Count <= 0)
             {
                 result.Add(file);
                 return;

--- a/src/docfx/build/toc/TableOfContentsMap.cs
+++ b/src/docfx/build/toc/TableOfContentsMap.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Docs.Build
 
         private void SplitToc(FilePath file, TableOfContentsNode toc, ConcurrentBag<FilePath> result)
         {
-            if (!Array.Exists(_config.SplitTOC, e => e.Equals(file.Path.Value)) || toc.Items.Count <= 0)
+            if (!_config.SplitTOC.Contains(file.Path) || toc.Items.Count <= 0)
             {
                 result.Add(file);
                 return;

--- a/src/docfx/build/toc/TableOfContentsMap.cs
+++ b/src/docfx/build/toc/TableOfContentsMap.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Docs.Build
     /// </summary>
     internal class TableOfContentsMap
     {
+        private readonly Config _config;
         private readonly Input _input;
         private readonly ErrorBuilder _errors;
         private readonly BuildScope _buildScope;
@@ -27,6 +28,7 @@ namespace Microsoft.Docs.Build
         private readonly Lazy<(Dictionary<FilePath, FilePath[]> tocToTocs, Dictionary<FilePath, FilePath[]> docToTocs, List<FilePath> servicePages)> _tocs;
 
         public TableOfContentsMap(
+            Config config,
             ErrorBuilder errors,
             Input input,
             BuildScope buildScope,
@@ -36,6 +38,7 @@ namespace Microsoft.Docs.Build
             DocumentProvider documentProvider,
             ContentValidator contentValidator)
         {
+            _config = config;
             _errors = errors;
             _input = input;
             _buildScope = buildScope;
@@ -218,7 +221,7 @@ namespace Microsoft.Docs.Build
 
         private void SplitToc(FilePath file, TableOfContentsNode toc, ConcurrentBag<FilePath> result)
         {
-            if (string.IsNullOrEmpty(toc.SplitItemsBy) || toc.Items.Count <= 0)
+            if (Array.Exists<string>(_config.SplitTOC, e => e.Equals(file.Path.Value)) || toc.Items.Count <= 0)
             {
                 result.Add(file);
                 return;
@@ -237,7 +240,7 @@ namespace Microsoft.Docs.Build
 
                 var newNode = SplitTocNode(child);
                 var newNodeToken = JsonUtility.ToJObject(newNode);
-                var name = newNodeToken.TryGetValue<JValue>(toc.SplitItemsBy, out var splitByValue) ? splitByValue.ToString() : null;
+                var name = newNodeToken.TryGetValue<JValue>("name", out var splitByValue) ? splitByValue.ToString() : null;
                 if (string.IsNullOrEmpty(name))
                 {
                     newToc.Items.Add(item);

--- a/src/docfx/build/toc/TableOfContentsNode.cs
+++ b/src/docfx/build/toc/TableOfContentsNode.cs
@@ -34,10 +34,6 @@ namespace Microsoft.Docs.Build
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool MaintainContext { get; set; }
 
-        public string? SplitItemsBy { get; set; }
-
-        public static bool ShouldSerializeSplitItemsBy() => false;
-
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public MonikerList Monikers { get; set; }
 
@@ -67,7 +63,6 @@ namespace Microsoft.Docs.Build
             Expanded = item.Expanded;
             MaintainContext = item.MaintainContext;
             ExtensionData = item.ExtensionData;
-            SplitItemsBy = item.SplitItemsBy;
             Document = item.Document;
             Children = item.Children;
             LandingPageType = item.LandingPageType;

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -320,6 +320,8 @@ namespace Microsoft.Docs.Build
 
         public JoinTOCConfig[] JoinTOC { get; private set; } = Array.Empty<JoinTOCConfig>();
 
+        public string[] SplitTOC { get; private set; } = Array.Empty<string>();
+
         public IEnumerable<SourceInfo<string>> GetFileReferences()
         {
             foreach (var url in Xref)

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -320,7 +320,7 @@ namespace Microsoft.Docs.Build
 
         public JoinTOCConfig[] JoinTOC { get; private set; } = Array.Empty<JoinTOCConfig>();
 
-        public string[] SplitTOC { get; private set; } = Array.Empty<string>();
+        public HashSet<PathString> SplitTOC { get; private set; } = new HashSet<PathString>();
 
         public IEnumerable<SourceInfo<string>> GetFileReferences()
         {

--- a/src/docfx/config/ops/OpsConfigLoader.cs
+++ b/src/docfx/config/ops/OpsConfigLoader.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Docs.Build
                     ["open_to_public_contributors"] = docsetConfig.OpenToPublicContributors,
                 };
 
-                result["SplitTOC"] = JArray.FromObject(docsetConfig.SplitTOC);
+                result["splitTOC"] = JArray.FromObject(docsetConfig.SplitTOC);
             }
 
             var joinTOCPluginConfig = docsetConfig?.JoinTOCPlugin ?? opsConfig.JoinTOCPlugin ?? Array.Empty<OpsJoinTocConfig>();

--- a/src/docfx/config/ops/OpsConfigLoader.cs
+++ b/src/docfx/config/ops/OpsConfigLoader.cs
@@ -81,6 +81,8 @@ namespace Microsoft.Docs.Build
                 {
                     ["open_to_public_contributors"] = docsetConfig.OpenToPublicContributors,
                 };
+
+                result["SplitTOC"] = JArray.FromObject(docsetConfig.SplitTOC);
             }
 
             var joinTOCPluginConfig = docsetConfig?.JoinTOCPlugin ?? opsConfig.JoinTOCPlugin ?? Array.Empty<OpsJoinTocConfig>();

--- a/src/docfx/config/ops/OpsDocsetConfig.cs
+++ b/src/docfx/config/ops/OpsDocsetConfig.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Docs.Build
 
         public Dictionary<string, string[]>? CustomizedTasks { get; private set; }
 
-        [JsonProperty("SplitTOC")]
-        public string[] SplitTOC { get; private set; } = Array.Empty<string>();
+        [JsonProperty(nameof(SplitTOC))]
+        public HashSet<PathString> SplitTOC { get; private set; } = new HashSet<PathString>();
 
         [JsonProperty(nameof(JoinTOCPlugin))]
         public OpsJoinTocConfig[]? JoinTOCPlugin { get; private set; }

--- a/src/docfx/config/ops/OpsDocsetConfig.cs
+++ b/src/docfx/config/ops/OpsDocsetConfig.cs
@@ -22,6 +22,9 @@ namespace Microsoft.Docs.Build
 
         public Dictionary<string, string[]>? CustomizedTasks { get; private set; }
 
+        [JsonProperty("SplitTOC")]
+        public string[] SplitTOC { get; private set; } = Array.Empty<string>();
+
         [JsonProperty(nameof(JoinTOCPlugin))]
         public OpsJoinTocConfig[]? JoinTOCPlugin { get; private set; }
 


### PR DESCRIPTION
Split specified toc.yml in ops.config by name by default.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6661)