### PR TITLE
Git enable longpaths upon fetch

### DIFF
--- a/src/docfx/lib/git/GitUtility.cs
+++ b/src/docfx/lib/git/GitUtility.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Docs.Build
 
             var (http, secret) = GetGitCommandLineConfig(url, config);
 
-            ExecuteNonQuery(path, $"{http} fetch --progress {options} \"{url}\" {refspecs}", secret);
+            ExecuteNonQuery(path, $"{http} -c core.longpaths=true fetch --progress {options} \"{url}\" {refspecs}", secret);
         }
 
         /// <summary>


### PR DESCRIPTION
Try to fix `get fetch` failure caused by `file path too long`.

[Failed CI](https://dev.azure.com/ceapex/Engineering/_build/results?buildId=288081&view=logs&j=8ece563f-0a8c-5d87-c885-36e22bfebabf&t=808082cd-37aa-51df-2086-96182d3a7d8e&l=961)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/7020)