### PR TITLE
Add document_url to error log

### DIFF
--- a/.github/actions/spell-check/dictionary/custom-dictionary.txt
+++ b/.github/actions/spell-check/dictionary/custom-dictionary.txt
@@ -590,3 +590,4 @@ csv
 nettrace
 speedscope
 dns
+middleware

--- a/docs/specs/config.yml
+++ b/docs/specs/config.yml
@@ -349,17 +349,19 @@ outputs:
   docs/a.json: |
     { "conceptual": "<p><a href=\"b.md\">b</a></p>" }
 ---
-# Adjust error message using custom errors
+# Adjust error message, document_url using custom errors
 inputs:
   docfx.yml: |
     rules:
       file-not-found:
         severity: error
         additionalMessage: 'NOTE:'
+    documentUrls:
+      file-not-found: 'https://docs.com'
   a.md: a [b](b.md)
 outputs:
   .errors.log: |
-    {"message_severity":"error","code":"file-not-found","message":"Invalid file link: 'b.md'. NOTE:","file":"a.md","line":1,"column":3}
+    {"message_severity":"error","code":"file-not-found","message":"Invalid file link: 'b.md'. NOTE:","file":"a.md","line":1,"column":3,"document_url":"https://docs.com"}
 ---
 # Treat warnings as errors
 inputs:

--- a/docs/specs/lsp.yml
+++ b/docs/specs/lsp.yml
@@ -1,7 +1,9 @@
 ---
 # Basic lsp test
 inputs:
-  docfx.yml:
+  docfx.yml: |
+    documentUrls:
+      file-not-found: "https://docs.com"
 languageServer:
   - openFiles:
       a.md: "# Heading\nInvalid Link [B](b.md)"
@@ -14,6 +16,8 @@ languageServer:
             end: { "line": 1, "character": 13 }
           severity: 2
           code: file-not-found
+          codeDescription:
+            href: "https://docs.com"
           source: Docs Validation
           message: "Invalid file link: 'b.md'."
       toc.md: [{ "code": "file-not-found" }]

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Gets moniker range group configuration for v2 backward compatibility.
         /// </summary>
-        public Dictionary<string, GroupConfig> Groups { get; } = new Dictionary<string, GroupConfig>();
+        public Dictionary<string, GroupConfig> Groups { get; } = new();
 
         /// <summary>
         /// Gets output file type
@@ -112,7 +112,7 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Gets the global metadata added to each document.
         /// </summary>
-        public GlobalMetadata GlobalMetadata { get; init; } = new GlobalMetadata();
+        public GlobalMetadata GlobalMetadata { get; init; } = new();
 
         /// <summary>
         /// Gets the {Schema}://{HostName}
@@ -138,14 +138,13 @@ namespace Microsoft.Docs.Build
         /// Gets the file metadata added to each document.
         /// It is a map of `{metadata-name} -> {glob} -> {metadata-value}`
         /// </summary>
-        public Dictionary<string, SourceInfo<Dictionary<string, JToken>>> FileMetadata { get; } =
-            new Dictionary<string, SourceInfo<Dictionary<string, JToken>>>();
+        public Dictionary<string, SourceInfo<Dictionary<string, JToken>>> FileMetadata { get; } = new();
 
         /// <summary>
         /// Gets a map from source folder path and output URL path.
         /// We rely on a Dictionary behavior that the enumeration order is the same as insertion order if there is no other mutations.
         /// </summary>
-        public Dictionary<PathString, PathString> Routes { get; } = new Dictionary<PathString, PathString>();
+        public Dictionary<PathString, PathString> Routes { get; } = new();
 
         /// <summary>
         /// Specify the repository url for contribution
@@ -160,24 +159,29 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// The excluded contributors which you don't want to show
         /// </summary>
