### PR TITLE
Don't get full path when --template is an URL

### DIFF
--- a/azure-pipelines-v3.yml
+++ b/azure-pipelines-v3.yml
@@ -209,6 +209,8 @@ jobs:
         params: https://github.com/MicrosoftDocs/test --timeout 15 --no-dry-sync
       dryrun.azure-docs-pr:
         params: https://github.com/MicrosoftDocs/azure-docs-pr --timeout 50 --dry-run --regression-rules
+      dryrun.bot-docs-pr:
+        params: https://github.com/MicrosoftDocs/bot-docs-pr --timeout 15 --no-dry-sync --dry-run --public-template
       learn-pr:
         params: https://github.com/MicrosoftDocs/learn-pr --timeout 100 --no-dry-sync
       PowerShell-Docs:

--- a/src/docfx/cli/CommandLineOptions.cs
+++ b/src/docfx/cli/CommandLineOptions.cs
@@ -48,7 +48,11 @@ namespace Microsoft.Docs.Build
 
             if (Template != null)
             {
-                config["template"] = Path.GetFullPath(Template);
+                config["template"] = new PackagePath(Template).Type switch
+                {
+                    PackageType.Folder => Path.GetFullPath(Template),
+                    _ => Template,
+                };
             }
 
             if (TemplateBasePath != null)

--- a/test/docfx.RegressionTest/Options.cs
+++ b/test/docfx.RegressionTest/Options.cs
@@ -25,6 +25,9 @@ namespace Microsoft.Docs.Build
         [Option("dry-run")]
         public bool DryRun { get; set; }
 
+        [Option("public-template")]
+        public bool PublicTemplate { get; set; }
+
         [Option("no-dry-sync")]
         public bool NoDrySync { get; set; }
 

--- a/test/docfx.RegressionTest/RegressionTest.cs
+++ b/test/docfx.RegressionTest/RegressionTest.cs
@@ -203,19 +203,20 @@ namespace Microsoft.Docs.Build
         private static TimeSpan Build(string repositoryPath, string outputPath, Options opts, string docfxConfig)
         {
             var dryRunOption = opts.DryRun ? "--dry-run" : "";
+            var templateOption = opts.PublicTemplate ? "--template https://static.docs.com/ui/latest" : "";
             var noDrySyncOption = opts.NoDrySync ? "--no-dry-sync" : "";
             var logOption = $"--log \"{Path.Combine(outputPath, ".errors.log")}\"";
 
             Exec(
                 Path.Combine(AppContext.BaseDirectory, "docfx.exe"),
-                arguments: $"restore {logOption} --verbose --stdin",
+                arguments: $"restore {logOption} {templateOption} --verbose --stdin",
                 stdin: docfxConfig,
                 cwd: repositoryPath,
                 allowExitCodes: new int[] { 0 });
 
             return Exec(
                 Path.Combine(AppContext.BaseDirectory, "docfx.exe"),
-                arguments: $"build -o \"{outputPath}\" {logOption} {dryRunOption} {noDrySyncOption} --verbose --no-restore --stdin",
+                arguments: $"build -o \"{outputPath}\" {logOption} {templateOption} {dryRunOption} {noDrySyncOption} --verbose --no-restore --stdin",
                 stdin: docfxConfig,
                 cwd: repositoryPath);
         }


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6877)