### PR TITLE
Fix libgit2 DLL load failure

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -195,6 +195,7 @@ dotnetcontent
 dryrun
 dsc
 duplicatedword
+dylib
 ecma
 edia
 edm

--- a/src/docfx/lib/git/LibGit2.cs
+++ b/src/docfx/lib/git/LibGit2.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Reflection;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Docs.Build;
@@ -249,7 +249,6 @@ internal static class LibGit2
             }
         }
     }
-
 
     private static IntPtr ResolveDllImport(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
     {

--- a/src/docfx/lib/git/LibGit2.cs
+++ b/src/docfx/lib/git/LibGit2.cs
@@ -16,6 +16,8 @@ internal static class LibGit2
 
     static LibGit2()
     {
+        LoadNativeLibrary();
+
         if (git_libgit2_init() == 1)
         {
             git_openssl_set_locking();
@@ -244,6 +246,23 @@ internal static class LibGit2
                 git_oid_fmt(str, p);
                 return new string(str, 0, 40);
             }
+        }
+    }
+
+    private static void LoadNativeLibrary()
+    {
+        var arch = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
+        if (OperatingSystem.IsWindows())
+        {
+            NativeLibrary.TryLoad(Path.Combine(AppContext.BaseDirectory, $"runtimes/win-{arch}/native/{LibName}.dll"), out _);
+        }
+        else if (OperatingSystem.IsMacOS())
+        {
+            NativeLibrary.TryLoad(Path.Combine(AppContext.BaseDirectory, $"runtimes/osx-{arch}/native/lib{LibName}.dylib"), out _);
+        }
+        else if (OperatingSystem.IsLinux())
+        {
+            NativeLibrary.TryLoad(Path.Combine(AppContext.BaseDirectory, $"runtimes/linux-{arch}/native/lib{LibName}.so"), out _);
         }
     }
 }


### PR DESCRIPTION
Fixes [AB#523537](https://dev.azure.com/ceapex/Engineering/_workitems/edit/523537/)

```
Unhandled exception. System.TypeInitializationException: The type initializer for 'Microsoft.Docs.Build.LibGit2' threw an exception.
 ---> System.DllNotFoundException: Unable to load DLL 'git2-6777db8' or one of its dependencies: The specified module could not be found. (0x8007007E)
   at Microsoft.Docs.Build.LibGit2.git_libgit2_init()
   at Microsoft.Docs.Build.LibGit2..cctor()
   --- End of inner exception stack trace ---
   at Microsoft.Docs.Build.LibGit2.git_libgit2_init()
   at Microsoft.Docs.Build.Docfx.Main(String[] args)
```
