### PR TITLE
Fix docfx serve crash

### DIFF
--- a/src/docfx/serve/Serve.cs
+++ b/src/docfx/serve/Serve.cs
@@ -92,7 +92,7 @@ internal static class Serve
 
         foreach (var publishFile in publishFiles)
         {
-            var directory = Path.GetDirectoryName(publishFile);
+            var directory = Path.GetDirectoryName(Path.GetFullPath(publishFile));
             PrintServeDirectory(directory);
             app.UseFileServer(new FileServerOptions
             {


### PR DESCRIPTION
Fixes this exception on mac

```
yufeih@Yufeis-MacBook-Pro docs % docfx serve .
Serving ./_site
Unhandled exception: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.ArgumentException: The path must be absolute. (Parameter 'root')
   at Microsoft.Extensions.FileProviders.PhysicalFileProvider..ctor(String root, ExclusionFilters filters)
   at Microsoft.Docs.Build.Serve.ServeStaticFiles(IApplicationBuilder app, CommandLineOptions options) in D:\a\docfx\docfx\src\docfx\serve\Serve.cs:line 97
   at Microsoft.Docs.Build.Serve.Run(CommandLineOptions options, Package package, Action`1 onUrl) in D:\a\docfx\docfx\src\docfx\serve\Serve.cs:line 36
   at Microsoft.Docs.Build.Docfx.<>c__DisplayClass5_0.<ServeCommand>b__0(CommandLineOptions options) in D:\a\docfx\docfx\src\docfx\cli\Docfx.cs:line 120
   at Microsoft.Docs.Build.Docfx.<>c__DisplayClass6_0.<CreateCommand>b__0(CommandLineOptions options) in D:\a\docfx\docfx\src\docfx\cli\Docfx.cs:line 149
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Span`1& arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Delegate.DynamicInvokeImpl(Object[] args)
   at System.Delegate.DynamicInvoke(Object[] args)
   at System.CommandLine.Invocation.ModelBindingCommandHandler.InvokeAsync(InvocationContext context)
   at System.CommandLine.Invocation.InvocationPipeline.<>c__DisplayClass4_0.<<BuildInvocationChain>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<UseParseErrorReporting>b__21_0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass16_0.<<UseHelp>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass25_0.<<UseVersionOption>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass23_0.<<UseTypoCorrections>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<UseSuggestDirective>b__22_0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<UseParseDirective>b__20_0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<UseDebugDirective>b__11_0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<RegisterWithDotnetSuggest>b__10_0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass14_0.<<UseExceptionHandler>b__0>d.MoveNext()
```