### PR TITLE
Make ErrorBuilder a transient build argument

### DIFF
--- a/src/docfx/lib/log/ErrorList.cs
+++ b/src/docfx/lib/log/ErrorList.cs
@@ -16,11 +16,6 @@ namespace Microsoft.Docs.Build
 
         public int Count => _items.Count;
 
-        public override void Clear()
-        {
-            _items.Clear();
-        }
-
         public override bool HasError => _items.Any(item => item.Level == ErrorLevel.Error);
 
         public override void Add(Error error) => _items.Add(error);

--- a/src/docfx/lib/log/ErrorLog.cs
+++ b/src/docfx/lib/log/ErrorLog.cs
@@ -3,59 +3,51 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
 
 namespace Microsoft.Docs.Build
 {
     internal class ErrorLog : ErrorBuilder
     {
         private readonly ErrorBuilder _errors;
-        private readonly Config _config;
-        private readonly SourceMap? _sourceMap;
-        private readonly MetadataProvider? _metadataProvider;
-        private readonly Func<CustomRuleProvider>? _customRuleProvider;
+        private readonly PathString _docsetBasePath;
 
-        private readonly ErrorSink _errorSink = new();
-        private readonly ConcurrentDictionary<FilePath, ErrorSink> _fileSink = new();
+        private readonly Scoped<ErrorSink> _errorSink = new();
+        private readonly Scoped<ConcurrentDictionary<FilePath, ErrorSink>> _fileSink = new();
 
-        public override bool HasError => _errors.HasError;
+        public Config? Config { get; set; }
 
-        public override bool FileHasError(FilePath file) => _fileSink.TryGetValue(file, out var sink) && sink.ErrorCount > 0;
+        public SourceMap? SourceMap { get; set; }
 
-        public ErrorLog(
-            ErrorBuilder errors,
-            Config config,
-            SourceMap? sourceMap = null,
-            MetadataProvider? metadataProvider = null,
-            Func<CustomRuleProvider>? customRuleProvider = null)
+        public MetadataProvider? MetadataProvider { get; set; }
+
+        public CustomRuleProvider? CustomRuleProvider { get; set; }
+
+        public override bool HasError => _errorSink.Value.ErrorCount > 0 || _fileSink.Value.Values.Any(file => file.ErrorCount > 0);
+
+        public override bool FileHasError(FilePath file) => _fileSink.Value.TryGetValue(file, out var sink) && sink.ErrorCount > 0;
+
+        public ErrorLog(ErrorBuilder errors, string workingDirectory, string docsetPath)
         {
             _errors = errors;
-            _config = config;
-            _sourceMap = sourceMap;
-            _metadataProvider = metadataProvider;
-            _customRuleProvider = customRuleProvider;
-        }
-
-        public override void Clear()
-        {
-            _errors.Clear();
-            _errorSink.Clear();
-            _fileSink.Clear();
+            _docsetBasePath = new PathString(Path.GetRelativePath(workingDirectory, docsetPath));
         }
 
         public override void Add(Error error)
         {
             try
             {
-                if (_metadataProvider != null && error.Source?.File is FilePath source)
+                if (error.Source?.File is FilePath source)
                 {
-                    var msAuthor = _metadataProvider.GetMetadata(Null, source).MsAuthor;
+                    var msAuthor = MetadataProvider?.GetMetadata(Null, source).MsAuthor;
                     if (msAuthor != default)
                     {
                         error = error with { MsAuthor = msAuthor };
                     }
                 }
 
-                error = _customRuleProvider?.Invoke().ApplyCustomRule(error) ?? error;
+                error = CustomRuleProvider?.ApplyCustomRule(error) ?? error;
             }
             catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
             {
@@ -67,45 +59,72 @@ namespace Microsoft.Docs.Build
                 return;
             }
 
-            if (_config.WarningsAsErrors && error.Level == ErrorLevel.Warning)
+            if (error.Source != null && SourceMap != null)
             {
-                error = error with { Level = ErrorLevel.Error };
+                error = error with { OriginalPath = SourceMap.GetOriginalFilePath(error.Source.File)?.Path };
             }
 
-            if (error.Source?.File != null && error.Source?.File.Origin == FileOrigin.Fallback)
+            var config = Config;
+            if (config != null)
             {
-                if (error.Level == ErrorLevel.Error)
+                if (config.WarningsAsErrors && error.Level == ErrorLevel.Warning)
                 {
-                    Add(Errors.Logging.FallbackError(_config.DefaultLocale));
+                    error = error with { Level = ErrorLevel.Error };
                 }
-                return;
-            }
 
-            if (error.Source != null)
-            {
-                error = error with { OriginalPath = _sourceMap?.GetOriginalFilePath(error.Source.File)?.Path };
-            }
-
-            var errorSink = error.Source?.File is null ? _errorSink : _fileSink.GetOrAdd(error.Source.File, _ => new ErrorSink());
-
-            switch (errorSink.Add(error.Source?.File is null ? null : _config, error))
-            {
-                case ErrorSinkResult.Ok:
-                    _errors.Add(error);
-                    break;
-
-                case ErrorSinkResult.Exceed when error.Source?.File != null:
-                    var maxAllowed = error.Level switch
+                if (error.Source?.File != null && error.Source?.File.Origin == FileOrigin.Fallback)
+                {
+                    if (error.Level == ErrorLevel.Error)
                     {
-                        ErrorLevel.Error => _config.MaxFileErrors,
-                        ErrorLevel.Warning => _config.MaxFileWarnings,
-                        ErrorLevel.Suggestion => _config.MaxFileSuggestions,
-                        ErrorLevel.Info => _config.MaxFileInfos,
-                        _ => 0,
-                    };
-                    _errors.Add(Errors.Logging.ExceedMaxFileErrors(maxAllowed, error.Level, error.Source.File));
-                    break;
+                        Add(Errors.Logging.FallbackError(config.DefaultLocale));
+                    }
+                    return;
+                }
             }
+
+            Watcher.Write(() =>
+            {
+                var errorSink = error.Source?.File is null ? _errorSink.Value : _fileSink.Value.GetOrAdd(error.Source.File, _ => new ErrorSink());
+
+                switch (errorSink.Add(error.Source?.File is null ? null : config, error))
+                {
+                    case ErrorSinkResult.Ok:
+                        AddError(error);
+                        break;
+
+                    case ErrorSinkResult.Exceed when error.Source?.File != null && config != null:
+                        var maxAllowed = error.Level switch
+                        {
+                            ErrorLevel.Error => config.MaxFileErrors,
+                            ErrorLevel.Warning => config.MaxFileWarnings,
+                            ErrorLevel.Suggestion => config.MaxFileSuggestions,
+                            ErrorLevel.Info => config.MaxFileInfos,
+                            _ => 0,
+                        };
+                        AddError(Errors.Logging.ExceedMaxFileErrors(maxAllowed, error.Level, error.Source.File));
+                        break;
+                }
+            });
+        }
+
+        private void AddError(Error error)
+        {
+            // Convert from path relative to docset to path relative to working directory
+            if (!_docsetBasePath.IsDefault)
+            {
+                if (error.Source != null)
+                {
+                    var path = _docsetBasePath.Concat(error.Source.File.Path);
+                    error = error with { Source = error.Source with { File = error.Source.File with { Path = path } } };
+                }
+
+                if (error.OriginalPath != null)
+                {
+                    error = error with { OriginalPath = _docsetBasePath.Concat(error.OriginalPath.Value) };
+                }
+            }
+
+            _errors.Add(error);
         }
     }
 }