-        public HashSet<string> ExcludeContributors { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        public HashSet<string> ExcludeContributors { get; } = new(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Gets the map from dependency name to git url
         /// All dependencies need to be restored locally before build
         /// The default value is empty mappings
         /// </summary>
-        public Dictionary<PathString, DependencyConfig> Dependencies { get; } = new Dictionary<PathString, DependencyConfig>();
+        public Dictionary<PathString, DependencyConfig> Dependencies { get; } = new();
 
         /// <summary>
         /// Gets the document id configuration section
         /// </summary>
-        public Dictionary<PathString, DocumentIdConfig> DocumentId { get; } = new Dictionary<PathString, DocumentIdConfig>();
+        public Dictionary<PathString, DocumentIdConfig> DocumentId { get; } = new();
 
         /// <summary>
         /// Gets allow custom error code, severity and message.
         /// </summary>
-        public Dictionary<string, SourceInfo<CustomRule>> Rules { get; } = new Dictionary<string, SourceInfo<CustomRule>>();
+        public Dictionary<string, SourceInfo<CustomRule>> Rules { get; } = new();
+
+        /// <summary>
+        /// Gets a map from error code to document URL.
+        /// </summary>
+        public Dictionary<string, string> DocumentUrls { get; } = new();
 
         /// <summary>
         /// Gets whether warnings should be treated as errors.
@@ -194,33 +198,33 @@ namespace Microsoft.Docs.Build
         /// <summary>
         /// Gets the moniker range mapping
         /// </summary>
-        public Dictionary<string, SourceInfo<string?>> MonikerRange { get; } = new Dictionary<string, SourceInfo<string?>>();
+        public Dictionary<string, SourceInfo<string?>> MonikerRange { get; } = new();
 
         /// <summary>
         /// Get the definition of monikers
         /// It should be absolute url or relative path
         /// </summary>
-        public SourceInfo<string> MonikerDefinition { get; init; } = new SourceInfo<string>("");
+        public SourceInfo<string> MonikerDefinition { get; init; } = new("");
 
         /// <summary>
         /// Get the file path of content validation rules
         /// </summary>
-        public SourceInfo<string> MarkdownValidationRules { get; init; } = new SourceInfo<string>("");
+        public SourceInfo<string> MarkdownValidationRules { get; init; } = new("");
 
         /// <summary>
         /// Get the file path of Azure SandboxEnabledModuleList
         /// </summary>
-        public SourceInfo<string> SandboxEnabledModuleList { get; private set; } = new SourceInfo<string>("");
+        public SourceInfo<string> SandboxEnabledModuleList { get; private set; } = new("");
 
         /// <summary>
         /// Get the file path of build validation rules
         /// </summary>
-        public SourceInfo<string> BuildValidationRules { get; init; } = new SourceInfo<string>("");
+        public SourceInfo<string> BuildValidationRules { get; init; } = new("");
 
         /// <summary>
         /// Get the file path of allow lists
         /// </summary>
-        public SourceInfo<string> Allowlists { get; init; } = new SourceInfo<string>("");
+        public SourceInfo<string> Allowlists { get; init; } = new("");
 
         /// <summary>
         /// Get the metadata JSON schema file path.
@@ -331,9 +335,9 @@ namespace Microsoft.Docs.Build
 
         public JoinTOCConfig[] JoinTOC { get; init; } = Array.Empty<JoinTOCConfig>();
 
-        public HashSet<PathString> SplitTOC { get; init; } = new HashSet<PathString>();
+        public HashSet<PathString> SplitTOC { get; init; } = new();
 
-        public HashSet<string> RedirectionFiles { get; init; } = new HashSet<string>();
+        public HashSet<string> RedirectionFiles { get; init; } = new();
 
         public IEnumerable<SourceInfo<string>> GetFileReferences()
         {
@@ -346,6 +350,7 @@ namespace Microsoft.Docs.Build
             {
                 yield return sourceMap;
             }
+
             yield return MonikerDefinition;
             yield return MarkdownValidationRules;
             yield return BuildValidationRules;
@@ -361,7 +366,7 @@ namespace Microsoft.Docs.Build
             {
                 if (item.TopLevelToc != null)
                 {
-                    yield return new SourceInfo<string>(item.TopLevelToc);
+                    yield return new(item.TopLevelToc);
                 }
             }
         }
@@ -372,7 +377,7 @@ namespace Microsoft.Docs.Build
             if (LowerCaseUrl)
             {
                 HostName = HostName.ToLowerInvariant();
-                BasePath = new BasePath(BasePath.Value.ToLowerInvariant());
+                BasePath = new(BasePath.Value.ToLowerInvariant());
             }
         }
     }

--- a/src/docfx/config/ops/OpsAccessor.cs
+++ b/src/docfx/config/ops/OpsAccessor.cs
@@ -52,6 +52,11 @@ namespace Microsoft.Docs.Build
             return FetchBuild("/v2/monikertrees/allfamiliesproductsmonikers");
         }
 
