### PR TITLE
regression test: remove repo powerbi-docs-pr.de-DE

### DIFF
--- a/azure-pipelines-v3.yml
+++ b/azure-pipelines-v3.yml
@@ -219,8 +219,6 @@ parameters:
       params: https://github.com/MicrosoftDocs/azure-devops-docs-pr --timeout 30 --regression-rules
     microsoft-365-docs-pr.zh-CN:
       params: https://github.com/MicrosoftDocs/microsoft-365-docs-pr.zh-CN --branch live --profile --timeout 25
-    powerbi-docs-pr.de-DE:
-      params: https://github.com/MicrosoftDocs/powerbi-docs-pr.de-DE --branch live --timeout 25
     PowerShell-Docs:
       params: https://github.com/MicrosoftDocs/PowerShell-Docs --timeout 75 --branch live
     roslyn-api-docs:


### PR DESCRIPTION
As powerbi-docs-pr.de-DE moves to new localization pipeline, the regression test here is no longer needed.