### PR TITLE
ignore contributors_to_exclude for github_contributors

### DIFF
--- a/docs/specs/git.yml
+++ b/docs/specs/git.yml
@@ -165,7 +165,7 @@ outputs:
           { "name": "charlie", "profile_url": "https://github.com/charlie", "display_name": "Charlie", "id": "3" },
         "contributors": undefined
       },
-      "github_contributors": ["charlie"]
+      "github_contributors": ["charlie", "bob", "alice"]
     }
 ---
 # Author can be excluded if it is not specified in YAML header
@@ -265,7 +265,7 @@ outputs:
           { "name": "alice", "profile_url": "https://github.com/alice", "display_name": "Alice", "id": "1" }
         ]
       },
-      "github_contributors": ["bob", "alice"]
+      "github_contributors": ["charlie", "bob", "alice"]
     }
 ---
 # Author CAN be excluded if implicitly extracted from commit history using contributors_to_exclude global metadata

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Docs.Build
 
             // Resolve contributors from commits
             var contributors = new List<Contributor>();
+            var githubContributor = new List<string>();
             if (UrlUtility.TryParseGitHubUrl(_config.EditRepositoryUrl, out var repoOwner, out var repoName) ||
                 UrlUtility.TryParseGitHubUrl(repo.Url, out repoOwner, out repoName))
             {
@@ -81,14 +82,18 @@ namespace Microsoft.Docs.Build
                     var (error, githubUser) = _githubAccessor.GetUserByEmail(commit.AuthorEmail, repoOwner, repoName, commit.Sha);
                     errors.AddIfNotNull(error);
                     var contributor = githubUser?.ToContributor();
-                    if (!string.IsNullOrEmpty(contributor?.Name) && !excludes.Contains(contributor.Name))
+                    if (!string.IsNullOrEmpty(contributor?.Name))
                     {
-                        contributors.Add(contributor);
+                        if (!excludes.Contains(contributor.Name))
+                        {
+                            contributors.Add(contributor);
+                        }
+                        githubContributor.Add(contributor.Name);
                     }
                 }
             }
 
-            var githubContributors = contributors.Distinct().Select(e => e.Name).Where(e => !string.IsNullOrEmpty(e)).ToArray();
+            var githubContributors = githubContributor.Distinct().ToArray();
 
             var author = contributors.Count > 0 ? contributors[^1] : null;
             if (!string.IsNullOrEmpty(authorName))

--- a/src/docfx/build/metadata/ContributionProvider.cs
+++ b/src/docfx/build/metadata/ContributionProvider.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Docs.Build
 
             // Resolve contributors from commits
             var contributors = new List<Contributor>();
-            var githubContributor = new List<string>();
+            var githubContributors = new List<string>();
             if (UrlUtility.TryParseGitHubUrl(_config.EditRepositoryUrl, out var repoOwner, out var repoName) ||
                 UrlUtility.TryParseGitHubUrl(repo.Url, out repoOwner, out repoName))
             {
@@ -88,12 +88,10 @@ namespace Microsoft.Docs.Build
                         {
                             contributors.Add(contributor);
                         }
-                        githubContributor.Add(contributor.Name);
+                        githubContributors.Add(contributor.Name);
                     }
                 }
             }
-
-            var githubContributors = githubContributor.Distinct().ToArray();
 
             var author = contributors.Count > 0 ? contributors[^1] : null;
             if (!string.IsNullOrEmpty(authorName))
@@ -112,7 +110,7 @@ namespace Microsoft.Docs.Build
             contributionInfo.Author = author;
             contributionInfo.Contributors = contributors.Distinct().ToArray();
 
-            return (contributionInfo, githubContributors);
+            return (contributionInfo, githubContributors.Distinct().ToArray());
         }
 
         public DateTime GetUpdatedAt(FilePath file, Repository? repository, GitCommit[] fileCommits)


### PR DESCRIPTION
Mike and Presley prefer to have the contributors in metadata store even they are set to hide in contributors_to_exclude.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6783)