### PR TITLE
json: SortProperties -> SerializeStable

### DIFF
--- a/src/docfx/build/context/Output.cs
+++ b/src/docfx/build/context/Output.cs
@@ -32,8 +32,8 @@ internal class Output
 
         _queue.Post(() =>
         {
-            using var writer = new StreamWriter(EnsureDestinationPath(destRelativePath));
-            JsonUtility.Serialize(writer, graph);
+            using var stream = new FileStream(EnsureDestinationPath(destRelativePath), FileMode.Create);
+            JsonUtility.SerializeStable(stream, graph);
         });
     }
 
@@ -47,10 +47,7 @@ internal class Output
 
         if (text != null)
         {
-            _queue.Post(() =>
-            {
-                File.WriteAllText(EnsureDestinationPath(destRelativePath), text);
-            });
+            _queue.Post(() => File.WriteAllText(EnsureDestinationPath(destRelativePath), text));
         }
     }
 

--- a/src/docfx/build/page/PageBuilder.cs
+++ b/src/docfx/build/page/PageBuilder.cs
@@ -146,28 +146,27 @@ internal class PageBuilder
         }
 
         outputModel["schema"] = mime.Value;
-        outputModel = JsonUtility.SortProperties(outputModel);
         if (_config.OutputType == OutputType.Json)
         {
-            return (outputModel, JsonUtility.SortProperties(outputMetadata));
+            return (outputModel, outputMetadata);
         }
 
         var (templateModel, templateMetadata) = _templateEngine.CreateTemplateModel(file, mime, outputModel);
 
         if (_config.OutputType == OutputType.PageJson)
         {
-            return (templateModel, JsonUtility.SortProperties(templateMetadata));
+            return (templateModel, templateMetadata);
         }
 
         try
         {
             var html = _templateEngine.RunLiquid(errors, mime, templateModel);
-            return (html, JsonUtility.SortProperties(templateMetadata));
+            return (html, templateMetadata);
         }
         catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var dex))
         {
             errors.AddRange(dex.Select(ex => ex.Error));
-            return (templateModel, JsonUtility.SortProperties(templateMetadata));
+            return (templateModel, templateMetadata);
         }
     }
 

--- a/src/docfx/lib/HtmlUtility.cs
+++ b/src/docfx/lib/HtmlUtility.cs
@@ -294,7 +294,7 @@ internal static class HtmlUtility
     {
         var result = new StringBuilder();
 
-        foreach (var (key, value) in metadata)
+        foreach (var (key, value) in ((IEnumerable<KeyValuePair<string, JToken>>)metadata).OrderBy(p => p.Key))
         {
             if (value is null || value is JObject || s_htmlMetaHidden.Contains(key))
             {


### PR DESCRIPTION
[AB#530209](https://dev.azure.com/ceapex/Engineering/_workitems/edit/530209/)

Replace `SortProperties` with a `SerializeStable` method that produces a stable output for `JToken`. The `SortProperties` method creates a deep clone of the JSON node graph and isn't memory friendly.

The serializer is using `Utf8JsonWriter`, as part of the effort to move to `System.Text.Json`.