+        public Task<string> GetDocumentUrls()
+        {
+            return Fetch("https://docsvalidation.azurefd.net/errorcodes");
+        }
+
         public async Task<string[]> GetXrefMaps(string tag, string xrefEndpoint, string xrefMapQueryParams)
         {
             var environment = xrefEndpoint.StartsWith("https://xref.docs.microsoft.com", StringComparison.OrdinalIgnoreCase)

--- a/src/docfx/config/ops/OpsAccessor.cs
+++ b/src/docfx/config/ops/OpsAccessor.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -22,16 +21,7 @@ namespace Microsoft.Docs.Build
 {
     internal class OpsAccessor : ILearnServiceAccessor
     {
-        private const string TaxonomyServiceProdPath = "https://taxonomyservice.azurefd.net/taxonomies/simplified?" +
-            "name=ms.author&name=ms.devlang&name=ms.prod&name=ms.service&name=ms.topic&name=devlang&name=product";
-
-        private const string TaxonomyServicePPEPath = "https://taxonomyserviceppe.azurefd.net/taxonomies/simplified?" +
-            "name=ms.author&name=ms.devlang&name=ms.prod&name=ms.service&name=ms.topic&name=devlang&name=product";
-
-        private const string SandboxEnabledModuleListPath = "https://docs.microsoft.com/api/resources/sandbox/verify";
-        private const string DocsProdServiceEndpoint = "https://buildapi.docs.microsoft.com";
-        private const string DocsPPEServiceEndpoint = "https://BuildApiPubDev.azurefd.net";
-        private const string DocsPerfServiceEndpoint = "https://op-build-perf.azurewebsites.net";
+        private delegate Task<HttpResponseMessage> HttpMiddleware(HttpRequestMessage request, Func<HttpRequestMessage, Task<HttpResponseMessage>> next);
 
         public static readonly DocsEnvironment DocsEnvironment = GetDocsEnvironment();
 
@@ -44,7 +34,7 @@ namespace Microsoft.Docs.Build
 
         private readonly CredentialHandler _credentialHandler;
         private readonly ErrorBuilder _errors;
-        private readonly HttpClient _http = new HttpClient(new HttpClientHandler { CheckCertificateRevocationList = true });
+        private readonly HttpClient _http = new(new HttpClientHandler { CheckCertificateRevocationList = true });
 
         public OpsAccessor(ErrorBuilder errors, CredentialHandler credentialHandler)
         {
@@ -52,177 +42,117 @@ namespace Microsoft.Docs.Build
             _credentialHandler = credentialHandler;
         }
 
-        public async Task<string> GetDocsetInfo(string repositoryUrl)
+        public Task<string> GetDocsetInfo(string repositoryUrl)
         {
-            var fetchUrl = $"/v2/Queries/Docsets?git_repo_url={repositoryUrl}&docset_query_status=Created";
-            return await Fetch(fetchUrl, value404: "[]");
+            return FetchBuild($"/v2/Queries/Docsets?git_repo_url={repositoryUrl}&docset_query_status=Created", value404: "[]");
         }
 
         public Task<string> GetMonikerDefinition()
         {
-            return Fetch("/v2/monikertrees/allfamiliesproductsmonikers");
+            return FetchBuild("/v2/monikertrees/allfamiliesproductsmonikers");
         }
 
         public async Task<string[]> GetXrefMaps(string tag, string xrefEndpoint, string xrefMapQueryParams)
         {
-            var xrefMapDocsEnvironment = GetXrefMapEnvironment(xrefEndpoint);
-            var response = await Fetch(
-                $"/v1/xrefmap{tag}{xrefMapQueryParams}", value404: "{}", environment: xrefMapDocsEnvironment);
-            return JsonConvert.DeserializeAnonymousType(response, new { links = new[] { "" } }).links
-                ?? Array.Empty<string>();
+            var environment = xrefEndpoint.StartsWith("https://xref.docs.microsoft.com", StringComparison.OrdinalIgnoreCase)
+                ? DocsEnvironment.Prod
+                : DocsEnvironment;
+
+            var response = await FetchBuild($"/v1/xrefmap{tag}{xrefMapQueryParams}", value404: "{}", environment);
+
+            return JsonConvert.DeserializeAnonymousType(response, new { links = new[] { "" } }).links ?? Array.Empty<string>();
         }
 
-        public async Task<string> GetMarkdownValidationRules((string repositoryUrl, string branch) tuple)
+        public Task<string> GetMarkdownValidationRules((string repositoryUrl, string branch) tuple)
         {
-            return await FetchValidationRules($"/route/validationmgt/rulesets/contentrules", tuple.repositoryUrl, tuple.branch);
+            return FetchValidationRules($"/route/validationmgt/rulesets/contentrules", tuple.repositoryUrl, tuple.branch);
         }
 
-        public async Task<string> GetBuildValidationRules((string repositoryUrl, string branch) tuple)
+        public Task<string> GetBuildValidationRules((string repositoryUrl, string branch) tuple)
         {
-            return await FetchValidationRules($"/route/validationmgt/rulesets/buildrules", tuple.repositoryUrl, tuple.branch);
+            return FetchValidationRules($"/route/validationmgt/rulesets/buildrules", tuple.repositoryUrl, tuple.branch);
         }
 
-        public async Task<string> GetAllowlists()
+        public Task<string> GetAllowlists(DocsEnvironment environment = DocsEnvironment.Prod)
         {
-            return await FetchTaxonomies();
+            return Fetch(TaxonomyApi(environment) +
+                "/taxonomies/simplified?name=ms.author&name=ms.devlang&name=ms.prod&name=ms.service&name=ms.topic&name=devlang&name=product");
         }
 
-        public async Task<string> GetSandboxEnabledModuleList()
+        public Task<string> GetSandboxEnabledModuleList()
         {
-            return await FetchGetSandboxEnabledModuleList();
-        }
-
-        public async Task<string> GetRegressionAllAllowlists()
-        {
-            return await FetchTaxonomies(DocsEnvironment.PPE);
+            return Fetch("https://docs.microsoft.com/api/resources/sandbox/verify");
         }
 
         public async Task<string> GetMetadataSchema((string repositoryUrl, string branch) tuple)
         {
             var metadataRules = FetchValidationRules($"/route/validationmgt/rulesets/metadatarules", tuple.repositoryUrl, tuple.branch);
-            var allowlists = FetchTaxonomies();
+            var allowlists = GetAllowlists();
 
             return OpsMetadataRuleConverter.GenerateJsonSchema(await metadataRules, await allowlists);
         }
 
-        public async Task<string> GetRegressionAllContentRules()
+        public Task<string> GetRegressionAllContentRules()
         {
-            return await FetchValidationRules(
-                "/route/validationmgt/rulesets/contentrules?name=_regression_all_",
-                environment: DocsEnvironment.PPE);
+            return FetchValidationRules("/route/validationmgt/rulesets/contentrules?name=_regression_all_", environment: DocsEnvironment.PPE);
         }
 
         public async Task<string> GetRegressionAllMetadataSchema()
         {
-            var metadataRules = FetchValidationRules(
-                "/route/validationmgt/rulesets/metadatarules?name=_regression_all_",
-                environment: DocsEnvironment.PPE);
-
-            var allowlists = FetchTaxonomies(DocsEnvironment.PPE);
+            var metadataRules = FetchValidationRules("/route/validationmgt/rulesets/metadatarules?name=_regression_all_", environment: DocsEnvironment.PPE);
+            var allowlists = GetAllowlists(DocsEnvironment.PPE);
 
             return OpsMetadataRuleConverter.GenerateJsonSchema(await metadataRules, await allowlists);
         }
 
-        public async Task<string> GetRegressionAllBuildRules()
+        public Task<string> GetRegressionAllBuildRules()
         {
-            return await FetchValidationRules(
-                "/route/validationmgt/rulesets/buildrules?name=_regression_all_",
-                environment: DocsEnvironment.PPE);
-        }
-
-        public async Task<string> HierarchyDrySync(string body)
-        {
-            var response = await SendRequest(() => new HttpRequestMessage
-            {
-                RequestUri = new Uri($"{BuildServiceEndpoint()}/route/mslearnhierarchy/api/OnDemandHierarchyDrySync"),
-                Method = HttpMethod.Post,
-                Content = new StringContent(body, Encoding.UTF8, "application/json"),
-            });
-            return await response.EnsureSuccessStatusCode().Content.ReadAsStringAsync();
+            return FetchValidationRules("/route/validationmgt/rulesets/buildrules?name=_regression_all_", environment: DocsEnvironment.PPE);
         }
 
         public async Task<bool> CheckLearnPathItemExist(string branch, string locale, string uid, CheckItemType type)
         {
             var path = type == CheckItemType.Module ? $"modules/{uid}" : $"units/{uid}";
-            var url = $"{BuildServiceEndpoint()}/route/docs/api/hierarchy/{path}?branch={branch}&locale={locale}";
+            var url = $"{BuildApi()}/route/docs/api/hierarchy/{path}?branch={branch}&locale={locale}";
 
-            var response = await SendRequest(() =>
+            return await Fetch(url, value404: "404", middleware: (request, next) =>
             {
-                var request = new HttpRequestMessage(HttpMethod.Get, url);
-                request.Headers.TryAddWithoutValidation("Referer", "https://tcexplorer.azurewebsites.net");
-                return request;
-            });
-
-            Console.WriteLine("[LearnValidationPlugin] check {0} call: {1}", type, url);
-            Console.WriteLine("[LearnValidationPlugin] check {0} result: {1}", type, response.IsSuccessStatusCode);
-            return response.IsSuccessStatusCode;
+                request.Headers.Referrer = new("https://tcexplorer.azurewebsites.net");
+                return next(request);
+            }) != "404";
         }
 
-        private async Task<string> Fetch(
-            string routePath,
-            IReadOnlyDictionary<string, string>? headers = null,
-            string? value404 = null,
-            DocsEnvironment? environment = null)
+        public Task<string> HierarchyDrySync(string body)
         {
-            Debug.Assert(routePath.StartsWith("/"));
-            var url = BuildServiceEndpoint(environment) + routePath;
-            var response = await SendRequest(
-                () =>
-                    {
-                        var request = new HttpRequestMessage(HttpMethod.Get, url);
-                        if (headers != null)
-                        {
-                            foreach (var (key, value) in headers)
-                            {
-                                request.Headers.TryAddWithoutValidation(key, value);
-                            }
-                        }
-                        return request;
-                    },
-                environment);
-
-            if (value404 != null && response.StatusCode == HttpStatusCode.NotFound)
-            {
-                return value404;
-            }
-            return await response.EnsureSuccessStatusCode().Content.ReadAsStringAsync();
+            return Fetch(
+                () => new HttpRequestMessage
+                {
+                    RequestUri = new Uri($"{BuildApi()}/route/mslearnhierarchy/api/OnDemandHierarchyDrySync"),
+                    Method = HttpMethod.Post,
+                    Content = new StringContent(body, Encoding.UTF8, "application/json"),
+                },
+                middleware: BuildMiddleware());
         }
 
-        private async Task<string> FetchValidationRules(string routePath, string repositoryUrl = "", string branch = "", DocsEnvironment? environment = null)
+        private async Task<string> FetchValidationRules(string urlPath, string repositoryUrl = "", string branch = "", DocsEnvironment? environment = null)
         {
             try
             {
-                Debug.Assert(routePath.StartsWith("/"));
-                var url = BuildServiceEndpoint(environment) + routePath;
-                using (PerfScope.Start($"[{nameof(OpsConfigAdapter)}] Fetching '{url}'"))
+                return await Fetch(BuildApi(environment) + urlPath, middleware: async (request, next) =>
                 {
-                    using var response = await HttpPolicyExtensions
-                       .HandleTransientHttpError()
-                       .Or<OperationCanceledException>()
-                       .Or<IOException>()
-                       .RetryAsync(3, onRetry: (_, i) => Log.Write($"[{i}] Retrying '{url}'"))
-                       .ExecuteAsync(async () =>
-                       {
-                           var response = await SendRequest(
-                               () =>
-                                   {
-                                       var request = new HttpRequestMessage(HttpMethod.Get, url);
+                    request.Headers.TryAddWithoutValidation("X-Metadata-RepositoryUrl", repositoryUrl);
+                    request.Headers.TryAddWithoutValidation("X-Metadata-RepositoryBranch", branch);
 
-                                       request.Headers.TryAddWithoutValidation("X-Metadata-RepositoryUrl", repositoryUrl);
-                                       request.Headers.TryAddWithoutValidation("X-Metadata-RepositoryBranch", branch);
-                                       return request;
-                                   },
-                               environment);
-                           if (response.Headers.TryGetValues("X-Metadata-Version", out var metadataVersion) &&
-                               Interlocked.Exchange(ref s_validationRulesetReported, 1) == 0)
-                           {
-                               _errors.Add(Errors.System.MetadataValidationRuleset(string.Join(',', metadataVersion)));
-                           }
-                           return response;
-                       });
+                    var response = await next(request);
 
-                    return await response.EnsureSuccessStatusCode().Content.ReadAsStringAsync();
-                }
+                    if (response.Headers.TryGetValues("X-Metadata-Version", out var metadataVersion) &&
+                        Interlocked.Exchange(ref s_validationRulesetReported, 1) == 0)
+                    {
+                        _errors.Add(Errors.System.MetadataValidationRuleset(string.Join(',', metadataVersion)));
+                    }
+
+                    return response;
+                });
             }
             catch (Exception ex)
             {
@@ -234,115 +164,98 @@ namespace Microsoft.Docs.Build
             }
         }
 
-        private async Task<string> FetchTaxonomies(DocsEnvironment? environment = null)
+        private Task<string> FetchBuild(string urlPath, string? value404 = null, DocsEnvironment? environment = null)
         {
-            try
-            {
-                var url = TaxonomyServicePath(environment);
-                using (PerfScope.Start($"[{nameof(OpsConfigAdapter)}] Fetching '{url}'"))
-                {
-                    using var response = await HttpPolicyExtensions
-                       .HandleTransientHttpError()
-                       .Or<OperationCanceledException>()
-                       .Or<IOException>()
-                       .RetryAsync(3, onRetry: (_, i) => Log.Write($"[{i}] Retrying '{url}'"))
-                       .ExecuteAsync(async () =>
-                       {
-                           using var request = new HttpRequestMessage(HttpMethod.Get, url);
-                           request.Headers.TryAddWithoutValidation("User-Agent", "Docfx v3");
-                           var response = await _http.SendAsync(request);
-                           return response;
-                       });
-
-                    return await response.EnsureSuccessStatusCode().Content.ReadAsStringAsync();
-                }
-            }
-            catch (Exception ex)
-            {
-                // Getting taxonomies failure should not block build proceeding,
-                // catch and log the exception without rethrow.
-                Log.Write(ex);
-                _errors.Add(Errors.System.ValidationIncomplete());
-                return "{}";
-            }
+            return Fetch(BuildApi(environment) + urlPath, value404, BuildMiddleware(environment));
         }
 
-        private async Task<string> FetchGetSandboxEnabledModuleList()
+        private Task<string> Fetch(string url, string? value404 = null, HttpMiddleware? middleware = null)
         {
-            try
-            {
-                var url = SandboxEnabledModuleListPath;
-                using (PerfScope.Start($"[{nameof(OpsConfigAdapter)}] Fetching '{url}'"))
-                {
-                    using var response = await HttpPolicyExtensions
-                       .HandleTransientHttpError()
-                       .Or<OperationCanceledException>()
-                       .Or<IOException>()
-                       .RetryAsync(3, onRetry: (_, i) => Log.Write($"[{i}] Retrying '{url}'"))
-                       .ExecuteAsync(async () =>
-                       {
-                           using var request = new HttpRequestMessage(HttpMethod.Get, url);
-                           request.Headers.TryAddWithoutValidation("User-Agent", "Docfx v3");
-                           var response = await _http.SendAsync(request);
-                           return response;
-                       });
-
-                    return await response.EnsureSuccessStatusCode().Content.ReadAsStringAsync();
-                }
-            }
-            catch (Exception ex)
-            {
-                // Getting taxonomies failure should not block build proceeding,
-                // catch and log the exception without rethrow.
-                Log.Write(ex);
-                _errors.Add(Errors.System.ValidationIncomplete());
-                return "{}";
-            }
+            return Fetch(() => new HttpRequestMessage(HttpMethod.Get, url), value404, middleware);
         }
 
-        private async Task<HttpResponseMessage> SendRequest(Func<HttpRequestMessage> httpRequestFactory, DocsEnvironment? environment = null)
+        private async Task<string> Fetch(Func<HttpRequestMessage> requestFactory, string? value404 = null, HttpMiddleware? middleware = null)
         {
-            return await _credentialHandler.SendRequest(httpRequestFactory, async request =>
+            middleware ??= (request, next) => next(request);
+
+            using var response = await HttpPolicyExtensions
+               .HandleTransientHttpError()
+               .Or<OperationCanceledException>()
+               .Or<IOException>()
+               .RetryAsync(3)
+               .ExecuteAsync(() => _credentialHandler.SendRequest(
+                   requestFactory,
+                   request => middleware(request, request =>
+                   {
+                       using (PerfScope.Start($"[{nameof(OpsAccessor)}] Fetching '{request.RequestUri}'"))
+                       {
+                           request.Headers.TryAddWithoutValidation("User-Agent", "docfx");
+                           return _http.SendAsync(request);
+                       }
+                   })));
+
+            if (value404 != null && response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return value404;
+            }
+
+            return await response.EnsureSuccessStatusCode().Content.ReadAsStringAsync();
+        }
+
+        private static HttpMiddleware BuildMiddleware(DocsEnvironment? environment = null)
+        {
+            return async (request, next) =>
             {
                 // Default header which allows fallback to public data when credential is not provided.
-                request.Headers.TryAddWithoutValidation("X-OP-FallbackToPublicData", true.ToString());
+                request.Headers.TryAddWithoutValidation("X-OP-FallbackToPublicData", "True");
 
-                await FillOpsToken(request, environment);
+                // don't access key vault for osx since azure-cli will crash in osx
+                // https://github.com/Azure/azure-cli/issues/7519
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
+                    !request.Headers.Contains("X-OP-BuildUserToken"))
+                {
+                    // For development usage
+                    try
+                    {
+                        environment ??= DocsEnvironment;
+                        var token = environment switch
+                        {
+                            DocsEnvironment.Prod => s_opsTokenPublic,
+                            DocsEnvironment.PPE => s_opsTokenPubDev,
+                            _ => throw new InvalidOperationException(),
+                        };
 
-                return await _http.SendAsync(request);
-            });
+                        request.Headers.Add("X-OP-BuildUserToken", await token.Value);
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Write($"Cannot get 'OPBuildUserToken' from azure key vault, please make sure you have been granted the permission to access.");
+                        Log.Write(ex);
+                    }
+                }
+
+                return await next(request);
+            };
         }
 
