### PR TITLE
Add warnings and errors for multuple redirection files

### DIFF
--- a/docs/specs/redirection.yml
+++ b/docs/specs/redirection.yml
@@ -880,5 +880,5 @@ repos:
 outputs:
   a/.publish.json:
   .errors.log: |
-    {"message_severity":"error","code":"redirection-path-syntax-error","message":"Redirection path syntax is incorrect. 'source_path' should start without '/' and 'source_path_from_root' should start with '/'.","file":".openpublishing.redirection.json","line":2,"column":67}
-    {"message_severity":"error","code":"redirection-path-syntax-error","message":"Redirection path syntax is incorrect. 'source_path' should start without '/' and 'source_path_from_root' should start with '/'.","file":"a/b/.openpublishing.redirection.json","line":2,"end_column":60}
+    {"message_severity":"warning","code":"redirection-path-syntax-error","message":"Redirection path syntax is incorrect. 'source_path' should start without '/' and 'source_path_from_root' should start with '/'.","file":".openpublishing.redirection.json","line":2,"column":67}
+    {"message_severity":"warning","code":"redirection-path-syntax-error","message":"Redirection path syntax is incorrect. 'source_path' should start without '/' and 'source_path_from_root' should start with '/'.","file":"a/b/.openpublishing.redirection.json","line":2,"end_column":60}

--- a/docs/specs/redirection.yml
+++ b/docs/specs/redirection.yml
@@ -794,3 +794,91 @@ outputs:
         {"url": "/c", "source_path": "c.md", "locale": "en-us", "redirect_url": "/aa"}
       ]
     }
+---
+# File not found for a registered redirection file.
+repos:
+  https://github.com/redirection/multiple-redirection-files-file-not-found:
+  - files:
+      .openpublishing.publish.config.json: |
+        {
+          "docsets_to_publish": [{"build_source_folder":"a"}],
+          "redirection_files": [
+            "a/b/.openpublishing.redirection.json"
+          ],
+        }
+      a/docfx.yml:
+outputs:
+  .errors.log: |
+    {"message_severity":"error","code":"file-not-found","message":"Redirection file 'a/b/.openpublishing.redirection.json' registered in .openpublishing.publish.json is not found in the repo."}
+---
+# source_path and source_path_from_root exist at the same time
+repos:
+  https://github.com/redirection/two-path-at-the-same-time:
+  - files:
+      .openpublishing.publish.config.json: |
+        {
+          "docsets_to_publish": [{"build_source_folder":"a"}],
+          "redirection_files": [
+            "a/b/.openpublishing.redirection.json"
+          ],
+        }
+      a/docfx.yml:
+      a/b/.openpublishing.redirection.json: |
+        {"redirections": [{"source_path": "c.md", "source_path_from_root": "/a/c.md", "redirect_url": "/aa"}]}
+outputs:
+  a/.publish.json:
+  .errors.log: |
+    {"message_severity":"error","code":"source-path-conflict","message":"A redirection item cannot contain 'source_path' and 'source_path_from_root' at the same time.","file":"a/b/.openpublishing.redirection.json","line":1,"column":99}
+---
+# redirection conflicts for multiple redirection files
+repos:
+  https://github.com/redirection/multiple-redirection-files-redirection-conflict:
+  - files:
+      .openpublishing.publish.config.json: |
+        {
+          "docsets_to_publish": [{"build_source_folder":"a"}],
+          "redirection_files": [
+            ".openpublishing.redirection.json",
+            "a/b/.openpublishing.redirection.json"
+          ],
+        }
+      .openpublishing.redirection.json: |
+        {
+          "redirections": [{"source_path": "a/a.md", "redirect_url": "/aa"}]
+        }
+      a/docfx.yml:
+      a/b/.openpublishing.redirection.json: |
+        {"redirections": 
+          [{"source_path_from_root": "/a/a.md", "redirect_url": "/aa"}]
+        }
+outputs:
+  a/.publish.json:
+  .errors.log: |
+    {"message_severity":"error","code":"redirection-conflict","message":"The 'a.md' appears twice or more in the redirection mappings.","file":"a/b/.openpublishing.redirection.json","line":2,"column":61}
+---
+# redirection syntax check
+repos:
+  https://github.com/redirection/multiple-redirection-files-redirection-syntax-check:
+  - files:
+      .openpublishing.publish.config.json: |
+        {
+          "docsets_to_publish": [{"build_source_folder":"a"}],
+          "redirection_files": [
+            ".openpublishing.redirection.json",
+            "a/b/.openpublishing.redirection.json"
+          ],
+        }
+      .openpublishing.redirection.json: |
+        {
+          "redirections": [{"source_path": "/a/a.md", "redirect_url": "/aa"}]
+        }
+      a/docfx.yml:
+      a/b/.openpublishing.redirection.json: |
+        {"redirections": 
+          [{"source_path_from_root": "a/a.md", "redirect_url": "/aa"}]
+        }
+outputs:
+  a/.publish.json:
+  .errors.log: |
+    {"message_severity":"error","code":"redirection-path-syntax-error","message":"Redirection path syntax is incorrect. 'source_path' should start without '/' and 'source_path_from_root' should start with '/'.","file":".openpublishing.redirection.json","line":2,"column":67}
+    {"message_severity":"error","code":"redirection-path-syntax-error","message":"Redirection path syntax is incorrect. 'source_path' should start without '/' and 'source_path_from_root' should start with '/'.","file":"a/b/.openpublishing.redirection.json","line":2,"end_column":60}

