### PR TITLE
[Fix] Correct link type to external when leading host is not removed

### DIFF
--- a/src/docfx/build/link/LinkResolver.cs
+++ b/src/docfx/build/link/LinkResolver.cs
@@ -142,7 +142,6 @@ internal class LinkResolver
         ValidateLink(inclusionRoot, linkNode);
         if (linkType == LinkType.External)
         {
-            var resolvedHref = _config.RemoveHostName ? UrlUtility.RemoveLeadingHostName(href, _config.HostName) : href;
             if (_config.TrustedDomains.TryGetValue(tagName, out var domains) && !domains.IsTrusted(href, out var untrustedDomain))
             {
                 if (tagName == "img")
@@ -156,7 +155,13 @@ internal class LinkResolver
                 return (errors, "", fragment, LinkType.AbsolutePath, null, false);
             }
 
-            return (errors, resolvedHref, fragment, LinkType.AbsolutePath, null, false);
+            var resolvedHref = _config.RemoveHostName ? UrlUtility.RemoveLeadingHostName(href, _config.HostName) : href;
+            if (!string.Equals(href, resolvedHref, StringComparison.Ordinal))
+            {
+                linkType = LinkType.AbsolutePath;
+            }
+
+            return (errors, resolvedHref, fragment, linkType, null, false);
         }
 
         // Cannot resolve the file, leave href as is

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.4.1" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.2.0" />
-    <PackageReference Include="docs.validation" Version="1.0.1-rc-00122-31a09e6" />
+    <PackageReference Include="docs.validation" Version="1.0.1-rc-00134-de38ac5" />
     <PackageReference Include="DotLiquid" Version="2.2.595" />
     <PackageReference Include="Glob" Version="1.1.9" />
     <PackageReference Include="HtmlReaderWriter" Version="1.0.0-preview-0001-gcf3636c5d9" />
@@ -43,7 +43,7 @@
     <!-- This package was transitively referenced by OmniSharp server, stop propagating it to other projects by explicitly marking it as private assets -->
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.0.64" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.255" PrivateAssets="all" />
-    <PackageReference Include="docs.validation.analyzer" Version="1.0.1-rc-00122-31a09e6" PrivateAssets="all" />
+    <PackageReference Include="docs.validation.analyzer" Version="1.0.1-rc-00134-de38ac5" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
AB#563013

Discussed with @live1206, if the host is removed, it's AbsolutePath, otherwise, External.