--- a/src/docfx/lib/log/ErrorSink.cs
+++ b/src/docfx/lib/log/ErrorSink.cs
@@ -72,14 +72,5 @@ namespace Microsoft.Docs.Build
                 return ErrorSinkResult.Ok;
             }
         }
-
-        public void Clear()
-        {
-            ErrorCount = 0;
-            WarningCount = 0;
-            SuggestionCount = 0;
-            InfoCount = 0;
-            _errors.Clear();
-        }
     }
 }

--- a/src/docfx/lib/log/ErrorWriter.cs
+++ b/src/docfx/lib/log/ErrorWriter.cs
@@ -27,10 +27,6 @@ namespace Microsoft.Docs.Build
 
         public override bool FileHasError(FilePath file) => throw new NotSupportedException();
 
-        public override void Clear()
-        {
-        }
-
         public ErrorWriter(string? outputPath = null)
         {
             _output = new(() => outputPath is null ? TextWriter.Null : CreateOutput(outputPath));

--- a/src/docfx/lib/log/ScopedErrorBuilder.cs
+++ b/src/docfx/lib/log/ScopedErrorBuilder.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+
+namespace Microsoft.Docs.Build
+{
+    internal class ScopedErrorBuilder : ErrorBuilder
+    {
+        private readonly AsyncLocal<ErrorBuilder?> _errors = new();
+
+        private ErrorBuilder EnsureValue => _errors.Value ?? throw new InvalidOperationException();
+
+        public IDisposable BeginScope(ErrorBuilder errors)
+        {
+            _errors.Value = errors;
+            return new DelegatingDisposable(() => _errors.Value = null);
+        }
+
+        public override bool HasError => EnsureValue.HasError;
+
+        public override bool FileHasError(FilePath file) => EnsureValue.FileHasError(file);
+
+        public override void Add(Error error) => Watcher.Write(() => EnsureValue.Add(error));
+    }
+}

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -38,25 +38,25 @@ namespace Microsoft.Docs.Build
         public static void RestoreDocset(
             ErrorBuilder errors, string workingDirectory, string docsetPath, string? outputPath, CommandLineOptions options, FetchOptions fetchOptions)
         {
-            errors = errors.WithDocsetPath(workingDirectory, docsetPath);
+            var errorLog = new ErrorLog(errors, workingDirectory, docsetPath);
 
             try
             {
                 // load configuration from current entry or fallback repository
                 var (config, buildOptions, packageResolver, fileResolver, _) = ConfigLoader.Load(
-                    errors, docsetPath, outputPath, options, fetchOptions, new LocalPackage(Path.Combine(workingDirectory, docsetPath)));
+                    errorLog, docsetPath, outputPath, options, fetchOptions, new LocalPackage(Path.Combine(workingDirectory, docsetPath)));
 
-                if (errors.HasError)
+                if (errorLog.HasError)
                 {
                     return;
                 }
 
-                errors = new ErrorLog(errors, config);
-                RestoreDocset(errors, config, buildOptions, packageResolver, fileResolver);
+                errorLog.Config = config;
+                RestoreDocset(errorLog, config, buildOptions, packageResolver, fileResolver);
             }
             catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
             {
-                errors.AddRange(dex);
+                errorLog.AddRange(dex);
             }
         }
 

