### PR TITLE
add propertyPath to validateExternalXrefs error

### DIFF
--- a/docs/specs/learn.yml
+++ b/docs/specs/learn.yml
@@ -1253,7 +1253,7 @@ outputs:
     {"message_severity":"error","code":"unit-duration-missing","message":"Missing attribute: durationInMinutes. DurationInMinutes is required for each unit and must be greater than 0.","file":"unit-b.yml","line":3}
     {"message_severity":"error","code":"unit-multiple-parents","message":"Unit 'unit-c' can't have two or more parents ('module-a.yml(2,19)', 'module-b.yml(2,9)').","file":"unit-c.yml","line":2}
     {"message_severity":"error","code":"unit-no-module-parent","message":"Unit 'unit-a' must belong to a valid module.","file":"unit-a.yml","line":2}
-    {"message_severity":"error","code":"uid-not-found","message":"UID 'nofound' with type 'module' not found, which is referenced by repository 'https://github.com/learn/learn-pr2'.","line": 0}
+    {"message_severity":"error","code":"uid-not-found","message":"UID 'nofound' with type 'module' not found, which is referenced by repository 'https://github.com/learn/learn-pr2' on property ''.","line": 0}
 ---
 # Test: unit-task-and-quiz, task-type-invalid, tasks-format-invalid, quiz-no-answer, quiz-multiple-answers
 # SDP validation to implement Learn Validation 

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -1860,6 +1860,7 @@ repos:
               {"uid": "nofound",
                 "docsetName": "docset_a",
                 "schemaType": "a-type",
+                "propertyPath": "p1",
                 "count": 1}
             ]
           }
@@ -1889,15 +1890,17 @@ outputs:
         {"uid": "c", 
           "docsetName": "docset_b",
           "schemaType": "c-type",
+          "propertyPath": "ref_other",
           "count": 2},
         {"uid": "d", 
           "docsetName": "docset_b",
           "schemaType": "d-type",
+          "propertyPath": "ref_other",
           "count": 1}
       ]
     }
   .errors.log: |
-    {"message_severity":"warning","code":"uid-not-found","message":"UID 'nofound' with type 'a-type' not found, which is referenced by repository 'b_repository_url'.","line":0,"column":0}
+    {"message_severity":"warning","code":"uid-not-found","message":"UID 'nofound' with type 'a-type' not found, which is referenced by repository 'b_repository_url' on property 'p1'.","line":0,"column":0}
 ---
 # support SDP validation validateExternalXrefs, locale build
 noSingleFile: true
@@ -1921,6 +1924,7 @@ repos:
             {"uid": "nofound",
               "docsetName": "docset_a",
               "schemaType": "a-type",
+              "propertyPath": "p1",
               "count": 1}
           ]
         }
@@ -1961,7 +1965,82 @@ outputs:
       ]
     }
   .errors.log: |
