### PR TITLE
Output absolute links for TSType mime

### DIFF
--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -1992,13 +1992,13 @@ inputs:
     ---
   docs/a/a/a.json: |
     {
-      "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TestData.json",
+      "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TSType.json",
       "uid": "a",
       "summary": "@c Hello docfx!"
     }
   docs/b/b.md: |
     Link to @a?displayProperty=summary
-  _themes/ContentTemplate/schemas/TestData.schema.json: |
+  _themes/ContentTemplate/schemas/TSType.schema.json: |
     {
       "properties": {
         "summary": { "contentType": "Markdown" },
@@ -2010,11 +2010,11 @@ outputs:
   docs/a/a/a.json:
   docs/c/c.json:
   docs/b/b.json: |
-    {"conceptual": "<p>Link to <a href=\"/en-us/docs/a/a/a\" data-linktype=\"absolute-path\">&lt;a href=&quot;/docs/c/c&quot;&gt;Title from yaml header c&lt;/a&gt; Hello docfx!</a></p>\n"}
+    {"conceptual": "<p>Link to <a href=\"../a/a/a\" data-linktype=\"relative-path\">&lt;p&gt;&lt;a href=&quot;/docs/c/c&quot;&gt;Title from yaml header c&lt;/a&gt; Hello docfx!&lt;/p&gt;\n</a></p>\n"}
   .xrefmap.json: | 
     {
       "references":[
-        {"uid":"a","summary":"<a href=\"/docs/c/c\">Title from yaml header c</a> Hello docfx!"},
+        {"uid":"a","summary":"<p><a href=\"/docs/c/c\">Title from yaml header c</a> Hello docfx!</p>"},
         {"uid": "c", "href": "https://docs.com/docs/c/c?branch=xref-chain", "name": "Title from yaml header c"}
       ]
     }

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -1615,7 +1615,6 @@ inputs:
     ### YamlMime:TestPage
       xref: a
   docs/v2/a.yml: |
-  docs/v2/a.yml: |
     ### YamlMime:TestData
     uid: a
     name: name 2.0
@@ -1982,3 +1981,40 @@ outputs:
   .errors.log: |
     {"message_severity":"warning","code":"duplicate-uid","message":"UID 'a' is duplicated in 'test.yml(2,6)', 'test.yml(4,8)'.","file":"test.yml","line":4,"column":8}
     {"message_severity":"warning","code":"duplicate-uid","message":"UID 'a' is duplicated in 'test.yml(2,6)', 'test.yml(4,8)'.","file":"test.yml","line":2,"column":6}
+---
+# Xref property field references to uid
+inputs:
+  docfx.yml: |
+  docs/c/c.md: |
+    ---
+    title: Title from yaml header c
+    uid: c
+    ---
+  docs/a/a/a.json: |
+    {
+      "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TestData.json",
+      "uid": "a",
+      "summary": "@c Hello docfx!"
+    }
+  docs/b/b.md: |
+    Link to @a?displayProperty=summary
+  _themes/ContentTemplate/schemas/TestData.schema.json: |
+    {
+      "properties": {
+        "summary": { "contentType": "Markdown" },
+        "uid": { "contentType": "uid" }
+      },
+      "xrefProperties": ["summary"]
+    }
+outputs:
+  docs/a/a/a.json:
+  docs/c/c.json:
+  docs/b/b.json: |
+    {"conceptual": "<p>Link to <a href=\"/en-us/docs/a/a/a\" data-linktype=\"absolute-path\">&lt;a href=&quot;/docs/c/c&quot;&gt;Title from yaml header c&lt;/a&gt; Hello docfx!</a></p>\n"}
+  .xrefmap.json: | 
+    {
+      "references":[
+        {"uid":"a","summary":"<a href=\"/docs/c/c\">Title from yaml header c</a> Hello docfx!"},
+        {"uid": "c", "href": "https://docs.com/docs/c/c?branch=xref-chain", "name": "Title from yaml header c"}
+      ]
+    }

--- a/src/docfx/build/DocsetBuilder.cs
+++ b/src/docfx/build/DocsetBuilder.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Docs.Build
                 var markdownEngine = new MarkdownEngine(_config, _input, _fileResolver, linkResolver, xrefResolver, _documentProvider, _metadataProvider, _monikerProvider, _templateEngine, contentValidator, publishUrlMap);
                 jsonSchemaTransformer = new JsonSchemaTransformer(_documentProvider, markdownEngine, linkResolver, xrefResolver, _errors, _monikerProvider, _templateEngine, _input);
 
-                var tocParser = new TocParser(_input, markdownEngine, _documentProvider);
+                var tocParser = new TocParser(_input, markdownEngine);
                 var tocLoader = new TocLoader(_buildOptions.DocsetPath, _input, linkResolver, xrefResolver, tocParser, _monikerProvider, dependencyMapBuilder, contentValidator, _config, _errors, _buildScope);
 
                 var tocMap = new TocMap(_config, _errors, _input, _buildScope, dependencyMapBuilder, tocParser, tocLoader, _documentProvider, contentValidator, publishUrlMap);

--- a/src/docfx/build/link/LinkResolver.cs
+++ b/src/docfx/build/link/LinkResolver.cs
@@ -79,7 +79,8 @@ namespace Microsoft.Docs.Build
                 var (xrefError, resolvedHref, _, declaringFile) = _xrefResolver.ResolveXrefByHref(
                     new SourceInfo<string>(href.Value.Substring("xref:".Length), href),
                     referencingFile,
-                    inclusionRoot);
+                    inclusionRoot,
+                    absoluteUrl);
 
                 return (xrefError, resolvedHref ?? href, declaringFile);
             }

