### PR TITLE
Publish manifest for single file build is single file

### DIFF
--- a/docs/specs/single-file.yml
+++ b/docs/specs/single-file.yml
@@ -13,6 +13,8 @@ outputs:
     { "conceptual": "<p>a</p>" }
   b.json: |
     { "conceptual": "<p>b</p>" }
+  .publish.json: |
+    { "files": [{ "source_path": "a.md" }, { "source_path": "b.md" }] }
 ---
 # Support building a subset of files for multiple docsets
 buildFiles:
@@ -29,6 +31,10 @@ inputs:
 outputs:
   a/a.json:
   b/b.json:
+  a/.publish.json: |
+    { "files": [{ "source_path": "a.md" }] }
+  b/.publish.json: |
+    { "files": [{ "source_path": "b.md" }] }
 ---
 # Ignore include files and invalid files
 buildFiles:
@@ -40,3 +46,5 @@ inputs:
   a.md:
   c/a.md:
 outputs:
+  .publish.json: |
+    { "files": undefined }

--- a/docs/specs/single-file.yml
+++ b/docs/specs/single-file.yml
@@ -2,19 +2,17 @@
 # Support building a subset of files
 buildFiles:
 - a.md
-- b.md
 inputs:
   docfx.yml:
-  a.md: a
-  b.md: b
-  c.md: c
+  a.md: https://a.com
+  b.md: https://b.com
 outputs:
   a.json: |
-    { "conceptual": "<p>a</p>" }
-  b.json: |
-    { "conceptual": "<p>b</p>" }
+    { "conceptual": "<p><a href='https://a.com'>https://a.com</a></p>" }
   .publish.json: |
-    { "files": [{ "source_path": "a.md" }, { "source_path": "b.md" }] }
+    { "files": [{ "source_path": "a.md" }] }
+  .links.json: |
+    { "links": [{ "target_url": "https://a.com" }] }
 ---
 # Support building a subset of files for multiple docsets
 buildFiles:

--- a/src/docfx/build/DocsetBuilder.cs
+++ b/src/docfx/build/DocsetBuilder.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Docs.Build
                 contentValidator = new ContentValidator(_config, _fileResolver, _errors, _documentProvider, _monikerProvider, zonePivotProvider, new Lazy<PublishUrlMap>(() => publishUrlMap!));
 
                 var bookmarkValidator = new BookmarkValidator(_errors);
-                var fileLinkMapBuilder = new FileLinkMapBuilder(_errors, _documentProvider, _monikerProvider, _contributionProvider);
+                var fileLinkMapBuilder = new FileLinkMapBuilder(_documentProvider, _monikerProvider, _contributionProvider);
                 var xrefResolver = new XrefResolver(_config, _fileResolver, _buildOptions.Repository, dependencyMapBuilder, fileLinkMapBuilder, _errors, _documentProvider, _metadataProvider, _monikerProvider, _buildScope, new Lazy<JsonSchemaTransformer>(() => jsonSchemaTransformer!));
                 var linkResolver = new LinkResolver(_config, _buildOptions, _buildScope, redirectionProvider, _documentProvider, bookmarkValidator, dependencyMapBuilder, xrefResolver, _templateEngine, fileLinkMapBuilder, _metadataProvider);
                 var markdownEngine = new MarkdownEngine(_config, _input, _fileResolver, linkResolver, xrefResolver, _documentProvider, _metadataProvider, _monikerProvider, _templateEngine, contentValidator, new Lazy<PublishUrlMap>(() => publishUrlMap!));
@@ -178,7 +178,7 @@ namespace Microsoft.Docs.Build
                     () => output.WriteJson(".xrefmap.json", xrefMapModel),
                     () => output.WriteJson(".publish.json", publishModel),
                     () => output.WriteJson(".dependencymap.json", dependencyMap.ToDependencyMapModel()),
-                    () => output.WriteJson(".links.json", fileLinkMapBuilder.Build(publishUrlMap.GetAllFiles())),
+                    () => output.WriteJson(".links.json", fileLinkMapBuilder.Build(publishModel)),
                     () => output.WriteText(".lunr.json", searchIndexBuilder.Build()),
                     () => Legacy.ConvertToLegacyModel(_buildOptions.DocsetPath, legacyContext, fileManifests, dependencyMap));
 

--- a/src/docfx/build/DocsetBuilder.cs
+++ b/src/docfx/build/DocsetBuilder.cs
@@ -115,8 +115,7 @@ namespace Microsoft.Docs.Build
                 contentValidator = new ContentValidator(_config, _fileResolver, _errors, _documentProvider, _monikerProvider, zonePivotProvider, new Lazy<PublishUrlMap>(() => publishUrlMap!));
 
                 var bookmarkValidator = new BookmarkValidator(_errors);
