### PR TITLE
Add Watch<T> debug view

### DIFF
--- a/src/docfx/lib/watch/WatchDebugView{T}.cs
+++ b/src/docfx/lib/watch/WatchDebugView{T}.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Docs.Build
+{
+    internal class WatchDebugView<T>
+    {
+        private readonly Watch<T> _watch;
+
+        public WatchDebugView(Watch<T> watch) => _watch = watch;
+
+        public T? Value => _watch.ValueForDebugDisplay;
+    }
+}

--- a/src/docfx/lib/watch/Watch{T}.cs
+++ b/src/docfx/lib/watch/Watch{T}.cs
@@ -2,11 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace Microsoft.Docs.Build
 {
+    [DebuggerTypeProxy(typeof(WatchDebugView<>))]
+    [DebuggerDisplay("{ValueForDebugDisplay}")]
     public class Watch<T>
     {
         private readonly Func<T> _valueFactory;
@@ -60,6 +63,8 @@ namespace Microsoft.Docs.Build
                 }
             }
         }
+
+        internal T? ValueForDebugDisplay => _value;
 
         private bool TryGetValue([NotNullWhen(true)] out T? value)
         {


### PR DESCRIPTION
Otherwise visual studio debugger freezes because it tried to call `.Value` that internally does the heavy lifting of checking if things changed and re-evaluate the value on change.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6961)