### PR TITLE
Improve shutdown and exception handling of language server

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -59,6 +59,7 @@ dotnet_diagnostic.men007.severity = none
 # Suppress Microsoft.VisualStudio.Threading warnings due to transitive dependency by OmniSharp.Extensions.LanguageServer
 dotnet_diagnostic.vsthrd002.severity = none
 dotnet_diagnostic.vsthrd011.severity = none
+dotnet_diagnostic.vsthrd100.severity = none
 dotnet_diagnostic.vsthrd200.severity = none
 
 # CA1001: Types that own disposable fields should be disposable

--- a/.github/actions/spell-check/dictionary/custom-dictionary.txt
+++ b/.github/actions/spell-check/dictionary/custom-dictionary.txt
@@ -565,3 +565,4 @@ Quickenshtein
 IFunction
 TChange
 vsthrd
+IAsync

--- a/docs/specs/lsp.yml
+++ b/docs/specs/lsp.yml
@@ -110,17 +110,3 @@ languageServer:
       docfx.yml: []
       a.md: []
 ---
-# Isolate bookmark validation states between builds
-inputs:
-  docfx.yml:
-languageServer:
-  - openFiles:
-      a.md: "[](b.md#anchor-missing)"
-      b.md: "## anchor"
-  - expectDiagnostics: 
-      a.md: [{ "code": "bookmark-not-found" }]
-  - openFiles:
-      a.md: "[](b.md#anchor)"
-      b.md: "## anchor"
-  - expectDiagnostics: 
-      a.md: []

--- a/docs/specs/single-file.yml
+++ b/docs/specs/single-file.yml
@@ -91,3 +91,39 @@ inputs:
   b.png.md:
   b.png:
 outputs:
+---
+# Isolate bookmark validation state between builds
+languageServer:
+  - openFiles:
+      docfx.yml:
+      a.md: "[](b.md#anchor-missing)"
+      b.md: "## anchor"
+  - expectDiagnostics: 
+      a.md: [{ "code": "bookmark-not-found" }]
+  - editFiles:
+      a.md: "[](b.md#anchor)"
+  - expectDiagnostics: 
+      a.md: []
+  - editFiles:
+      b.md: "## anchor-1"
+  - expectDiagnostics: 
+      a.md: [{ "code": "bookmark-not-found" }]
+---
+# Isolate metadata state between builds
+languageServer:
+  - openFiles:
+      docfx.yml: |
+        globalMetadata:
+          title: {}
+      a.md:
+  - expectDiagnostics:
+      docfx.yml: [{ "code": "violate-schema" }]
+  - editFiles:
+      docfx.yml:
+      a.md: |
+        ---
+        title: {}
+        ---
+  - expectDiagnostics:
+      a.md: [{ "code": "violate-schema" }]
+---

--- a/src/docfx/build/DocsetBuilder.cs
+++ b/src/docfx/build/DocsetBuilder.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Docs.Build
             _fileResolver = fileResolver;
             _opsAccessor = opsAccessor;
             _repositoryProvider = repositoryProvider;
-            _sourceMap = _errors.SourceMap = new(_errors, new PathString(_buildOptions.DocsetPath), _config, _fileResolver);
+            _sourceMap = _errors.SourceMap = new(_errors, new(_buildOptions.DocsetPath), _config, _fileResolver);
             _input = new(_buildOptions, _config, _packageResolver, _repositoryProvider, _sourceMap, package);
             _buildScope = new(_config, _input, _buildOptions);
             _githubAccessor = new(_config);

--- a/src/docfx/restore/MemoryPackage.cs
+++ b/src/docfx/restore/MemoryPackage.cs
@@ -17,15 +17,9 @@ namespace Microsoft.Docs.Build
 
         public override PathString BasePath => _directory;
 
-        public MemoryPackage(string directory = ".")
-        {
-            _directory = new(Path.GetFullPath(directory));
-        }
+        public MemoryPackage(string directory = ".") => _directory = new(Path.GetFullPath(directory));
 
