### PR TITLE
Workaround git.exe hang by forcing shell execute in language server mode

### DIFF
--- a/.github/actions/spell-check/dictionary/custom-dictionary.txt
+++ b/.github/actions/spell-check/dictionary/custom-dictionary.txt
@@ -571,3 +571,4 @@ vsthrd
 IAsync
 IDid
 IProducer
+msys

--- a/src/docfx/serve/Serve.cs
+++ b/src/docfx/serve/Serve.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Docs.Build
                 return true;
             }
 
+            GitUtility.ForceShellExecute = true;
+
             LanguageServerHost.RunLanguageServer(options, package).GetAwaiter().GetResult();
             return false;
         }


### PR DESCRIPTION
Related git issue: https://github.com/git-for-windows/git/issues/2376

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6975)