### PR TITLE
Drop .loc in locale regex match

### DIFF
--- a/src/docfx/lib/LocalizationUtility.cs
+++ b/src/docfx/lib/LocalizationUtility.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Docs.Build
                 CultureInfo.GetCultures(CultureTypes.NeutralCultures)).Select(c => c.Name).Concat(
                 new[] { "zh-cn", "zh-tw", "zh-hk", "zh-sg", "zh-mo" }), StringComparer.OrdinalIgnoreCase);
 
-        private static readonly Regex s_nameWithLocale = new(@"^.+?(\.[a-z]{2,4}-[a-z]{2,4}(-[a-z]{2,4})?|\.loc)?$", RegexOptions.IgnoreCase);
+        private static readonly Regex s_nameWithLocale = new(@"^.+?(\.[a-z]{2,4}-[a-z]{2,4}(-[a-z]{2,4})?)?$", RegexOptions.IgnoreCase);
         private static readonly Regex s_lrmAdjustment = new(@"(^|\s|\>)(C#|F#|C\+\+)(\s*|[.!?;:]*)(\<|[\n\r]|$)", RegexOptions.IgnoreCase);
 
         public static bool IsValidLocale(string locale) => s_locales.Contains(locale);

--- a/test/docfx.Test/build/ConfigTest.cs
+++ b/test/docfx.Test/build/ConfigTest.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Docs.Build
         [InlineData("https://test.visualstudio.com/_git/abc.zh-cn", "master", "https://test.visualstudio.com/_git/abc", "master")]
         [InlineData("https://test.visualstudio.com/_git/abc.bs-Cyrl-BA", "master", "https://test.visualstudio.com/_git/abc", "master")]
         [InlineData("https://github.com/docs.zh-cn", "master-sxs", "https://github.com/docs", "master")]
-        [InlineData("https://github.com/docs.loc", "master-sxs.zh-cn", "https://github.com/docs", "master")]
         public static void LocConfigConventionSourceRepo(string remote, string branch, string expectedSourceRemote, string expectedSourceBranch)
         {
             var (sourceRemote, sourceBranch) = LocalizationUtility.GetFallbackRepository(remote, branch);


### PR DESCRIPTION
Clean up the locale regex to remove `.loc` support. Trigger all builds wants to filter all locale repos and this is the regex to see if it is en-us.