-        private static string BuildServiceEndpoint(DocsEnvironment? environment = null)
+        private static string BuildApi(DocsEnvironment? environment = null)
         {
             return (environment ?? DocsEnvironment) switch
             {
-                DocsEnvironment.Prod => DocsProdServiceEndpoint,
-                DocsEnvironment.PPE => DocsPPEServiceEndpoint,
-                DocsEnvironment.Perf => DocsPerfServiceEndpoint,
+                DocsEnvironment.Prod => "https://buildapi.docs.microsoft.com",
+                DocsEnvironment.PPE => "https://BuildApiPubDev.azurefd.net",
+                DocsEnvironment.Perf => "https://op-build-perf.azurewebsites.net",
                 _ => throw new NotSupportedException(),
             };
         }
 
-        private static string TaxonomyServicePath(DocsEnvironment? environment = null)
+        private static string TaxonomyApi(DocsEnvironment? environment = null)
         {
             return (environment ?? DocsEnvironment) switch
             {
-                DocsEnvironment.Prod => TaxonomyServiceProdPath,
-                DocsEnvironment.PPE => TaxonomyServicePPEPath,
-                DocsEnvironment.Perf => TaxonomyServicePPEPath,
-                _ => throw new NotSupportedException(),
+                DocsEnvironment.Prod => "https://taxonomyservice.azurefd.net",
+                _ => "https://taxonomyserviceppe.azurefd.net",
             };
-        }
-
-        private static DocsEnvironment GetXrefMapEnvironment(string xrefEndpoint)
-        {
-            if (!string.IsNullOrEmpty(xrefEndpoint) &&
-                string.Equals(xrefEndpoint.TrimEnd('/'), "https://xref.docs.microsoft.com", StringComparison.OrdinalIgnoreCase))
-            {
-                return DocsEnvironment.Prod;
-            }
-            return DocsEnvironment;
         }
 
         private static async Task<string> GetSecret(string secret, bool isPubDev = false)
