### PR TITLE
Watcher watch created values

### DIFF
--- a/src/docfx/lib/watch/Watcher.cs
+++ b/src/docfx/lib/watch/Watcher.cs
@@ -77,5 +77,14 @@ namespace Microsoft.Docs.Build
                 }
             }
         }
+
+        internal static void AttachToParent(IFunction child)
+        {
+            var stack = t_callstack.Value;
+            if (stack != null && !stack.IsEmpty)
+            {
+                stack.Peek().AddChild(child);
+            }
+        }
     }
 }

--- a/src/docfx/lib/watch/Watch{T}.cs
+++ b/src/docfx/lib/watch/Watch{T}.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Docs.Build
                 var function = _function;
                 if (function != null && !function.HasChanged())
                 {
+                    Watcher.AttachToParent(function);
                     return _value!;
                 }
 

--- a/test/docfx.Test/lib/WatcherTest.cs
+++ b/test/docfx.Test/lib/WatcherTest.cs
@@ -182,6 +182,24 @@ namespace Microsoft.Docs.Build
         }
 
         [Fact]
+        public static void Watch_Created_Value()
+        {
+            var counter = 0;
+            var childCounter = 0;
+            var parentCounter = 0;
+            var child = new Watch<int>(() => ++childCounter + Watcher.Watch(() => 0, () => ++counter));
+            var parent = new Watch<int>(() => ++parentCounter + child.Value);
+
+            Assert.Equal(1, child.Value);
+            Assert.True(child.IsValueCreated);
+            Assert.Equal(2, parent.Value);
+
+            Watcher.StartActivity();
+
+            Assert.Equal(4, parent.Value);
+        }
+
+        [Fact]
         public static void Watch_Value_Rebuild_Dependency_Graph_On_Dependency_Change()
         {
             var exists = false;


### PR DESCRIPTION
Fix a case where a `Watcher<T>` failed to respond to changes when the value is already evaluated.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6856)