### PR TITLE
no longer release packages to ADO

### DIFF
--- a/azure-pipelines-master.yml
+++ b/azure-pipelines-master.yml
@@ -219,7 +219,6 @@ steps:
   env:
     NUGETAPIKEY: $(NugetAPIKey)
     CHOCO_TOKEN: $(ChocoleteyPublishToken)
-    AZDEVOPSPAT: $(AzureDevOpsFeedPAT)
     TOKEN: $(ServiceAccountGithubToken)
 
 - task: ComponentGovernanceComponentDetection@0

--- a/azure-pipelines-stable.yml
+++ b/azure-pipelines-stable.yml
@@ -169,8 +169,6 @@ steps:
     failOnStderr: true
     filePath: 'tools\Deployment\deploy.ps1'
     arguments: '-targets pack,release'
-  env:
-    AZDEVOPSPAT: $(AzureDevOpsFeedPAT)
 
 - task: PublishBuildArtifacts@1
   condition: always()

--- a/tools/Deployment/config.ps1
+++ b/tools/Deployment/config.ps1
@@ -17,13 +17,6 @@ $docfx = @{
     docfxJson = "$homeDir\Documentation\docfx.json"
 }
 
-$azdevops = @{
-    ppeName = "docs-build-v2-ppe"
-    ppeUrl = "https://docfx.pkgs.visualstudio.com/docfx/_packaging/docs-build-v2-ppe/nuget/v3/index.json"
-    prodName = "docs-build-v2-prod"
-    prodUrl = "https://docfx.pkgs.visualstudio.com/docfx/_packaging/docs-build-v2-prod/nuget/v3/index.json"
-}
-
 $choco = @{
     homeDir = "$homeDir\src\nuspec\chocolatey\docfx"
     nuspec = "$homeDir\src\nuspec\chocolatey\docfx\docfx.nuspec"

--- a/tools/Deployment/deploy-tasks.ps1
+++ b/tools/Deployment/deploy-tasks.ps1
@@ -60,12 +60,6 @@ function PublishToNuget {
     }
 }
 
-function PublishToAzureDevOps {
-    param($nugetCommand, $sourceName, $sourceUrl, $artifactsFolder, $token)
-    & $nugetCommand sources add -Name $sourceName -Source $sourceUrl -Username anything -Password $token
-    PublishToNuget $nugetCommand $sourceUrl $artifactsFolder
-}
-
 function UpdateChocoConfig {
     param($chocoScriptPath, $chocoNuspecPath, $version, $hash)
     $chocoScript = Get-Content $chocoScriptPath -Encoding UTF8 -Raw

--- a/tools/Deployment/deploy.ps1
+++ b/tools/Deployment/deploy.ps1
@@ -69,16 +69,12 @@ try {
                 if (IsReleaseNoteVersionChanged $gitCommand $docfx.releaseNotePath) 
                 {
                     PackAssetZip $docfx.releaseFolder $docfx.assetZipPath
-                    PublishToAzureDevOps $nugetCommand $azdevops.prodName $azdevops.prodUrl $docfx.artifactsFolder $env:AZDEVOPSPAT
                     PublishToNuget $nugetCommand $nuget."nuget.org" $docfx.artifactsFolder $env:NUGETAPIKEY
                     PublishToGithub $docfx.assetZipPath $docfx.releaseNotePath $docfx.sshRepoUrl $env:TOKEN
                     PublishToChocolatey $chocoCommand $docfx.releaseNotePath $docfx.assetZipPath $choco.chocoScript $choco.nuspec $choco.homeDir $env:CHOCO_TOKEN
                 } else {
                     Write-Host "`$releaseNotePath $($docfx.releaseNotePath) hasn't been changed. Ignore to publish package." -ForegroundColor Yellow
                 }
-            } else {
-                # Always do publish for dev release
-                PublishToAzureDevOps $nugetCommand $azdevops.ppeName $azdevops.ppeUrl $docfx.artifactsFolder $env:AZDEVOPSPAT
             }
         }
     }


### PR DESCRIPTION
Stop releasing packages to ADO as it seems the usage of ADO packages is very limited nowadays.

Related: [AB#396814](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/396814)