### PR TITLE
Parallel load external xrefmap respect order

### DIFF
--- a/src/docfx/build/xref/ExternalXrefMap.cs
+++ b/src/docfx/build/xref/ExternalXrefMap.cs
@@ -8,26 +8,44 @@ namespace Microsoft.Docs.Build
 {
     internal class ExternalXrefMap
     {
-        private readonly IReadOnlyDictionary<string, Lazy<ExternalXrefSpec>> _externalXrefMap;
+        private readonly Dictionary<string, Lazy<ExternalXrefSpec>> _xrefSpecs;
+        private readonly List<ExternalXref> _externalXrefs;
 
-        private readonly IEnumerable<ExternalXref> _externalXref;
-
-        public ExternalXrefMap(IReadOnlyDictionary<string, Lazy<ExternalXrefSpec>> externalXrefMap, IEnumerable<ExternalXref> externalXref)
+        public ExternalXrefMap(Dictionary<string, Lazy<ExternalXrefSpec>> xrefSpecs, List<ExternalXref> externalXrefs)
         {
-            _externalXrefMap = externalXrefMap;
-            _externalXref = externalXref;
+            _xrefSpecs = xrefSpecs;
+            _externalXrefs = externalXrefs;
         }
 
-        public bool ExternalXrefMapTryGetValue(string uid, out ExternalXrefSpec? spec)
+        public ExternalXrefMap(IEnumerable<ExternalXrefMap> xrefMaps)
         {
-            var result = _externalXrefMap.TryGetValue(uid, out var lazySpec);
+            _externalXrefs = new List<ExternalXref>();
+            _xrefSpecs = new Dictionary<string, Lazy<ExternalXrefSpec>>();
+
+            foreach (var xrefMap in xrefMaps)
+            {
+                foreach (var (key, value) in xrefMap._xrefSpecs)
+                {
+                    _xrefSpecs.TryAdd(key, value);
+                }
+
+                foreach (var externalXref in xrefMap._externalXrefs)
+                {
+                    _externalXrefs.Add(externalXref);
+                }
+            }
+        }
+
+        public bool TryGetValue(string uid, out ExternalXrefSpec? spec)
+        {
+            var result = _xrefSpecs.TryGetValue(uid, out var lazySpec);
             spec = lazySpec?.Value;
             return result;
         }
 
-        public IEnumerable<ExternalXref> GetExternalXref()
+        public IEnumerable<ExternalXref> GetExternalXrefs()
         {
-            return _externalXref;
+            return _externalXrefs;
         }
     }
 }

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Docs.Build
 
             foreach (var xrefSpec in globalXrefSpecs)
             {
-                if (_externalXrefMap.Value.ExternalXrefMapTryGetValue(xrefSpec.Uid, out var spec))
+                if (_externalXrefMap.Value.TryGetValue(xrefSpec.Uid, out var spec))
                 {
                     _errorLog.Add(Errors.Xref.DuplicateUidGlobal(xrefSpec.Uid, spec!.RepositoryUrl, xrefSpec.PropertyPath)
                         .WithLevel(_config.RunLearnValidation ? ErrorLevel.Error : ErrorLevel.Warning));
@@ -235,7 +235,7 @@ namespace Microsoft.Docs.Build
 
         private void ValidateExternalXref()
         {
-            var localXrefGroups = _externalXrefMap.Value.GetExternalXref()
+            var localXrefGroups = _externalXrefMap.Value.GetExternalXrefs()
                 .Where(xref => string.Equals(xref.DocsetName, _config.Name, StringComparison.OrdinalIgnoreCase))
                 .GroupBy(xref => xref.Uid);
 
@@ -286,7 +286,7 @@ namespace Microsoft.Docs.Build
 
         private (IXrefSpec? xrefSpec, string? href) ResolveExternalXrefSpec(string uid)
         {
-            if (_externalXrefMap.Value.ExternalXrefMapTryGetValue(uid, out var spec))
+            if (_externalXrefMap.Value.TryGetValue(uid, out var spec))
             {
                 var href = RemoveSharingHost(spec!.Href, _config.HostName);
                 return (spec, href);

--- a/test/docfx.Test/build/XrefMapLoaderTest.cs
+++ b/test/docfx.Test/build/XrefMapLoaderTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Xunit;
 
 namespace Microsoft.Docs.Build
@@ -67,19 +68,12 @@ namespace Microsoft.Docs.Build
         public void LoadXrefMapFile(string json, string[] uids, string[] externalUids)
         {
             var filePath = WriteJsonToTempFile(json);
-            var result = ExternalXrefMapLoader.LoadJsonFile(filePath);
-            var resultUids = new List<string>();
-            var resultExternalUids = new List<string>();
-            foreach (var (_, spec) in result.externalXrefSpec)
-            {
-                resultUids.Add(((ExternalXrefSpec)spec.Value).Uid);
-            }
-            foreach (var xref in result.externalXref)
-            {
-                resultExternalUids.Add(xref.Uid);
-            }
-            Assert.Equal(uids, resultUids);
-            Assert.Equal(externalUids, resultExternalUids);
+            var xrefSpecs = new Dictionary<string, Lazy<ExternalXrefSpec>>();
+            var externalXrefs = new List<ExternalXref>();
+            ExternalXrefMapLoader.LoadJsonFile(xrefSpecs, externalXrefs, filePath);
+
+            Assert.Equal(uids, xrefSpecs.Keys);
+            Assert.Equal(externalUids, externalXrefs.Select(item => item.Uid));
         }
 
         private static string WriteJsonToTempFile(string json)


### PR DESCRIPTION
Fix order regression caused by #6747 

Test failure: https://dev.azure.com/ceapex/Engineering/_build/results?buildId=230043&view=ms.vss-test-web.build-test-results-tab&runId=1342040&resultId=101053&paneView=debug

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6769)