### PR TITLE
test repo use master branch

### DIFF
--- a/azure-pipelines-v3.yml
+++ b/azure-pipelines-v3.yml
@@ -220,7 +220,7 @@ parameters:
     DevSandbox:
       params: https://github.com/MicrosoftDocs/DevSandbox --timeout 30
     test:
-      params: https://github.com/MicrosoftDocs/test --branch main --timeout 20 --no-dry-sync
+      params: https://github.com/MicrosoftDocs/test --branch master --timeout 20 --no-dry-sync
     DocsRoot:
       params: https://github.com/MicrosoftDocs/DocsRoot --timeout 20
     windows-compatibility:
@@ -237,7 +237,7 @@ parameters:
       params: https://github.com/microsoftgraph/microsoft-graph-docs --timeout 30
     # render HTML
     html.test:
-      params: https://github.com/MicrosoftDocs/test --timeout 20 --no-dry-sync --output-type html
+      params: https://github.com/MicrosoftDocs/test --branch master --timeout 20 --no-dry-sync --output-type html
     html.AspNetCore.Docs:
       params: https://github.com/dotnet/AspNetCore.Docs --profile --timeout 30 --output-type html --template https://github.com/Microsoft/templates.docs.msft.pdf
     # dry-runs


### PR DESCRIPTION
[AB#466544](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/466544)

- https://github.com/MicrosoftDocs/test never renamed master to main, so main can't be fallbackable
- SRE updated DevOps PAT scope, so `cpubwin` fails, we're asking them to fix the scope