### PR TITLE
Optionally enable Markdig extensions that are not included by default in DocFX

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Constants.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Constants.cs
@@ -13,40 +13,21 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         }
 
         /// <summary>
-        /// Optional extensions that can be enabled from
-        /// the markdownEngineProperties property in the docfx.json.
+        /// Names of properties supported in the markdownEngineProperties
+        /// property in the docfx.json
         /// </summary>
-        public static class OptionalExtensionPropertyNames
+        public static class EngineProperties
         {
             /// <summary>
-            /// Enables the Task List Markdig extension by invoking <see cref="Markdig.MarkdownExtensions.UseTaskLists(Markdig.MarkdownPipelineBuilder)"/>.
+            /// Enables the <see cref="LineNumberExtension"/>.
             /// </summary>
-            public const string EnableTaskLists = "enableTaskLists";
+            public const string EnableSourceInfo = "EnableSourceInfo";
 
             /// <summary>
-            /// Enables the Grid Tables Markdig extension by invoking <see cref="Markdig.MarkdownExtensions.UseGridTables(Markdig.MarkdownPipelineBuilder)"/>.
+            /// Contains a list of optional Markdig extensions that are not
+            /// enabled by default by DocFX.
             /// </summary>
-            public const string EnableGridTables = "enableGridTables";
-
-            /// <summary>
-            /// Enables the Footnotes Markdig extension by invoking <see cref="Markdig.MarkdownExtensions.UseFootnotes(Markdig.MarkdownPipelineBuilder)"/>.
-            /// </summary>
-            public const string EnableFootnotes = "enableFootnotes";
-
-            /// <summary>
-            /// Enables the Mathematics Markdig extension by invoking <see cref="Markdig.MarkdownExtensions.UseMathematics(Markdig.MarkdownPipelineBuilder)"/>.
-            /// </summary>
-            public const string EnableMathematics = "enableMathematics";
-
-            /// <summary>
-            /// Enables the Diagrams Markdig extension by invoking <see cref="Markdig.MarkdownExtensions.UseDiagrams(Markdig.MarkdownPipelineBuilder)"/>.
-            /// </summary>
-            public const string EnableDiagrams = "enableDiagrams";
-
-            /// <summary>
-            /// Enables the Definition Lists Markdig extension by invoking <see cref="Markdig.MarkdownExtensions.UseDefinitionLists(Markdig.MarkdownPipelineBuilder)"/>.
-            /// </summary>
-            public const string EnableDefinitionLists = "enableDefinitionLists";
+            public const string MarkdigExtensions = "markdigExtensions";
         }
     }
 }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Constants.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/Constants.cs
@@ -11,5 +11,42 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         {
             public const string InvalidTabGroup = "InvalidTabGroup";
         }
+
+        /// <summary>
+        /// Optional extensions that can be enabled from
+        /// the markdownEngineProperties property in the docfx.json.
+        /// </summary>
+        public static class OptionalExtensionPropertyNames
+        {
+            /// <summary>
+            /// Enables the Task List Markdig extension by invoking <see cref="Markdig.MarkdownExtensions.UseTaskLists(Markdig.MarkdownPipelineBuilder)"/>.
+            /// </summary>
+            public const string EnableTaskLists = "enableTaskLists";
+
+            /// <summary>
+            /// Enables the Grid Tables Markdig extension by invoking <see cref="Markdig.MarkdownExtensions.UseGridTables(Markdig.MarkdownPipelineBuilder)"/>.
+            /// </summary>
+            public const string EnableGridTables = "enableGridTables";
+
+            /// <summary>
+            /// Enables the Footnotes Markdig extension by invoking <see cref="Markdig.MarkdownExtensions.UseFootnotes(Markdig.MarkdownPipelineBuilder)"/>.
+            /// </summary>
+            public const string EnableFootnotes = "enableFootnotes";
+
+            /// <summary>
+            /// Enables the Mathematics Markdig extension by invoking <see cref="Markdig.MarkdownExtensions.UseMathematics(Markdig.MarkdownPipelineBuilder)"/>.
+            /// </summary>
+            public const string EnableMathematics = "enableMathematics";
+
+            /// <summary>
+            /// Enables the Diagrams Markdig extension by invoking <see cref="Markdig.MarkdownExtensions.UseDiagrams(Markdig.MarkdownPipelineBuilder)"/>.
+            /// </summary>
+            public const string EnableDiagrams = "enableDiagrams";
+
+            /// <summary>
+            /// Enables the Definition Lists Markdig extension by invoking <see cref="Markdig.MarkdownExtensions.UseDefinitionLists(Markdig.MarkdownPipelineBuilder)"/>.
+            /// </summary>
+            public const string EnableDefinitionLists = "enableDefinitionLists";
+        }
     }
 }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownExtensions.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownExtensions.cs
