### PR TITLE
Add strict-inline and note about SDP

### DIFF
--- a/docs/designs/sanitize-html.md
+++ b/docs/designs/sanitize-html.md
@@ -14,6 +14,7 @@ Content authors can embed arbitrary HTML tags to markdown documents. These HTML 
 - Apply HTML sanitization consistently for all user content
 - Report warnings for removing disallowed HTML tags and attributes
 - Sanitize URL, it is tracked by 
+- Enable referencing sanitization modes from YAML schemas
 
 ### Out of scope
 
@@ -26,10 +27,11 @@ The sanitization is performed against user HTML, that is in most cases HTML tags
 
 ### Sanitization Modes
 
-There are 3 sanitization modes:
+There are 4 sanitization modes:
 
 - `standard` (*default*): Described below
 - `strict`: Disallow html
+- `strict-inline`: Based on strict, permitting only phrasing content. Block elements such as `blockquote`, `ul`, and `p` are not permitted.
 - `loose`: This is based on the `standard` mode, with a few more allowed HTML attributes like `class`, `style`. The final list came from the telemetry of the old hub/landing pages and archived contents.
 
 Sanitization mode is automatically set to `loose` for old hub pages, landing pages and archived contents.


### PR DESCRIPTION
PR for discussion, no need to merge if this is covered elsewhere.

In the marketing schema and stay current we've encountered the need to limit markdown to inline elements.

Also looking for the plan for how we'll reference the modes from SDP schemas. We have `contentType: markdown`. How do sanitization modes relate? `markdown-{sanitization-mode}`? `sanitizationMode` property?

@herohua @yufeih @wibjorn

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6977)