### PR TITLE
Bump Microsoft.DocAsCode.ECMAHelper from 1.1.765 to 1.1.766

### DIFF
--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.15.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.9" />
     <PackageReference Include="Microsoft.ChakraCore" Version="1.11.22" />
-    <PackageReference Include="Microsoft.DocAsCode.ECMAHelper" Version="1.1.765" />
+    <PackageReference Include="Microsoft.DocAsCode.ECMAHelper" Version="1.1.766" />
     <PackageReference Include="Microsoft.DocAsCode.MAML2Yaml.Lib" Version="1.0.72" Aliases="maml" />
     <PackageReference Include="Microsoft.Graph" Version="3.18.0" />
     <PackageReference Include="Microsoft.Experimental.Collections" Version="1.0.6-e190117-3" />


### PR DESCRIPTION
To fix Azure/azure-cosmos-dotnet-v3#1855.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6707)