### PR TITLE
Allow moniker definition to be defined inline

### DIFF
--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -11,20 +11,16 @@ inputs:
       docs/: .
       docs/v1/: .
       docs/v2/: .
-    monikerDefinition: monikerDefinition.json
+    monikerDefinition:
+      monikers:
+      - { moniker_name: netcore-1.0, product_name: .NET Core }
+      - { moniker_name: netcore-1.1, product_name: .NET Core }
+      - { moniker_name: netcore-2.0, product_name: .NET Core }
+      - { moniker_name: netcore-2.1, product_name: .NET Core }
   docs/v1/a.md: |
     Moniker: netcore-1.0, netcore-1.1
   docs/v2/a.md: |
     Moniker: netcore-2.0, netcore-2.1
-  monikerDefinition.json: |
-    {
-      "monikers": [
-        { "moniker_name": "netcore-1.0", "product_name": ".NET Core" },
-        { "moniker_name": "netcore-1.1", "product_name": ".NET Core" },
-        { "moniker_name": "netcore-2.0", "product_name": ".NET Core" },
-        { "moniker_name": "netcore-2.1", "product_name": ".NET Core" }
-      ]
-    }
 outputs:
   docs/17b9fe681514513cbf7d5c90e32f107a/a.json: |
     {

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -210,9 +210,10 @@ internal class Config : PreloadConfig
 
     /// <summary>
     /// Get the definition of monikers
-    /// It should be absolute url or relative path
+    /// It should be absolute url, relative path, or inline definition
     /// </summary>
-    public SourceInfo<string> MonikerDefinition { get; init; } = new("");
+    [JsonConverter(typeof(UnionTypeConverter))]
+    public (MonikerDefinitionModel? value, SourceInfo<string>? src) MonikerDefinition { get; init; }
 
     /// <summary>
     /// Get a list of trusted domains by tag name.
@@ -361,7 +362,12 @@ internal class Config : PreloadConfig
         }
 
         yield return DocumentIdOverride;
-        yield return MonikerDefinition;
+
+        if (MonikerDefinition.src != null)
+        {
+            yield return MonikerDefinition.src.Value;
+        }
+
         yield return MarkdownValidationRules;
         yield return BuildValidationRules;
         yield return Allowlists;

--- a/src/docfx/lib/json/SourceInfoJsonConverter.cs
+++ b/src/docfx/lib/json/SourceInfoJsonConverter.cs
@@ -10,6 +10,8 @@ internal class SourceInfoJsonConverter : JsonConverter
 {
     public override bool CanConvert(Type objectType)
     {
+        objectType = UnwrapNullable(objectType);
+
         return objectType.IsGenericType && objectType.GetGenericTypeDefinition() == typeof(SourceInfo<>);
     }
 
@@ -31,6 +33,8 @@ internal class SourceInfoJsonConverter : JsonConverter
                 }
                 break;
         }
+
+        objectType = UnwrapNullable(objectType);
 
         var valueType = objectType.GenericTypeArguments[0];
         var value = serializer.Deserialize(reader, valueType);
@@ -54,5 +58,12 @@ internal class SourceInfoJsonConverter : JsonConverter
         {
             serializer.Serialize(writer, sourceInfo.GetValue());
         }
+    }
+
+    private static Type UnwrapNullable(Type objectType)
+    {
+        return objectType.IsGenericType && objectType.GetGenericTypeDefinition() == typeof(Nullable<>)
+            ? objectType.GetGenericArguments()[0]
+            : objectType;
     }
 }

--- a/src/docfx/lib/json/UnionTypeConverter.cs
+++ b/src/docfx/lib/json/UnionTypeConverter.cs
@@ -32,7 +32,7 @@ internal class UnionTypeConverter : JsonConverter
         // Trying to find an exact match first
         for (var i = 0; i < genericTypes.Length; i++)
         {
-            if (TypeExactlyMatches(reader.TokenType, genericTypes[i]))
+            if (TypeExactlyMatches(reader.TokenType, UnwrapKnownGenericType(genericTypes[i])))
             {
                 args[i] = serializer.Deserialize(reader, genericTypes[i]);
                 return args;
@@ -42,7 +42,7 @@ internal class UnionTypeConverter : JsonConverter
         // Exclude types that never matches
         for (var i = 0; i < genericTypes.Length; i++)
         {
-            if (!TypeNeverMatches(reader.TokenType, genericTypes[i]))
+            if (!TypeNeverMatches(reader.TokenType, UnwrapKnownGenericType(genericTypes[i])))
             {
                 args[i] = serializer.Deserialize(reader, genericTypes[i]);
                 return args;
@@ -65,5 +65,21 @@ internal class UnionTypeConverter : JsonConverter
     private static bool TypeNeverMatches(JsonToken tokenType, Type objectType)
     {
         return objectType.IsArray && tokenType != JsonToken.StartArray;
+    }
+
+    private static Type UnwrapKnownGenericType(Type type)
+    {
+        // Unwrap Nullable<T>
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+        {
+            type = type.GenericTypeArguments[0];
+        }
+
+        // Unwrap SourceInfo<T>
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(SourceInfo<>))
+        {
+            type = type.GenericTypeArguments[0];
+        }
+        return type;
     }
 }


### PR DESCRIPTION
To simplify moniker definition for community release, allow monikers to be defined both in the config and in a separate file.