### PR TITLE
separate html element into tag and attribute

### DIFF
--- a/src/docfx/lib/HtmlUtility.cs
+++ b/src/docfx/lib/HtmlUtility.cs
@@ -343,7 +343,7 @@ internal static class HtmlUtility
                 continue;
             }
 
-            var tokenName = token.Name.ToString();
+            var tokenName = token.Name.ToString().ToLowerInvariant();
             if (!elementCount.ContainsKey(tokenName))
             {
                 elementCount.Add(tokenName, new Dictionary<string, int>());
@@ -358,7 +358,7 @@ internal static class HtmlUtility
             {
                 foreach (ref var attribute in token.Attributes.Span)
                 {
-                    var attributeName = attribute.Name.ToString();
+                    var attributeName = attribute.Name.ToString().ToLowerInvariant();
                     CollectionsMarshal.GetValueRefOrAddDefault(attributeCount, attributeName, out _)++;
                 }
             }

--- a/src/docfx/lib/log/Telemetry.cs
+++ b/src/docfx/lib/log/Telemetry.cs
@@ -90,7 +90,8 @@ internal static class Telemetry
             new MetricIdentifier(
                 null,
                 "HtmlElement",
-                "ElementType",
+                "Tag",
+                "Attribute",
                 "IsAllowed",
                 "FileExtension",
                 "DocumentType",
@@ -271,12 +272,12 @@ internal static class Telemetry
             {
                 foreach (var (attributeName, count) in attributeCount)
                 {
-                    var elementType = string.IsNullOrEmpty(attributeName) ? tokenName : $"{tokenName}_{attributeName}";
                     TrackValueWithEnsurance(
                     s_htmlElementCountMetric.Identifier.MetricId,
                     s_htmlElementCountMetric.TrackValue(
                     count,
-                    CoalesceEmpty(elementType),
+                    CoalesceEmpty(tokenName),
+                    CoalesceEmpty(attributeName),
                     isAllowed(tokenName, attributeName).ToString(),
                     fileExtension,
                     documentType,


### PR DESCRIPTION
[AB#532859](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/532859)
why?
In order to filter data more accurately, we need to collect tag and attribute separately.