### PR TITLE
 warnAsError in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ jobs:
       with:
         fetch-depth: 0
     - uses: actions/setup-dotnet@v1
-    - run: dotnet test -c Release
-    - run: dotnet pack -c Release -o drop
+    - run: dotnet test -warnAsError -c Release
+    - run: dotnet pack -warnAsError -c Release -o drop
     - name: Publish binary packages
       shell: pwsh
       run: |
@@ -23,7 +23,7 @@ jobs:
         $rids = @("win7-x64", "osx-x64", "linux-x64") # Microsoft.ChakraCore doesn't provide win-x64 runtime build, using win7-x64
         foreach ($rid in $rids)
         {
-          dotnet publish src\docfx\docfx.csproj -c release -r $rid -o $packagesBasePath/$rid /p:PackAsTool=false
+          dotnet publish src\docfx\docfx.csproj -warnAsError -c release -r $rid -o $packagesBasePath/$rid /p:PackAsTool=false
           if ($rid -eq "win7-x64") {
             $version = Invoke-Expression "$packagesBasePath/win7-x64/docfx.exe --version"
             Write-Host "package version: $version"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
     - name: Dotnet Test
-      run: dotnet test -c Release -warnAsError /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+      run: dotnet test -warnAsError -c Release /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       if: ${{ matrix.os == 'macos-latest' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
     - name: Dotnet Test
-      run: dotnet test -c Release /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+      run: dotnet test -c Release -warnAsError /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       if: ${{ matrix.os == 'macos-latest' }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,7 +21,6 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <TreatWarningsAsErrors Condition="'$(Configuration)'=='Release'">true</TreatWarningsAsErrors>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>

--- a/azure-pipelines-v3.yml
+++ b/azure-pipelines-v3.yml
@@ -10,7 +10,7 @@ pr:
 variables:
 - group: devresourcekeyvault
 - name: dotnetVersion
-  value: 5.0.100
+  value: 5.0.200
 - name: runCodesignValidationInjection
   value: false
 - name: NugetSecurityAnalysisWarningLevel
@@ -43,7 +43,7 @@ jobs:
     displayName: dotnet test
     inputs:
       command: test
-      arguments: -c Release /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
+      arguments: -c Release -warnAsError /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
       publishTestResults: true
     env:
       DOCS_GITHUB_TOKEN: $(gitHubTestToken)

--- a/azure-pipelines-v3.yml
+++ b/azure-pipelines-v3.yml
@@ -43,7 +43,7 @@ jobs:
     displayName: dotnet test
     inputs:
       command: test
-      arguments: -c Release -warnAsError /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
+      arguments:  -warnAsError -c Release /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
       publishTestResults: true
     env:
       DOCS_GITHUB_TOKEN: $(gitHubTestToken)
@@ -96,7 +96,7 @@ jobs:
 
   # Build RegressionTest into Artifact 
   - powershell: |
-      dotnet build ./test/docfx.RegressionTest -c Release -r win7-x64 -o ./drop/RegressionTest
+      dotnet build ./test/docfx.RegressionTest -warnAsError -c Release -r win7-x64 -o ./drop/RegressionTest
     displayName: Build RegressionTest into Artifact 
 
   # Publish RegressionTest binary


### PR DESCRIPTION
So warnings break CI.

Related #7071 https://github.com/dotnet/roslyn/issues/43051

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/docfx/pull/7123)