### PR TITLE
Fixed copy-paste typo

### DIFF
--- a/Documentation/tutorial/walkthrough/advanced_walkthrough.md
+++ b/Documentation/tutorial/walkthrough/advanced_walkthrough.md
@@ -27,7 +27,7 @@ To change the CSS of the HTML or PDF template:
 
 - Copy `_exported_templates/default/styles/main.css` or `_exported_templates/pdf.default/styles/main.css`.
 - Paste it in `templates/<your custom template folder>/styles`.
-- Edit `templates/<your custom template folder>/partials`.
+- Edit `templates/<your custom template folder>/styles/main.css`.
 
 Example of changing heading styles in `main.css` for an HTML template:
 


### PR DESCRIPTION
This line seems to be copied from the paragraph above. I have changed it. 

For me, the situation was different, though.

 My `main.css` is empty. But I see an `docfx.css` which i can us, to customize the style of the website. Perhaps this could be outlined in the docs as well.

