### PR TITLE
Treat standalone include as block inside a table cell

### DIFF
--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -816,3 +816,27 @@ outputs:
     { "code": "unknown-language-code", "file": "b.md", "line": 2, "column": 1 }
     { "code": "invalid-code", "file": "b.md", "line": 2, "column": 1 }
 ---
+# Treat standalone include as block inside table cell
+inputs:
+  docfx.yml:
+  a.md: |
+    a | b
+    --|--
+    [!INCLUDE[](block.md)] | inline [!INCLUDE[](block.md)]
+  block.md: |
+   - foo
+   - bar
+outputs:
+  a.json: |
+    {
+      "conceptual": "
+        <table>
+          <thead><tr><th>a</th><th>b</th></tr></thead>
+          <tbody><tr>
+            <td><ul><li>foo</li><li>bar</li></ul></td>
+            <td>inline - foo - bar</td>
+          </tr></tbody>
+        </table>"
+    }
+  block.json:
+---


### PR DESCRIPTION
[AB#355957](https://ceapex.visualstudio.com/Engineering/_workitems/edit/355957)

This is to unblock startup. Today there is no way to write list (or any block level elements) inside a table cell. This PR treats standalone include token inside table cell as include block, allowing for list into table cell using the `[!include[]()]` syntax.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/6983)