### PR TITLE
Fix a Watch<T> multi-threading bug

### DIFF
--- a/src/docfx/lib/watch/WatchFunction.cs
+++ b/src/docfx/lib/watch/WatchFunction.cs
@@ -46,8 +46,9 @@ namespace Microsoft.Docs.Build
                     return _hasChanged;
                 }
 
+                _hasChanged = HasChangedCore();
                 _hasChangedScope = scope;
-                return _hasChanged = HasChangedCore();
+                return _hasChanged;
             }
         }
 


### PR DESCRIPTION
Fix the flaky test failure: https://github.com/dotnet/docfx/pull/6967/checks?check_run_id=1654622596 and also the problem I found when testing the extension.

![image](https://user-images.githubusercontent.com/511355/103738969-d7415480-502f-11eb-9356-b84f1a11f72e.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6968)