### PR TITLE
report: refine error message for moniker range defined in file metadata or in moniker zone

### DIFF
--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -472,8 +472,8 @@ outputs:
     { "monikers": undefined }
   docs/toc.json:
   .errors.log: |
-    {"message_severity":"suggestion","code":"moniker-range-undefined","message":"Moniker range '> netcore-1.0' is missing from the 'groups' setting in docfx.yml/docfx.json. It should not be defined in file metadata or moniker zone.","file":"docs/a.md","line":2,"column":15}
-    {"message_severity":"suggestion","code":"moniker-range-undefined","message":"Moniker range '> netcore-1.0' is missing from the 'groups' setting in docfx.yml/docfx.json. It should not be defined in file metadata or moniker zone.","file":"docfx.yml","line":4,"column":16}
+    {"message_severity":"suggestion","code":"moniker-range-undefined","message":"Moniker range '> netcore-1.0' should not be defined in file metadata of docfx.yml/docfx.json or in moniker zone of file 'docs/a.md'. Please check the 'groups' setting in docfx.yml/docfx.json.","file":"docs/a.md","line":2,"column":15}
+    {"message_severity":"suggestion","code":"moniker-range-undefined","message":"Moniker range '> netcore-1.0' should not be defined in file metadata of docfx.yml/docfx.json or in moniker zone of file 'docs/b.md'. Please check the 'groups' setting in docfx.yml/docfx.json.","file":"docfx.yml","line":4,"column":16}
 ---
 # With moniker range not defined in config, user should not define it in moniker zone
 inputs:
@@ -496,7 +496,7 @@ outputs:
       "monikers": undefined
     }
   .errors.log: |
-    {"message_severity":"suggestion","code":"moniker-range-undefined","message":"Moniker range is missing from the 'groups' setting in docfx.yml/docfx.json. It should not be defined in file metadata or moniker zone.","file":"docs/v1/a.md","line":2,"column":1}
+    {"message_severity":"suggestion","code":"moniker-range-undefined","message":"Moniker range 'netcore-1.0' should not be defined in file metadata of docfx.yml/docfx.json or in moniker zone of file 'docs/v1/a.md'. Please check the 'groups' setting in docfx.yml/docfx.json.","file":"docs/v1/a.md","line":2,"column":1}
 ---
 # No intersection of config monikers and file monikers
 inputs:

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -469,10 +469,9 @@ internal static class Errors
         /// which used monikerRange in its yaml header or used moniker-zone syntax.
         /// </summary>
         /// Behavior: ✔️ Message: ❌
-        public static Error MonikerRangeUndefined(SourceInfo? source, string? monikerRange)
+        public static Error MonikerRangeUndefined(SourceInfo<string?> source, FilePath file)
         {
-            var processedMonikerRange = monikerRange != null ? $"'{monikerRange}' " : string.Empty;
-            return new(ErrorLevel.Suggestion, "moniker-range-undefined", $"Moniker range {processedMonikerRange}is missing from the 'groups' setting in docfx.yml/docfx.json. It should not be defined in file metadata or moniker zone.", source);
+            return new(ErrorLevel.Suggestion, "moniker-range-undefined", $"Moniker range '{source}' should not be defined in file metadata of docfx.yml/docfx.json or in moniker zone of file '{file}'. Please check the 'groups' setting in docfx.yml/docfx.json.", source);
         }
 
         /// <summary>

--- a/src/docfx/build/moniker/MonikerProvider.cs
+++ b/src/docfx/build/moniker/MonikerProvider.cs
@@ -77,7 +77,7 @@ internal class MonikerProvider
         // User should not define it in moniker zone
         if (configMonikerRange.Value is null && ShouldValidateMoniker(file))
         {
-            errors.Add(Errors.Versioning.MonikerRangeUndefined(rangeString, null));
+            errors.Add(Errors.Versioning.MonikerRangeUndefined(rangeString, file));
             return default;
         }
 
@@ -118,7 +118,7 @@ internal class MonikerProvider
             // user should not define it in file metadata
             if (shouldValidateMoniker && configMonikerRange.Value is null)
             {
-                errors.Add(Errors.Versioning.MonikerRangeUndefined(metadata.MonikerRange.Source, metadata.MonikerRange.Value));
+                errors.Add(Errors.Versioning.MonikerRangeUndefined(metadata.MonikerRange, file));
                 return (errors, default, default);
             }
         }


### PR DESCRIPTION
This PR supersedes #7834 and #7839 . For moniker range defined in file metadata or in moniker zone, we'd better let end users know that they need to 1) include the file in a group; 2) the group must have moniker range defined.

[AB#479182](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/479182)