### PR TITLE
use NuGet.ProjectModel 5.7.0 to resolve nuget install circular dependency issue

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn.csproj
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.Composition" Version="1.0.31" />
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.5.0" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
-    <PackageReference Include="NuGet.ProjectModel" Version="4.5.0" />
+    <PackageReference Include="NuGet.ProjectModel" Version="5.7.0" />
     <PackageReference Include="NuGet.Packaging.Core" Version="5.7.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.5.24" />
     <PackageReference Include="Microsoft.VisualStudio.RemoteControl" Version="14.0.262-masterA5CACE98" />


### PR DESCRIPTION
Issue: 
![image](https://user-images.githubusercontent.com/25164547/139817068-91558f1e-4e35-4533-9efd-7a765f449f8e.png)

Circular dependency:
![image](https://user-images.githubusercontent.com/25164547/139817033-7b2bf147-24f5-49d1-b4fe-cf355afcc9c6.png)
