### PR TITLE
Limit the markdown !include syntax to only support .md extension

### DIFF
--- a/docs/specs/resolve.yml
+++ b/docs/specs/resolve.yml
@@ -272,12 +272,14 @@ inputs:
   docs/a.md: |
     [!include[B](../media/b.png)]
     Link to [!include[C](../c.ps1)]
+    Empty inclusion [!include[D]()]
   media/b.png: Token
   c.ps1: Token
 outputs:
   .errors.log: |
-    {"message_severity":"warning","code":"include-not-support","message":"Invalid include link extension: '../media/b.png'.","file":"docs/a.md","line":1,"column":1}
-    {"message_severity":"warning","code":"include-not-support","message":"Invalid include link extension: '../c.ps1'.","file":"docs/a.md","line":2,"column":9}
+    {"message_severity":"warning","code":"include-invalid","message":"Invalid include link extension: '../media/b.png'.","file":"docs/a.md","line":1,"column":1}
+    {"message_severity":"warning","code":"include-invalid","message":"Invalid include link extension: '../c.ps1'.","file":"docs/a.md","line":2,"column":9}
+    {"message_severity":"warning","code":"include-invalid","message":"Invalid include link extension: ''.","file":"docs/a.md","line":3,"column":17}
 ---
 # Show warning if redirection file conflicts with existing file
 inputs:

--- a/docs/specs/resolve.yml
+++ b/docs/specs/resolve.yml
@@ -272,14 +272,12 @@ inputs:
   docs/a.md: |
     [!include[B](../media/b.png)]
     Link to [!include[C](../c.ps1)]
-    Empty inclusion [!include[D]()]
   media/b.png: Token
   c.ps1: Token
 outputs:
   .errors.log: |
     {"message_severity":"warning","code":"include-invalid","message":"Invalid include link extension: '../media/b.png'.","file":"docs/a.md","line":1,"column":1}
     {"message_severity":"warning","code":"include-invalid","message":"Invalid include link extension: '../c.ps1'.","file":"docs/a.md","line":2,"column":9}
-    {"message_severity":"warning","code":"include-invalid","message":"Invalid include link extension: ''.","file":"docs/a.md","line":3,"column":17}
 ---
 # Show warning if redirection file conflicts with existing file
 inputs:

--- a/docs/specs/resolve.yml
+++ b/docs/specs/resolve.yml
@@ -265,6 +265,20 @@ outputs:
   .errors.log: |
     {"message_severity":"error","code":"include-not-found","message":"Invalid include link: 'redirect.md'.","file":"docs/a.md","line":1,"column":9}
 ---
+# Show warning if inclusion is using links not `.md` extension
+dryRunOnly: true
+inputs:
+  docfx.yml:
+  docs/a.md: |
+    [!include[B](../media/b.png)]
+    Link to [!include[C](../c.ps1)]
+  media/b.png: Token
+  c.ps1: Token
+outputs:
+  .errors.log: |
+    {"message_severity":"warning","code":"include-not-support","message":"Invalid include link extension: '../media/b.png'.","file":"docs/a.md","line":1,"column":1}
+    {"message_severity":"warning","code":"include-not-support","message":"Invalid include link extension: '../c.ps1'.","file":"docs/a.md","line":2,"column":9}
+---
 # Show warning if redirection file conflicts with existing file
 inputs:
   docfx.yml:
@@ -467,19 +481,6 @@ inputs:
 outputs:
   .errors.log: |
     {"message_severity":"error","code":"include-not-found","message":"Invalid include link: '~/b.md'.","file":"docs/a.md","line":1,"column":1}
----
-# Markdown inclusion using links not `.md` extension
-inputs:
-  docfx.yml:
-  docs/a.md: |
-    [!include[B1](../media/b.png)]
-    Link to [!include[B2](../c.ps1)]
-  media/b.png: Token
-  c.ps1: Token
-outputs:
-  .errors.log: |
-    {"message_severity":"warning","code":"include-not-support","message":"Invalid include link extension: '../media/b.png'.","file":"docs/a.md","line":1,"column":1}
-    {"message_severity":"warning","code":"include-not-support","message":"Invalid include link extension: '../c.ps1'.","file":"docs/a.md","line":2,"column":9}
 ---
 # Links to self with empty href or query string only
 inputs:

--- a/docs/specs/resolve.yml
+++ b/docs/specs/resolve.yml
@@ -468,6 +468,19 @@ outputs:
   .errors.log: |
     {"message_severity":"error","code":"include-not-found","message":"Invalid include link: '~/b.md'.","file":"docs/a.md","line":1,"column":1}
 ---
