### PR TITLE
refine ContentType compare logic in Validation Build Rules

### DIFF
--- a/src/docfx/validation/CustomRuleProvider.cs
+++ b/src/docfx/validation/CustomRuleProvider.cs
@@ -126,7 +126,7 @@ internal class CustomRuleProvider
                         pageType == null ||
                         rule.ContentTypes == null ||
                         rule.ContentTypes.Contains(pageType);
-                    if (rule.PropertyPath.Equals(error.PropertyPath, StringComparison.Ordinal) && isPageTypeInScope)
+                    if (rule.PropertyPath == error.PropertyPath && isPageTypeInScope)
                     {
                         customRule = rule;
                         return true;

--- a/src/docfx/validation/CustomRuleProvider.cs
+++ b/src/docfx/validation/CustomRuleProvider.cs
@@ -122,9 +122,11 @@ internal class CustomRuleProvider
                     // compare with code + propertyPath + contentType
                     var source = error.Source?.File;
                     var pageType = source != null ? _documentProvider.GetPageType(source) : null;
-                    if (rule.PropertyPath.Equals(error.PropertyPath, StringComparison.Ordinal) &&
-                        rule.ContentTypes != null &&
-                        rule.ContentTypes.Contains(pageType))
+                    var isPageTypeInScope =
+                        pageType == null ||
+                        rule.ContentTypes == null ||
+                        rule.ContentTypes.Contains(pageType);
+                    if (rule.PropertyPath.Equals(error.PropertyPath, StringComparison.Ordinal) && isPageTypeInScope)
                     {
                         customRule = rule;
                         return true;


### PR DESCRIPTION
[AB#530134](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/530134)

when compare Error.File.ContentType & Rule.ContentType, if any type is null, then ignore content  type comparison.

For `uid-not-found` error, since the Learn Modules file got deleted, we have no idea of it's ContentType.