### PR TITLE
TOC -> toc

### DIFF
--- a/docs/specs/legacy.yml
+++ b/docs/specs/legacy.yml
@@ -21,7 +21,7 @@ repos:
         ---
         [d](d.png)
       d.png:
-      TOC.md: |
+      toc.md: |
         # [c](c.md)
       schema.json: |
         {
@@ -69,7 +69,7 @@ outputs:
         <meta name=\"depot_name\" content=\".\" />
         <meta name=\"document_id\" content=\"d4c1d336-d9a7-3b5c-e27f-b8c630a6d5c2\" />
         <meta name=\"document_version_independent_id\" content=\"d4c1d336-d9a7-3b5c-e27f-b8c630a6d5c2\" />
-        <meta name=\"gitcommit\" content=\"https://github.com/legacy/test/blob/42eb7605fdef9f5e7674a1cae803f86a39ee628a/c.md\" />
+        <meta name=\"gitcommit\" content=\"https://github.com/legacy/test/blob/5bafb3dc8f9d74504f430bdb51fe7667d4e9eeb9/c.md\" />
         <meta name=\"locale\" content=\"en-us\" />
         <meta name=\"ms.author\" content=\"yufeih\" />
         <meta name=\"original_content_git_url\" content=\"https://github.com/legacy/test/blob/main/c.md\" />
@@ -116,7 +116,7 @@ repos:
         # Title
         [d](d.png)
       d.png:
-      TOC.md: |
+      toc.md: |
         # [c](c.md)
       index.yml: |
         ### YamlMime:YamlDocument
@@ -162,7 +162,7 @@ outputs:
         "content_git_url": "https://github.com/a/rawmetadata/blob/main/c.md",
         "original_content_git_url": "https://github.com/a/rawmetadata/blob/main/c.md",
         "original_content_git_url_template": "{repo}/blob/{branch}/c.md",
-        "gitcommit": "https://github.com/a/rawmetadata/blob/059da4c838d11026288349e031208d1e1c9aeeb5/c.md",
+        "gitcommit": "https://github.com/a/rawmetadata/blob/ca95ae33a6924b1a6d35e2099a0e994f115ecd24/c.md",
         "site_name": "Docs",
         "depot_name": ".",
         "_path": "c.json",
@@ -357,9 +357,9 @@ inputs:
       docs/v1/: .
       docs/v2/: .
     monikerDefinition: monikerDefinition.json
-  docs/v1/TOC.md:
+  docs/v1/toc.md:
   docs/v1/f1/a.md:
-  docs/v2/TOC.md:
+  docs/v2/toc.md:
   docs/v2/f1/a.md:
   monikerDefinition.json: |
     {

--- a/docs/specs/localization.yml
+++ b/docs/specs/localization.yml
@@ -235,9 +235,9 @@ locale: zh-cn
 repos:
   https://docs.com/toc1#master:
     - files:
-        docs/TOC.md: |
+        docs/toc.md: |
           # [reference a](a.md)
-        docs/b/TOC.md: |
+        docs/b/toc.md: |
           # [reference b](../b.md)
         docfx.yml:
   https://docs.com/toc1.zh-cn#master:
@@ -245,7 +245,7 @@ repos:
         docfx.yml:
         docs/a.md:
         docs/b.md:
-        docs/TOC.md: |
+        docs/toc.md: |
           # [reference a](a.md)
           # [reference b](b.md)
 outputs:
@@ -262,13 +262,13 @@ repos:
   https://docs.com/toc2#master:
     - files:
         docs/a/a.md:
-        docs/b/TOC.md: |
+        docs/b/toc.md: |
           # [reference b](b.md)
         docfx.yml:
   https://docs.com/toc2.zh-cn#master:
     - files:
         docfx.yml:
-        docs/a/TOC.md: |
+        docs/a/toc.md: |
           # [reference a](a.md)
         docs/b/b.md:
 outputs:
@@ -397,13 +397,13 @@ locale: zh-cn
 repos:
   https://github.com/conflictedtoc/a:
     - files:
-        docs/a/TOC.md: |
+        docs/a/toc.md: |
           # [md reference a](a.md)
         docfx.yml:
   https://github.com/conflictedtoc/a.zh-cn:
     - files:
         docfx.yml:
-        docs/a/TOC.yml: |
+        docs/a/toc.yml: |
           - href: a.md
             name: yml reference a
         docs/a/a.md:
@@ -475,14 +475,14 @@ repos:
         docfx.yml:
     - files:
         docfx.yml:
-        docs/a/TOC.yml: |
+        docs/a/toc.yml: |
           - href: a.md
             name: reference markdown a
   https://github.com/deletedtoc/a.zh-cn:
     - files:
         docfx.yml:
-        docs/b/TOC.yml: |
-          - href: ../a/TOC.yml
+        docs/b/toc.yml: |
+          - href: ../a/toc.yml
             name: reference toc a
         docs/a/a.md:
 outputs:
@@ -495,13 +495,13 @@ repos:
   https://github.com/onlyloc/a:
     - files:
         docfx.yml:
-        docs/b/TOC.yml: |
-          - href: ../a/TOC.yml
+        docs/b/toc.yml: |
+          - href: ../a/toc.yml
             name: reference toc a
         docs/a/a.md:
     - files:
         docfx.yml:
-        docs/a/TOC.yml: |
+        docs/a/toc.yml: |
           - href: a.md
             name: reference markdown a
 outputs:
@@ -536,16 +536,16 @@ repos:
   https://github.com/inclusiontoc/a:
     - files:
         docfx.yml:
-        docs/b/TOC.yml: |
-          - href: ../a/TOC.yml
+        docs/b/toc.yml: |
+          - href: ../a/toc.yml
             name: reference toc a
-        docs/a/TOC.yml: |
+        docs/a/toc.yml: |
           - href: b.md
             name: reference markdown b
   https://github.com/inclusiontoc/a.zh-cn:
     - files:
         docfx.yml:
-        docs/a/TOC.yml: |
+        docs/a/toc.yml: |
           - href: a.md
             name: reference markdown a
         docs/a/a.md:
@@ -750,7 +750,7 @@ outputs:
   docs/a.json: |
     { "conceptual":"<p>test</p>"}
 ---
-# should fallback to deleted TOC.md not TOC.json
+# should fallback to deleted toc.md not toc.json
 locale: zh-cn
 repos:
   https://github.com/deletedtoc-1/a:
@@ -760,42 +760,42 @@ repos:
         docs/c.md:
     - files:
         docfx.yml:
-        docs/dir/TOC.json: |
+        docs/dir/toc.json: |
           {"items":[{"name":"reference c", "href":"../c.md"}]}
-        docs/dir/TOC.md: |
+        docs/dir/toc.md: |
           # [reference b.md](../b.md)
         docs/b.md:
         docs/c.md:
   https://github.com/deletedtoc-1/a.zh-cn:
     - files:
         docfx.yml:
-        docs/TOC.yml: |
+        docs/toc.yml: |
           - name: name
             href: dir/
 outputs:
   docs/toc.json: |
     {"items":[{"href":"b"}]}
 ---
-# should not fallback to deleted TOC.md if TOC.yml exists
+# should not fallback to deleted toc.md if toc.yml exists
 locale: zh-cn
 repos:
   https://github.com/deletedtoc-2/a:
     - files:
         docfx.yml:
-        docs/dir/TOC.yml: |
+        docs/dir/toc.yml: |
           - name: toc existed
             href: ../a.md
         docs/a.md:
         docs/b.md:
     - files:
         docfx.yml:
-        docs/dir/TOC.md: |
+        docs/dir/toc.md: |
           # [reference b.md](../b.md)
         docs/b.md:
   https://github.com/deletedtoc-2/a.zh-cn:
     - files:
         docfx.yml:
-        docs/TOC.yml: |
+        docs/toc.yml: |
           - name: name
             href: dir/
 outputs:
@@ -870,7 +870,7 @@ repos:
   https://github.com/error-from-fallback#live:
     - files:
         docfx.yml:
-        docs/TOC.md: |
+        docs/toc.md: |
           # a 
           ### b
   https://github.com/error-from-fallback.zh-cn#live:
@@ -888,10 +888,10 @@ repos:
         .openpublishing.publish.config.json: |
           {
             "docsets_to_publish": [{  "build_source_folder": "a"}],
-            "JoinTOCPlugin": [{"ReferenceTOC": "a/api/bot/TOC.yml", "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml"}]
+            "JoinTOCPlugin": [{"ReferenceTOC": "a/api/bot/toc.yml", "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml"}]
           }
         a/docfx.yml:
-        a/api/bot/TOC.yml: |
+        a/api/bot/toc.yml: |
           items:
           - name: MS.ServicePage2.xxx
             items:
@@ -904,9 +904,9 @@ repos:
         .openpublishing.publish.config.json: |
           {
             "docsets_to_publish": [{  "build_source_folder": "a"}],
-            "JoinTOCPlugin": [{"ReferenceTOC": "a/api/bot/TOC.yml", "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml"}]
+            "JoinTOCPlugin": [{"ReferenceTOC": "a/api/bot/toc.yml", "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml"}]
           }
         a/docfx.yml:
-        a/TOC.yml:
+        a/toc.yml:
 outputs:
   a/toc.json:

--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -295,13 +295,13 @@ outputs:
 # Errors from one file does not affect another file
 inputs:
   docfx.yml:
-  docs/TOC.md: |
+  docs/toc.md: |
     #[bad](b.md)
   docs/b.md:
 outputs:
   docs/b.json:
   .errors.log: |
-    {"message_severity":"error","code":"invalid-toc-syntax","message":"The toc syntax is invalid, *","file":"docs/TOC.md","line":1,"column":1}
+    {"message_severity":"error","code":"invalid-toc-syntax","message":"The toc syntax is invalid, *","file":"docs/toc.md","line":1,"column":1}
 ---
 # do not allow custom js, styles and css
 inputs:

--- a/docs/specs/metadata.yml
+++ b/docs/specs/metadata.yml
@@ -139,12 +139,12 @@ outputs:
 # yaml&json toc metadata
 inputs:
   docfx.yml:
-  docs/json/TOC.json: |
+  docs/json/toc.json: |
     {
       "metadata": {"a":"b"},
       "items": [{ "name": "title" }]
     }
-  docs/yaml/TOC.yml: |
+  docs/yaml/toc.yml: |
     metadata:
       a: b
     items:
@@ -164,9 +164,9 @@ outputs:
 # yaml&json toc leaf metadata
 inputs:
   docfx.yml:
-  docs/json/TOC.json: |
+  docs/json/toc.json: |
     [{ "name": "title", "a": "b" }]
-  docs/yaml/TOC.yml: |
+  docs/yaml/toc.yml: |
     - name: title
       a: b
 outputs:
@@ -183,14 +183,14 @@ outputs:
 # child's root metadata will be dropped
 inputs:
   docfx.yml:
-  docs/json/TOC.json: |
+  docs/json/toc.json: |
     {  
       "metadata": {"a": "b"},
       "items":[{"name":"title", "c": "d"}]
     }
-  docs/yaml/TOC.yml: |
+  docs/yaml/toc.yml: |
     - name: toc reference
-      tocHref: ../json/TOC.json
+      tocHref: ../json/toc.json
 outputs:
   docs/yaml/toc.json: |
     {  
@@ -204,12 +204,12 @@ inputs:
       a: b
     fileMetadata:
       area:
-        docs/json/TOC.json: 2
-  docs/json/TOC.json: '{}'
-  docs/yaml/TOC.yml: |
+        docs/json/toc.json: 2
+  docs/json/toc.json: '{}'
+  docs/yaml/toc.yml: |
     metadata:
       c: d
-  docs/md/TOC.md:
+  docs/md/toc.md:
 outputs:
   docs/yaml/toc.json: |
     { "metadata": { "a": "b", "c": "d"} }
@@ -286,9 +286,9 @@ outputs:
 inputs:
   docfx.yml: |
     globalMetadata:
-      breadcrumb_path: ~/breadcrumbs/TOC.json
+      breadcrumb_path: ~/breadcrumbs/toc.json
   a.md:
-  breadcrumbs/TOC.json: '{}'
+  breadcrumbs/toc.json: '{}'
 outputs:
   a.json: |
     { "breadcrumb_path": "breadcrumbs/toc.json" }
@@ -298,9 +298,9 @@ outputs:
 inputs:
   docfx.yml: |
     globalMetadata:
-      breadcrumb_path: breadcrumbs/TOC.json
+      breadcrumb_path: breadcrumbs/toc.json
   a-folder/a.md:
-  breadcrumbs/TOC.json: '{}'
+  breadcrumbs/toc.json: '{}'
 outputs:
   a-folder/a.json: |
     { "breadcrumb_path": "../breadcrumbs/toc.json" }

--- a/docs/specs/moniker.yml
+++ b/docs/specs/moniker.yml
@@ -449,7 +449,7 @@ inputs:
     ---
     Moniker: netcore-1.1
   docs/b.md:
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - name: A
       href: a.md
   monikerDefinition.json: |
@@ -888,7 +888,7 @@ outputs:
 # Build toc with monikers info
 inputs:
   docfx.yml: |
-    exclude: 'docs/v1/folder/TOC.yml'
+    exclude: 'docs/v1/folder/toc.yml'
     monikerRange:
       'docs/v1/**': '>= netcore-1.0'
     routes:
@@ -906,7 +906,7 @@ inputs:
     monikerRange: netcore-1.2 || netcore-1.1
     ---
     Moniker: netcore-1.1, netcore-1.2
-  docs/v1/TOC.md: |
+  docs/v1/toc.md: |
     ---
     monikerRange: '>= netcore-1.1'
     ---
@@ -999,7 +999,7 @@ inputs:
     Moniker: netcore-1.0
   docs/v2/a.md: |
     Moniker: netcore-2.0
-  docs/v1-v2/TOC.md: |
+  docs/v1-v2/toc.md: |
     # [A-1](../v1/a.md)
     # [A-2](../v2/a.md)
 outputs:
@@ -1017,7 +1017,7 @@ outputs:
 usePhysicalInput: true
 inputs:
   docfx.yml: |
-    exclude: 'docs/v1/folder/TOC.yml'
+    exclude: 'docs/v1/folder/toc.yml'
     monikerRange:
       'docs/v1/**': '>= netcore-1.0 <= netcore-1.3'
     routes:
@@ -1043,28 +1043,28 @@ inputs:
     monikerRange: netcore-1.3
     ---
     Moniker: netcore-1.3
-  docs/v1/TOC.yml: |
+  docs/v1/toc.yml: |
     metadata:
       monikerRange: '>= netcore-1.1'
     items:
       - name: Toc ref
-        href: folder/TOC.yml
+        href: folder/toc.yml
         items:
           - name: D
             href: d.md
       - name: Toc ref with topicHref
-        href: folder/TOC.yml
+        href: folder/toc.yml
         topicHref: e.md
         items:
           - name: D
             href: d.md
       - name: Toc ref with external link topicHref
-        href: folder/TOC.yml
+        href: folder/toc.yml
         topicHref: https://hostname/test
         items:
           - name: D
             href: d.md
-  docs/v1/folder/TOC.yml: |
+  docs/v1/folder/toc.yml: |
     metadata:
       monikerRange: '<= netcore-1.1'
     items:
@@ -1113,7 +1113,7 @@ outputs:
 usePhysicalInput: true
 inputs:
   docfx.yml: |
-    exclude: 'docs/v1/folder/TOC.yml'
+    exclude: 'docs/v1/folder/toc.yml'
     monikerRange:
       'docs/v1/**': '>= netcore-1.0 <= netcore-1.3'
     routes:
@@ -1139,7 +1139,7 @@ inputs:
     monikerRange: netcore-1.3
     ---
     Moniker: netcore-1.3
-  docs/v1/TOC.yml: |
+  docs/v1/toc.yml: |
     metadata:
       monikerRange: '>= netcore-1.1'
     items:
@@ -1160,7 +1160,7 @@ inputs:
         items:
           - name: D
             href: d.md
-  docs/v1/folder/TOC.yml: |
+  docs/v1/folder/toc.yml: |
     metadata:
       monikerRange: '<= netcore-1.1'
     items:
@@ -1214,9 +1214,9 @@ inputs:
       docs/v1/: docs/
       docs/v2/: docs/
     monikerDefinition: monikerDefinition.json
-  docs/v1/TOC.md: |
+  docs/v1/toc.md: |
     # Node
-  docs/v2/TOC.md: |
+  docs/v2/toc.md: |
     # Node
   monikerDefinition.json: |
     {
@@ -1239,7 +1239,7 @@ outputs:
       ]
     }
   .errors.log: |
-    {"message_severity":"warning","code":"publish-url-conflict","message":"Two or more files of the same version('netcore-2.0') publish to the same url '/docs/toc.json': 'docs/v1/TOC.md<'netcore-1.0', 'netcore-2.0'>', 'docs/v2/TOC.md<'netcore-2.0'>'."}
+    {"message_severity":"warning","code":"publish-url-conflict","message":"Two or more files of the same version('netcore-2.0') publish to the same url '/docs/toc.json': 'docs/v1/toc.md<'netcore-1.0', 'netcore-2.0'>', 'docs/v2/toc.md<'netcore-2.0'>'."}
 ---
 # No intersection of config monikers and file monikers of TOC file
 inputs:
@@ -1249,7 +1249,7 @@ inputs:
     routes:
       docs/v1/: docs/
     monikerDefinition: monikerDefinition.json
-  docs/v1/TOC.md: |
+  docs/v1/toc.md: |
     ---
     monikerRange: netcore-1.0
     ---
@@ -1263,7 +1263,7 @@ inputs:
     }
 outputs:
   .errors.log: |
-    {"message_severity":"error","code":"moniker-range-out-of-scope","message":"No moniker intersection between docfx.yml/docfx.json and file metadata. Config moniker range '>= netcore-2.0' is 'netcore-2.0', while file monikers is 'netcore-1.0'.","file":"docs/v1/TOC.md","line":2,"column":15}
+    {"message_severity":"error","code":"moniker-range-out-of-scope","message":"No moniker intersection between docfx.yml/docfx.json and file metadata. Config moniker range '>= netcore-2.0' is 'netcore-2.0', while file monikers is 'netcore-1.0'.","file":"docs/v1/toc.md","line":2,"column":15}
 ---
 # Build resource file with moniker
 inputs:
@@ -1475,12 +1475,12 @@ inputs:
     monikerDefinition: monikerDefinition.json
   docs/v1/a.md: |
     ![image](b.png)
-  docs/v1/TOC.md:
+  docs/v1/toc.md:
     # [A](a.md)
   docs/v1/b.png:
   docs/a.md: |
     ![image](b.png)
-  docs/TOC.md:
+  docs/toc.md:
     # [A](a.md)
   docs/b.png:
   monikerDefinition.json: |
@@ -1504,7 +1504,7 @@ outputs:
   .errors.log: |
     {"message_severity":"warning","code":"publish-url-conflict","message":"Two or more files publish to the same url '/docs/b.png': 'docs/b.png', 'docs/v1/b.png'."}
     {"message_severity":"warning","code":"publish-url-conflict","message":"Two or more files publish to the same url '/docs/a': 'docs/a.md', 'docs/v1/a.md'."}
-    {"message_severity":"warning","code":"publish-url-conflict","message":"Two or more files publish to the same url '/docs/toc.json': 'docs/TOC.md', 'docs/v1/TOC.md'."}
+    {"message_severity":"warning","code":"publish-url-conflict","message":"Two or more files publish to the same url '/docs/toc.json': 'docs/toc.md', 'docs/v1/toc.md'."}
 ---
 # monikers output should be stable
 inputs:
@@ -1518,7 +1518,7 @@ inputs:
       docs/v1/: .
     monikerDefinition: monikerDefinition.json
   docs/v1/a.md: 
-  docs/v1/TOC.md: |
+  docs/v1/toc.md: |
     # [A](a.md)
   monikerDefinition.json: |
     {
@@ -1604,7 +1604,7 @@ inputs:
     routes:
       docs/v1/: docs/
     monikerDefinition: monikerDefinition.json
-  docs/v1/TOC.md: |
+  docs/v1/toc.md: |
     ---
     monikers: netcore-1.0
     ---
@@ -1618,7 +1618,7 @@ inputs:
     }
 outputs:
   .errors.log: |
-    {"message_severity":"error","code":"moniker-range-out-of-scope","message":"No moniker intersection between docfx.yml/docfx.json and file metadata. Config moniker range '>= netcore-2.0' is 'netcore-2.0', while file monikers is 'netcore-1.0'.","file":"docs/v1/TOC.md","line":2,"column":11}
+    {"message_severity":"error","code":"moniker-range-out-of-scope","message":"No moniker intersection between docfx.yml/docfx.json and file metadata. Config moniker range '>= netcore-2.0' is 'netcore-2.0', while file monikers is 'netcore-1.0'.","file":"docs/v1/toc.md","line":2,"column":11}
 ---
 # Warn on moniker config duplication
 inputs:
@@ -1628,7 +1628,7 @@ inputs:
     routes:
       docs/v1/: docs/
     monikerDefinition: monikerDefinition.json
-  docs/v1/TOC.md: |
+  docs/v1/toc.md: |
     ---
     monikers: NETCore-1.0
     monikerRange: netcore-1.0
@@ -1643,8 +1643,8 @@ inputs:
     }
 outputs:
   .errors.log: |
