### PR TITLE
support addOnly validation

### DIFF
--- a/src/docfx/config/ops/OpsMetadataRule.cs
+++ b/src/docfx/config/ops/OpsMetadataRule.cs
@@ -52,7 +52,10 @@ internal class OpsMetadataRule
 
     public bool? CanonicalVersionOnly { get; set; }
 
+    // TODO: Retire PullRequestOnly.
     public bool? PullRequestOnly { get; set; }
+
+    public bool? AddOnly { get; set; }
 
     public string[]? Tags { get; set; }
 }

--- a/src/docfx/config/ops/OpsMetadataRuleConverter.cs
+++ b/src/docfx/config/ops/OpsMetadataRuleConverter.cs
@@ -192,6 +192,7 @@ internal static class OpsMetadataRuleConverter
                             additionalMessage = ruleInfo.AdditionalErrorMessage,
                             canonicalVersionOnly = ruleInfo.CanonicalVersionOnly,
                             pullRequestOnly = ruleInfo.PullRequestOnly,
+                            addOnly = ruleInfo.AddOnly,
                             contentTypes = ruleInfo.ContentTypes,
                             tags = ruleInfo.Tags,
                         });

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Azure.Identity" Version="1.4.1" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.2.0" />
     <PackageReference Include="docs.validation" Version="1.0.1-rc-00108-289f8c6" />
-    <PackageReference Include="DotLiquid" Version="2.2.585" />
+    <PackageReference Include="DotLiquid" Version="2.2.595" />
     <PackageReference Include="Glob" Version="1.1.9" />
     <PackageReference Include="HtmlReaderWriter" Version="1.0.0-preview-0001-gcf3636c5d9" />
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.314" />

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.4.1" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.2.0" />
-    <PackageReference Include="docs.validation" Version="1.0.1-beta-00091-e73ca1c" />
+    <PackageReference Include="docs.validation" Version="1.0.1-rc-00108-289f8c6" />
     <PackageReference Include="DotLiquid" Version="2.2.585" />
     <PackageReference Include="Glob" Version="1.1.9" />
     <PackageReference Include="HtmlReaderWriter" Version="1.0.0-preview-0001-gcf3636c5d9" />

--- a/src/docfx/lib/log/CustomRule.cs
+++ b/src/docfx/lib/log/CustomRule.cs
@@ -20,7 +20,10 @@ internal record CustomRule
 
     public bool CanonicalVersionOnly { get; init; }
 
+    // TODO: Retire PullRequestOnly.
     public bool PullRequestOnly { get; init; }
+
+    public bool AddOnly { get; init; }
 
     [JsonConverter(typeof(OneOrManyConverter))]
     public string[] Exclude { get; init; } = Array.Empty<string>();

--- a/src/docfx/lib/log/Error.cs
+++ b/src/docfx/lib/log/Error.cs
@@ -21,6 +21,8 @@ internal record Error
 
     public bool PullRequestOnly { get; init; }
 
+    public bool AddOnly { get; init; }
+
     public string? DocumentUrl { get; init; }
 
     public object?[] MessageArguments { get; init; } = Array.Empty<object?>();
@@ -60,6 +62,7 @@ internal record Error
             end_column,
             log_item_type = Type,
             pull_request_only = PullRequestOnly ? (bool?)true : null,
+            add_only = AddOnly ? (bool?)true : null,
             property_path = PropertyPath,
             ms_author = AdditionalErrorInfo?.MsAuthor,
             ms_prod = AdditionalErrorInfo?.MsProd,

--- a/src/docfx/validation/CustomRuleProvider.cs
+++ b/src/docfx/validation/CustomRuleProvider.cs
@@ -108,6 +108,7 @@ internal class CustomRuleProvider
             Code = string.IsNullOrEmpty(customRule.Code) ? error.Code : customRule.Code,
             Message = message,
             PullRequestOnly = customRule.PullRequestOnly,
+            AddOnly = customRule.AddOnly,
         };
     }
 
@@ -182,20 +183,20 @@ internal class CustomRuleProvider
                     customRules.Remove(validationRule.Code);
                 }
             }