@@ -361,36 +274,6 @@ namespace Microsoft.Docs.Build
             return Enum.TryParse(Environment.GetEnvironmentVariable("DOCS_ENVIRONMENT"), true, out DocsEnvironment docsEnvironment)
                 ? docsEnvironment
                 : DocsEnvironment.Prod;
-        }
-
-        private static async Task FillOpsToken(HttpRequestMessage request, DocsEnvironment? environment = null)
-        {
-            // don't access key vault for osx since azure-cli will crash in osx
-            // https://github.com/Azure/azure-cli/issues/7519
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
-                request.RequestUri?.ToString() is string url &&
-                url.StartsWith(BuildServiceEndpoint(environment)) &&
-                !request.Headers.Contains("X-OP-BuildUserToken"))
-            {
-                // For development usage
-                try
-                {
-                    var tokenTask = (environment ?? DocsEnvironment) switch
-                    {
-                        DocsEnvironment.Prod => s_opsTokenPublic,
-                        DocsEnvironment.PPE => s_opsTokenPubDev,
-                        _ => throw new InvalidOperationException(),
-                    };
-                    var token = await tokenTask.Value;
-
-                    request.Headers.Add("X-OP-BuildUserToken", token);
-                }
-                catch (Exception ex)
-                {
-                    Log.Write($"Cannot get 'OPBuildUserToken' from azure key vault, please make sure you have been granted the permission to access.");
-                    Log.Write(ex);
-                }
-            }
         }
     }
 }

