### PR TITLE
Remove tab group hash function

### DIFF
--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -467,19 +467,19 @@ outputs:
   docs/a.json: |
     {
       "conceptual": "
-        <div class='tabGroup' id='tabgroup_bHGHmlrG6S'>
+        <div class='tabGroup' id='tabgroup_1'>
           <ul role='tablist'>
             <li role='presentation'>
-              <a href='#tabpanel_bHGHmlrG6S_a' role='tab' aria-controls='tabpanel_bHGHmlrG6S_a' data-tab='a' tabindex='0' aria-selected='true'>a</a>
+              <a href='#tabpanel_1_a' role='tab' aria-controls='tabpanel_1_a' data-tab='a' tabindex='0' aria-selected='true'>a</a>
             </li>
             <li role='presentation'>
-              <a href='#tabpanel_bHGHmlrG6S_b' role='tab' aria-controls='tabpanel_bHGHmlrG6S_b' data-tab='b' tabindex='-1'>b</a>
+              <a href='#tabpanel_1_b' role='tab' aria-controls='tabpanel_1_b' data-tab='b' tabindex='-1'>b</a>
             </li>
           </ul>
-          <section id='tabpanel_bHGHmlrG6S_a' role='tabpanel' data-tab='a'>
+          <section id='tabpanel_1_a' role='tabpanel' data-tab='a'>
             <p>a</p>
           </section>
-          <section id='tabpanel_bHGHmlrG6S_b' role='tabpanel' data-tab='b' aria-hidden='true' hidden='hidden'>
+          <section id='tabpanel_1_b' role='tabpanel' data-tab='b' aria-hidden='true' hidden='hidden'>
             <p>b</p>
           </section>
         </div>"

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Aggregator/TabGroupAggregator.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Aggregator/TabGroupAggregator.cs
@@ -69,22 +69,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             int startSpan,
             int offset)
         {
-            var groupId = GetHashString(items[0]?.Content?.ToString() ?? "").Replace("/", "-").Remove(10);
-
-            context.AggregateTo(
-                new TabGroupBlock(
-                                groupId,
-                                items.ToImmutableArray(),
-                                startLine,
-                                startSpan,
-                                0),
-                offset);
-        }
-
-        private static string GetHashString(string content)
-        {
-            using var sha256 = SHA256.Create();
-            return Convert.ToBase64String(sha256.ComputeHash(Encoding.UTF8.GetBytes(content)));
+            context.AggregateTo(new TabGroupBlock(items.ToImmutableArray(), startLine, startSpan, 0), offset);
         }
 
         private static TabItemBlock CreateTabItem(

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TabGroup/HtmlTabGroupBlockRenderer.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TabGroup/HtmlTabGroupBlockRenderer.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         protected override void Write(HtmlRenderer renderer, TabGroupBlock block)
         {
             renderer.Write(@"<div class=""tabGroup"" id=""tabgroup_");
-            var groupId = ExtensionsHelper.Escape(block.Id);
+            var groupId = block.Id.ToString();
             renderer.Write(groupId);
             renderer.Write("\"");
             renderer.WriteAttributes(block);

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TabGroup/TabGroupBlock.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TabGroup/TabGroupBlock.cs
@@ -9,16 +9,15 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 {
     public class TabGroupBlock : ContainerBlock
     {
-        public string Id { get; set; }
+        public int Id { get; set; }
 
         public int ActiveTabIndex { get; set; }
 
         public ImmutableArray<TabItemBlock> Items { get; set; }
 
-        public TabGroupBlock(string id, ImmutableArray<TabItemBlock> blocks, int startLine, int startSpan, int activeTabIndex)
+        public TabGroupBlock(ImmutableArray<TabItemBlock> blocks, int startLine, int startSpan, int activeTabIndex)
             : base(null)
         {
-            Id = id;
             ActiveTabIndex = activeTabIndex;
             Items = blocks;
             Line = startLine;

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TabGroup/TabGroupIdRewriter.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TabGroup/TabGroupIdRewriter.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using Markdig.Syntax;
 using Microsoft.DocAsCode.MarkdigEngine.Extensions;
 
@@ -9,7 +8,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine
 {
     public class TabGroupIdRewriter : IMarkdownObjectRewriter
     {
-        private readonly Dictionary<string, int> _dict = new();
+        private int _id;
 
         public void PostProcess(IMarkdownObject markdownObject)
         {
@@ -23,22 +22,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine
         {
             if (markdownObject is TabGroupBlock block)
             {
-                var groupId = block.Id;
-                while (true)
-                {
-                    if (_dict.TryGetValue(groupId, out var index))
-                    {
-                        _dict[groupId] += 1;
-                        groupId = $"{groupId}-{index}";
-                        block.Id = groupId;
-                        return block;
-                    }
-                    else
-                    {
-                        _dict.Add(groupId, 1);
-                        return markdownObject;
-                    }
-                }
+                block.Id = ++_id;
             }
 
             return markdownObject;

--- a/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/GeneralTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/GeneralTest.cs
@@ -91,7 +91,7 @@ tag started with alphabet should not be encode: <abc> <a-hello> &lt;a?world&gt; 
         [InlineData("Hot keys: <kbd>Ctrl+[</kbd> and <kbd>Ctrl+]</kbd>", "<p>Hot keys: <kbd>Ctrl+[</kbd> and <kbd>Ctrl+]</kbd></p>\n")]
         [InlineData("<div>Some text here</div>", "<div>Some text here</div>\n")]
         [InlineData(
-            @"# Hello @CrossLink1 @'CrossLink2'dummy 
+            @"# Hello @CrossLink1 @'CrossLink2'dummy
 @World",
             "<h1 id=\"hello--dummy\">Hello <xref href=\"CrossLink1\" data-throw-if-not-resolved=\"False\" data-raw-source=\"@CrossLink1\"></xref> <xref href=\"CrossLink2\" data-throw-if-not-resolved=\"False\" data-raw-source=\"@'CrossLink2'\"></xref>dummy</h1>\n<p><xref href=\"World\" data-throw-if-not-resolved=\"False\" data-raw-source=\"@World\"></xref></p>\n")]
         [InlineData(
@@ -195,20 +195,19 @@ content-a
 # <a id=""x""></a>[title-b](#tab/b/c)
 content-b
 - - -";
-            var groupId = "bHGHmlrG6S";
-            var expected = $@"<div class=""tabGroup"" id=""tabgroup_{groupId}"" sourceFile=""test.md"" sourceStartLineNumber=""1"">
+            var expected = $@"<div class=""tabGroup"" id=""tabgroup_1"" sourceFile=""test.md"" sourceStartLineNumber=""1"">
 <ul role=""tablist"">
 <li role=""presentation"">
-<a href=""#tabpanel_{groupId}_a"" role=""tab"" aria-controls=""tabpanel_{groupId}_a"" data-tab=""a"" tabindex=""0"" aria-selected=""true"" sourceFile=""test.md"" sourceStartLineNumber=""1"">title-a</a>
+<a href=""#tabpanel_1_a"" role=""tab"" aria-controls=""tabpanel_1_a"" data-tab=""a"" tabindex=""0"" aria-selected=""true"" sourceFile=""test.md"" sourceStartLineNumber=""1"">title-a</a>
 </li>
 <li role=""presentation"" aria-hidden=""true"" hidden=""hidden"">
-<a href=""#tabpanel_{groupId}_b_c"" role=""tab"" aria-controls=""tabpanel_{groupId}_b_c"" data-tab=""b"" data-condition=""c"" tabindex=""-1"" sourceFile=""test.md"" sourceStartLineNumber=""3"">title-b</a>
+<a href=""#tabpanel_1_b_c"" role=""tab"" aria-controls=""tabpanel_1_b_c"" data-tab=""b"" data-condition=""c"" tabindex=""-1"" sourceFile=""test.md"" sourceStartLineNumber=""3"">title-b</a>
 </li>
 </ul>
-<section id=""tabpanel_{groupId}_a"" role=""tabpanel"" data-tab=""a"">
+<section id=""tabpanel_1_a"" role=""tabpanel"" data-tab=""a"">
 <p sourceFile=""test.md"" sourceStartLineNumber=""2"">content-a</p>
 </section>
-<section id=""tabpanel_{groupId}_b_c"" role=""tabpanel"" data-tab=""b"" data-condition=""c"" aria-hidden=""true"" hidden=""hidden"">
+<section id=""tabpanel_1_b_c"" role=""tabpanel"" data-tab=""b"" data-condition=""c"" aria-hidden=""true"" hidden=""hidden"">
 <p sourceFile=""test.md"" sourceStartLineNumber=""4"">content-b</p>
 </section>
 </div>
@@ -230,37 +229,36 @@ content-a
 # [title-b](#tab/b/a)
 content-b
 - - -";
-            var groupId = "bHGHmlrG6S";
-            var expected = $@"<div class=""tabGroup"" id=""tabgroup_{groupId}"" sourceFile=""test.md"" sourceStartLineNumber=""1"">
+            var expected = $@"<div class=""tabGroup"" id=""tabgroup_1"" sourceFile=""test.md"" sourceStartLineNumber=""1"">
 <ul role=""tablist"">
 <li role=""presentation"">
-<a href=""#tabpanel_{groupId}_a"" role=""tab"" aria-controls=""tabpanel_{groupId}_a"" data-tab=""a"" tabindex=""0"" aria-selected=""true"" sourceFile=""test.md"" sourceStartLineNumber=""1"">title-a</a>
+<a href=""#tabpanel_1_a"" role=""tab"" aria-controls=""tabpanel_1_a"" data-tab=""a"" tabindex=""0"" aria-selected=""true"" sourceFile=""test.md"" sourceStartLineNumber=""1"">title-a</a>
 </li>
 <li role=""presentation"" aria-hidden=""true"" hidden=""hidden"">
-<a href=""#tabpanel_{groupId}_b_c"" role=""tab"" aria-controls=""tabpanel_{groupId}_b_c"" data-tab=""b"" data-condition=""c"" tabindex=""-1"" sourceFile=""test.md"" sourceStartLineNumber=""3"">title-b</a>
+<a href=""#tabpanel_1_b_c"" role=""tab"" aria-controls=""tabpanel_1_b_c"" data-tab=""b"" data-condition=""c"" tabindex=""-1"" sourceFile=""test.md"" sourceStartLineNumber=""3"">title-b</a>
 </li>
 </ul>
-<section id=""tabpanel_{groupId}_a"" role=""tabpanel"" data-tab=""a"">
+<section id=""tabpanel_1_a"" role=""tabpanel"" data-tab=""a"">
 <p sourceFile=""test.md"" sourceStartLineNumber=""2"">content-a</p>
 </section>
-<section id=""tabpanel_{groupId}_b_c"" role=""tabpanel"" data-tab=""b"" data-condition=""c"" aria-hidden=""true"" hidden=""hidden"">
+<section id=""tabpanel_1_b_c"" role=""tabpanel"" data-tab=""b"" data-condition=""c"" aria-hidden=""true"" hidden=""hidden"">
 <p sourceFile=""test.md"" sourceStartLineNumber=""4"">content-b</p>
 </section>
 </div>
-<div class=""tabGroup"" id=""tabgroup_{groupId}-1"" sourceFile=""test.md"" sourceStartLineNumber=""6"">
+<div class=""tabGroup"" id=""tabgroup_2"" sourceFile=""test.md"" sourceStartLineNumber=""6"">
 <ul role=""tablist"">
 <li role=""presentation"">
-<a href=""#tabpanel_{groupId}-1_a"" role=""tab"" aria-controls=""tabpanel_{groupId}-1_a"" data-tab=""a"" tabindex=""0"" aria-selected=""true"" sourceFile=""test.md"" sourceStartLineNumber=""6"">title-a</a>
+<a href=""#tabpanel_2_a"" role=""tab"" aria-controls=""tabpanel_2_a"" data-tab=""a"" tabindex=""0"" aria-selected=""true"" sourceFile=""test.md"" sourceStartLineNumber=""6"">title-a</a>
 </li>
 <li role=""presentation"">
-<a href=""#tabpanel_{groupId}-1_b_a"" role=""tab"" aria-controls=""tabpanel_{groupId}-1_b_a"" data-tab=""b"" data-condition=""a"" tabindex=""-1"" sourceFile=""test.md"" sourceStartLineNumber=""8"">title-b</a>
+<a href=""#tabpanel_2_b_a"" role=""tab"" aria-controls=""tabpanel_2_b_a"" data-tab=""b"" data-condition=""a"" tabindex=""-1"" sourceFile=""test.md"" sourceStartLineNumber=""8"">title-b</a>
 </li>
 </ul>
-<section id=""tabpanel_{groupId}-1_a"" role=""tabpanel"" data-tab=""a"">
+<section id=""tabpanel_2_a"" role=""tabpanel"" data-tab=""a"">
 
 <p sourceFile=""test.md"" sourceStartLineNumber=""7"">content-a</p>
 </section>
-<section id=""tabpanel_{groupId}-1_b_a"" role=""tabpanel"" data-tab=""b"" data-condition=""a"" aria-hidden=""true"" hidden=""hidden"">
+<section id=""tabpanel_2_b_a"" role=""tabpanel"" data-tab=""b"" data-condition=""a"" aria-hidden=""true"" hidden=""hidden"">
 
 <p sourceFile=""test.md"" sourceStartLineNumber=""9"">content-b</p>
 </section>
@@ -275,13 +273,13 @@ content-b
         {
             var source = @"---
 title: ""如何使用 Visual C++ 工具集报告问题 | Microsoft Docs""
-ms.custom: 
+ms.custom:
 ms.date: 11/04/2016
-ms.reviewer: 
-ms.suite: 
+ms.reviewer:
+ms.suite:
 ms.technology:
 - cpp
-ms.tgt_pltfrm: 
+ms.tgt_pltfrm:
 ms.topic: article
 dev_langs:
 - C++

--- a/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/TabGroupTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/TabGroupTest.cs
@@ -11,7 +11,6 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Tests
         [Trait("Related", "TabGroup")]
         public void Test_General()
         {
-            var groupId = "bHGHmlrG6S";
             TestMarkupInGeneral(
                 @"Tab group test case
 # [title-a](#tab/a)
@@ -20,20 +19,20 @@ content-a
 content-b
 - - -",
                 $@"<p sourceFile=""Topic.md"" sourceStartLineNumber=""1"">Tab group test case</p>
-<div class=""tabGroup"" id=""tabgroup_{groupId}"" sourceFile=""Topic.md"" sourceStartLineNumber=""2"">
+<div class=""tabGroup"" id=""tabgroup_1"" sourceFile=""Topic.md"" sourceStartLineNumber=""2"">
 <ul role=""tablist"">
 <li role=""presentation"">
-<a href=""#tabpanel_{groupId}_a"" role=""tab"" aria-controls=""tabpanel_{groupId}_a"" data-tab=""a"" tabindex=""0"" aria-selected=""true"" sourceFile=""Topic.md"" sourceStartLineNumber=""2"">title-a</a>
+<a href=""#tabpanel_1_a"" role=""tab"" aria-controls=""tabpanel_1_a"" data-tab=""a"" tabindex=""0"" aria-selected=""true"" sourceFile=""Topic.md"" sourceStartLineNumber=""2"">title-a</a>
 </li>
 <li role=""presentation"" aria-hidden=""true"" hidden=""hidden"">
-<a href=""#tabpanel_{groupId}_b_c"" role=""tab"" aria-controls=""tabpanel_{groupId}_b_c"" data-tab=""b"" data-condition=""c"" tabindex=""-1"" sourceFile=""Topic.md"" sourceStartLineNumber=""4"">title-b</a>
+<a href=""#tabpanel_1_b_c"" role=""tab"" aria-controls=""tabpanel_1_b_c"" data-tab=""b"" data-condition=""c"" tabindex=""-1"" sourceFile=""Topic.md"" sourceStartLineNumber=""4"">title-b</a>
 </li>
 </ul>
-<section id=""tabpanel_{groupId}_a"" role=""tabpanel"" data-tab=""a"">
+<section id=""tabpanel_1_a"" role=""tabpanel"" data-tab=""a"">
 
 <p sourceFile=""Topic.md"" sourceStartLineNumber=""3"">content-a</p>
 </section>
-<section id=""tabpanel_{groupId}_b_c"" role=""tabpanel"" data-tab=""b"" data-condition=""c"" aria-hidden=""true"" hidden=""hidden"">
+<section id=""tabpanel_1_b_c"" role=""tabpanel"" data-tab=""b"" data-condition=""c"" aria-hidden=""true"" hidden=""hidden"">
 
 <p sourceFile=""Topic.md"" sourceStartLineNumber=""5"">content-b</p>
 </section>
@@ -45,7 +44,6 @@ content-b
         [Trait("Related", "TabGroup")]
         public void Test_TabGroup_Combining()
         {
-            var groupId = "bHGHmlrG6S";
             TestMarkupInGeneral(
                 @"# [title-a or b](#tab/a+b)
 content-a or b
@@ -57,36 +55,36 @@ content-a
 # [title-b or c](#tab/b+c)
 content-b or c
 - - -",
-                $@"<div class=""tabGroup"" id=""tabgroup_{groupId}"" sourceFile=""Topic.md"" sourceStartLineNumber=""1"">
+                $@"<div class=""tabGroup"" id=""tabgroup_1"" sourceFile=""Topic.md"" sourceStartLineNumber=""1"">
 <ul role=""tablist"">
 <li role=""presentation"">
-<a href=""#tabpanel_{groupId}_a+b"" role=""tab"" aria-controls=""tabpanel_{groupId}_a+b"" data-tab=""a+b"" tabindex=""0"" aria-selected=""true"" sourceFile=""Topic.md"" sourceStartLineNumber=""1"">title-a or b</a>
+<a href=""#tabpanel_1_a+b"" role=""tab"" aria-controls=""tabpanel_1_a+b"" data-tab=""a+b"" tabindex=""0"" aria-selected=""true"" sourceFile=""Topic.md"" sourceStartLineNumber=""1"">title-a or b</a>
 </li>
 <li role=""presentation"">
-<a href=""#tabpanel_{groupId}_c"" role=""tab"" aria-controls=""tabpanel_{groupId}_c"" data-tab=""c"" tabindex=""-1"" sourceFile=""Topic.md"" sourceStartLineNumber=""3"">title-c</a>
+<a href=""#tabpanel_1_c"" role=""tab"" aria-controls=""tabpanel_1_c"" data-tab=""c"" tabindex=""-1"" sourceFile=""Topic.md"" sourceStartLineNumber=""3"">title-c</a>
 </li>
 </ul>
-<section id=""tabpanel_{groupId}_a+b"" role=""tabpanel"" data-tab=""a+b"">
+<section id=""tabpanel_1_a+b"" role=""tabpanel"" data-tab=""a+b"">
 <p sourceFile=""Topic.md"" sourceStartLineNumber=""2"">content-a or b</p>
 </section>
-<section id=""tabpanel_{groupId}_c"" role=""tabpanel"" data-tab=""c"" aria-hidden=""true"" hidden=""hidden"">
+<section id=""tabpanel_1_c"" role=""tabpanel"" data-tab=""c"" aria-hidden=""true"" hidden=""hidden"">
 <p sourceFile=""Topic.md"" sourceStartLineNumber=""4"">content-c</p>
 </section>
 </div>
-<div class=""tabGroup"" id=""tabgroup_{groupId}-1"" sourceFile=""Topic.md"" sourceStartLineNumber=""6"">
+<div class=""tabGroup"" id=""tabgroup_2"" sourceFile=""Topic.md"" sourceStartLineNumber=""6"">
 <ul role=""tablist"">
 <li role=""presentation"">
-<a href=""#tabpanel_{groupId}-1_a"" role=""tab"" aria-controls=""tabpanel_{groupId}-1_a"" data-tab=""a"" tabindex=""0"" aria-selected=""true"" sourceFile=""Topic.md"" sourceStartLineNumber=""6"">title-a</a>
+<a href=""#tabpanel_2_a"" role=""tab"" aria-controls=""tabpanel_2_a"" data-tab=""a"" tabindex=""0"" aria-selected=""true"" sourceFile=""Topic.md"" sourceStartLineNumber=""6"">title-a</a>
 </li>
 <li role=""presentation"">
-<a href=""#tabpanel_{groupId}-1_b+c"" role=""tab"" aria-controls=""tabpanel_{groupId}-1_b+c"" data-tab=""b+c"" tabindex=""-1"" sourceFile=""Topic.md"" sourceStartLineNumber=""8"">title-b or c</a>
+<a href=""#tabpanel_2_b+c"" role=""tab"" aria-controls=""tabpanel_2_b+c"" data-tab=""b+c"" tabindex=""-1"" sourceFile=""Topic.md"" sourceStartLineNumber=""8"">title-b or c</a>
 </li>
 </ul>
-<section id=""tabpanel_{groupId}-1_a"" role=""tabpanel"" data-tab=""a"">
+<section id=""tabpanel_2_a"" role=""tabpanel"" data-tab=""a"">
 
 <p sourceFile=""Topic.md"" sourceStartLineNumber=""7"">content-a</p>
 </section>
-<section id=""tabpanel_{groupId}-1_b+c"" role=""tabpanel"" data-tab=""b+c"" aria-hidden=""true"" hidden=""hidden"">
+<section id=""tabpanel_2_b+c"" role=""tabpanel"" data-tab=""b+c"" aria-hidden=""true"" hidden=""hidden"">
 
 <p sourceFile=""Topic.md"" sourceStartLineNumber=""9"">content-b or c</p>
 </section>
@@ -97,20 +95,19 @@ content-b or c
         [Fact]
         public void TestTableInTabGroup()
         {
-            var groupId = "bHGHmlrG6S";
             TestMarkupInGeneral(
                 @"# [title](#tab/id)
 
 a | b
 - | -
 c | d",
-                $@"<div class=""tabGroup"" id=""tabgroup_{groupId}"" sourceFile=""Topic.md"" sourceStartLineNumber=""1"">
+                $@"<div class=""tabGroup"" id=""tabgroup_1"" sourceFile=""Topic.md"" sourceStartLineNumber=""1"">
 <ul role=""tablist"">
 <li role=""presentation"">
-<a href=""#tabpanel_{groupId}_id"" role=""tab"" aria-controls=""tabpanel_{groupId}_id"" data-tab=""id"" tabindex=""0"" aria-selected=""true"" sourceFile=""Topic.md"" sourceStartLineNumber=""1"">title</a>
+<a href=""#tabpanel_1_id"" role=""tab"" aria-controls=""tabpanel_1_id"" data-tab=""id"" tabindex=""0"" aria-selected=""true"" sourceFile=""Topic.md"" sourceStartLineNumber=""1"">title</a>
 </li>
 </ul>
-<section id=""tabpanel_{groupId}_id"" role=""tabpanel"" data-tab=""id"">
+<section id=""tabpanel_1_id"" role=""tabpanel"" data-tab=""id"">
 
 <table sourceFile=""Topic.md"" sourceStartLineNumber=""3"">
 <thead>

--- a/test/docfx.Test/lib/MarkdownElementTelemetryExtensionTest.cs
+++ b/test/docfx.Test/lib/MarkdownElementTelemetryExtensionTest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Docs.Build
                 new object[] { new ListBlock(null), "List" },
                 new object[] { new CodeSnippet(null), "CodeSnippet" },
                 new object[] { new Table(), "Table" },
-                new object[] { new TabGroupBlock(null, new List<TabItemBlock>() { new TabItemBlock("Fake", "Fake", new TabTitleBlock(), new TabContentBlock(new List<Block>()), false) }.ToImmutableArray(), 0, 0, 0), "TabbedContent" },
+                new object[] { new TabGroupBlock(new List<TabItemBlock>() { new TabItemBlock("Fake", "Fake", new TabTitleBlock(), new TabContentBlock(new List<Block>()), false) }.ToImmutableArray(), 0, 0, 0), "TabbedContent" },
                 new object[] { new MonikerRangeBlock(null), "MonikerRange" },
                 new object[] { new RowBlock(null), "Row" },
                 new object[] { new NestedColumnBlock(null), "NestedColumn" },


### PR DESCRIPTION
The tab group hash result is always `bHGHmlrG6S` because the input is always `Microsoft.DocAsCode.MarkdigEngine.Extensions.TabItemBlock`, so remove the hash function.

The `TabGroupIdAggregator` already generates a unique tab group id per markdown document.