### PR TITLE
Adds support for nullable reference types

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/Models/ReferenceItem.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/Models/ReferenceItem.cs
@@ -121,8 +121,8 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                             for (int i = 0; i < sourceParts.Count; i++)
                             {
                                 Debug.Assert(sourceParts[i].Name == targetParts[i].Name);
-                                Debug.Assert(sourceParts[i].DisplayName == targetParts[i].DisplayName);
-                                Debug.Assert(sourceParts[i].DisplayQualifiedNames == targetParts[i].DisplayQualifiedNames);
+                                Debug.Assert(sourceParts[i].DisplayName == targetParts[i].DisplayName || sourceParts[i].DisplayName.Replace("?", "") == targetParts[i].DisplayName.Replace("?", ""));
+                                Debug.Assert(sourceParts[i].DisplayQualifiedNames == targetParts[i].DisplayQualifiedNames || sourceParts[i].DisplayQualifiedNames.Replace("?","") == targetParts[i].DisplayQualifiedNames.Replace("?", ""));
                                 targetParts[i].IsExternalPath &= sourceParts[i].IsExternalPath;
                                 targetParts[i].Href = targetParts[i].Href ?? sourceParts[i].Href;
                             }

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Visitors/NameVisitor.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Visitors/NameVisitor.cs
@@ -183,6 +183,10 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                     WriteGeneric(symbol.TypeParameters);
                 }
             }
+            if(symbol.NullableAnnotation == NullableAnnotation.Annotated)
+            {
+                Append("?");
+            }
         }
 
         public override void VisitNamespace(INamespaceSymbol symbol)
@@ -478,6 +482,8 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
             {
                 case SpecialType.System_Object:
                     Append("object");
+                    if (symbol.NullableAnnotation == NullableAnnotation.Annotated)
+                        Append("?");
                     return true;
                 case SpecialType.System_Void:
                     Append("void");
@@ -523,6 +529,8 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                     return true;
                 case SpecialType.System_String:
                     Append("string");
+                    if (symbol.NullableAnnotation == NullableAnnotation.Annotated)
+                        Append("?");
                     return true;
                 case SpecialType.System_IntPtr:
                     if (symbol.IsNativeIntegerType)


### PR DESCRIPTION
Here's my attempt at adding support for nullable reference types and address #4007 and #7115

Here's the class I used for testing and all came out right in the generated HTML:

```cs
    public class Class1 
    {
        public string? NullableString { get; set; }
        public int? NullableInt { get; set; }
        public Class1? NullableClass1 { get; set; }
        public System.Collections.Generic.List<string>? NullableCollection { get; set; }
        public System.Collections.Generic.List<string?> CollectionNullableT { get; set; } = new System.Collections.Generic.List<string?>();

        public object? ReturnsNull() { return null; }
        public string? ReturnsNullString() { return null; }
        public int? ReturnsNullInt() { return null; }
        public (string?,Class1?) ReturnsTupleWithNulls() { return (null,null); }
        public (string, Class1)? ReturnsNullableTuple() { return null; }

        public void AcceptsNull(object? parameter) { }
        public void AcceptsNullString(string? parameter) { }
        public void AcceptsNullInt(int? parameter) { }
    }
```

Generated output:
![image](https://user-images.githubusercontent.com/1378165/140577373-261ddba1-e439-450a-bc1d-ae03a08ed262.png)