--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -104,6 +104,10 @@ namespace Microsoft.Docs.Build
             }
 
             var xrefHostName = GetXrefHostName(docset.site_name, branch);
+            var documentUrls = JsonConvert.DeserializeAnonymousType(
+                    await _opsAccessor.GetDocumentUrls(), new[] { new { log_code = "", document_url = "" } })
+                .ToDictionary(item => item.log_code, item => item.document_url);
+
             return JsonConvert.SerializeObject(new
             {
                 product = docset.product_name,
@@ -112,6 +116,7 @@ namespace Microsoft.Docs.Build
                 basePath = docset.base_path.ValueWithLeadingSlash,
                 xrefHostName,
                 monikerDefinition = MonikerDefinitionApi,
+                documentUrls,
                 markdownValidationRules = $"{MarkdownValidationRulesApi}{metadataServiceQueryParams}",
                 buildValidationRules = $"{BuildValidationRulesApi}{metadataServiceQueryParams}",
                 metadataSchema = new[]

--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Docs.Build
     internal class OpsConfigAdapter
     {
         public const string BuildConfigApi = "https://ops/buildconfig/";
+
         private const string MonikerDefinitionApi = "https://ops/monikerDefinition/";
         private const string OpsMetadataApi = "https://ops/opsmetadatas/";
         private const string MetadataSchemaApi = "https://ops/metadataschema/";
@@ -46,7 +47,7 @@ namespace Microsoft.Docs.Build
                 (BuildValidationRulesApi, url => _opsAccessor.GetBuildValidationRules(GetValidationServiceParameters(url))),
                 (AllowlistsApi, _ => _opsAccessor.GetAllowlists()),
                 (SandboxEnabledModuleListApi, _ => _opsAccessor.GetSandboxEnabledModuleList()),
-                (RegressionAllAllowlistsApi, _ => _opsAccessor.GetRegressionAllAllowlists()),
+                (RegressionAllAllowlistsApi, _ => _opsAccessor.GetAllowlists(DocsEnvironment.PPE)),
                 (RegressionAllContentRulesApi, _ => _opsAccessor.GetRegressionAllContentRules()),
                 (RegressionAllBuildRulesApi, _ => _opsAccessor.GetRegressionAllBuildRules()),
                 (RegressionAllMetadataSchemaApi, _ => _opsAccessor.GetRegressionAllMetadataSchema()),

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Identity.Client" Version="4.27.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Jint" Version="3.0.0-beta-2031" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.18.3" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.0" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="Quickenshtein" Version="1.5.0" />
     <PackageReference Include="Stubble.Core" Version="1.9.3" />

--- a/src/docfx/lib/log/Error.cs
+++ b/src/docfx/lib/log/Error.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Docs.Build
 
         public bool PullRequestOnly { get; init; }
 
+        public string? DocumentUrl { get; init; }
+
         public object?[] MessageArguments { get; init; } = Array.Empty<object?>();
 
         public Error(ErrorLevel level, string code, FormattableString message, SourceInfo? source = null, string? propertyPath = null)
@@ -58,6 +60,7 @@ namespace Microsoft.Docs.Build
                 pull_request_only = PullRequestOnly ? (bool?)true : null,
                 property_path = PropertyPath,
                 ms_author = MsAuthor,
+                document_url = DocumentUrl,
                 date_time = DateTime.UtcNow, // Leave data_time as the last field to make regression test stable
             }).Replace("\"ms_author\"", "\"ms.author\"");
         }

