### PR TITLE
Fix docfx new command failure

### DIFF
--- a/src/docfx/build/Builder.cs
+++ b/src/docfx/build/Builder.cs
@@ -12,20 +12,18 @@ namespace Microsoft.Docs.Build
     internal class Builder
     {
         private readonly ScopedErrorBuilder _errors = new();
-        private readonly string _workingDirectory;
         private readonly CommandLineOptions _options;
         private readonly Watch<DocsetBuilder[]> _docsets;
         private readonly Package _package;
 
-        public Builder(string workingDirectory, CommandLineOptions options, Package package)
+        public Builder(CommandLineOptions options, Package package)
         {
-            _workingDirectory = workingDirectory;
             _options = options;
             _package = package;
             _docsets = new(LoadDocsets);
         }
 
-        public static bool Run(string workingDirectory, CommandLineOptions options, Package? package = null)
+        public static bool Run(CommandLineOptions options, Package? package = null)
         {
             var stopwatch = Stopwatch.StartNew();
 
@@ -33,9 +31,9 @@ namespace Microsoft.Docs.Build
 
             var files = options.Files?.Select(Path.GetFullPath).ToArray();
 
-            package ??= new LocalPackage(workingDirectory);
+            package ??= new LocalPackage(options.WorkingDirectory);
 
-            new Builder(workingDirectory, options, package).Build(errors, files);
+            new Builder(options, package).Build(errors, files);
 
             Telemetry.TrackOperationTime("build", stopwatch.Elapsed);
             Log.Important($"Build done in {Progress.FormatTimeSpan(stopwatch.Elapsed)}", ConsoleColor.Green);
@@ -72,19 +70,19 @@ namespace Microsoft.Docs.Build
             var docsets = ConfigLoader.FindDocsets(_errors, _package, _options);
             if (docsets.Length == 0)
             {
-                _errors.Add(Errors.Config.ConfigNotFound(_workingDirectory));
+                _errors.Add(Errors.Config.ConfigNotFound(_options.WorkingDirectory));
             }
 
             return (from docset in docsets
                     let item = DocsetBuilder.Create(
-                        _errors, _workingDirectory, docset.docsetPath, docset.outputPath, _package.CreateSubPackage(docset.docsetPath), _options)
+                        _errors, docset.docsetPath, docset.outputPath, _package.CreateSubPackage(docset.docsetPath), _options)
                     where item != null
                     select item).ToArray();
         }
 
         private string GetPathToDocset(DocsetBuilder docset, string file)
         {
-            return Path.GetRelativePath(docset.BuildOptions.DocsetPath, Path.Combine(_workingDirectory, file));
+            return Path.GetRelativePath(docset.BuildOptions.DocsetPath, Path.Combine(_options.WorkingDirectory, file));
         }
     }
 }

