### PR TITLE
Fix unit tests

### DIFF
--- a/src/docfx/lib/log/ErrorLog.cs
+++ b/src/docfx/lib/log/ErrorLog.cs
@@ -42,14 +42,25 @@ namespace Microsoft.Docs.Build
                     if (error.AdditionalErrorInfo == null)
                     {
                         var metadata = MetadataProvider?.GetMetadata(Null, source);
-                        var additionalInfo = new AdditionalErrorInfo(
+                        if (new[]
+                            {
                             metadata?.MsAuthor,
                             metadata?.MsProd,
                             metadata?.MsTechnology,
                             metadata?.MsService,
-                            metadata?.MsSubservice);
-
-                        error = error with { AdditionalErrorInfo = additionalInfo };
+                            metadata?.MsSubservice,
+                            }.Any(value => !string.IsNullOrEmpty(value)))
+                        {
+                            error = error with
+                            {
+                                AdditionalErrorInfo = new AdditionalErrorInfo(
+                                    metadata?.MsAuthor,
+                                    metadata?.MsProd,
+                                    metadata?.MsTechnology,
+                                    metadata?.MsService,
+                                    metadata?.MsSubservice),
+                            };
+                        }
                     }
                 }
                 catch

--- a/src/docfx/lib/log/ErrorSink.cs
+++ b/src/docfx/lib/log/ErrorSink.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Docs.Build
                     return ErrorSinkResult.Ignore;
                 }
 
-                if (!_errors.Add(error with { MessageArguments = Array.Empty<string>(), AdditionalErrorInfo = null }))
+                if (!_errors.Add(error with { MessageArguments = Array.Empty<string>() }))
                 {
                     return ErrorSinkResult.Ignore;
                 }

--- a/src/docfx/lib/log/ErrorSink.cs
+++ b/src/docfx/lib/log/ErrorSink.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Docs.Build
                     return ErrorSinkResult.Ignore;
                 }
 
-                if (!_errors.Add(error with { MessageArguments = Array.Empty<string>() }))
+                if (!_errors.Add(error with { MessageArguments = Array.Empty<string>(), AdditionalErrorInfo = null }))
                 {
                     return ErrorSinkResult.Ignore;
                 }

--- a/test/docfx.Test/build/OpsConfigAdapterTest.cs
+++ b/test/docfx.Test/build/OpsConfigAdapterTest.cs
@@ -23,8 +23,8 @@ namespace Microsoft.Docs.Build
             "https://ops/buildconfig/?name=e2eppe-azure-documents&repository_url=https://github.com/OPS-E2E-PPE/azure-docs-pr.cs-cz&branch=live-sxs",
             "{'product':'MSDN','siteName':'Docs','hostName':'ppe.docs.microsoft.com','basePath':'/e2eppe-azure-documents','xrefHostName':'ppe.docs.microsoft.com'}")]
         [InlineData(
-            "https://ops/buildconfig/?name=e2e-ppe-dotnetapidocs&repository_url=https://github.com/OPS-E2E-PPE/dotnet-api-docs/&branch=master",
-            "{'product':'MSDN','siteName':'Docs','hostName':'ppe.docs.microsoft.com','basePath':'/e2eppe-core-docs','xrefHostName':'ppe.docs.microsoft.com'}")]
+            "https://ops/buildconfig/?name=E2E_RepoConifg_Docfxv3&repository_url=https://github.com/OPS-E2E-PPE/E2E_RepoConifg_Docfxv3/&branch=master",
+            "{'product':'MSDN','siteName':'Docs','hostName':'ppe.docs.microsoft.com','basePath':'/E2E_RepoConifg_Docfxv3','xrefHostName':'ppe.docs.microsoft.com'}")]
         public static async Task AdaptOpsServiceConfig(string url, string expectedJson)
         {
             var token = Environment.GetEnvironmentVariable("DOCS_OPS_TOKEN");

--- a/test/docfx.Test/build/OpsConfigAdapterTest.cs
+++ b/test/docfx.Test/build/OpsConfigAdapterTest.cs
@@ -23,8 +23,8 @@ namespace Microsoft.Docs.Build
             "https://ops/buildconfig/?name=e2eppe-azure-documents&repository_url=https://github.com/OPS-E2E-PPE/azure-docs-pr.cs-cz&branch=live-sxs",
             "{'product':'MSDN','siteName':'Docs','hostName':'ppe.docs.microsoft.com','basePath':'/e2eppe-azure-documents','xrefHostName':'ppe.docs.microsoft.com'}")]
         [InlineData(
-            "https://ops/buildconfig/?name=E2E_RepoConifg_Docfxv3&repository_url=https://github.com/OPS-E2E-PPE/E2E_RepoConifg_Docfxv3/&branch=master",
-            "{'product':'MSDN','siteName':'Docs','hostName':'ppe.docs.microsoft.com','basePath':'/E2E_RepoConifg_Docfxv3','xrefHostName':'ppe.docs.microsoft.com'}")]
+            "https://ops/buildconfig/?name=E2E_DocFxV3&repository_url=https://github.com/OPS-E2E-PPE/E2E_DocFxV3/&branch=master",
+            "{'product':'MSDN','siteName':'Docs','hostName':'ppe.docs.microsoft.com','basePath':'/E2E_DocFxV3','xrefHostName':'ppe.docs.microsoft.com'}")]
         public static async Task AdaptOpsServiceConfig(string url, string expectedJson)
         {
             var token = Environment.GetEnvironmentVariable("DOCS_OPS_TOKEN");


### PR DESCRIPTION
- flaky test: [AB#417016](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/417016)
Local debug shows HashSet<Error> contains "duplicate" entries caused by `AdditionalErrorInfo`
![image](https://user-images.githubusercontent.com/42199316/118937427-1f7a6700-b980-11eb-8f12-b3b0aed1462f.png)

- https://github.com/OPS-E2E-PPE/dotnet-api-docs is removed and deprovisioned