--- a/src/docfx/lib/log/ErrorLog.cs
+++ b/src/docfx/lib/log/ErrorLog.cs
@@ -78,6 +78,11 @@ namespace Microsoft.Docs.Build
                     }
                     return;
                 }
+
+                if (config.DocumentUrls.TryGetValue(error.Code, out var documentUrl))
+                {
+                    error = error with { DocumentUrl = documentUrl };
+                }
             }
 
             Watcher.Write(() =>

--- a/src/docfx/serve/LanguageServerBuilder.cs
+++ b/src/docfx/serve/LanguageServerBuilder.cs
@@ -157,6 +157,9 @@ namespace Microsoft.Docs.Build
                      new(ConvertLocation(source.Line), ConvertLocation(source.Column)),
                      new(ConvertLocation(source.EndLine), ConvertLocation(source.EndColumn))),
                 Code = error.Code,
+                CodeDescription = error.DocumentUrl != null && Uri.TryCreate(error.DocumentUrl, UriKind.Absolute, out var href)
+                    ? new() { Href = href }
+                    : null,
                 Source = "Docs Validation",
                 Severity = error.Level switch
                 {

--- a/src/docfx/serve/lsp/DidChangeWatchedFilesHandler.cs
+++ b/src/docfx/serve/lsp/DidChangeWatchedFilesHandler.cs
@@ -64,16 +64,14 @@ namespace Microsoft.Docs.Build
             return Unit.Task;
         }
 