@@ -5,6 +5,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using Markdig;
     using Markdig.Extensions.AutoIdentifiers;
     using Markdig.Extensions.CustomContainers;
@@ -44,43 +45,18 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         /// Enables optional Markdig extensions that are not added by default with DocFX
         /// </summary>
         /// <param name="pipeline">The markdown pipeline builder</param>
-        /// <param name="context">The markdown context</param>
-        /// <param name="extensions">The extension dictionary</param>
+        /// <param name="optionalExtensions">The list of optional extensions</param>
         /// <returns>The pipeline with optional extensions enabled</returns>
         public static MarkdownPipelineBuilder UseOptionalExtensions(
             this MarkdownPipelineBuilder pipeline,
-            MarkdownContext context,
-            IReadOnlyDictionary<string, object> extensions)
+            IEnumerable<string> optionalExtensions)
         {
-            if (IsExtensionEnabled(Constants.OptionalExtensionPropertyNames.EnableTaskLists, extensions))
+            if (!optionalExtensions.Any())
             {
-                pipeline.UseTaskLists();
+                return pipeline;
             }
 
-            if (IsExtensionEnabled(Constants.OptionalExtensionPropertyNames.EnableGridTables, extensions))
-            {
-                pipeline.UseGridTables();
-            }
-
-            if (IsExtensionEnabled(Constants.OptionalExtensionPropertyNames.EnableFootnotes, extensions))
-            {
-                pipeline.UseFootnotes();
-            }
-
-            if (IsExtensionEnabled(Constants.OptionalExtensionPropertyNames.EnableMathematics, extensions))
-            {
-                pipeline.UseMathematics();
-            }
-
-            if (IsExtensionEnabled(Constants.OptionalExtensionPropertyNames.EnableDiagrams, extensions))
-            {
-                pipeline.UseDiagrams();
-            }
-
-            if (IsExtensionEnabled(Constants.OptionalExtensionPropertyNames.EnableDefinitionLists, extensions))
-            {
-                pipeline.UseDefinitionLists();
-            }
+            pipeline.Configure(string.Join("+", optionalExtensions));
 
             return pipeline;
         }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownExtensions.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownExtensions.cs
@@ -172,19 +172,5 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             pipeline.Extensions.AddIfNotAlready(new NolocExtension());
             return pipeline;
         }
