### PR TITLE
Make docfx GitHub release immutable

### DIFF
--- a/azure-pipelines-master.yml
+++ b/azure-pipelines-master.yml
@@ -222,6 +222,13 @@ steps:
     AZDEVOPSPAT: $(AzureDevOpsFeedPAT)
     TOKEN: $(ServiceAccountGithubToken)
 
+- task: PublishBuildArtifacts@1
+  condition: always()
+  displayName: 'upload docfx.zip'
+  inputs:
+    pathtoPublish: 'Documentation\tutorial\artifacts'
+    artifactName: docfx-artifacts
+
 - task: ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))

--- a/azure-pipelines-stable.yml
+++ b/azure-pipelines-stable.yml
@@ -168,7 +168,7 @@ steps:
     pwsh: true
     failOnStderr: true
     filePath: 'tools\Deployment\deploy.ps1'
-    arguments: '-targets pack,release'
+    arguments: '-targets pack'
 
 - task: PublishBuildArtifacts@1
   condition: always()

--- a/tools/Deployment/config.ps1
+++ b/tools/Deployment/config.ps1
@@ -9,7 +9,6 @@ $docfx = @{
     targetFolder = "$homeDir\target"
     artifactsFolder = "$homeDir\artifacts"
     exe = "$homeDir\target\Release\docfx\docfx.exe"
-    account = "openpublishbuild"
     releaseNotePath = "$homeDir\RELEASENOTE.md"
     releaseFolder = "$homeDir\target\Release\docfx"
     assetZipPath = "$homeDir\Documentation\tutorial\artifacts\docfx.zip"
@@ -31,9 +30,4 @@ $git = @{
     name = "DocFX CI"
     email = "vscopbld@microsoft.com"
     message = "Update gh-pages"
-}
-
-$sync = @{
-    fromBranch = "dev"
-    targetBranch = "stable"
 }

--- a/tools/Deployment/deploy-tasks.ps1
+++ b/tools/Deployment/deploy-tasks.ps1
@@ -77,7 +77,7 @@ function UpdateChocoConfig {
 
 function PublishToChocolatey {
     param($chocoCommand, $releaseNotePath, $assetZipPath, $chocoScript, $chocoNuspecPath, $chocoHomeDir, $token)
-    Write-Host "Start publihsing to Chocolatey.."
+    Write-Host "Start publishing to Chocolatey.."
     $version = GetVersionFromReleaseNote $releaseNotePath
     $nupkgName = "docfx.$version.nupkg"
     $hash = ($assetZipPath | Get-FileHash -Algorithm SHA256).Hash.ToLower()
@@ -173,7 +173,7 @@ function PublishGithubRelease {
         }
     }
     if ($latestRelease.tag_name -eq $description.tag_name) {
-        throw "The release to create '$($description.tag_name)' has already existed on Github: '$($latestRelease.tag_name)' with id '$($latestRelease.id)'"
+        throw "The release to create '$($description.tag_name)' has already been created on Github: '$($latestRelease.tag_name)' with id '$($latestRelease.id)'"
     }
     Write-Host "Latest release is '$($latestRelease.tag_name)', creating new github release '$($description.tag_name)'.."
     $release = CreateGithubRelease $description $userAndRepo $headers
@@ -215,7 +215,7 @@ function PublishToGithub {
     $releaseDescription = GetReleaseDescription $releaseNotePath
     $releaseId = PublishGithubRelease $releaseDescription $userAndRepo $headers
     if ($releaseId) {
-        PublishGithubAssets $assetZipPath $releaseToUploadAsset.id $userAndRepo $headers
+        PublishGithubAssets $assetZipPath $releaseId $userAndRepo $headers
     } else {
         throw "Invalid github release id '$releaseId' for release '$($releaseDescription.tag_name)'"
     }

--- a/tools/Deployment/deploy-tasks.ps1
+++ b/tools/Deployment/deploy-tasks.ps1
@@ -33,6 +33,7 @@ function IsReleaseNoteVersionChanged {
     param($gitCommand, $releaseNotePath)
     $versionFromTag = GetCurrentVersionFromGitTag $gitCommand
     $versionFromReleaseNote = GetVersionFromReleaseNote $releaseNotePath
+    Write-Host "Version from tag is '$versionFromTag', version from release note is 'v$versionFromReleaseNote'"
     return ("v$versionFromReleaseNote".ToLower() -ne $versionFromTag.ToLower())
 }
 
@@ -42,6 +43,7 @@ function PackAssetZip {
     Add-Type -AssemblyName System.IO.Compression.FileSystem
     [System.AppContext]::SetSwitch('Switch.System.IO.Compression.ZipFile.UseBackslash', $false)
     try {
+        Write-Host "Start packing asset zip.."
         $zip = [System.IO.Compression.ZipFile]::Open($assetZipPath, 'update')
         Get-ChildItem "$releaseFolder\*" -File -Exclude '*.xml','*.pdb' | Foreach-Object {
             [System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile($zip, $_.FullName, (Split-Path $_.FullName -Leaf), [System.IO.Compression.CompressionLevel]::Optimal) | Out-Null
@@ -55,6 +57,7 @@ function PackAssetZip {
 
 function PublishToNuget {
     param($nugetCommand, $sourceUrl, $artifactsFolder, $apiKey = "anything")
+    Write-Host "Start publishing packages to $sourceUrl.."
     Get-ChildItem "$artifactsFolder/*.nupkg" -Recurse -Exclude "*.symbols.nupkg" | Foreach-Object -Parallel {
         & $using:nugetCommand push $_ $using:apiKey -Source $using:sourceUrl -SkipDuplicate
     }
@@ -80,9 +83,11 @@ function UpdateChocoConfig {
 
 function PublishToChocolatey {
     param($chocoCommand, $releaseNotePath, $assetZipPath, $chocoScript, $chocoNuspecPath, $chocoHomeDir, $token)
+    Write-Host "Start publihsing to Chocolatey.."
     $version = GetVersionFromReleaseNote $releaseNotePath
     $nupkgName = "docfx.$version.nupkg"
     $hash = ($assetZipPath | Get-FileHash -Algorithm SHA256).Hash.ToLower()
+    Write-Host "Use hash '$hash' for chocolatey package verification"
     UpdateChocoConfig $chocoScript $chocoNuspecPath $version $hash
 
     Push-Location $chocoHomeDir
@@ -148,19 +153,7 @@ function GetGithubLatestRelease {
         Uri = "$gitApiBaseUrl/repos/$($userAndRepo)/releases/latest"
         Headers = $headers
     }
-    return Invoke-WebRequest @params
-}
-
-function UpdateGithubRelease {
-    param($id, $description, $userAndRepo, $headers)
-    $params = @{
-        Method = "PATCH"
-        Uri = "$gitApiBaseUrl/repos/$($userAndRepo)/releases/$id"
-        Headers = $headers
-        Body = $description | ConvertTo-Json
-        ContentType = "application/json"
-    }
-    return Invoke-WebRequest @params
+    return Invoke-RestMethod @params
 }
 
 function CreateGithubRelease {
@@ -172,36 +165,25 @@ function CreateGithubRelease {
         Body = $description | ConvertTo-Json
         ContentType = "application/json"
     }
-    return Invoke-WebRequest @params
+    return Invoke-RestMethod @params
 }
 
 function PublishGithubRelease {
     param($description, $userAndRepo, $headers)
     try {
-        $latestReleaseInfo = GetGithubLatestRelease $userAndRepo $headers
+        Write-Host "Getting latest github release.."
+        $latestRelease = GetGithubLatestRelease $userAndRepo $headers
     } catch {
         if ($_.Exception.Response.StatusCode -ne 404) {
             throw "Get github latest release failed($($_.Exception.Response.StatusCode.value__)): $($_.ErrorDetails.Message)"
         }
     }
-    if ($latestReleaseInfo.Content) {
-        $latestRelease = $latestReleaseInfo.Content | ConvertFrom-Json
-        if ($latestRelease.tag_name -eq $description.tag_name) {
-            return UpdateGithubRelease $latestRelease.id $description $userAndRepo $headers
-        }
-        Write-host $latestRelease.tag_name
+    if ($latestRelease.tag_name -eq $description.tag_name) {
+        throw "The release to create '$($description.tag_name)' has already existed on Github: '$($latestRelease.tag_name)' with id '$($latestRelease.id)'"
     }
-    return CreateGithubRelease $description $userAndRepo $headers
-}
-
-function DeleteAssetByUrl {
-    param($assetUrl, $headers)
-    $params = @{
-        Method = "DELETE"
-        Uri = $assetUrl
-        Headers = $headers
-    }
-    Invoke-WebRequest @params
+    Write-Host "Latest release is '$($latestRelease.tag_name)', creating new github release '$($description.tag_name)'.."
+    $release = CreateGithubRelease $description $userAndRepo $headers
+    return $release.id
 }
 
 function UploadAsset {
@@ -217,25 +199,14 @@ function UploadAsset {
 }
 
 function PublishGithubAssets {
-    param($assetZipPath, $userAndRepo, $headers)  
+    param($assetZipPath, $releaseId, $userAndRepo, $headers)  
     $assetInfo = @{
         contentType = "application/zip"
         name = Split-Path $assetZipPath -leaf
         data = [System.IO.File]::ReadAllBytes($assetZipPath)
     }
-
-    $latestReleaseInfo = GetGithubLatestRelease $userAndRepo $headers
-    if ($latestReleaseInfo) {
-        $latestRelease = $latestReleaseInfo.Content | ConvertFrom-Json
-        $latestRelease.assets | Foreach-Object {
-            if ($_.name -eq $assetInfo.name) {
-                DeleteAssetByUrl $_.url $headers
-            }
-        }
-        UploadAsset $latestRelease.id $assetInfo $userAndRepo $headers
-    } else {
-        throw "Cannot find any release to upload assets."
-    }
+    Write-Host "Uploading asset to release '$releaseId'.."
+    UploadAsset $releaseId $assetInfo $userAndRepo $headers
 }
 
 function PublishToGithub {
@@ -248,6 +219,10 @@ function PublishToGithub {
     }
 
     $releaseDescription = GetReleaseDescription $releaseNotePath
-    PublishGithubRelease $releaseDescription $userAndRepo $headers
-    PublishGithubAssets $assetZipPath $userAndRepo $headers
+    $releaseId = PublishGithubRelease $releaseDescription $userAndRepo $headers
+    if ($releaseId) {
+        PublishGithubAssets $assetZipPath $releaseToUploadAsset.id $userAndRepo $headers
+    } else {
+        throw "Invalid github release id '$releaseId' for release '$($releaseDescription.tag_name)'"
+    }
 }


### PR DESCRIPTION
[AB#546544](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/546544)
1. Upload docfx.zip to github release with the release id that returned by github create release api
2. Upload docfx.zip to azure pipeline artifacts for backup when master release
3. Remove the logic that updates existing github release. Throw exception if the release exists
4. Add some log to make azure pipeline log more readable and help troubleshooting