### PR TITLE
run CodeQL on windows-2019

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,2 +1,4 @@
 paths-ignore:
   - '**/docfx.vendor.js'
+
+runs-on: windows-2019

--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,4 +1,2 @@
 paths-ignore:
   - '**/docfx.vendor.js'
-
-runs-on: windows-2019

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: CodeQL
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     permissions:
       security-events: write


### PR DESCRIPTION
This is to fix the issue that CodeQL cannot run on Windows 11 or Windows Server 2022.
![image](https://user-images.githubusercontent.com/2174068/155251840-57a40749-0888-493c-bad0-1f1ba981ce42.png)
