### PR TITLE
Update Microsoft.DocAsCode.Metadata.ManagedReference.csproj

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Microsoft.DocAsCode.Metadata.ManagedReference.csproj
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Microsoft.DocAsCode.Metadata.ManagedReference.csproj
@@ -21,6 +21,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.2" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The previous version, 1.2.2, requires you to have MSBuild 15 on your computer. This version allows MSBuild 15 _or greater_. I've been dealing with the issue described here for two days.
https://github.com/dotnet/docfx/issues/4880

This resolves it.