### PR TITLE
TripleColon Image Extension Body/Long Description no longer parsed as markdown

### DIFF
--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/ImageExtension.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/ImageExtension.cs
@@ -176,7 +176,9 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
                 var htmlId = GetHtmlId(obj);
                 renderer.Write("<img").WriteAttributes(obj).WriteLine(">");
                 renderer.WriteLine($"<div id=\"{htmlId}\" class=\"visually-hidden\">");
-                renderer.WriteChildren(tripleColonObj as ContainerBlock);
+                renderer.WriteLine($"<p>");
+                renderer.Write(tripleColonObj as TripleColonInline);
+                renderer.WriteLine("</p>");
                 renderer.WriteLine("</div>");
             }
             if (!string.IsNullOrEmpty(currentLightbox) || !string.IsNullOrEmpty(currentLink))

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/ImageExtension.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/ImageExtension.cs
@@ -168,18 +168,16 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
             }
             else
             {
-                if (currentType == "complex" && tripleColonObj.Count == 0)
+                if (currentType == "complex" && string.IsNullOrWhiteSpace(tripleColonObj.Body))
                 {
                     logWarning("If type is \"complex\", then descriptive content is required. Please make sure you have descriptive content.");
                     return false;
                 }
                 var htmlId = GetHtmlId(obj);
                 renderer.Write("<img").WriteAttributes(obj).WriteLine(">");
-                renderer.WriteLine($"<div id=\"{htmlId}\" class=\"visually-hidden\">");
-                renderer.WriteLine($"<p>");
-                renderer.Write(tripleColonObj as TripleColonInline);
-                renderer.WriteLine("</p>");
-                renderer.WriteLine("</div>");
+                renderer.WriteLine($"<div id=\"{htmlId}\" class=\"visually-hidden\"><p>");
+                renderer.Write(tripleColonObj.Body);
+                renderer.WriteLine("</p></div>");
             }
             if (!string.IsNullOrEmpty(currentLightbox) || !string.IsNullOrEmpty(currentLink))
             {

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/TripleColonBlock.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/TripleColonBlock.cs
@@ -10,6 +10,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
     {
         public IDictionary<string, string> RenderProperties { get; set; }
         public ITripleColonExtensionInfo Extension { get; set; }
+        public string Body { get; set; }
         public TripleColonBlock(BlockParser parser) : base(parser) { }
         public bool Closed { get; set; }
         public bool EndingTripleColons { get; set; }
@@ -20,6 +21,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
     {
         public IDictionary<string, string> RenderProperties { get; set; }
         public ITripleColonExtensionInfo Extension { get; set; }
+        public string Body { get; set; }
         public bool Closed { get; set; }
         public bool EndingTripleColons { get; set; }
         public IDictionary<string, string> Attributes { get; set; }

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/TripleColonBlockParser.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/TripleColonBlockParser.cs
@@ -165,7 +165,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         public override bool Close(BlockProcessor processor, Block block)
         {
             var tripleColonBlock = (TripleColonBlock)block;
-             if (tripleColonBlock.Extension.SelfClosing)
+            if (tripleColonBlock.Extension.SelfClosing)
             {
                 block.IsOpen = false;
                 return true;

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/TripleColonBlockParser.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/TripleColonBlockParser.cs
@@ -109,6 +109,8 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
 
                 if (!ExtensionsHelper.MatchStart(ref slice, ":::"))
                 {
+                    // create a block for the image long description
+                    ((TripleColonBlock)block).Body = slice.ToString();
                     ExtensionsHelper.ResetLineIndent(processor);
                     return BlockState.Continue;
                 }
@@ -163,7 +165,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
         public override bool Close(BlockProcessor processor, Block block)
         {
             var tripleColonBlock = (TripleColonBlock)block;
-            if (tripleColonBlock.Extension.SelfClosing)
+             if (tripleColonBlock.Extension.SelfClosing)
             {
                 block.IsOpen = false;
                 return true;

--- a/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/TripleColonInline.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine.Extensions/TripleColon/TripleColonInline.cs
@@ -11,6 +11,7 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Extensions
     {
         public IDictionary<string, string> RenderProperties { get; set; }
         public ITripleColonExtensionInfo Extension { get; set; }
+        public string Body { get; set; }
         public TripleColonInline(InlineParser parser) : base() { }
         public bool Closed { get; set; }
         public bool EndingTripleColons { get; set; }

--- a/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/ImageTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/ImageTest.cs
@@ -92,17 +92,17 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Tests
 :::image type=""icon"" source=""example.svg"":::
 
 :::image type=""complex"" source=""example.jpg"" alt-text=""example"" loc-scope=""azure""::: 
-Lorem Ipsum is simply dummy text of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+Lorem Ipsum is simply dummy text `code` of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
 :::image-end:::
 
 :::image source=""example.jpg"" alt-text=""example"" loc-scope=""azure"":::
 
 :::image type=""complex"" source=""example.jpg"" alt-text=""example"" loc-scope=""azure"" lightbox=""example-expanded.jpg""::: 
-Lorem Ipsum is simply dummy text of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+Lorem Ipsum is simply dummy text `code` of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
 :::image-end:::
 
 :::image type=""complex"" source=""example.jpg"" alt-text=""example"" loc-scope=""azure"" lightbox=""example-expanded.jpg"" border=""false""::: 
-Lorem Ipsum is simply dummy text of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+Lorem Ipsum is simply dummy text `code` of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
 :::image-end:::
 ";
 
@@ -110,9 +110,9 @@ Lorem Ipsum is simply dummy text of the printing and [link](https://microsoft.co
 </p>
 <p class=""mx-imgBorder"">
 <img src=""example.jpg"" alt=""example"" aria-describedby=""3-0"">
-<div id=""3-0"" class=""visually-hidden"">
-<p>Lorem Ipsum is simply dummy text of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
-</div>
+<div id=""3-0"" class=""visually-hidden""><p>
+Lorem Ipsum is simply dummy text `code` of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+</p></div>
 </p>
 <p><span class=""mx-imgBorder"">
 <img src=""example.jpg"" alt=""example"">
@@ -121,17 +121,17 @@ Lorem Ipsum is simply dummy text of the printing and [link](https://microsoft.co
 <p class=""mx-imgBorder"">
 <a href=""example-expanded.jpg#lightbox"" data-linktype=""relative-path"">
 <img src=""example.jpg"" alt=""example"" aria-describedby=""9-0"">
-<div id=""9-0"" class=""visually-hidden"">
-<p>Lorem Ipsum is simply dummy text of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
-</div>
+<div id=""9-0"" class=""visually-hidden""><p>
+Lorem Ipsum is simply dummy text `code` of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+</p></div>
 </a>
 </p>
 <p>
 <a href=""example-expanded.jpg#lightbox"" data-linktype=""relative-path"">
 <img src=""example.jpg"" alt=""example"" aria-describedby=""13-0"">
-<div id=""13-0"" class=""visually-hidden"">
-<p>Lorem Ipsum is simply dummy text of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
-</div>
+<div id=""13-0"" class=""visually-hidden""><p>
+Lorem Ipsum is simply dummy text `code` of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+</p></div>
 </a>
 </p>
 ";

--- a/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/ImageTest.cs
+++ b/test/Microsoft.DocAsCode.MarkdigEngine.Extensions.Tests/ImageTest.cs
@@ -92,17 +92,17 @@ namespace Microsoft.DocAsCode.MarkdigEngine.Tests
 :::image type=""icon"" source=""example.svg"":::
 
 :::image type=""complex"" source=""example.jpg"" alt-text=""example"" loc-scope=""azure""::: 
-Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+Lorem Ipsum is simply dummy text of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
 :::image-end:::
 
 :::image source=""example.jpg"" alt-text=""example"" loc-scope=""azure"":::
 
 :::image type=""complex"" source=""example.jpg"" alt-text=""example"" loc-scope=""azure"" lightbox=""example-expanded.jpg""::: 
-Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+Lorem Ipsum is simply dummy text of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
 :::image-end:::
 
 :::image type=""complex"" source=""example.jpg"" alt-text=""example"" loc-scope=""azure"" lightbox=""example-expanded.jpg"" border=""false""::: 
-Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+Lorem Ipsum is simply dummy text of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
 :::image-end:::
 ";
 
@@ -111,7 +111,7 @@ Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
 <p class=""mx-imgBorder"">
 <img src=""example.jpg"" alt=""example"" aria-describedby=""3-0"">
 <div id=""3-0"" class=""visually-hidden"">
-<p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
+<p>Lorem Ipsum is simply dummy text of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
 </div>
 </p>
 <p><span class=""mx-imgBorder"">
@@ -122,7 +122,7 @@ Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
 <a href=""example-expanded.jpg#lightbox"" data-linktype=""relative-path"">
 <img src=""example.jpg"" alt=""example"" aria-describedby=""9-0"">
 <div id=""9-0"" class=""visually-hidden"">
-<p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
+<p>Lorem Ipsum is simply dummy text of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
 </div>
 </a>
 </p>
@@ -130,7 +130,7 @@ Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
 <a href=""example-expanded.jpg#lightbox"" data-linktype=""relative-path"">
 <img src=""example.jpg"" alt=""example"" aria-describedby=""13-0"">
 <div id=""13-0"" class=""visually-hidden"">
-<p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
+<p>Lorem Ipsum is simply dummy text of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
 </div>
 </a>
 </p>


### PR DESCRIPTION
Fixed small bug in :::image::: extension for long description being rendered as HTML. This was causing problems with link validation, and checking the links in :::image::: body/long description.
- Added Body property to TripleColonBlock and TripleColonInline
- Set Body to the string value of the slices during parsing
- Writing the output of body as string instead of HTML
 
Bug described in this [Task #549897](https://dev.azure.com/ceapex/Engineering/_workitems/edit/549897)