### PR TITLE
Remove _internalXrefMapValidated flag

### DIFF
--- a/docs/designs/xref.md
+++ b/docs/designs/xref.md
@@ -22,7 +22,7 @@ Besides using file path to link to another file, DocFX also allows you to give a
   ```
   > **_Notice_**: Only title will be considered as xref property for `uid` definition in `.md` files
 - Define multiple UID with same value internally with different versions and reference to this UID without versioning within the current repository. 
-    - The user should define multiple UID of the same value with the same `title` for conceptual repository. Otherwise, a `xref-property-conflict` warning will be logged and the first UID order by the declaring file will be picked
+    - The user should define multiple UID of the same value with the same `title` for conceptual repository. Otherwise, the first UID order by the declaring file will be picked
         ```yaml
         # v1: 1.0, 2.0, 3.0
         # v2: 4.0, 5.0
@@ -42,8 +42,6 @@ Besides using file path to link to another file, DocFX also allows you to give a
         outputs:
             docs/b.json: |
                 {"conceptual":"<p>Link to <a href=\"a\">Title from v1</a></p>\n"}
-            .errors.log: |
-                ["warning","xref-property-conflict","UID 'a' is defined with different names: 'netcore-1.1', 'netcore-2.0'"]
         ```
     - Define multiple UID with same value internally with overlapping versions, we should throw `moniker-overlapping` warning. And the first UID order by the declaring file will be picked.
         ```yaml

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -638,11 +638,10 @@ inputs:
       ]
     }
 outputs:
-  docs/c.json:
+  docs/c.json: |
+    { "conceptual": "<p>Link to <a href=\"a\">netcore-2.0</a></p>" }
   218c13d0/docs/a.json:
   4667fedf/docs/a.json:
-  .errors.log: |
-    {"message_severity":"info","code":"xref-property-conflict","message":"UID 'a' is defined with different names: 'netcore-1.1', 'netcore-2.0'."}
 ---
 # Define same uid with multiple moniker ranges with same name, 
 # reference to it without moniker in the same docset, anyone can be taken
@@ -736,7 +735,6 @@ outputs:
     {"conceptual":"<p>Link to <a href=\"a\" data-linktype=\"relative-path\">netcore-2.0, netcore-2.1</a></p>"}
   .errors.log: |
     {"message_severity":"error","code":"moniker-overlapping","message":"Two or more documents with the same uid `a`('docs/v1/a.md', 'docs/v2/a.md') have defined overlapping moniker: 'netcore-2.0'."}
-    {"message_severity":"info","code":"xref-property-conflict","message":"UID 'a' is defined with different names: 'netcore-1.1, netcore-2.0', 'netcore-2.0, netcore-2.1'."}
     {"message_severity":"warning","code":"publish-url-conflict","message":"Two or more files of the same version('netcore-2.0') publish to the same url '/docs/a': 'docs/v1/a.md<'netcore-1.1', 'netcore-2.0'>', 'docs/v2/a.md<'netcore-2.0', 'netcore-2.1'>'."}
   .xrefmap.json: | 
     {"references":[{"uid":"a","name":"netcore-2.0, netcore-2.1"}]}
@@ -916,8 +914,6 @@ outputs:
     }
   .xrefmap.json: | 
     {"references":[{"uid":"a","name":"b with no version"}]}
-  .errors.log: |
-    {"message_severity":"info","code":"xref-property-conflict","message":"UID 'a' is defined with different names: 'b with no version', 'netcore-1.1', 'netcore-2.0'."}
 ---
 # Build toc with monikers info
 inputs:

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -1581,9 +1581,13 @@ outputs:
   136a42ac/docs/a.json:
   136a42ac/docs/b.json:
   4667fedf/docs/a.json:
-  .errors.log: |
-    {"message_severity":"info","code":"xref-property-conflict","message":"UID 'a' is defined with different names: 'name 1', 'name 2'."}
-    {"message_severity":"info","code":"xref-property-conflict","message":"UID 'a' is defined with different descriptions: '<p>test 1</p>\n', '<p>test 2 <a href=\"b.json\">name b</a></p>\n'."}
+  .xrefmap.json: |
+    {
+      "references": [
+        { "uid": "a", "name": "name 2", "description": "<p>test 2 <a href=\"b.json\">name b</a></p>" },
+        { "uid": "b", "name": "name b" }
+      ]
+    }
 ---
 # referencing multiple version, using uid with intersection for toc & SDP
 inputs:
@@ -1654,8 +1658,6 @@ outputs:
   4667fedf/docs/a.json:
   4667fedf/docs/toc.json: |
     {"items":[{"name":"node","href":"a.json","uid":"a","monikers":["netcore-2.0"]}]}
