### PR TITLE
update error description

### DIFF
--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -470,7 +470,10 @@ internal static class Errors
         /// </summary>
         /// Behavior: ✔️ Message: ❌
         public static Error MonikerRangeUndefined(SourceInfo? source, string? monikerRange)
-            => new(ErrorLevel.Suggestion, "moniker-range-undefined", $"Moniker range {(monikerRange != null ? $"'{monikerRange}' " : string.Empty)}is missing from the 'groups' setting in docfx.yml/docfx.json. It should not be defined in file metadata or moniker zone.", source);
+        {
+            var processedMonikerRange = monikerRange != null ? $"'{monikerRange}' " : string.Empty;
+            return new(ErrorLevel.Suggestion, "moniker-range-undefined", $"Moniker range {processedMonikerRange}is missing from the 'groups' setting in docfx.yml/docfx.json. It should not be defined in file metadata or moniker zone.", source);
+        }
 
         /// <summary>
         /// Moniker-zone defined in article.md has no intersection with file-level monikers.


### PR DESCRIPTION
why?
[AB#545136](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/545136)

seems code analyzer used in docs.Validation cannot understand conditional operator, the error message is imported as
`Moniker range {0}' \" : string.Empty)}is missing from the 'groups' setting in docfx.yml/docfx.json. It should not be defined in file metadata or moniker zone.`

After this change, the message can be correctly imported (tested locally):
`Moniker range {0}is missing from the 'groups' setting in docfx.yml/docfx.json. It should not be defined in file metadata or moniker zone.`