### PR TITLE
fix pdf render type

### DIFF
--- a/src/docfx/template/JsonSchemaProvider.cs
+++ b/src/docfx/template/JsonSchemaProvider.cs
@@ -103,6 +103,11 @@ internal class JsonSchemaProvider
 
     private RenderType GetTocRenderType()
     {
+        // Refer to https://ceapex.visualstudio.com/Engineering/_workitems/edit/537091
+        // There is a TOC.schema.json file existing in templates.docs.msft repo whose 'renderType' is set to 'component'
+        // (https://github.com/microsoft/templates.docs.msft/blob/master/ContentTemplate/schemas/Toc.schema.json#L7)
+        // This will break the PDF process because PDF asks it to be 'content' (so that docfx can generate 'toc.html' which is necessary for building PDF)
+        // To avoid unexpected breaking PDF process through sync templates, special logic dealing with PDF cases goes first.
         if (_template.Url.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase) ||
             _template.Path.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
         {

--- a/src/docfx/template/JsonSchemaProvider.cs
+++ b/src/docfx/template/JsonSchemaProvider.cs
@@ -114,6 +114,13 @@ internal class JsonSchemaProvider
             return RenderType.Content;
         }
 
-        return GetSchema(new SourceInfo<string?>("toc")).RenderType;
+        try
+        {
+            return GetSchema(new SourceInfo<string?>("toc")).RenderType;
+        }
+        catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var _))
+        {
+            return RenderType.Component;
+        }
     }
 }

--- a/src/docfx/template/JsonSchemaProvider.cs
+++ b/src/docfx/template/JsonSchemaProvider.cs
@@ -103,16 +103,12 @@ internal class JsonSchemaProvider
 
     private RenderType GetTocRenderType()
     {
-        try
+        if (_template.Url.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase) ||
+            _template.Path.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
         {
-            return GetSchema(new SourceInfo<string?>("toc")).RenderType;
+            return RenderType.Content;
         }
-        catch (Exception ex) when (DocfxException.IsDocfxException(ex, out var _))
-        {
-            // TODO: Remove after schema of toc is support in template
-            var isContentRenderType = _template.Url.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase)
-                || _template.Path.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase);
-            return isContentRenderType ? RenderType.Content : RenderType.Component;
-        }
+
+        return GetSchema(new SourceInfo<string?>("toc")).RenderType;
     }
 }


### PR DESCRIPTION
This PR is to fix a potential bug described [here](https://ceapex.visualstudio.com/Engineering/_workitems/edit/537091).

Currently, content team has already added a `Toc.schema.json` to the [template repo](https://github.com/microsoft/templates.docs.msft). In [this schema file](https://github.com/microsoft/templates.docs.msft/blob/master/ContentTemplate/schemas/Toc.schema.json#L7), the `renderType` has been set to `component`.

PDF requires TOC should have a renderType of `content` (Because only `content` will make docfx generate HTML file, which will be consumed by PDF processes). So simply syncing this template to PDF template repo will break the PDF building process, until we push this fix.