### PR TITLE
Dedupe xref tags to avoid duplicated API calls

### DIFF
--- a/src/docfx/config/ops/OpsConfigAdapter.cs
+++ b/src/docfx/config/ops/OpsConfigAdapter.cs
@@ -80,7 +80,8 @@ internal class OpsConfigAdapter
         var branch = queries["branch"] ?? "";
         var locale = queries["locale"] ?? "";
         var xrefEndpoint = queries["xref_endpoint"] ?? "";
-        var xrefQueryTags = (queries["xref_query_tags"] ?? "").Split(',', StringSplitOptions.RemoveEmptyEntries).ToList();
+        var xrefQueryTags =
+            (queries["xref_query_tags"] ?? "").Split(',', StringSplitOptions.RemoveEmptyEntries).ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         var getDocsetInfo = s_docsetInfoCache.GetOrAdd(repository, new Lazy<Task<string>>(() => _opsAccessor.GetDocsetInfo(repository)));
         var docsetInfo = await getDocsetInfo.Value;


### PR DESCRIPTION
[AB#552940](https://dev.azure.com/ceapex/Engineering/_workitems/edit/552940)

Not found the root cause of file read conflicting yet, this change can avoid duplicated API calls of the same XRef tag.