### PR TITLE
Reduce SourceInfo memory usage

### DIFF
--- a/src/docfx/build/metadata/UserMetadata.cs
+++ b/src/docfx/build/metadata/UserMetadata.cs
@@ -22,22 +22,22 @@ internal class UserMetadata
     public SourceInfo<string> Author { get; init; } = new SourceInfo<string>("");
 
     [JsonProperty("ms.author")]
-    public SourceInfo<string?> MsAuthor { get; init; }
+    public string? MsAuthor { get; init; }
 
     [JsonProperty("ms.prod")]
-    public SourceInfo<string?> MsProd { get; init; }
+    public string? MsProd { get; init; }
 
     [JsonProperty("ms.technology")]
-    public SourceInfo<string?> MsTechnology { get; init; }
+    public string? MsTechnology { get; init; }
 
     [JsonProperty("ms.service")]
-    public SourceInfo<string?> MsService { get; init; }
+    public string? MsService { get; init; }
 
     [JsonProperty("ms.subservice")]
-    public SourceInfo<string?> MsSubservice { get; init; }
+    public string? MsSubservice { get; init; }
 
     [JsonProperty("ms.topic")]
-    public SourceInfo<string?> MsTopic { get; init; }
+    public string? MsTopic { get; init; }
 
     public SourceInfo<string> BreadcrumbPath { get; init; } = new SourceInfo<string>("");
 

--- a/src/docfx/lib/log/SourceInfo.cs
+++ b/src/docfx/lib/log/SourceInfo.cs
@@ -8,22 +8,22 @@ internal record SourceInfo(FilePath File) : IComparable<SourceInfo>
     /// <summary>
     /// A one based start line value, or zero if there is no line info.
     /// </summary>
-    public int Line { get; init; }
+    public ushort Line { get; init; }
 
     /// <summary>
     /// A one based start column value, or zero if there is no line info.
     /// </summary>
-    public int Column { get; init; }
+    public ushort Column { get; init; }
 
     /// <summary>
     /// A one based end line value, or zero if there is no line info.
     /// </summary>
-    public int EndLine { get; init; }
+    public ushort EndLine { get; init; }
 
     /// <summary>
     /// A one based end column value, or zero if there is no line info.
     /// </summary>
-    public int EndColumn { get; init; }
+    public ushort EndColumn { get; init; }
 
     /// <summary>
     /// A special storage for source info of the JObject property key
@@ -35,10 +35,10 @@ internal record SourceInfo(FilePath File) : IComparable<SourceInfo>
         : this(file)
     {
         File = file;
-        Line = startLine;
-        Column = startColumn;
-        EndLine = endLine ?? startLine;
-        EndColumn = endColumn ?? startColumn;
+        Line = (ushort)Math.Clamp(startLine, 0, ushort.MaxValue);
+        Column = (ushort)Math.Clamp(startColumn, 0, ushort.MaxValue);
+        EndLine = (ushort)Math.Clamp(endLine ?? startLine, 0, ushort.MaxValue);
+        EndColumn = (ushort)Math.Clamp(endColumn ?? startColumn, 0, ushort.MaxValue);
     }
 
     public SourceInfo WithOffset(SourceInfo? offset)
@@ -107,13 +107,15 @@ internal record SourceInfo(FilePath File) : IComparable<SourceInfo>
         return result;
     }
 
-    private static (int line, int column) OffSet(int line1, int column1, int line2, int column2)
+    private static (ushort line, ushort column) OffSet(int line1, int column1, int line2, int column2)
     {
         line1 = line1 <= 0 ? 1 : line1;
         column1 = column1 <= 0 ? 1 : column1;
         line2 = line2 <= 0 ? 1 : line2;
         column2 = column2 <= 0 ? 1 : column2;
 
-        return line2 == 1 ? (line1, column1 + column2 - 1) : (line1 + line2 - 1, column2);
+        var (line, column) = line2 == 1 ? (line1, column1 + column2 - 1) : (line1 + line2 - 1, column2);
+
+        return ((ushort)Math.Clamp(line, 0, ushort.MaxValue), (ushort)Math.Clamp(column, 0, ushort.MaxValue));
     }
 }

--- a/src/docfx/lib/path/FilePath.cs
+++ b/src/docfx/lib/path/FilePath.cs
@@ -10,13 +10,6 @@ namespace Microsoft.Docs.Build;
 /// </summary>
 internal record FilePath : IComparable<FilePath>
 {
-    private const int IsGitCommitBitMask = 0x000000_10;
-
-    /// <summary>
-    /// A bit flag to encode HashCode, IsGitCommit, Origin.
-    /// </summary>
-    private readonly int _flags;
-
     /// <summary>
     /// Gets the file path relative to the main docset.
     /// </summary>
@@ -35,12 +28,12 @@ internal record FilePath : IComparable<FilePath>
     /// <summary>
     /// Gets the value to indicate where is this file from.
     /// </summary>
-    public FileOrigin Origin => (FileOrigin)(_flags & ~IsGitCommitBitMask);
+    public FileOrigin Origin { get; }
 
     /// <summary>
     /// Indicate if the file is from git commit history.
     /// </summary>
-    public bool IsGitCommit => (_flags & IsGitCommitBitMask) != 0;
+    public bool IsGitCommit { get; }
 
     /// <summary>
     /// Monikers for redirection files.
@@ -53,7 +46,7 @@ internal record FilePath : IComparable<FilePath>
     public FilePath(string path)
     {
         Path = new PathString(path);
-        _flags = GetFlags(FileOrigin.External, isGitCommit: false);
+        Origin = FileOrigin.External;
     }
 
     private FilePath(FileOrigin origin, PathString path, PathString dependencyName, bool isGitCommit, MonikerList monikers)
@@ -61,12 +54,8 @@ internal record FilePath : IComparable<FilePath>
         Path = path;
         DependencyName = dependencyName;
         RedirectionMonikers = monikers;
-        _flags = GetFlags(origin, isGitCommit);
-    }
-
-    private static int GetFlags(FileOrigin origin, bool isGitCommit)
-    {
-        return isGitCommit ? (IsGitCommitBitMask | (int)origin) : (int)origin;
+        Origin = origin;
+        IsGitCommit = isGitCommit;
     }
 
     public static FilePath Content(PathString path)


### PR DESCRIPTION
[AB#530209](https://dev.azure.com/ceapex/Engineering/_workitems/edit/530209/)

This is a quick way to give away some free memory occupied by `SourceInfo`, by condensing these fields:

- line/column/endline/endcolumn `int` -> `ushort`
- remove `FilePath.Format`
- merge `FileOrigin` with `IsGitCommit`.

![sourceinfo](https://user-images.githubusercontent.com/511355/146138309-04d24c80-04df-4556-a78e-de7f026bb0f4.png)
.