### PR TITLE
Ensure process standard output is consumed when stdout is false

### DIFF
--- a/src/docfx/lib/process/ProcessUtility.cs
+++ b/src/docfx/lib/process/ProcessUtility.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Buffers;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -20,7 +20,6 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Start a new process and wait for its execution to complete
         /// </summary>
-        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "MemoryStream properly disposed")]
         public static string Execute(string fileName, string commandLineArgs, string? cwd = null, bool stdout = true, string[]? secrets = null)
         {
             var sanitizedCommandLineArgs = secrets != null ? secrets.Aggregate(commandLineArgs, HideSecrets) : commandLineArgs;
@@ -39,18 +38,19 @@ namespace Microsoft.Docs.Build
 
                 using var process = Process.Start(psi) ?? throw new InvalidOperationException($"Failed to start {fileName}");
 
-                using var errorStream = new MemoryStream();
-                var readError = Task.Run(() => PipeStream(process.StandardError.BaseStream, Console.Out, errorStream));
-                var result = stdout ? process.StandardOutput.ReadToEnd() : "";
+                var error = new StringBuilder();
+                var result = new StringBuilder();
 
-                Task.WhenAll(process.WaitForExitAsync(), readError).GetAwaiter().GetResult();
+                var pipeError = Task.Run(() => PipeStream(process.StandardError, Console.Out, new StringWriter(error)));
+                var pipeOutput = stdout
+                    ? Task.Run(() => PipeStream(process.StandardOutput, new StringWriter(result)))
+                    : Task.Run(() => PipeStream(process.StandardOutput, Console.Out));
+
+                Task.WhenAll(process.WaitForExitAsync(), pipeError, pipeOutput).GetAwaiter().GetResult();
 
                 if (process.ExitCode != 0)
                 {
-                    errorStream.Seek(0, SeekOrigin.Begin);
-
-                    using var errorReader = new StreamReader(errorStream);
-                    var errorData = errorReader.ReadToEnd();
+                    var errorData = error.ToString();
                     var sanitizedErrorData = secrets != null ? secrets.Aggregate(errorData, HideSecrets) : errorData;
 
                     throw new InvalidOperationException(
@@ -58,7 +58,7 @@ namespace Microsoft.Docs.Build
                         $"\nSTDOUT:'{result}': \nSTDERR:'{sanitizedErrorData}'");
                 }
 
-                return result;
+                return result.ToString();
             }
 
             static string HideSecrets(string arg, string secret)
@@ -66,21 +66,17 @@ namespace Microsoft.Docs.Build
                 return arg.Replace(secret, secret.Length > 10 ? secret[0..3] + "***" + secret[^3..] : "***");
             }
 
-            static void PipeStream(Stream input, TextWriter consoleOutput, Stream output)
+            static void PipeStream(TextReader input, TextWriter output1, TextWriter? output2 = null)
             {
-                var buffer = new byte[1024];
+                var buffer = ArrayPool<char>.Shared.Rent(1024);
 
-                while (true)
+                while (input.Read(buffer, 0, buffer.Length) is var length && length > 0)
                 {
-                    var bytesRead = input.Read(buffer, 0, buffer.Length);
-                    if (bytesRead <= 0)
-                    {
-                        break;
-                    }
-
-                    consoleOutput.Write(Encoding.UTF8.GetString(buffer, 0, bytesRead));
-                    output.Write(buffer, 0, bytesRead);
+                    output1.Write(buffer, 0, length);
+                    output2?.Write(buffer, 0, length);
                 }
+
+                ArrayPool<char>.Shared.Return(buffer);
             }
         }
 


### PR DESCRIPTION
Fix 2 problems introduced in #6936 

1. `Encoding.UTF8.GetString` could potentially throw or give incorrect result when a character is 2 bytes (non-ASCII chars like Chinese) but the `input.Read` method reads the first byte to the end of the buffer. Replace it with `TextReader.Read`
2. When `stdout` is false, the standard output of launched process is redirected but never consumed, this could cause the process to hang when the redirected buffer is full.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6940)