--- a/test/docfx.Test/lib/ErrorLogTest.cs
+++ b/test/docfx.Test/lib/ErrorLogTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Docs.Build
         public void DedupErrors()
         {
             using var errors = new ErrorWriter();
-            var errorLog = new ErrorLog(errors, new Config());
+            var errorLog = new ErrorLog(errors, ".", ".");
             errorLog.Add(new Error(ErrorLevel.Error, "an-error-code", $"message 1"));
             errorLog.Add(new Error(ErrorLevel.Error, "an-error-code", $"message 1"));
             errorLog.Add(new Error(ErrorLevel.Warning, "an-error-code", $"message 2"));
@@ -26,7 +26,7 @@ namespace Microsoft.Docs.Build
         {
             using var errors = new ErrorWriter();
             var config = new Config();
-            var errorLog = new ErrorLog(errors, config);
+            var errorLog = new ErrorLog(errors, ".", ".") { Config = config };
 
             var testFiles = 100;
             var testErrors = new List<Error>();


### PR DESCRIPTION
[AB#350122](https://dev.azure.com/ceapex/Engineering/_workitems/edit/350122/)

- Remove `ErrorBuilder.Clear`
- Move `ErrorBuilder` from constructor to `Build` function parameter
- Annotate `ErrorLog` states with `Scoped<T>` and `Watcher.Write`.
- Consolidate `ErrorBuilder.WithDocsetPath` into `ErrorLog` to make it easier for the above annotation.

This PR depends on #6911 for `Scoped<T>`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6913)