-
-        /// <summary>
-        /// Checks the extensions dictionary if an extension is enabled.
-        /// </summary>
-        /// <param name="extensionPropertyName">The property name for the extension</param>
-        /// <param name="extensions">The read-only dictionary containing the extensions</param>
-        /// <returns>True if the extension is in the dictionary and its value is set to true. False, otherwise.</returns>
-        private static bool IsExtensionEnabled(string extensionPropertyName, IReadOnlyDictionary<string, object> extensions)
-        {
-            object enableExtensionObj = null;
-            extensions?.TryGetValue(extensionPropertyName, out enableExtensionObj);
-
-            return enableExtensionObj is bool enabled && enabled;
-        }
     }
 }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownExtensions.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownExtensions.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 {
     using System;
+    using System.Collections.Generic;
     using Markdig;
     using Markdig.Extensions.AutoIdentifiers;
     using Markdig.Extensions.CustomContainers;
@@ -36,8 +37,52 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
                 .UseTripleColon(context)
                 .UseNoloc()
                 .UseResolveLink(context)
-                .UseTaskLists()
                 .RemoveUnusedExtensions();
+        }
+
+        /// <summary>
+        /// Enables optional Markdig extensions that are not added by default with DocFX
+        /// </summary>
+        /// <param name="pipeline">The markdown pipeline builder</param>
+        /// <param name="context">The markdown context</param>
+        /// <param name="extensions">The extension dictionary</param>
+        /// <returns>The pipeline with optional extensions enabled</returns>
+        public static MarkdownPipelineBuilder UseOptionalExtensions(
+            this MarkdownPipelineBuilder pipeline,
+            MarkdownContext context,
+            IReadOnlyDictionary<string, object> extensions)
+        {
+            if (IsExtensionEnabled(Constants.OptionalExtensionPropertyNames.EnableTaskLists, extensions))
+            {
+                pipeline.UseTaskLists();
+            }
+
+            if (IsExtensionEnabled(Constants.OptionalExtensionPropertyNames.EnableGridTables, extensions))
+            {
+                pipeline.UseGridTables();
+            }
+
+            if (IsExtensionEnabled(Constants.OptionalExtensionPropertyNames.EnableFootnotes, extensions))
+            {
+                pipeline.UseFootnotes();
+            }
+
+            if (IsExtensionEnabled(Constants.OptionalExtensionPropertyNames.EnableMathematics, extensions))
+            {
+                pipeline.UseMathematics();
+            }
+
+            if (IsExtensionEnabled(Constants.OptionalExtensionPropertyNames.EnableDiagrams, extensions))
+            {
+                pipeline.UseDiagrams();
+            }
+
+            if (IsExtensionEnabled(Constants.OptionalExtensionPropertyNames.EnableDefinitionLists, extensions))
+            {
+                pipeline.UseDefinitionLists();
+            }
+
+            return pipeline;
         }
 
         private static MarkdownPipelineBuilder RemoveUnusedExtensions(this MarkdownPipelineBuilder pipeline)
@@ -150,6 +195,20 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         {
             pipeline.Extensions.AddIfNotAlready(new NolocExtension());
             return pipeline;
+        }
+
+        /// <summary>
+        /// Checks the extensions dictionary if an extension is enabled.
+        /// </summary>
+        /// <param name="extensionPropertyName">The property name for the extension</param>
+        /// <param name="extensions">The read-only dictionary containing the extensions</param>
+        /// <returns>True if the extension is in the dictionary and its value is set to true. False, otherwise.</returns>
+        private static bool IsExtensionEnabled(string extensionPropertyName, IReadOnlyDictionary<string, object> extensions)
+        {
+            object enableExtensionObj = null;
+            extensions?.TryGetValue(extensionPropertyName, out enableExtensionObj);
+
+            return enableExtensionObj is bool enabled && enabled;
         }
     }
 }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownExtensions.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/MarkdownExtensions.cs
@@ -36,6 +36,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
                 .UseTripleColon(context)
                 .UseNoloc()
                 .UseResolveLink(context)
+                .UseTaskLists()
                 .RemoveUnusedExtensions();
         }
 

--- a/src/Microsoft.DocAsCode.MarkdigEngine/MarkdigMarkdownService.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine/MarkdigMarkdownService.cs
@@ -160,6 +160,8 @@ namespace Microsoft.DocAsCode.MarkdigEngine
                 builder.UseInlineOnly();
             }
 
+            builder.UseOptionalExtensions(_context, _parameters.Extensions);
+
             return builder.Build();
         }
 

