### PR TITLE
Reduce JsonSchemaMap memory usage

### DIFF
--- a/docs/specs/schema.yml
+++ b/docs/specs/schema.yml
@@ -927,6 +927,7 @@ inputs:
     anyOf:
     - _markdown_
     - inline _markdown_
+    - value: 'mark`down`'
   _themes/ContentTemplate/schemas/TestSchema.schema.json: |
     {
       "properties": {
@@ -936,6 +937,7 @@ inputs:
             "anyOf": [
               { "type": "string", "maxlength": 10, "contentType": "markdown" },
               { "type": "string", "minlength": 11, "contentType": "inlineMarkdown" },
+              { "type": "object", "properties": { "value": { "type": "string", "contentType": "markdown" } } }
             ]
           }
         }
@@ -943,7 +945,13 @@ inputs:
     }
 outputs:
   a.json: |
-    { "anyOf": ["<p><em>markdown</em></p>", "inline <em>markdown</em>"] }
+    {
+      "anyOf": [
+        "<p><em>markdown</em></p>",
+        "inline <em>markdown</em>",
+        { "value": "<p>mark<code>down</code></p>" }
+      ]
+    }
 ---
 # Schema based transform supports if-then-else
 inputs:

--- a/src/docfx/build/toc/TocMap.cs
+++ b/src/docfx/build/toc/TocMap.cs
@@ -156,7 +156,7 @@ internal class TocMap
     {
         using var scope = Progress.Start("Loading TOC");
 
-        var allTocFiles = new ConcurrentBag<FilePath>();
+        var allTocFiles = new ConcurrentHashSet<FilePath>();
         var allTocs = new List<(FilePath file, HashSet<FilePath> docs, HashSet<FilePath> tocs, bool shouldBuildFile)>();
         var includedTocs = new HashSet<FilePath>();
         var allServicePages = new List<FilePath>();
@@ -235,11 +235,11 @@ internal class TocMap
         }
     }
 
-    private void SplitToc(FilePath file, TocNode toc, ConcurrentBag<FilePath> result)
+    private void SplitToc(FilePath file, TocNode toc, ConcurrentHashSet<FilePath> result)
     {
         if (!_config.SplitTOC.Contains(file.Path) || toc.Items.Count <= 0)
         {
-            result.Add(file);
+            result.TryAdd(file);
             return;
         }
 
@@ -267,7 +267,7 @@ internal class TocMap
             var newNodeFile = FilePath.Generated(newNodeFilePath);
 
             _input.AddGeneratedContent(newNodeFile, new JArray { newNodeToken }, null);
-            result.Add(newNodeFile);
+            result.TryAdd(newNodeFile);
 
             var newChild = new TocNode(child)
             {
@@ -280,7 +280,7 @@ internal class TocMap
         var newTocFilePath = new PathString(Path.ChangeExtension(file.Path, ".yml"));
         var newTocFile = FilePath.Generated(newTocFilePath);
         _input.AddGeneratedContent(newTocFile, JsonUtility.ToJObject(newToc), null);
-        result.Add(newTocFile);
+        result.TryAdd(newTocFile);
     }
 
     private TocNode SplitTocNode(TocNode node)

--- a/src/docfx/lib/schema/JsonSchema.cs
+++ b/src/docfx/lib/schema/JsonSchema.cs
@@ -98,7 +98,7 @@ internal class JsonSchema
     /// The JSON schema that applies to the array items if the current value is array.
     /// </summary>
     [JsonConverter(typeof(UnionTypeConverter))]
-    public (JsonSchema? items, JsonSchema[]? eachItem) Items { get; init; }
+    public (JsonSchema? allItems, JsonSchema[]? eachItem) Items { get; init; }
 
     /// <summary>
     /// The JSON schema that applies to additional items of an array.
@@ -190,15 +190,13 @@ internal class JsonSchema
     /// Split from the dependencies in draft 2019-09
     /// </summary>
     [JsonProperty(ItemConverterType = typeof(UnionTypeConverter))]
-    public Dictionary<string, (string[] propertyNames, JsonSchema schema)> DependentSchemas { get; }
-     = new Dictionary<string, (string[] propertyNames, JsonSchema schema)>();
+    public Dictionary<string, (string[] propertyNames, JsonSchema schema)> DependentSchemas { get; } = new();
 
     /// <summary>
     /// [Obsolete] Properties that are used to indicate the dependencies between fields
     /// </summary>
     [JsonProperty(ItemConverterType = typeof(UnionTypeConverter))]
-    public Dictionary<string, (string[] propertyNames, JsonSchema schema)> Dependencies { get; }
-     = new Dictionary<string, (string[] propertyNames, JsonSchema schema)>();
+    public Dictionary<string, (string[] propertyNames, JsonSchema schema)> Dependencies { get; } = new();
 
     /// <summary>
     /// The given data must be valid against any (one or more) of the given subschemas.

--- a/src/docfx/lib/schema/JsonSchema.cs
+++ b/src/docfx/lib/schema/JsonSchema.cs
@@ -98,7 +98,7 @@ internal class JsonSchema
     /// The JSON schema that applies to the array items if the current value is array.
     /// </summary>
     [JsonConverter(typeof(UnionTypeConverter))]
-    public (JsonSchema? schema, JsonSchema[]? schemas) Items { get; init; }
+    public (JsonSchema? items, JsonSchema[]? eachItem) Items { get; init; }
 
     /// <summary>
     /// The JSON schema that applies to additional items of an array.

--- a/src/docfx/lib/schema/JsonSchemaMap.cs
+++ b/src/docfx/lib/schema/JsonSchemaMap.cs
@@ -30,10 +30,10 @@ internal class JsonSchemaMap
                 return subschema;
             }
 
