### PR TITLE
Watcher.Watch -> Watcher.Read

### DIFF
--- a/src/docfx/build/Builder.cs
+++ b/src/docfx/build/Builder.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Docs.Build
             _options = options;
             _errors = errors;
             _package = package;
-            _docsets = Watcher.Create(LoadDocsets);
+            _docsets = new(LoadDocsets);
         }
 
         public static bool Run(string workingDirectory, CommandLineOptions options, Package? package = null)

--- a/src/docfx/build/context/BuildScope.cs
+++ b/src/docfx/build/context/BuildScope.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Docs.Build
             _configReferences = config.Extend.Concat(config.GetFileReferences()).Select(path => PathUtility.Normalize(path.Value))
                 .ToHashSet(PathUtility.PathComparer);
 
-            _files = Watcher.Create(GlobFiles);
+            _files = new(GlobFiles);
         }
 
         public IEnumerable<FilePath> GetFiles(ContentType contentType)

--- a/src/docfx/build/document/DocumentProvider.cs
+++ b/src/docfx/build/document/DocumentProvider.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Docs.Build
 
         private Document GetDocument(FilePath path)
         {
-            return _documents.GetOrAdd(path, key => Watcher.Create(() => GetDocumentCore(key))).Value;
+            return _documents.GetOrAdd(path, key => new(() => GetDocumentCore(key))).Value;
         }
 
         private bool TryGetDocumentIdConfig(PathString path, out DocumentIdConfig result, out PathString remainingPath)

--- a/src/docfx/build/metadata/MetadataProvider.cs
+++ b/src/docfx/build/metadata/MetadataProvider.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Docs.Build
 
         public UserMetadata GetMetadata(ErrorBuilder errors, FilePath file)
         {
-            var (error, result) = _metadataCache.GetOrAdd(file, key => Watcher.Create(() => GetMetadataCore(key))).Value;
+            var (error, result) = _metadataCache.GetOrAdd(file, key => new(() => GetMetadataCore(key))).Value;
             errors.AddRange(error);
             return result;
         }

--- a/src/docfx/build/moniker/MonikerProvider.cs
+++ b/src/docfx/build/moniker/MonikerProvider.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Docs.Build
 
         private (MonikerList monikers, MonikerList ignoreExclude) GetFileLevelMonikersAndExclude(ErrorBuilder errors, FilePath file)
         {
-            var (error, monikers, ignoreExclude) = _monikerCache.GetOrAdd(file, key => Watcher.Create(() => GetFileLevelMonikersCore(key))).Value;
+            var (error, monikers, ignoreExclude) = _monikerCache.GetOrAdd(file, key => new(() => GetFileLevelMonikersCore(key))).Value;
             errors.AddRange(error);
             return (monikers, ignoreExclude);
         }

--- a/src/docfx/build/redirection/RedirectionProvider.cs
+++ b/src/docfx/build/redirection/RedirectionProvider.cs
@@ -43,8 +43,8 @@ namespace Microsoft.Docs.Build
             _monikerProvider = monikerProvider;
             _publishUrlMap = publishUrlMap;
 
-            _redirects = Watcher.Create(LoadRedirections);
-            _history = Watcher.Create(LoadHistory);
+            _redirects = new(LoadRedirections);
+            _history = new(LoadHistory);
         }
 
         public bool TryGetValue(PathString file, [NotNullWhen(true)] out FilePath? actualPath)

