### PR TITLE
Optimize commonly used glob pattern performance

### DIFF
--- a/src/docfx/lib/GlobUtility.cs
+++ b/src/docfx/lib/GlobUtility.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Docs.Build
             private readonly string? _subFolder;
             private readonly bool _allowTrailingFolders;
 
-            public KnownGlob(string? extension, string? startsWithFolder, string? subFolder, bool allowTrailingFolders)
+            private KnownGlob(string? extension, string? startsWithFolder, string? subFolder, bool allowTrailingFolders)
             {
                 _extension = extension;
                 _startsWithFolder = startsWithFolder;
@@ -114,29 +114,29 @@ namespace Microsoft.Docs.Build
             public static KnownGlob? TryCreate(string pattern)
             {
                 var match = Regex.Match(pattern.Replace('\\', '/'), @"^(\*\*)?([\w-._/]+\/)?(\*\*\/?)?(\*\.\w+)?$");
-                if (match.Success)
+                if (!match.Success)
                 {
-                    var allowLeadingFolders = match.Groups[1].Success;
-                    var folder = match.Groups[2].Success ? match.Groups[2].Value : null;
-                    var allowTrailingFolders = match.Groups[3].Success;
-                    var extension = match.Groups[4].Success ? match.Groups[4].Value.TrimStart('*') : null;
-                    var startsWithFolder = !allowLeadingFolders ? folder : null;
-                    var subFolder = allowLeadingFolders ? folder?.TrimStart('/') : null;
-
-                    if (extension is null && folder is null)
-                    {
-                        return null;
-                    }
-
-                    if (allowLeadingFolders && folder is null)
-                    {
-                        allowTrailingFolders = true;
-                    }
-
-                    return new KnownGlob(extension, startsWithFolder, subFolder, allowTrailingFolders);
+                    return null;
                 }
 
-                return null;
+                var allowLeadingFolders = match.Groups[1].Success;
+                var folder = match.Groups[2].Success ? match.Groups[2].Value : null;
+                var allowTrailingFolders = match.Groups[3].Success;
+                var extension = match.Groups[4].Success ? match.Groups[4].Value.TrimStart('*') : null;
+                var startsWithFolder = !allowLeadingFolders ? folder : null;
+                var subFolder = allowLeadingFolders ? folder?.TrimStart('/') : null;
+
+                if (extension is null && folder is null)
+                {
+                    return null;
+                }
+
+                if (allowLeadingFolders && folder is null)
+                {
+                    allowTrailingFolders = true;
+                }
+
+                return new KnownGlob(extension, startsWithFolder, subFolder, allowTrailingFolders);
             }
 
             public bool IsMatch(string path)

--- a/src/docfx/lib/GlobUtility.cs
+++ b/src/docfx/lib/GlobUtility.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Docs.Build
         {
             var glob = CreateGlob(pattern);
 
-            return path => !IsFileStartingWithDot(path) && glob.IsMatch(path);
+            return path => !IsFileStartingWithDot(path) && glob(path);
         }
 
         public static Func<string, bool> CreateGlobMatcher(string[] includePatterns, string[]? excludePatterns = null)
@@ -32,7 +32,7 @@ namespace Microsoft.Docs.Build
 
                 foreach (var exclude in excludeGlobs)
                 {
-                    if (exclude != null && exclude.IsMatch(path))
+                    if (exclude != null && exclude(path))
                     {
                         return false;
                     }
@@ -40,7 +40,7 @@ namespace Microsoft.Docs.Build
 
                 foreach (var include in includeGlobs)
                 {
-                    if (include != null && include.IsMatch(path))
+                    if (include != null && include(path))
                     {
                         return true;
                     }
@@ -49,13 +49,20 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static Glob CreateGlob(string pattern)
+        private static Func<string, bool> CreateGlob(string pattern)
         {
+            pattern = PreProcessPattern(pattern);
+
+            if (KnownGlob.TryCreate(pattern) is KnownGlob knownGlob)
+            {
+                return knownGlob.IsMatch;
+            }
+
             try
             {
                 var options = PathUtility.IsCaseSensitive ? GlobOptions.None : GlobOptions.CaseInsensitive;
 
-                return new Glob(PreProcessPattern(pattern), options | GlobOptions.MatchFullPath | GlobOptions.Compiled);
+                return new Glob(pattern, options | GlobOptions.MatchFullPath | GlobOptions.Compiled).IsMatch;
             }
             catch (Exception ex)
             {
@@ -74,7 +81,106 @@ namespace Microsoft.Docs.Build
             // **** => **, **.md => **/*.md
             pattern = Regex.Replace(pattern, @"\*{2,}", "**");
             pattern = Regex.Replace(pattern, @"^\*{2}\.", "**/*.");
-            return pattern.Replace("/**.", "/**/*.");
+            pattern = Regex.Replace(pattern, @"\*\*\/\*$", "**");
+            return pattern.Replace("/**.", "/**/*.").Replace("/**/**/", "/**/");
+        }
+
+        /// <summary>
+        /// Fast pass to process commonly known glob patterns:
+        ///
+        ///   - **/*.md
+        ///   - **/includes/**
+        ///   - **/includes/*.md
+        ///   - **/includes/**/*.md
+        ///   - includes/*.md
+        ///   - includes/**/*.md
+        ///   - includes/**
+        /// </summary>
+        private class KnownGlob
+        {
+            private readonly string? _extension;
+            private readonly string? _startsWithFolder;
+            private readonly string? _containsFolder;
+            private readonly bool _allowTrailingFolders;
+
+            public KnownGlob(string? extension, string? startsWithFolder, string? containsFolder, bool allowTrailingFolders)
+            {
+                _extension = extension;
+                _startsWithFolder = startsWithFolder;
+                _containsFolder = containsFolder;
+                _allowTrailingFolders = allowTrailingFolders;
+            }
+
+            public static KnownGlob? TryCreate(string pattern)
+            {
+                var match = Regex.Match(pattern.Replace('\\', '/'), @"^(\*\*)?([\w-._/]+\/)?(\*\*\/?)?(\*\.\w+)?$");
+                if (match.Success)
+                {
+                    var allowLeadingFolders = match.Groups[1].Success;
+                    var folder = match.Groups[2].Success ? match.Groups[2].Value : null;
+                    var allowTrailingFolders = match.Groups[3].Success;
+                    var extension = match.Groups[4].Success ? match.Groups[4].Value.TrimStart('*') : null;
+                    var startsWithFolder = !allowLeadingFolders ? folder : null;
+                    var containsFolder = allowLeadingFolders ? folder?.TrimStart('/') : null;
+
+                    if (extension is null && folder is null)
+                    {
+                        return null;
+                    }
+
+                    if (allowLeadingFolders && folder is null)
+                    {
+                        allowTrailingFolders = true;
+                    }
+
+                    return new KnownGlob(extension, startsWithFolder, containsFolder, allowTrailingFolders);
+                }
+
+                return null;
+            }
+
+            public bool IsMatch(string path)
+            {
+                // TODO: Use PathString as contract to remove this replace process
+                path = path.Replace('\\', '/');
+
+                var trailingFolderStartIndex = 0;
+
+                // Handle file extension: *.md
+                if (_extension != null && !path.EndsWith(_extension, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+
+                // Handle path starts: includes/**
+                if (_startsWithFolder != null)
+                {
+                    if (!path.StartsWith(_startsWithFolder))
+                    {
+                        return false;
+                    }
+                    trailingFolderStartIndex = _startsWithFolder.Length;
+                }
+
+                // Handle path in the middle: **/includes/**
+                if (_containsFolder != null)
+                {
+                    var index = path.LastIndexOf(_containsFolder, StringComparison.OrdinalIgnoreCase);
+                    if (index < 0 || (index > 0 && path[index - 1] != '/'))
+                    {
+                        return false;
+                    }
+                    trailingFolderStartIndex = index + _containsFolder.Length;
+                }
+
+                // Handle /**/ before extension
+                if (!_allowTrailingFolders && path.AsSpan(trailingFolderStartIndex + 1).Contains('/'))
+                {
+                    return false;
+                }
+
+                return true;
+            }
         }
     }
 }

--- a/src/docfx/lib/GlobUtility.cs
+++ b/src/docfx/lib/GlobUtility.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Docs.Build
                 // Handle path starts: includes/**
                 if (_startsWithFolder != null)
                 {
-                    if (!path.StartsWith(_startsWithFolder))
+                    if (!path.StartsWith(_startsWithFolder, StringComparison.OrdinalIgnoreCase))
                     {
                         return false;
                     }

--- a/test/docfx.Test/lib/GlobUtilityTest.cs
+++ b/test/docfx.Test/lib/GlobUtilityTest.cs
@@ -79,6 +79,7 @@ namespace Microsoft.Docs.Build
         [InlineData("**/a/*.md", "a/b/c.md, a/b/c", false)]
         [InlineData("**/a/**/*.md", "a/b.md, a/b/c.md, x/a/b.md, x/a/b/c.md", true)]
         [InlineData("**/a/**/*.md", "a/b/c", false)]
+        [InlineData("**/sample/**", "aspnetcore/security/anti-request-forgery/sample/MvcSample/wwwroot/lib/bootstrap/grunt/sauce_browsers.yml", true)]
 
         // For backward compatibility with v2
         [InlineData("****", "a.md, a/b.md", true)]

--- a/test/docfx.Test/lib/GlobUtilityTest.cs
+++ b/test/docfx.Test/lib/GlobUtilityTest.cs
@@ -63,6 +63,23 @@ namespace Microsoft.Docs.Build
         [InlineData("a.b**.md", "a.b.c.md, a.b.c.a.md", true)]
         [InlineData("a.b**.md", "a.e.md, a.c.a.md", false)]
 
+        // Known glob
+        [InlineData("**", "a, a.md, a/b, a/b/c", true)]
+        [InlineData("**/*.md", "a.md, a/b.md", true)]
+        [InlineData("**/*.md", "a, a/b", false)]
+        [InlineData("a/**", "a/b, a/b/c", true)]
+        [InlineData("a/**", "a, b/c, x/a/b", false)]
+        [InlineData("a/*.md", "a/b.md", true)]
+        [InlineData("a/*.md", "a/b/c.md, a/b/c, x/a/b.md", false)]
+        [InlineData("a/**/*.md", "a/b.md, a/b/c.md", true)]
+        [InlineData("a/**/*.md", "a/b/c, x/a/b.md, x/a/b/c.md", false)]
+        [InlineData("**/a/**", "a/b, a/b/c, x/a/b, x/a/b/c", true)]
+        [InlineData("**/a/**", "a, b/c", false)]
+        [InlineData("**/a/*.md", "a/b.md, x/a/b.md", true)]
+        [InlineData("**/a/*.md", "a/b/c.md, a/b/c", false)]
+        [InlineData("**/a/**/*.md", "a/b.md, a/b/c.md, x/a/b.md, x/a/b/c.md", true)]
+        [InlineData("**/a/**/*.md", "a/b/c", false)]
+
         // For backward compatibility with v2
         [InlineData("****", "a.md, a/b.md", true)]
         [InlineData("**.*", "a.md, a/b.md", true)]


### PR DESCRIPTION
Eliminate `GlobUtility.IsMatch` hot path by recognizing and optimizing commonly used glob patterns that matches a file extension, or a subdirectory.

_Before:_

![image](https://user-images.githubusercontent.com/511355/97522853-b7603580-19db-11eb-923d-44be7384b389.png)

_After:_

![image](https://user-images.githubusercontent.com/511355/97532433-4a579a80-19f1-11eb-8ffc-ec3e6a31432f.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6708)