### PR TITLE
added 4 more inheritance levels

### DIFF
--- a/src/docfx.website.themes/default/styles/docfx.css
+++ b/src/docfx.website.themes/default/styles/docfx.css
@@ -42,7 +42,11 @@ h6 mark {
 .inheritance .level2:before,
 .inheritance .level3:before,
 .inheritance .level4:before,
-.inheritance .level5:before {
+.inheritance .level5:before,
+.inheritance .level6:before,
+.inheritance .level7:before,
+.inheritance .level8:before,
+.inheritance .level9:before {
     content: '↳';
     margin-right: 5px;
 }
@@ -69,6 +73,22 @@ h6 mark {
 
 .inheritance .level5 {
     margin-left: 5em;
+}
+
+.inheritance .level6 {
+    margin-left: 6em;
+}
+
+.inheritance .level7 {
+    margin-left: 7em;
+}
+
+.inheritance .level8 {
+    margin-left: 8em;
+}
+
+.inheritance .level9 {
+    margin-left: 9em;
 }
 
 .level0.summary {


### PR DESCRIPTION
**Operating System**: Windows

**DocFX Version Used**: 2.56.6

**Template used**: default

**Steps to Reproduce**:

1. inherit classes more than 5 levels from System.Object

**Expected Behavior**:
The expected behavior is that result HTML code will be rendered correctly as on attached picture
![inheritance_more_levels](https://user-images.githubusercontent.com/1199225/101775279-84878200-3aef-11eb-8f38-56d5df200113.png)

**Actual Behavior**:
The actual behavior is that up to 5th inheritance level from System.Object is inheritance rendered correctly. After 5th level the inheritance is not rendered correctly.
![inheritance_2_56_6](https://user-images.githubusercontent.com/1199225/101775313-936e3480-3aef-11eb-8953-d7c82bc350af.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6880)