### PR TITLE
Disable hierarchy validation on partial build

### DIFF
--- a/src/docfx/build/DocsetBuilder.cs
+++ b/src/docfx/build/DocsetBuilder.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Docs.Build
                     () => _repositoryProvider.Save(),
                     () => _errors.AddRange(_githubAccessor.Save()),
                     () => _errors.AddRange(_microsoftGraphAccessor.Save()),
-                    () => _jsonSchemaTransformer.PostValidate(),
+                    () => _jsonSchemaTransformer.PostValidate(files != null),
                     () => learnHierarchyBuilder.ValidateHierarchy());
 
                 if (_config.DryRun)

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -52,8 +52,13 @@ namespace Microsoft.Docs.Build
             _input = input;
         }
 
-        public void PostValidate()
+        public void PostValidate(bool isPartialBuild)
         {
+            if (isPartialBuild)
+            {
+                return;
+            }
+
             foreach (var (uid, propertyPath, schema, minReferenceCount, maxReferenceCount) in _uidReferenceCountList.Value)
             {
                 var references = _xrefList.Value.Where(item => item.xref == uid).Select(item => item.xref.Source).ToArray();


### PR DESCRIPTION
Learn hierarchy validation requires full hierarchy which we don't currently have for single file validation.

![image](https://user-images.githubusercontent.com/511355/103605693-8b1ee300-4f4f-11eb-9b51-2a556318bcda.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6965)