### PR TITLE
Don't warn for $schema element

### DIFF
--- a/src/docfx/SubCommands/CompositeCommand.cs
+++ b/src/docfx/SubCommands/CompositeCommand.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.DocAsCode.SubCommands
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
 
@@ -26,7 +27,10 @@ namespace Microsoft.DocAsCode.SubCommands
             {
                 if (!controller.TryGetCommandCreator(pair.Key, out ISubCommandCreator command))
                 {
-                    Logger.LogWarning($"{pair.Key} is not a recognized command name, ignored.");
+                    if (!pair.Key.Equals("$schema", StringComparison.Ordinal))
+                    {
+                        Logger.LogWarning($"{pair.Key} is not a recognized command name, ignored.");
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Adding a `$schema` attribute pointing to the official schema is a nice way to get completion in an editor. This caused a warning during build, however.

This checks for that element when building the commands so we don't warn for what is already a supported scenario.

Fixes Using $schema to get completion causes a build warning #6926

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6927)