### PR TITLE
Provide Source URL in error.log

### DIFF
--- a/docs/specs/error.yml
+++ b/docs/specs/error.yml
@@ -241,4 +241,30 @@ outputs:
   a.json:
   .errors.log: |
     {"message_severity":"suggestion","code":"altText-equal-filename","message":"AltText 'pig3' is the same as the image file name.","file":"a.md","line":1,"end_line":1,"column":1,"end_column":1}
-   
+---
+# provide source url in error log, CRR page is also supported
+noDryRun: true
+repos:
+  https://github.com/ops1/repo:
+  - files:
+      docfx.yml: |
+        routes:
+            "crr/": "crr"
+        dependencies:
+              crr:
+                url: https://github.com/ops1/crr
+                branch: live
+                includeInBuild: true
+      a.md: |
+        <br2/>
+  https://github.com/ops1/crr#live:
+  - files:
+      b.md: |
+        <br3/>
+outputs:
+  a.json:
+  crr/b.json:
+  .errors.log: |
+    {"message_severity":"info","code":"disallowed-html-tag","file":"a.md", "source_url":"https://github.com/ops1/repo/blob/main/a.md","message":"HTML tag 'br2' isn't allowed. Disallowed HTML poses a security risk and must be replaced with approved Docs Markdown syntax."}
+    {"message_severity":"info","code":"disallowed-html-tag","file":"crr/b.md","source_url":"https://github.com/ops1/crr/blob/live/b.md","message":"HTML tag 'br3' isn't allowed. Disallowed HTML poses a security risk and must be replaced with approved Docs Markdown syntax."}
+    

--- a/docs/specs/error.yml
+++ b/docs/specs/error.yml
@@ -242,7 +242,7 @@ outputs:
   .errors.log: |
     {"message_severity":"suggestion","code":"altText-equal-filename","message":"AltText 'pig3' is the same as the image file name.","file":"a.md","line":1,"end_line":1,"column":1,"end_column":1}
 ---
-# provide source url in error log, CRR page is also supported
+# provide source url in error log, CRR pages are also supported
 noDryRun: true
 repos:
   https://github.com/ops1/repo:

--- a/docs/specs/error.yml
+++ b/docs/specs/error.yml
@@ -243,7 +243,6 @@ outputs:
     {"message_severity":"suggestion","code":"altText-equal-filename","message":"AltText 'pig3' is the same as the image file name.","file":"a.md","line":1,"end_line":1,"column":1,"end_column":1}
 ---
 # provide source url in error log, CRR pages are also supported
-noDryRun: true
 repos:
   https://github.com/ops1/repo:
   - files:

--- a/src/docfx/build/DocsetBuilder.cs
+++ b/src/docfx/build/DocsetBuilder.cs
@@ -78,7 +78,7 @@ internal class DocsetBuilder
         _monikerProvider = new(_config, _buildScope, _metadataProvider, _fileResolver);
         _jsonSchemaProvider = new(_config, _packageResolver, _jsonSchemaLoader);
         _documentProvider = new(_input, _errors, _config, _buildOptions, _buildScope, _fileResolver, _jsonSchemaProvider, _monikerProvider, _metadataProvider);
-        _contributionProvider = new(_config, _buildOptions, _input, _githubAccessor, _repositoryProvider);
+        _contributionProvider = _errors.ContributionProvider = new(_config, _buildOptions, _input, _githubAccessor, _repositoryProvider);
         _redirectionProvider = new(_config, _buildOptions, _errors, _buildScope, package, _documentProvider, _monikerProvider, () => Ensure(_publishUrlMap));
         _publishUrlMap = new(_config, _errors, _buildScope, _redirectionProvider, _documentProvider, _monikerProvider);
         _customRuleProvider = _errors.CustomRuleProvider = new(_config, _errors, _fileResolver, _documentProvider, _publishUrlMap, _monikerProvider, _metadataProvider);

--- a/src/docfx/lib/log/Error.cs
+++ b/src/docfx/lib/log/Error.cs
@@ -44,14 +44,9 @@ internal record Error
         PropertyPath = propertyPath;
     }
 
-    public string? GetFile()
-    {
-        return OriginalPath ?? Source?.File?.Path;
-    }
-
     public override string ToString()
     {
-        var file = GetFile();
+        var file = OriginalPath ?? Source?.File?.Path;
         var source = OriginalPath is null ? Source : null;
         var line = source?.Line ?? 0;
         var end_line = source?.EndLine ?? 0;

--- a/src/docfx/lib/log/Error.cs
+++ b/src/docfx/lib/log/Error.cs
@@ -20,7 +20,7 @@ internal record Error
     public PathString? OriginalPath { get; init; }
 
     // Git Url
-    public string SourceUrl { get; init; }
+    public string? SourceUrl { get; init; }
 
     public bool PullRequestOnly { get; init; }
 
@@ -44,14 +44,14 @@ internal record Error
         PropertyPath = propertyPath;
     }
 
