### PR TITLE
Remove usage of JToken.Parent

### DIFF
--- a/docs/specs/learn.yml
+++ b/docs/specs/learn.yml
@@ -296,7 +296,7 @@ inputs:
         "modules": {"items": {"contentType": "xref"}},
         "achievement": {"contentType": "xref"},
         "trophy": {
-          "properties": {"uid" : {"contentType": "uid"}}
+          "properties": {"uid" : {"contentType": "uid", "schemaType": "trophy"}}
         }
       }
     }
@@ -307,7 +307,7 @@ inputs:
         "units": {"items": {"contentType": "xref" }},
         "achievement": {"contentType": "xref"},
         "badge": {
-          "properties": {"uid" : {"contentType": "uid"}}
+          "properties": {"uid" : {"contentType": "uid", "schemaType": "badge"}}
         }
       }
     }

--- a/src/docfx/build/xref/InternalXrefSpec.cs
+++ b/src/docfx/build/xref/InternalXrefSpec.cs
@@ -7,8 +7,6 @@ namespace Microsoft.Docs.Build;
 
 internal record InternalXrefSpec(SourceInfo<string> Uid, string Href, FilePath DeclaringFile, MonikerList Monikers) : IXrefSpec
 {
-    public string? DeclaringPropertyPath { get; init; }
-
     public string? PropertyPath { get; init; }
 
     public bool UidGlobalUnique { get; init; }

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -321,8 +321,8 @@ internal class XrefResolver
                 return DependencyType.Hierarchy;
             case ("LearningPath", "Achievement"):
             case ("Module", "Achievement"):
-            case ("LearningPath", "LearningPath") when string.Equals(xref.DeclaringPropertyPath, "trophy", StringComparison.OrdinalIgnoreCase):
-            case ("Module", "Module") when string.Equals(xref.DeclaringPropertyPath, "badge", StringComparison.OrdinalIgnoreCase):
+            case ("LearningPath", "LearningPath") when string.Equals(xref.SchemaType, "trophy", StringComparison.OrdinalIgnoreCase):
+            case ("Module", "Module") when string.Equals(xref.SchemaType, "badge", StringComparison.OrdinalIgnoreCase):
                 return DependencyType.Achievement;
         }
 

--- a/src/docfx/lib/schema/JsonSchemaTransformer.cs
+++ b/src/docfx/lib/schema/JsonSchemaTransformer.cs
@@ -208,13 +208,12 @@ internal class JsonSchemaTransformer
         string? propertyPath)
     {
         schemaMap.TryGetSchema(obj, out var schema);
-        var href = GetXrefHref(file, uid, uidCount, obj.Parent == null);
+        var href = GetXrefHref(file, uid, uidCount, string.IsNullOrEmpty(propertyPath));
         var monikers = _monikerProvider.GetFileLevelMonikers(errors, file);
         var schemaType = GetSchemaType(uidSchema.SchemaType, schema?.SchemaTypeProperty, propertyPath, obj, file);
 
         var xref = new InternalXrefSpec(uid, href, file, monikers)
         {
-            DeclaringPropertyPath = obj.Parent?.Path,
             PropertyPath = JsonUtility.AddToPropertyPath(propertyPath, "uid"),
             UidGlobalUnique = uidSchema.UidGlobalUnique,
             SchemaType = schemaType,


### PR DESCRIPTION
[AB#530209](https://dev.azure.com/ceapex/Engineering/_workitems/edit/530209/)

This is to pave the road of transitioning to `System.Text.Json` for better performance and less memory consumption. `Parent` isn't available in `JsonElement`, and have a `Parent` pointer means pining the whole json node tree even if we only reference a leaf node.