### PR TITLE
Don't skip later validations if previous one fails in Hierarchy Data Validation

### DIFF
--- a/src/Microsoft.Docs.Build.Specialized/learn/Validator.cs
+++ b/src/Microsoft.Docs.Build.Specialized/learn/Validator.cs
@@ -49,7 +49,8 @@ internal partial class Validator
 
         // no duplicated uids
         var itemDict = hierarchyItems.ToDictionary(i => i.Uid, i => i);
-        var isValid = validators.All(v => v.Validate(itemDict));
+        var isValid = true;
+        validators.ForEach(v => isValid &= v.Validate(itemDict));
         return (isValid, hierarchyItems);
     }
 


### PR DESCRIPTION
[AB#532550](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/532550)

The validators run in the order: LearningPath => Module => ModuleUnit => Achievement. The validators are involed by Linq.All which returns false and skips the later delegation funcs if any delegation fails. Say, if learning path validation fails, all other three will be skipped. (Kudos to @mingwli) 