### PR TITLE
Load external xrefmap in parallel

### DIFF
--- a/src/docfx/lib/collections/DictionaryBuilder.cs
+++ b/src/docfx/lib/collections/DictionaryBuilder.cs
@@ -17,6 +17,10 @@ namespace System.Collections.Concurrent
             }
         }
 
-        public IReadOnlyDictionary<TKey, TValue> AsDictionary() => _dictionary;
+        public IReadOnlyDictionary<TKey, TValue> AsDictionary()
+        {
+            _dictionary.TrimExcess();
+            return _dictionary;
+        }
     }
 }

--- a/src/docfx/lib/collections/ListBuilder.cs
+++ b/src/docfx/lib/collections/ListBuilder.cs
@@ -28,6 +28,10 @@ namespace System.Collections.Concurrent
             }
         }
 
-        public IReadOnlyList<T> AsList() => _array;
+        public IReadOnlyList<T> AsList()
+        {
+            _array.TrimExcess();
+            return _array;
+        }
     }
 }


### PR DESCRIPTION
Address some of the recent _azure-docs-pr_ perf regressions:

**Before**:

![image](https://user-images.githubusercontent.com/511355/98507405-7a782680-2298-11eb-8880-f86e74a825f4.png)

**After**:

![image](https://user-images.githubusercontent.com/511355/98507638-f96d5f00-2298-11eb-91bc-da0decc33522.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6747)