### PR TITLE
Regression test log peak memory usage

### DIFF
--- a/test/docfx.RegressionTest/RegressionTest.cs
+++ b/test/docfx.RegressionTest/RegressionTest.cs
@@ -350,7 +350,7 @@ internal static class RegressionTest
         }
     }
 
-    private static async (TimeSpan time, long peakMemory) Exec(
+    private static (TimeSpan time, long peakMemory) Exec(
         string fileName,
         string arguments = "",
         string? stdin = null,

--- a/test/docfx.RegressionTest/RegressionTest.cs
+++ b/test/docfx.RegressionTest/RegressionTest.cs
@@ -266,6 +266,8 @@ internal static class RegressionTest
             allowExitCodes: new[] { 0, 1 },
             env: profiler != null ? new() { ["DOTNET_DiagnosticPorts"] = diagnosticPort } : null);
 
+        Console.WriteLine($"docfx peak memory usage: {testResult.PeakMemory / 1000 / 1000}MB");
+
         if (profiler != null)
         {
             profiler.WaitForExit();

--- a/test/docfx.RegressionTest/RegressionTestResult.cs
+++ b/test/docfx.RegressionTest/RegressionTestResult.cs
@@ -9,6 +9,8 @@ internal class RegressionTestResult
 
     public TimeSpan BuildTime { get; set; }
 
+    public long PeakMemory { get; set; }
+
     public int? Timeout { get; set; }
 
     public string? Diff { get; set; }


### PR DESCRIPTION
[AB#530209](https://dev.azure.com/ceapex/Engineering/_workitems/edit/530209/)

This is to see the memory impact using regression tests