--- a/src/docfx/build/toc/TocParser.cs
+++ b/src/docfx/build/toc/TocParser.cs
@@ -17,13 +17,11 @@ namespace Microsoft.Docs.Build
     {
         private readonly Input _input;
         private readonly MarkdownEngine _markdownEngine;
-        private readonly DocumentProvider _documentProvider;
 
-        public TocParser(Input input, MarkdownEngine markdownEngine, DocumentProvider documentProvider)
+        public TocParser(Input input, MarkdownEngine markdownEngine)
         {
             _input = input;
             _markdownEngine = markdownEngine;
-            _documentProvider = documentProvider;
         }
 
         public TocNode Parse(FilePath file, ErrorBuilder errors)

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Docs.Build
         }
 
         public (Error? error, string? href, string display, FilePath? declaringFile) ResolveXrefByHref(
-            SourceInfo<string> href, FilePath referencingFile, FilePath inclusionRoot)
+            SourceInfo<string> href, FilePath referencingFile, FilePath inclusionRoot, bool absoluteUrl)
         {
             var (uid, query, fragment) = UrlUtility.SplitUrl(href);
 
@@ -88,7 +88,7 @@ namespace Microsoft.Docs.Build
             queries.Remove("displayProperty");
 
             // need to url decode uid from input content
-            var (xrefError, xrefSpec, resolvedHref) = ResolveXrefSpec(new SourceInfo<string>(uid, href.Source), referencingFile, inclusionRoot);
+            var (xrefError, xrefSpec, resolvedHref) = ResolveXrefSpec(new SourceInfo<string>(uid, href.Source), referencingFile, inclusionRoot, absoluteUrl);
             if (xrefError != null || xrefSpec is null || string.IsNullOrEmpty(resolvedHref))
             {
                 return (xrefError, null, alt ?? "", null);
@@ -114,7 +114,7 @@ namespace Microsoft.Docs.Build
         }
 
         public (Error? error, string? href, string display, FilePath? declaringFile) ResolveXrefByUid(
-            SourceInfo<string> uid, FilePath referencingFile, FilePath inclusionRoot, MonikerList? monikers = null)
+            SourceInfo<string> uid, FilePath referencingFile, FilePath inclusionRoot, MonikerList? monikers = null, bool absoluteUrl = false)
         {
             if (string.IsNullOrEmpty(uid))
             {
@@ -122,7 +122,7 @@ namespace Microsoft.Docs.Build
             }
 
             // need to url decode uid from input content
-            var (error, xrefSpec, href) = ResolveXrefSpec(uid, referencingFile, inclusionRoot, monikers);
+            var (error, xrefSpec, href) = ResolveXrefSpec(uid, referencingFile, inclusionRoot, absoluteUrl, monikers);
             if (error != null || xrefSpec == null || href == null)
             {
                 return (error, null, "", null);
@@ -132,9 +132,9 @@ namespace Microsoft.Docs.Build
         }
 
         public (Error?, IXrefSpec?, string? href) ResolveXrefSpec(
-            SourceInfo<string> uid, FilePath referencingFile, FilePath inclusionRoot, MonikerList? monikers = null)
+            SourceInfo<string> uid, FilePath referencingFile, FilePath inclusionRoot, bool absoluteUrl, MonikerList? monikers = null)
         {
-            var (error, xrefSpec, href) = Resolve(uid, referencingFile, inclusionRoot, monikers);
+            var (error, xrefSpec, href) = Resolve(uid, referencingFile, inclusionRoot, monikers, absoluteUrl);
             if (xrefSpec == null)
             {
                 return (error, null, null);
@@ -268,9 +268,9 @@ namespace Microsoft.Docs.Build
         }
 
         private (Error?, IXrefSpec?, string? href) Resolve(
-            SourceInfo<string> uid, FilePath referencingFile, FilePath inclusionRoot, MonikerList? monikers = null)
+            SourceInfo<string> uid, FilePath referencingFile, FilePath inclusionRoot, MonikerList? monikers, bool absoluteUrl)
         {
-            var (xrefSpec, href) = ResolveInternalXrefSpec(uid, referencingFile, inclusionRoot, monikers);
+            var (xrefSpec, href) = ResolveInternalXrefSpec(uid, referencingFile, inclusionRoot, monikers, absoluteUrl);
             if (xrefSpec is null)
             {
                 (xrefSpec, href) = ResolveExternalXrefSpec(uid);
@@ -307,7 +307,7 @@ namespace Microsoft.Docs.Build
         }
 
         private (IXrefSpec?, string? href) ResolveInternalXrefSpec(
-            string uid, FilePath referencingFile, FilePath inclusionRoot, MonikerList? monikers = null)
+            string uid, FilePath referencingFile, FilePath inclusionRoot, MonikerList? monikers, bool absoluteUrl)
         {
             if (EnsureInternalXrefMap().TryGetValue(uid, out var specs))
             {
@@ -324,7 +324,7 @@ namespace Microsoft.Docs.Build
                 var dependencyType = GetDependencyType(referencingFile, spec);
                 _dependencyMapBuilder.AddDependencyItem(referencingFile, spec.DeclaringFile, dependencyType);
 
-                var href = UrlUtility.GetRelativeUrl(_documentProvider.GetSiteUrl(inclusionRoot), spec.Href);
+                var href = absoluteUrl ? UrlUtility.GetRelativeUrl(_documentProvider.GetSiteUrl(inclusionRoot), spec.Href) : spec.Href;
                 return (spec, href);
             }
             return default;

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -324,7 +324,7 @@ namespace Microsoft.Docs.Build
                 var dependencyType = GetDependencyType(referencingFile, spec);
                 _dependencyMapBuilder.AddDependencyItem(referencingFile, spec.DeclaringFile, dependencyType);
 
-                var href = absoluteUrl ? UrlUtility.GetRelativeUrl(_documentProvider.GetSiteUrl(inclusionRoot), spec.Href) : spec.Href;
+                var href = absoluteUrl ? spec.Href : UrlUtility.GetRelativeUrl(_documentProvider.GetSiteUrl(inclusionRoot), spec.Href);
                 return (spec, href);
             }
             return default;

--- a/src/docfx/lib/markdown/MarkdownPipelineType.cs
+++ b/src/docfx/lib/markdown/MarkdownPipelineType.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Docs.Build
         Markdown,
         MarkdownWithAbsoluteUrl,
         InlineMarkdown,
-        InlineMarkdownWithAbsoluteUrl,
         TocMarkdown,
     }
 }

--- a/src/docfx/lib/markdown/MarkdownPipelineType.cs
+++ b/src/docfx/lib/markdown/MarkdownPipelineType.cs
@@ -6,7 +6,9 @@ namespace Microsoft.Docs.Build
     public enum MarkdownPipelineType
     {
         Markdown,
+        MarkdownWithAbsoluteUrl,
         InlineMarkdown,
+        InlineMarkdownWithAbsoluteUrl,
         TocMarkdown,
     }
 }


### PR DESCRIPTION
[AB#340821](https://dev.azure.com/ceapex/Engineering/_workitems/edit/340821)
This PR is a temporary fix, narrow down the scope to output absolute link for `markdown` content type within `TSType` mime.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6838)