### PR TITLE
Remove SchemaMap lambda capture

### DIFF
--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -230,8 +230,7 @@ internal class JsonSchemaTransformer
                 }
 
                 xref.XrefProperties[xrefProperty] = new Lazy<JToken>(
-                    () => LoadXrefProperty(
-                        schemaMap, file, uid, value, rootSchema, uidCount, JsonUtility.AddToPropertyPath(propertyPath, xrefProperty)),
+                    () => LoadXrefProperty(file, uid, value, rootSchema, JsonUtility.AddToPropertyPath(propertyPath, xrefProperty)),
                     LazyThreadSafetyMode.PublicationOnly);
             }
         }
@@ -289,12 +288,10 @@ internal class JsonSchemaTransformer
     }
 
     private JToken LoadXrefProperty(
-        JsonSchemaMap schemaMap,
         FilePath file,
         SourceInfo<string> uid,
         JToken value,
         JsonSchema rootSchema,
-        int uidCount,
         string propertyPath)
     {
         var recursionDetector = s_recursionDetector.Value!;
@@ -306,6 +303,7 @@ internal class JsonSchemaTransformer
         try
         {
             recursionDetector.Push(uid);
+            var (token, schema, schemaMap, uidCount) = ValidateContent(ErrorBuilder.Null, file);
             return TransformContentCore(
                 _errors,
                 schemaMap,


### PR DESCRIPTION
[AB#530209](https://dev.azure.com/ceapex/Engineering/_workitems/edit/530209/)

The `SchemaMap` is a big object that consumes a lot of memory. It maps `JToken` to a schema. The current code captures the `SchemaMap` in the `xrefProperties` lazy callback function, causing the `SchemaMap` to be pinned by that lazy callback, thus evicting entries from `_schemaDocumentsCache` on low memory conditions does not deallocate the big schema map. 

This fix _uncaptures_ the schema map lambda capture, allowing us to deallocate the schema map on low memory conditions.

As part of the investigation, I'm dumping more `GC` related info as part of memory monitor.

The results shows we can limit memory usage < 10G for _azure-docs-sdk-java_ at xref map build stage, whereas before it was > 15G. 

It was too slow to build the TOC map, so I couldn't capture the memory past that stage. I may need to improve TOC map build first as a next step.