### PR TITLE
When getting an MSBuild instance, get the latest

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/MsBuildEnvironmentScope.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/MsBuildEnvironmentScope.cs
@@ -61,21 +61,24 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
             try
             {
-                var instances = MSBuildLocator.QueryVisualStudioInstances().ToList();
-
                 // workaround for https://github.com/dotnet/docfx/issues/1969
                 // FYI https://github.com/dotnet/roslyn/issues/21799#issuecomment-343695700
-                var latest = instances.FirstOrDefault(a => a.Version.Major >= 15);
-                if (latest != null)
+                IEnumerable<VisualStudioInstance> instances = MSBuildLocator.QueryVisualStudioInstances();
+                VisualStudioInstance latestVS =
+                    instances?.Any() ?? false
+                    ? instances.Aggregate((vs1, vs2) => vs1.Version > vs2.Version ? vs1 : vs2)
+                    : null;
+
+                if (latestVS?.Version.Major >= 15)
                 {
-                    Logger.LogInfo($"Using msbuild {latest.MSBuildPath} as inner compiler.");
-                    MSBuildLocator.RegisterInstance(latest);
+                    Logger.LogInfo($"Using msbuild {latestVS.MSBuildPath} as inner compiler.");
+                    MSBuildLocator.RegisterInstance(latestVS);
                     return new EnvironmentScope(new Dictionary<string, string>
                     {
-                        ["VSINSTALLDIR"] = latest.VisualStudioRootPath,
+                        ["VSINSTALLDIR"] = latestVS.VisualStudioRootPath,
                         // VS2019 defines VisualStudioVersion=16.0. Do not include minor version here to avoid breaking UWP projects.
                         // See: https://github.com/dotnet/docfx/issues/5011
-                        ["VisualStudioVersion"] = $"{latest.Version.Major}.0",
+                        ["VisualStudioVersion"] = $"{latestVS.Version.Major}.0",
                     });
                 }
                 else


### PR DESCRIPTION
The issue ticket suggested sorting the instances. Really, though, we just want the latest one, so we can do it in O(n).

Tested to make sure things are fine if instances is null or empty.

Fix for https://github.com/dotnet/docfx/issues/7463.