-                var contributionProvider = new ContributionProvider(_config, _buildOptions, _input, _githubAccessor, _repositoryProvider);
-                var fileLinkMapBuilder = new FileLinkMapBuilder(_errors, _documentProvider, _monikerProvider, contributionProvider);
+                var fileLinkMapBuilder = new FileLinkMapBuilder(_errors, _documentProvider, _monikerProvider, _contributionProvider);
                 var xrefResolver = new XrefResolver(_config, _fileResolver, _buildOptions.Repository, dependencyMapBuilder, fileLinkMapBuilder, _errors, _documentProvider, _metadataProvider, _monikerProvider, _buildScope, new Lazy<JsonSchemaTransformer>(() => jsonSchemaTransformer!));
                 var linkResolver = new LinkResolver(_config, _buildOptions, _buildScope, redirectionProvider, _documentProvider, bookmarkValidator, dependencyMapBuilder, xrefResolver, _templateEngine, fileLinkMapBuilder, _metadataProvider);
                 var markdownEngine = new MarkdownEngine(_config, _input, _fileResolver, linkResolver, xrefResolver, _documentProvider, _metadataProvider, _monikerProvider, _templateEngine, contentValidator, new Lazy<PublishUrlMap>(() => publishUrlMap!));
@@ -135,7 +134,7 @@ namespace Microsoft.Docs.Build
                 var searchIndexBuilder = new SearchIndexBuilder(_config, _errors, _documentProvider, _metadataProvider);
 
                 var resourceBuilder = new ResourceBuilder(_input, _documentProvider, _config, output, publishModelBuilder);
-                var pageBuilder = new PageBuilder(_config, _buildOptions, _input, output, _documentProvider, _metadataProvider, _monikerProvider, _templateEngine, tocMap, linkResolver, contributionProvider, bookmarkValidator, publishModelBuilder, contentValidator, metadataValidator, markdownEngine, searchIndexBuilder, redirectionProvider, jsonSchemaTransformer);
+                var pageBuilder = new PageBuilder(_config, _buildOptions, _input, output, _documentProvider, _metadataProvider, _monikerProvider, _templateEngine, tocMap, linkResolver, _contributionProvider, bookmarkValidator, publishModelBuilder, contentValidator, metadataValidator, markdownEngine, searchIndexBuilder, redirectionProvider, jsonSchemaTransformer);
                 var tocBuilder = new TocBuilder(_config, tocLoader, contentValidator, _metadataProvider, metadataValidator, _documentProvider, _monikerProvider, publishModelBuilder, _templateEngine, output);
                 var redirectionBuilder = new RedirectionBuilder(publishModelBuilder, redirectionProvider, _documentProvider);
 

--- a/src/docfx/build/DocsetBuilder.cs
+++ b/src/docfx/build/DocsetBuilder.cs
@@ -129,7 +129,12 @@ namespace Microsoft.Docs.Build
 
                 var tocMap = new TocMap(_config, _errors, _input, _buildScope, dependencyMapBuilder, tocParser, tocLoader, _documentProvider, contentValidator);
                 publishUrlMap = new PublishUrlMap(_config, _errors, _buildScope, redirectionProvider, _documentProvider, _monikerProvider, tocMap);
-                var publishModelBuilder = new PublishModelBuilder(_config, _errors, _monikerProvider, _buildOptions, publishUrlMap, _sourceMap, _documentProvider, linkResolver);
+
+                var filesToBuild = files.Length > 0
+                    ? files.Select(file => FilePath.Content(new PathString(file))).Where(file => _input.Exists(file) && _buildScope.Contains(file.Path)).ToHashSet()
+                    : publishUrlMap.GetAllFiles();
+
+                var publishModelBuilder = new PublishModelBuilder(filesToBuild, _config, _errors, _monikerProvider, _buildOptions, _sourceMap, _documentProvider);
                 var metadataValidator = new MetadataValidator(_config, _microsoftGraphAccessor, _jsonSchemaLoader, _monikerProvider, customRuleProvider);
                 var searchIndexBuilder = new SearchIndexBuilder(_config, _errors, _documentProvider, _metadataProvider);
 
@@ -137,10 +142,6 @@ namespace Microsoft.Docs.Build
                 var pageBuilder = new PageBuilder(_config, _buildOptions, _input, output, _documentProvider, _metadataProvider, _monikerProvider, _templateEngine, tocMap, linkResolver, _contributionProvider, bookmarkValidator, publishModelBuilder, contentValidator, metadataValidator, markdownEngine, searchIndexBuilder, redirectionProvider, jsonSchemaTransformer);
                 var tocBuilder = new TocBuilder(_config, tocLoader, contentValidator, _metadataProvider, metadataValidator, _documentProvider, _monikerProvider, publishModelBuilder, _templateEngine, output);
                 var redirectionBuilder = new RedirectionBuilder(publishModelBuilder, redirectionProvider, _documentProvider);