-  .errors.log: |
-    {"message_severity":"info","code":"xref-property-conflict","message":"UID 'a' is defined with different names: 'name 1.0', 'name 2.0'."}
 ---
 # can cross version referencing single-version uid
 inputs:
@@ -1752,8 +1754,6 @@ outputs:
   439a76d0/v3/b.raw.page.json: |
     {"content": "<a href=\"../v2/a.json\" data-linktype=\"relative-path\"> name 2.0 </a>"}
   439a76d0/v3/b.mta.json:
-  .errors.log: |
-    {"message_severity":"info","code":"xref-property-conflict","message":"UID 'a' is defined with different names: 'name 1.0', 'name 2.0'."}
 ---
 # When href doesn't exist, should display the alt but not the text.
 inputs:

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -441,15 +441,6 @@ namespace Microsoft.Docs.Build
             /// Behavior: ✔️ Message: ✔️
             public static Error DuplicateUidGlobal(SourceInfo<string> uid, string? repositoryUrl, string? propertyPath)
                 => new Error(ErrorLevel.Warning, "duplicate-uid-global", $"UID '{uid}' is duplicated globally in repository '{repositoryUrl}'.", uid, propertyPath);
-
-            /// <summary>
-            /// Same uid defined within different versions with different values of the same xref property.
-            /// Examples:
-            ///   - Same uid defined in multiple .md files with different versions have different titles.
-            /// </summary>
-            /// Behavior: ✔️ Message: ❌
-            public static Error XrefPropertyConflict(string uid, string propertyName, IEnumerable<string?> conflicts)
-                => new Error(ErrorLevel.Info, "xref-property-conflict", $"UID '{uid}' is defined with different {propertyName}s: {StringUtility.Join(conflicts)}.");
         }
 
         public static class Versioning

--- a/src/docfx/build/xref/InternalXrefMapBuilder.cs
+++ b/src/docfx/build/xref/InternalXrefMapBuilder.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Docs.Build
         private readonly MetadataProvider _metadataProvider;
         private readonly MonikerProvider _monikerProvider;
         private readonly BuildScope _buildScope;
-        private readonly JsonSchemaTransformer _jsonSchemaTransformer;
+        private readonly Func<JsonSchemaTransformer> _jsonSchemaTransformer;
 
         public InternalXrefMapBuilder(
             Config config,
@@ -26,7 +26,7 @@ namespace Microsoft.Docs.Build
             MetadataProvider metadataProvider,
             MonikerProvider monikerProvider,
             BuildScope buildScope,
-            JsonSchemaTransformer jsonSchemaTransformer)
+            Func<JsonSchemaTransformer> jsonSchemaTransformer)
         {
             _config = config;
             _errors = errors;
@@ -74,7 +74,7 @@ namespace Microsoft.Docs.Build
 
                 case FileFormat.Yaml:
                 case FileFormat.Json:
-                    var specs = _jsonSchemaTransformer.LoadXrefSpecs(errors, file);
+                    var specs = _jsonSchemaTransformer().LoadXrefSpecs(errors, file);
                     xrefs.AddRange(specs);
                     break;
             }

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
-using System.Threading;
 using System.Web;
 
 namespace Microsoft.Docs.Build
@@ -19,12 +18,11 @@ namespace Microsoft.Docs.Build
         private readonly FileLinkMapBuilder _fileLinkMapBuilder;
         private readonly Repository? _repository;
         private readonly string _xrefHostName;
+        private readonly InternalXrefMapBuilder _internalXrefMapBuilder;
         private readonly Func<JsonSchemaTransformer> _jsonSchemaTransformer;
 
         private readonly Lazy<ExternalXrefMap> _externalXrefMap;
         private readonly Lazy<IReadOnlyDictionary<string, InternalXrefSpec[]>> _internalXrefMap;
