### PR TITLE
add ephemeralKeySet storage flag

### DIFF
--- a/src/docfx/lib/msgraph/MicrosoftGraphAuthenticationProvider.cs
+++ b/src/docfx/lib/msgraph/MicrosoftGraphAuthenticationProvider.cs
@@ -24,7 +24,10 @@ namespace Microsoft.Docs.Build
 
         public MicrosoftGraphAuthenticationProvider(string tenantId, string clientId, string clientCertificate)
         {
-            _clientCertificate = new X509Certificate2(Convert.FromBase64String(clientCertificate), password: "");
+            _clientCertificate = new X509Certificate2(
+                Convert.FromBase64String(clientCertificate),
+                password: "",
+                X509KeyStorageFlags.EphemeralKeySet);
             _cca = ConfidentialClientApplicationBuilder.Create(clientId)
                 .WithCertificate(_clientCertificate)
                 .WithAuthority(new Uri($"https://login.microsoftonline.com/{tenantId}/v2.0"))


### PR DESCRIPTION
use ephemeralKeySet storage flag to avoid creating temp file each time using certificate.
[AB#403500](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/403500)