### PR TITLE
suppress credscan errors in MaskUtilityTest 

### DIFF
--- a/azure-pipelines-lgtm.yml
+++ b/azure-pipelines-lgtm.yml
@@ -55,6 +55,7 @@ jobs:
     displayName: Security - CredScan
     inputs:
       toolMajorVersion: 'V2'
+      suppressionsFile: credscan-suppressions.json
 
   # Run SDL tools
   - task: BinSkim@3

--- a/credscan-suppressions.json
+++ b/credscan-suppressions.json
@@ -1,0 +1,9 @@
+{
+  "tool": "Credential Scanner",
+  "suppressions": [
+    {
+      "file": "\\test\\docfx.Test\\lib\\MaskUtilityTest.cs",
+      "_justification": "test data"
+    }
+  ]
+}


### PR DESCRIPTION
MaskUtilityTest is using several test data which looks like cred, and we need to add suppression for it.

https://dev.azure.com/ceapex/Engineering/_build/results?buildId=432660&view=logs&j=fa965d9e-e9c2-54a2-3314-91eb96ef2d15&t=7600efd7-595c-5dc2-6cf5-8272e849c2cb
Detected 1 issue(s) in D:\a\1\s\test\docfx.Test\lib\MaskUtilityTest.cs

Fix reference:
https://docs.microsoft.com/en-us/azure/security/develop/security-code-analysis-faq