### PR TITLE
Bump ECMAHelper version from 1.2.1726.13 to 1.2.1732.15

### DIFF
--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.314" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.18.0" />
     <PackageReference Include="Microsoft.ChakraCore" Version="1.11.24" />
-    <PackageReference Include="Microsoft.DocAsCode.ECMAHelper" Version="1.2.1726.13" />
+    <PackageReference Include="Microsoft.DocAsCode.ECMAHelper" Version="1.2.1732.15" />
     <PackageReference Include="Microsoft.DocAsCode.MAML2Yaml.Lib" Version="1.1.1719.2" Aliases="maml" />
     <PackageReference Include="Microsoft.Docs.MetadataService.Models" Version="0.3.6" />
     <PackageReference Include="Microsoft.Graph" Version="4.6.0" />


### PR DESCRIPTION
To resolve issue https://dev.azure.com/ceapex/Engineering/_workitems/edit/494425/, we have to rollback one commit in previous version.