### PR TITLE
Support output-type for TOC

### DIFF
--- a/docs/specs/static.yml
+++ b/docs/specs/static.yml
@@ -401,3 +401,57 @@ outputs:
     <script src='/dev/test.js' ></script>
     <link rel="stylesheet" href="/dev/test.css">
     <div></div>
+---
+# TOC with output-type="html"
+repos:
+  https://github.com/toc/toc-output-type-is-html:
+  - files:
+      docfx.yml: |
+        outputType: html
+        renderType: Content
+        template: https://docs.com/theme
+      TOC.yml: |
+        - name: link-a
+          href: a.md
+      a.md:
+  https://docs.com/theme:
+  - files:
+      ContentTemplate/toc.json.js: |
+        exports.transform = function (model) {
+          model["outputType"] = "html"
+          return {
+            content: JSON.stringify(model)
+          }
+        }
+      ContentTemplate/toc.html.tmpl:  |
+        {{!Copyright-Microsoft.}}
+        <h1>TOC</h1>
+        {{#items}}
+          <a href="{{href}}"> {{name}} </a>
+        {{/items}}
+      Conceptual.html.liquid: |
+        <!DOCTYPE html>
+          <div>
+              {{content}}
+          </div>
+      ContentTemplate/schemas/toc.schema.json: |
+        {
+          "title": "TOC",
+          "additionalProperties": true,
+          "properties": {
+            "items": {
+              "type": "object",
+              "properties": {
+                "href": { "contentType": "href", "type": "string" },
+                "name": { "type": "string" }
+              }
+            }
+          }
+        }
+outputs:
+  a.html:
+  toc.html: |
+    <h1>TOC</h1>
+      <a href="a"> link-a </a>
+  toc.json: |
+    {"items":[{"name":"link-a","href":"a"}],"_path":"toc.json","schema":"toc", "outputType":"html"}

--- a/docs/specs/toc/toc.yml
+++ b/docs/specs/toc/toc.yml
@@ -1524,14 +1524,52 @@ outputs:
     }
 ---
 # TOC with output-type="json"
-inputs:
-  docfx.yml: |
-    outputType: Json
-  TOC.yml: |
-    - name: a
-      href: a.md
-  a.md:
+repos:
+  https://github.com/toc/toc-output-type-is-json:
+  - files:
+      docfx.yml: |
+        outputType: Json
+        template: https://docs.com/theme
+      TOC.yml: |
+        - name: a
+          href: a.md
+      a.md:
+  https://docs.com/theme:
+  - files:
+      ContentTemplate/toc.json.js: |
+        exports.transform = function (model) {
+          model["outputType"] = "json"
+          return {
+            content: JSON.stringify(model)
+          }
+        }
 outputs:
   a.json:
   toc.json: |
     {"items":[{"name":"a","href":"a"}],"_path":"toc.json","schema":"toc"}
+---
+# TOC with output-type="pageJson"
+repos:
+  https://github.com/toc/toc-output-type-is-pageJson:
+  - files:
+      docfx.yml: |
+        outputType: PageJson
+        template: https://docs.com/theme
+      TOC.yml: |
+        - name: a
+          href: a.md
+      a.md:
+  https://docs.com/theme:
+  - files:
+      ContentTemplate/toc.json.js: |
+        exports.transform = function (model) {
+          model["outputType"] = "pagejson"
+          return {
+            content: JSON.stringify(model)
+          }
+        }
+outputs:
+  a.raw.page.json:
+  a.mta.json:
+  toc.json: |
+    {"items":[{"name":"a","href":"a"}],"_path":"toc.json","schema":"toc","outputType":"pagejson"}

--- a/docs/specs/toc/toc.yml
+++ b/docs/specs/toc/toc.yml
@@ -1522,3 +1522,16 @@ outputs:
         "a.md": [{ "source": "TOC.yml", "type": "metadata" }]
       }
     }
+---
+# TOC with output-type="json"
+inputs:
+  docfx.yml: |
+    outputType: Json
+  TOC.yml: |
+    - name: a
+      href: a.md
+  a.md:
+outputs:
+  a.json:
+  toc.json: |
+    {"items":[{"name":"a","href":"a"}],"_path":"toc.json","schema":"toc"}

