### PR TITLE
Fix for memberpage reference (dotnet/docfx#7422)

### DIFF
--- a/plugins/Microsoft.DocAsCode.Build.MemberLevelManagedReference/Microsoft.DocAsCode.Build.MemberLevelManagedReference.csproj
+++ b/plugins/Microsoft.DocAsCode.Build.MemberLevelManagedReference/Microsoft.DocAsCode.Build.MemberLevelManagedReference.csproj
@@ -12,5 +12,12 @@
     <ProjectReference Include="..\..\src\Microsoft.DocAsCode.Common\Microsoft.DocAsCode.Common.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.DocAsCode.Plugins\Microsoft.DocAsCode.Plugins.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.DocAsCode.DataContracts.ManagedReference\Microsoft.DocAsCode.DataContracts.ManagedReference.csproj" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="docfx.plugins.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/plugins/Microsoft.DocAsCode.Build.MemberLevelManagedReference/Microsoft.DocAsCode.Build.MemberLevelManagedReference.csproj
+++ b/plugins/Microsoft.DocAsCode.Build.MemberLevelManagedReference/Microsoft.DocAsCode.Build.MemberLevelManagedReference.csproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="..\..\src\Microsoft.DocAsCode.Plugins\Microsoft.DocAsCode.Plugins.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.DocAsCode.DataContracts.ManagedReference\Microsoft.DocAsCode.DataContracts.ManagedReference.csproj" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/plugins/Microsoft.DocAsCode.Build.MemberLevelManagedReference/docfx.plugins.config
+++ b/plugins/Microsoft.DocAsCode.Build.MemberLevelManagedReference/docfx.plugins.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/plugins/Microsoft.DocAsCode.Build.MemberLevelManagedReference/docfx.plugins.config
+++ b/plugins/Microsoft.DocAsCode.Build.MemberLevelManagedReference/docfx.plugins.config
@@ -6,6 +6,10 @@
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>


### PR DESCRIPTION
The memberpage (Microsoft.DocAsCode.Build.MemberLevelManagedReference) project needed a reference to
System.Runtime.CompilerServices.Unsafe. Also, it needed to publish docfx.plugins.config with a binding redirect.

It also needs System.Collections.Immutable.