-    {"message_severity":"error","code":"moniker-range-out-of-scope","message":"No moniker intersection between docfx.yml/docfx.json and file metadata. Config moniker range '>= netcore-2.0' is 'netcore-2.0', while file monikers is 'netcore-1.0'.","file":"docs/v1/TOC.md","line":3,"column":15}
-    {"message_severity":"warning","code":"duplicate-moniker-config","message":"Both 'monikers' and 'monikerRange' are defined, 'monikers' is ignored.","file":"docs/v1/TOC.md","line":2,"column":11}
+    {"message_severity":"error","code":"moniker-range-out-of-scope","message":"No moniker intersection between docfx.yml/docfx.json and file metadata. Config moniker range '>= netcore-2.0' is 'netcore-2.0', while file monikers is 'netcore-1.0'.","file":"docs/v1/toc.md","line":3,"column":15}
+    {"message_severity":"warning","code":"duplicate-moniker-config","message":"Both 'monikers' and 'monikerRange' are defined, 'monikers' is ignored.","file":"docs/v1/toc.md","line":2,"column":11}
 ---
 # Throw on monikers value invalid
 inputs:
@@ -1654,7 +1654,7 @@ inputs:
     routes:
       docs/v1/: docs/
     monikerDefinition: monikerDefinition.json
-  docs/v1/TOC.md: |
+  docs/v1/toc.md: |
     ---
     monikers: netcore-1.1
     ---
@@ -1668,8 +1668,8 @@ inputs:
     }
 outputs:
   .errors.log: |
-    {"message_severity":"error","code":"moniker-range-invalid","message":"Invalid moniker range: Moniker 'netcore-1.1' is not defined.","file":"docs/v1/TOC.md","line":2,"column":11}
-    {"message_severity":"error","code":"moniker-range-out-of-scope","message":"No moniker intersection between docfx.yml/docfx.json and file metadata. Config moniker range '>= netcore-2.0' is 'netcore-2.0', while file monikers is ''.","file":"docs/v1/TOC.md","line":2,"column":11}
+    {"message_severity":"error","code":"moniker-range-invalid","message":"Invalid moniker range: Moniker 'netcore-1.1' is not defined.","file":"docs/v1/toc.md","line":2,"column":11}
+    {"message_severity":"error","code":"moniker-range-out-of-scope","message":"No moniker intersection between docfx.yml/docfx.json and file metadata. Config moniker range '>= netcore-2.0' is 'netcore-2.0', while file monikers is ''.","file":"docs/v1/toc.md","line":2,"column":11}
 ---
 # Should take monikerRange as final monikers even it outputs empty
 inputs:
@@ -1679,7 +1679,7 @@ inputs:
     routes:
       docs/v1/: docs/
     monikerDefinition: monikerDefinition.json
-  docs/v1/TOC.md: |
+  docs/v1/toc.md: |
     ---
     monikers: netcore-1.0
     monikerRange: '>netcore-1.0 <netcore-1.0'
@@ -1694,8 +1694,8 @@ inputs:
     }
 outputs:
   .errors.log: |
-    {"message_severity":"warning","code":"duplicate-moniker-config","message":"Both 'monikers' and 'monikerRange' are defined, 'monikers' is ignored.","file":"docs/v1/TOC.md","line":2,"column":11}
-    {"message_severity":"error","code":"moniker-range-out-of-scope","message":"No moniker intersection between docfx.yml/docfx.json and file metadata. Config moniker range '>= netcore-1.0' is 'netcore-1.0', 'netcore-2.0', while file monikers is ''.","file":"docs/v1/TOC.md","line":3,"column":15}
+    {"message_severity":"warning","code":"duplicate-moniker-config","message":"Both 'monikers' and 'monikerRange' are defined, 'monikers' is ignored.","file":"docs/v1/toc.md","line":2,"column":11}
+    {"message_severity":"error","code":"moniker-range-out-of-scope","message":"No moniker intersection between docfx.yml/docfx.json and file metadata. Config moniker range '>= netcore-1.0' is 'netcore-1.0', 'netcore-2.0', while file monikers is ''.","file":"docs/v1/toc.md","line":3,"column":15}
 ---
 # Should take monikers as final monikers if user inputs empty string for monikerRange
 # and no duplicate-moniker-config warning
@@ -1731,7 +1731,7 @@ inputs:
     routes:
       docs/v1/: docs/
     monikerDefinition: monikerDefinition.json
-  docs/v1/TOC.md: |
+  docs/v1/toc.md: |
     ---
     monikers:
       -
@@ -1749,7 +1749,7 @@ outputs:
   9b52f68bce2b10c7aa018b696f8ca916/docs/toc.json: |
     {"metadata":{}}
   .errors.log: |
-    {"message_severity":"warning","code":"null-array-value","message":"'monikers' contains null value, the null value has been removed.","file":"docs/v1/TOC.md","line":3,"column":4}
+    {"message_severity":"warning","code":"null-array-value","message":"'monikers' contains null value, the null value has been removed.","file":"docs/v1/toc.md","line":3,"column":4}
     {"message_severity":"warning","code":"duplicate-moniker-config","message":"Both 'monikers' and 'monikerRange' are defined, 'monikers' is ignored."}
 ---
 # Skip moniker validation for .yml files

--- a/docs/specs/ops.yml
+++ b/docs/specs/ops.yml
@@ -219,26 +219,26 @@ repos:
           }],
           "JoinTOCPlugin": [
             {
-              "ReferenceTOC": "a/api/TOC.yml",
+              "ReferenceTOC": "a/api/toc.yml",
               "ReferenceTOCUrl": "/dotnet/api/azure_ref_toc/toc.json",
               "ConceptualTOCUrl": "/dotnet/azure/sdk/toc.json",
-              "ConceptualTOC": "a/docs-ref-conceptual/TOC.yml"
+              "ConceptualTOC": "a/docs-ref-conceptual/toc.yml"
             },
             {
-              "ReferenceTOC": "a/api-1/TOC.yml",
+              "ReferenceTOC": "a/api-1/toc.yml",
               "ConceptualTOCUrl": "/dotnet-1/azure/sdk/toc.json",
             },
             {
               "ReferenceTOCUrl": "/dotnet-2/api/azure_ref_toc/toc.json",
-              "ConceptualTOC": "a/docs-ref-conceptual-2/TOC.yml"
+              "ConceptualTOC": "a/docs-ref-conceptual-2/toc.yml"
             }
           ],
         }
       a/docfx.yml:
-      a/api/TOC.yml:
-      a/docs-ref-conceptual/TOC.yml:
-      a/api-1/TOC.yml:
-      a/docs-ref-conceptual-2/TOC.yml:
+      a/api/toc.yml:
+      a/docs-ref-conceptual/toc.yml:
+      a/api-1/toc.yml:
+      a/docs-ref-conceptual-2/toc.yml:
 outputs:
   a/api/toc.json: |
     { "metadata": { "universal_conceptual_toc": "/dotnet/azure/sdk/toc.json", "universal_ref_toc": undefined } }

--- a/docs/specs/output.yml
+++ b/docs/specs/output.yml
@@ -3,7 +3,7 @@
 inputs:
   docfx.yml:
   docs/a.md:
-  docs/TOC.md:
+  docs/toc.md:
   docs/folder/b~$.md:
   docs/index.md:
 outputs:
@@ -17,7 +17,7 @@ outputs:
         { "url": "/docs/a", "path": "docs/a.json", "source_path": "docs/a.md" },
         { "url": "/docs/folder/b~$", "path": "docs/folder/b~$.json", "source_path": "docs/folder/b~$.md" },
         { "url": "/docs/", "path": "docs/index.json", "source_path": "docs/index.md" },
-        { "url": "/docs/toc.json", "path": "docs/toc.json", "source_path": "docs/TOC.md" }
+        { "url": "/docs/toc.json", "path": "docs/toc.json", "source_path": "docs/toc.md" }
       ]
     }
 ---
@@ -98,7 +98,7 @@ outputs:
 inputs:
   docfx.yml:
   docs/a.md:
-  docs/TOC.md: |
+  docs/toc.md: |
     # [file reference](a.md)
 outputs:
   docs/a.json:
@@ -106,7 +106,7 @@ outputs:
   .dependencymap.json: |
     {  
        "dependencies":{  
-          "docs/TOC.md":[  
+          "docs/toc.md":[  
              {  
                 "source":"docs/a.md",
                 "type":"file"
@@ -182,9 +182,9 @@ outputs:
 # Manifest contains nested TOC dependencies
 inputs:
   docfx.yml:
-  docs/TOC.md: |
-    # [a](a/TOC.md)
-  docs/a/TOC.md: |
+  docs/toc.md: |
+    # [a](a/toc.md)
+  docs/a/toc.md: |
     # [b](b.md)
   docs/a/b.md:
 outputs:
@@ -193,8 +193,8 @@ outputs:
   .dependencymap.json: |
     {
        "dependencies": {
-          "docs/TOC.md": [{ "source":"docs/a/TOC.md", "type": "include" }],
-          "docs/a/TOC.md": [{ "source":"docs/a/b.md", "type": "file" }]
+          "docs/toc.md": [{ "source":"docs/a/toc.md", "type": "include" }],
+          "docs/a/toc.md": [{ "source":"docs/a/b.md", "type": "file" }]
        }
     }
 ---
@@ -505,12 +505,12 @@ repos:
         some text
       docs/v2/d.md: |
         # title 1
-      docs/a/TOC.yml: |
+      docs/a/toc.yml: |
         - name: Toc Reference
           href: ../v1/b.md
         - name: Non-existed Toc reference
           href: b.md
-      docs/v1/TOC.yml: |
+      docs/v1/toc.yml: |
         - name: Toc Reference
           href: b.md
       monikerDefinition.json: |
@@ -534,8 +534,8 @@ outputs:
   .links.json: |
     {
       "links":[
-        {"source_url":"/docs/a/toc.json","target_url":"/docs/b","source_git_url":"https://github.com/output-links/markdown/blob/main/docs/a/TOC.yml","source_line":2},
-        {"source_url":"/docs/a/toc.json","target_url":"b.md","source_git_url":"https://github.com/output-links/markdown/blob/main/docs/a/TOC.yml","source_line":4},
+        {"source_url":"/docs/a/toc.json","target_url":"/docs/b","source_git_url":"https://github.com/output-links/markdown/blob/main/docs/a/toc.yml","source_line":2},
+        {"source_url":"/docs/a/toc.json","target_url":"b.md","source_git_url":"https://github.com/output-links/markdown/blob/main/docs/a/toc.yml","source_line":4},
         {"source_url":"/docs/b","source_moniker_group":"17b9fe681514513cbf7d5c90e32f107a","target_url":"/docs/a","source_git_url":"https://github.com/output-links/markdown/blob/main/docs/v1/b.md","source_line":1},
         {"source_url":"/docs/b","source_moniker_group":"ed8f7746ec932ae7c9f595c1f2c97d5a","target_url":"/docs/a","source_git_url":"https://github.com/output-links/markdown/blob/main/docs/v2/b.md","source_line":1},
         {"source_url":"/docs/b","source_moniker_group":"17b9fe681514513cbf7d5c90e32f107a","target_url":"/docs/c","source_git_url":"https://github.com/output-links/markdown/blob/main/docs/v1/b.md","source_line":2},
@@ -545,12 +545,12 @@ outputs:
         {"source_url":"/docs/b","source_moniker_group":"17b9fe681514513cbf7d5c90e32f107a","target_url":"/docs/e.png","source_git_url":"https://github.com/output-links/markdown/blob/main/docs/v1/b.md","source_line":8},
         {"source_url":"/docs/b","source_moniker_group":"17b9fe681514513cbf7d5c90e32f107a","target_url":"c.md","source_git_url":"https://github.com/output-links/markdown/blob/main/docs/v1/b.md","source_line":3},
         {"source_url":"/docs/b","source_moniker_group":"17b9fe681514513cbf7d5c90e32f107a","target_url":"https://autolink","source_git_url":"https://github.com/output-links/markdown/blob/main/docs/v1/b.md","source_line": 9},
-        {"source_url":"/docs/toc.json","source_moniker_group":"17b9fe681514513cbf7d5c90e32f107a","target_url":"/docs/b","source_git_url":"https://github.com/output-links/markdown/blob/main/docs/v1/TOC.yml","source_line":2}
+        {"source_url":"/docs/toc.json","source_moniker_group":"17b9fe681514513cbf7d5c90e32f107a","target_url":"/docs/b","source_git_url":"https://github.com/output-links/markdown/blob/main/docs/v1/toc.yml","source_line":2}
       ]
     }
   .errors.log: |
     {"message_severity":"warning","code":"file-not-found","message":"Invalid file link: 'c.md'.","file":"docs/v1/b.md","line":3,"column":9}
-    {"message_severity":"warning","code":"file-not-found","message":"Invalid file link: 'b.md'.","file":"docs/a/TOC.yml","line":4,"column":9}
+    {"message_severity":"warning","code":"file-not-found","message":"Invalid file link: 'b.md'.","file":"docs/a/toc.yml","line":4,"column":9}
 ---
 # source_url is the includer for links and xrefs in markdown token
 repos:
@@ -587,16 +587,16 @@ repos:
         warningsAsErrors: true
         globalMetadata:
           "breadcrumb_path": "/docs/breadcrumbs/toc.json"
-      docs/breadcrumbs/TOC.yml: |
+      docs/breadcrumbs/toc.yml: |
         - name: Docs
           tocHref: /
           topicHref: /
-      docs/TOC.yml: |
+      docs/toc.yml: |
         - name: TOC Ref
-          tocHref: a/TOC.yml
+          tocHref: a/toc.yml
         - name: link
           href: c.md
-      docs/a/TOC.yml: |
+      docs/a/toc.yml: |
         - name: Link
           href: ../b.md
         - name: Uid ref
@@ -628,7 +628,7 @@ outputs:
             "target_url": "/docs/breadcrumbs/toc.json"
         },
         {
-            "source_git_url": "https://github.com/toc-inclusion/markdown/blob/main/docs/breadcrumbs/TOC.yml",
+            "source_git_url": "https://github.com/toc-inclusion/markdown/blob/main/docs/breadcrumbs/toc.yml",
             "source_line": 3,
             "source_url": "/docs/breadcrumbs/toc.json",
             "target_url": "/"
@@ -640,19 +640,19 @@ outputs:
             "target_url": "/docs/breadcrumbs/toc.json"
         },
         {
-            "source_git_url": "https://github.com/toc-inclusion/markdown/blob/main/docs/a/TOC.yml",
+            "source_git_url": "https://github.com/toc-inclusion/markdown/blob/main/docs/a/toc.yml",
             "source_line": 4,
             "source_url": "/docs/toc.json",
             "target_url": "/docs/a"
         },
         {
-            "source_git_url": "https://github.com/toc-inclusion/markdown/blob/main/docs/a/TOC.yml",
+            "source_git_url": "https://github.com/toc-inclusion/markdown/blob/main/docs/a/toc.yml",
             "source_line": 2,
             "source_url": "/docs/toc.json",
             "target_url": "/docs/b"
         },
         {
-            "source_git_url": "https://github.com/toc-inclusion/markdown/blob/main/docs/TOC.yml",
+            "source_git_url": "https://github.com/toc-inclusion/markdown/blob/main/docs/toc.yml",
             "source_line": 4,
             "source_url": "/docs/toc.json",
             "target_url": "/docs/c"
@@ -838,9 +838,9 @@ outputs:
 inputs:
   docfx.yml:
   docs/a.md:
-  docs/TOC.md: |
+  docs/toc.md: |
     # [file reference](a.md)
-  docs/a/TOC.md: |
+  docs/a/toc.md: |
     # [file reference](../a.md)
 outputs:
   docs/a.json:
@@ -853,26 +853,26 @@ outputs:
               "dependencies": [
                   {
                       "from_file_path": "docs/a.md",
-                      "to_file_path": "docs/TOC.md",
+                      "to_file_path": "docs/toc.md",
                       "dependency_type": "metadata"
                   }
               ],
               "type": "Content"
           },
-          "docs/a/TOC.md": {
+          "docs/a/toc.md": {
               "dependencies": [
                   {
-                      "from_file_path": "docs/a/TOC.md",
+                      "from_file_path": "docs/a/toc.md",
                       "to_file_path": "docs/a.md",
                       "dependency_type": "file"
                   }
               ],
               "type": "Toc"
           },
-          "docs/TOC.md": {
+          "docs/toc.md": {
               "dependencies": [
                   {
-                      "from_file_path": "docs/TOC.md",
+                      "from_file_path": "docs/toc.md",
                       "to_file_path": "docs/a.md",
                       "dependency_type": "file"
                   }

--- a/docs/specs/redirection.yml
+++ b/docs/specs/redirection.yml
@@ -3,10 +3,10 @@ inputs:
   docfx.yml:
   redirections.yml: |
     redirections:
-      docs/TOC.md: /absolute/path
+      docs/toc.md: /absolute/path
 outputs:
   .errors.log: |
-    {"message_severity":"error","code":"redirection-invalid","message":"File 'docs/TOC.md' is redirected to '/absolute/path'. Only content files can be redirected.","file":"redirections.yml","line":2,"column":16}
+    {"message_severity":"error","code":"redirection-invalid","message":"File 'docs/toc.md' is redirected to '/absolute/path'. Only content files can be redirected.","file":"redirections.yml","line":2,"column":16}
 ---
 # Redirection url conflict
 inputs:
@@ -47,7 +47,7 @@ inputs:
   docfx.yml:
   redirections.yml: |
     renames:
-      docs/TOC.md: /absolute/path
+      docs/toc.md: /absolute/path
       docs/a.md: /docs/b
     redirections:
       docs/a.md: /absolute/path2
@@ -55,7 +55,7 @@ inputs:
 outputs:
   docs/b.json:
   .errors.log: |
-    {"message_severity":"error","code":"redirection-invalid","message":"File 'docs/TOC.md' is redirected to '/absolute/path'. Only content files can be redirected.","file":"redirections.yml","line":2,"column":16}
+    {"message_severity":"error","code":"redirection-invalid","message":"File 'docs/toc.md' is redirected to '/absolute/path'. Only content files can be redirected.","file":"redirections.yml","line":2,"column":16}
     {"message_severity":"error","code":"redirection-conflict","message":"The 'docs/a.md' appears twice or more in the redirection mappings.","file":"redirections.yml","line":5,"column":14}
 ---
 # redirect to not starting with '/' is allowed in config.redirectionWithoutIds

--- a/docs/specs/schema.yml
+++ b/docs/specs/schema.yml
@@ -79,13 +79,13 @@ outputs:
 # Support schema documents with Href content
 inputs:
   docfx.yml:
-  docs/A/TOC.yml:
-  docs/TOC.yml:
+  docs/A/toc.yml:
+  docs/toc.yml:
   docs/a.yml: |
     #YamlMime:ContextObject
     brand: azure
-    breadcrumb_path: TOC.yml
-    toc_rel: A/TOC.yml
+    breadcrumb_path: toc.yml
+    toc_rel: A/toc.yml
   _themes/ContentTemplate/schemas/ContextObject.schema.json: |
     {
       "renderType": "component",
@@ -108,8 +108,8 @@ outputs:
       {
          "dependencies":{
             "docs/a.yml":[
-               { "source": "docs/A/TOC.yml", "type": "file" },
-               { "source": "docs/TOC.yml", "type": "file" }
+               { "source": "docs/A/toc.yml", "type": "file" },
+               { "source": "docs/toc.yml", "type": "file" }
             ]
          }
       }
@@ -117,13 +117,13 @@ outputs:
 # schema documents with Href content but wrong type
 inputs:
   docfx.yml:
-  TOC.yml:
-  docs/TOC.yml:
+  toc.yml:
+  docs/toc.yml:
   docs/a.yml: |
     #YamlMime:ContextObject
     brand: azure
     breadcrumb_path: {}
-    toc_rel: ../TOC.yml
+    toc_rel: ../toc.yml
   _themes/ContentTemplate/schemas/ContextObject.schema.json: |
     {
       "type": "object",

--- a/docs/specs/single-file.yml
+++ b/docs/specs/single-file.yml
@@ -101,8 +101,8 @@ inputs:
     this [!include[](b.md)] should cause circular reference
   xref.json: |
     { apparently a syntax error
-  TOC.md: |
-    # [circular reference](TOC.md)
+  toc.md: |
+    # [circular reference](toc.md)
 outputs:
 ---
 # Get canonical version for document without versioning does not touch url map
@@ -232,19 +232,19 @@ languageServer:
 languageServer:
   - openFiles:
       docfx.yml:
-      TOC.yml: |
+      toc.yml: |
         items:
         - href: b.md
       a.md:
   - expectDiagnostics:
-      TOC.yml: [{ "code": "file-not-found" }, { "code": "missing-attribute" }]
+      toc.yml: [{ "code": "file-not-found" }, { "code": "missing-attribute" }]
   - editFiles:
-      TOC.yml: |
+      toc.yml: |
         items:
         - href: a.md
           name: a
   - expectDiagnostics:
-      TOC.yml: []
+      toc.yml: []
 ---
 # Isolate metadata validation state between builds
 inputs:

--- a/docs/specs/static.yml
+++ b/docs/specs/static.yml
@@ -44,7 +44,7 @@ noDryRun: true
 inputs: 
   docfx.yml: |
     outputType: html
-  TOC.md:
+  toc.md:
   _themes/ContentTemplate/schemas/TestData.schema.json: "{\"renderType\": \"component\"}"
 outputs: 
   toc.json:
@@ -54,7 +54,7 @@ noDryRun: true
 inputs: 
   docfx.yml: |
     outputType: html
-  TOC.md:
+  toc.md:
   _themes/ContentTemplate/schemas/TestData.schema.json: "{\"renderType\": \"content\"}"
 outputs: 
   toc.json:
@@ -64,7 +64,7 @@ inputs:
   docfx.yml: |
     template: _themes
     outputType: html
-  TOC.md:
+  toc.md:
   _themes/ContentTemplate/test:
 outputs: 
   toc.html: 
@@ -75,7 +75,7 @@ inputs:
   docfx.yml: |
     template: _themes.pdf
     outputType: html
-  TOC.md:
+  toc.md:
   _themes.pdf/ContentTemplate/toc.html.js: |
     exports.transform = function (model) {
       return {
@@ -216,7 +216,7 @@ inputs:
     ---
     monikerRange: netcore-1.1
     ---
-  docs/v1/TOC.md: |
+  docs/v1/toc.md: |
     # [A](a.md)
 outputs:
   c83d387e11975a5f5fe51ced25ba46a7/toc.html: |
@@ -246,7 +246,7 @@ outputs:
           "group": "c83d387e11975a5f5fe51ced25ba46a7",
           "version":"< netcore-2.0",
           "is_moniker_range": true,
-          "source_relative_path": "docs/v1/TOC.md"
+          "source_relative_path": "docs/v1/toc.md"
         },
       ]
     }
@@ -390,7 +390,7 @@ repos:
       docfx.yml: |
         outputType: html
         template: https://docs.com/theme
-      TOC.yml: |
+      toc.yml: |
         - name: link-a
           href: a.md
       a.md:
@@ -441,7 +441,7 @@ inputs:
   docfx.yml: |
     outputType: html
     urlType: pretty
-  TOC.yml: |
+  toc.yml: |
     - name: a
 outputs:
   toc.json: |

--- a/docs/specs/toc/service-page.yml
+++ b/docs/specs/toc/service-page.yml
@@ -7,7 +7,7 @@ repos:
           "docsets_to_publish": [{  "build_source_folder": "a"}],
           "JoinTOCPlugin": [
             {
-              "ReferenceTOC": "a/api/TOC.yml",
+              "ReferenceTOC": "a/api/toc.yml",
               "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml",
               "OutputFolder": "a/results",
               "ContainerPageMetadata": {"langs": ["csharp"]}
@@ -62,7 +62,7 @@ repos:
           "$schema": "https://raw.githubusercontent.com/dotnet/docfx/v3/schemas/TestData.json",
           "uid": "aa", "name": "test", "fullName": "test.test", "description": "a.description"
         }
-      a/api/TOC.yml: |
+      a/api/toc.yml: |
         name: TOC
         items:
         - name: MS.ServicePage.xxx
@@ -111,7 +111,7 @@ repos:
         {
           "docsets_to_publish": [{  "build_source_folder": "a"}],
           "JoinTOCPlugin": [
-            {"ReferenceTOC": "a/api/bot/TOC.yml",
+            {"ReferenceTOC": "a/api/bot/toc.yml",
               "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml"}],
         }
       a/docfx.yml:
@@ -135,7 +135,7 @@ repos:
           }
         }
       a/test/doc.md:
-      a/api/bot/TOC.yml: |
+      a/api/bot/toc.yml: |
         name: TOC
         items:
         - name: MS.ServicePage.xxx
@@ -159,9 +159,9 @@ repos:
   - files:
       .openpublishing.publish.config.json: |
         {
-          "docsets_to_publish": [{  "build_source_folder": "a", "SplitTOC": ["api/bot/TOC.yml"]}],
+          "docsets_to_publish": [{  "build_source_folder": "a", "SplitTOC": ["api/bot/toc.yml"]}],
           "JoinTOCPlugin": [
-            {"ReferenceTOC": "a/api/bot/TOC.yml",
+            {"ReferenceTOC": "a/api/bot/toc.yml",
               "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml"}],
         }
       a/docfx.yml:
@@ -185,7 +185,7 @@ repos:
           }
         }
       a/test/doc.md:
-      a/api/bot/TOC.yml: |
+      a/api/bot/toc.yml: |
         items:
         - name: MS.ServicePage2.xxx
           items:
@@ -210,9 +210,9 @@ repos:
   - files:
       .openpublishing.publish.config.json: |
         {
-          "docsets_to_publish": [{  "build_source_folder": "a", "SplitTOC": ["api/bot/TOC.yml"]}],
+          "docsets_to_publish": [{  "build_source_folder": "a", "SplitTOC": ["api/bot/toc.yml"]}],
           "JoinTOCPlugin": [
-            {"ReferenceTOC": "a/api/bot/TOC.yml",
+            {"ReferenceTOC": "a/api/bot/toc.yml",
               "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml"}],
         }
       a/docfx.yml:
@@ -236,7 +236,7 @@ repos:
           }
         }
       a/test/doc.md:
-      a/api/bot/TOC.yml: |
+      a/api/bot/toc.yml: |
         items:
         - name: MS.ServicePage2.xxx
           items:
@@ -283,7 +283,7 @@ repos:
         {
           "docsets_to_publish": [{  "build_source_folder": "a"}],
           "JoinTOCPlugin": [
-            {"ReferenceTOC": "a/api/bot/TOC.yml",
+            {"ReferenceTOC": "a/api/bot/toc.yml",
               "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml"}],
         }
       a/docfx.yml:
@@ -306,7 +306,7 @@ repos:
             "pageType": { "enum": ["root", "service"], "type": "string" }
           }
         }
-      a/api/bot/TOC.yml: |
+      a/api/bot/toc.yml: |
         name: TOC
         items:
         - name: MS.ServicePage.xxx
@@ -328,9 +328,9 @@ repos:
   - files:
       .openpublishing.publish.config.json: |
         {
-          "docsets_to_publish": [{  "build_source_folder": "a", "SplitTOC": ["api/bot/TOC.yml"]}],
+          "docsets_to_publish": [{  "build_source_folder": "a", "SplitTOC": ["api/bot/toc.yml"]}],
           "JoinTOCPlugin": [
-            {"ReferenceTOC": "a/api/bot/TOC.yml",
+            {"ReferenceTOC": "a/api/bot/toc.yml",
               "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml"}],
         }
       a/docfx.yml:
@@ -354,7 +354,7 @@ repos:
           }
         }
       a/test/doc.md:
-      a/api/bot/TOC.yml: |
+      a/api/bot/toc.yml: |
         items:
         - name: MS.ServicePage2.xxx
           items:
@@ -402,7 +402,7 @@ repos:
         {
           "docsets_to_publish": [{  "build_source_folder": "a"}],
           "JoinTOCPlugin": [
-            {"ReferenceTOC": "a/api/bot/TOC.yml",
+            {"ReferenceTOC": "a/api/bot/toc.yml",
               "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml"}],
         }
       a/docfx.yml:
@@ -430,7 +430,7 @@ repos:
         name: a
         uid: test
         ---
-      a/api/bot/TOC.yml: |
+      a/api/bot/toc.yml: |
         items:
         - name: MS.ServicePage.xxx
           items:
@@ -456,7 +456,7 @@ repos:
         {
           "docsets_to_publish": [{  "build_source_folder": "a"}],
           "JoinTOCPlugin": [
-            {"ReferenceTOC": "a/api/bot/TOC.yml",
+            {"ReferenceTOC": "a/api/bot/toc.yml",
              "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml",
              "OutputFolder": "a/results"}],
         }
@@ -496,7 +496,7 @@ repos:
         name: a
         uid: test
         ---
-      a/api/bot/TOC.yml: |
+      a/api/bot/toc.yml: |
         items:
         - name: MS.ServicePage.xxx
           items:
@@ -518,9 +518,9 @@ repos:
   - files:
       .openpublishing.publish.config.json: |
         {
-          "docsets_to_publish": [{  "build_source_folder": "a", "SplitTOC": ["api/bot/TOC.yml"]}],
+          "docsets_to_publish": [{  "build_source_folder": "a", "SplitTOC": ["api/bot/toc.yml"]}],
           "JoinTOCPlugin": [
-            {"ReferenceTOC": "a/api/bot/TOC.yml",
+            {"ReferenceTOC": "a/api/bot/toc.yml",
               "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml"}],
         }
       a/docfx.yml:
@@ -548,7 +548,7 @@ repos:
         title: a-content
         uid: a
         ---
-      a/api/bot/TOC.yml: |
+      a/api/bot/toc.yml: |
         items:
         - name: MS.ServicePage2.xxx
           uid: a
@@ -575,7 +575,7 @@ repos:
         {
           "docsets_to_publish": [{  "build_source_folder": "a"}],
           "JoinTOCPlugin": [
-            {"ReferenceTOC": "a/api/bot/TOC.yml",
+            {"ReferenceTOC": "a/api/bot/toc.yml",
               "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml",
               "OutputFolder": "a/test"
               }]
@@ -602,7 +602,7 @@ repos:
         }
       a/test/Client.md: |
         # hello world
-      a/api/bot/TOC.yml: |
+      a/api/bot/toc.yml: |
         items:
         - name: MS.ServicePage.xxx
       a/docs-ref-toc/top_level_toc.yml: |
@@ -627,9 +627,9 @@ repos:
   - files:
       .openpublishing.publish.config.json: |
         {
-          "docsets_to_publish": [{  "build_source_folder": "a", "SplitTOC": ["api/bot/TOC.yml"]}],
+          "docsets_to_publish": [{  "build_source_folder": "a", "SplitTOC": ["api/bot/toc.yml"]}],
           "JoinTOCPlugin": [
-            {"ReferenceTOC": "a/api/bot/TOC.yml",
+            {"ReferenceTOC": "a/api/bot/toc.yml",
               "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml",
               "ReferenceTOCUrl": "/a/b/toc"}],
         }
@@ -653,7 +653,7 @@ repos:
             "pageType": { "enum": ["root", "service"], "type": "string" }
           }
         }
-      a/api/bot/TOC.yml: |
+      a/api/bot/toc.yml: |
         items:
         - name: MS.ServicePage2.xxx
           items:
@@ -674,7 +674,7 @@ repos:
         {
           "docsets_to_publish": [{  "build_source_folder": "a"}],
           "JoinTOCPlugin": [
-            {"ReferenceTOC": "a/api/bot/TOC.yml",
+            {"ReferenceTOC": "a/api/bot/toc.yml",
               "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml",
               "OutputFolder": "a/test"
               }]
@@ -701,7 +701,7 @@ repos:
         }
       a/test/index.md: |
         # hello world
-      a/api/bot/TOC.yml: |
+      a/api/bot/toc.yml: |
         items:
         - name: MS.ServicePage.xxx
       a/docs-ref-toc/top_level_toc.yml: |
@@ -728,7 +728,7 @@ repos:
         {
           "docsets_to_publish": [{  "build_source_folder": "a"}],
           "JoinTOCPlugin": [
-            {"ReferenceTOC": "a/api/bot/TOC.yml",
+            {"ReferenceTOC": "a/api/bot/toc.yml",
               "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml",
               "OutputFolder": "a/test"
             }
@@ -771,7 +771,7 @@ repos:
         }
       a/test1/index.md: |
         # hello world
-      a/api/bot/TOC.yml: |
+      a/api/bot/toc.yml: |
         items:
         - name: MS.ServicePage.xxx
       a/docs-ref-toc/top_level_toc.yml: |
@@ -796,7 +796,7 @@ outputs:
         {
           "url": "/api/bot/toc.json",
           "path": "api/bot/toc.json",
-          "source_path": "api/bot/TOC.yml"
+          "source_path": "api/bot/toc.yml"
         },
         {
           "url": "/docs/",
@@ -821,7 +821,7 @@ repos:
               "build_source_folder": "a",
               "JoinTOCPlugin": [
                 {
-                  "ReferenceTOC": "api/bot/TOC.yml",
+                  "ReferenceTOC": "api/bot/toc.yml",
                   "TopLevelTOC": "docs-ref-toc/top_level_toc.yml",
                   "OutputFolder": "result"
                 }
@@ -849,7 +849,7 @@ repos:
             "pageType": { "enum": ["root", "service"], "type": "string" }
           }
         }
-      a/api/bot/TOC.yml: |
+      a/api/bot/toc.yml: |
         items:
         - name: MS.ServicePage.xxx
       a/docs-ref-toc/top_level_toc.yml: |

--- a/docs/specs/toc/split-toc.yml
+++ b/docs/specs/toc/split-toc.yml
@@ -7,12 +7,12 @@ repos:
           "docsets_to_publish": [
             {
               "build_source_folder": ".", 
-              "SplitTOC": ["TOC.yml"]
+              "SplitTOC": ["toc.yml"]
             }
           ]
         }
       docfx.yml:
-      TOC.yml: |
+      toc.yml: |
         items:
         - name: 1
           href: a.md
@@ -62,15 +62,15 @@ repos:
           "docsets_to_publish": [
             {
               "build_source_folder": ".", 
-              "SplitTOC": ["TOC.yml"]
+              "SplitTOC": ["toc.yml"]
             }
           ]
         }
       docfx.yml: |
         fileMetadata:
           key:
-            _splitted/**/TOC.yml: value
-      TOC.yml: |
+            _splitted/**/toc.yml: value
+      toc.yml: |
         items:
         - name: 1
           items:
@@ -89,7 +89,7 @@ repos:
           "docsets_to_publish": [
             {
               "build_source_folder": ".", 
-              "SplitTOC": ["TOC.yml"]
+              "SplitTOC": ["toc.yml"]
             }
           ]
         }
@@ -97,14 +97,14 @@ repos:
         {
           "content":[
             {
-              "files": ["**/TOC.yml"],
+              "files": ["**/toc.yml"],
               "src": ".",
               "dest": "toc-dest"
             }
           ]
         }
     
-      TOC.yml: |
+      toc.yml: |
         items:
         - name: 1
           items:
@@ -125,13 +125,13 @@ repos:
           }],
           "JoinTOCPlugin": [
             {
-              "ReferenceTOC": "a/api/TOC.yml",
+              "ReferenceTOC": "a/api/toc.yml",
               "TopLevelTOC": "a/docs-ref-toc/top_level_toc.yml"
             }
           ],
         }
       a/docfx.yml:
-      a/api/TOC.yml: |
+      a/api/toc.yml: |
         items:
         - name: Microsoft.Identity.xxx
           items:
@@ -201,17 +201,17 @@ repos:
       docfx.yml:
       .openpublishing.publish.config.json: |
         {
-          "docsets_to_publish": [{  "build_source_folder": ".", "SplitTOC": ["a/TOC.yml", "b/TOC.yml"]}],
+          "docsets_to_publish": [{  "build_source_folder": ".", "SplitTOC": ["a/toc.yml", "b/toc.yml"]}],
           "JoinTOCPlugin": [
             {
-              "ConceptualTOC": "b/TOC.yml",
+              "ConceptualTOC": "b/toc.yml",
               "ReferenceTOCUrl": "/dotnet-test/api/toc.json",
               "ConceptualTOCUrl": "dotnet-test/learn/toc.json",
-              "ReferenceTOC": "a/TOC.yml"
+              "ReferenceTOC": "a/toc.yml"
             }
           ]
         }
-      a/TOC.yml: |
+      a/toc.yml: |
         items:
         - name: a
           items:
@@ -219,7 +219,7 @@ repos:
         - name: b
           items:
           - name: b-b
-      b/TOC.yml: |
+      b/toc.yml: |
         items:
         - name: 1
           items:
@@ -243,17 +243,17 @@ repos:
       test/docfx.yml:
       .openpublishing.publish.config.json: |
         {
-          "docsets_to_publish": [{  "build_source_folder": "test", "SplitTOC": ["a/TOC.yml", "b/TOC.yml"]}],
+          "docsets_to_publish": [{  "build_source_folder": "test", "SplitTOC": ["a/toc.yml", "b/toc.yml"]}],
           "JoinTOCPlugin": [
             {
-              "ConceptualTOC": "test/b/TOC.yml",
+              "ConceptualTOC": "test/b/toc.yml",
               "ReferenceTOCUrl": "/dotnet-test/api/toc.json",
               "ConceptualTOCUrl": "dotnet-test/learn/toc.json",
-              "ReferenceTOC": "test/a/TOC.yml"
+              "ReferenceTOC": "test/a/toc.yml"
             }
           ]
         }
-      test/a/TOC.yml: |
+      test/a/toc.yml: |
         items:
         - name: a
           items:
@@ -261,7 +261,7 @@ repos:
         - name: b
           items:
           - name: b-b
-      test/b/TOC.yml: |
+      test/b/toc.yml: |
         items:
         - name: 1
           items:
@@ -284,7 +284,7 @@ repos:
   - files:
       .openpublishing.publish.config.json: |
         {
-          "SplitTOC": ["a/TOC.yml"],
+          "SplitTOC": ["a/toc.yml"],
           "docsets_to_publish": [
             {
               "build_source_folder": "a"
@@ -294,8 +294,8 @@ repos:
       a/docfx.yml: |
         fileMetadata:
           key:
-            _splitted/**/TOC.yml: value
-      a/TOC.yml: |
+            _splitted/**/toc.yml: value
+      a/toc.yml: |
         items:
         - name: 1
           items:
@@ -313,12 +313,12 @@ repos:
           "docsets_to_publish": [
             {
               "build_source_folder": "a",
-              "SplitTOC": ["a/TOC.yml"]
+              "SplitTOC": ["a/toc.yml"]
             }
           ]
         }
       a/docfx.yml:
-      a/TOC.yml: |
+      a/toc.yml: |
         items:
         - name: 1
           items:
@@ -331,13 +331,13 @@ repos:
   https://github.com/ops/add-monikers-for-the-root-node-of-splitToc:
   - files:
       .openpublishing.publish.config.json: |
-          {"docsets_to_publish": [{"build_source_folder": ".", "SplitTOC": ["TOC.yml"]}]}
+          {"docsets_to_publish": [{"build_source_folder": ".", "SplitTOC": ["toc.yml"]}]}
       docfx.yml: |
         monikerRange:
           '**/*': '>= v-1.1'
         monikerDefinition: 'monikerDefinition.json'
       a.md:
-      TOC.yml: |
+      toc.yml: |
         items:
           - name: 1
             href: ./a.md

--- a/docs/specs/toc/toc.yml
+++ b/docs/specs/toc/toc.yml
@@ -3,7 +3,7 @@
 inputs:
   docfx.yml:
   index.md:
-  docs/TOC.md: |
+  docs/toc.md: |
     # [Index Reference](index.md)
     ## Existing File Reference
     ### [Reference Normal File 1](n1.md)
@@ -42,7 +42,7 @@ outputs:
 # TOC can be a json file
 inputs:
   docfx.yml:
-  docs/TOC.json: |
+  docs/toc.json: |
     [{ "name": "title" }]
 outputs:
   docs/toc.json: |
@@ -53,18 +53,18 @@ outputs:
 # TOC json file is invalid
 inputs:
   docfx.yml:
-  docs/TOC.json: |
+  docs/toc.json: |
     [{ "name": "title" ]
 outputs:
   .errors.log: |
-    {"message_severity":"error","code":"json-syntax-error","message":"JsonToken EndArray is not valid for closing JsonType Object.","file":"docs/TOC.json","line":1,"column":20}
+    {"message_severity":"error","code":"json-syntax-error","message":"JsonToken EndArray is not valid for closing JsonType Object.","file":"docs/toc.json","line":1,"column":20}
 ---
 # Probe TOC in JSON format
 inputs:
   docfx.yml:
-  docs/TOC.json: |
+  docs/toc.json: |
     [{ "name": "a", "href": "a/?query" }]
-  docs/a/TOC.json: |
+  docs/a/toc.json: |
     [{ "name": "b", "href": "b.md" }]
   docs/a/b.md:
 outputs:
@@ -78,10 +78,10 @@ outputs:
     }
   docs/a/b.json:
 ---
-# TOC.md can contain xml comments
+# toc.md can contain xml comments
 inputs:
   docfx.yml:
-  TOC.md: |
+  toc.md: |
     <!-- this is an xml comment -->
 outputs:
   toc.json:
@@ -90,7 +90,7 @@ outputs:
 inputs:
   docfx.yml:
   docs/index.md:
-  docs/TOC.md: |
+  docs/toc.md: |
     # [Index Reference](index.md)
     ## No Existing File Reference
     ### [Reference No-Existing File 1](no-existing.md)
@@ -113,31 +113,31 @@ outputs:
       }]
     }
   .errors.log: |
-    {"message_severity":"warning","code":"file-not-found","message":"Invalid file link: 'no-existing.md'.","file":"docs/TOC.md","line":3,"column":5}
-    {"message_severity":"warning","code":"file-not-found","message":"Invalid file link: 'no-existing.system.md'.","file":"docs/TOC.md","line":4,"column":5}
-    {"message_severity":"warning","code":"file-not-found","message":"Invalid file link: '../no-existing.md'.","file":"docs/TOC.md","line":5,"column":5}
-    {"message_severity":"warning","code":"file-not-found","message":"Invalid file link: '~/docs/no-existing.md'.","file":"docs/TOC.md","line":6,"column":5}
+    {"message_severity":"warning","code":"file-not-found","message":"Invalid file link: 'no-existing.md'.","file":"docs/toc.md","line":3,"column":5}
+    {"message_severity":"warning","code":"file-not-found","message":"Invalid file link: 'no-existing.system.md'.","file":"docs/toc.md","line":4,"column":5}
+    {"message_severity":"warning","code":"file-not-found","message":"Invalid file link: '../no-existing.md'.","file":"docs/toc.md","line":5,"column":5}
+    {"message_severity":"warning","code":"file-not-found","message":"Invalid file link: '~/docs/no-existing.md'.","file":"docs/toc.md","line":6,"column":5}
 ---
 # Invalid markdown TOC metadata
 inputs:
   docfx.yml:
-  docs/TOC.md: |
+  docs/toc.md: |
     ---
     pdf_absolute_path: []
     ---
 outputs:
   .errors.log: |
-    {"message_severity":"error","code":"violate-schema","message":"Expected type String, please input String or type compatible with String.","file":"docs/TOC.md","line":2,"column":20}
+    {"message_severity":"error","code":"violate-schema","message":"Expected type String, please input String or type compatible with String.","file":"docs/toc.md","line":2,"column":20}
 ---
 # Absolute file reference
 inputs:
   docfx.yml:
   docs/index.md:
-  docs/TOC.md: |
+  docs/toc.md: |
     # [Index Reference](index.md)
     ## Absolute File Reference
     ### [Reference Absolute path 1](https://worldready.cloudapp.net/Styleguide/Read?id=2700&topicid=26906)
-    ### [Reference Absolute Path 2](/help/style/style-how-to-accessibility?toc=/help/contribute/TOC.json&bc=toc=%2Fazure%2Fapi-management%2Ftoc.json)
+    ### [Reference Absolute Path 2](/help/style/style-how-to-accessibility?toc=/help/contribute/toc.json&bc=toc=%2Fazure%2Fapi-management%2Ftoc.json)
 outputs:
   docs/index.json:
   docs/toc.json: |
@@ -146,7 +146,7 @@ outputs:
         "items":[{
           "items":[
             { "name":"Reference Absolute path 1", "href":"https://worldready.cloudapp.net/Styleguide/Read?id=2700&topicid=26906" },
-            { "name":"Reference Absolute Path 2", "href":"/help/style/style-how-to-accessibility?toc=/help/contribute/TOC.json&bc=toc=%2Fazure%2Fapi-management%2Ftoc.json" }
+            { "name":"Reference Absolute Path 2", "href":"/help/style/style-how-to-accessibility?toc=/help/contribute/toc.json&bc=toc=%2Fazure%2Fapi-management%2Ftoc.json" }
           ]
         }]
       }]
@@ -156,11 +156,11 @@ outputs:
 # reference toc
 inputs:
   docfx.yml:
-  docs/TOC.md: |
-    # [Reference TOC File 1](f1/TOC.md)
-    # [Reference TOC File 2](../docs/f1/TOC.md)
-    # [Reference TOC File 3](~/docs/f1/TOC.md)
-  docs/f1/TOC.md: |
+  docs/toc.md: |
+    # [Reference TOC File 1](f1/toc.md)
+    # [Reference TOC File 2](../docs/f1/toc.md)
+    # [Reference TOC File 3](~/docs/f1/toc.md)
+  docs/f1/toc.md: |
     # [Index Reference](index.md)
   docs/f1/index.md:
 outputs:
@@ -176,19 +176,19 @@ outputs:
 ---
 # Nested TOC reference 2
 # multiple level
-# docs/TOC.md -> docs/f1/TOC.md  -> docs/f2/TOC.md
-#             -> docs/f2/TOC.md --> docs/f1/f11/TOC.md
+# docs/toc.md -> docs/f1/toc.md  -> docs/f2/toc.md
+#             -> docs/f2/toc.md --> docs/f1/f11/toc.md
 inputs:
   docfx.yml:
-  docs/TOC.md: |
-    # [Reference TOC File 1](f1/TOC.md)
-    # [Reference TOC File 2](~/docs/f2/TOC.yml)
-  docs/f1/TOC.md: |
+  docs/toc.md: |
+    # [Reference TOC File 1](f1/toc.md)
+    # [Reference TOC File 2](~/docs/f2/toc.yml)
+  docs/f1/toc.md: |
     # [Reference TOC Folder](../f2/)
-  docs/f2/TOC.yml: |
+  docs/f2/toc.yml: |
     - name: Toc Reference
-      href: ../f1/f11/TOC.md
-  docs/f1/f11/TOC.md: |
+      href: ../f1/f11/toc.md
+  docs/f1/f11/toc.md: |
     # [Index Reference](index.md)
     # [A File reference](a.md)
   docs/f1/f11/index.md:
@@ -213,20 +213,20 @@ outputs:
   .dependencymap.json: |
     {
       "dependencies": {
-        "docs/f1/f11/TOC.md": [
+        "docs/f1/f11/toc.md": [
             { "source": "docs/f1/f11/a.md", "type": "file" },
             { "source": "docs/f1/f11/index.md", "type": "file" }
         ],
-        "docs/f1/TOC.md": [
+        "docs/f1/toc.md": [
             { "source": "docs/f1/f11/index.md", "type": "file" },
-            { "source": "docs/f2/TOC.yml", "type": "include" }
+            { "source": "docs/f2/toc.yml", "type": "include" }
         ],
-        "docs/f2/TOC.yml": [
-            { "source": "docs/f1/f11/TOC.md", "type": "include" }
+        "docs/f2/toc.yml": [
+            { "source": "docs/f1/f11/toc.md", "type": "include" }
         ],
-        "docs/TOC.md": [
-            { "source": "docs/f1/TOC.md", "type": "include" },
-            { "source": "docs/f2/TOC.yml", "type": "include" },
+        "docs/toc.md": [
+            { "source": "docs/f1/toc.md", "type": "include" },
+            { "source": "docs/f2/toc.yml", "type": "include" },
         ]
       }
     }
@@ -234,7 +234,7 @@ outputs:
 # Title with # or End with #
 inputs:
   docfx.yml:
-  docs/TOC.md: |
+  docs/toc.md: |
     # [Topic1](index.md) #
     ## Topic1.1 Language C#
     ### [Topic1.1.1](/href1.1.1) ##
@@ -268,52 +268,52 @@ outputs:
 inputs:
   docfx.yml: |
     files:
-    - docs/TOC.md
+    - docs/toc.md
     - docs/index.md
-  docs/TOC.md: |
+  docs/toc.md: |
     # [Topic1](index.md) #
     ## Reference toc
-    ### [Reference TOC 1.1](f1/TOC.md)
-  docs/f1/TOC.md: |
+    ### [Reference TOC 1.1](f1/toc.md)
+  docs/f1/toc.md: |
     # [Topic1](../index.md)
-    ## [Reference TOC 1.1.1](../f2/TOC.md)
-  docs/f2/TOC.md: |
+    ## [Reference TOC 1.1.1](../f2/toc.md)
+  docs/f2/toc.md: |
     # [Topic1](../index.md)
-    ## [Reference TOC back](../TOC.md)
+    ## [Reference TOC back](../toc.md)
   docs/index.md:
 outputs:
   docs/index.json:
   .errors.log: |
-    {"message_severity":"error","code":"circular-reference","message":"Build has identified file(s) referencing each other: 'docs/TOC.md' --> 'docs/f1/TOC.md' --> 'docs/f2/TOC.md' --> 'docs/TOC.md'.","file":"docs/TOC.md","line":1,"column":1}
+    {"message_severity":"error","code":"circular-reference","message":"Build has identified file(s) referencing each other: 'docs/toc.md' --> 'docs/f1/toc.md' --> 'docs/f2/toc.md' --> 'docs/toc.md'.","file":"docs/toc.md","line":1,"column":1}
 ---
 # Circle toc referencing 2
 inputs:
   docfx.yml: |
     files:
-    - docs/TOC.md
+    - docs/toc.md
     - docs/index.md
-  docs/TOC.md: |
+  docs/toc.md: |
     # [Topic1](index.md) #
-    ## [Reference itself](TOC.md)
+    ## [Reference itself](toc.md)
   docs/index.md:
 outputs:
   docs/index.json:
   .errors.log: |
-    {"message_severity":"error","code":"circular-reference","message":"Build has identified file(s) referencing each other: 'docs/TOC.md' --> 'docs/TOC.md'.","file":"docs/TOC.md","line":1,"column":1}
+    {"message_severity":"error","code":"circular-reference","message":"Build has identified file(s) referencing each other: 'docs/toc.md' --> 'docs/toc.md'.","file":"docs/toc.md","line":1,"column":1}
 ---
 # Reference to a folder, basic usages
 # Reference to a folder behavior is not same with reference to a toc file
 inputs:
   docfx.yml:
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - name: Toc Reference
-      href: f1/TOC.md
+      href: f1/toc.md
     - name: Folder Reference1
       href: f1/
     - name: Folder Reference2
       href: f1/
       topicHref: f1/a.md
-  docs/f1/TOC.md: |
+  docs/f1/toc.md: |
     # [Index Reference](index.md)
   docs/f1/index.md:
   docs/f1/a.md:
@@ -336,9 +336,9 @@ outputs:
 # Folder referenced toc doesn't belong to nested toc
 inputs:
   docfx.yml:
-  docs/TOC.md: |
+  docs/toc.md: |
     # [Folder Reference](f1/)
-  docs/f1/TOC.md: |
+  docs/f1/toc.md: |
     # [Index Reference](index.md)
   docs/f1/index.md:
 outputs:
@@ -354,13 +354,13 @@ outputs:
 # Horizontal traversal first
 inputs:
   docfx.yml:
-  docs/TOC.md: |
+  docs/toc.md: |
     # [Folder Reference1](f1/)
     # [Folder Reference2](f2/)
-  docs/f1/TOC.md: |
+  docs/f1/toc.md: |
     # Title
     # [File Reference](b.md)
-  docs/f2/TOC.md: |
+  docs/f2/toc.md: |
     # Title1
     ## Child Title1
     ## [File Reference](b.md)
@@ -384,18 +384,18 @@ outputs:
   .dependencymap.json: |
     {
       "dependencies": {
-        "docs/f1/TOC.md": [
+        "docs/f1/toc.md": [
           { "source": "docs/f1/b.md", "type": "file" }
         ],
-        "docs/f2/TOC.md": [
+        "docs/f2/toc.md": [
           { "source": "docs/f2/a.md", "type": "file" },
           { "source": "docs/f2/b.md", "type": "file" }
         ],
-        "docs/TOC.md": [
-          { "source": "docs/f1/TOC.md", "type": "include" },
+        "docs/toc.md": [
           { "source": "docs/f1/b.md", "type": "file" },
-          { "source": "docs/f2/TOC.md", "type": "include" },
-          { "source": "docs/f2/a.md", "type": "file" }
+          { "source": "docs/f1/toc.md", "type": "include" },
+          { "source": "docs/f2/a.md", "type": "file" },
+          { "source": "docs/f2/toc.md", "type": "include" }
         ]
       }
     }
@@ -403,7 +403,7 @@ outputs:
 # Topic href can replace href
 inputs:
   docfx.yml:
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - name: File Reference
       topicHref: f1/a.md
   docs/f1/a.md:
@@ -417,7 +417,7 @@ outputs:
 # Homepage only shows when topic href is set and href is not 
 inputs:
   docfx.yml:
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - name: name1
       href: /f1/a
     - name: name2
@@ -435,7 +435,7 @@ outputs:
 # Toc href takes precedence over topic href
 inputs:
   docfx.yml:
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - name: Azure
       tocHref: /azure/
       topicHref: /azure/index
@@ -450,17 +450,17 @@ outputs:
 # Parent(including) toc doesn't participate in _tocRel resolution
 inputs:
   docfx.yml:
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - name: parent-a
       tocHref: child-a/
       topicHref: ../a.md
     - name: parent-b
       tocHref: child-b/
       topicHref: ../b.md
-  docs/child-a/TOC.yml: |
+  docs/child-a/toc.yml: |
     - name: child-a
       topicHref: ../../a.md
-  docs/child-b/TOC.yml: |
+  docs/child-b/toc.yml: |
     - name: child-b
       topicHref: ../../b.md
   a.md:
@@ -477,12 +477,12 @@ outputs:
 # Combine toc href, topic href => href + items
 inputs:
   docfx.yml:
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - name: href + items
       topicHref: f1/a.md
-      tocHref: f1/TOC.md
+      tocHref: f1/toc.md
   docs/f1/a.md:
-  docs/f1/TOC.md: |
+  docs/f1/toc.md: |
     # [Reference a](a.md)
 outputs:
   docs/f1/a.json:
@@ -500,12 +500,12 @@ outputs:
 # Combine toc href, href => href + items
 inputs:
   docfx.yml:
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - name: href + items
       href: f1/a.md
-      tocHref: f1/TOC.md
+      tocHref: f1/toc.md
   docs/f1/a.md:
-  docs/f1/TOC.md: |
+  docs/f1/toc.md: |
     # [Reference a](a.md)
 outputs:
   docs/f1/a.json:
@@ -523,13 +523,13 @@ outputs:
 # Combine toc href, href(toc) => toc href > href + items
 inputs:
   docfx.yml:
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - name: toc href > href + items
-      href: f1/TOC.md
-      tocHref: f2/TOC.md
-  docs/f1/TOC.md:
+      href: f1/toc.md
+      tocHref: f2/toc.md
+  docs/f1/toc.md:
   docs/f2/a.md:
-  docs/f2/TOC.md: |
+  docs/f2/toc.md: |
     # [Reference a](a.md)
 outputs:
   docs/f2/a.json:
@@ -548,10 +548,10 @@ outputs:
 # Combine topic href and href => topic href has higher priority
 inputs:
   docfx.yml: |
-    files: docs/f1/TOC.yml
+    files: docs/f1/toc.yml
   docs/f1/n1.md:
   docs/f1/n2.md:
-  docs/f1/TOC.yml: |
+  docs/f1/toc.yml: |
     - name: topic href has higher priority
       href: ~/docs/f1/n1.md
       topicHref: ~/docs/f1/n2.md
@@ -561,20 +561,20 @@ outputs:
       "items": [{ "name":"topic href has higher priority", "href":"~/docs/f1/n2.md" }]
     }
   .errors.log: |
-    {"message_severity":"warning","code":"link-out-of-scope","message":"File 'docs/f1/n2.md' referenced by link '~/docs/f1/n2.md' will not be built because it is not included in build scope.","file":"docs/f1/TOC.yml","line":3,"column":14}
+    {"message_severity":"warning","code":"link-out-of-scope","message":"File 'docs/f1/n2.md' referenced by link '~/docs/f1/n2.md' will not be built because it is not included in build scope.","file":"docs/f1/toc.yml","line":3,"column":14}
 ---
 # Combine topic href and href(toc) => href + items
 # replace href finally
 inputs:
   docfx.yml: |
-    files: docs/f1/TOC.yml
-  docs/f1/TOC.yml: |
+    files: docs/f1/toc.yml
+  docs/f1/toc.yml: |
     - name: Toc Reference 1
-      href: f11/TOC.md
+      href: f11/toc.md
       topicHref: f11/n1.md
     - name: Toc Reference 2
       href: f11/
-  docs/f1/f11/TOC.md: |
+  docs/f1/f11/toc.md: |
     # [Index Reference](n1.md)
   docs/f1/f11/n1.md:
 outputs:
@@ -593,18 +593,18 @@ outputs:
       ]
     }
   .errors.log: |
-    {"message_severity":"warning","code":"link-out-of-scope","message":"File 'docs/f1/f11/n1.md' referenced by link 'f11/n1.md' will not be built because it is not included in build scope.","file":"docs/f1/TOC.yml","line":3,"column":14}
-    {"message_severity":"warning","code":"link-out-of-scope","message":"File 'docs/f1/f11/n1.md' referenced by link 'n1.md' will not be built because it is not included in build scope.","file":"docs/f1/f11/TOC.md","line":1,"column":3}
+    {"message_severity":"warning","code":"link-out-of-scope","message":"File 'docs/f1/f11/n1.md' referenced by link 'f11/n1.md' will not be built because it is not included in build scope.","file":"docs/f1/toc.yml","line":3,"column":14}
+    {"message_severity":"warning","code":"link-out-of-scope","message":"File 'docs/f1/f11/n1.md' referenced by link 'n1.md' will not be built because it is not included in build scope.","file":"docs/f1/f11/toc.md","line":1,"column":3}
 ---
 # Combine topic href and toc href(folder) -> topic href > toc href(folder)
 inputs:
   docfx.yml:
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - name: topic href has higher priority
       topicHref: f1/a.md
       tocHref: f1/
   docs/f1/a.md:
-  docs/f1/TOC.md:
+  docs/f1/toc.md:
 outputs:
   docs/f1/a.json:
   docs/f1/toc.json:
@@ -616,13 +616,13 @@ outputs:
 # Combine toc href(folder), href => href > toc href(folder)
 inputs:
   docfx.yml:
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - name: href has higher priority than toc href
       href: f1/a.md
       tocHref: f1/
   docs/f1/a.md:
   docs/f1/b.md:
-  docs/f1/TOC.md: |
+  docs/f1/toc.md: |
     # [Reference b](b.md)
 outputs:
   docs/f1/a.json:
@@ -639,14 +639,14 @@ outputs:
 # href has higher priority than toc href(folder)
 inputs:
   docfx.yml:
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - name: topic href has highest priority
       topicHref: f1/a.md
       tocHref: f1/
       href: f1/b.md
   docs/f1/a.md:
   docs/f1/b.md:
-  docs/f1/TOC.md:
+  docs/f1/toc.md:
 outputs:
   docs/f1/a.json:
   docs/f1/b.json:
@@ -659,44 +659,44 @@ outputs:
 # Topic href cannot reference a local TOC file or folder
 inputs:
   docfx.yml:
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - name: Invalid Topic Reference1
       topicHref: f1/
     - name: Invalid Topic Reference2
-      topicHref: f1/TOC.md
+      topicHref: f1/toc.md
     - name: Invalid Topic Reference3
-      topicHref: f1/TOC.md
+      topicHref: f1/toc.md
       href: /abc/def
-  docs/f1/TOC.md:
+  docs/f1/toc.md:
 outputs:
   docs/f1/toc.json:
   .errors.log: |
-    {"message_severity":"error","code":"invalid-topic-href","message":"The topic href 'f1/' can only reference to a local file or absolute path.","file":"docs/TOC.yml","line":2,"column":14}
-    {"message_severity":"error","code":"invalid-topic-href","message":"The topic href 'f1/TOC.md' can only reference to a local file or absolute path.","file":"docs/TOC.yml","line":4,"column":14}
-    {"message_severity":"error","code":"invalid-topic-href","message":"The topic href 'f1/TOC.md' can only reference to a local file or absolute path.","file":"docs/TOC.yml","line":6,"column":14}
+    {"message_severity":"error","code":"invalid-topic-href","message":"The topic href 'f1/' can only reference to a local file or absolute path.","file":"docs/toc.yml","line":2,"column":14}
+    {"message_severity":"error","code":"invalid-topic-href","message":"The topic href 'f1/toc.md' can only reference to a local file or absolute path.","file":"docs/toc.yml","line":4,"column":14}
+    {"message_severity":"error","code":"invalid-topic-href","message":"The topic href 'f1/toc.md' can only reference to a local file or absolute path.","file":"docs/toc.yml","line":6,"column":14}
 ---
 # Toc href cannot reference a local file
 inputs:
   docfx.yml:
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - name: Invalid Toc Reference1
       tocHref: f1/a.md
     - name: Invalid Toc Reference2
       tocHref: f1/a.md
       href: /abc/def
-  docs/f1/TOC.md:
+  docs/f1/toc.md:
   docs/f1/a.md:
 outputs:
   docs/f1/toc.json:
   docs/f1/a.json:
   .errors.log: |
-    {"message_severity":"error","code":"invalid-toc-href","message":"The toc href 'f1/a.md' can only reference to a local TOC file, folder or absolute path.","file":"docs/TOC.yml","line":2,"column":12}
-    {"message_severity":"error","code":"invalid-toc-href","message":"The toc href 'f1/a.md' can only reference to a local TOC file, folder or absolute path.","file":"docs/TOC.yml","line":4,"column":12}
+    {"message_severity":"error","code":"invalid-toc-href","message":"The toc href 'f1/a.md' can only reference to a local TOC file, folder or absolute path.","file":"docs/toc.yml","line":2,"column":12}
+    {"message_severity":"error","code":"invalid-toc-href","message":"The toc href 'f1/a.md' can only reference to a local TOC file, folder or absolute path.","file":"docs/toc.yml","line":4,"column":12}
 ---
 # Toc syntax error with duplicated keys
 inputs:
   docfx.yml:
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - name: Duplicated keys
       topicHref: f1/a.md
       topicHref: f1/b.md
@@ -710,16 +710,16 @@ outputs:
   docs/toc.json: |
     {"items":[{"name":"Duplicated keys","href":"f1/b"}]}
   .errors.log: |
-    {"message_severity":"warning","code":"yaml-duplicate-key","message":"Key 'topicHref' is already defined, remove the duplicate key.","file":"docs/TOC.yml","line":3,"column":3}
-    {"message_severity":"warning","code":"toc-not-found","message":"Unable to find either toc.yml or toc.md inside f1/ Please make sure the file exists.","file":"docs/TOC.yml","line":4,"column":12}
+    {"message_severity":"warning","code":"yaml-duplicate-key","message":"Key 'topicHref' is already defined, remove the duplicate key.","file":"docs/toc.yml","line":3,"column":3}
+    {"message_severity":"warning","code":"toc-not-found","message":"Unable to find either toc.yml or toc.md inside f1/ Please make sure the file exists.","file":"docs/toc.yml","line":4,"column":12}
 ---
 # The included TOC's errors/warning should be assigned to itself, not its parent
 inputs:
   docfx.yml: |
-    files: docs/TOC.md
-  docs/TOC.md: |
-    # [Reference TOC File](f1/TOC.yml)
-  docs/f1/TOC.yml: |
+    files: docs/toc.md
+  docs/toc.md: |
+    # [Reference TOC File](f1/toc.yml)
+  docs/f1/toc.yml: |
     - name: Invalid Index Reference
       href: index.md
     - name: Invalid TocHref Reference
@@ -727,13 +727,13 @@ inputs:
 outputs:
   docs/toc.json:
   .errors.log: |
-    {"message_severity":"warning","code":"file-not-found","message":"Invalid file link: 'index.md'.","file":"docs/f1/TOC.yml","line":2,"column":9}
-    {"message_severity":"error","code":"invalid-toc-href","message":"The toc href 'index.md' can only reference to a local TOC file, folder or absolute path.","file":"docs/f1/TOC.yml","line":4,"column":12}
+    {"message_severity":"warning","code":"file-not-found","message":"Invalid file link: 'index.md'.","file":"docs/f1/toc.yml","line":2,"column":9}
+    {"message_severity":"error","code":"invalid-toc-href","message":"The toc href 'index.md' can only reference to a local TOC file, folder or absolute path.","file":"docs/f1/toc.yml","line":4,"column":12}
 ---
 # TOC includes same href at different levels
 inputs:
   docfx.yml:
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - name: level 1
       tocHref: index.md
       href: index.md
@@ -747,17 +747,17 @@ inputs:
               href: index.md
 outputs:
   .errors.log: |
-    {"message_severity":"warning","code":"file-not-found","message":"Invalid file link: 'index.md'.","file":"docs/TOC.yml","line":3,"column":9}
-    {"message_severity":"warning","code":"file-not-found","message":"Invalid file link: 'index.md'.","file":"docs/TOC.yml","line":7,"column":13}
-    {"message_severity":"warning","code":"file-not-found","message":"Invalid file link: 'index.md'.","file":"docs/TOC.yml","line":11,"column":17}
-    {"message_severity":"error","code":"invalid-toc-href","message":"The toc href 'index.md' can only reference to a local TOC file, folder or absolute path.","file":"docs/TOC.yml","line":2,"column":12}
-    {"message_severity":"error","code":"invalid-toc-href","message":"The toc href 'index.md' can only reference to a local TOC file, folder or absolute path.","file":"docs/TOC.yml","line":6,"column":16}
-    {"message_severity":"error","code":"invalid-toc-href","message":"The toc href 'index.md' can only reference to a local TOC file, folder or absolute path.","file":"docs/TOC.yml","line":10,"column":20}
+    {"message_severity":"warning","code":"file-not-found","message":"Invalid file link: 'index.md'.","file":"docs/toc.yml","line":3,"column":9}
+    {"message_severity":"warning","code":"file-not-found","message":"Invalid file link: 'index.md'.","file":"docs/toc.yml","line":7,"column":13}
+    {"message_severity":"warning","code":"file-not-found","message":"Invalid file link: 'index.md'.","file":"docs/toc.yml","line":11,"column":17}
+    {"message_severity":"error","code":"invalid-toc-href","message":"The toc href 'index.md' can only reference to a local TOC file, folder or absolute path.","file":"docs/toc.yml","line":2,"column":12}
+    {"message_severity":"error","code":"invalid-toc-href","message":"The toc href 'index.md' can only reference to a local TOC file, folder or absolute path.","file":"docs/toc.yml","line":6,"column":16}
+    {"message_severity":"error","code":"invalid-toc-href","message":"The toc href 'index.md' can only reference to a local TOC file, folder or absolute path.","file":"docs/toc.yml","line":10,"column":20}
 ---
 # Toc with null value
 inputs:
   docfx.yml:
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - name: Null value
       topicHref: f1/a.md
       tocHref: 
@@ -773,9 +773,9 @@ outputs:
 # Toc with violation
 inputs:
   docfx.yml:
-  docs/f1/TOC.md: |
+  docs/f1/toc.md: |
     #
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - topicHref: f1/a.md
       tocHref: 
       href: f1/b.md
@@ -791,14 +791,14 @@ outputs:
   docs/toc.json:
   docs/f1/toc.json:
   .errors.log: |
-    {"message_severity":"warning","code":"missing-attribute","message":"Missing required attribute: 'name'.","file":"docs/TOC.yml","line":5,"column":8}
-    {"message_severity":"warning","code":"missing-attribute","message":"Missing required attribute: 'name'.","file":"docs/TOC.yml","line":7,"column":3}
-    {"message_severity":"warning","code":"missing-attribute","message":"Missing required attribute: 'name'.","file":"docs/f1/TOC.md","line":1,"column":1}
+    {"message_severity":"warning","code":"missing-attribute","message":"Missing required attribute: 'name'.","file":"docs/toc.yml","line":5,"column":8}
+    {"message_severity":"warning","code":"missing-attribute","message":"Missing required attribute: 'name'.","file":"docs/toc.yml","line":7,"column":3}
+    {"message_severity":"warning","code":"missing-attribute","message":"Missing required attribute: 'name'.","file":"docs/f1/toc.md","line":1,"column":1}
 ---
 # Orphan file(not explicitly referenced in toc file)'s toc, only look up parent folder toc files
 inputs:
   docfx.yml: 
-  docs/dir1/TOC.md:
+  docs/dir1/toc.md:
   docs/file-with-no-toc.md:
   docs/dir1/dir2/file-with-toc.md:
 outputs:
@@ -813,9 +813,9 @@ inputs:
   docfx.yml: |
     routes:
       dir2/path/: .
-  dir1/TOC.md: |
+  dir1/toc.md: |
     # [link](../a.md)
-  dir2/path/TOC.md: |
+  dir2/path/toc.md: |
     # [link](../../a.md)
   a.md:
 outputs:
@@ -830,10 +830,10 @@ outputs:
 inputs:
   docfx.yml:
   dir1/a.md:
-  dir1/TOC.yml: |
+  dir1/toc.yml: |
     - name: Include dir2 toc
       href: dir2/
-  dir1/dir2/TOC.yml: |
+  dir1/dir2/toc.yml: |
     - name: reference a.md
       href: ../a.md
 outputs:
@@ -845,13 +845,13 @@ outputs:
 # File referenced by multiple toc with same relative file path, use order alphabetical. For other tests, reference build/TocTest.
 inputs:
   docfx.yml: 
-  docs/dir1/a/TOC.yml: |
+  docs/dir1/a/toc.yml: |
     - name: TOC Ref
       href: ../c/file1.md
-  docs/dir1/b/TOC.yml: |
+  docs/dir1/b/toc.yml: |
     - name: TOC Ref
       href: ../c/file1.md
-  docs/dir1/aa/TOC.yml: |
+  docs/dir1/aa/toc.yml: |
     - name: TOC Ref
       href: ../c/file1.md
   docs/dir1/c/file1.md:
@@ -865,7 +865,7 @@ outputs:
 # Bad Toc markdown
 inputs:
   docfx.yml:
-  docs/TOC.md: |
+  docs/toc.md: |
     # [good](test.md)
     # [good with trailing space](test.md)  
     [bad1]()
@@ -876,43 +876,43 @@ inputs:
 outputs:
   docs/test.json:
   .errors.log: |
-    {"message_severity":"error","code":"invalid-toc-syntax","message":"The toc syntax is invalid, *","file":"docs/TOC.md","line":3,"column":1}
+    {"message_severity":"error","code":"invalid-toc-syntax","message":"The toc syntax is invalid, *","file":"docs/toc.md","line":3,"column":1}
 ---
 # Skip-level Toc markdown
 inputs:
   docfx.yml:
-  docs/TOC.md: |
+  docs/toc.md: |
     # level 1
     ### level 3
 outputs:
   .errors.log: |
-    {"message_severity":"error","code":"invalid-toc-level","message":"The toc level can't be skipped from 1 to 3.","file":"docs/TOC.md","line":2,"column":1}
+    {"message_severity":"error","code":"invalid-toc-level","message":"The toc level can't be skipped from 1 to 3.","file":"docs/toc.md","line":2,"column":1}
 ---
 # Markdown TOC root can start from any level, but must be aligned
 inputs:
   docfx.yml:
-  TOC.md: |
+  toc.md: |
     ## level 2
     # level 1
 outputs:
   .errors.log: |
-    {"message_severity":"error","code":"invalid-toc-level","message":"The toc level can't be skipped from 0 to 1.","file":"TOC.md","line":2,"column":1}
+    {"message_severity":"error","code":"invalid-toc-level","message":"The toc level can't be skipped from 0 to 1.","file":"toc.md","line":2,"column":1}
 ---
 # Missing TOC heading name
 inputs:
   docfx.yml:
-  docs/TOC.md: |
+  docs/toc.md: |
     # Title
     ##
 outputs:
   docs/toc.json:
   .errors.log: |
-    {"message_severity":"warning","code":"missing-attribute","message":"Missing required attribute: 'name'.","file":"docs/TOC.md","line":2,"column":1}
+    {"message_severity":"warning","code":"missing-attribute","message":"Missing required attribute: 'name'.","file":"docs/toc.md","line":2,"column":1}
 ---
 # Multiple leaf inlines in toc title
 inputs:
   docfx.yml:
-  docs/TOC.md: |
+  docs/toc.md: |
     # [Test <X> Y](a.md)
     # [Test <X> Y]
     # [Test **Title2** Title3](a.md)
@@ -933,7 +933,7 @@ outputs:
 # Expanded, MaintainContext and DisplayName
 inputs:
   docfx.yml:
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - href: https://github.com/docfx
       maintainContext: true
       expanded: true
@@ -947,10 +947,10 @@ outputs:
 noSingleFile: true
 inputs:
   docfx.yml:
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - href: a.md
       name: yml reference a
-  docs/TOC.md: |
+  docs/toc.md: |
     # [md reference a](a.md)
   docs/a.md:
 outputs:
@@ -958,7 +958,7 @@ outputs:
     {"_tocRel": "toc.json"}
   docs/toc.json:
   .errors.log: |
-    {"message_severity":"warning","code":"output-path-conflict","message":"Two or more files output to the same path 'docs/toc.json': 'docs/TOC.md', 'docs/TOC.yml'."}
+    {"message_severity":"warning","code":"output-path-conflict","message":"Two or more files output to the same path 'docs/toc.json': 'docs/toc.md', 'docs/toc.yml'."}
 ---
 # validate bookmarks in toc
 noSingleFile: true
@@ -966,7 +966,7 @@ inputs:
   docfx.yml:
   docs/a.md: |
     # title 1
-  docs/TOC.md: |
+  docs/toc.md: |
     # [link to title 1](a.md#title-1)
     # [link to title 2](a.md#title-2)
 outputs:
@@ -979,7 +979,7 @@ outputs:
       ]
     }
   .errors.log: |
-    {"message_severity":"warning","code":"bookmark-not-found","message":"Cannot find bookmark '#title-2' in 'docs/a.md', did you mean '#title-1'?","file":"docs/TOC.md","line":2,"column":3}
+    {"message_severity":"warning","code":"bookmark-not-found","message":"Cannot find bookmark '#title-2' in 'docs/a.md', did you mean '#title-1'?","file":"docs/toc.md","line":2,"column":3}
 ---
 # reference uid within link
 inputs:
@@ -989,7 +989,7 @@ inputs:
     title: Title from yaml header a
     uid: a
     ---
-  docs/TOC.md: |
+  docs/toc.md: |
     # [Title](xref:a#bookmark)
 outputs:
   docs/a.json:
@@ -1008,7 +1008,7 @@ inputs:
     title: Title from yaml header a
     uid: a
     ---
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - name: Uid Ref
       uid: a
 outputs:
@@ -1038,7 +1038,7 @@ inputs:
     title: b-frag title
     uid: b#frag
     ---
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - name: Uid Ref
       uid: a
     - name: Uid Ref 1
@@ -1058,7 +1058,7 @@ outputs:
       ]
     }
   .errors.log: |
-    {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'b'.","file":"docs/TOC.yml","line":6,"column":8}
+    {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'b'.","file":"docs/toc.yml","line":6,"column":8}
 ---
 # href reference first in yaml toc
 inputs:
@@ -1069,7 +1069,7 @@ inputs:
     uid: a
     ---
   docs/b.md:
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - name: Uid Ref
       uid: a
       href: b.md
@@ -1099,8 +1099,8 @@ outputs:
       ]
     }
   .errors.log: |
-    {"message_severity":"warning","code":"file-not-found","message":"Invalid file link: 'c.md'.","file":"docs/TOC.yml","line":12,"column":9}
-    {"message_severity":"warning","code":"file-not-found","message":"Invalid file link: 'c.md'.","file":"docs/TOC.yml","line":9,"column":9}
+    {"message_severity":"warning","code":"file-not-found","message":"Invalid file link: 'c.md'.","file":"docs/toc.yml","line":12,"column":9}
+    {"message_severity":"warning","code":"file-not-found","message":"Invalid file link: 'c.md'.","file":"docs/toc.yml","line":9,"column":9}
 ---
 # uid reference with monikers in yaml toc
 inputs:
@@ -1122,7 +1122,7 @@ inputs:
     monikerRange: netcore-1.1 || netcore-1.2
     uid: a
     ---
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - name: Uid Ref
       uid: a
 outputs:
@@ -1137,7 +1137,7 @@ outputs:
 # uid reference in markdown toc
 inputs:
   docfx.yml:
-  docs/TOC.md: |
+  docs/toc.md: |
     # @b
   docs/a.md: |
     ---
@@ -1174,7 +1174,7 @@ inputs:
     monikerRange: netcore-1.1 || netcore-1.2
     uid: b
     ---
-  docs/TOC.md: |
+  docs/toc.md: |
     # @b
 outputs:
   cb8e4dad4d4bcb3bdefdfe9f87ccffda/docs/a.json:
@@ -1193,10 +1193,10 @@ inputs:
     title: Title from yaml header a
     uid: a
     ---
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - name: TOC Ref
-      tocHref: a/TOC.yml
-  docs/a/TOC.yml: |
+      tocHref: a/toc.yml
+  docs/a/toc.yml: |
     - name: Uid Ref
       uid: a
 outputs:
@@ -1213,7 +1213,7 @@ outputs:
 # markdown toc using bad syntax(multiple inlines for one heading block)
 inputs:
   docfx.yml:
-  docs/TOC.md: |
+  docs/toc.md: |
     # @b abc
     # @b @a
     # [Title X](a.md) bcd
@@ -1236,19 +1236,19 @@ outputs:
   docs/a.json:
   docs/b.json:
   .errors.log: |
-    {"message_severity":"error","code":"invalid-toc-syntax","message":"The toc syntax is invalid, *","file":"docs/TOC.md","line":1,"column":1}
-    {"message_severity":"error","code":"invalid-toc-syntax","message":"The toc syntax is invalid, *","file":"docs/TOC.md","line":2,"column":1}
-    {"message_severity":"error","code":"invalid-toc-syntax","message":"The toc syntax is invalid, *","file":"docs/TOC.md","line":3,"column":1}
-    {"message_severity":"error","code":"invalid-toc-syntax","message":"The toc syntax is invalid, *","file":"docs/TOC.md","line":4,"column":1}
-    {"message_severity":"error","code":"invalid-toc-syntax","message":"The toc syntax is invalid, *","file":"docs/TOC.md","line":5,"column":1}
-    {"message_severity":"error","code":"invalid-toc-syntax","message":"The toc syntax is invalid, *","file":"docs/TOC.md","line":6,"column":1}
-    {"message_severity":"error","code":"invalid-toc-syntax","message":"The toc syntax is invalid, *","file":"docs/TOC.md","line":7,"column":1}
-    {"message_severity":"error","code":"invalid-toc-syntax","message":"The toc syntax is invalid, *","file":"docs/TOC.md","line":8,"column":1}
+    {"message_severity":"error","code":"invalid-toc-syntax","message":"The toc syntax is invalid, *","file":"docs/toc.md","line":1,"column":1}
+    {"message_severity":"error","code":"invalid-toc-syntax","message":"The toc syntax is invalid, *","file":"docs/toc.md","line":2,"column":1}
+    {"message_severity":"error","code":"invalid-toc-syntax","message":"The toc syntax is invalid, *","file":"docs/toc.md","line":3,"column":1}
+    {"message_severity":"error","code":"invalid-toc-syntax","message":"The toc syntax is invalid, *","file":"docs/toc.md","line":4,"column":1}
+    {"message_severity":"error","code":"invalid-toc-syntax","message":"The toc syntax is invalid, *","file":"docs/toc.md","line":5,"column":1}
+    {"message_severity":"error","code":"invalid-toc-syntax","message":"The toc syntax is invalid, *","file":"docs/toc.md","line":6,"column":1}
+    {"message_severity":"error","code":"invalid-toc-syntax","message":"The toc syntax is invalid, *","file":"docs/toc.md","line":7,"column":1}
+    {"message_severity":"error","code":"invalid-toc-syntax","message":"The toc syntax is invalid, *","file":"docs/toc.md","line":8,"column":1}
 ---
 # more than 6 leading count of `#`
 inputs:
   docfx.yml:
-  docs/TOC.md: |
+  docs/toc.md: |
     ################### [19 leading count](a.md)
     #################### [20 leading count](a.md)
   docs/a.md:
@@ -1260,7 +1260,7 @@ outputs:
 # toc with some unknown fields
 inputs:
   docfx.yml:
-  docs/TOC.yml: |
+  docs/toc.yml: |
     items:
       - name: test
         href: a.md
@@ -1275,9 +1275,9 @@ outputs:
 # respects user input _tocRel
 inputs:
   docfx.yml:
-  docs/f1/TOC.md: |
+  docs/f1/toc.md: |
     # [File Reference](../index.md)
-  docs/f2/TOC.md: |
+  docs/f2/toc.md: |
     # Nothing here
   docs/index.md: |
     ---
@@ -1294,14 +1294,14 @@ inputs:
   docfx.yml: |
     rules:
       invalid-toc-level: warning
-  docs/TOC.md: |
+  docs/toc.md: |
     # level 1
     ### level 3
     #### level 4
     ## level 2
 outputs:
   .errors.log: |
-    {"message_severity":"warning","code":"invalid-toc-level","message":"The toc level can't be skipped from 1 to 3.","file":"docs/TOC.md","line":2,"column":1}
+    {"message_severity":"warning","code":"invalid-toc-level","message":"The toc level can't be skipped from 1 to 3.","file":"docs/toc.md","line":2,"column":1}
   docs/toc.json: |
     {
       "items": [{
@@ -1327,7 +1327,7 @@ inputs:
       ]
     }
   docs/b.md:
-  docs/TOC.yml: |
+  docs/toc.yml: |
     - name: item with children
       href: /a
       items:
@@ -1371,7 +1371,7 @@ outputs:
 # Generate metadata dependency for PR comment preview link
 inputs:
   docfx.yml:
-  TOC.yml: |
+  toc.yml: |
     - name: a
       href: a.md
   a.md:
@@ -1381,7 +1381,7 @@ outputs:
   .dependencymap.json: |
     {
       "dependencies": {
-        "a.md": [{ "source": "TOC.yml", "type": "metadata" }]
+        "a.md": [{ "source": "toc.yml", "type": "metadata" }]
       }
     }
 ---
@@ -1392,7 +1392,7 @@ repos:
       docfx.yml: |
         outputType: Json
         template: https://docs.com/theme
-      TOC.yml: |
+      toc.yml: |
         - name: a
           href: a.md
       a.md:
@@ -1417,7 +1417,7 @@ repos:
       docfx.yml: |
         outputType: PageJson
         template: https://docs.com/theme
-      TOC.yml: |
+      toc.yml: |
         - name: a
           href: a.md
       a.md:

--- a/docs/specs/validation/metadata-validation.yml
+++ b/docs/specs/validation/metadata-validation.yml
@@ -350,7 +350,7 @@ inputs:
       author: dotnet-bot
       title: a
       description: a
-  docs/TOC.md:
+  docs/toc.md:
     # [Index](index.md)
   _themes/ContentTemplate/schemas/NetType.schema.json: |
     {

--- a/docs/specs/validation/publish-url-validation.yml
+++ b/docs/specs/validation/publish-url-validation.yml
@@ -45,7 +45,7 @@ inputs:
     Moniker: netcore-1.0
   v2/folder1/folder2/a.md: |
     Moniker: netcore-2.0
-  folder0/folder1/folder2/TOC.md:
+  folder0/folder1/folder2/toc.md:
   folder0/b.md: '![](folder1/folder2/image.png)'
   folder0/folder1/folder2/image.png:
 outputs:
@@ -107,7 +107,7 @@ inputs:
     Moniker: netcore-1.0
   v2/duplicatedword/folder1/DuplicatedWord.md: |
     Moniker: netcore-2.0
-  folder0/duplicatedword/duplicatedword/TOC.md:
+  folder0/duplicatedword/duplicatedword/toc.md:
   folder0/duplicatedword/duplicatedword/image.png:
   folder0/duplicated-base-path/docs/a.md:
 outputs:

--- a/docs/specs/validation/toc-breadcrumb-validation.yml
+++ b/docs/specs/validation/toc-breadcrumb-validation.yml
@@ -11,7 +11,7 @@ inputs:
         "rules": [
           {
             "type": "TocDeprecated",
-            "message": "Markdown TOC files are deprecated. Convert to a YAML TOC.",
+            "message": "Markdown TOC files are deprecated. Convert to a YAML toc.",
             "code": "toc-deprecated",
             "severity": "SUGGESTION",
             "contentTypes": ["toc"]
@@ -19,13 +19,13 @@ inputs:
         ]
       }
     }
-  a/TOC.md:
-  b/TOC.md:
-  c/TOC.yml:
+  a/toc.md:
+  b/toc.md:
+  c/toc.yml:
 outputs:
   .errors.log: |
-    {"message_severity":"suggestion","code":"toc-deprecated","message":"Markdown TOC files are deprecated. Convert to a YAML TOC.","file":"a/TOC.md","line":0,"end_line":0,"column":0,"end_column":0}
-    {"message_severity":"suggestion","code":"toc-deprecated","message":"Markdown TOC files are deprecated. Convert to a YAML TOC.","file":"b/TOC.md","line":0,"end_line":0,"column":0,"end_column":0}
+    {"message_severity":"suggestion","code":"toc-deprecated","message":"Markdown TOC files are deprecated. Convert to a YAML toc.","file":"a/toc.md","line":0,"end_line":0,"column":0,"end_column":0}
+    {"message_severity":"suggestion","code":"toc-deprecated","message":"Markdown TOC files are deprecated. Convert to a YAML toc.","file":"b/toc.md","line":0,"end_line":0,"column":0,"end_column":0}
   a/toc.json:
   b/toc.json:
   c/toc.json:
@@ -42,7 +42,7 @@ inputs:
         "rules": [
           {
             "type": "TocEntryDuplicated",
-            "message": "Article is referenced in more than one TOC node: {0}. Each article can only be referenced once in a TOC.",
+            "message": "Article is referenced in more than one TOC node: {0}. Each article can only be referenced once in a toc.",
             "code": "toc-entry-duplicated",
             "severity": "SUGGESTION",
             "contentTypes": ["toc"]
@@ -52,7 +52,7 @@ inputs:
     }
   path/a.md:
   path/b.md:
-  TOC.yml: |
+  toc.yml: |
     - name: a
       href: path/a.md
     - name: b
@@ -61,7 +61,7 @@ inputs:
       href: path/a.md
 outputs:
   .errors.log: |
-    {"message_severity":"suggestion","code":"toc-entry-duplicated","message":"Article is referenced in more than one TOC node: a.md. Each article can only be referenced once in a TOC.","file":"TOC.yml","line":0,"end_line":0,"column":0,"end_column":0}
+    {"message_severity":"suggestion","code":"toc-entry-duplicated","message":"Article is referenced in more than one TOC node: a.md. Each article can only be referenced once in a toc.","file":"toc.yml","line":0,"end_line":0,"column":0,"end_column":0}
   toc.json:
   path/a.json:
   path/b.json:
@@ -88,7 +88,7 @@ inputs:
         ]
       }
     }
-  bread/TOC.yml: |
+  bread/toc.yml: |
     - name: a
       href: /a
     - name: b
@@ -97,7 +97,7 @@ inputs:
       href: /c
 outputs:
   .errors.log: |
-    {"message_severity":"suggestion","code":"toc-breadcrumb-link-external","message":"External link: http://www.msn.com. TOC and breadcrumb links can’t be to pages outside of Docs.","file":"bread/TOC.yml","line":3,"end_line":3,"column":3,"end_column":3}
+    {"message_severity":"suggestion","code":"toc-breadcrumb-link-external","message":"External link: http://www.msn.com. TOC and breadcrumb links can’t be to pages outside of Docs.","file":"bread/toc.yml","line":3,"end_line":3,"column":3,"end_column":3}
   bread/toc.json:
 ---
 #TOC validation - toc-missing
@@ -114,7 +114,7 @@ inputs:
         "rules": [
           {
             "type": "TocMissing",
-            "message": "Article is not referenced from a table of contents. Every article must be in a TOC.",
+            "message": "Article is not referenced from a table of contents. Every article must be in a toc.",
             "code": "toc-missing",
             "severity": "suggestion",
             "contentTypes": ["conceptual", "toc"]
@@ -124,12 +124,12 @@ inputs:
     }
   a.md:
   b.md:
-  TOC.yml: |
+  toc.yml: |
     - name: a
       href: a.md
 outputs:
   .errors.log: |
-    {"message_severity":"suggestion","log_item_type":"user","code":"toc-missing","message":"Article is not referenced from a table of contents. Every article must be in a TOC.","file":"b.md","line":0,"end_line":0,"column":0,"end_column":0}
+    {"message_severity":"suggestion","log_item_type":"user","code":"toc-missing","message":"Article is not referenced from a table of contents. Every article must be in a toc.","file":"b.md","line":0,"end_line":0,"column":0,"end_column":0}
   a.json:
   b.json:
   toc.json:
@@ -144,7 +144,7 @@ inputs:
       "rules": [
         {
           "type": "TocEntryDuplicated",
-          "message": "Article is referenced in more than one TOC node: {0}. Each article can only be referenced once in a TOC.",
+          "message": "Article is referenced in more than one TOC node: {0}. Each article can only be referenced once in a toc.",
           "code": "toc-entry-duplicated",
           "severity": "SUGGESTION",
           "contentTypes": ["toc"]
@@ -152,7 +152,7 @@ inputs:
       ]
     }
     }
-  TOC.yml: |
+  toc.yml: |
     items:
     - name: 1
       href: a.md
@@ -193,4 +193,4 @@ outputs:
   f.json:
   toc.json:
   .errors.log: |
-    {"message_severity":"suggestion","code":"toc-entry-duplicated","message":"Article is referenced in more than one TOC node: a.md, b.md, c.md, d.md, e.md, f.md. Each article can only be referenced once in a TOC.","file":"TOC.yml","line":0,"end_line":0,"column":0,"end_column":0,"log_item_type":"user"}
+    {"message_severity":"suggestion","code":"toc-entry-duplicated","message":"Article is referenced in more than one TOC node: a.md, b.md, c.md, d.md, e.md, f.md. Each article can only be referenced once in a toc.","file":"toc.yml","line":0,"end_line":0,"column":0,"end_column":0,"log_item_type":"user"}

--- a/docs/specs/xref.yml
+++ b/docs/specs/xref.yml
@@ -1612,7 +1612,7 @@ inputs:
     ### YamlMime:TestData
     uid: a
     name: name 1.0
-  docs/v1/TOC.yml: |
+  docs/v1/toc.yml: |
     items:
       - name: node
         uid: a
@@ -1623,7 +1623,7 @@ inputs:
     ### YamlMime:TestData
     uid: a
     name: name 2.0
-  docs/v2/TOC.yml: |
+  docs/v2/toc.yml: |
     items:
       - name: node
         uid: a
@@ -2154,14 +2154,14 @@ outputs:
 # make sure no-loc attribute won't be added to toc (plain text content)
 inputs:
   docfx.yml:
-  docs/TOC.md: |
+  docs/toc.md: |
     # @b
 outputs: 
   docs/toc.json: |
     {"items":[{"uid":"b"}],"metadata":{},"schema":"toc"}
   .errors.log: |
-    {"message_severity":"warning","code":"missing-attribute","message":"Missing required attribute: 'name'.","file":"docs/TOC.md"}
-    {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'b'.","file":"docs/TOC.md"}
+    {"message_severity":"warning","code":"missing-attribute","message":"Missing required attribute: 'name'.","file":"docs/toc.md"}
+    {"message_severity":"warning","code":"xref-not-found","message":"Cross reference not found: 'b'.","file":"docs/toc.md"}
 ---
 # exclude redirected files from xref map
 noSingleFile: true

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,0 +1,2 @@
+- name: Getting Started
+  href: getting-started.md

--- a/src/docfx/build/context/BuildScope.cs
+++ b/src/docfx/build/context/BuildScope.cs
@@ -98,7 +98,7 @@ internal class BuildScope
             return ContentType.Resource;
         }
 
-        if (name.Equals("TOC", PathUtility.PathComparison))
+        if (name.Equals("toc", PathUtility.PathComparison))
         {
             return ContentType.Toc;
         }

--- a/src/docfx/build/toc/ServicePageGenerator.cs
+++ b/src/docfx/build/toc/ServicePageGenerator.cs
@@ -170,7 +170,7 @@ internal class ServicePageGenerator
 
     private string? GetUidFromSplitTOC(string childHref, string referenceTOCFullPath)
     {
-        childHref = Path.Combine(childHref, "TOC.yml");
+        childHref = Path.Combine(childHref, "toc.yml");
         var childHrefFullPath = Path.Combine(referenceTOCFullPath, childHref);
         var childHrefRelativeToDocset = Path.GetRelativePath(_docsetPath, childHrefFullPath);
 

--- a/src/docfx/build/toc/TocLoader.cs
+++ b/src/docfx/build/toc/TocLoader.cs
@@ -23,7 +23,7 @@ internal class TocLoader
 
     private readonly MemoryCache<FilePath, Watch<(TocNode, List<FilePath>, List<FilePath>, List<FilePath>)>> _cache = new();
 
-    private static readonly string[] s_tocFileNames = new[] { "TOC.md", "TOC.json", "TOC.yml" };
+    private static readonly string[] s_tocFileNames = new[] { "toc.md", "toc.json", "toc.yml" };
 
     private static readonly AsyncLocal<ImmutableStack<FilePath>> s_recursionDetector = new();
 

--- a/src/docfx/build/toc/TocMap.cs
+++ b/src/docfx/build/toc/TocMap.cs
@@ -75,7 +75,7 @@ internal class TocMap
     /// Return the nearest toc relative to the current file
     /// "near" means less subdirectory count
     /// when subdirectory counts are same, "near" means less parent directory count
-    /// e.g. "../../a/TOC.md" is nearer than "b/c/TOC.md".
+    /// e.g. "../../a/toc.md" is nearer than "b/c/toc.md".
     /// when the file is not referenced, return only toc in the same or higher folder level.
     /// </summary>
     internal FilePath? FindNearestToc(FilePath file)
@@ -282,7 +282,7 @@ internal class TocMap
                 continue;
             }
 
-            var newNodeFilePath = new PathString(Path.Combine(Path.GetDirectoryName(file.Path) ?? "", $"_splitted/{name}/TOC.yml"));
+            var newNodeFilePath = new PathString(Path.Combine(Path.GetDirectoryName(file.Path) ?? "", $"_splitted/{name}/toc.yml"));
             var newNodeFile = FilePath.Generated(newNodeFilePath);
 
             _input.AddGeneratedContent(newNodeFile, new JArray { newNodeToken }, null);

--- a/src/docfx/data/new/conceptual/TOC.yml
+++ b/src/docfx/data/new/conceptual/TOC.yml
@@ -1,2 +1,0 @@
-- name: Getting Started
-  href: getting-started.md

--- a/src/docfx/data/new/conceptual/toc.yml
+++ b/src/docfx/data/new/conceptual/toc.yml
@@ -1,0 +1,2 @@
+- name: Getting Started
+  href: getting-started.md

--- a/src/docfx/template/JsonSchemaProvider.cs
+++ b/src/docfx/template/JsonSchemaProvider.cs
@@ -104,7 +104,7 @@ internal class JsonSchemaProvider
     private RenderType GetTocRenderType()
     {
         // Refer to https://ceapex.visualstudio.com/Engineering/_workitems/edit/537091
-        // There is a TOC.schema.json file existing in templates.docs.msft repo whose 'renderType' is set to 'component'
+        // There is a toc.schema.json file existing in templates.docs.msft repo whose 'renderType' is set to 'component'
         // (https://github.com/microsoft/templates.docs.msft/blob/master/ContentTemplate/schemas/Toc.schema.json#L7)
         // This will break the PDF process because PDF asks it to be 'content' (so that docfx can generate 'toc.html' which is necessary for building PDF)
         // To avoid unexpected breaking PDF process through sync templates, special logic dealing with PDF cases goes first.

--- a/test/docfx.Test/build/TocTest.cs
+++ b/test/docfx.Test/build/TocTest.cs
@@ -10,29 +10,29 @@ public static class TocTest
     [Theory]
 
     // same level
-    [InlineData(new[] { "TOC.md" }, "b.md", "TOC.md", "TOC.md")]
-    [InlineData(new[] { "TOC.md", "a/TOC.md" }, "b.md", "TOC.md", "TOC.md")]
-    [InlineData(new[] { "TOC.md", "a/TOC.md" }, "a/b.md", "a/TOC.md", "a/TOC.md")]
-    [InlineData(new[] { "b/TOC.md", "a/TOC.md" }, "a/b.md", "a/TOC.md", "a/TOC.md")]
-    [InlineData(new[] { "TOC.md", "a/b/TOC.md" }, "a/b/b.md", "a/b/TOC.md", "a/b/TOC.md")]
-    [InlineData(new[] { "c/a/d/TOC.md", "c/a/TOC.md" }, "c/a/d/b.md", "c/a/d/TOC.md", "c/a/d/TOC.md")]
+    [InlineData(new[] { "toc.md" }, "b.md", "toc.md", "toc.md")]
+    [InlineData(new[] { "toc.md", "a/toc.md" }, "b.md", "toc.md", "toc.md")]
+    [InlineData(new[] { "toc.md", "a/toc.md" }, "a/b.md", "a/toc.md", "a/toc.md")]
+    [InlineData(new[] { "b/toc.md", "a/toc.md" }, "a/b.md", "a/toc.md", "a/toc.md")]
+    [InlineData(new[] { "toc.md", "a/b/toc.md" }, "a/b/b.md", "a/b/toc.md", "a/b/toc.md")]
+    [InlineData(new[] { "c/a/d/toc.md", "c/a/toc.md" }, "c/a/d/b.md", "c/a/d/toc.md", "c/a/d/toc.md")]
 
     // next level(nearest)
-    [InlineData(new[] { "b/c/TOC.md", "a/TOC.md" }, "b.md", "a/TOC.md", null)]
-    [InlineData(new[] { "b/TOC.md", "a/b/TOC.md" }, "b.md", "b/TOC.md", null)]
+    [InlineData(new[] { "b/c/toc.md", "a/toc.md" }, "b.md", "a/toc.md", null)]
+    [InlineData(new[] { "b/toc.md", "a/b/toc.md" }, "b.md", "b/toc.md", null)]
 
     // order by folder name
-    [InlineData(new[] { "b/c/TOC.md", "b/d/TOC.md" }, "b.md", "b/c/TOC.md", null)]
+    [InlineData(new[] { "b/c/toc.md", "b/d/toc.md" }, "b.md", "b/c/toc.md", null)]
 
     // up level(nearest)
-    [InlineData(new[] { "TOC.md", "a/TOC.md" }, "b/b.md", "TOC.md", "TOC.md")]
-    [InlineData(new[] { "TOC.md", "c/a/TOC.md" }, "c/a/d/b.md", "c/a/TOC.md", "c/a/TOC.md")]
-    [InlineData(new[] { "c/b/TOC.md", "c/a/TOC.md" }, "c/a/d/b.md", "c/a/TOC.md", "c/a/TOC.md")]
+    [InlineData(new[] { "toc.md", "a/toc.md" }, "b/b.md", "toc.md", "toc.md")]
+    [InlineData(new[] { "toc.md", "c/a/toc.md" }, "c/a/d/b.md", "c/a/toc.md", "c/a/toc.md")]
+    [InlineData(new[] { "c/b/toc.md", "c/a/toc.md" }, "c/a/d/b.md", "c/a/toc.md", "c/a/toc.md")]
 
     // mix level(nearest)
-    [InlineData(new[] { "c/b/TOC.md", "TOC.md" }, "c/a.md", "TOC.md", "TOC.md")]
-    [InlineData(new[] { "c/b/TOC.md", "TOC.md" }, "c/b/a.md", "c/b/TOC.md", "c/b/TOC.md")]
-    [InlineData(new[] { "c/b/TOC.md", "c/d/e/TOC.md" }, "c/f/h/a.md", "c/b/TOC.md", null)]
+    [InlineData(new[] { "c/b/toc.md", "toc.md" }, "c/a.md", "toc.md", "toc.md")]
+    [InlineData(new[] { "c/b/toc.md", "toc.md" }, "c/b/a.md", "c/b/toc.md", "c/b/toc.md")]
+    [InlineData(new[] { "c/b/toc.md", "c/d/e/toc.md" }, "c/f/h/a.md", "c/b/toc.md", null)]
 
     public static void FindNearestToc(string[] tocs, string file, string expectedTocPath, string expectedOrphanTocPath)
     {


### PR DESCRIPTION
This only affects linux builds. Since the `toc.yml` file generated by dotnet reference pipeline is all lowercase, turning the toc file name to lower makes linux build pass for .NET API reference.