-
-        private int _internalXrefMapValidated;
 
         public XrefResolver(
             Config config,
@@ -47,10 +45,10 @@ namespace Microsoft.Docs.Build
             _dependencyMapBuilder = dependencyMapBuilder;
             _fileLinkMapBuilder = fileLinkMapBuilder;
             _xrefHostName = string.IsNullOrEmpty(config.XrefHostName) ? config.HostName : config.XrefHostName;
+            _internalXrefMapBuilder = new(config, errorLog, documentProvider, metadataProvider, monikerProvider, buildScope, jsonSchemaTransformer);
 
-            _internalXrefMap = new(() => new InternalXrefMapBuilder(
-                config, errorLog, documentProvider, metadataProvider, monikerProvider, buildScope, jsonSchemaTransformer()).Build());
             _externalXrefMap = new(() => ExternalXrefMapLoader.Load(config, fileResolver, errorLog));
+            _internalXrefMap = new(BuildInternalXrefMap);
         }
 
         public (Error? error, string? href, string display, FilePath? declaringFile) ResolveXrefByHref(
@@ -142,7 +140,7 @@ namespace Microsoft.Docs.Build
 
             if (!isLocalizedBuild)
             {
-                references = EnsureInternalXrefMap().Values
+                references = _internalXrefMap.Value.Values
                     .Select(xrefs =>
                     {
                         var xref = xrefs.First();
@@ -183,35 +181,17 @@ namespace Microsoft.Docs.Build
             return model;
         }
 
-        private void ValidateInternalXrefProperties()
+        private IReadOnlyDictionary<string, InternalXrefSpec[]> BuildInternalXrefMap()
         {
-            foreach (var xrefs in _internalXrefMap.Value.Values)
-            {
-                if (xrefs.Length == 1)
-                {
-                    continue;
-                }
-
-                var uid = xrefs.First().Uid;
-
-                // validate xref properties
-                // uid conflicts with different values of the same xref property
-                // log an warning and take the first one order by the declaring file
-                var xrefProperties = xrefs.SelectMany(x => x.XrefProperties.Keys).Distinct();
-                foreach (var xrefProperty in xrefProperties)
-                {
-                    var conflictingNames = xrefs.Select(x => x.GetXrefPropertyValueAsString(xrefProperty)).Distinct();
-                    if (conflictingNames.Count() > 1)
-                    {
-                        _errorLog.Add(Errors.Xref.XrefPropertyConflict(uid, xrefProperty, conflictingNames));
-                    }
-                }
-            }
+            var result = _internalXrefMapBuilder.Build();
+            ValidateUidGlobalUnique(result);
+            ValidateExternalXref(result);
+            return result;
         }
 
-        private void ValidateUidGlobalUnique()
+        private void ValidateUidGlobalUnique(IReadOnlyDictionary<string, InternalXrefSpec[]> internalXrefMap)
         {
-            var globalXrefSpecs = _internalXrefMap.Value.Values.Where(xrefs => xrefs.Any(xref => xref.UidGlobalUnique)).Select(xrefs => xrefs.First());
+            var globalXrefSpecs = internalXrefMap.Values.Where(xrefs => xrefs.Any(xref => xref.UidGlobalUnique)).Select(xrefs => xrefs.First());
 
             foreach (var xrefSpec in globalXrefSpecs)
             {
@@ -224,7 +204,7 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private void ValidateExternalXref()
+        private void ValidateExternalXref(IReadOnlyDictionary<string, InternalXrefSpec[]> internalXrefMap)
         {
             var localXrefGroups = _externalXrefMap.Value.GetExternalXrefs()
                 .Where(xref => string.Equals(xref.DocsetName, _config.Name, StringComparison.OrdinalIgnoreCase))
@@ -232,7 +212,7 @@ namespace Microsoft.Docs.Build
 
             foreach (var xrefGroup in localXrefGroups)
             {
-                if (!_internalXrefMap.Value.ContainsKey(xrefGroup.Key))
+                if (!internalXrefMap.ContainsKey(xrefGroup.Key))
                 {
                     _errorLog.Add(Errors.Xref.UidNotFound(
                         xrefGroup.Key, xrefGroup.Select(xref => xref.ReferencedRepositoryUrl).Distinct(), xrefGroup.First().SchemaType) with
@@ -285,22 +265,10 @@ namespace Microsoft.Docs.Build
             return default;
         }
 
-        private IReadOnlyDictionary<string, InternalXrefSpec[]> EnsureInternalXrefMap()
-        {
-            if (Interlocked.Exchange(ref _internalXrefMapValidated, 1) == 0)
-            {
-                ValidateInternalXrefProperties();
-                ValidateUidGlobalUnique();
-                ValidateExternalXref();
-            }
-
-            return _internalXrefMap.Value;
-        }
-
         private (IXrefSpec?, string? href) ResolveInternalXrefSpec(
             string uid, FilePath referencingFile, FilePath inclusionRoot, MonikerList? monikers)
         {
-            if (EnsureInternalXrefMap().TryGetValue(uid, out var specs))
+            if (_internalXrefMap.Value.TryGetValue(uid, out var specs))
             {
                 var spec = specs.Length == 1 || !monikers.HasValue || !monikers.Value.HasMonikers
                     ? specs[0]
@@ -313,6 +281,7 @@ namespace Microsoft.Docs.Build
                 var href = TemplateEngine.OutputAbsoluteUrl(_documentProvider.GetMime(inclusionRoot))
                     ? spec.Href
                     : UrlUtility.GetRelativeUrl(_documentProvider.GetSiteUrl(inclusionRoot), spec.Href);
+
                 return (spec, href);
             }
             return default;


### PR DESCRIPTION
Now that `xref-property-conflict` is turned off by #6601, we could remove the detection and get rid of the`_internalXrefMapValidated` state.

[AB#349017](https://dev.azure.com/ceapex/Engineering/_workitems/edit/349017/)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6942)