### PR TITLE
Add back the missed function

### DIFF
--- a/src/docfx/restore/Package.cs
+++ b/src/docfx/restore/Package.cs
@@ -34,6 +34,16 @@ namespace Microsoft.Docs.Build
             return new StreamReader(ReadStream(path));
         }
 
+        public PathString? TryGetFullFilePath(PathString path)
+        {
+            var fullPath = GetFullFilePath(path);
+            if (Exists(fullPath))
+            {
+                return fullPath;
+            }
+            return null;
+        }
+
         // TODO: Retire this method after abstracting git read operations in Package.
         public virtual PathString? TryGetGitFilePath(PathString path) => null;
 


### PR DESCRIPTION
This function has been removed from https://github.com/dotnet/docfx/pull/6846.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6850)