-            var (items, eachItem) = schema.Items;
-            if (items != null)
+            var (allItems, eachItem) = schema.Items;
+            if (allItems != null)
             {
-                return items;
+                return allItems;
             }
             else if (eachItem != null)
             {

--- a/src/docfx/lib/schema/JsonSchemaMap.cs
+++ b/src/docfx/lib/schema/JsonSchemaMap.cs
@@ -12,12 +12,7 @@ namespace Microsoft.Docs.Build;
 /// </summary>
 internal class JsonSchemaMap
 {
-    private readonly Func<JsonSchema, bool> _predicate;
     private readonly Dictionary<JToken, JsonSchema> _map = new(ReferenceEqualsComparer.Default);
-
-    public JsonSchemaMap(Func<JsonSchema, bool> predicate) => _predicate = predicate;
-
-    public JsonSchemaMap(JsonSchemaMap map) => _predicate = map._predicate;
 
     public IEnumerable<(JToken item, JsonSchema? subschema)> ForEachJArray(JsonSchema? schema, JArray array)
     {
@@ -92,10 +87,7 @@ internal class JsonSchemaMap
 
     public void Add(JToken token, JsonSchema schema)
     {
-        if (_predicate(schema))
-        {
-            _map.TryAdd(token, schema);
-        }
+        _map.TryAdd(token, schema);
     }
 
     public void Add(JsonSchemaMap map)

--- a/src/docfx/lib/schema/JsonSchemaResolver.cs
+++ b/src/docfx/lib/schema/JsonSchemaResolver.cs
@@ -36,6 +36,11 @@ internal class JsonSchemaResolver
         ExpandSchemaIdAndRef(_baseUrl, _schema, _schemasById);
     }
 
+    public JsonSchema? ResolveSchema(JsonSchema? schema)
+    {
+        return string.IsNullOrEmpty(schema?.Ref) ? schema : ResolveSchema(schema.Ref) ?? schema;
+    }
+
     public JsonSchema? ResolveSchema(string schemaRef)
     {
         return _references.GetOrAdd(schemaRef, schemaRef => ResolveSchemaCore(schemaRef, new HashSet<string>()));

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -116,17 +116,12 @@ internal class JsonSchemaTransformer
         };
         var mime = _documentProvider.GetMime(file);
         var schemaValidator = _jsonSchemaProvider.GetSchemaValidator(mime);
-        var schemaMap = new JsonSchemaMap(IsContentTransform);
+        var schemaMap = new JsonSchemaMap();
         var schemaErrors = schemaValidator.Validate(token, file, schemaMap);
         errors.AddRange(schemaErrors);
 
         var uidCount = GetFileUidCount(schemaMap, token, schemaValidator.Schema);
         return (token, schemaValidator.Schema, schemaMap, uidCount);
-    }
-
-    private static bool IsContentTransform(JsonSchema schema)
-    {
-        return schema.ContentType != null || schema.XrefProperties.Count > 0 || schema.SchemaTypeProperty != null;
     }
 
     private void LoadXrefSpecsCore(

--- a/src/docfx/lib/schema/JsonSchemaValidator.cs
+++ b/src/docfx/lib/schema/JsonSchemaValidator.cs
@@ -161,13 +161,13 @@ internal class JsonSchemaValidator
 
     private void ValidateItems(JsonSchema schema, string propertyPath, JArray array, List<Error> errors, JsonSchemaMap? schemaMap)
     {
-        var (items, eachItem) = schema.Items;
+        var (allItems, eachItem) = schema.Items;
 
-        if (items != null)
+        if (allItems != null)
         {
             foreach (var item in array)
             {
-                Validate(items, propertyPath, item, errors, schemaMap);
+                Validate(allItems, propertyPath, item, errors, schemaMap);
             }
         }
         else if (eachItem != null)

--- a/src/docfx/lib/schema/JsonSchemaValidator.cs
+++ b/src/docfx/lib/schema/JsonSchemaValidator.cs
@@ -68,10 +68,7 @@ internal class JsonSchemaValidator
 
     private void Validate(JsonSchema schema, string propertyPath, JToken token, List<Error> errors, JsonSchemaMap? schemaMap)
     {
-        if (!string.IsNullOrEmpty(schema.Ref))
-        {
-            schema = schema.SchemaResolver.ResolveSchema(schema.Ref) ?? schema;
-        }
+        schema = schema.SchemaResolver.ResolveSchema(schema) ?? schema;
 
         if (!ValidateType(schema, propertyPath, token, errors))
         {

--- a/src/docfx/lib/schema/JsonSchemaValidator.cs
+++ b/src/docfx/lib/schema/JsonSchemaValidator.cs
@@ -611,7 +611,7 @@ internal class JsonSchemaValidator
         foreach (var subschema in schema.AnyOf)
         {
             var subschemaErrors = new List<Error>();
-            var subschemaMap = schemaMap is null ? null : new JsonSchemaMap(schemaMap);
+            var subschemaMap = schemaMap is null ? null : new JsonSchemaMap();
             Validate(subschema, propertyPath, token, subschemaErrors, subschemaMap);
 
             if (subschemaErrors.Count <= 0)
@@ -660,7 +660,7 @@ internal class JsonSchemaValidator
         foreach (var subschema in schema.OneOf)
         {
             var subschemaErrors = new List<Error>();
-            var subschemaMap = schemaMap is null ? null : new JsonSchemaMap(schemaMap);
+            var subschemaMap = schemaMap is null ? null : new JsonSchemaMap();
             Validate(subschema, propertyPath, token, subschemaErrors, subschemaMap);
 
             if (subschemaErrors.Count <= 0)

--- a/src/docfx/lib/schema/JsonSchemaValidator.cs
+++ b/src/docfx/lib/schema/JsonSchemaValidator.cs
@@ -616,9 +616,10 @@ internal class JsonSchemaValidator
 
             if (subschemaErrors.Count <= 0)
             {
-                if (subschemaMap != null)
+                if (schemaMap != null && subschemaMap != null)
                 {
-                    schemaMap?.Add(subschemaMap);
+                    schemaMap.Add(token, subschema);
+                    schemaMap.Add(subschemaMap);
                 }
                 return;
             }
@@ -652,6 +653,7 @@ internal class JsonSchemaValidator
         }
 
         var validCount = 0;
+        JsonSchema? bestSchema = null;
         JsonSchemaMap? bestSchemaMap = null;
         List<Error>? bestErrors = null;
 
@@ -663,6 +665,7 @@ internal class JsonSchemaValidator
 
             if (subschemaErrors.Count <= 0)
             {
+                bestSchema = subschema;
                 bestSchemaMap = subschemaMap;
                 validCount++;
                 continue;
@@ -686,9 +689,10 @@ internal class JsonSchemaValidator
                 errors.Add(Errors.JsonSchema.OneOfFailed(JsonUtility.GetSourceInfo(token), propertyPath, token));
             }
         }
-        else if (bestSchemaMap != null)
+        else if (schemaMap != null && bestSchemaMap != null && bestSchema != null)
         {
-            schemaMap?.Add(bestSchemaMap);
+            schemaMap.Add(token, bestSchema);
+            schemaMap.Add(bestSchemaMap);
         }
     }
 

--- a/src/docfx/lib/schema/JsonSchemaValidator.cs
+++ b/src/docfx/lib/schema/JsonSchemaValidator.cs
@@ -100,8 +100,6 @@ internal class JsonSchemaValidator
         ValidateOneOf(schema, propertyPath, token, errors, schemaMap);
         ValidateIfThenElse(schema, propertyPath, token, errors, schemaMap);
         ValidateNot(schema, propertyPath, token, errors);
-
-        schemaMap?.Add(token, schema);
     }
 
     private static bool ValidateType(JsonSchema schema, string propertyPath, JToken token, List<Error> errors)
@@ -709,6 +707,7 @@ internal class JsonSchemaValidator
             if (schema.Then != null)
             {
                 Validate(schema.Then, propertyPath, token, errors, schemaMap);
+                schemaMap?.Add(token, schema.Then);
             }
         }
         else
@@ -716,6 +715,7 @@ internal class JsonSchemaValidator
             if (schema.Else != null)
             {
                 Validate(schema.Else, propertyPath, token, errors, schemaMap);
+                schemaMap?.Add(token, schema.Else);
             }
         }
     }


### PR DESCRIPTION
[AB#530209](https://dev.azure.com/ceapex/Engineering/_workitems/edit/530209/)

The `SchemaMap` is a big object that consumes a lot of memory. It maps `JToken` to a schema. The current implementation adds all the `JToken`s to the map as long as it will be transformed, this takes up quite a lot of memory. This optimizes the memory usage by only adding `JToken`s that needs dynamic dispatch (AnyOf/OneOf/IfThenElse).