### PR TITLE
Add instructions on how to install on a M1 Mac

### DIFF
--- a/Documentation/tutorial/docfx_getting_started.md
+++ b/Documentation/tutorial/docfx_getting_started.md
@@ -25,7 +25,13 @@ For a detailed description about DFM, please refer to [DFM](../spec/docfx_flavor
 
 *Step1.* Install DocFX. Choose from one of the following sources:
 * **[Chocolatey](https://chocolatey.org/packages/docfx)**: `choco install docfx -y`.
-* **[Homebrew](https://formulae.brew.sh/formula/docfx)** (owned by community): `brew install docfx`.
+* **[Homebrew](https://formulae.brew.sh/formula/docfx)** (owned by community): 
+   * Intel chip: `brew install docfx`.
+   * M1 chip: DocFX doesn't support the new mac chips so you will need to use rosetta to run it. Follow these steps:
+      * [Uninstall Homebrew](https://github.com/homebrew/install#uninstall-homebrew)
+      * Re-install brew with the following command: `arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
+      * Install docfx: `arch -x86_64 brew install docfx`
+      * Run docfx: `arch -x86_64 docfx path/to/docfx.json --serve`
 * **GitHub**: download and unzip `docfx.zip` from https://github.com/dotnet/docfx/releases, extract it to a local folder, and add it to PATH so you can run it anywhere.
 * **NuGet**: `nuget install docfx.console`. `docfx.exe` is under folder *docfx.console/tools/*.
 

--- a/Documentation/tutorial/docfx_getting_started.md
+++ b/Documentation/tutorial/docfx_getting_started.md
@@ -27,7 +27,7 @@ For a detailed description about DFM, please refer to [DFM](../spec/docfx_flavor
 * **[Chocolatey](https://chocolatey.org/packages/docfx)**: `choco install docfx -y`.
 * **[Homebrew](https://formulae.brew.sh/formula/docfx)** (owned by community): 
    * Intel chip: `brew install docfx`.
-   * M1 chip: DocFX doesn't support the new mac chips so you will need to use rosetta to run it. Follow these steps:
+   * M1 chip: DocFX doesn't support the new mac M1 chips so you will need to use [Rosetta](https://support.apple.com/en-nz/HT211861) to run it. Follow these steps:
       * [Uninstall Homebrew](https://github.com/homebrew/install#uninstall-homebrew)
       * Re-install brew with the following command: `arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
       * Install docfx: `arch -x86_64 brew install docfx`


### PR DESCRIPTION
This adds instructions to get docfx running on a Mac using an M1 chip. The solution is to use Rosetta to install brew and docfx so that it can run on the old architecture.