### PR TITLE
add link telemetry

### DIFF
--- a/src/docfx/build/link/LinkResolver.cs
+++ b/src/docfx/build/link/LinkResolver.cs
@@ -113,6 +113,7 @@ internal class LinkResolver
 
         if (!string.IsNullOrEmpty(link))
         {
+            Telemetry.TrackLink(linkType.ToString());
             _fileLinkMapBuilder.AddFileLink(inclusionRoot, referencingFile, link, href.Source);
         }
 

--- a/src/docfx/build/xref/XrefResolver.cs
+++ b/src/docfx/build/xref/XrefResolver.cs
@@ -105,6 +105,7 @@ internal class XrefResolver
 
         query = queries.AllKeys.Length == 0 ? "" : "?" + string.Join('&', queries);
         var fileLink = UrlUtility.MergeUrl(xrefSpec.Href, query, fragment);
+        Telemetry.TrackLink("xref");
         _fileLinkMapBuilder.AddFileLink(inclusionRoot, referencingFile, fileLink, href.Source);
 
         resolvedHref = UrlUtility.MergeUrl(resolvedHref, query, fragment);
@@ -127,6 +128,7 @@ internal class XrefResolver
         }
 
         var localizable = IsNameLocalizable(xrefSpec);
+        Telemetry.TrackLink("uid");
         _fileLinkMapBuilder.AddFileLink(inclusionRoot, referencingFile, xrefSpec.Href, uid.Source);
         return (null, new XrefLink(href, xrefSpec.GetName() ?? xrefSpec.Uid, xrefSpec.DeclaringFile, localizable));
     }


### PR DESCRIPTION
[AB#564511](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/564511)

We are planning to move broken link service to build phase. In order to support that, we will need to know some of the key data, for example: number of the links that are not validated by docfx, average number of links in each content file, and etc. We need to collect the link part in docfx.

design spec: https://microsoft-my.sharepoint.com/:w:/p/shanluo/EXP2FbwFZcJAifEI1iCJAToBNBpAf-EX9IPm6Xg9whLxbw?e=iraqp9