-
-                var filesToBuild = files.Length > 0
-                    ? files.Select(file => FilePath.Content(new PathString(file))).Where(file => _input.Exists(file) && _buildScope.Contains(file.Path)).ToHashSet()
-                    : publishUrlMap.GetAllFiles();
 
                 using (Progress.Start($"Building {filesToBuild.Count} files"))
                 {

--- a/src/docfx/build/DocsetBuilder.cs
+++ b/src/docfx/build/DocsetBuilder.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Docs.Build
                 contentValidator = new ContentValidator(_config, _fileResolver, _errors, _documentProvider, _monikerProvider, zonePivotProvider, new Lazy<PublishUrlMap>(() => publishUrlMap!));
 
                 var bookmarkValidator = new BookmarkValidator(_errors);
-                var fileLinkMapBuilder = new FileLinkMapBuilder(_documentProvider, _monikerProvider, _contributionProvider);
+                var fileLinkMapBuilder = new FileLinkMapBuilder(_errors, _documentProvider, _monikerProvider, _contributionProvider);
                 var xrefResolver = new XrefResolver(_config, _fileResolver, _buildOptions.Repository, dependencyMapBuilder, fileLinkMapBuilder, _errors, _documentProvider, _metadataProvider, _monikerProvider, _buildScope, new Lazy<JsonSchemaTransformer>(() => jsonSchemaTransformer!));
                 var linkResolver = new LinkResolver(_config, _buildOptions, _buildScope, redirectionProvider, _documentProvider, bookmarkValidator, dependencyMapBuilder, xrefResolver, _templateEngine, fileLinkMapBuilder, _metadataProvider);
                 var markdownEngine = new MarkdownEngine(_config, _input, _fileResolver, linkResolver, xrefResolver, _documentProvider, _metadataProvider, _monikerProvider, _templateEngine, contentValidator, new Lazy<PublishUrlMap>(() => publishUrlMap!));

--- a/src/docfx/build/link/FileLinkMapBuilder.cs
+++ b/src/docfx/build/link/FileLinkMapBuilder.cs
@@ -8,13 +8,16 @@ namespace Microsoft.Docs.Build
 {
     internal class FileLinkMapBuilder
     {
+        private readonly ErrorBuilder _errors;
         private readonly DocumentProvider _documentProvider;
         private readonly MonikerProvider _monikerProvider;
         private readonly ContributionProvider _contributionProvider;
         private readonly ConcurrentHashSet<FileLinkItem> _links = new ConcurrentHashSet<FileLinkItem>();
 
-        public FileLinkMapBuilder(DocumentProvider documentProvider, MonikerProvider monikerProvider, ContributionProvider contributionProvider)
+        public FileLinkMapBuilder(
+            ErrorBuilder errors, DocumentProvider documentProvider, MonikerProvider monikerProvider, ContributionProvider contributionProvider)
         {
+            _errors = errors;
             _documentProvider = documentProvider;
             _monikerProvider = monikerProvider;
             _contributionProvider = contributionProvider;
@@ -29,7 +32,7 @@ namespace Microsoft.Docs.Build
                 return;
             }
 
-            var monikers = _monikerProvider.GetFileLevelMonikers(ErrorBuilder.Null, inclusionRoot);
+            var monikers = _monikerProvider.GetFileLevelMonikers(_errors, inclusionRoot);
             var sourceGitUrl = _contributionProvider.GetGitUrl(referencingFile).originalContentGitUrl;
 
             _links.TryAdd(new FileLinkItem(inclusionRoot, sourceUrl, monikers.MonikerGroup, targetUrl, sourceGitUrl, source is null ? 1 : source.Line));

--- a/src/docfx/build/page/PageBuilder.cs
+++ b/src/docfx/build/page/PageBuilder.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Docs.Build
                 }
             }
 
-            _publishModelBuilder.SetPublishItem(file, metadata, outputPath);
+            _publishModelBuilder.AddOrUpdate(file, metadata, outputPath);
         }
 
         private (object output, JObject metadata) CreatePageOutput(ErrorBuilder errors, FilePath file, JObject sourceModel)

--- a/src/docfx/build/redirection/RedirectionBuilder.cs
+++ b/src/docfx/build/redirection/RedirectionBuilder.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Docs.Build
                 ["canonical_url"] = _documentProvider.GetCanonicalUrl(file),
             };
 
-            _publishModelBuilder.SetPublishItem(file, publishMetadata, outputPath: null);
+            _publishModelBuilder.AddOrUpdate(file, publishMetadata, outputPath: null);
         }
     }
 }

