### PR TITLE
Remove trailing empty spaces for markdig tests

### DIFF
--- a/test/Microsoft.Docs.MarkdigExtensions.Tests/CodeTest.cs
+++ b/test/Microsoft.Docs.MarkdigExtensions.Tests/CodeTest.cs
@@ -61,7 +61,7 @@ namespace TableSnippets
             tbl.Columns[1].Background = Brushes.AliceBlue;
             tbl.Columns[2].Width = new GridLength(20);
             tbl.Columns[3].Background = Brushes.AliceBlue;
-#endregion 
+#endregion
 
             // Get a count of columns hosted by the table.
             // <Snippet_Table_Columns_Count>
@@ -170,7 +170,7 @@ namespace TableSnippets
             tbl.RowGroups.Add(trg);
 
             // Add rows to a TableRowGroup collection.
-            int rowsToAdd = 4; 
+            int rowsToAdd = 4;
             for (int x = 0; x < rowsToAdd; x++)
                 trg.Rows.Add(new TableRow());
 
@@ -201,7 +201,7 @@ namespace TableSnippets
 
             // Remove all rows...
             trg.Rows.Clear();
-            // </Snippet_TableRowGroup_Rows>        
+            // </Snippet_TableRowGroup_Rows>
         }
 
         void TableCellConst()
@@ -723,14 +723,14 @@ int main()
     AppDomain^ root = AppDomain::CurrentDomain;
 
     AppDomainSetup^ setup = gcnew AppDomainSetup();
-    setup->ApplicationBase = 
+    setup->ApplicationBase =
         root->SetupInformation->ApplicationBase + ""MyAppSubfolder\\"";
 
     AppDomain^ domain = AppDomain::CreateDomain(""MyDomain"", nullptr, setup);
 