-    {"message_severity":"warning","code":"uid-not-found","message":"UID 'nofound' with type 'a-type' not found, which is referenced by repository 'b_repository_url'.","line":0,"column":0}
+    {"message_severity":"warning","code":"uid-not-found","message":"UID 'nofound' with type 'a-type' not found, which is referenced by repository 'b_repository_url' on property 'p1'.","line":0,"column":0}
+---
+# support SDP validation validateExternalXrefs, propertyPath
+noSingleFile: true
+repos:
+  https://docs.com/test-valdiate-external-xref:
+    - files:
+        docfx.yml: |
+          name: docset_a
+          xref:
+          - 1.xrefmap.json
+        1.xrefmap.json: |
+          {
+            "repository_url": "b_repository_url",
+            "docset_name": "docset_b",
+            "references":[
+              {"uid": "c", "schemaType": "c-type"},
+              {"uid": "d", "schemaType": "d-type"}
+            ],
+            "external_xrefs":[
+              {"uid": "e",
+                "docsetName": "docset_a",
+                "schemaType": "a-type",
+                "propertyPath": "p1",
+                "count": 1},
+              {"uid": "e",
+                "docsetName": "docset_a",
+                "schemaType": "a-type",
+                "propertyPath": "p2",
+                "count": 1}
+            ]
+          }
+        docs/a.yml: |
+          ### YamlMime:TestData1
+          uid: a
+          ref_other: ["b", "c", "d"]
+        docs/b.yml: |
+          ### YamlMime:TestData1
+          uid: b
+          ref_other_2: ["c"]
+        _themes/ContentTemplate/schemas/TestData1.schema.json: |
+          {
+            "properties": {
+              "uid": { "contentType": "uid"},
+              "ref_other": { "type": "array", "items": {"contentType": "xref", "validateExternalXrefs": true}},
+              "ref_other_2": { "type": "array", "items": {"contentType": "xref", "validateExternalXrefs": true}}
+            }
+          }
+outputs:
+  docs/a.json:
+  docs/b.json:
+  .xrefmap.json: |
+    {
+      "docset_name": "docset_a",
+      "repository_url": "https://docs.com/test-valdiate-external-xref",
+      "external_xrefs":[
+        {"uid": "c", 
+          "docsetName": "docset_b",
+          "schemaType": "c-type",
+          "propertyPath": "ref_other",
+          "count": 1},
+        {"uid": "c", 
+          "docsetName": "docset_b",
+          "schemaType": "c-type",
+          "propertyPath": "ref_other_2",
+          "count": 1},
+        {"uid": "d", 
+          "docsetName": "docset_b",
+          "schemaType": "d-type",
+          "propertyPath": "ref_other",
+          "count": 1}
+      ]
+    }
+  .errors.log: |
+    {"message_severity":"warning","code":"uid-not-found","message":"UID 'e' with type 'a-type' not found, which is referenced by repository 'b_repository_url' on property 'p1'.","line":0,"column":0}
+    {"message_severity":"warning","code":"uid-not-found","message":"UID 'e' with type 'a-type' not found, which is referenced by repository 'b_repository_url' on property 'p2'.","line":0,"column":0}
 ---
 # multiple duplicated uids with the same MonkerList
 inputs:

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -421,8 +421,8 @@ internal static class Errors
         public static Error XrefTypeInvalid(SourceInfo<string> xref, string expectedXrefType, string? actualXrefType)
            => new(ErrorLevel.Warning, "xref-type-invalid", $"Invalid cross reference: '{xref}'. Expected type '{expectedXrefType}' but got '{actualXrefType}'.", xref);
 
-        public static Error UidNotFound(string uid, IEnumerable<string?> repositories, string? schemaType)
-            => new(ErrorLevel.Warning, "uid-not-found", $"UID '{uid}' with type '{schemaType}' not found, which is referenced by repository {StringUtility.Join(repositories)}.", null);
+        public static Error UidNotFound(string uid, string? repository, string? schemaType, string? propertyPath)
+            => new(ErrorLevel.Warning, "uid-not-found", $"UID '{uid}' with type '{schemaType}' not found, which is referenced by repository '{repository}' on property '{propertyPath}'.", null, propertyPath);
 
         /// <summary>
         /// The same uid of the same version is defined in multiple places

--- a/src/docfx/build/xref/ExternalXref.cs
+++ b/src/docfx/build/xref/ExternalXref.cs
@@ -15,6 +15,8 @@ internal class ExternalXref
 
     public string? SchemaType { get; set; }
 
+    public string? PropertyPath { get; set; }
+
     [JsonIgnore]
     public string? ReferencedRepositoryUrl { get; set; }
 }

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -224,9 +224,15 @@ internal class XrefResolver
         {
             if (!internalXrefMap.ContainsKey(xrefGroup.Key))
             {
-                _errorLog.Add(Errors.Xref.UidNotFound(
-                    xrefGroup.Key, xrefGroup.Select(xref => xref.ReferencedRepositoryUrl).Distinct(), xrefGroup.First().SchemaType) with
-                { Level = _config.IsLearn ? ErrorLevel.Error : ErrorLevel.Warning });
+                foreach (var item in xrefGroup)
+                {
+                    _errorLog.Add(Errors.Xref.UidNotFound(
+                        xrefGroup.Key,
+                        repository: item.ReferencedRepositoryUrl,
+                        item.SchemaType,
+                        item.PropertyPath) with
+                    { Level = _config.IsLearn ? ErrorLevel.Error : ErrorLevel.Warning });
+                }
             }
         }
     }

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -230,8 +230,7 @@ internal class XrefResolver
                         xrefGroup.Key,
                         repository: item.ReferencedRepositoryUrl,
                         item.SchemaType,