--- a/src/Microsoft.DocAsCode.MarkdigEngine/MarkdigMarkdownService.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine/MarkdigMarkdownService.cs
@@ -15,6 +15,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine
     using Markdig.Syntax;
     using Microsoft.DocAsCode.Plugins;
     using Microsoft.DocAsCode.Common;
+    using System.Collections.Generic;
 
     public class MarkdigMarkdownService : IMarkdownService
     {
@@ -136,7 +137,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine
         private MarkdownPipeline CreateMarkdownPipeline(bool isInline, bool enableValidation)
         {
             object enableSourceInfoObj = null;
-            _parameters?.Extensions?.TryGetValue("EnableSourceInfo", out enableSourceInfoObj);
+            _parameters?.Extensions?.TryGetValue(Constants.EngineProperties.EnableSourceInfo, out enableSourceInfoObj);
 
             var enableSourceInfo = !(enableSourceInfoObj is bool enabled) || enabled;
 
@@ -160,7 +161,12 @@ namespace Microsoft.DocAsCode.MarkdigEngine
                 builder.UseInlineOnly();
             }
 
-            builder.UseOptionalExtensions(_context, _parameters.Extensions);
+            object optionalExtensionsObj = null;
+            if ((_parameters?.Extensions?.TryGetValue(Constants.EngineProperties.MarkdigExtensions, out optionalExtensionsObj) ?? false)
+                && optionalExtensionsObj is IEnumerable<object> optionalExtensions)
+            {
+                builder.UseOptionalExtensions(optionalExtensions.Select(e => e as string).Where(e => e != null));
+            }
 
             return builder.Build();
         }

--- a/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/GeneralTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/GeneralTest.cs
@@ -27,8 +27,8 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Tests
         {
             // Confirm that the [ ] and { } in the middle of list should not be parsed.
             var source = @"* Not contain a special character: &#92; ! # $ % & * + / = ? ^ &#96; { } | ~ < > ( ) ' ; : , [ ] "" @ _";
-            var expected = @"<ul>
-<li>Not contain a special character: \ ! # $ % &amp; * + / = ? ^ ` { } | ~ &lt; &gt; ( ) ' ; : , [ ] &quot; @ _</li>
+            var expected = @"<ul class=""contains-task-list"">
+<li class=""task-list-item"">Not contain a special character: \ ! # $ % &amp; * + / = ? ^ ` { } | ~ &lt; &gt; ( ) ' ; : , <input disabled=""disabled"" type=""checkbox"" /> &quot; @ _</li>
 </ul>
 ";
             TestUtility.VerifyMarkup(source, expected);

--- a/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/GeneralTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/GeneralTest.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Tests
 ";
             TestUtility.VerifyMarkup(source, expected, optionalExtensions: new Dictionary<string, object>
             {
-                { "EnableTaskLists", false }
+                { "enableTaskLists", false }
             });
         }
 
@@ -62,7 +62,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Tests
 ";
             TestUtility.VerifyMarkup(source, expected, optionalExtensions: new Dictionary<string, object>
             {
-                { "EnableTaskLists", true }
+                { "enableTaskLists", true }
             });
         }
 

--- a/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/GeneralTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/GeneralTest.cs
@@ -36,22 +36,6 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Tests
 
         [Fact]
         [Trait("Related", "DfmMarkdown")]
