### PR TITLE
retire apex link&image validation

### DIFF
--- a/docs/specs/validation/link-validation.yml
+++ b/docs/specs/validation/link-validation.yml
@@ -412,7 +412,6 @@ outputs:
     {"message_severity":"suggestion","code":"redirected-link","message":"Redirected link 'https://go.microsoft.com/fwlink/p/?LinkId=389595' will be broken in isolated environments. Replace with a relative link.","file":"file1.md","line":1,"end_line":1,"column":1,"end_column":1}
     {"message_severity":"suggestion","code":"redirected-link","message":"Redirected link 'https://go.microsoft.com/fwlink/p/?LinkId=666' will be broken in isolated environments. Replace with a relative link.","file":"file1.md","line":2,"end_line":2,"column":10,"end_column":55}
   file1.json:
-
 ---
 # Validate secure link
 inputs:
@@ -446,15 +445,12 @@ inputs:
     <a href="http://docs.microsoft.com/test">inline html link</a>
     [external link](http://www.google.com)
     ![image link](http://technet.com/index-hero.jpg)
-
-
 outputs:
   .errors.log: |
     {"message_severity":"suggestion","code":"insecure-link","message":"Link 'http://docs.microsoft.com/test' is insecure. Links to Microsoft sites must use 'https' instead of 'http'.","file":"file1.md","line":1,"end_line":1,"column":1,"end_column":1}
     {"message_severity":"suggestion","code":"insecure-link","message":"Link 'http://docs.microsoft.com/test' is insecure. Links to Microsoft sites must use 'https' instead of 'http'.","file":"file1.md","line":2,"end_line":2,"column":10,"end_column":40}
     {"message_severity":"suggestion","code":"insecure-link","message":"Link 'http://technet.com/index-hero.jpg' is insecure. Links to Microsoft sites must use 'https' instead of 'http'.","file":"file1.md","line":4,"end_line":4,"column":1,"end_column":1}
   file1.json:
-
 ---
 # Validate html link
 inputs:
@@ -478,13 +474,11 @@ inputs:
     [external link](https://aka.ms/az-learn)
     <a href="http://docs.microsoft.com/test">inline html link</a>
     ![Illustration to use for new users](https://azurecomcdn.azureedge.net/cvt-779fa2985e70b1ef1c34d319b505f7b4417add09948df4c5b81db2a9bad966e5/images/page/services/devops/hero-images/index-hero.jpg)
-
 outputs:
   .errors.log: |
     {"message_severity":"suggestion","code":"html-link","message":"HTML link http://docs.microsoft.com/test is not allowed. Use a Markdown link.","file":"file1.md","line":2,"end_line":2,"column":10,"end_column":40}
 
   file1.json:
-
 ---
 # Validate link locales
 inputs:
@@ -520,7 +514,6 @@ outputs:
     {"message_severity":"suggestion","code":"hard-coded-locale","message":"Link 'http://docs.microsoft.com/tr-tr' contains locale code 'tr-tr'. For localizability, remove 'tr-tr' from links to most Microsoft sites.","file":"file1.md","line":2,"end_line":2,"column":10,"end_column":41}
 
   file1.json:
-
 ---
 # Validate link preview not set
 inputs:
@@ -552,7 +545,6 @@ outputs:
 
   file1.json:
 ---
-
 # Validate link text not set
 inputs:
   docfx.yml: |
@@ -575,16 +567,8 @@ inputs:
     [external link](http://docs.microsoft.com/tr-tr)
     <a href="https://docs.microsoft.com/en-us/sql/t-sql/functions/cast-and-convert-transact-sql?view=sql-server-ver15">inline html link</a>
     [](http://docs.microsoft.com/tr-tr)
-    [](http://docs.microsoft.com/tr-tr "title")
     ![Illustration to use for new users](https://azurecomcdn.azureedge.net/cvt-779fa2985e70b1ef1c34d319b505f7b4417add09948df4c5b81db2a9bad966e5/images/page/services/devops/hero-images/index-hero.jpg)
-
-
-
 outputs:
   .errors.log: |
     {"message_severity":"suggestion","code":"link-text-missing","message":"Missing link text for link 'http://docs.microsoft.com/tr-tr'. Add appropriate text. ","file":"file1.md","line":3,"end_line":3,"column":1,"end_column":1}
-
   file1.json:
----
-
-

--- a/docs/specs/validation/link-validation.yml
+++ b/docs/specs/validation/link-validation.yml
@@ -218,6 +218,8 @@ inputs:
     <img src="pig4.jpg" alt=""></img>
 
     ![`test alt text quote`](pig1.jpg)
+
+    :::image type="icon" source="pig1.jpg" alt-text="":::
 outputs:
   pig1.jpg:
   pig2.jpg:

--- a/docs/specs/validation/link-validation.yml
+++ b/docs/specs/validation/link-validation.yml
@@ -570,6 +570,7 @@ inputs:
     <a href="https://docs.microsoft.com/en-us/sql/t-sql/functions/cast-and-convert-transact-sql?view=sql-server-ver15">inline html link</a>
     [](http://docs.microsoft.com/tr-tr)
     ![Illustration to use for new users](https://azurecomcdn.azureedge.net/cvt-779fa2985e70b1ef1c34d319b505f7b4417add09948df4c5b81db2a9bad966e5/images/page/services/devops/hero-images/index-hero.jpg)
+    [![](https://google.com/media/4-metrics-data.png "Screenshot of Storage Explorer displaying the minute metrics data for blobs")](/media/4-metrics-data.png#lightbox)
 outputs:
   .errors.log: |
     {"message_severity":"suggestion","code":"link-text-missing","message":"Missing link text for link 'http://docs.microsoft.com/tr-tr'. Add appropriate text. ","file":"file1.md","line":3,"end_line":3,"column":1,"end_column":1}

--- a/docs/specs/validation/link-validation.yml
+++ b/docs/specs/validation/link-validation.yml
@@ -412,3 +412,179 @@ outputs:
     {"message_severity":"suggestion","code":"redirected-link","message":"Redirected link 'https://go.microsoft.com/fwlink/p/?LinkId=389595' will be broken in isolated environments. Replace with a relative link.","file":"file1.md","line":1,"end_line":1,"column":1,"end_column":1}
     {"message_severity":"suggestion","code":"redirected-link","message":"Redirected link 'https://go.microsoft.com/fwlink/p/?LinkId=666' will be broken in isolated environments. Replace with a relative link.","file":"file1.md","line":2,"end_line":2,"column":10,"end_column":55}
   file1.json:
+
+---
+# Validate secure link
+inputs:
+  docfx.yml: |
+    markdownValidationRules: rules.json
+  rules.json: |
+    {
+      "links": {
+        "rules": [
+          {
+            "type": "SecureLinks",
+            "message": "Link '{0}' is insecure. Links to Microsoft sites must use 'https' instead of 'http'.",
+            "code": "insecure-link",
+            "severity": "SUGGESTION",
+            "contentTypes": ["conceptual"],
+            "domains": [
+              "microsoft.com",
+              "office.com",
+              "msdn.com",
+              "aka.ms",
+              "visualstudio.com",
+              "azure.com",
+              "technet.com"
+            ]
+          }
+        ]
+      }
+    }
+  file1.md: |
+    [external link](http://docs.microsoft.com/test)
+    <a href="http://docs.microsoft.com/test">inline html link</a>
+    [external link](http://www.google.com)
+    ![image link](http://technet.com/index-hero.jpg)
+
+
+outputs:
+  .errors.log: |
+    {"message_severity":"suggestion","code":"insecure-link","message":"Link 'http://docs.microsoft.com/test' is insecure. Links to Microsoft sites must use 'https' instead of 'http'.","file":"file1.md","line":1,"end_line":1,"column":1,"end_column":1}
+    {"message_severity":"suggestion","code":"insecure-link","message":"Link 'http://docs.microsoft.com/test' is insecure. Links to Microsoft sites must use 'https' instead of 'http'.","file":"file1.md","line":2,"end_line":2,"column":10,"end_column":40}
+    {"message_severity":"suggestion","code":"insecure-link","message":"Link 'http://technet.com/index-hero.jpg' is insecure. Links to Microsoft sites must use 'https' instead of 'http'.","file":"file1.md","line":4,"end_line":4,"column":1,"end_column":1}
+  file1.json:
+
+---
+# Validate html link
+inputs:
+  docfx.yml: |
+    markdownValidationRules: rules.json
+  rules.json: |
+    {
+      "links": {
+        "rules": [
+          {
+            "type": "HtmlLinks",
+            "message": "HTML link {0} is not allowed. Use a Markdown link.",
+            "code": "html-link",
+            "severity": "SUGGESTION",
+            "contentTypes": ["conceptual"]
+          }
+        ]
+      }
+    }
+  file1.md: |
+    [external link](https://aka.ms/az-learn)
+    <a href="http://docs.microsoft.com/test">inline html link</a>
+    ![Illustration to use for new users](https://azurecomcdn.azureedge.net/cvt-779fa2985e70b1ef1c34d319b505f7b4417add09948df4c5b81db2a9bad966e5/images/page/services/devops/hero-images/index-hero.jpg)
+
+outputs:
+  .errors.log: |
+    {"message_severity":"suggestion","code":"html-link","message":"HTML link http://docs.microsoft.com/test is not allowed. Use a Markdown link.","file":"file1.md","line":2,"end_line":2,"column":10,"end_column":40}
+
+  file1.json:
+
+---
+# Validate link locales
+inputs:
+  docfx.yml: |
+    markdownValidationRules: rules.json
+  rules.json: |
+    {
+      "links": {
+        "rules": [
+          {
+            "type": "LocalesInLink",
+            "message": "Link '{0}' contains locale code '{1}'. For localizability, remove '{1}' from links to most Microsoft sites.",
+            "code": "hard-coded-locale",
+            "severity": "SUGGESTION",
+            "contentTypes": ["conceptual"],
+            "domains": [
+              "docs.microsoft.com",
+              "msdn.microsoft.com",
+              "technet.microsoft.com",
+              "partner.microsoft.com"
+            ],
+          }
+        ]
+      }
+    }
+  file1.md: |
+    [external link](http://docs.microsoft.com/tr-tr)
+    <a href="http://docs.microsoft.com/tr-tr">inline html link</a>
+    [external link](http://docs.microsoft.com/nolocale)
+outputs:
+  .errors.log: |
+    {"message_severity":"suggestion","code":"hard-coded-locale","message":"Link 'http://docs.microsoft.com/tr-tr' contains locale code 'tr-tr'. For localizability, remove 'tr-tr' from links to most Microsoft sites.","file":"file1.md","line":1,"end_line":1,"column":1,"end_column":1}
+    {"message_severity":"suggestion","code":"hard-coded-locale","message":"Link 'http://docs.microsoft.com/tr-tr' contains locale code 'tr-tr'. For localizability, remove 'tr-tr' from links to most Microsoft sites.","file":"file1.md","line":2,"end_line":2,"column":10,"end_column":41}
+
+  file1.json:
+
+---
+# Validate link preview not set
+inputs:
+  docfx.yml: |
+    markdownValidationRules: rules.json
+  rules.json: |
+    {
+      "links": {
+        "rules": [
+          {
+            "type": "PreserveViewNotSet",
+            "message": "Did you mean to link to a specific version? If so, add &preserve-view=true to the url: {0}",
+            "code": "preserve-view-not-set",
+            "severity": "SUGGESTION",
+            "contentTypes": ["conceptual"]
+          }
+        ]
+      }
+    }
+  file1.md: |
+    [external link](https://docs.microsoft.com/en-us/sql/t-sql/functions/cast-and-convert-transact-sql?view=sql-server-ver15)
+    <a href="https://docs.microsoft.com/en-us/sql/t-sql/functions/cast-and-convert-transact-sql?view=sql-server-ver15">inline html link</a>
+    [relative link](/en-us/sql/t-sql/functions/cast-and-convert-transact-sql?view=sql-server-ver15)
+outputs:
+  .errors.log: |
+    {"message_severity":"suggestion","code":"preserve-view-not-set","message":"Did you mean to link to a specific version? If so, add &preserve-view=true to the url: https://docs.microsoft.com/en-us/sql/t-sql/functions/cast-and-convert-transact-sql?view=sql-server-ver15","file":"file1.md","line":1,"end_line":1,"column":1,"end_column":1}
+    {"message_severity":"suggestion","code":"preserve-view-not-set","message":"Did you mean to link to a specific version? If so, add &preserve-view=true to the url: https://docs.microsoft.com/en-us/sql/t-sql/functions/cast-and-convert-transact-sql?view=sql-server-ver15","file":"file1.md","line":2,"end_line":2,"column":10,"end_column":114}
+    {"message_severity":"suggestion","code":"preserve-view-not-set","message":"Did you mean to link to a specific version? If so, add &preserve-view=true to the url: /en-us/sql/t-sql/functions/cast-and-convert-transact-sql?view=sql-server-ver15","file":"file1.md","line":3,"end_line":3,"column":1,"end_column":1}
+
+  file1.json:
+---
+
+# Validate link text not set
+inputs:
+  docfx.yml: |
+    markdownValidationRules: rules.json
+  rules.json: |
+    {
+      "links": {
+        "rules": [
+          {
+            "type": "LinkTextPresent",
+            "message": "Missing link text for link '{0}'. Add appropriate text. ",
+            "code": "link-text-missing",
+            "severity": "SUGGESTION",
+            "contentTypes": ["conceptual"]
+          }
+        ]
+      }
+    }
+  file1.md: |
+    [external link](http://docs.microsoft.com/tr-tr)
+    <a href="https://docs.microsoft.com/en-us/sql/t-sql/functions/cast-and-convert-transact-sql?view=sql-server-ver15">inline html link</a>
+    [](http://docs.microsoft.com/tr-tr)
+    [](http://docs.microsoft.com/tr-tr "title")
+    ![Illustration to use for new users](https://azurecomcdn.azureedge.net/cvt-779fa2985e70b1ef1c34d319b505f7b4417add09948df4c5b81db2a9bad966e5/images/page/services/devops/hero-images/index-hero.jpg)
+
+
+
+outputs:
+  .errors.log: |
+    {"message_severity":"suggestion","code":"link-text-missing","message":"Missing link text for link 'http://docs.microsoft.com/tr-tr'. Add appropriate text. ","file":"file1.md","line":3,"end_line":3,"column":1,"end_column":1}
+
+  file1.json:
+---
+
+

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownContext.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownContext.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         /// <param name="path">Path of the link</param>
         /// <param name="origin">The original markdown element that triggered the read request.</param>
         /// <returns>Image url bound to the path</returns>
-        public delegate string GetImageLinkDelegate(string path, MarkdownObject origin, string altText, string? imageType = null);
+        public delegate string GetImageLinkDelegate(string path, MarkdownObject origin, string altText, string imageType);
 
         /// <summary>
         /// Reads a file as text.

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownContext.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownContext.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         /// <param name="path">Path of the link</param>
         /// <param name="origin">The original markdown element that triggered the read request.</param>
         /// <returns>Image url bound to the path</returns>
-        public delegate string GetImageLinkDelegate(string path, MarkdownObject origin, string altText);
+        public delegate string GetImageLinkDelegate(string path, MarkdownObject origin, string altText, bool? isIcon = null);
 
         /// <summary>
         /// Reads a file as text.
@@ -92,7 +92,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             _getToken = getToken ?? (_ => null);
             ReadFile = readFile ?? ((a, b, c) => (a, a));
             GetLink = getLink ?? ((a, b) => a);
-            GetImageLink = getImageLink ?? ((a, b, c) => a);
+            GetImageLink = getImageLink ?? ((a, b, c, d) => a);
             LogInfo = logInfo ?? ((a, b, c, d) => { });
             LogSuggestion = logSuggestion ?? ((a, b, c, d) => { });
             LogWarning = logWarning ?? ((a, b, c, d) => { });

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownContext.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownContext.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         /// <param name="path">Path of the link</param>
         /// <param name="origin">The original markdown element that triggered the read request.</param>
         /// <returns>Image url bound to the path</returns>
-        public delegate string GetImageLinkDelegate(string path, MarkdownObject origin, string altText, bool? isIcon = null);
+        public delegate string GetImageLinkDelegate(string path, MarkdownObject origin, string altText, string? imageType = null);
 
         /// <summary>
         /// Reads a file as text.

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/ResolveLink/ResolveLinkExtension.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/ResolveLink/ResolveLinkExtension.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
                 case LinkInline linkInline:
                     linkInline.Url = linkInline.IsImage
-                        ? _context.GetImageLink(linkInline.Url, linkInline, null)
+                        ? _context.GetImageLink(linkInline.Url, linkInline, null, "default")
                         : _context.GetLink(linkInline.Url, linkInline);
                     foreach (var subBlock in linkInline)
                     {

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/ImageExtension.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/ImageExtension.cs
@@ -98,15 +98,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
             var htmlAttributes = new HtmlAttributes();
 
-            // alt is allowed to be empty for icon type image
-            if (string.IsNullOrEmpty(alt) && currentType == "icon")
-            {
-                htmlAttributes.AddProperty("src", _context.GetLink(src, obj));
-            }
-            else
-            {
-                htmlAttributes.AddProperty("src", _context.GetImageLink(src, obj, alt));
-            }
+            htmlAttributes.AddProperty("src", _context.GetImageLink(src, obj, alt, currentType == "icon"));
 
             if (currentType == "icon")
             {

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/ImageExtension.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/ImageExtension.cs
@@ -98,7 +98,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
             var htmlAttributes = new HtmlAttributes();
 
-            htmlAttributes.AddProperty("src", _context.GetImageLink(src, obj, alt, currentType == "icon"));
+            htmlAttributes.AddProperty("src", _context.GetImageLink(src, obj, alt, currentType));
 
             if (currentType == "icon")
             {

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/ImageExtension.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/ImageExtension.cs
@@ -147,7 +147,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             else if (!string.IsNullOrEmpty(currentLightbox))
             {
                 var lightboxHtmlAttributes = new HtmlAttributes();
-                var path = _context.GetLink(currentLightbox, obj);
+                var path = _context.GetImageLink(currentLightbox, obj, alt);
                 lightboxHtmlAttributes.AddProperty("href", $"{path}#lightbox");
                 lightboxHtmlAttributes.AddProperty("data-linktype", $"relative-path");
                 renderer.Write("<a").WriteAttributes(lightboxHtmlAttributes).WriteLine(">");

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/ImageExtension.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/ImageExtension.cs
@@ -147,7 +147,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             else if (!string.IsNullOrEmpty(currentLightbox))
             {
                 var lightboxHtmlAttributes = new HtmlAttributes();
-                var path = _context.GetImageLink(currentLightbox, obj, alt);
+                var path = _context.GetLink(currentLightbox, obj);
                 lightboxHtmlAttributes.AddProperty("href", $"{path}#lightbox");
                 lightboxHtmlAttributes.AddProperty("data-linktype", $"relative-path");
                 renderer.Write("<a").WriteAttributes(lightboxHtmlAttributes).WriteLine(">");

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.3.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
-    <PackageReference Include="docs.validation" Version="1.0.0-beta-00383-cbd2c48" />
+    <PackageReference Include="docs.validation" Version="1.0.0-beta-00471-d14b18f" />
     <PackageReference Include="DotLiquid" Version="2.0.366" />
     <PackageReference Include="Glob" Version="1.1.8" />
     <PackageReference Include="HtmlReaderWriter" Version="1.0.0-preview-0001-gcf3636c5d9" />

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.3.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
-    <PackageReference Include="docs.validation" Version="1.0.0-beta-00379-196fd6d" />
+    <PackageReference Include="docs.validation" Version="1.0.0-beta-00383-cbd2c48" />
     <PackageReference Include="DotLiquid" Version="2.0.366" />
     <PackageReference Include="Glob" Version="1.1.8" />
     <PackageReference Include="HtmlReaderWriter" Version="1.0.0-preview-0001-gcf3636c5d9" />
@@ -34,7 +34,7 @@
     <PackageReference Include="Quickenshtein" Version="1.5.0" />
     <PackageReference Include="Stubble.Core" Version="1.9.3" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
-    <PackageReference Include="Validations.DocFx.Adapter" Version="1.2.29-beta012" />
+    <PackageReference Include="Validations.DocFx.Adapter" Version="1.2.29-beta013" />
     <PackageReference Include="YamlDotNet" Version="9.1.4" />
   </ItemGroup>
 

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.3.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
-    <PackageReference Include="docs.validation" Version="1.0.0-beta-00471-d14b18f" />
+    <PackageReference Include="docs.validation" Version="1.0.0-beta-00505-54cc828" />
     <PackageReference Include="DotLiquid" Version="2.0.366" />
     <PackageReference Include="Glob" Version="1.1.8" />
     <PackageReference Include="HtmlReaderWriter" Version="1.0.0-preview-0001-gcf3636c5d9" />

--- a/src/docfx/lib/markdown/MarkdigUtility.cs
+++ b/src/docfx/lib/markdown/MarkdigUtility.cs
@@ -241,6 +241,8 @@ namespace Microsoft.Docs.Build
                     YamlFrontMatterBlock _ => false,
                     HeadingBlock headingBlock when headingBlock.Inline is null || !headingBlock.Inline.Any() => false,
                     LeafBlock leafBlock when leafBlock.Inline is null || !leafBlock.Inline.Any() => true,
+                    LinkInline linkInline when linkInline.IsImage => true,
+                    LiteralInline literal when !string.IsNullOrWhiteSpace(literal.Content.Text) => true,
                     LeafInline _ => true,
                     _ => false,
                 };

--- a/src/docfx/lib/markdown/MarkdigUtility.cs
+++ b/src/docfx/lib/markdown/MarkdigUtility.cs
@@ -242,6 +242,7 @@ namespace Microsoft.Docs.Build
                     HeadingBlock headingBlock when headingBlock.Inline is null || !headingBlock.Inline.Any() => false,
                     LeafBlock leafBlock when leafBlock.Inline is null || !leafBlock.Inline.Any() => true,
                     LinkInline linkInline when linkInline.IsImage => true,
+                    TripleColonInline tripleColonInline when tripleColonInline.Extension is ImageExtension => true,
                     LiteralInline literal when !string.IsNullOrWhiteSpace(literal.Content.Text) => true,
                     LeafInline _ => true,
                     _ => false,

--- a/src/docfx/lib/markdown/MarkdownEngine.cs
+++ b/src/docfx/lib/markdown/MarkdownEngine.cs
@@ -358,7 +358,7 @@ namespace Microsoft.Docs.Build
             var node = new HyperLinkNode
             {
                 UrlLink = link,
-                LinkText = (origin is LinkInline) ? ToPlainText(origin) : null,
+                IsVisible = MarkdigUtility.IsVisible(origin),
                 HyperLinkType = origin switch
                 {
                     AutolinkInline => HyperLinkType.AutoLink,

--- a/src/docfx/lib/markdown/MarkdownEngine.cs
+++ b/src/docfx/lib/markdown/MarkdownEngine.cs
@@ -358,7 +358,7 @@ namespace Microsoft.Docs.Build
                 HyperLinkType = origin switch
                 {
                     AutolinkInline => HyperLinkType.AutoLink,
-                    HtmlBlock or HtmlInline => HyperLinkType.HtmlAnchor,
+                    HtmlBlock or HtmlInline or TripleColonInline or TripleColonBlock => HyperLinkType.HtmlAnchor,
                     _ => HyperLinkType.Default,
                 },
             };
@@ -369,7 +369,7 @@ namespace Microsoft.Docs.Build
 
         private string GetLink(SourceInfo<string> href, MarkdownObject origin, LinkNode outer)
         {
-            // fullfill common field of LinkNode
+            // fill common field of LinkNode
             var node = outer with
             {
                 SourceInfo = href.Source,

--- a/src/docfx/lib/markdown/MarkdownEngine.cs
+++ b/src/docfx/lib/markdown/MarkdownEngine.cs
@@ -364,7 +364,7 @@ namespace Microsoft.Docs.Build
             var node = new HyperLinkNode
             {
                 UrlLink = link,
-                LinkText = ToPlainText(origin),
+                LinkText = (origin is LinkInline {IsImage: false}) ? ToPlainText(origin) : null,
                 HyperLinkType = origin switch
                 {
                     AutolinkInline => HyperLinkType.AutoLink,

--- a/src/docfx/lib/markdown/MarkdownEngine.cs
+++ b/src/docfx/lib/markdown/MarkdownEngine.cs
@@ -174,18 +174,7 @@ namespace Microsoft.Docs.Build
         {
             if (markdownObject is LinkInline {IsImage: false} link)
             {
-                    if (link.FirstChild != null && link.FirstChild.NextSibling == null)
-                    {
-                        return link.FirstChild.ToString();
-                    }
-                    if (link.FirstChild == null)
-                    {
-                        return link.Title;
-                    }
-            }
-            else if (markdownObject is HtmlInline aLink)
-            {
-                return ToPlainText(aLink.Parent);
+                return ToPlainText(markdownObject);
             }
             return null;
         }

--- a/src/docfx/lib/markdown/MarkdownEngine.cs
+++ b/src/docfx/lib/markdown/MarkdownEngine.cs
@@ -321,7 +321,7 @@ namespace Microsoft.Docs.Build
             return file is null ? default : (_input.ReadString(file).Replace("\r", ""), new SourceInfo(file));
         }
 
-        private string GetImageLink(string path, MarkdownObject origin, string? altText, string imageType)
+        private string GetImageLink(string path, MarkdownObject origin, string? altText, string? imageType)
         {
             if (altText is null && origin is LinkInline linkInline && linkInline.IsImage)
             {

--- a/src/docfx/validation/ContentValidator.cs
+++ b/src/docfx/validation/ContentValidator.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
 using Microsoft.Docs.Validation;
 
 namespace Microsoft.Docs.Build
@@ -51,26 +52,11 @@ namespace Microsoft.Docs.Build
                 this);
         }
 
-        public void ValidateLink(FilePath file, SourceInfo<string> link, MarkdownObject origin, bool isInHtml, bool isImage, string? linkText, string? altText, int imageIndex)
+        public void ValidateLink(FilePath file, LinkNode node)
         {
-            // validate image link and altText here
             if (TryCreateValidationContext(file, out var validationContext))
             {
-                var item = new LinkNode
-                {
-                    UrlLink = link,
-                    LinkText = linkText,
-                    AltText = altText,
-                    IsImage = isImage,
-                    IsInlineImage = origin.IsInlineImage(imageIndex),
-                    SourceInfo = link.Source,
-                    ParentSourceInfoList = origin.GetInclusionStack(),
-                    Monikers = origin.GetZoneLevelMonikers(),
-                    ZonePivots = origin.GetZonePivots(),
-                    TabbedConceptualHeader = origin.GetTabId(),
-                    IsInHtmlBlock = isInHtml,
-                };
-                Write(_validator.ValidateLink(item, validationContext).GetAwaiter().GetResult());
+                Write(_validator.ValidateLink(node, validationContext).GetAwaiter().GetResult());
             }
         }
 

--- a/src/docfx/validation/ContentValidator.cs
+++ b/src/docfx/validation/ContentValidator.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Docs.Build
                 this);
         }
 
-        public void ValidateLink(FilePath file, SourceInfo<string> link, MarkdownObject origin, bool isImage, string? altText, int imageIndex)
+        public void ValidateLink(FilePath file, SourceInfo<string> link, MarkdownObject origin, bool isInHtml, bool isImage, string? linkText, string? altText, int imageIndex)
         {
             // validate image link and altText here
             if (TryCreateValidationContext(file, out var validationContext))
@@ -59,6 +59,7 @@ namespace Microsoft.Docs.Build
                 var item = new LinkNode
                 {
                     UrlLink = link,
+                    LinkText = linkText,
                     AltText = altText,
                     IsImage = isImage,
                     IsInlineImage = origin.IsInlineImage(imageIndex),
@@ -67,6 +68,7 @@ namespace Microsoft.Docs.Build
                     Monikers = origin.GetZoneLevelMonikers(),
                     ZonePivots = origin.GetZonePivots(),
                     TabbedConceptualHeader = origin.GetTabId(),
+                    IsInHtmlBlock = isInHtml,
                 };
                 Write(_validator.ValidateLink(item, validationContext).GetAwaiter().GetResult());
             }

--- a/test/docfx.Test/lib/MarkdigUtilityTest.cs
+++ b/test/docfx.Test/lib/MarkdigUtilityTest.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Docs.Build
         [InlineData("  \n <!--comments \n--> \n  ", false)]
         [InlineData("  \n <!--comments \n--> <div>text</div>\n  ", true)]
         [InlineData("[![](image.png)](https://github.com)", true)]
+        [InlineData("[:::image type=\"content\" source=\"img.png\" alt-text=\"Azure\":::](./media/how-to-read-replica-portal/list-replica.png#lightbox)", true)]
         public static void IsVisibleTest(string markdownContent, bool expectedVisible)
         {
             var markdownDocument = Markdig.Markdown.Parse(markdownContent, s_markdownPipeline);

--- a/test/docfx.Test/lib/MarkdigUtilityTest.cs
+++ b/test/docfx.Test/lib/MarkdigUtilityTest.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Docs.Build
         [InlineData("  \n <!--comments--> \n  ", false)]
         [InlineData("  \n <!--comments \n--> \n  ", false)]
         [InlineData("  \n <!--comments \n--> <div>text</div>\n  ", true)]
+        [InlineData("[![](image.png)](https://github.com)", true)]
         public static void IsVisibleTest(string markdownContent, bool expectedVisible)
         {
             var markdownDocument = Markdig.Markdown.Parse(markdownContent, s_markdownPipeline);


### PR DESCRIPTION
retire link&image validation in Apex and migrate to Docs
[AB#360087](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/360087)
###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/docfx/pull/7023)