### PR TITLE
Watch<T> detects changes based on value

### DIFF
--- a/src/docfx/build/Builder.cs
+++ b/src/docfx/build/Builder.cs
@@ -45,15 +45,21 @@ namespace Microsoft.Docs.Build
 
         public void Build(params string[] files)
         {
-            try
+            for (var i = 0; i < 20; i++)
             {
-                Watcher.StartActivity();
+                using (Progress.Start("single file build"))
+                {
+                    try
+                    {
+                        Watcher.StartActivity();
 
-                Parallel.ForEach(_docsets.Value, docset => docset.Build(Array.ConvertAll(files, path => GetPathToDocset(docset, path))));
-            }
-            catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
-            {
-                _errors.AddRange(dex);
+                        Parallel.ForEach(_docsets.Value, docset => docset.Build(Array.ConvertAll(files, path => GetPathToDocset(docset, path))));
+                    }
+                    catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
+                    {
+                        _errors.AddRange(dex);
+                    }
+                }
             }
         }
 

--- a/src/docfx/lib/watch/IFunction.cs
+++ b/src/docfx/lib/watch/IFunction.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Docs.Build
 {
     internal interface IFunction
     {
-        bool HasChanged();
+        bool HasChanged(int activityId);
 
         void AddChild(IFunction child);
     }

--- a/src/docfx/lib/watch/LeafFunction{T}.cs
+++ b/src/docfx/lib/watch/LeafFunction{T}.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Docs.Build
 
         public LeafFunction(Func<T> changeTokenFactory) => _changeTokenFactory = changeTokenFactory;
 
-        public bool HasChanged() => !Equals(ChangeToken, _changeTokenFactory());
+        public bool HasChanged(int activityId) => !Equals(ChangeToken, _changeTokenFactory());
 
         public void AddChild(IFunction childFunction) { }
     }

--- a/src/docfx/lib/watch/Watcher.cs
+++ b/src/docfx/lib/watch/Watcher.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Docs.Build
             finally
             {
                 EndFunctionScope();
+                AttachToParent(function);
             }
         }
 
@@ -51,6 +52,7 @@ namespace Microsoft.Docs.Build
             finally
             {
                 EndFunctionScope();
+                AttachToParent(function);
             }
         }
 
@@ -65,16 +67,12 @@ namespace Microsoft.Docs.Build
             t_callstack.Value = stack.Push(function);
         }
 
-        internal static void EndFunctionScope(bool attachToParent = true)
+        internal static void EndFunctionScope()
         {
             var stack = t_callstack.Value;
             if (stack != null && !stack.IsEmpty)
             {
-                t_callstack.Value = stack = stack.Pop(out var child);
-                if (attachToParent && !stack.IsEmpty)
-                {
-                    stack.Peek().AddChild(child);
-                }
+                t_callstack.Value = stack.Pop();
             }
         }
 

--- a/test/docfx.Test/lib/WatcherTest.cs
+++ b/test/docfx.Test/lib/WatcherTest.cs
@@ -306,6 +306,45 @@ namespace Microsoft.Docs.Build
         }
 
         [Fact]