-        public void TestDfm_TaskList_ExtensionDisabled()
-        {
-            // Confirm that the [ ] and { } in the middle of list should not be parsed if the Task List extension is explicitly enabled.
-            var source = @"* Not contain a special character: &#92; ! # $ % & * + / = ? ^ &#96; { } | ~ < > ( ) ' ; : , [ ] "" @ _";
-            var expected = @"<ul>
-<li>Not contain a special character: \ ! # $ % &amp; * + / = ? ^ ` { } | ~ &lt; &gt; ( ) ' ; : , [ ] &quot; @ _</li>
-</ul>
-";
-            TestUtility.VerifyMarkup(source, expected, optionalExtensions: new Dictionary<string, object>
-            {
-                { "enableTaskLists", false }
-            });
-        }
-
-        [Fact]
-        [Trait("Related", "DfmMarkdown")]
         public void TestDfm_TaskList_ExtensionEnabled()
         {
             // Confirm that the [ ] and { } in the middle of list should be parsed if the Task List extension is enabled.
@@ -60,9 +44,35 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Tests
 <li class=""task-list-item"">Not contain a special character: \ ! # $ % &amp; * + / = ? ^ ` { } | ~ &lt; &gt; ( ) ' ; : , <input disabled=""disabled"" type=""checkbox"" /> &quot; @ _</li>
 </ul>
 ";
-            TestUtility.VerifyMarkup(source, expected, optionalExtensions: new Dictionary<string, object>
+            TestUtility.VerifyMarkup(source, expected, optionalExtensions: new List<string>
             {
-                { "enableTaskLists", true }
+                "tasklists"
+            });
+        }
+
+        [Fact]
+        [Trait("Related", "DfmMarkdown")]
+        public void TestDfm_MultipleOptionalExtensionsEnabled()
+        {
+            // Confirm that multiple optional extensions can be enabled at once
+            var source = @"* Not contain a special character: &#92; ! # $ % & * + / = ? ^ &#96; { } | ~ < > ( ) ' ; : , [ ] "" @ _
+
+Term 1
+:   Definition 1";
+            var expected = @"<ul class=""contains-task-list"">
+<li class=""task-list-item"">Not contain a special character: \ ! # $ % &amp; * + / = ? ^ ` { } | ~ &lt; &gt; ( ) ' ; : , <input disabled=""disabled"" type=""checkbox"" /> &quot; @ _</li>
+</ul>
+
+<dl>
+<dt>Term 1</dt>
+<dd>Definition 1</dd>
+</dl>
+";
+
+            TestUtility.VerifyMarkup(source, expected, optionalExtensions: new List<string>
+            {
+                "tasklists",
+                "definitionlists"
             });
         }
 

--- a/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/GeneralTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/GeneralTest.cs
@@ -23,15 +23,47 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Tests
 
         [Fact]
         [Trait("Related", "DfmMarkdown")]
-        public void TestDfm_TaskList()
+        public void TestDfm_TaskList_ExtensionDisabledByDefault()
         {
-            // Confirm that the [ ] and { } in the middle of list should not be parsed.
+            // Confirm that the [ ] and { } in the middle of list should not be parsed by default.
+            var source = @"* Not contain a special character: &#92; ! # $ % & * + / = ? ^ &#96; { } | ~ < > ( ) ' ; : , [ ] "" @ _";
+            var expected = @"<ul>
+<li>Not contain a special character: \ ! # $ % &amp; * + / = ? ^ ` { } | ~ &lt; &gt; ( ) ' ; : , [ ] &quot; @ _</li>
+</ul>
+";
+            TestUtility.VerifyMarkup(source, expected);
+        }
+
+        [Fact]
+        [Trait("Related", "DfmMarkdown")]
+        public void TestDfm_TaskList_ExtensionDisabled()
+        {
+            // Confirm that the [ ] and { } in the middle of list should not be parsed if the Task List extension is explicitly enabled.
+            var source = @"* Not contain a special character: &#92; ! # $ % & * + / = ? ^ &#96; { } | ~ < > ( ) ' ; : , [ ] "" @ _";
+            var expected = @"<ul>
+<li>Not contain a special character: \ ! # $ % &amp; * + / = ? ^ ` { } | ~ &lt; &gt; ( ) ' ; : , [ ] &quot; @ _</li>
+</ul>
+";
+            TestUtility.VerifyMarkup(source, expected, optionalExtensions: new Dictionary<string, object>
+            {
+                { "EnableTaskLists", false }
+            });
+        }
+
+        [Fact]
+        [Trait("Related", "DfmMarkdown")]
+        public void TestDfm_TaskList_ExtensionEnabled()
+        {
+            // Confirm that the [ ] and { } in the middle of list should be parsed if the Task List extension is enabled.
             var source = @"* Not contain a special character: &#92; ! # $ % & * + / = ? ^ &#96; { } | ~ < > ( ) ' ; : , [ ] "" @ _";
             var expected = @"<ul class=""contains-task-list"">
 <li class=""task-list-item"">Not contain a special character: \ ! # $ % &amp; * + / = ? ^ ` { } | ~ &lt; &gt; ( ) ' ; : , <input disabled=""disabled"" type=""checkbox"" /> &quot; @ _</li>
 </ul>
 ";
-            TestUtility.VerifyMarkup(source, expected);
+            TestUtility.VerifyMarkup(source, expected, optionalExtensions: new Dictionary<string, object>
+            {
+                { "EnableTaskLists", true }
+            });
         }
 
         [Fact]

--- a/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/TestUtility.cs
+++ b/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/TestUtility.cs
@@ -23,11 +23,13 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Tests
             string filePath = "test.md",
             Dictionary<string, string> tokens = null,
             Dictionary<string, string> files = null,
-            Action<MarkdownObject> verifyAST = null)
+            Action<MarkdownObject> verifyAST = null,
+            Dictionary<string, object> optionalExtensions = null)
         {
             errors = errors ?? Array.Empty<string>();
             tokens = tokens ?? new Dictionary<string, string>();
             files = files ?? new Dictionary<string, string>();
+            optionalExtensions = optionalExtensions ?? new Dictionary<string, object>();
 
             var actualErrors = new List<string>();
             var actualDependencies = new HashSet<string>();
@@ -42,7 +44,8 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Tests
 
             var pipelineBuilder = new MarkdownPipelineBuilder()
                 .UseDocfxExtensions(markdownContext)
-                .UseYamlFrontMatter();
+                .UseYamlFrontMatter()
+                .UseOptionalExtensions(markdownContext, optionalExtensions);
 
             if (lineNumber)
             {

--- a/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/TestUtility.cs
+++ b/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/TestUtility.cs
@@ -24,12 +24,12 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Tests
             Dictionary<string, string> tokens = null,
             Dictionary<string, string> files = null,
             Action<MarkdownObject> verifyAST = null,
-            Dictionary<string, object> optionalExtensions = null)
+            IEnumerable<string> optionalExtensions = null)
         {
             errors = errors ?? Array.Empty<string>();
             tokens = tokens ?? new Dictionary<string, string>();
             files = files ?? new Dictionary<string, string>();
-            optionalExtensions = optionalExtensions ?? new Dictionary<string, object>();
+            optionalExtensions = optionalExtensions ?? new List<string>();
 
             var actualErrors = new List<string>();
             var actualDependencies = new HashSet<string>();
@@ -45,7 +45,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Tests
             var pipelineBuilder = new MarkdownPipelineBuilder()
                 .UseDocfxExtensions(markdownContext)
                 .UseYamlFrontMatter()
-                .UseOptionalExtensions(markdownContext, optionalExtensions);
+                .UseOptionalExtensions(optionalExtensions);
 
             if (lineNumber)
             {


### PR DESCRIPTION
Taking a first crack at #3387

This change will allow users to optionally enable various Markdig extensions that are disabled by default in DocFX. The following extensions are included in this change (more can be added later):
- Task lists
- Grid tables
- Footnotes
- Mathematics
- Diagrams
- Definition lists

To enable them, simply include them as a property in your `markdownEngineProperties` (make sure Markdig is set as your `markdownEngine`):

```json
{
  "build": {
    ...
    "markdownEngineName": "markdig",
    "markdownEngineProperties": {
      "enableTaskLists": true,
      "enableDefinitionLists": true
    }
  }
}
```