--- a/src/docfx/build/toc/TocBuilder.cs
+++ b/src/docfx/build/toc/TocBuilder.cs
@@ -85,7 +85,15 @@ namespace Microsoft.Docs.Build
                     var output = _templateEngine.RunJavaScript("toc.json.js", JsonUtility.ToJObject(model));
                     _output.WriteJson(Path.ChangeExtension(outputPath, ".json"), output);
                 }
-                else
+
+                if (_config.OutputType == OutputType.Json)
+                {
+                    var outputModel = JsonUtility.ToJObject(model);
+                    outputModel["schema"] = "toc";
+                    _output.WriteJson(outputPath, outputModel);
+                }
+
+                if (_config.OutputType == OutputType.PageJson)
                 {
                     var output = _templateEngine.RunJavaScript("toc.json.js", JsonUtility.ToJObject(model));
                     _output.WriteJson(outputPath, output);

--- a/src/docfx/build/toc/TocBuilder.cs
+++ b/src/docfx/build/toc/TocBuilder.cs
@@ -72,7 +72,16 @@ namespace Microsoft.Docs.Build
 
             if (!errors.FileHasError(file) && !_config.DryRun)
             {
-                if (_config.OutputType == OutputType.Html)
+                if (_config.OutputType == OutputType.Json)
+                {
+                    _output.WriteJson(outputPath, JsonUtility.ToJObject(model));
+                }
+                else if (_config.OutputType == OutputType.PageJson)
+                {
+                    var output = _templateEngine.RunJavaScript("toc.json.js", JsonUtility.ToJObject(model));
+                    _output.WriteJson(outputPath, output);
+                }
+                else
                 {
                     if (_documentProvider.GetRenderType(file) == RenderType.Content)
                     {
@@ -84,17 +93,6 @@ namespace Microsoft.Docs.Build
                     // Just for current PDF build. toc.json is used for generate PDF outline
                     var output = _templateEngine.RunJavaScript("toc.json.js", JsonUtility.ToJObject(model));
                     _output.WriteJson(Path.ChangeExtension(outputPath, ".json"), output);
-                }
-                else if (_config.OutputType == OutputType.Json)
-                {
-                    var outputModel = JsonUtility.ToJObject(model);
-                    outputModel["schema"] = "toc";
-                    _output.WriteJson(outputPath, outputModel);
-                }
-                else
-                {
-                    var output = _templateEngine.RunJavaScript("toc.json.js", JsonUtility.ToJObject(model));
-                    _output.WriteJson(outputPath, output);
                 }
             }
 

--- a/src/docfx/build/toc/TocBuilder.cs
+++ b/src/docfx/build/toc/TocBuilder.cs
@@ -85,15 +85,13 @@ namespace Microsoft.Docs.Build
                     var output = _templateEngine.RunJavaScript("toc.json.js", JsonUtility.ToJObject(model));
                     _output.WriteJson(Path.ChangeExtension(outputPath, ".json"), output);
                 }
-
-                if (_config.OutputType == OutputType.Json)
+                else if (_config.OutputType == OutputType.Json)
                 {
                     var outputModel = JsonUtility.ToJObject(model);
                     outputModel["schema"] = "toc";
                     _output.WriteJson(outputPath, outputModel);
                 }
-
-                if (_config.OutputType == OutputType.PageJson)
+                else
                 {
                     var output = _templateEngine.RunJavaScript("toc.json.js", JsonUtility.ToJObject(model));
                     _output.WriteJson(outputPath, output);

--- a/src/docfx/build/toc/TocModel.cs
+++ b/src/docfx/build/toc/TocModel.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Docs.Build
         [JsonProperty("_path")]
         public string Path { get; }
 
+        public string Schema { get; init; } = "toc";
+
         public TocModel(TocNode[] items, TocMetadata metadata, string path)
         {
             Items = items;

--- a/src/docfx/build/toc/TocModel.cs
+++ b/src/docfx/build/toc/TocModel.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Docs.Build
         [JsonProperty("_path")]
         public string Path { get; }
 
-        public string Schema { get; init; } = "toc";
+        public string Schema { get; } = "toc";
 
         public TocModel(TocNode[] items, TocMetadata metadata, string path)
         {


### PR DESCRIPTION
* no template when output-type is "json"
* add a schema named "toc" to the output json