### PR TITLE
CommitBuildTimeProvider read latest state file before save

### DIFF
--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -282,7 +282,7 @@ internal class Config : PreloadConfig
     /// <summary>
     /// Overwrite current <see cref="CommitBuildTimeProvider._buildTime"/>
     /// </summary>
-    public DateTime? BuildTime { get; init; }
+    public DateTime BuildTime { get; init; } = DateTime.UtcNow;
 
     /// <summary>
     /// Determines how long at most a user remains valid in cache.

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -282,7 +282,7 @@ internal class Config : PreloadConfig
     /// <summary>
     /// Overwrite current <see cref="CommitBuildTimeProvider._buildTime"/>
     /// </summary>
-    public DateTime BuildTime { get; init; } = DateTime.UtcNow;
+    public DateTime? BuildTime { get; init; }
 
     /// <summary>
     /// Determines how long at most a user remains valid in cache.

--- a/src/docfx/lib/git/CommitBuildTimeProvider.cs
+++ b/src/docfx/lib/git/CommitBuildTimeProvider.cs
@@ -36,7 +36,7 @@ internal class CommitBuildTimeProvider
 
         lock (s_lock)
         {
-            using (PerfScope.Start($"Saving commit build time for {_repo.Commit}"))
+            using (PerfScope.Start($"Saving commit build time for {_repo.Path} {_repo.Commit}"))
             {
                 _buildTimeByCommit = ReadLatestCacheIfAny();
                 var commits = _buildTimeByCommit.Select(item => new CommitBuildTimeItem { Sha = item.Key, BuiltAt = item.Value }).ToList();

--- a/src/docfx/lib/git/CommitBuildTimeProvider.cs
+++ b/src/docfx/lib/git/CommitBuildTimeProvider.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Docs.Build;
 internal class CommitBuildTimeProvider
 {
     private static readonly object s_lock = new();
+    private static readonly DateTime s_now = DateTime.UtcNow;
 
     private readonly DateTime _buildTime;
     private readonly Repository _repo;
@@ -18,7 +19,7 @@ internal class CommitBuildTimeProvider
         _repo = repo;
         _config = config;
         _commitBuildTimePath = AppData.BuildHistoryStatePath;
-        _buildTime = config.BuildTime;
+        _buildTime = config.BuildTime ?? s_now;
 
         _buildTimeByCommit = ReadLatestCacheIfAny();
     }


### PR DESCRIPTION
1. `CommitBuildTimeProvider` read latest state file before save to avoid later `CommitBuildTimeProvider.Save()` cover the previous one's content
2. initialize `_buildTime` in the global `Config` to guarantee all `CommitBuildTimeProvider` instances share the same value.