### PR TITLE
Remove .deps.json reference in csproj

### DIFF
--- a/test/docfx.RegressionTest/docfx.RegressionTest.csproj
+++ b/test/docfx.RegressionTest/docfx.RegressionTest.csproj
@@ -7,10 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="../../src/docfx/bin/$(Configuration)/$(TargetFramework)/*.json" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
-  
-  <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>

--- a/test/docfx.Test/docfx.Test.csproj
+++ b/test/docfx.Test/docfx.Test.csproj
@@ -19,8 +19,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="*.json" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="*.yml" CopyToOutputDirectory="PreserveNewest" />
     <None Include="data/**/*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 


### PR DESCRIPTION
These lines walkaround the https://github.com/dotnet/sdk/issues/1675, now that dotnet SDK 5.0.200 officially supports exes as project references, we can remove them.