### PR TITLE
Add layout to liquid-not-found error message

### DIFF
--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -838,8 +838,8 @@ internal static class Errors
         /// Liquid is not found for current mime type.
         /// </summary>
         /// Behavior: ❌ Message: ❌
-        public static Error LiquidNotFound(SourceInfo<string?> source, string layout)
-            => new(ErrorLevel.Warning, "liquid-not-found", $"Liquid template is not found for layout '{layout}' and mime type '{source}', the output HTML will not be generated.", source);
+        public static Error LiquidNotFound(SourceInfo<string?> source, string templateName)
+            => new(ErrorLevel.Warning, "liquid-not-found", $"Liquid template '{templateName}' not found for mime type '{source}', the output HTML will not be generated.", source);
 
         /// <summary>
         /// Mustache is not found for current mime type.

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -838,8 +838,8 @@ internal static class Errors
         /// Liquid is not found for current mime type.
         /// </summary>
         /// Behavior: ❌ Message: ❌
-        public static Error LiquidNotFound(SourceInfo<string?> source)
-            => new(ErrorLevel.Warning, "liquid-not-found", $"Liquid template is not found for mime type '{source}', the output HTML will not be generated.", source);
+        public static Error LiquidNotFound(SourceInfo<string?> source, string layout)
+            => new(ErrorLevel.Warning, "liquid-not-found", $"Liquid template is not found for layout '{layout}' and mime type '{source}', the output HTML will not be generated.", source);
 
         /// <summary>
         /// Mustache is not found for current mime type.

--- a/src/docfx/template/liquid/LiquidTemplate.cs
+++ b/src/docfx/template/liquid/LiquidTemplate.cs
@@ -41,7 +41,7 @@ internal class LiquidTemplate
         var template = LoadTemplate(new PathString($"{templateName}.html.liquid"));
         if (template is null)
         {
-            errors.Add(Errors.Template.LiquidNotFound(mime, templateName));
+            errors.Add(Errors.Template.LiquidNotFound(mime, $"{templateName}.html.liquid"));
             return "";
         }
 

--- a/src/docfx/template/liquid/LiquidTemplate.cs
+++ b/src/docfx/template/liquid/LiquidTemplate.cs
@@ -41,7 +41,7 @@ internal class LiquidTemplate
         var template = LoadTemplate(new PathString($"{templateName}.html.liquid"));
         if (template is null)
         {
-            errors.Add(Errors.Template.LiquidNotFound(mime));
+            errors.Add(Errors.Template.LiquidNotFound(mime, templateName));
             return "";
         }
 


### PR DESCRIPTION
The mime type isn't the actual liquid file name, the liquid file name is typically named after `layout` metadata, add layout to the error message to make it easier to see where went wrong.