### PR TITLE
Allow environment variable to have nested properties

### DIFF
--- a/src/docfx/lib/StringUtility.cs
+++ b/src/docfx/lib/StringUtility.cs
@@ -18,9 +18,13 @@ internal static class StringUtility
 
     public static string ToCamelCase(char wordSeparator, string value)
     {
+        var words = value.ToLowerInvariant().Split(wordSeparator, StringSplitOptions.RemoveEmptyEntries);
+        if (words.Length <= 0)
+        {
+            return "";
+        }
+
         var sb = new StringBuilder();
-        var words = value.ToLowerInvariant().Split(wordSeparator);
-        sb.Length = 0;
         sb.Append(words[0]);
         for (var i = 1; i < words.Length; i++)
         {

--- a/test/docfx.Test/build/ConfigTest.cs
+++ b/test/docfx.Test/build/ConfigTest.cs
@@ -1,12 +1,25 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.Docs.Build;
 
 public static class ConfigTest
 {
+    [Theory]
+    [InlineData("DOCFX_FOO", "bar", "{'foo':'bar'}")]
+    [InlineData("DOCFX_FOO", "a;b;c", "{'foo':['a','b','c']}")]
+    [InlineData("DOCFX__SECRETS__GITHUB_TOKEN", "a", "{'secrets':{'githubToken':'a'}}")]
+    [InlineData("DOCFX_SECRETS", "{\"githubToken\":\"a\"}", "{'secrets':{'githubToken':'a'}}")]
+    public static void LoadConfigFromEnvironmentVariable(string name, string value, string expected)
+    {
+        var actual = ConfigLoader.LoadEnvironmentVariables(new[] { new DictionaryEntry(name, value) });
+        Assert.Equal(expected, actual.ToString(Formatting.None).Replace('\"', '\''));
+    }
+
     [Theory]
     [InlineData("https://github.com/docs", "master", null, null)]
     [InlineData("", "master", null, null)]

--- a/test/docfx.Test/lib/StringUtilityTest.cs
+++ b/test/docfx.Test/lib/StringUtilityTest.cs
@@ -11,6 +11,9 @@ public static class StringUtilityTest
     [InlineData("", "")]
     [InlineData("a", "a")]
     [InlineData("OUTPUT_PATH", "outputPath")]
+    [InlineData("OUTPUT_PATH_", "outputPath")]
+    [InlineData("_OUTPUT_PATH", "outputPath")]
+    [InlineData("_OUTPUT_PATH_", "outputPath")]
     [InlineData("OUTPUT_PATH_NAME", "outputPathName")]
     public static void ToCamelCaseTest(string name, string camelCaseName)
     {


### PR DESCRIPTION
Allows configuring nested properties using environment variables, specifically the GitHub token using `DOCFX__SECRETS__GITHUB_TOKEN`. Environment variables are handy for [github actions](https://github.com/docascode/template/blob/feature/ghpage/.github/workflows/gh-page.yml#L21).

With this change, a double-underscore (`__`) creates a nested property, a single underscore (`_`) indicates camel casing separator.

This change is backward compatible.