+# Markdown inclusion using links not `.md` extension
+inputs:
+  docfx.yml:
+  docs/a.md: |
+    [!include[B1](../media/b.png)]
+    Link to [!include[B2](../c.ps1)]
+  media/b.png: Token
+  c.ps1: Token
+outputs:
+  .errors.log: |
+    {"message_severity":"warning","code":"include-not-support","message":"Invalid include link extension: '../media/b.png'.","file":"docs/a.md","line":1,"column":1}
+    {"message_severity":"warning","code":"include-not-support","message":"Invalid include link extension: '../c.ps1'.","file":"docs/a.md","line":2,"column":9}
+---
 # Links to self with empty href or query string only
 inputs:
   docfx.yml:

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionBlock/HtmlInclusionBlockRenderer.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionBlock/HtmlInclusionBlockRenderer.cs
@@ -22,18 +22,18 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
         protected override void Write(HtmlRenderer renderer, InclusionBlock inclusion)
         {
+            if (!inclusion.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            {
+                _context.LogWarning("include-invalid", $"Invalid include link extension: '{inclusion.IncludedFilePath}'.", inclusion);
+                renderer.Write(inclusion.GetRawToken());
+                return;
+            }
+
             var (content, includeFilePath) = _context.ReadFile(inclusion.IncludedFilePath, inclusion);
 
             if (content == null)
             {
                 _context.LogWarning("include-not-found", $"Invalid include link: '{inclusion.IncludedFilePath}'.", inclusion);
-                renderer.Write(inclusion.GetRawToken());
-                return;
-            }
-
-            if (!inclusion.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
-            {
-                _context.LogWarning("include-not-support", $"Invalid include link extension: '{inclusion.IncludedFilePath}'.", inclusion);
                 renderer.Write(inclusion.GetRawToken());
                 return;
             }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionBlock/HtmlInclusionBlockRenderer.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionBlock/HtmlInclusionBlockRenderer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
         protected override void Write(HtmlRenderer renderer, InclusionBlock inclusion)
         {
-            if (!inclusion.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            if (!string.IsNullOrEmpty(inclusion.IncludedFilePath) && !inclusion.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
             {
                 _context.LogWarning("include-invalid", $"Invalid include link extension: '{inclusion.IncludedFilePath}'.", inclusion);
                 renderer.Write(inclusion.GetRawToken());

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionBlock/HtmlInclusionBlockRenderer.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionBlock/HtmlInclusionBlockRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Linq;
 using Markdig;
 using Markdig.Renderers;
@@ -26,6 +27,13 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             if (content == null)
             {
                 _context.LogWarning("include-not-found", $"Invalid include link: '{inclusion.IncludedFilePath}'.", inclusion);
+                renderer.Write(inclusion.GetRawToken());
+                return;
+            }
+
+            if (!inclusion.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            {
+                _context.LogWarning("include-not-support", $"Invalid include link extension: '{inclusion.IncludedFilePath}'.", inclusion);
                 renderer.Write(inclusion.GetRawToken());
                 return;
             }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionInline/HtmlInclusionInlineRenderer.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionInline/HtmlInclusionInlineRenderer.cs
@@ -22,18 +22,18 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
         protected override void Write(HtmlRenderer renderer, InclusionInline inclusion)
         {
+            if (!inclusion.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            {
+                _context.LogWarning("include-invalid", $"Invalid include link extension: '{inclusion.IncludedFilePath}'.", inclusion);
+                renderer.Write(inclusion.GetRawToken());
+                return;
+            }
+
             var (content, includeFilePath) = _context.ReadFile(inclusion.IncludedFilePath, inclusion);
 
             if (content == null)
             {
                 _context.LogWarning("include-not-found", $"Cannot resolve '{inclusion.IncludedFilePath}' relative to '{InclusionContext.File}'.", inclusion);
-                renderer.Write(inclusion.GetRawToken());
-                return;
-            }
-
-            if (!inclusion.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
-            {
-                _context.LogWarning("include-not-support", $"Invalid include link extension: '{inclusion.IncludedFilePath}'.", inclusion);
                 renderer.Write(inclusion.GetRawToken());
                 return;
             }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionInline/HtmlInclusionInlineRenderer.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionInline/HtmlInclusionInlineRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Linq;
 using Markdig;
 using Markdig.Renderers;
@@ -26,6 +27,13 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             if (content == null)
             {
                 _context.LogWarning("include-not-found", $"Cannot resolve '{inclusion.IncludedFilePath}' relative to '{InclusionContext.File}'.", inclusion);
+                renderer.Write(inclusion.GetRawToken());
+                return;
+            }
+
+            if (!inclusion.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            {
+                _context.LogWarning("include-not-support", $"Invalid include link extension: '{inclusion.IncludedFilePath}'.", inclusion);
                 renderer.Write(inclusion.GetRawToken());
                 return;
             }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionInline/HtmlInclusionInlineRenderer.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Inclusion/InclusionInline/HtmlInclusionInlineRenderer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
         protected override void Write(HtmlRenderer renderer, InclusionInline inclusion)
         {
-            if (!inclusion.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            if (!string.IsNullOrEmpty(inclusion.IncludedFilePath) && !inclusion.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
             {
                 _context.LogWarning("include-invalid", $"Invalid include link extension: '{inclusion.IncludedFilePath}'.", inclusion);
                 renderer.Write(inclusion.GetRawToken());

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -503,11 +503,11 @@ namespace Microsoft.Docs.Build
 
         public static class Markdown
         {
+            public static Error IncludeInvalid(SourceInfo<string?> source)
+                => new Error(ErrorLevel.Warning, "include-invalid", $"Invalid include link extension: '{source}'.", source);
+
             public static Error IncludeNotFound(SourceInfo<string?> source)
                 => new Error(ErrorLevel.Error, "include-not-found", $"Invalid include link: '{source}'.", source);
-
-            public static Error IncludeNotSupport(SourceInfo<string?> source)
-                => new Error(ErrorLevel.Warning, "include-not-support", $"Invalid include link extension: '{source}'.", source);
         }
 
         public static class JsonSchema

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -505,6 +505,9 @@ namespace Microsoft.Docs.Build
         {
             public static Error IncludeNotFound(SourceInfo<string?> source)
                 => new Error(ErrorLevel.Error, "include-not-found", $"Invalid include link: '{source}'.", source);
+
+            public static Error IncludeNotSupport(SourceInfo<string?> source)
+                => new Error(ErrorLevel.Warning, "include-not-support", $"Invalid include link extension: '{source}'.", source);
         }
 
         public static class JsonSchema

--- a/src/docfx/lib/markdown/IncludeExtension.cs
+++ b/src/docfx/lib/markdown/IncludeExtension.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Docs.Build
         private static void ExpandInclusionBlock(
             MarkdownContext context, InclusionBlock inclusionBlock, MarkdownPipeline pipeline, MarkdownPipeline inlinePipeline, ErrorBuilder errors)
         {
-            if (!inclusionBlock.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            if (!string.IsNullOrEmpty(inclusionBlock.IncludedFilePath) && !inclusionBlock.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
             {
                 errors.Add(Errors.Markdown.IncludeInvalid(new SourceInfo<string?>(inclusionBlock.IncludedFilePath, inclusionBlock.GetSourceInfo())));
                 return;
@@ -88,7 +88,7 @@ namespace Microsoft.Docs.Build
         private static void ExpandInclusionInline(
             MarkdownContext context, InclusionInline inclusionInline, MarkdownPipeline pipeline, MarkdownPipeline inlinePipeline, ErrorBuilder errors)
         {
-            if (!inclusionInline.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            if (!string.IsNullOrEmpty(inclusionInline.IncludedFilePath) && !inclusionInline.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
             {
                 errors.Add(Errors.Markdown.IncludeInvalid(new SourceInfo<string?>(inclusionInline.IncludedFilePath, inclusionInline.GetSourceInfo())));
                 return;

--- a/src/docfx/lib/markdown/IncludeExtension.cs
+++ b/src/docfx/lib/markdown/IncludeExtension.cs
@@ -65,6 +65,12 @@ namespace Microsoft.Docs.Build
                 return;
             }
 
+            if (!inclusionBlock.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            {
+                errors.Add(Errors.Markdown.IncludeNotSupport(new SourceInfo<string?>(inclusionBlock.IncludedFilePath, inclusionBlock.GetSourceInfo())));
+                return;
+            }
+
             if (InclusionContext.IsCircularReference(file, out var dependencyChain))
             {
                 throw Errors.Link.CircularReference((SourceInfo)file, file, dependencyChain.Reverse()).ToException();
@@ -86,6 +92,12 @@ namespace Microsoft.Docs.Build
             if (content is null)
             {
                 errors.Add(Errors.Markdown.IncludeNotFound(new SourceInfo<string?>(inclusionInline.IncludedFilePath, inclusionInline.GetSourceInfo())));
+                return;
+            }
+
+            if (!inclusionInline.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            {
+                errors.Add(Errors.Markdown.IncludeNotSupport(new SourceInfo<string?>(inclusionInline.IncludedFilePath, inclusionInline.GetSourceInfo())));
                 return;
             }
 

--- a/src/docfx/lib/markdown/IncludeExtension.cs
+++ b/src/docfx/lib/markdown/IncludeExtension.cs
@@ -58,7 +58,8 @@ namespace Microsoft.Docs.Build
         private static void ExpandInclusionBlock(
             MarkdownContext context, InclusionBlock inclusionBlock, MarkdownPipeline pipeline, MarkdownPipeline inlinePipeline, ErrorBuilder errors)
         {
-            if (!string.IsNullOrEmpty(inclusionBlock.IncludedFilePath) && !inclusionBlock.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            if (!string.IsNullOrEmpty(inclusionBlock.IncludedFilePath)
+                && !inclusionBlock.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
             {
                 errors.Add(Errors.Markdown.IncludeInvalid(new SourceInfo<string?>(inclusionBlock.IncludedFilePath, inclusionBlock.GetSourceInfo())));
                 return;
@@ -88,7 +89,8 @@ namespace Microsoft.Docs.Build
         private static void ExpandInclusionInline(
             MarkdownContext context, InclusionInline inclusionInline, MarkdownPipeline pipeline, MarkdownPipeline inlinePipeline, ErrorBuilder errors)
         {
-            if (!string.IsNullOrEmpty(inclusionInline.IncludedFilePath) && !inclusionInline.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            if (!string.IsNullOrEmpty(inclusionInline.IncludedFilePath)
+                && !inclusionInline.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
             {
                 errors.Add(Errors.Markdown.IncludeInvalid(new SourceInfo<string?>(inclusionInline.IncludedFilePath, inclusionInline.GetSourceInfo())));
                 return;

--- a/src/docfx/lib/markdown/IncludeExtension.cs
+++ b/src/docfx/lib/markdown/IncludeExtension.cs
@@ -58,16 +58,16 @@ namespace Microsoft.Docs.Build
         private static void ExpandInclusionBlock(
             MarkdownContext context, InclusionBlock inclusionBlock, MarkdownPipeline pipeline, MarkdownPipeline inlinePipeline, ErrorBuilder errors)
         {
+            if (!inclusionBlock.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            {
+                errors.Add(Errors.Markdown.IncludeInvalid(new SourceInfo<string?>(inclusionBlock.IncludedFilePath, inclusionBlock.GetSourceInfo())));
+                return;
+            }
+
             var (content, file) = context.ReadFile(inclusionBlock.IncludedFilePath, inclusionBlock);
             if (content is null || file is null)
             {
                 errors.Add(Errors.Markdown.IncludeNotFound(new SourceInfo<string?>(inclusionBlock.IncludedFilePath, inclusionBlock.GetSourceInfo())));
-                return;
-            }
-
-            if (!inclusionBlock.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
-            {
-                errors.Add(Errors.Markdown.IncludeNotSupport(new SourceInfo<string?>(inclusionBlock.IncludedFilePath, inclusionBlock.GetSourceInfo())));
                 return;
             }
 
@@ -88,16 +88,16 @@ namespace Microsoft.Docs.Build
         private static void ExpandInclusionInline(
             MarkdownContext context, InclusionInline inclusionInline, MarkdownPipeline pipeline, MarkdownPipeline inlinePipeline, ErrorBuilder errors)
         {
+            if (!inclusionInline.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            {
+                errors.Add(Errors.Markdown.IncludeInvalid(new SourceInfo<string?>(inclusionInline.IncludedFilePath, inclusionInline.GetSourceInfo())));
+                return;
+            }
+
             var (content, file) = context.ReadFile(inclusionInline.IncludedFilePath, inclusionInline);
             if (content is null)
             {
                 errors.Add(Errors.Markdown.IncludeNotFound(new SourceInfo<string?>(inclusionInline.IncludedFilePath, inclusionInline.GetSourceInfo())));
-                return;
-            }
-
-            if (!inclusionInline.IncludedFilePath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
-            {
-                errors.Add(Errors.Markdown.IncludeNotSupport(new SourceInfo<string?>(inclusionInline.IncludedFilePath, inclusionInline.GetSourceInfo())));
                 return;
             }
 


### PR DESCRIPTION
[AB#336152](https://dev.azure.com/ceapex/Engineering/_workitems/edit/336152)

Limit the markdown !include syntax to only support .md extension, any other file extensions raises a warning.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6954)