### PR TITLE
feat: treat .yml as .md in computation of document id for Architecture

### DIFF
--- a/docs/specs/redirection.yml
+++ b/docs/specs/redirection.yml
@@ -369,7 +369,7 @@ outputs:
   azure/active-directory-b2c/test.json: |
     {"metadata": { "document_id": "89987066-1e32-4f92-1957-329cfa9de0a0", "document_version_independent_id": "8f254336-d196-b36f-649e-dec30465941b"}}
 ---
-# Hub/Landing page is treated as *.md when calculating document id
+# Hub/Landing/Architecture page is treated as *.md when calculating document id
 os: windows, osx
 inputs:
   docfx.yml: |
@@ -384,15 +384,21 @@ inputs:
     ### YamlMime:Hub
   articles/active-directory-b2c/test.yml : |
     ### YamlMime:landing
+  articles/active-directory-b2c/architecture.yml : |
+    ### YamlMime:Architecture
   _themes/ContentTemplate/schemas/Hub.schema.json:
   _themes/ContentTemplate/Hub.html.primary.tmpl:
   _themes/ContentTemplate/schemas/Landing.schema.json:
   _themes/ContentTemplate/Landing.html.primary.tmpl:
+  _themes/ContentTemplate/schemas/Architecture.schema.json:
+  _themes/ContentTemplate/Architecture.html.primary.tmpl:
 outputs:
   azure/active-directory-b2c/index.json: |
     {"metadata": { "document_id": "4b5e7225-dae6-053e-4657-c4731dbd7d64", "document_version_independent_id": "fdf17736-63c4-6c9f-825b-393312bbd63a"}}
   azure/active-directory-b2c/test.json: |
     {"metadata": { "document_id": "89987066-1e32-4f92-1957-329cfa9de0a0", "document_version_independent_id": "8f254336-d196-b36f-649e-dec30465941b"}}
+  azure/active-directory-b2c/architecture.json: |
+    {"metadata": { "document_id": "a482b6c7-7a1c-c123-0a93-28c4565cc43b", "document_version_independent_id": "0ea6a82f-f89d-1b92-3e01-06fbf8d4bf6a"}}
 ---
 # index.yml's document id also follows the redirection rules
 # trailing 'index' redirect-to will be trimmed

--- a/src/docfx/template/TemplateEngine.cs
+++ b/src/docfx/template/TemplateEngine.cs
@@ -74,7 +74,8 @@ namespace Microsoft.Docs.Build
         {
             return "Hub".Equals(mime, StringComparison.OrdinalIgnoreCase) ||
                    "Landing".Equals(mime, StringComparison.OrdinalIgnoreCase) ||
-                   "LandingData".Equals(mime, StringComparison.OrdinalIgnoreCase);
+                   "LandingData".Equals(mime, StringComparison.OrdinalIgnoreCase) ||
+                   "Architecture".Equals(mime, StringComparison.OrdinalIgnoreCase);
         }
 
         public JsonSchema GetSchema(SourceInfo<string?> mime)

--- a/src/docfx/template/TemplateEngine.cs
+++ b/src/docfx/template/TemplateEngine.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,6 +25,14 @@ namespace Microsoft.Docs.Build
 
         private readonly ConcurrentDictionary<string, JsonSchemaValidator?> _schemas
                    = new ConcurrentDictionary<string, JsonSchemaValidator?>(StringComparer.OrdinalIgnoreCase);
+
+        private static readonly HashSet<string> s_yamlMimesMigratedFromMarkdown = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "Architecture",
+                "Hub",
+                "Landing",
+                "LandingData",
+            };
 
         public TemplateEngine(
             ErrorBuilder errors,
@@ -72,10 +81,7 @@ namespace Microsoft.Docs.Build
 
         public static bool IsMigratedFromMarkdown(string? mime)
         {
-            return "Hub".Equals(mime, StringComparison.OrdinalIgnoreCase) ||
-                   "Landing".Equals(mime, StringComparison.OrdinalIgnoreCase) ||
-                   "LandingData".Equals(mime, StringComparison.OrdinalIgnoreCase) ||
-                   "Architecture".Equals(mime, StringComparison.OrdinalIgnoreCase);
+            return mime != null && s_yamlMimesMigratedFromMarkdown.Contains(mime);
         }
 
         public JsonSchema GetSchema(SourceInfo<string?> mime)


### PR DESCRIPTION
[AB#331835](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/331835)

Searched in metadata store - no .yml with YamlMime Architecture exists for live branch for now, so it is safe to apply this change without any side effect to existing document ids.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6731)