### PR TITLE
Free up memory used by WatchFunction in full build

### DIFF
--- a/src/docfx/build/Builder.cs
+++ b/src/docfx/build/Builder.cs
@@ -51,7 +51,6 @@ internal class Builder
             return;
         }
 
-        using (Watcher.BeginScope())
         using (_errors.BeginScope(errors))
         using (_progressReporter.BeginScope(progressReporter))
         {

--- a/src/docfx/lib/watch/Watcher.cs
+++ b/src/docfx/lib/watch/Watcher.cs
@@ -13,6 +13,11 @@ public static class Watcher
 
     public static T Read<T>(Func<T> valueFactory)
     {
+        if (s_scope.Value is null)
+        {
+            return valueFactory();
+        }
+
         var function = new ReadFunction<T>(valueFactory);
         BeginFunctionScope(function);
 
@@ -31,6 +36,11 @@ public static class Watcher
 
     public static T Read<T, TChangeToken>(Func<T> valueFactory, Func<TChangeToken> changeTokenFactory)
     {
+        if (s_scope.Value is null)
+        {
+            return valueFactory();
+        }
+
         var function = new ReadFunction<TChangeToken>(changeTokenFactory);
         BeginFunctionScope(function);
 
@@ -50,6 +60,12 @@ public static class Watcher
 
     public static void Write(Action action)
     {
+        if (s_scope.Value is null)
+        {
+            action();
+            return;
+        }
+
         var function = new WriteFunction(action);
         BeginFunctionScope(function);
 

--- a/src/docfx/serve/LanguageServerBuilder.cs
+++ b/src/docfx/serve/LanguageServerBuilder.cs
@@ -71,7 +71,11 @@ internal class LanguageServerBuilder
                 // But the responses of language server are handled sequentially, which cause the deadlock.
                 await Task.Yield();
                 Telemetry.SetIsRealTimeBuild(true);
-                _builder.Build(errors, progressReporter, filesToBuild.Select(f => f.Value).ToArray());
+
+                using (Watcher.BeginScope())
+                {
+                    _builder.Build(errors, progressReporter, filesToBuild.Select(f => f.Value).ToArray());
+                }
 
                 PublishDiagnosticsParams(errors, filesToBuild);
 


### PR DESCRIPTION
[AB#530209](https://dev.azure.com/ceapex/Engineering/_workitems/edit/530209/)

This is going to have a sizable amount of impact on memory usage reduction.

![image](https://user-images.githubusercontent.com/511355/147052986-4189479d-ffa8-4cb1-a06d-d7571e61236b.png)