-        public void AddOrUpdate(PathString path, string content)
-        {
-            _inMemoryFiles.AddOrUpdate(_directory.Concat(path), (key) => (DateTime.UtcNow, content), (key, oldValue) => (DateTime.UtcNow, content));
-        }
+        public void AddOrUpdate(PathString path, string content) => _inMemoryFiles[_directory.Concat(path)] = (DateTime.UtcNow, content);
 
         public override bool Exists(PathString path) => _inMemoryFiles.ContainsKey(_directory.Concat(path));
 
@@ -33,45 +27,31 @@ namespace Microsoft.Docs.Build
 
         public override IEnumerable<PathString> GetFiles(PathString directory = default, string[]? allowedFileNames = null)
         {
-            var directoryPathString = _directory.Concat(new PathString(directory));
-            var files = _inMemoryFiles.Keys.Select((PathString file)
-                => file.StartsWithPath(directoryPathString, out var relativePath) ? relativePath : default)
+            var directoryPathString = _directory.Concat(new(directory));
+            var files = _inMemoryFiles.Keys
+                .Select(file => file.StartsWithPath(directoryPathString, out var relativePath) ? relativePath : default)
                 .Where(file => file != default);
 
             if (allowedFileNames != null)
             {
-                files = files.Where((file) =>
+                files = files.Where(file =>
                 {
                     var fileName = Path.GetFileName(file);
-                    return allowedFileNames.Any((allowedFileName) => fileName.Equals(allowedFileName, StringComparison.OrdinalIgnoreCase));
+                    return allowedFileNames.Any(allowedFileName => fileName.Equals(allowedFileName, StringComparison.OrdinalIgnoreCase));
                 });
             }
             return files;
         }
 
-        public override PathString GetFullFilePath(PathString path) => new PathString(_directory.Concat(path));
+        public override PathString GetFullFilePath(PathString path) => new(_directory.Concat(path));
 
-        public override DateTime? TryGetLastWriteTimeUtc(PathString path)
-        {
-            if (_inMemoryFiles.TryGetValue(_directory.Concat(path), out var value))
-            {
-                return value.lastWriteTime;
-            }
-            return null;
-        }
+        public override DateTime? TryGetLastWriteTimeUtc(PathString path) => _inMemoryFiles.GetValueOrDefault(_directory.Concat(path)).lastWriteTime;
 
-        public override byte[] ReadBytes(PathString path)
-        {
-            var value = _inMemoryFiles.GetValueOrDefault(_directory.Concat(path));
-            return Encoding.UTF8.GetBytes(value.content ?? string.Empty);
-        }
+        public override string ReadString(PathString path) => _inMemoryFiles[_directory.Concat(path)].content;
 
-        public override Stream ReadStream(PathString path)
-        {
-            var value = _inMemoryFiles.GetValueOrDefault(_directory.Concat(path));
-            var byteArray = Encoding.UTF8.GetBytes(value.content);
-            return new MemoryStream(byteArray);
-        }
+        public override byte[] ReadBytes(PathString path) => Encoding.UTF8.GetBytes(ReadString(path));
+
+        public override Stream ReadStream(PathString path) => new MemoryStream(ReadBytes(path), writable: false);
 
         public void RemoveFile(PathString path) => _inMemoryFiles.TryRemove(_directory.Concat(path), out _);
 

--- a/src/docfx/restore/Package.cs
+++ b/src/docfx/restore/Package.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Docs.Build
 
         public abstract Stream ReadStream(PathString path);
 
-        public string ReadString(PathString path)
+        public virtual string ReadString(PathString path)
         {
             using var reader = ReadText(path);
             return reader.ReadToEnd();

--- a/src/docfx/serve/LanguageServerBuilder.cs
+++ b/src/docfx/serve/LanguageServerBuilder.cs
@@ -7,12 +7,14 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.Docs.Build
 {
     internal class LanguageServerBuilder
     {
+        private readonly ILogger _logger;
         private readonly Builder _builder;
         private readonly Channel<bool> _buildChannel = Channel.CreateUnbounded<bool>();
         private readonly DiagnosticPublisher _diagnosticPublisher;
@@ -22,6 +24,7 @@ namespace Microsoft.Docs.Build
         private List<PathString> _filesWithDiagnostics = new();
 
         public LanguageServerBuilder(
+            ILoggerFactory loggerFactory,
             CommandLineOptions options,
             DiagnosticPublisher diagnosticPublisher,
             LanguageServerPackage languageServerPackage,
@@ -33,8 +36,8 @@ namespace Microsoft.Docs.Build
             _diagnosticPublisher = diagnosticPublisher;
             _languageServerPackage = languageServerPackage;
             _notificationListener = notificationListener;
+            _logger = loggerFactory.CreateLogger<LanguageServerBuilder>();
             _builder = new(languageServerPackage.BasePath, options, _languageServerPackage);
-            _ = StartAsync();
         }
 
         public void QueueBuild()
@@ -42,30 +45,38 @@ namespace Microsoft.Docs.Build
             _buildChannel.Writer.TryWrite(true);
         }
 
-        private async Task StartAsync()
+        public async void Run(CancellationToken cancellationToken = default)
         {
-            while (true)
+            while (!cancellationToken.IsCancellationRequested)
             {
-                await WaitToTriggerBuild();
+                try
+                {
+                    await WaitToTriggerBuild(cancellationToken);
 
-                var errors = new ErrorList();
-                var filesToBuild = _languageServerPackage.GetAllFilesInMemory();
-                _builder.Build(errors, filesToBuild.Select(f => f.Value).ToArray());
+                    var errors = new ErrorList();
+                    var filesToBuild = _languageServerPackage.GetAllFilesInMemory();
+                    _builder.Build(errors, filesToBuild.Select(f => f.Value).ToArray());
 
-                PublishDiagnosticsParams(errors, filesToBuild);
-                _notificationListener.OnNotificationHandled();
+                    PublishDiagnosticsParams(errors, filesToBuild);
+                    _notificationListener.OnNotificationHandled();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogCritical(ex, "Failed to handle build request");
+                }
             }
         }
 
-        private async Task WaitToTriggerBuild()
+        private async Task WaitToTriggerBuild(CancellationToken cancellationToken)
         {
-            await _buildChannel.Reader.ReadAsync();
+            await _buildChannel.Reader.ReadAsync(cancellationToken);
 
             try
             {
                 while (true)
                 {
-                    using var cts = new CancellationTokenSource(1000);
+                    using var timeout = new CancellationTokenSource(1000);
+                    using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeout.Token);
                     await _buildChannel.Reader.ReadAsync(cts.Token);
                     _notificationListener.OnNotificationHandled();
                 }

--- a/src/docfx/serve/Serve.cs
+++ b/src/docfx/serve/Serve.cs
@@ -15,8 +15,7 @@ namespace Microsoft.Docs.Build
                 return true;
             }
 
-            var server = LanguageServerHost.StartLanguageServer(workingDirectory, options, package).GetAwaiter().GetResult();
-            server.WaitForExit.GetAwaiter().GetResult();
+            LanguageServerHost.RunLanguageServer(workingDirectory, options, package).GetAwaiter().GetResult();
             return false;
         }
     }

--- a/src/docfx/serve/lsp/TextDocumentHandler.cs
+++ b/src/docfx/serve/lsp/TextDocumentHandler.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Docs.Build
             return new TextDocumentAttributes(uri, "docfx");
         }
 
-        private bool TryUpdatePackage(DocumentUri file, string content)
+        private bool TryUpdatePackage(DocumentUri file, string? content)
         {
             var filePath = new PathString(file.GetFileSystemPath());
             if (!filePath.StartsWithPath(_package.BasePath, out _))
@@ -120,7 +120,7 @@ namespace Microsoft.Docs.Build
                 return false;
             }
 
-            _package.AddOrUpdate(filePath, content);
+            _package.AddOrUpdate(filePath, content ?? "");
             return true;
         }
 

--- a/test/docfx.Test/DocfxTest.cs
+++ b/test/docfx.Test/DocfxTest.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Docs.Build
 
         private static async Task RunLanguageServer(string docsetPath, DocfxTestSpec spec, Package package)
         {
-            var client = new LanguageServerTestClient(docsetPath, package);
+            await using var client = new LanguageServerTestClient(docsetPath, package);
 
             foreach (var command in spec.LanguageServer)
             {


### PR DESCRIPTION
- Fixed a `MemoryPackage` null exception problem
- Make test fail immediately on unhandled exception
- Ensure language server shutdown properly when test completes
- Some minor code tweaks

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6919)