### PR TITLE
Support '--template-base-path' to specific the template base path when apply liquid

### DIFF
--- a/docs/specs/static.yml
+++ b/docs/specs/static.yml
@@ -383,3 +383,20 @@ outputs:
   .lunr.json: |
     { "version": "2.3.8", "fields": ["title", "body"] }
 ---
+# Liquid with register tag
+inputs:
+  docfx.yml: |
+    outputType: html
+    templateBasePath: /dev
+  docs/a.md:
+  _themes/Conceptual.html.liquid: |
+    {% js test.js %}
+    {% style test.css %}
+    {{content}}
+  _themes/test.js:
+  _themes/test.css:
+outputs:
+  docs/a.html: |
+    <script src='/dev/test.js' ></script>
+    <link rel="stylesheet" href="/dev/test.css">
+    <div></div>

--- a/src/docfx/cli/CommandLineOptions.cs
+++ b/src/docfx/cli/CommandLineOptions.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Docs.Build
         public bool NoCache;
         public bool NoRestore;
         public string? Template;
+        public string? TemplateBasePath;
 
         public JObject? StdinConfig;
 
@@ -44,6 +45,11 @@ namespace Microsoft.Docs.Build
             if (Template != null)
             {
                 config["template"] = Template;
+            }
+
+            if (TemplateBasePath != null)
+            {
+                config["templateBasePath"] = TemplateBasePath;
             }
 
             return config;

--- a/src/docfx/cli/Docfx.cs
+++ b/src/docfx/cli/Docfx.cs
@@ -129,6 +129,10 @@ namespace Microsoft.Docs.Build
                     syntax.DefineOption("no-dry-sync", ref options.NoDrySync, "Do not run dry sync for learn validation.");
                     syntax.DefineOption("no-restore", ref options.NoRestore, "Do not restore dependencies before build.");
                     syntax.DefineOption("no-cache", ref options.NoCache, "Do not use cache dependencies in build, always fetch latest dependencies.");
+                    syntax.DefineOption(
+                        "template-base-path",
+                        ref options.TemplateBasePath,
+                        "The base path used for referencing the template resource file when applying liquid.");
                     DefineCommonOptions(syntax, ref workingDirectory, options);
                 });
 

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -229,6 +229,12 @@ namespace Microsoft.Docs.Build
         public PackagePath Template { get; private set; } = new PackagePath();
 
         /// <summary>
+        /// Get the template base path used for referencing the template resource file when apply liquid.
+        /// If not provided, referencing to template resource file will be resolved to physical absolute path.
+        /// </summary>
+        public string? TemplateBasePath { get; private set; }
+
+        /// <summary>
         /// Gets the search index type like [lunr](https://lunrjs.com/)
         /// </summary>
         public SearchEngineType SearchEngine { get; private set; }

--- a/src/docfx/template/TemplateEngine.cs
+++ b/src/docfx/template/TemplateEngine.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Docs.Build
 
             _global = LoadGlobalTokens(errors);
 
-            _liquid = new LiquidTemplate(_package, _global);
+            _liquid = new LiquidTemplate(_package, config.TemplateBasePath, _global);
             _js = new ThreadLocal<JavaScriptEngine>(() => JavaScriptEngine.Create(_package, _global));
             _mustacheTemplate = new MustacheTemplate(_package, "ContentTemplate", _global, jsonSchemaTransformer);
         }

--- a/src/docfx/template/liquid/JavaScriptTag.cs
+++ b/src/docfx/template/liquid/JavaScriptTag.cs
@@ -10,7 +10,8 @@ namespace Microsoft.Docs.Build
     {
         public override void Render(DotLiquid.Context context, TextWriter result)
         {
-            result.Write($@"<script src=""{LiquidTemplate.GetThemeRelativePath(Markup)}"" ></script>");
+            var templateBasePath = (string?)context.Registers["template_base_path"];
+            result.Write($@"<script src=""{LiquidTemplate.GetThemeRelativePath(templateBasePath, Markup)}"" ></script>");
         }
     }
 }

--- a/src/docfx/template/liquid/JavaScriptTag.cs
+++ b/src/docfx/template/liquid/JavaScriptTag.cs
@@ -10,8 +10,7 @@ namespace Microsoft.Docs.Build
     {
         public override void Render(DotLiquid.Context context, TextWriter result)
         {
-            var templateBasePath = (string?)context.Registers["template_base_path"];
-            result.Write($@"<script src=""{LiquidTemplate.GetThemeRelativePath(templateBasePath, Markup)}"" ></script>");
+            result.Write($@"<script src=""{LiquidTemplate.GetThemeRelativePath(context, Markup)}"" ></script>");
         }
     }
 }

--- a/src/docfx/template/liquid/LiquidTemplate.cs
+++ b/src/docfx/template/liquid/LiquidTemplate.cs
@@ -82,8 +82,9 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public static string? GetThemeRelativePath(string? templateBasePath, string resourcePath)
+        public static string? GetThemeRelativePath(DotLiquid.Context context, string resourcePath)
         {
+            var templateBasePath = (string?)context.Registers["template_base_path"];
             if (string.IsNullOrEmpty(templateBasePath))
             {
                 return t_package?.TryGetPhysicalPath(new PathString(resourcePath));

--- a/src/docfx/template/liquid/StyleTag.cs
+++ b/src/docfx/template/liquid/StyleTag.cs
@@ -10,8 +10,7 @@ namespace Microsoft.Docs.Build
     {
         public override void Render(DotLiquid.Context context, TextWriter result)
         {
-            var templateBasePath = (string?)context.Registers["template_base_path"];
-            result.Write($@"<link rel=""stylesheet"" href=""{LiquidTemplate.GetThemeRelativePath(templateBasePath, Markup)}"">");
+            result.Write($@"<link rel=""stylesheet"" href=""{LiquidTemplate.GetThemeRelativePath(context, Markup)}"">");
         }
     }
 }

--- a/src/docfx/template/liquid/StyleTag.cs
+++ b/src/docfx/template/liquid/StyleTag.cs
@@ -10,7 +10,8 @@ namespace Microsoft.Docs.Build
     {
         public override void Render(DotLiquid.Context context, TextWriter result)
         {
-            result.Write($@"<link rel=""stylesheet"" href=""{LiquidTemplate.GetThemeRelativePath(Markup)}"">");
+            var templateBasePath = (string?)context.Registers["template_base_path"];
+            result.Write($@"<link rel=""stylesheet"" href=""{LiquidTemplate.GetThemeRelativePath(templateBasePath, Markup)}"">");
         }
     }
 }


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6685)