--- a/docs/specs/redirection.yml
+++ b/docs/specs/redirection.yml
@@ -809,7 +809,7 @@ repos:
       a/docfx.yml:
 outputs:
   .errors.log: |
-    {"message_severity":"error","code":"file-not-found","message":"Redirection file 'a/b/.openpublishing.redirection.json' registered in .openpublishing.publish.json is not found in the repo."}
+    {"message_severity":"error","code":"redirection-file-not-found","message":"Redirection file 'a/b/.openpublishing.redirection.json' registered in .openpublishing.publish.json is not found in the repo."}
 ---
 # source_path and source_path_from_root exist at the same time
 repos:

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -343,8 +343,8 @@ namespace Microsoft.Docs.Build
             /// A redirection file registered in .openpublishing.publish.json is not found in the repo.
             /// </summary>
             /// Behavior: ✔️ Message: ✔️
-            public static Error FileNotFound(string path)
-                => new Error(ErrorLevel.Error, "file-not-found", $"Redirection file '{path}' registered in .openpublishing.publish.json is not found in the repo.");
+            public static Error RedirectionFileNotFound(string path)
+                => new Error(ErrorLevel.Error, "redirection-file-not-found", $"Redirection file '{path}' registered in .openpublishing.publish.json is not found in the repo.");
 
             /// <summary>
             /// A redirection item cannot contain ‘source_path’ and ‘source_path_from_root’ at the same time.

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -354,10 +354,11 @@ namespace Microsoft.Docs.Build
                 => new Error(ErrorLevel.Error, "source-path-conflict", $"A redirection item cannot contain 'source_path' and 'source_path_from_root' at the same time.", source);
 
             /// <summary>
+            /// Check redirection source path syntax.
             /// </summary>
             /// Behavior: ✔️ Message: ✔️
             public static Error RedirectionPathSyntaxError(SourceInfo<string> source)
-                => new Error(ErrorLevel.Error, "redirection-path-syntax-error", $"Redirection path syntax is incorrect. 'source_path' should start without '/' and 'source_path_from_root' should start with '/'.", source);
+                => new Error(ErrorLevel.Warning, "redirection-path-syntax-error", $"Redirection path syntax is incorrect. 'source_path' should start without '/' and 'source_path_from_root' should start with '/'.", source);
         }
 
         public static class Toc

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -338,6 +338,26 @@ namespace Microsoft.Docs.Build
             /// Behavior: ✔️ Message: ✔️
             public static Error RedirectedFileNotRemoved(FilePath path)
                 => new Error(ErrorLevel.Warning, "redirected-file-not-removed", $"Redirected file '{path}' is still in the repo. After adding a file to the redirection JSON file, you must delete the original file from the repo.");
+
+            /// <summary>
+            /// A redirection file registered in .openpublishing.publish.json is not found in the repo.
+            /// </summary>
+            /// Behavior: ✔️ Message: ✔️
+            public static Error FileNotFound(string path)
+                => new Error(ErrorLevel.Error, "file-not-found", $"Redirection file '{path}' registered in .openpublishing.publish.json is not found in the repo.");
+
+            /// <summary>
+            /// A redirection item cannot contain ‘source_path’ and ‘source_path_from_root’ at the same time.
+            /// </summary>
+            /// /// Behavior: ✔️ Message: ✔️
+            public static Error SourcePathConflict(SourceInfo<string> source)
+                => new Error(ErrorLevel.Error, "source-path-conflict", $"A redirection item cannot contain 'source_path' and 'source_path_from_root' at the same time.", source);
+
+            /// <summary>
+            /// </summary>
+            /// Behavior: ✔️ Message: ✔️
+            public static Error RedirectionPathSyntaxError(SourceInfo<string> source)
+                => new Error(ErrorLevel.Error, "redirection-path-syntax-error", $"Redirection path syntax is incorrect. 'source_path' should start without '/' and 'source_path_from_root' should start with '/'.", source);
         }
 
         public static class Toc