--- a/src/docfx/build/DocsetBuilder.cs
+++ b/src/docfx/build/DocsetBuilder.cs
@@ -74,13 +74,12 @@ namespace Microsoft.Docs.Build
 
         public static DocsetBuilder? Create(
             ErrorBuilder errors,
-            string workingDirectory,
             string docsetPath,
             string? outputPath,
             Package package,
             CommandLineOptions options)
         {
-            var errorLog = new ErrorLog(errors, workingDirectory, docsetPath);
+            var errorLog = new ErrorLog(errors, options.WorkingDirectory, docsetPath);
 
             try
             {

--- a/src/docfx/cli/CommandLineOptions.cs
+++ b/src/docfx/cli/CommandLineOptions.cs
@@ -27,6 +27,9 @@ namespace Microsoft.Docs.Build
         public string? TemplateBasePath;
         public IReadOnlyList<string>? Files;
 
+        public string? TemplateName;
+        public string WorkingDirectory = ".";
+
         public JObject? StdinConfig;
 
         public JObject ToJObject()

--- a/src/docfx/cli/New.cs
+++ b/src/docfx/cli/New.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Microsoft.Docs.Build
 {
@@ -11,27 +12,29 @@ namespace Microsoft.Docs.Build
     {
         private static readonly string s_templatePath = Path.Combine(AppContext.BaseDirectory, "data", "new");
 
-        public static bool Run(string type, CommandLineOptions options)
+        public static bool Run(CommandLineOptions options)
         {
-            if (type == "." || !Directory.Exists(Path.Combine(s_templatePath, type)))
+            var templateName = options.TemplateName;
+
+            if (string.IsNullOrEmpty(templateName) ||
+                !templateName.All(ch => char.IsLetterOrDigit(ch) || ch == '-') ||
+                !Directory.Exists(Path.Combine(s_templatePath, templateName)))
             {
                 ShowTemplates();
-                return false;
+                return true;
             }
 
             if (options.Force)
             {
-                CreateFromTemplate(type, options, dryRun: false);
-                return false;
+                return CreateFromTemplate(templateName, options, dryRun: false);
             }
 
-            if (CreateFromTemplate(type, options, dryRun: true))
+            if (CreateFromTemplate(templateName, options, dryRun: true))
             {
-                CreateFromTemplate(type, options, dryRun: false);
-                return false;
+                return true;
             }
 
-            return true;
+            return CreateFromTemplate(templateName, options, dryRun: false);
         }
 
         private static void ShowTemplates()
@@ -61,19 +64,19 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private static bool CreateFromTemplate(string type, CommandLineOptions options, bool dryRun)
+        private static bool CreateFromTemplate(string templateName, CommandLineOptions options, bool dryRun)
         {
             var output = options.Output ?? ".";
             var overwriteFiles = new List<string>();
 
-            foreach (var file in Directory.GetFiles(Path.Combine(s_templatePath, type)))
+            foreach (var file in Directory.GetFiles(Path.Combine(s_templatePath, templateName)))
             {
                 if (Path.GetFileName(file).StartsWith("__"))
                 {
                     continue;
                 }
 
-                var target = Path.GetRelativePath(Path.Combine(s_templatePath, type), file);
+                var target = Path.GetRelativePath(Path.Combine(s_templatePath, templateName), file);
                 var targetFullPath = Path.GetFullPath(Path.Combine(output, target));
 
                 if (dryRun)
@@ -94,7 +97,7 @@ namespace Microsoft.Docs.Build
             {
                 if (overwriteFiles.Count <= 0)
                 {
-                    return true;
+                    return false;
                 }
 
                 Console.ForegroundColor = ConsoleColor.Red;
@@ -108,14 +111,16 @@ namespace Microsoft.Docs.Build
                 Console.WriteLine();
                 Console.WriteLine("Rerun the command and pass --force to accept and create.");
                 Console.ResetColor();
-                return false;
+                return true;
             }
 
-            Console.WriteLine($"The template \"{type}\" was created successfully.");
+            Console.WriteLine($"The template \"{templateName}\" was created successfully.");
             Console.WriteLine();
 
             Console.WriteLine($"Restoring dependencies in \"{output}\"");
-            return Restore.Run(output, options);
+
+            options.WorkingDirectory = output;
+            return Restore.Run(options);
         }
     }
 }

--- a/src/docfx/restore/LocalPackage.cs
+++ b/src/docfx/restore/LocalPackage.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Enumeration;
-using System.Linq;
 
 namespace Microsoft.Docs.Build
 {
@@ -15,10 +14,7 @@ namespace Microsoft.Docs.Build
 
         private readonly PathString _directory;
 
-        public LocalPackage(string directory = ".")
-        {
-            _directory = new(Path.GetFullPath(directory));
-        }
+        public LocalPackage(string directory = ".") => _directory = new(Path.GetFullPath(directory));
 
         public override PathString BasePath => _directory;
 

--- a/src/docfx/restore/Restore.cs
+++ b/src/docfx/restore/Restore.cs
@@ -12,21 +12,21 @@ namespace Microsoft.Docs.Build
 {
     internal static class Restore
     {
-        public static bool Run(string workingDirectory, CommandLineOptions options)
+        public static bool Run(CommandLineOptions options)
         {
             var stopwatch = Stopwatch.StartNew();
             using var errors = new ErrorWriter(options.Log);
 
-            var docsets = ConfigLoader.FindDocsets(errors, new LocalPackage(workingDirectory), options);
+            var docsets = ConfigLoader.FindDocsets(errors, new LocalPackage(options.WorkingDirectory), options);
             if (docsets.Length == 0)
             {
-                errors.Add(Errors.Config.ConfigNotFound(workingDirectory));
+                errors.Add(Errors.Config.ConfigNotFound(options.WorkingDirectory));
                 return errors.HasError;
             }
 
             Parallel.ForEach(docsets, docset =>
             {
-                RestoreDocset(errors, workingDirectory, docset.docsetPath, docset.outputPath, options, FetchOptions.Latest);
+                RestoreDocset(errors, docset.docsetPath, docset.outputPath, options, FetchOptions.Latest);
             });
 
             Telemetry.TrackOperationTime("restore", stopwatch.Elapsed);
@@ -36,15 +36,15 @@ namespace Microsoft.Docs.Build
         }
 
         public static void RestoreDocset(
-            ErrorBuilder errors, string workingDirectory, string docsetPath, string? outputPath, CommandLineOptions options, FetchOptions fetchOptions)
+            ErrorBuilder errors, string docsetPath, string? outputPath, CommandLineOptions options, FetchOptions fetchOptions)
         {
-            var errorLog = new ErrorLog(errors, workingDirectory, docsetPath);
+            var errorLog = new ErrorLog(errors, options.WorkingDirectory, docsetPath);
 
             try
             {
                 // load configuration from current entry or fallback repository
                 var (config, buildOptions, packageResolver, fileResolver, _) = ConfigLoader.Load(
-                    errorLog, docsetPath, outputPath, options, fetchOptions, new LocalPackage(Path.Combine(workingDirectory, docsetPath)));
+                    errorLog, docsetPath, outputPath, options, fetchOptions, new LocalPackage(Path.Combine(options.WorkingDirectory, docsetPath)));
 
                 if (errorLog.HasError)
                 {

--- a/src/docfx/serve/LanguageServerBuilder.cs
+++ b/src/docfx/serve/LanguageServerBuilder.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Docs.Build
             _languageServerPackage = languageServerPackage;
             _notificationListener = notificationListener;
             _logger = loggerFactory.CreateLogger<LanguageServerBuilder>();
-            _builder = new(languageServerPackage.BasePath, options, _languageServerPackage);
+            _builder = new(options, _languageServerPackage);
         }
 
         public void QueueBuild()

--- a/src/docfx/serve/Serve.cs
+++ b/src/docfx/serve/Serve.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Docs.Build
 {
     internal static class Serve
     {
-        public static bool Run(string workingDirectory, CommandLineOptions options, Package? package = null)
+        public static bool Run(CommandLineOptions options, Package? package = null)
         {
             if (!options.LanguageServer)
             {
@@ -15,7 +15,7 @@ namespace Microsoft.Docs.Build
                 return true;
             }
 
-            LanguageServerHost.RunLanguageServer(workingDirectory, options, package).GetAwaiter().GetResult();
+            LanguageServerHost.RunLanguageServer(options, package).GetAwaiter().GetResult();
             return false;
         }
     }

--- a/test/docfx.Test/cli/NewTest.cs
+++ b/test/docfx.Test/cli/NewTest.cs
@@ -9,24 +9,33 @@ namespace Microsoft.Docs.Build
 {
     public static class NewTest
     {
-        public static TheoryData<string> TemplateTypes { get; } = new TheoryData<string>();
+        public static TheoryData<string> TemplateNames { get; } = new TheoryData<string>();
 
         static NewTest()
         {
-            foreach (var templateType in Directory.GetDirectories(Path.Combine(AppContext.BaseDirectory, "data", "new")))
+            var basePath = Path.Combine(AppContext.BaseDirectory, "data", "new");
+            foreach (var path in Directory.GetDirectories(basePath))
             {
-                TemplateTypes.Add(templateType);
+                TemplateNames.Add(Path.GetRelativePath(basePath, path));
             }
         }
 
         [Theory]
-        [MemberData(nameof(TemplateTypes))]
-        public static void Create_Build_Docset(string type)
+        [MemberData(nameof(TemplateNames))]
+        public static void Create_Build_Docset(string templateName)
         {
             var path = Path.Combine("new-test", Guid.NewGuid().ToString("N"));
 
-            Assert.Equal(0, Docfx.Run(new[] { "new", type, "-o", path }));
+            Assert.Equal(0, Docfx.Run(new[] { "new", templateName, "-o", path }));
             Assert.Equal(0, Docfx.Run(new[] { "build", path }));
+        }
+
+        [Fact]
+        public static void Create_Build_Invalid_Docset()
+        {
+            var path = Path.Combine("new-test", Guid.NewGuid().ToString("N"));
+
+            Assert.Equal(1, Docfx.Run(new[] { "new", "C:/Users", "-o", path }));
         }
     }
 }

--- a/test/docfx.Test/lsp/LanguageServerTestClient.cs
+++ b/test/docfx.Test/lsp/LanguageServerTestClient.cs
@@ -175,7 +175,8 @@ namespace Microsoft.Docs.Build
                     OnNotification();
                 }));
 
-            Task.Run(() => LanguageServerHost.RunLanguageServer(workingDirectory, new(), clientPipe.Reader, serverPipe.Writer, package, this)).GetAwaiter();
+            Task.Run(() => LanguageServerHost.RunLanguageServer(
+                new() { WorkingDirectory = workingDirectory }, clientPipe.Reader, serverPipe.Writer, package, this)).GetAwaiter();
 
             await client.Initialize(default);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/docfx/issues/6924

Fix `docfx new` failure cased by misusing `WorkingDirectory` as template name, the `WorkingDirectory` value was changed to a full path.
- Added a new test to assert docfx new with a bad name returns exit code 1
- Restrict template name to letters, digits or `-`.
- Moves `WorkingDirectory` to `CommandLineOptions` class

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6930)