### PR TITLE
Fix wrong NuGet package layout

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,8 @@ steps:
 
 - task: NuGetToolInstaller@1
   displayName: 'Use NuGet'
+  inputs:
+    versionSpec: 5.10.0
 
 - task: CmdLine@1
   displayName: 'npm install'


### PR DESCRIPTION
Fixes #7557 

There is a behavior change in NuGet 5.11.0 when <files> look like this. 

5.10.0 put `build/docfx.console.targets` inside `/build/docfx.console.targets`, but 5.11.0 put it under `/docfx.console.targets`.

```xml
    <file src="build/**" target=""/>
```

Related NuGet issue: https://github.com/NuGet/Home/issues/11125