### PR TITLE
Fix TOC wrong output path when render type is set to component

### DIFF
--- a/docs/specs/static.yml
+++ b/docs/specs/static.yml
@@ -383,13 +383,12 @@ outputs:
     <link rel="stylesheet" href="/dev/test.css">
     <div></div>
 ---
-# TOC with output-type="html"
+# TOC with outputType: html and urlType: docs
 repos:
   https://github.com/toc/toc-output-type-is-html:
   - files:
       docfx.yml: |
         outputType: html
-        renderType: Content
         template: https://docs.com/theme
       TOC.yml: |
         - name: link-a
@@ -436,3 +435,14 @@ outputs:
       <a href="a"> link-a </a>
   toc.json: |
     {"items":[{"name":"link-a","href":"a"}],"_path":"toc.json","schema":"toc", "outputType":"html"}
+---
+# TOC with outputType: html and urlType: pretty
+inputs:
+  docfx.yml: |
+    outputType: html
+    urlType: pretty
+  TOC.yml: |
+    - name: a
+outputs:
+  toc.json: |
+    {"items":[{"name":"a"}]}

--- a/src/docfx/build/document/DocumentProvider.cs
+++ b/src/docfx/build/document/DocumentProvider.cs
@@ -207,7 +207,7 @@ internal class DocumentProvider
         var sitePath = ApplyRoutes(filePath.Path).Value;
         if (contentType == ContentType.Page || contentType == ContentType.Redirection || contentType == ContentType.Toc)
         {
-            sitePath = contentType == ContentType.Page && renderType == RenderType.Component
+            sitePath = renderType == RenderType.Component
                 ? Path.ChangeExtension(sitePath, ".json")
                 : urlType switch
                 {


### PR DESCRIPTION
When `urlType=pretty` and TOC is rendered as a component, the output path should be `toc.json`, but the actual output today is `toc/index.json`. The actual output path failed to load in browser.
