### PR TITLE
Add another dotnet repo to test

### DIFF
--- a/azure-pipelines-v3.yml
+++ b/azure-pipelines-v3.yml
@@ -219,6 +219,8 @@ parameters:
       params: https://github.com/MicrosoftDocs/PowerShell-Docs --timeout 75 --branch live
     roslyn-api-docs:
       params: https://github.com/dotnet/roslyn-api-docs --profile --timeout 120
+    EntityFramework.ApiDocs:
+      params: https://github.com/dotnet/EntityFramework.ApiDocs --timeout 120
     azure-docs-rest-apis:
       params: https://github.com/Azure/azure-docs-rest-apis --timeout 130 --error-level Warning
     dynamics365-docs-odata-apis:

--- a/test/docfx.RegressionTest/RegressionTest.cs
+++ b/test/docfx.RegressionTest/RegressionTest.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Docs.Build
 
                 var workingFolder = Path.Combine(s_testDataRoot, $"regression-test.{s_testName}");
 
+                EnsureTestData(opts, workingFolder);
                 if (opts.WarmUp)
                 {
                     var (_, outputPath, repositoryPath, docfxConfig) = Prepare(opts, workingFolder);

--- a/test/docfx.RegressionTest/RegressionTest.cs
+++ b/test/docfx.RegressionTest/RegressionTest.cs
@@ -59,7 +59,6 @@ namespace Microsoft.Docs.Build
 
                 var workingFolder = Path.Combine(s_testDataRoot, $"regression-test.{s_testName}");
 
-                EnsureTestData(opts, workingFolder);
                 if (opts.WarmUp)
                 {
                     var (_, outputPath, repositoryPath, docfxConfig) = Prepare(opts, workingFolder);


### PR DESCRIPTION
And another dotnet EntityFramework.ApiDocs to test repo. Since roslyn-api-docs repo missed some cases.