### PR TITLE
Optimize memory usage by not capturing SchemaMap in xref lazy callback.

### DIFF
--- a/src/docfx/build/metadata/MetadataProvider.cs
+++ b/src/docfx/build/metadata/MetadataProvider.cs
@@ -14,7 +14,7 @@ internal class MetadataProvider
     private readonly List<(Func<string, bool> glob, string key, JToken value)> _rules = new();
     private readonly List<(Func<string, bool> glob, string key, JToken value)> _monikerRules = new();
 
-    private readonly ConcurrentDictionary<FilePath, Watch<(ErrorList, UserMetadata)>> _metadataCache = new();
+    private readonly MemoryCache<FilePath, Watch<(ErrorList, UserMetadata)>> _metadataCache = new();
 
     public MetadataProvider(Config config, Input input, BuildScope buildScope)
     {

--- a/src/docfx/lib/cache/MemoryCache{TKey,TValue}.cs
+++ b/src/docfx/lib/cache/MemoryCache{TKey,TValue}.cs
@@ -36,7 +36,7 @@ internal class MemoryCache<TKey, TValue> : ConcurrentDictionary<TKey, TValue>, I
 
         if (removedCount > 0)
         {
-            Log.Write($"Memory cache removed {removedCount} items on low memory");
+            Log.Write($"Memory {GetType()} removed {removedCount} items on low memory");
         }
     }
 }

--- a/src/docfx/lib/schema/JsonSchemaMap.cs
+++ b/src/docfx/lib/schema/JsonSchemaMap.cs
@@ -32,4 +32,9 @@ internal class JsonSchemaMap
             _map.TryAdd(token, schema);
         }
     }
+
+    public void TrimExcess()
+    {
+        _map.TrimExcess();
+    }
 }


### PR DESCRIPTION
[AB#530209](https://dev.azure.com/ceapex/Engineering/_workitems/edit/530209/)

The `SchemaMap` is a big object that consumes a lot of memory. It maps `JToken` to a schema. The current code captures the `SchemaMap` in the `xrefProperties` lazy callback function, causing the `SchemaMap` to be pinned by that lazy callback, thus evicting entries from `_schemaDocumentsCache` on low memory conditions does not deallocate the big schema map. 

This fix _uncaptures_ the schema map lambda capture, allowing us to deallocate the schema map on low memory conditions.

As part of the investigation, I'm dumping more `GC` related info as part of memory monitor.

The results shows we can limit memory usage < 10G for _azure-docs-sdk-java_ at xref map build stage, whereas before it was > 15G. 

It was too slow to build the TOC map, so I couldn't capture the memory past that stage. I may need to improve TOC map build first as a next step.