### PR TITLE
TripleColon Image Extension Body/Long Description no longer parsed as markdown

### DIFF
--- a/src/Microsoft.Docs.MarkdigExtensions/TripleColon/ImageExtension.cs
+++ b/src/Microsoft.Docs.MarkdigExtensions/TripleColon/ImageExtension.cs
@@ -173,9 +173,9 @@ public class ImageExtension : ITripleColonExtensionInfo
                 return false;
             }
             renderer.Write("<img").WriteAttributes(htmlAttributes).WriteLine(">");
-            renderer.WriteLine($"<div id=\"{htmlId}\" class=\"visually-hidden\">");
-            renderer.WriteChildren(tripleColonObj as ContainerBlock);
-            renderer.WriteLine("</div>");
+            renderer.WriteLine($"<div id=\"{htmlId}\" class=\"visually-hidden\"><p>");
+            renderer.Write(tripleColonObj.Body);
+            renderer.WriteLine("</p></div>");
         }
         if (!string.IsNullOrEmpty(currentLightbox) || !string.IsNullOrEmpty(currentLink))
         {

--- a/src/Microsoft.Docs.MarkdigExtensions/TripleColon/TripleColonBlock.cs
+++ b/src/Microsoft.Docs.MarkdigExtensions/TripleColon/TripleColonBlock.cs
@@ -11,6 +11,8 @@ public class TripleColonBlock : ContainerBlock, ITripleColon
 
     public ITripleColonExtensionInfo Extension { get; set; }
 
+    public string Body { get; set; }
+
     public TripleColonBlock(BlockParser parser)
         : base(parser) { }
 
@@ -26,6 +28,8 @@ internal interface ITripleColon
     public IDictionary<string, string> RenderProperties { get; set; }
 
     public ITripleColonExtensionInfo Extension { get; set; }
+
+    public string Body { get; set; }
 
     public bool Closed { get; set; }
 

--- a/src/Microsoft.Docs.MarkdigExtensions/TripleColon/TripleColonBlockParser.cs
+++ b/src/Microsoft.Docs.MarkdigExtensions/TripleColon/TripleColonBlockParser.cs
@@ -118,6 +118,8 @@ public class TripleColonBlockParser : BlockParser
 
             if (!ExtensionsHelper.MatchStart(ref slice, ":::"))
             {
+                // create a block for the image long description
+                ((TripleColonBlock)block).Body = slice.ToString();
                 ExtensionsHelper.ResetLineIndent(processor);
                 return BlockState.Continue;
             }

--- a/src/Microsoft.Docs.MarkdigExtensions/TripleColon/TripleColonInline.cs
+++ b/src/Microsoft.Docs.MarkdigExtensions/TripleColon/TripleColonInline.cs
@@ -10,6 +10,8 @@ public class TripleColonInline : Inline, ITripleColon
 
     public ITripleColonExtensionInfo Extension { get; set; }
 
+    public string Body { get; set; }
+
     public TripleColonInline()
         : base() { }
 

--- a/test/Microsoft.Docs.MarkdigExtensions.Tests/ImageTest.cs
+++ b/test/Microsoft.Docs.MarkdigExtensions.Tests/ImageTest.cs
@@ -90,18 +90,18 @@ public class ImageTest
         var source = @"
 :::image type=""icon"" source=""example.svg"":::
 
-:::image type=""complex"" source=""example.jpg"" alt-text=""example"" loc-scope=""azure"":::
-Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+:::image type=""complex"" source=""example.jpg"" alt-text=""example"" loc-scope=""azure""::: 
+Lorem Ipsum is simply dummy text `code` of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
 :::image-end:::
 
 :::image source=""example.jpg"" alt-text=""example"" loc-scope=""azure"":::
 
-:::image type=""complex"" source=""example.jpg"" alt-text=""example"" loc-scope=""azure"" lightbox=""example-expanded.jpg"":::
-Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+:::image type=""complex"" source=""example.jpg"" alt-text=""example"" loc-scope=""azure"" lightbox=""example-expanded.jpg""::: 
+Lorem Ipsum is simply dummy text `code` of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
 :::image-end:::
 
-:::image type=""complex"" source=""example.jpg"" alt-text=""example"" loc-scope=""azure"" lightbox=""example-expanded.jpg"" border=""false"":::
-Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+:::image type=""complex"" source=""example.jpg"" alt-text=""example"" loc-scope=""azure"" lightbox=""example-expanded.jpg"" border=""false""::: 
+Lorem Ipsum is simply dummy text `code` of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
 :::image-end:::
 ";
 
@@ -109,9 +109,9 @@ Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
 </p>
 <p class=""mx-imgBorder"">
 <img src=""example.jpg"" alt=""example"" aria-describedby=""3-0"">
-<div id=""3-0"" class=""visually-hidden"">
-<p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
-</div>
+<div id=""3-0"" class=""visually-hidden""><p>
+Lorem Ipsum is simply dummy text `code` of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+</p></div>
 </p>
 <p><span class=""mx-imgBorder"">
 <img src=""example.jpg"" alt=""example"">
@@ -120,17 +120,17 @@ Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
 <p class=""mx-imgBorder"">
 <a href=""example-expanded.jpg#lightbox"" data-linktype=""relative-path"">
 <img src=""example.jpg"" alt=""example"" aria-describedby=""9-0"">
-<div id=""9-0"" class=""visually-hidden"">
-<p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
-</div>
+<div id=""9-0"" class=""visually-hidden""><p>
+Lorem Ipsum is simply dummy text `code` of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+</p></div>
 </a>
 </p>
 <p>
 <a href=""example-expanded.jpg#lightbox"" data-linktype=""relative-path"">
 <img src=""example.jpg"" alt=""example"" aria-describedby=""13-0"">
-<div id=""13-0"" class=""visually-hidden"">
-<p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
-</div>
+<div id=""13-0"" class=""visually-hidden""><p>
+Lorem Ipsum is simply dummy text `code` of the printing and [link](https://microsoft.com) typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+</p></div>
 </a>
 </p>
 ";


### PR DESCRIPTION
Fixed small bug in :::image::: extension for long description being rendered as HTML. This was causing problems with link validation, and checking the links in :::image::: body/long description.
- Added Body property to TripleColonBlock and TripleColonInline
- Set Body to the string value of the slice during parsing
- Writing the output of body as string instead of HTML
 
Bug described in this [Task #549897](https://dev.azure.com/ceapex/Engineering/_workitems/edit/549897)