### PR TITLE
Get canonical version for document without versioning does not touch urlmap

### DIFF
--- a/docs/specs/single-file.yml
+++ b/docs/specs/single-file.yml
@@ -65,3 +65,29 @@ inputs:
   TOC.md: |
     # [circular reference](TOC.md)
 outputs:
+---
+# Get canonical version for document without versioning does not touch url map
+dryRunOnly: true
+buildFiles:
+- a.md
+inputs:
+  docfx.yml: |
+    markdownValidationRules: rules.json
+  rules.json: |
+    {
+      "title": {
+        "rules": [
+          {
+            "type": "TitleUnique",
+            "code": "duplicate-titles",
+            "severity": "SUGGESTION",
+            "canonicalVersionOnly" : true,
+            "exclusions": []
+          }
+        ]
+      }
+    }
+  a.md: 'a'
+  b.png.md:
+  b.png:
+outputs:

--- a/src/docfx/publish/PublishUrlMap.cs
+++ b/src/docfx/publish/PublishUrlMap.cs
@@ -39,6 +39,14 @@ namespace Microsoft.Docs.Build
 
         public string? GetCanonicalVersion(FilePath file)
         {
+            // If the file does not have versioning configured, assume it does not have canonical version,
+            // this avoids the expensive creation of url map.
+            var monikers = _monikerProvider.GetFileLevelMonikers(ErrorBuilder.Null, file);
+            if (!monikers.HasMonikers)
+            {
+                return default;
+            }
+
             return _canonicalVersionCache.GetOrAdd(file, key => Watcher.Create(() => GetCanonicalVersionCore(key))).Value;
         }
 


### PR DESCRIPTION
[AB#338815](https://dev.azure.com/ceapex/Engineering/_workitems/edit/338815/)

This change optimizes single file build scenario to avoid building the url map during `IsCanonicalVersion` check on files without versioning configured.

This has a significant speed boost to real-time single file validation, the average build time of a single file dropped from 800ms to 60ms 🚀🚀🚀



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6875)