-    Console::WriteLine(""Application base of {0}:\r\n\t{1}"", 
+    Console::WriteLine(""Application base of {0}:\r\n\t{1}"",
         root->FriendlyName, root->SetupInformation->ApplicationBase);
-    Console::WriteLine(""Application base of {0}:\r\n\t{1}"", 
+    Console::WriteLine(""Application base of {0}:\r\n\t{1}"",
         domain->FriendlyName, domain->SetupInformation->ApplicationBase);
 
     AppDomain::Unload(domain);
@@ -961,14 +961,14 @@ int main()
     AppDomain^ root = AppDomain::CurrentDomain;
 
     AppDomainSetup^ setup = gcnew AppDomainSetup();
-    setup->ApplicationBase = 
+    setup->ApplicationBase =
         root->SetupInformation->ApplicationBase + ""MyAppSubfolder\\"";
 
     AppDomain^ domain = AppDomain::CreateDomain(""MyDomain"", nullptr, setup);
 
-    Console::WriteLine(""Application base of {0}:\r\n\t{1}"", 
+    Console::WriteLine(""Application base of {0}:\r\n\t{1}"",
         root->FriendlyName, root->SetupInformation->ApplicationBase);
-    Console::WriteLine(""Application base of {0}:\r\n\t{1}"", 
+    Console::WriteLine(""Application base of {0}:\r\n\t{1}"",
         domain->FriendlyName, domain->SetupInformation->ApplicationBase);
 
     AppDomain::Unload(domain);
@@ -1326,14 +1326,14 @@ int main()
     AppDomain^ root = AppDomain::CurrentDomain;
 
     AppDomainSetup^ setup = gcnew AppDomainSetup();
-    setup-&gt;ApplicationBase = 
+    setup-&gt;ApplicationBase =
         root-&gt;SetupInformation-&gt;ApplicationBase + &quot;MyAppSubfolder\\&quot;;
 
     AppDomain^ domain = AppDomain::CreateDomain(&quot;MyDomain&quot;, nullptr, setup);
 
-    Console::WriteLine(&quot;Application base of {0}:\r\n\t{1}&quot;, 
+    Console::WriteLine(&quot;Application base of {0}:\r\n\t{1}&quot;,
         root-&gt;FriendlyName, root-&gt;SetupInformation-&gt;ApplicationBase);
-    Console::WriteLine(&quot;Application base of {0}:\r\n\t{1}&quot;, 
+    Console::WriteLine(&quot;Application base of {0}:\r\n\t{1}&quot;,
         domain-&gt;FriendlyName, domain-&gt;SetupInformation-&gt;ApplicationBase);
 
     AppDomain::Unload(domain);

--- a/test/Microsoft.Docs.MarkdigExtensions.Tests/ImageTest.cs
+++ b/test/Microsoft.Docs.MarkdigExtensions.Tests/ImageTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Docs.MarkdigExtensions.Tests
 
 |Capability   | Admin  | Member  | Contributor  | Viewer |
 |---|---|---|---|---|
-| Update and delete the workspace.  |  |   |   |   | 
+| Update and delete the workspace.  |  |   |   |   |
 | Add/remove people, including other admins.  | :::image type=""icon"" source=""green-checkmark.png"":::  |   |   |   |
 | Add members or others with lower permissions.  |  X | X  |  |   |";
 
@@ -90,17 +90,17 @@ namespace Microsoft.Docs.MarkdigExtensions.Tests
             var source = @"
 :::image type=""icon"" source=""example.svg"":::
 
-:::image type=""complex"" source=""example.jpg"" alt-text=""example"" loc-scope=""azure""::: 
+:::image type=""complex"" source=""example.jpg"" alt-text=""example"" loc-scope=""azure"":::
 Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
 :::image-end:::
 
 :::image source=""example.jpg"" alt-text=""example"" loc-scope=""azure"":::
 
-:::image type=""complex"" source=""example.jpg"" alt-text=""example"" loc-scope=""azure"" lightbox=""example-expanded.jpg""::: 
+:::image type=""complex"" source=""example.jpg"" alt-text=""example"" loc-scope=""azure"" lightbox=""example-expanded.jpg"":::
 Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
 :::image-end:::
 
-:::image type=""complex"" source=""example.jpg"" alt-text=""example"" loc-scope=""azure"" lightbox=""example-expanded.jpg"" border=""false""::: 
+:::image type=""complex"" source=""example.jpg"" alt-text=""example"" loc-scope=""azure"" lightbox=""example-expanded.jpg"" border=""false"":::
 Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
 :::image-end:::
 ";

--- a/test/Microsoft.Docs.MarkdigExtensions.Tests/QuoteSectionNoteTest.cs
+++ b/test/Microsoft.Docs.MarkdigExtensions.Tests/QuoteSectionNoteTest.cs
@@ -224,9 +224,9 @@ this is also warning</p>
             @"the following is note type
   > [!NOTE]
   > note text 1-1
-  > note text 1-2  
+  > note text 1-2
   > note text 2-1
-This is also note  
+This is also note
 This is also note with br
 
 Skip the note
@@ -234,9 +234,9 @@ Skip the note
 <div class=""NOTE"">
 <h5>NOTE</h5>
 <p>note text 1-1
-note text 1-2<br />
+note text 1-2
 note text 2-1
-This is also note<br />
+This is also note
 This is also note with br</p>
 </div>
 <p>Skip the note</p>
@@ -245,7 +245,7 @@ This is also note with br</p>
             @"the following is not note type
   > no-note text 1-1
   > [!NOTE]
-  > no-note text 1-2  
+  > no-note text 1-2
   > no-note text 2-1
 ", @"<p>the following is not note type</p>
 <blockquote>
@@ -253,7 +253,7 @@ This is also note with br</p>
 </blockquote>
 <div class=""NOTE"">
 <h5>NOTE</h5>
-<p>no-note text 1-2<br />
+<p>no-note text 1-2
 no-note text 2-1</p>
 </div>
 ")]
@@ -262,7 +262,7 @@ no-note text 2-1</p>
   > no-note text 1-1
   >
   > [!NOTE]
-  > no-note text 2-1  
+  > no-note text 2-1
   > no-note text 2-2
 ", @"<p>the following is not note type</p>
 <blockquote>
@@ -270,7 +270,7 @@ no-note text 2-1</p>
 </blockquote>
 <div class=""NOTE"">
 <h5>NOTE</h5>
-<p>no-note text 2-1<br />
+<p>no-note text 2-1
 no-note text 2-2</p>
 </div>
 ")]
@@ -279,12 +279,12 @@ no-note text 2-2</p>
 
     > code text 1-1
     > [!NOTE]
-    > code text 1-2  
+    > code text 1-2
     > code text 2-1
 ", @"<p>the following is code</p>
 <pre><code>&gt; code text 1-1
 &gt; [!NOTE]
-&gt; code text 1-2  
+&gt; code text 1-2
 &gt; code text 2-1
 </code></pre>
 ")]
@@ -328,7 +328,7 @@ no-note text 2-2</p>
 >                System.Diagnostics.Debug.WriteLine(""Event '{0}'."", calendarEvent.Subject);
 >            }
 >```
-> 
+>
 >```javascript-i
 >outlookClient.me.events.getEvents().fetch().then(function(result) {
 >        result.currentPage.forEach(function(event) {

--- a/test/Microsoft.Docs.MarkdigExtensions.Tests/RenderZoneTest.cs
+++ b/test/Microsoft.Docs.MarkdigExtensions.Tests/RenderZoneTest.cs
@@ -38,7 +38,7 @@ a pivot
 :::    zone-end
 
 :::  zone  pivot="" foo,bar ""    target=""docs""
-a pivot with target 
+a pivot with target
 :::    zone-end
 
 ::: zone target=""docs"" pivot=""csharp7-is-great""

--- a/test/Microsoft.Docs.MarkdigExtensions.Tests/RowTest.cs
+++ b/test/Microsoft.Docs.MarkdigExtensions.Tests/RowTest.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Docs.MarkdigExtensions.Tests
         ### Another Headline
         This is where your content goes.
         [I'm an inline-style link](https://www.google.com)
-    :::column-end::: 
+    :::column-end:::
 :::row-end:::
 ";
             var expected = @"<section class=""row"">
@@ -179,7 +179,7 @@ namespace Microsoft.Docs.MarkdigExtensions.Tests
         ### Another Headline
         This is where your content goes.
         [I'm an inline-style link](https://www.google.com)
-    :::column-end::: 
+    :::column-end:::
 :::row-end:::
 ";
             var expected = @"<section class=""row"" sourceFile=""Topic.md"" sourceStartLineNumber=""1"">


### PR DESCRIPTION
Test would fail if you remove trailing whitespaces on some of the old markdig tests. This PR removes all trailing whitespaces in the markdig extension test projects and adjust the test expectations accordingly.

https://github.com/dotnet/docfx/pull/7495/files