--- a/src/docfx/lib/watch/ReadFunction{T}.cs
+++ b/src/docfx/lib/watch/ReadFunction{T}.cs
@@ -5,13 +5,13 @@ using System;
 
 namespace Microsoft.Docs.Build
 {
-    internal class LeafFunction<T> : IFunction
+    internal class ReadFunction<T> : IFunction
     {
         private readonly Func<T> _changeTokenFactory;
 
         internal T? ChangeToken { get; set; }
 
-        public LeafFunction(Func<T> changeTokenFactory) => _changeTokenFactory = changeTokenFactory;
+        public ReadFunction(Func<T> changeTokenFactory) => _changeTokenFactory = changeTokenFactory;
 
         public bool HasChanged() => !Equals(ChangeToken, _changeTokenFactory());
 

--- a/src/docfx/lib/watch/WatchFunction.cs
+++ b/src/docfx/lib/watch/WatchFunction.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Docs.Build
 {
-    internal class ContainerFunction : IFunction
+    internal class WatchFunction : IFunction
     {
         private readonly List<IFunction> _children = new();
 

--- a/src/docfx/lib/watch/Watcher.cs
+++ b/src/docfx/lib/watch/Watcher.cs
@@ -12,14 +12,9 @@ namespace Microsoft.Docs.Build
         private static readonly AsyncLocal<ImmutableStack<IFunction>> t_callstack = new();
         private static readonly AsyncLocal<int> t_activityId = new();
 
-        public static Watch<T> Create<T>(Func<T> valueFactory)
+        public static T Read<T>(Func<T> valueFactory)
         {
-            return new Watch<T>(valueFactory);
-        }
-
-        public static T Watch<T>(Func<T> valueFactory)
-        {
-            var function = new LeafFunction<T>(valueFactory);
+            var function = new ReadFunction<T>(valueFactory);
             BeginFunctionScope(function);
 
             try
@@ -35,9 +30,9 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        public static T Watch<T, TChangeToken>(Func<T> valueFactory, Func<TChangeToken> changeTokenFactory)
+        public static T Read<T, TChangeToken>(Func<T> valueFactory, Func<TChangeToken> changeTokenFactory)
         {
-            var function = new LeafFunction<TChangeToken>(changeTokenFactory);
+            var function = new ReadFunction<TChangeToken>(changeTokenFactory);
             BeginFunctionScope(function);
 
             try

--- a/src/docfx/lib/watch/Watch{T}.cs
+++ b/src/docfx/lib/watch/Watch{T}.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Docs.Build
 
         private T? _value;
 
-        private volatile ContainerFunction? _function;
+        private volatile WatchFunction? _function;
         private object? _syncLock;
 
         public Watch(Func<T> valueFactory) => _valueFactory = valueFactory;
@@ -32,7 +32,7 @@ namespace Microsoft.Docs.Build
                     return _value!;
                 }
 
-                function = new ContainerFunction();
+                function = new WatchFunction();
 
                 Watcher.BeginFunctionScope(function);
 

--- a/src/docfx/publish/PublishUrlMap.cs
+++ b/src/docfx/publish/PublishUrlMap.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Docs.Build
             _redirectionProvider = redirectionProvider;
             _documentProvider = documentProvider;
             _monikerProvider = monikerProvider;
-            _state = Watcher.Create(Initialize);
+            _state = new(Initialize);
         }
 
         public string? GetCanonicalVersion(FilePath file)
@@ -47,7 +47,7 @@ namespace Microsoft.Docs.Build
                 return default;
             }
 
-            return _canonicalVersionCache.GetOrAdd(file, key => Watcher.Create(() => GetCanonicalVersionCore(key))).Value;
+            return _canonicalVersionCache.GetOrAdd(file, key => new(() => GetCanonicalVersionCore(key))).Value;
         }
 
         public IEnumerable<FilePath> GetFilesByUrl(string url)

--- a/src/docfx/restore/LanguageServerPackage.cs
+++ b/src/docfx/restore/LanguageServerPackage.cs
@@ -29,19 +29,19 @@ namespace Microsoft.Docs.Build
 
         public void AddOrUpdate(PathString path, string content) => MemoryPackage.AddOrUpdate(path, content);
 
-        public override bool Exists(PathString path) => Watcher.Watch(() => _packages.Any(pkg => pkg.Exists(path)));
+        public override bool Exists(PathString path) => Watcher.Read(() => _packages.Any(pkg => pkg.Exists(path)));
 
         public IEnumerable<PathString> GetAllFilesInMemory() => MemoryPackage.GetAllFilesInMemory();
 
         public override IEnumerable<PathString> GetFiles(PathString directory = default, string[]? allowedFileNames = null)
-            => Watcher.Watch(
+            => Watcher.Read(
                 () => _packages.SelectMany(pkg => pkg.GetFiles(directory, allowedFileNames)),
                 () => _lastPackageFilesUpdateTime);
 
         public override PathString GetFullFilePath(PathString path) => _packages.First().GetFullFilePath(path);
 
         public override DateTime? TryGetLastWriteTimeUtc(PathString path)
-            => Watcher.Watch(() =>
+            => Watcher.Read(() =>
             {
                 for (int i = 0; i < _packages.Count; i++)
                 {
@@ -56,12 +56,12 @@ namespace Microsoft.Docs.Build
             });
 
         public override byte[] ReadBytes(PathString path)
-            => Watcher.Watch(
+            => Watcher.Read(
                 () => _packages.First((pkg) => pkg.Exists(path)).ReadBytes(path),
                 () => TryGetLastWriteTimeUtc(path));
 
         public override Stream ReadStream(PathString path)
-             => Watcher.Watch(
+             => Watcher.Read(
                 () => _packages.First((pkg) => pkg.Exists(path)).ReadStream(path),
                 () => TryGetLastWriteTimeUtc(path));
 
@@ -70,7 +70,7 @@ namespace Microsoft.Docs.Build
         public void RemoveFile(PathString path) => MemoryPackage.RemoveFile(path);
 
         public override PathString? TryGetPhysicalPath(PathString path)
-            => Watcher.Watch(() =>
+            => Watcher.Read(() =>
             {
                 for (int i = 0; i < _packages.Count; i++)
                 {

--- a/test/docfx.Test/lib/WatcherTest.cs
+++ b/test/docfx.Test/lib/WatcherTest.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Docs.Build
             var counter = 0;
             var watch = new Watch<int>(() => GetCounter());
 
-            int GetCounter() => Watcher.Watch(() => ++counter);
+            int GetCounter() => Watcher.Read(() => ++counter);
 
             Assert.Equal(1, watch.Value);
             Assert.Equal(1, watch.Value);
@@ -85,7 +85,7 @@ namespace Microsoft.Docs.Build
             var childWatch = new Watch<int>(() => GetCounter());
             var watch = new Watch<int>(() => childWatch.Value);
 
-            int GetCounter() => Watcher.Watch(() => ++counter);
+            int GetCounter() => Watcher.Read(() => ++counter);
 
             Assert.Equal(1, watch.Value);
             Assert.Equal(1, watch.Value);
@@ -107,7 +107,7 @@ namespace Microsoft.Docs.Build
             var counter = 0;
             var watch = new Watch<int>(() => GetCounter());
 
-            int GetCounter() => Watcher.Watch(() => Watcher.Watch(() => ++counter));
+            int GetCounter() => Watcher.Read(() => Watcher.Read(() => ++counter));
 
             Assert.Equal(1, watch.Value);
             Assert.Equal(1, watch.Value);
@@ -130,7 +130,7 @@ namespace Microsoft.Docs.Build
             var changeTokenCounter = 0;
             var watch = new Watch<int>(() => GetCounter());
 
-            int GetCounter() => Watcher.Watch(() => ++valueCounter, () => ++changeTokenCounter);
+            int GetCounter() => Watcher.Read(() => ++valueCounter, () => ++changeTokenCounter);
 
             Assert.Equal(1, watch.Value);
             Assert.Equal(1, watch.Value);
@@ -152,8 +152,8 @@ namespace Microsoft.Docs.Build
             var counter = 0;
             var watch = new Watch<int>(() => GetCounterChange() + GetCounterNoChange());
 
-            int GetCounterNoChange() => Watcher.Watch(() => 0);
-            int GetCounterChange() => Watcher.Watch(() => ++counter);
+            int GetCounterNoChange() => Watcher.Read(() => 0);
+            int GetCounterChange() => Watcher.Read(() => ++counter);
 
             Assert.Equal(1, watch.Value);
             Assert.Equal(1, watch.Value);
@@ -170,7 +170,7 @@ namespace Microsoft.Docs.Build
             var counter = 0;
             var watch = new Watch<int>(() => ++counter + GetCounterNoChange());
 
-            int GetCounterNoChange() => Watcher.Watch(() => 0);
+            int GetCounterNoChange() => Watcher.Read(() => 0);
 
             Assert.Equal(1, watch.Value);
             Assert.Equal(1, watch.Value);
@@ -187,7 +187,7 @@ namespace Microsoft.Docs.Build
             var counter = 0;
             var childCounter = 0;
             var parentCounter = 0;
-            var child = new Watch<int>(() => ++childCounter + Watcher.Watch(() => 0, () => ++counter));
+            var child = new Watch<int>(() => ++childCounter + Watcher.Read(() => 0, () => ++counter));
             var parent = new Watch<int>(() => ++parentCounter + child.Value);
 
             Assert.Equal(1, child.Value);
@@ -213,8 +213,8 @@ namespace Microsoft.Docs.Build
                 return 0;
             });
 
-            bool FileExists() => Watcher.Watch(() => exists);
-            int ReadFile() => Watcher.Watch(() => counter);
+            bool FileExists() => Watcher.Read(() => exists);
+            int ReadFile() => Watcher.Read(() => counter);
 
             Assert.Equal(0, watch.Value);
             Assert.Equal(0, watch.Value);
@@ -246,7 +246,7 @@ namespace Microsoft.Docs.Build
                 return n;
             });
 
-            int GetCounter() => Watcher.Watch(() => Interlocked.Increment(ref counter));
+            int GetCounter() => Watcher.Read(() => Interlocked.Increment(ref counter));
 
             Assert.Equal(5050, watch.Value);
             Assert.Equal(5050, watch.Value);


### PR DESCRIPTION
[AB#349016](https://dev.azure.com/ceapex/Engineering/_workitems/edit/349016/)

Rename `Watcher.Watch` to `Watcher.Read`, to add `Watcher.Write` later. With target typed new, there is no need for the helper `Watcher.Create` method.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6898)