### PR TITLE
Remove dead code in TocDocumentProcessorBase

### DIFF
--- a/src/Microsoft.DocAsCode.Build.TableOfContents/TocDocumentProcessorBase.cs
+++ b/src/Microsoft.DocAsCode.Build.TableOfContents/TocDocumentProcessorBase.cs
@@ -23,7 +23,6 @@ namespace Microsoft.DocAsCode.Build.TableOfContents
             var filePath = file.FullPath;
             var toc = TocHelper.LoadSingleToc(filePath);
 
-            var repoDetail = GitUtility.TryGetFileDetail(filePath);
             var displayLocalPath = PathUtility.MakeRelativePath(EnvironmentContext.BaseDirectory, file.FullPath);
 
             // Apply metadata to TOC


### PR DESCRIPTION
I noticed what appears to be dead code in TocDocumentProcessorBase, if it's intentional to validate that TryGetFiledDetails succeeds we remove setting repoDetail and put a comment.