### PR TITLE
fix MacOS case insensitive file system

### DIFF
--- a/src/Microsoft.DocAsCode.Common/Path/PathUtility.cs
+++ b/src/Microsoft.DocAsCode.Common/Path/PathUtility.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DocAsCode.Common
 
         public static bool IsPathCaseInsensitive()
         {
-            return Environment.OSVersion.Platform < PlatformID.Unix;
+            return true;
         }
 
         public static string ToValidFilePath(this string input, char replacement = '_')

--- a/src/Microsoft.DocAsCode.Common/Path/PathUtility.cs
+++ b/src/Microsoft.DocAsCode.Common/Path/PathUtility.cs
@@ -26,6 +26,11 @@ namespace Microsoft.DocAsCode.Common
 
         public static bool IsPathCaseInsensitive()
         {
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux))
+            {
+                return false;
+            }
+
             return true;
         }
 


### PR DESCRIPTION
**Operating System**: MacOS

**DocFX Version Used**: 2.56.6

**Template used**: default

**Steps to Reproduce**:

1. use [docfx_conflict github project](https://github.com/farcasclaudiu/docfx_conflict) mentioned in #6852 

**Expected Behavior**:
The documentation is created.

**Actual Behavior**:
The actual behavior is that documentation is not created (the error is in #6852). The problem is caused by MacOS file system, which can or cannot be case sensitive. It depends on how is created partition and file system on MacOS. Also in [Microsoft documentation](https://docs.microsoft.com/is-is/dotnet/api/system.platformid?view=netcore-3.1) is stated that MacOS operating system is returned as PlatformID.Unix. In such case is it much more safe to assume that all file systems are case insensitive.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6888)