### PR TITLE
Bump Ecma2yaml version from 1.2.1732.15 to 1.2.1744.22

### DIFF
--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.314" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.18.0" />
     <PackageReference Include="Microsoft.ChakraCore" Version="1.11.24" />
-    <PackageReference Include="Microsoft.DocAsCode.ECMAHelper" Version="1.2.1732.15" />
+    <PackageReference Include="Microsoft.DocAsCode.ECMAHelper" Version="1.2.1744.22" />
     <PackageReference Include="Microsoft.DocAsCode.MAML2Yaml.Lib" Version="1.1.1719.2" Aliases="maml" />
     <PackageReference Include="Microsoft.Docs.MetadataService.Models" Version="0.3.6" />
     <PackageReference Include="Microsoft.Graph" Version="4.6.0" />


### PR DESCRIPTION
[AB#495448](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/495448)
[AB#485934](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/485934)

Change List:
- Fix bug [495448](https://ceapex.visualstudio.com/Engineering/_workitems/edit/495448) 
- Fix bug [485934](https://ceapex.visualstudio.com/Engineering/_workitems/edit/485934) 

Test:
- Local docfx build for repos **winrt-api-build** and **dotnet-api-docs** passed.
- yaml diff for repos **winrt-api-build** and **dotnet-api-docs** are expected.