-                        item.PropertyPath) with
-                    { Level = _config.IsLearn ? ErrorLevel.Error : ErrorLevel.Warning });
+                        item.PropertyPath) with { Level = _config.IsLearn ? ErrorLevel.Error : ErrorLevel.Warning });
                 }
             }
         }

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -25,7 +25,7 @@ internal class JsonSchemaTransformer
     private readonly MemoryCache<FilePath, Watch<(JToken, JsonSchema, JsonSchemaMap, int)>> _schemaDocumentsCache = new();
 
     private readonly Scoped<ConcurrentBag<(SourceInfo<string> uid, string? propertyPath, JsonSchema, int? min, int? max)>> _uidReferenceCountList = new();
-    private readonly Scoped<ConcurrentBag<(SourceInfo<string> xref, string? docsetName, string? schemaType)>> _xrefList = new();
+    private readonly Scoped<ConcurrentBag<(SourceInfo<string> xref, string? docsetName, string? schemaType, string? propertyPath)>> _xrefList = new();
 
     private static readonly ThreadLocal<Stack<SourceInfo<string>>> s_recursionDetector = new(() => new());
 
@@ -74,11 +74,17 @@ internal class JsonSchemaTransformer
 
     public ExternalXref[] GetValidateExternalXrefs()
     {
-        return _xrefList.Value.Where(item => item.docsetName != null).GroupBy(item => item.xref.Value).Select(xrefGroup =>
+        return _xrefList.Value.Where(item => item.docsetName != null).GroupBy(item => new { item.xref.Value, item.propertyPath }).Select(xrefGroup =>
         {
             return new ExternalXref
-            { Uid = xrefGroup.Key, Count = xrefGroup.Count(), DocsetName = xrefGroup.First().docsetName, SchemaType = xrefGroup.First().schemaType };
-        }).OrderBy(externalXref => externalXref.Uid).ToArray();
+            {
+                Uid = xrefGroup.Key.Value,
+                PropertyPath = xrefGroup.Key.propertyPath,
+                Count = xrefGroup.Count(),
+                DocsetName = xrefGroup.First().docsetName,
+                SchemaType = xrefGroup.First().schemaType,
+            };
+        }).OrderBy(externalXref => externalXref.Uid).ThenBy(xref => xref.PropertyPath).ToArray();
     }
 
     public JToken TransformContent(ErrorBuilder errors, FilePath file)
@@ -479,7 +485,8 @@ internal class JsonSchemaTransformer
                     Watcher.Write(() => _xrefList.Value.Add((
                         content,
                         (xrefSpec is ExternalXrefSpec externalXref && schema.ValidateExternalXrefs) ? externalXref.DocsetName : null,
-                        xrefSpec?.SchemaType)));
+                        xrefSpec?.SchemaType,
+                        propertyPath)));
                 }
                 return value;
         }

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -74,7 +74,7 @@ internal class JsonSchemaTransformer
 
     public ExternalXref[] GetValidateExternalXrefs()
     {
-        return _xrefList.Value.Where(item => item.docsetName != null).GroupBy(item => new { item.xref.Value, item.propertyPath }).Select(xrefGroup =>
+        return _xrefList.Value.Where(item => item.docsetName != null).GroupBy(item => (item.xref.Value, item.propertyPath)).Select(xrefGroup =>
         {
             return new ExternalXref
             {


### PR DESCRIPTION
[AB#530134](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/530134)

when do validateExternalXrefs, we need report different Error level based on `propertyPath`.

Learn → Module ← Cert.
When a Module topic is referenced by Learn & Cert by docs-ui schema and a relationship is broken, 
1. report Error for broken Learn → Modules relationship (strong)
2. report Warnning for broken Module ← Cert relationship (weak)