### PR TITLE
Only show public interfaces in generated syntax

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Visitors/CSYamlModelGenerator.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Visitors/CSYamlModelGenerator.cs
@@ -1197,11 +1197,11 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             IReadOnlyList<INamedTypeSymbol> baseTypeList;
             if (symbol.TypeKind != TypeKind.Class || symbol.BaseType == null || symbol.BaseType.GetDocumentationCommentId() == "T:System.Object")
             {
-                baseTypeList = symbol.AllInterfaces.Where(s=>s.DeclaredAccessibility == Accessibility.Public || s.DeclaredAccessibility == Accessibility.Protected || s.DeclaredAccessibility == Accessibility.ProtectedOrInternal).ToList();
+                baseTypeList = symbol.AllInterfaces.Where(s=>IsSymbolAccessible(s)).ToList();
             }
             else
             {
-                baseTypeList = new[] { symbol.BaseType }.Concat(symbol.AllInterfaces.Where(s => s.DeclaredAccessibility == Accessibility.Public || s.DeclaredAccessibility == Accessibility.Protected || s.DeclaredAccessibility == Accessibility.ProtectedOrInternal)).ToList();
+                baseTypeList = new[] { symbol.BaseType }.Concat(symbol.AllInterfaces.Where(s => IsSymbolAccessible(s))).ToList();
             }
             if (baseTypeList.Count == 0)
             {
@@ -1211,6 +1211,15 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 SyntaxFactory.SeparatedList<BaseTypeSyntax>(
                     from t in baseTypeList
                     select SyntaxFactory.SimpleBaseType(GetTypeSyntax(t))));
