### PR TITLE
FileLinkItem compare all properties

### DIFF
--- a/src/docfx/build/link/FileLinkItem.cs
+++ b/src/docfx/build/link/FileLinkItem.cs
@@ -41,6 +41,10 @@ namespace Microsoft.Docs.Build
             }
             if (result == 0)
             {
+                result = string.CompareOrdinal(SourceGitUrl, other.SourceGitUrl);
+            }
+            if (result == 0)
+            {
                 result = SourceLine - other.SourceLine;
             }
             return result;


### PR DESCRIPTION
Fix `.links.json` order diff in #6889

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6891)