### PR TITLE
Skip normalization for ssh git repository url

### DIFF
--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -8,7 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Runtime.InteropServices;
-
+using System.Text.RegularExpressions;
 using static Microsoft.Docs.Build.LibGit2;
 
 namespace Microsoft.Docs.Build
@@ -215,6 +215,12 @@ namespace Microsoft.Docs.Build
             git_repository_free(repo);
 
             return result;
+        }
+
+        public static string NormalizeGitUrl(string url)
+        {
+            // remove user name, token and .git from url like https://xxxxx@dev.azure.com/xxxx.git
+            return Regex.Replace(url, @"^((http|https):\/\/)([^\/\s]+@)?([\S]+?)(\.git)?$", "$1$4");
         }
 
         private static void ExecuteNonQuery(string cwd, string commandLineArgs, string[]? secrets = null)

--- a/src/docfx/lib/git/Repository.cs
+++ b/src/docfx/lib/git/Repository.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Text.RegularExpressions;
-
 namespace Microsoft.Docs.Build
 {
     internal class Repository
@@ -18,7 +16,7 @@ namespace Microsoft.Docs.Build
         private Repository(string url, string? branch, string commit, PathString path)
         {
             // remove user name, token and .git from url like https://xxxxx@dev.azure.com/xxxx.git
-            Url = Regex.Replace(url, @"^((http|https):\/\/)?([^\/\s]+@)?([\S]+?)(\.git)?$", "$1$4");
+            Url = GitUtility.NormalizeGitUrl(url);
             Branch = branch;
             Commit = commit;
             Path = path;

--- a/test/docfx.Test/lib/GitUtilityTest.cs
+++ b/test/docfx.Test/lib/GitUtilityTest.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Docs.Build
         }
 
         [Theory]
-        [InlineData("https://xxxxx@dev.azure.com/test-repo.git", "https://@dev.azure.com/test-repo")]
+        [InlineData("https://xxxxx@dev.azure.com/test-repo.git", "https://dev.azure.com/test-repo")]
         [InlineData("git@github.com/test-repo.git", "git@github.com/test-repo.git")]
         public static void NormalizeGitUrlTest(string url, string expected)
         {

--- a/test/docfx.Test/lib/GitUtilityTest.cs
+++ b/test/docfx.Test/lib/GitUtilityTest.cs
@@ -53,6 +53,14 @@ namespace Microsoft.Docs.Build
             gitCommitProvider.Save();
         }
 
+        [Theory]
+        [InlineData("https://xxxxx@dev.azure.com/test-repo.git", "https://@dev.azure.com/test-repo")]
+        [InlineData("git@github.com/test-repo.git", "git@github.com/test-repo.git")]
+        public static void NormalizeGitUrlTest(string url, string expected)
+        {
+            Assert.Equal(expected, GitUtility.NormalizeGitUrl(url));
+        }
+
         private static string Exec(string name, string args, string cwd)
         {
             var p = Process.Start(new ProcessStartInfo { FileName = name, Arguments = args, WorkingDirectory = cwd, RedirectStandardOutput = true });


### PR DESCRIPTION
With this fix, the ssh git repository url (`git@github.com/test-repo.git`) will be transformed into `github.com/test-repo.git`, which is not a valid git repository url and cause build error.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6690)