+        }
+
+        private static bool IsSymbolAccessible(ISymbol symbol)
+        {
+            if (symbol.DeclaredAccessibility != Accessibility.Public && symbol.DeclaredAccessibility != Accessibility.Protected && symbol.DeclaredAccessibility != Accessibility.ProtectedOrInternal)
+                return false;
+            if (symbol.ContainingSymbol != null && symbol.Kind == SymbolKind.NamedType)
+                return IsSymbolAccessible(symbol.ContainingSymbol);
+            return true;
         }
 
         private BaseListSyntax GetEnumBaseTypeList(INamedTypeSymbol symbol)

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Visitors/CSYamlModelGenerator.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Visitors/CSYamlModelGenerator.cs
@@ -1197,11 +1197,11 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             IReadOnlyList<INamedTypeSymbol> baseTypeList;
             if (symbol.TypeKind != TypeKind.Class || symbol.BaseType == null || symbol.BaseType.GetDocumentationCommentId() == "T:System.Object")
             {
-                baseTypeList = symbol.AllInterfaces;
+                baseTypeList = symbol.AllInterfaces.Where(s=>s.DeclaredAccessibility != Accessibility.Internal).ToList();
             }
             else
             {
-                baseTypeList = new[] { symbol.BaseType }.Concat(symbol.AllInterfaces).ToList();
+                baseTypeList = new[] { symbol.BaseType }.Concat(symbol.AllInterfaces.Where(s => s.DeclaredAccessibility != Accessibility.Internal)).ToList();
             }
             if (baseTypeList.Count == 0)
             {

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Visitors/CSYamlModelGenerator.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Visitors/CSYamlModelGenerator.cs
@@ -1197,11 +1197,11 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             IReadOnlyList<INamedTypeSymbol> baseTypeList;
             if (symbol.TypeKind != TypeKind.Class || symbol.BaseType == null || symbol.BaseType.GetDocumentationCommentId() == "T:System.Object")
             {
-                baseTypeList = symbol.AllInterfaces.Where(s=>s.DeclaredAccessibility != Accessibility.Internal).ToList();
+                baseTypeList = symbol.AllInterfaces.Where(s=>s.DeclaredAccessibility == Accessibility.Public || s.DeclaredAccessibility == Accessibility.Protected || s.DeclaredAccessibility == Accessibility.ProtectedOrInternal).ToList();
             }
             else
             {
-                baseTypeList = new[] { symbol.BaseType }.Concat(symbol.AllInterfaces.Where(s => s.DeclaredAccessibility != Accessibility.Internal)).ToList();
+                baseTypeList = new[] { symbol.BaseType }.Concat(symbol.AllInterfaces.Where(s => s.DeclaredAccessibility == Accessibility.Public || s.DeclaredAccessibility == Accessibility.Protected || s.DeclaredAccessibility == Accessibility.ProtectedOrInternal)).ToList();
             }
             if (baseTypeList.Count == 0)
             {

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Visitors/VBYamlModelGenerator.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Visitors/VBYamlModelGenerator.cs
@@ -956,11 +956,11 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
         private SyntaxList<ImplementsStatementSyntax> GetImplementsList(INamedTypeSymbol symbol)
         {
-            if (symbol.AllInterfaces.Where(t=>t.DeclaredAccessibility == Accessibility.Public).Any())
+            if (symbol.AllInterfaces.Where(t=>t.DeclaredAccessibility == Accessibility.Public || t.DeclaredAccessibility == Accessibility.Protected || t.DeclaredAccessibility == Accessibility.ProtectedOrInternal).Any())
             {
                 return SyntaxFactory.SingletonList(SyntaxFactory.ImplementsStatement(
                     (from t in symbol.AllInterfaces
-                     where t.DeclaredAccessibility == Accessibility.Public
+                     where t.DeclaredAccessibility == Accessibility.Public || t.DeclaredAccessibility == Accessibility.Protected || t.DeclaredAccessibility == Accessibility.ProtectedOrInternal
                      select GetTypeSyntax(t)).ToArray()));
             }
             return new SyntaxList<ImplementsStatementSyntax>();

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Visitors/VBYamlModelGenerator.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Visitors/VBYamlModelGenerator.cs
@@ -956,7 +956,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
         private SyntaxList<ImplementsStatementSyntax> GetImplementsList(INamedTypeSymbol symbol)
         {
-            if (symbol.AllInterfaces.Any())
+            if (symbol.AllInterfaces.Where(t=>t.DeclaredAccessibility == Accessibility.Public).Any())
             {
                 return SyntaxFactory.SingletonList(SyntaxFactory.ImplementsStatement(
                     (from t in symbol.AllInterfaces

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Visitors/VBYamlModelGenerator.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Visitors/VBYamlModelGenerator.cs
@@ -956,14 +956,23 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
         private SyntaxList<ImplementsStatementSyntax> GetImplementsList(INamedTypeSymbol symbol)
         {
-            if (symbol.AllInterfaces.Where(t=>t.DeclaredAccessibility == Accessibility.Public || t.DeclaredAccessibility == Accessibility.Protected || t.DeclaredAccessibility == Accessibility.ProtectedOrInternal).Any())
+            if (symbol.AllInterfaces.Where(t => IsSymbolAccessible(t)).Any())
             {
                 return SyntaxFactory.SingletonList(SyntaxFactory.ImplementsStatement(
                     (from t in symbol.AllInterfaces
-                     where t.DeclaredAccessibility == Accessibility.Public || t.DeclaredAccessibility == Accessibility.Protected || t.DeclaredAccessibility == Accessibility.ProtectedOrInternal
+                     where IsSymbolAccessible(t)
                      select GetTypeSyntax(t)).ToArray()));
             }
             return new SyntaxList<ImplementsStatementSyntax>();
+        }
+
+        private static bool IsSymbolAccessible(ISymbol symbol)
+        {
+            if (symbol.DeclaredAccessibility != Accessibility.Public && symbol.DeclaredAccessibility != Accessibility.Protected && symbol.DeclaredAccessibility != Accessibility.ProtectedOrInternal)
+                return false;
+            if (symbol.ContainingSymbol != null && symbol.Kind == SymbolKind.NamedType)
+                return IsSymbolAccessible(symbol.ContainingSymbol);
+            return true;
         }
 
         private AsClauseSyntax GetEnumUnderlyingType(INamedTypeSymbol symbol)

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Visitors/VBYamlModelGenerator.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Visitors/VBYamlModelGenerator.cs
@@ -960,6 +960,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             {
                 return SyntaxFactory.SingletonList(SyntaxFactory.ImplementsStatement(
                     (from t in symbol.AllInterfaces
+                     where t.DeclaredAccessibility == Accessibility.Public
                      select GetTypeSyntax(t)).ToArray()));
             }
             return new SyntaxList<ImplementsStatementSyntax>();

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromCSUnitTest.cs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromCSUnitTest.cs
@@ -358,6 +358,29 @@ namespace Test1
             Assert.Equal(new[] { "public", "interface" }, ifoobar.Modifiers[SyntaxLanguage.CSharp]);
         }
 
+        [Fact]
+        public void TestGenerateMetadataWithInternalInterfaceAndInherits()
+        {
+            string code = @"
+namespace Test1
+{
+    public class Foo : IFoo { }
+    internal interface IFoo { }
+}
+";
+            MetadataItem output = GenerateYamlMetadata(CreateCompilationFromCSharpCode(code));
+            Assert.Single(output.Items);
+
+            var foo = output.Items[0].Items[0];
+            Assert.NotNull(foo);
+            Assert.Equal("Foo", foo.DisplayNames[SyntaxLanguage.CSharp]);
+            Assert.Equal("Foo", foo.DisplayNamesWithType[SyntaxLanguage.CSharp]);
+            Assert.Equal("Test1.Foo", foo.DisplayQualifiedNames[SyntaxLanguage.CSharp]);
+            Assert.Equal("public class Foo", foo.Syntax.Content[SyntaxLanguage.CSharp]);
+            Assert.Equal(new[] { "public", "class" }, foo.Modifiers[SyntaxLanguage.CSharp]);
+            Assert.Null(foo.Implements);
+        }
+
         [Trait("Related", "Generic")]
         [Trait("Related", "Inheritance")]
         [Trait("Related", "Reference")]

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromCSUnitTest.cs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromCSUnitTest.cs
@@ -407,6 +407,32 @@ namespace Test1
             Assert.Equal("Test1.Foo.IFoo", subFoo.Implements[0]);
         }
 
+        [Fact]
+        public void TestGenerateMetadataWithPublicInterfaceNestedInternal()
+        {
+            string code = @"
+namespace Test1
+{
+    internal class FooInternal
+    {
+        public interface IFoo { }
+    }
+    public class Foo : FooInternal.IFoo { }
+}
+";
+            MetadataItem output = GenerateYamlMetadata(CreateCompilationFromCSharpCode(code));
+            Assert.Single(output.Items);
+
+            var foo = output.Items[0].Items[0];
+            Assert.NotNull(foo);
+            Assert.Equal("Foo", foo.DisplayNames[SyntaxLanguage.CSharp]);
+            Assert.Equal("Foo", foo.DisplayNamesWithType[SyntaxLanguage.CSharp]);
+            Assert.Equal("Test1.Foo", foo.DisplayQualifiedNames[SyntaxLanguage.CSharp]);
+            Assert.Equal("public class Foo", foo.Syntax.Content[SyntaxLanguage.CSharp]);
+            Assert.Equal(new[] { "public", "class" }, foo.Modifiers[SyntaxLanguage.CSharp]);
+            Assert.Null(foo.Implements);
+        }
+
         [Trait("Related", "Generic")]
         [Trait("Related", "Inheritance")]
         [Trait("Related", "Reference")]

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromCSUnitTest.cs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromCSUnitTest.cs
@@ -381,6 +381,32 @@ namespace Test1
             Assert.Null(foo.Implements);
         }
 
+        [Fact]
+        public void TestGenerateMetadataWithProtectedInterfaceAndInherits()
+        {
+            string code = @"
+namespace Test1
+{
+    public class Foo {
+       protected interface IFoo { }
+       public class SubFoo : IFoo { }
+    }
+}
+";
+            MetadataItem output = GenerateYamlMetadata(CreateCompilationFromCSharpCode(code));
+            Assert.Single(output.Items);
+
+            var subFoo = output.Items[0].Items[2];
+            Assert.NotNull(subFoo);
+            Assert.Equal("Foo.SubFoo", subFoo.DisplayNames[SyntaxLanguage.CSharp]);
+            Assert.Equal("Foo.SubFoo", subFoo.DisplayNamesWithType[SyntaxLanguage.CSharp]);
+            Assert.Equal("Test1.Foo.SubFoo", subFoo.DisplayQualifiedNames[SyntaxLanguage.CSharp]);
+            Assert.Equal("public class SubFoo : Foo.IFoo", subFoo.Syntax.Content[SyntaxLanguage.CSharp]);
+            Assert.Equal(new[] { "public", "class" }, subFoo.Modifiers[SyntaxLanguage.CSharp]);
+            Assert.NotNull(subFoo.Implements);
+            Assert.Equal("Test1.Foo.IFoo", subFoo.Implements[0]);
+        }
+
         [Trait("Related", "Generic")]
         [Trait("Related", "Inheritance")]
         [Trait("Related", "Reference")]

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromVBUnitTest.cs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromVBUnitTest.cs
@@ -224,6 +224,30 @@ End Namespace
             }
         }
 
+        [Fact]
+        public void TestGenerateMetadataWithInternalInterfaceAndInherits()
+        {
+            string code = @"
+Namespace Test1
+    Public Class Foo
+       Implements IFoo 
+    End Class
+    Internal Interface IFoo
+    End Interface
+";
+            MetadataItem output = GenerateYamlMetadata(CreateCompilationFromVBCode(code));
+            Assert.Single(output.Items);
+
+            var foo = output.Items[0].Items[0];
+            Assert.NotNull(foo);
+            Assert.Equal("Foo", foo.DisplayNames[SyntaxLanguage.VB]);
+            Assert.Equal("Foo", foo.DisplayNamesWithType[SyntaxLanguage.VB]);
+            Assert.Equal("Test1.Foo", foo.DisplayQualifiedNames[SyntaxLanguage.VB]);
+            Assert.Equal("Public Class Foo", foo.Syntax.Content[SyntaxLanguage.VB]);
+            Assert.Equal(new[] { "Public", "Class" }, foo.Modifiers[SyntaxLanguage.VB]);
+            Assert.Null(foo.Implements);
+        }
+
         [Trait("Related", "Generic")]
         [Fact]
         public void TestGenereateMetadataWithDelegate()

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromVBUnitTest.cs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromVBUnitTest.cs
@@ -276,6 +276,32 @@ Namespace Test1
             Assert.Equal("Test1.Foo.IFoo", subFoo.Implements[0]);
         }
 
+        [Fact]
+        public void TestGenerateMetadataWithPublicInterfaceNestedInternal()
+        {
+            string code = @"
+Namespace Test1
+    Internal Class FooInternal
+        Public Interface IFoo
+        End Interface
+    End Class
+    Public Class Foo
+       Implements FooInternal.IFoo 
+    End Class
+";
+            MetadataItem output = GenerateYamlMetadata(CreateCompilationFromVBCode(code));
+            Assert.Single(output.Items);
+
+            var foo = output.Items[0].Items[0];
+            Assert.NotNull(foo);
+            Assert.Equal("Foo", foo.DisplayNames[SyntaxLanguage.VB]);
+            Assert.Equal("Foo", foo.DisplayNamesWithType[SyntaxLanguage.VB]);
+            Assert.Equal("Test1.Foo", foo.DisplayQualifiedNames[SyntaxLanguage.VB]);
+            Assert.Equal("Public Class Foo", foo.Syntax.Content[SyntaxLanguage.VB]);
+            Assert.Equal(new[] { "Public", "Class" }, foo.Modifiers[SyntaxLanguage.VB]);
+            Assert.Null(foo.Implements);
+        }
+
         [Trait("Related", "Generic")]
         [Fact]
         public void TestGenereateMetadataWithDelegate()

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromVBUnitTest.cs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromVBUnitTest.cs
@@ -248,6 +248,34 @@ Namespace Test1
             Assert.Null(foo.Implements);
         }
 
+        [Fact]
+        public void TestGenerateMetadataWithProtectedInterfaceAndInherits()
+        {
+            string code = @"
+Namespace Test1
+    Public Class Foo
+       Protected Interface IFoo
+       End Interface
+       Public Class SubFoo 
+          Implements IFoo 
+       End Class
+    End Class
+
+";
+            MetadataItem output = GenerateYamlMetadata(CreateCompilationFromVBCode(code));
+            Assert.Single(output.Items);
+
+            var subFoo = output.Items[0].Items[2];
+            Assert.NotNull(subFoo);
+            Assert.Equal("Foo.SubFoo", subFoo.DisplayNames[SyntaxLanguage.VB]);
+            Assert.Equal("Foo.SubFoo", subFoo.DisplayNamesWithType[SyntaxLanguage.VB]);
+            Assert.Equal("Test1.Foo.SubFoo", subFoo.DisplayQualifiedNames[SyntaxLanguage.VB]);
+            Assert.Equal("Public Class SubFoo\r\n    Implements Foo.IFoo", subFoo.Syntax.Content[SyntaxLanguage.VB]);
+            Assert.Equal(new[] { "Public", "Class" }, subFoo.Modifiers[SyntaxLanguage.VB]);
+            Assert.NotNull(subFoo.Implements);
+            Assert.Equal("Test1.Foo.IFoo", subFoo.Implements[0]);
+        }
+
         [Trait("Related", "Generic")]
         [Fact]
         public void TestGenereateMetadataWithDelegate()


### PR DESCRIPTION
This addresses the issue with the generated syntax showing internal interfaces, as described in #3154
The changed method is only used to generate syntax, so should be safe. Since interfaces can only be public or internal, there's no need to check for any of the other accessibilities.