--- a/src/docfx/build/redirection/RedirectionProvider.cs
+++ b/src/docfx/build/redirection/RedirectionProvider.cs
@@ -283,7 +283,7 @@ namespace Microsoft.Docs.Build
 
                     if (!File.Exists(fullPath))
                     {
-                        _errors.Add(Errors.Redirection.FileNotFound(item));
+                        _errors.Add(Errors.Redirection.RedirectionFileNotFound(item));
                     }
                     else
                     {

--- a/src/docfx/build/redirection/RedirectionProvider.cs
+++ b/src/docfx/build/redirection/RedirectionProvider.cs
@@ -279,15 +279,15 @@ namespace Microsoft.Docs.Build
                         continue;
                     }
 
-                    var fullpath = Path.Combine(_buildOptions.Repository.Path, item);
+                    var fullPath = Path.Combine(_buildOptions.Repository.Path, item);
 
-                    if (!File.Exists(fullpath))
+                    if (!File.Exists(fullPath))
                     {
                         _errors.Add(Errors.Redirection.FileNotFound(item));
                     }
                     else
                     {
-                        yield return fullpath;
+                        yield return fullPath;
                     }
                 }
             }

--- a/src/docfx/build/redirection/RedirectionProvider.cs
+++ b/src/docfx/build/redirection/RedirectionProvider.cs
@@ -171,10 +171,7 @@ namespace Microsoft.Docs.Build
 
             foreach (var fullPath in ProbeSubRedirectionFiles())
             {
-                if (File.Exists(fullPath))
-                {
-                    GenerateRedirectionRules(fullPath, results);
-                }
+                GenerateRedirectionRules(fullPath, results);
             }
 
             return results.OrderBy(item => item.RedirectUrl.Source).ToArray();
@@ -214,7 +211,7 @@ namespace Microsoft.Docs.Build
                 }
                 else if (!item.SourcePath.IsDefault && !item.SourcePathFromRoot.IsDefault)
                 {
-                    // TODO: "source_path" and "source_path_from_root" exist at the same time.
+                    _errors.Add(Errors.Redirection.SourcePathConflict(item.RedirectUrl));
                     continue;
                 }
 
@@ -222,12 +219,20 @@ namespace Microsoft.Docs.Build
 
                 if (!item.SourcePath.IsDefault)
                 {
-                    // TODO: syntax check
+                    if (item.SourcePath.Value.StartsWith("/"))
+                    {
+                        _errors.Add(Errors.Redirection.RedirectionPathSyntaxError(item.RedirectUrl));
+                        continue;
+                    }
                     sourcePath = Path.GetRelativePath(_buildOptions.DocsetPath, Path.Combine(basedir, item.SourcePath));
                 }
                 else
                 {
-                    // TODO: syntax check
+                    if (!item.SourcePathFromRoot.Value.StartsWith("/"))
+                    {
+                        _errors.Add(Errors.Redirection.RedirectionPathSyntaxError(item.RedirectUrl));
+                        continue;
+                    }
                     var sourcePathRelativeToRepoRoot = item.SourcePathFromRoot.Value.Substring(1);
                     if (_buildOptions.Repository != null)
                     {
@@ -273,7 +278,17 @@ namespace Microsoft.Docs.Build
                     {
                         continue;
                     }
-                    yield return Path.Combine(_buildOptions.Repository.Path, item);
+
+                    var fullpath = Path.Combine(_buildOptions.Repository.Path, item);
+
+                    if (!File.Exists(fullpath))
+                    {
+                        _errors.Add(Errors.Redirection.FileNotFound(item));
+                    }
+                    else
+                    {
+                        yield return fullpath;
+                    }
                 }
             }
         }


### PR DESCRIPTION
[AB#341331](https://dev.azure.com/ceapex/Engineering/_workitems/edit/341331)

|Error code|Level|Description|
|---|---|---|
|redirection-file-not-found|Error|A registered file is not found in the repo.|
|source-path-conflict|Error| source_path and source_path_from_root exist at the same time.|
|redirection-path-syntax-error|Warning|Check whether starting with "/" or not.|
|redirection-conflict|Error|Same as before except including sub-redirection files check.|

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6837)