### PR TITLE
Add _rel system metadata

### DIFF
--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -5,7 +5,13 @@ inputs:
   docs/a.md: Hello `docfx`!
 outputs:
   docs/a.json: |
-    { "conceptual": "<p>Hello <code>docfx</code>!</p>", "wordCount": 2, "_op_canonicalUrlPrefix": "https://docs.com/en-us/", "_path": "docs/a.json"}
+    {
+      "conceptual": "<p>Hello <code>docfx</code>!</p>",
+      "wordCount": 2,
+      "_op_canonicalUrlPrefix": "https://docs.com/en-us/",
+      "_path": "docs/a.json",
+      "_rel": "../"
+    }
 ---
 # Basic markdown syntax
 inputs:

--- a/src/docfx/build/metadata/SystemMetadata.cs
+++ b/src/docfx/build/metadata/SystemMetadata.cs
@@ -59,6 +59,9 @@ internal class SystemMetadata
     [JsonProperty("_path")]
     public string? Path { get; set; }
 
+    [JsonProperty("_rel")]
+    public string? Rel { get; set; }
+
     [JsonProperty("_op_canonicalUrlPrefix")]
     public string? CanonicalUrlPrefix { get; set; }
 

--- a/src/docfx/build/page/PageBuilder.cs
+++ b/src/docfx/build/page/PageBuilder.cs
@@ -233,6 +233,7 @@ internal class PageBuilder
         systemMetadata.Locale = _buildOptions.Locale;
         systemMetadata.CanonicalUrl = userMetadata.PageType != "profile" ? _documentProvider.GetCanonicalUrl(file) : null;
         systemMetadata.Path = _documentProvider.GetSitePath(file);
+        systemMetadata.Rel = PathUtility.GetRelativePathToRoot(systemMetadata.Path);
         systemMetadata.CanonicalUrlPrefix = UrlUtility.Combine($"https://{_config.HostName}", systemMetadata.Locale, _config.BasePath) + "/";
 
         systemMetadata.EnableLocSxs = _buildOptions.EnableSideBySide;

--- a/src/docfx/lib/path/PathUtility.cs
+++ b/src/docfx/lib/path/PathUtility.cs
@@ -50,6 +50,21 @@ internal static class PathUtility
         return result;
     }
 
+    public static string GetRelativePathToRoot(string path)
+    {
+        var sb = new StringBuilder();
+
+        foreach (var ch in path)
+        {
+            if (ch == '/' || ch == '\\')
+            {
+                sb.Append("../");
+            }
+        }
+
+        return sb.Length > 0 ? sb.ToString() : "./";
+    }
+
     /// <summary>
     /// A normalized folder always ends with `/`, does not contain `\` and does not have consecutive `.` or `/`.
     /// </summary>

--- a/test/docfx.Test/lib/PathUtilityTest.cs
+++ b/test/docfx.Test/lib/PathUtilityTest.cs
@@ -62,6 +62,14 @@ public static class PathUtilityTest
         => Assert.Equal(expected, PathUtility.GetRelativePathToFile(relativeTo, path).Replace("\\", "/"));
 
     [Theory]
+    [InlineData("", "./")]
+    [InlineData("a", "./")]
+    [InlineData("a/b", "../")]
+    [InlineData("a/b/c", "../../")]
+    public static void GetRelativePathToRoot(string path, string expected)
+        => Assert.Equal(expected, PathUtility.GetRelativePathToRoot(path));
+
+    [Theory]
     [InlineData("", "", true, "")]
     [InlineData("a", "a", true, "")]
     [InlineData("a/b", "a/b", true, "")]


### PR DESCRIPTION
This is to allow static HTML output to use relative links for style and script references, allowing static build output to be published correctly even if it is published to a sub-path.

This is a parity feature against [v2](https://github.com/dotnet/docfx/blob/dev/src/Microsoft.DocAsCode.Build.Engine/SystemMetadata.cs#L37)