### PR TITLE
change UidNotFound error level

### DIFF
--- a/docs/specs/learn.yml
+++ b/docs/specs/learn.yml
@@ -1253,7 +1253,7 @@ outputs:
     {"message_severity":"error","code":"unit-duration-missing","message":"Missing attribute: durationInMinutes. DurationInMinutes is required for each unit and must be greater than 0.","file":"unit-b.yml","line":3}
     {"message_severity":"error","code":"unit-multiple-parents","message":"Unit 'unit-c' can't have two or more parents ('module-a.yml(2,19)', 'module-b.yml(2,9)').","file":"unit-c.yml","line":2}
     {"message_severity":"error","code":"unit-no-module-parent","message":"Unit 'unit-a' must belong to a valid module.","file":"unit-a.yml","line":2}
-    {"message_severity":"error","code":"uid-not-found","message":"UID 'nofound' with type 'module' not found, which is referenced by repository 'https://github.com/learn/learn-pr2'.","line": 0}
+    {"message_severity":"warning","code":"uid-not-found","message":"UID 'nofound' with type 'module' not found, which is referenced by repository 'https://github.com/learn/learn-pr2'.","line": 0}
 ---
 # Test: unit-task-and-quiz, task-type-invalid, tasks-format-invalid, quiz-no-answer, quiz-multiple-answers
 # SDP validation to implement Learn Validation 

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -267,6 +267,9 @@ internal static class Errors
         /// Behavior: ✔️ Message: ✔️
         public static Error FileNotFound(SourceInfo<string> source)
             => new(ErrorLevel.Warning, "file-not-found", $"Invalid file link: '{source}'.", source);
+
+        public static Error UidNotFound(string uid, IEnumerable<string?> repositories, string? schemaType)
+            => new(ErrorLevel.Warning, "uid-not-found", $"UID '{uid}' with type '{schemaType}' not found, which is referenced by repository {StringUtility.Join(repositories)}.", null);
     }
 
     public static class UrlPath
@@ -420,9 +423,6 @@ internal static class Errors
 
         public static Error XrefTypeInvalid(SourceInfo<string> xref, string expectedXrefType, string? actualXrefType)
            => new(ErrorLevel.Warning, "xref-type-invalid", $"Invalid cross reference: '{xref}'. Expected type '{expectedXrefType}' but got '{actualXrefType}'.", xref);
-
-        public static Error UidNotFound(string uid, IEnumerable<string?> repositories, string? schemaType)
-            => new(ErrorLevel.Warning, "uid-not-found", $"UID '{uid}' with type '{schemaType}' not found, which is referenced by repository {StringUtility.Join(repositories)}.", null);
 
         /// <summary>
         /// The same uid of the same version is defined in multiple places

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -224,9 +224,8 @@ internal class XrefResolver
         {
             if (!internalXrefMap.ContainsKey(xrefGroup.Key))
             {
-                _errorLog.Add(Errors.Xref.UidNotFound(
-                    xrefGroup.Key, xrefGroup.Select(xref => xref.ReferencedRepositoryUrl).Distinct(), xrefGroup.First().SchemaType) with
-                { Level = _config.IsLearn ? ErrorLevel.Error : ErrorLevel.Warning });
+                _errorLog.Add(Errors.Link.UidNotFound(
+                    xrefGroup.Key, xrefGroup.Select(xref => xref.ReferencedRepositoryUrl).Distinct(), xrefGroup.First().SchemaType));
             }
         }
     }


### PR DESCRIPTION
[AB#530134](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/530134)

"due to the decentralized nature of how content and certifications get created, could we just add a warning"
https://dev.azure.com/ceapex/Engineering/_boards/board/t/Docs%20Content%20Hosting%20and%20Storage%20Team/Stories/?workitem=328267#8939105

If a Module is referenced by another repo, with this PR, error level will become Warning from Error, since Module also uses `validateExternalXrefs` feature.

And I also move UidNotFound to Link category since it has no property path so Validation Build rules can't override on it (propertyPath is mandatory input in Rule edit form).