-        DidChangeWatchedFilesRegistrationOptions IRegistration<DidChangeWatchedFilesRegistrationOptions>.GetRegistrationOptions()
+        DidChangeWatchedFilesRegistrationOptions
+            IRegistration<DidChangeWatchedFilesRegistrationOptions, DidChangeWatchedFilesCapability>.GetRegistrationOptions(
+            DidChangeWatchedFilesCapability capability, ClientCapabilities clientCapabilities)
         {
             return new DidChangeWatchedFilesRegistrationOptions()
             {
                 Watchers = _watcher,
             };
-        }
-
-        public void SetCapability(DidChangeWatchedFilesCapability capability)
-        {
         }
     }
 }

--- a/src/docfx/serve/lsp/TextDocumentHandler.cs
+++ b/src/docfx/serve/lsp/TextDocumentHandler.cs
@@ -76,7 +76,8 @@ namespace Microsoft.Docs.Build
             return Unit.Task;
         }
 
-        TextDocumentChangeRegistrationOptions IRegistration<TextDocumentChangeRegistrationOptions>.GetRegistrationOptions()
+        TextDocumentChangeRegistrationOptions IRegistration<TextDocumentChangeRegistrationOptions, SynchronizationCapability>.GetRegistrationOptions(
+            SynchronizationCapability capability, ClientCapabilities clientCapabilities)
         {
             return new TextDocumentChangeRegistrationOptions()
             {
@@ -85,19 +86,26 @@ namespace Microsoft.Docs.Build
             };
         }
 
-        public void SetCapability(SynchronizationCapability capability)
+        TextDocumentOpenRegistrationOptions IRegistration<TextDocumentOpenRegistrationOptions, SynchronizationCapability>.GetRegistrationOptions(
+            SynchronizationCapability capability, ClientCapabilities clientCapabilities)
         {
-        }
-
-        TextDocumentRegistrationOptions IRegistration<TextDocumentRegistrationOptions>.GetRegistrationOptions()
-        {
-            return new TextDocumentRegistrationOptions()
+            return new TextDocumentOpenRegistrationOptions()
             {
                 DocumentSelector = _documentSelector,
             };
         }
 
-        TextDocumentSaveRegistrationOptions IRegistration<TextDocumentSaveRegistrationOptions>.GetRegistrationOptions()
+        TextDocumentCloseRegistrationOptions IRegistration<TextDocumentCloseRegistrationOptions, SynchronizationCapability>.GetRegistrationOptions(
+            SynchronizationCapability capability, ClientCapabilities clientCapabilities)
+        {
+            return new TextDocumentCloseRegistrationOptions()
+            {
+                DocumentSelector = _documentSelector,
+            };
+        }
+
+        TextDocumentSaveRegistrationOptions IRegistration<TextDocumentSaveRegistrationOptions, SynchronizationCapability>.GetRegistrationOptions(
+            SynchronizationCapability capability, ClientCapabilities clientCapabilities)
         {
             return new TextDocumentSaveRegistrationOptions()
             {

--- a/test/docfx.Test/docfx.Test.csproj
+++ b/test/docfx.Test/docfx.Test.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0096" />
     <PackageReference Include="coverlet.msbuild" Version="3.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.18.3" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.19.0" />
     <PackageReference Include="yunit" Version="1.0.0-preview-0056-g426293ca74" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />


### PR DESCRIPTION
[AB#388914](https://dev.azure.com/ceapex/Engineering/_workitems/edit/388914/)

With this change, vscode extension shows error code as a standard clickable link, so we could remove our custom code action provider:

![doc-url](https://user-images.githubusercontent.com/511355/110594891-5120c600-81b8-11eb-86d7-95418536f314.png)
