### PR TITLE
Component govenmance ignore bin directory

### DIFF
--- a/azure-pipelines-v3.yml
+++ b/azure-pipelines-v3.yml
@@ -83,6 +83,8 @@ jobs:
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    inputs:
+      ignoreDirectories: bin
 
   # Put this step in the end, for this step always return status:succeeded, and following task won't be skipped
   - task: PublishTestResults@2


### PR DESCRIPTION
Fixes https://dev.azure.com/ceapex/Engineering/_build/results?buildId=757752&view=logs&jobId=a29a2371-0793-5e14-39b9-20eb0beef0db&j=a29a2371-0793-5e14-39b9-20eb0beef0db&t=b826d808-621f-563a-bd04-10aa746af8d7

We aren't compiling/running these files, they are copied as part of the template clone process.