-            foreach (var validationRule in contentValidationRules.SelectMany(rules => rules.Value.Rules).Where(rule => rule.PullRequestOnly))
+            foreach (var validationRule in contentValidationRules.SelectMany(rules => rules.Value.Rules).Where(rule => rule.PullRequestOnly || rule.AddOnly))
             {
                 if (customRules.TryGetValue(validationRule.Code, out var customRule))
                 {
                     customRules[validationRule.Code] = new List<CustomRule>
                         {
-                            customRule.First() with { PullRequestOnly = validationRule.PullRequestOnly },
+                            customRule.First() with { PullRequestOnly = validationRule.PullRequestOnly, AddOnly = validationRule.AddOnly },
                         };
                 }
                 else
                 {
                     var list = new List<CustomRule>
                         {
-                            new CustomRule { PullRequestOnly = validationRule.PullRequestOnly },
+                            new CustomRule { PullRequestOnly = validationRule.PullRequestOnly, AddOnly = validationRule.AddOnly },
                         };
 
                     customRules.Add(validationRule.Code, list);
@@ -217,6 +218,7 @@ internal class CustomRuleProvider
                     PropertyPath = validationRule.PropertyPath,
                     CanonicalVersionOnly = validationRule.CanonicalVersionOnly,
                     PullRequestOnly = validationRule.PullRequestOnly,
+                    AddOnly = validationRule.AddOnly,
                     ContentTypes = validationRule.ContentTypes,
                     Disabled = validationRule.Disabled,
                 };

--- a/test/docfx.Test/lib/JsonSchemaTest.cs
+++ b/test/docfx.Test/lib/JsonSchemaTest.cs
@@ -386,9 +386,14 @@ public class JsonSchemaTest
         "{'message_severity':'warning','code':'key2-missing','message':'Missing attribute: 'key2'. If you specify 'key1', you must also specify 'key2'.','line':1,'column':1}")]
     [InlineData("{'required': ['author'], 'rules': {'author': {'missing-attribute': {'severity': 'suggestion', 'code': 'author-missing', 'additionalMessage': 'Add a valid GitHub ID.', 'pullRequestOnly': true}}}}", "{'b': 1}",
         "{'message_severity':'suggestion','code':'author-missing','message':'Missing required attribute: 'author'. Add a valid GitHub ID.','line':1,'column':1}")]
-
+    [InlineData("{'required': ['author'], 'rules': {'author': {'missing-attribute': {'severity': 'suggestion', 'code': 'author-missing', 'additionalMessage': 'Add a valid GitHub ID.', 'addOnly': true}}}}", "{'b': 1}",
+        "{'message_severity':'suggestion','code':'author-missing','message':'Missing required attribute: 'author'. Add a valid GitHub ID.','line':1,'column':1}")]
     [InlineData(
         "{'properties': {'key':{'required': ['author'],'properties': {'author': {'type': ['string']}}}},'rules': {'key.author': {'missing-attribute': {'severity': 'suggestion', 'code': 'author-missing', 'additionalMessage': 'Add a valid GitHub ID.', 'pullRequestOnly': true}}}}",
+        "{'key': {'b': 1}}",
+        "{'message_severity':'suggestion','code':'author-missing','message':'Missing required attribute: 'key.author'. Add a valid GitHub ID.','line':1,'column':9}")]
+    [InlineData(
+        "{'properties': {'key':{'required': ['author'],'properties': {'author': {'type': ['string']}}}},'rules': {'key.author': {'missing-attribute': {'severity': 'suggestion', 'code': 'author-missing', 'additionalMessage': 'Add a valid GitHub ID.', 'addOnly': true}}}}",
         "{'key': {'b': 1}}",
         "{'message_severity':'suggestion','code':'author-missing','message':'Missing required attribute: 'key.author'. Add a valid GitHub ID.','line':1,'column':9}")]
 


### PR DESCRIPTION
[AB#542072](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/542072)

Basically add AddOnly after PullRequestOnly. AddOnly rules will be applied to all the content files and the filter steps will be taken in OpenPublishing.Build.

TODO: retire PullRequestOnly when ready (decided by Megan).

Test:
Build a repo locally. Assign a testing ruleset contains AddOnly rules to this repo, and partial .error.log is attached below:
![image](https://user-images.githubusercontent.com/74176112/150317269-fc322370-8f89-47b1-b0bf-9d7a108b6e5a.png)

