### PR TITLE
docfx serve hosts HTML output

### DIFF
--- a/src/docfx/cli/Docfx.cs
+++ b/src/docfx/cli/Docfx.cs
@@ -122,7 +122,7 @@ public static class Docfx
         command.AddOption(new Option<bool>(
             "--language-server", "Starts a language server"));
         command.AddOption(new Option<string>(
-            "--address", () => "0.0.0.0", "The address used to serve"));
+            "--address", () => "127.0.0.1", "The address used to serve"));
         command.AddOption(new Option<int>(
             "--port", () => 8080, "The port used to communicate with the client"));
         command.AddOption(new Option<bool>(

--- a/src/docfx/cli/Docfx.cs
+++ b/src/docfx/cli/Docfx.cs
@@ -119,14 +119,14 @@ public static class Docfx
     {
         var command = CreateCommand("serve", "Serves content in a docset.", options => Serve.Run(options, package));
         DefineCommonCommands(command);
-        command.AddOption(new Option<bool>(
-            "--language-server", "Starts a language server"));
         command.AddOption(new Option<string>(
-            "--address", () => "127.0.0.1", "The address used to serve"));
+            "--address", () => "127.0.0.1", "Address to use."));
         command.AddOption(new Option<int>(
-            "--port", () => 8080, "The port used to communicate with the client"));
+            "--port", () => 8080, "Port to use. If 0, look for open port."));
         command.AddOption(new Option<bool>(
             "--no-cache", "Always fetch latest dependencies in build."));
+        command.AddOption(new Option<bool>(
+            "--language-server", "Starts a language server."));
         return command;
     }
 

--- a/test/docfx.Test/cli/NewTest.cs
+++ b/test/docfx.Test/cli/NewTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Net;
 using Xunit;
 
 namespace Microsoft.Docs.Build;
@@ -26,6 +27,28 @@ public static class NewTest
 
         Assert.Equal(0, Docfx.Run(new[] { "new", templateName, "-o", path }));
         Assert.Equal(0, Docfx.Run(new[] { "build", path }));
+    }
+
+    [Theory]
+    [MemberData(nameof(TemplateNames))]
+    public static void Create_Build_Serve_Docset(string templateName)
+    {
+        var path = Path.Combine("new-test", Guid.NewGuid().ToString("N"));
+
+        Assert.Equal(0, Docfx.Run(new[] { "new", templateName, "-o", path }));
+        Assert.Equal(0, Docfx.Run(new[] { "build", path }));
+
+        var exception = new Exception();
+        Assert.Equal(exception, Assert.Throws<Exception>(() =>
+            Serve.Run(new() { Directory = Path.GetFullPath(path), Address = "127.0.0.1" }, null, OnUrl)));
+
+        void OnUrl(string url)
+        {
+            using var http = new HttpClient();
+            var response = http.GetAsync(url).GetAwaiter().GetResult();
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            throw exception;
+        }
     }
 
     [Fact]


### PR DESCRIPTION
Allow `docfx serve` to serve HTML output after running `docfx build`. This is a very primitive static file server, it does not watch source file changes.

Contains changes in #7809 to allow test pass.