+        public static void Watch_Value_Dedup_Dependencies()
+        {
+            var counter = 0;
+            var childWatch = new Watch<int>(() => Watcher.Watch(() => ++counter));
+            var watch = new Watch<int>(() => childWatch.Value + childWatch.Value);
+
+            Assert.Equal(2, watch.Value);
+            Assert.Equal(2, watch.Value);
+
+            Watcher.StartActivity();
+
+            Assert.Equal(6, watch.Value);
+            Assert.Equal(6, watch.Value);
+        }
+
+        [Fact]
+        public static void Watch_Stop_Change_Propagation_On_Value_Not_Change()
+        {
+            var counter = 0;
+            var watchCounter = 0;
+            var childWatch = new Watch<int>(() => Watcher.Watch(() => 0, () => ++counter));
+            var watch = new Watch<int>(() =>
+            {
+                watchCounter++;
+                return childWatch.Value;
+            });
+
+            Assert.Equal(0, watch.Value);
+            Assert.Equal(0, watch.Value);
+            Assert.Equal(1, watchCounter);
+
+            Watcher.StartActivity();
+
+            Assert.Equal(0, watch.Value);
+            Assert.Equal(0, watch.Value);
+            Assert.Equal(1, watchCounter);
+        }
+
+        [Fact]
         public static void Watch_Value_Watch_Dependency_In_Parallel()
         {
             var counter = 0;

--- a/test/docfx.Test/lib/WatcherTest.cs
+++ b/test/docfx.Test/lib/WatcherTest.cs
@@ -274,6 +274,38 @@ namespace Microsoft.Docs.Build
         }
 
         [Fact]
+        public static void Watch_Value_Do_Not_Reevaluate_On_Stale_Dependency_Change()
+        {
+            var useA = true;
+            var valueA = "a";
+            var valueB = "b";
+            var counter = 0;
+
+            var childWatch = new Watch<string>(() => Watcher.Watch(() => useA) ? Watcher.Watch(() => valueA) : Watcher.Watch(() => valueB));
+            var watch = new Watch<string>(() =>
+            {
+                counter++;
+                return childWatch.Value;
+            });
+
+            Assert.Equal("a", watch.Value);
+            Assert.Equal("a", watch.Value);
+            Assert.Equal(1, counter);
+
+            Watcher.StartActivity();
+            useA = false;
+            Assert.Equal("b", watch.Value);
+            Assert.Equal("b", watch.Value);
+            Assert.Equal(2, counter);
+
+            Watcher.StartActivity();
+            valueA = "newValueA";
+            Assert.Equal("b", watch.Value);
+            Assert.Equal("b", watch.Value);
+            Assert.Equal(2, counter);
+        }
+
+        [Fact]
         public static void Watch_Value_Watch_Dependency_In_Parallel()
         {
             var counter = 0;

--- a/test/docfx.Test/lib/WatcherTest.cs
+++ b/test/docfx.Test/lib/WatcherTest.cs
@@ -147,6 +147,47 @@ namespace Microsoft.Docs.Build
         }
 
         [Fact]
+        public static void Watch_Value_With_Two_Parents()
+        {
+            var counter = 0;
+            var childCounter = 0;
+            var parentCounter1 = 0;
+            var parentCounter2 = 0;
+
+            var childWatch = new Watch<int>(() =>
+            {
+                ++childCounter;
+                return Watcher.Watch(() => ++counter);
+            });
+
+            var parent1 = new Watch<int>(() =>
+            {
+                ++parentCounter1;
+                return childWatch.Value;
+            });
+
+            var parent2 = new Watch<int>(() =>
+            {
+                ++parentCounter2;
+                return childWatch.Value;
+            });
+
+            Assert.Equal(1, parent1.Value);
+            Assert.Equal(1, parentCounter1);
+            Assert.Equal(1, parent2.Value);
+            Assert.Equal(1, parentCounter2);
+            Assert.Equal(1, childCounter);
+
+            Watcher.StartActivity();
+
+            Assert.Equal(3, parent1.Value);
+            Assert.Equal(2, parentCounter1);
+            Assert.Equal(3, parent2.Value);
+            Assert.Equal(2, parentCounter2);
+            Assert.Equal(2, childCounter);
+        }
+
+        [Fact]
         public static void Watch_Value_Reevaluate_On_Any_Dependency_Change()
         {
             var counter = 0;


### PR DESCRIPTION
[AB#338815](https://dev.azure.com/ceapex/Engineering/_workitems/edit/338815/)

This PR further optimizes `Watch<T>` to also compare value changes before reporting parent for a change. The change currently does not work lots of `T` are not compared using value semantics, we'll need [records](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-9#record-types) to detect changes based on value.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6861)