### PR TITLE
Fix <code source=...> tags from assemblies not respecting CodeSourceB…

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/Parsers/TripleSlashCommentModel.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/Parsers/TripleSlashCommentModel.cs
@@ -344,18 +344,27 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                     continue;
                 }
 
-                if (context.Source == null || string.IsNullOrEmpty(context.Source.Path))
-                {
-                    Logger.LogWarning($"Unable to get source file path for {node.ToString()}");
-                    return;
-                }
-
                 var region = node.Attribute("region");
 
                 var path = source.Value;
                 if (!Path.IsPathRooted(path))
                 {
-                    var basePath = !string.IsNullOrEmpty(context.CodeSourceBasePath) ? context.CodeSourceBasePath : Path.GetDirectoryName(Path.Combine(EnvironmentContext.BaseDirectory, context.Source.Path));
+                    string basePath;
+
+                    if (!string.IsNullOrEmpty(context.CodeSourceBasePath))
+                    {
+                        basePath = context.CodeSourceBasePath;
+                    }
+                    else
+                    {
+                        if (context.Source == null || string.IsNullOrEmpty(context.Source.Path))
+                        {
+                            Logger.LogWarning($"Unable to get source file path for {node.ToString()}");
+                            continue;
+                        }
+
+                        basePath = Path.GetDirectoryName(Path.Combine(EnvironmentContext.BaseDirectory, context.Source.Path));
+                    }
                     
                     path = Path.Combine(basePath, path);
                 }

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/ExtractMetadataWorker.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/ExtractMetadataWorker.cs
@@ -355,7 +355,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                         
                         if (mta != null)
                         {
-                            MergeCommentsHelper.MergeComments(mta.Item1, commentFiles);
+                            MergeCommentsHelper.MergeComments(options, mta.Item1, commentFiles);
                             projectMetadataList.Add(mta.Item1);
                         }
                     }

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/MergeComments/MergeCommentsHelper.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/MergeComments/MergeCommentsHelper.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
     public static class MergeCommentsHelper
     {
-        public static void MergeComments(MetadataItem item, IEnumerable<string> commentFiles)
+        public static void MergeComments(ExtractMetadataOptions options, MetadataItem item, IEnumerable<string> commentFiles)
         {
             if (item == null || commentFiles == null)
             {
@@ -27,7 +27,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                        from uidAndReader in EnumerateDeveloperComments(file)
                        select uidAndReader.ToCommentIdAndComment();
 
-            PatchMetadataItem(item, list);
+            PatchMetadataItem(options, item, list);
             RebuildReference(item);
         }
 
@@ -81,7 +81,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             }
         }
 
-        private static void PatchMetadataItem(MetadataItem assembly, IEnumerable<CommentIdAndComment> list)
+        private static void PatchMetadataItem(ExtractMetadataOptions options, MetadataItem assembly, IEnumerable<CommentIdAndComment> list)
         {
             var allItemsInAssembly = new Dictionary<string, MetadataItem>(StringComparer.OrdinalIgnoreCase);
             GetAllItemByCommentId(allItemsInAssembly, assembly);
@@ -91,7 +91,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 MetadataItem item = null;
                 if (allItemsInAssembly.TryGetValue(uidAndComment.CommentId, out item))
                 {
-                    PatchViewModel(item, uidAndComment.Comment);
+                    PatchViewModel(options, item, uidAndComment.Comment);
                 }
             }
         }
@@ -109,11 +109,13 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             }
         }
 
-        private static void PatchViewModel(MetadataItem item, string comment)
+        private static void PatchViewModel(ExtractMetadataOptions options, MetadataItem item, string comment)
         {
             var context = new TripleSlashCommentParserContext
             {
-                AddReferenceDelegate = (s, e) => { }
+                AddReferenceDelegate = (s, e) => { },
+                CodeSourceBasePath = options.CodeSourceBasePath,
+                
             };
             var commentModel = TripleSlashCommentModel.CreateModel(comment, SyntaxLanguage.CSharp, context);
             var summary = commentModel.Summary;


### PR DESCRIPTION
When using an assembly (DLL + XML doc file) as input to docfx, &lt;code> tags in the XML cannot resolve the referenced files in the source attribute. This is because docfx uses source relative paths to locate the file to include, and in this case the source files are not present.

A solution for this is to use codeSourceBasePath in the docfx.json - except this was broken - the check for the source file happened before CodeSourceBasePath was checked for, leading to an "Unable to get source file path for x.cs" error.

This patch reorders the checks to allow this to work (hopefully as intended)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/docfx/pull/7096)