### PR TITLE
Pin NuGet to 5.9.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ steps:
 - task: NuGetToolInstaller@1
   displayName: 'Use NuGet'
   inputs:
-    versionSpec: 5.10.0
+    versionSpec: 5.9.1
 
 - task: CmdLine@1
   displayName: 'npm install'


### PR DESCRIPTION
This is to fix issue #7570. The original PR, #7560, pinned NuGet to
version 5.10. However, the regression was introduced by 5.10. This
PR pins NuGet to 5.9.1.