### PR TITLE
Update dependencies per security reason

### DIFF
--- a/src/Microsoft.DocAsCode.HtmlToPdf/Microsoft.DocAsCode.HtmlToPdf.csproj
+++ b/src/Microsoft.DocAsCode.HtmlToPdf/Microsoft.DocAsCode.HtmlToPdf.csproj
@@ -7,7 +7,7 @@
     <Compile Remove="ManifestItemWithAssetId.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="iTextSharp" Version="5.5.12" />
+    <PackageReference Include="iTextSharp" Version="5.5.13.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DocAsCode.Build.Common\Microsoft.DocAsCode.Build.Common.csproj" />

--- a/src/docfx.website.themes/default/bower.json
+++ b/src/docfx.website.themes/default/bower.json
@@ -20,7 +20,7 @@
     "tests"
   ],
   "dependencies": {
-    "bootstrap": "~3.4.1",
+    "bootstrap": "^4.6.0",
     "highlightjs": "~9.12.0",
     "jquery": "~3.5.1",
     "js-url": "1.8.6",

--- a/src/docfx.website.themes/default/package.json
+++ b/src/docfx.website.themes/default/package.json
@@ -9,7 +9,7 @@
   "author": "docfx",
   "license": "MIT",
   "devDependencies": {
-    "bower": "^1.8.7",
+    "bower": "^1.8.12",
     "del": "^2.0.2",
     "gulp": "^4.0.0",
     "gulp-concat": "^2.6.0",

--- a/tools/XRefService/ManageXRefService/XRefService.Manage.csproj
+++ b/tools/XRefService/ManageXRefService/XRefService.Manage.csproj
@@ -13,16 +13,16 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Entityframework" Version="6.1.3" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.17.0" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="1.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.2" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="1.1.2" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="1.1.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.1" />

--- a/tools/XRefService/ManageXRefService/XRefService.Manage.csproj
+++ b/tools/XRefService/ManageXRefService/XRefService.Manage.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="1.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="1.1.2" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.0" />
   </ItemGroup>


### PR DESCRIPTION
[AB#383612](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/383612)
Update dependencies in dev branch to clear the cg alearts.
The alerts can be classified to following types:
1. Indirect npm packages referenced by bower
2. Indirect rubygems packages referenced by bootstrap
3. Microsoft.AspNetCore nuget packages needs to upgrade.
4. iTextSharp is scanned by snyk.