### PR TITLE
use nuget 5.9.1 for azure pipelines

### DIFF
--- a/azure-pipelines-master.yml
+++ b/azure-pipelines-master.yml
@@ -30,6 +30,8 @@ steps:
 
 - task: NuGetToolInstaller@1
   displayName: 'Use NuGet'
+  inputs:
+    versionSpec: 5.9.1
 
 - task: CmdLine@1
   displayName: 'npm install'

--- a/azure-pipelines-master.yml
+++ b/azure-pipelines-master.yml
@@ -31,7 +31,7 @@ steps:
 - task: NuGetToolInstaller@1
   displayName: 'Use NuGet'
   inputs:
-    versionSpec: 5.9.0
+    versionSpec: 5.9.1
 
 - task: CmdLine@1
   displayName: 'npm install'

--- a/azure-pipelines-master.yml
+++ b/azure-pipelines-master.yml
@@ -31,7 +31,7 @@ steps:
 - task: NuGetToolInstaller@1
   displayName: 'Use NuGet'
   inputs:
-    versionSpec: 5.9.1
+    versionSpec: 5.9.0
 
 - task: CmdLine@1
   displayName: 'npm install'

--- a/azure-pipelines-stable.yml
+++ b/azure-pipelines-stable.yml
@@ -30,6 +30,8 @@ steps:
 
 - task: NuGetToolInstaller@1
   displayName: 'Use NuGet'
+  inputs:
+    versionSpec: 5.9.1
 
 - task: CmdLine@1
   displayName: 'npm install'

--- a/azure-pipelines-stable.yml
+++ b/azure-pipelines-stable.yml
@@ -31,7 +31,7 @@ steps:
 - task: NuGetToolInstaller@1
   displayName: 'Use NuGet'
   inputs:
-    versionSpec: 5.9.0
+    versionSpec: 5.9.1
 
 - task: CmdLine@1
   displayName: 'npm install'

--- a/azure-pipelines-stable.yml
+++ b/azure-pipelines-stable.yml
@@ -31,7 +31,7 @@ steps:
 - task: NuGetToolInstaller@1
   displayName: 'Use NuGet'
   inputs:
-    versionSpec: 5.9.1
+    versionSpec: 5.9.0
 
 - task: CmdLine@1
   displayName: 'npm install'

--- a/pack.ps1
+++ b/pack.ps1
@@ -41,16 +41,16 @@ if (-not(ValidateCommand("dotnet"))) {
 
 # Check if nuget.exe exists
 if (ValidateCommand($globalNugetCommand)) {
-	$nugetCommand = $globalNugetCommand
+    $nugetCommand = $globalNugetCommand
 } elseIf (-not(ValidateCommand($nugetCommand))) {
     Write-Host "Downloading NuGet.exe..."
     mkdir -Path "$env:LOCALAPPDATA/Nuget" -Force
     $ProgressPreference = 'SilentlyContinue'
     [Net.WebRequest]::DefaultWebProxy.Credentials = [Net.CredentialCache]::DefaultCredentials
     
-	# Pin Nuget version to v5.9.1 to workaround for Nuget issue: https://github.com/NuGet/Home/issues/11125
-	# Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe' -OutFile $nugetCommand
-	Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/v5.9.1/nuget.exe' -OutFile $nugetCommand
+    # Pin Nuget version to v5.9.1 to workaround for Nuget issue: https://github.com/NuGet/Home/issues/11125
+    # Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe' -OutFile $nugetCommand
+    Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/v5.9.1/nuget.exe' -OutFile $nugetCommand
 }
 Write-Host "Using Nuget Command: $nugetCommand, $(& $nugetCommand help | Select -First 1)"
 
@@ -108,9 +108,9 @@ $packages = @{
         "nuspecs" = @("src/nuspec/YamlSplitter/YamlSplitter.nuspec");
     };
     "SandcastleRefMapper" = @{
-		"proj" = $null;
-		"nuspecs" = @("src/nuspec/SandcastleRefMapper/SandcastleRefMapper.nuspec")
-	};
+        "proj" = $null;
+        "nuspecs" = @("src/nuspec/SandcastleRefMapper/SandcastleRefMapper.nuspec")
+    };
 }
 
 # Pack plugins and tools

--- a/pack.ps1
+++ b/pack.ps1
@@ -17,6 +17,7 @@ else{
 
 $os = GetOperatingSystemName
 Write-Host "Running on OS $os"
+$globalNugetCommand = 'nuget'
 $nugetCommand = GetNuGetCommand ($os)
 $scriptPath = $MyInvocation.MyCommand.Path
 $scriptHome = Split-Path $scriptPath
@@ -39,13 +40,19 @@ if (-not(ValidateCommand("dotnet"))) {
 }
 
 # Check if nuget.exe exists
-if (-not(ValidateCommand($nugetCommand))) {
+if (ValidateCommand($globalNugetCommand)) {
+	$nugetCommand = $globalNugetCommand
+} elseIf (-not(ValidateCommand($nugetCommand))) {
     Write-Host "Downloading NuGet.exe..."
     mkdir -Path "$env:LOCALAPPDATA/Nuget" -Force
     $ProgressPreference = 'SilentlyContinue'
     [Net.WebRequest]::DefaultWebProxy.Credentials = [Net.CredentialCache]::DefaultCredentials
-    Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe' -OutFile $nugetCommand
+    
+	# Pin Nuget version to v5.9.1 to workaround for Nuget issue: https://github.com/NuGet/Home/issues/11125
+	# Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe' -OutFile $nugetCommand
+	Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/v5.9.1/nuget.exe' -OutFile $nugetCommand
 }
+Write-Host "Using Nuget Command: $nugetCommand, $(& $nugetCommand help | Select -First 1)"
 
 # dotnet pack first
 foreach ($proj in (Get-ChildItem -Path ("src", "plugins") -Include *.[cf]sproj -Exclude 'docfx.msbuild.csproj' -Recurse)) {


### PR DESCRIPTION
#7570 

With some test, the last worked version docfx.2.58 was packed with nuget.5.9.1. All version later than 5.9.1 are works differently with 5.9.0 till now.
See list of nuget available version on azure pipeline: https://dist.nuget.org/tools.json