### PR TITLE
chore: azureSubscription -> ConnectedServiceNameARM

### DIFF
--- a/azure-pipelines-v3.yml
+++ b/azure-pipelines-v3.yml
@@ -52,7 +52,7 @@ jobs:
     displayName: dotnet test
     condition: and(succeeded(), ne(variables['warm-up'], 'true'))
     inputs:
-      azureSubscription: 'DevRel - Docs Build Worker (PubDev)'
+      ConnectedServiceNameARM: 'DevRel - Docs Build Worker (PubDev)'
       scriptType: ps
       scriptLocation: inlineScript
       inlineScript: |
@@ -134,7 +134,7 @@ jobs:
     - task: AzureCLI@2
       displayName: Run
       inputs:
-        azureSubscription: 'DevRel - Docs.Build Docfx CI Test'
+        ConnectedServiceNameARM: 'DevRel - Docs.Build Docfx CI Test'
         scriptType: ps
         scriptLocation: inlineScript
         powerShellErrorActionPreference: continue
@@ -177,7 +177,7 @@ jobs:
       - task: AzureCLI@2
         displayName: ${{repo}}
         inputs:
-          azureSubscription: 'DevRel - Docs.Build Docfx CI Test'
+          ConnectedServiceNameARM: 'DevRel - Docs.Build Docfx CI Test'
           scriptType: ps
           scriptLocation: inlineScript
           powerShellErrorActionPreference: continue


### PR DESCRIPTION
Use official name `ConnectedServiceNameARM` in DevOps yml instead of alias `azureSubscription` to reduce confusion.

Reference: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/deploy/azure-powershell?view=azure-devops&branch=main#arguments