-    public string getFile()
+    public string? GetFile()
     {
-        return OriginalPath ?? Source?.File?.Path; 
+        return OriginalPath ?? Source?.File?.Path;
     }
 
     public override string ToString()
     {
-        var file = getFile();
+        var file = GetFile();
         var source = OriginalPath is null ? Source : null;
         var line = source?.Line ?? 0;
         var end_line = source?.EndLine ?? 0;

--- a/src/docfx/lib/log/Error.cs
+++ b/src/docfx/lib/log/Error.cs
@@ -19,6 +19,9 @@ internal record Error
 
     public PathString? OriginalPath { get; init; }
 
+    // Git Url
+    public string SourceUrl { get; init; }
+
     public bool PullRequestOnly { get; init; }
 
     public bool AddOnly { get; init; }
@@ -41,9 +44,14 @@ internal record Error
         PropertyPath = propertyPath;
     }
 
+    public string getFile()
+    {
+        return OriginalPath ?? Source?.File?.Path; 
+    }
+
     public override string ToString()
     {
-        var file = OriginalPath ?? Source?.File?.Path;
+        var file = getFile();
         var source = OriginalPath is null ? Source : null;
         var line = source?.Line ?? 0;
         var end_line = source?.EndLine ?? 0;
@@ -56,6 +64,7 @@ internal record Error
             Code,
             message = Message,
             file,
+            file_url = SourceUrl,
             line,
             end_line,
             column,

--- a/src/docfx/lib/log/Error.cs
+++ b/src/docfx/lib/log/Error.cs
@@ -64,7 +64,7 @@ internal record Error
             Code,
             message = Message,
             file,
-            file_url = SourceUrl,
+            source_url = SourceUrl,
             line,
             end_line,
             column,

--- a/src/docfx/lib/log/ErrorLog.cs
+++ b/src/docfx/lib/log/ErrorLog.cs
@@ -9,7 +9,6 @@ internal class ErrorLog : ErrorBuilder
 {
     private readonly ErrorBuilder _errors;
     private readonly PathString _docsetBasePath;
-    private readonly PathString _workingDirectory;
 
     private readonly Scoped<ErrorSink> _errorSink = new();
     private readonly Scoped<ConcurrentDictionary<FilePath, ErrorSink>> _fileSink = new();
@@ -31,7 +30,6 @@ internal class ErrorLog : ErrorBuilder
     public ErrorLog(ErrorBuilder errors, string workingDirectory, string docsetPath)
     {
         _errors = errors;
-        _workingDirectory = new PathString(workingDirectory);
         _docsetBasePath = new PathString(Path.GetRelativePath(workingDirectory, docsetPath));
     }
 
@@ -152,11 +150,11 @@ internal class ErrorLog : ErrorBuilder
             }
         }
 
-        if (originalFilePath != null)
+        if (originalFilePath != null && ContributionProvider != null)
         {
             // The original FilePath is used as key to fetch ContributionProvider git url cache
             // and meets the requirement of https://github.com/dotnet/docfx/blob/c8cb790043ae5b93173f3e28dafc28bf7f305d48/src/docfx/build/context/Input.cs#L292
-            (_, string? originalContentGitUrl, _) = ContributionProvider.GetGitUrl(originalFilePath);
+            (_, var originalContentGitUrl, _) = ContributionProvider.GetGitUrl(originalFilePath);
             error = error with { SourceUrl = originalContentGitUrl };
         }
         _errors.Add(error);

--- a/src/docfx/lib/log/ErrorLog.cs
+++ b/src/docfx/lib/log/ErrorLog.cs
@@ -135,6 +135,8 @@ internal class ErrorLog : ErrorBuilder
 
     private void AddError(Error error)
     {
+        var originalFilePath = error.Source?.File;
+
         // Convert from path relative to docset to path relative to working directory
         if (!_docsetBasePath.IsDefault)
         {
@@ -150,10 +152,11 @@ internal class ErrorLog : ErrorBuilder
             }
         }
 
-        var filePath = error.getFile();
-        if (filePath != null)
+        if (originalFilePath != null)
         {
-            (_, string? originalContentGitUrl, _) = ContributionProvider.GetGitUrl(new FilePath(_workingDirectory.Concat(new PathString(filePath))));
+            // The original FilePath is used as key to fetch ContributionProvider git url cache
+            // and meets the requirement of https://github.com/dotnet/docfx/blob/c8cb790043ae5b93173f3e28dafc28bf7f305d48/src/docfx/build/context/Input.cs#L292
+            (_, string? originalContentGitUrl, _) = ContributionProvider.GetGitUrl(originalFilePath);
             error = error with { SourceUrl = originalContentGitUrl };
         }
         _errors.Add(error);

--- a/src/docfx/lib/log/ErrorLog.cs
+++ b/src/docfx/lib/log/ErrorLog.cs
@@ -149,9 +149,11 @@ internal class ErrorLog : ErrorBuilder
                 error = error with { OriginalPath = _docsetBasePath.Concat(error.OriginalPath.Value) };
             }
         }
-        if (error.getFile() != null)
+
+        var filePath = error.getFile();
+        if (filePath != null)
         {
-            (_, string? originalContentGitUrl, _) = ContributionProvider.GetGitUrl(new FilePath(_workingDirectory.Concat(new PathString(error.getFile()))));
+            (_, string? originalContentGitUrl, _) = ContributionProvider.GetGitUrl(new FilePath(_workingDirectory.Concat(new PathString(filePath))));
             error = error with { SourceUrl = originalContentGitUrl };
         }
         _errors.Add(error);


### PR DESCRIPTION
[AB#418759](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/418759) 

Provide Source URL information for files (including CRR pages) in error.log so that reporting page is able to point to correct URL.