### PR TITLE
Fix docset-not-provisioned error on keyvault access failure

### DIFF
--- a/src/docfx/config/ops/OpsAccessor.cs
+++ b/src/docfx/config/ops/OpsAccessor.cs
@@ -319,27 +319,19 @@ namespace Microsoft.Docs.Build
         {
             // don't access key vault for osx since azure-cli will crash in osx
             // https://github.com/Azure/azure-cli/issues/7519
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
-                && url.StartsWith(BuildServiceEndpoint(environment))
-                && !request.Headers.Contains("X-OP-BuildUserToken"))
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
+                url.StartsWith(BuildServiceEndpoint(environment)) &&
+                !request.Headers.Contains("X-OP-BuildUserToken"))
             {
                 // For development usage
-                try
+                var token = (environment ?? DocsEnvironment) switch
                 {
-                    var token = (environment ?? DocsEnvironment) switch
-                    {
-                        DocsEnvironment.Prod => s_opsTokenProd,
-                        DocsEnvironment.PPE => s_opsTokenSandbox,
-                        _ => throw new InvalidOperationException(),
-                    };
+                    DocsEnvironment.Prod => s_opsTokenProd,
+                    DocsEnvironment.PPE => s_opsTokenSandbox,
+                    _ => throw new InvalidOperationException(),
+                };
 
-                    request.Headers.Add("X-OP-BuildUserToken", await token.Value);
-                }
-                catch (Exception ex)
-                {
-                    Log.Write(
-                        $"Cannot get 'OPBuildUserToken' from azure key vault, please make sure you have been granted the permission to access: {ex.Message}");
-                }
+                request.Headers.Add("X-OP-BuildUserToken", await token.Value);
             }
         }
     }


### PR DESCRIPTION
When there are problems retrieving key vault secret, the `catch` block allows code to continue which leads to a misleading `docset-not-provisioned` error. In general, don't cache exceptions let the them populate to the upper layer, in this case, removing the `catch` block eventually caused a `download-failed` error with the detailed exception message.

https://github.com/dotnet/docfx/pull/5762

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6766)