--- a/src/docfx/build/resource/ResourceBuilder.cs
+++ b/src/docfx/build/resource/ResourceBuilder.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Docs.Build
                 _output.Copy(outputPath, file);
             }
 
-            _publishModelBuilder.SetPublishItem(file, metadata: null, outputPath);
+            _publishModelBuilder.AddOrUpdate(file, metadata: null, outputPath);
         }
     }
 }

--- a/src/docfx/build/toc/TocBuilder.cs
+++ b/src/docfx/build/toc/TocBuilder.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Docs.Build
                 }
             }
 
-            _publishModelBuilder.SetPublishItem(file, metadata: null, outputPath);
+            _publishModelBuilder.AddOrUpdate(file, metadata: null, outputPath);
         }
     }
 }

--- a/src/docfx/publish/PublishItem.cs
+++ b/src/docfx/publish/PublishItem.cs
@@ -14,6 +14,9 @@ namespace Microsoft.Docs.Build
 
         public string? Path { get; }
 
+        [JsonIgnore]
+        public FilePath? SourceFile { get; }
+
         /// <summary>
         /// File source relative path to docset root
         /// will be used for PR comments
@@ -38,6 +41,7 @@ namespace Microsoft.Docs.Build
         public PublishItem(
             string url,
             string? path,
+            FilePath sourceFile,
             string? sourcePath,
             string locale,
             MonikerList monikers,
@@ -47,6 +51,7 @@ namespace Microsoft.Docs.Build
         {
             Url = url;
             Path = path;
+            SourceFile = sourceFile;
             SourcePath = sourcePath;
             Locale = locale;
             Monikers = monikers;

--- a/src/docfx/publish/PublishModelBuilder.cs
+++ b/src/docfx/publish/PublishModelBuilder.cs
@@ -50,20 +50,21 @@ namespace Microsoft.Docs.Build
         public (PublishModel, Dictionary<FilePath, PublishItem>) Build()
         {
             var publishItems = new Dictionary<FilePath, PublishItem>();
-            foreach (var sourcePath in _publishUrlMap.GetAllFiles().Concat(_linkResolver.GetAdditionalResources()))
+            foreach (var sourceFile in _publishUrlMap.GetAllFiles().Concat(_linkResolver.GetAdditionalResources()))
             {
-                var buildOutput = _buildOutput.TryGetValue(sourcePath, out var result);
+                var buildOutput = _buildOutput.TryGetValue(sourceFile, out var result);
 
                 var publishItem = new PublishItem(
-                    _documentProvider.GetSiteUrl(sourcePath),
+                    _documentProvider.GetSiteUrl(sourceFile),
                     buildOutput ? result.outputPath : null,
-                    _sourceMap.GetOriginalFilePath(sourcePath)?.Path ?? sourcePath.Path,
+                    sourceFile,
+                    _sourceMap.GetOriginalFilePath(sourceFile)?.Path ?? sourceFile.Path,
                     _locale,
-                    _monikerProvider.GetFileLevelMonikers(_errors, sourcePath),
-                    _monikerProvider.GetConfigMonikerRange(sourcePath),
-                    _errors.FileHasError(sourcePath),
+                    _monikerProvider.GetFileLevelMonikers(_errors, sourceFile),
+                    _monikerProvider.GetConfigMonikerRange(sourceFile),
+                    _errors.FileHasError(sourceFile),
                     buildOutput ? RemoveComplexValue(result.metadata) : null);
-                publishItems.Add(sourcePath, publishItem);
+                publishItems.Add(sourceFile, publishItem);
             }
 
             var items = (

--- a/test/docfx.Test/lib/JsonSchemaTest.cs
+++ b/test/docfx.Test/lib/JsonSchemaTest.cs
@@ -19,13 +19,14 @@ namespace Microsoft.Docs.Build
             var result = new TheoryData<string, string, string>();
             foreach (var file in Directory.GetFiles("data/jschema/draft7", "*.json", SearchOption.AllDirectories))
             {
+                var i = 0;
                 var suite = Path.GetFileNameWithoutExtension(file);
                 foreach (var schema in JArray.Parse(File.ReadAllText(file)))
                 {
                     var schemaText = schema["schema"].ToString(Formatting.None);
                     foreach (var test in schema["tests"])
                     {
-                        var description = $"{schema["description"]}/{test["description"]}";
+                        var description = $"[{++i:d2}]{schema["description"]}/{test["description"]}";
                         result.Add($"{suite}/{description}", schemaText, test.ToString());
                     }
                 }


### PR DESCRIPTION
[AB#338814](https://dev.azure.com/ceapex/Engineering/_workitems/edit/338814/)

- Publish manifest for single file build is single file
- `FileLinkMapBuilder` uses `PublishModel` instead of `PublishUrlMap`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6815)