### PR TITLE
Include QuoteSectionNoteType.DFMVideo and VideoExtension in ResolveLinkExtension

### DIFF
--- a/src/Microsoft.Docs.MarkdigExtensions/QuoteSectionNote/QuoteSectionNoteParser.cs
+++ b/src/Microsoft.Docs.MarkdigExtensions/QuoteSectionNote/QuoteSectionNoteParser.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Docs.MarkdigExtensions;
 public class QuoteSectionNoteParser : BlockParser
 {
     private readonly List<string> _noteTypes = new() { "[!NOTE]", "[!TIP]", "[!WARNING]", "[!IMPORTANT]", "[!CAUTION]" };
+    private readonly string _learnVideoUrl = "https://learn-video.azurefd.net/vod/player?id=";
     private readonly MarkdownContext _context;
 
     public QuoteSectionNoteParser(MarkdownContext context)
@@ -182,6 +183,16 @@ public class QuoteSectionNoteParser : BlockParser
             {
                 block.QuoteType = QuoteSectionNoteType.DFMVideo;
                 block.VideoLink = link.Trim();
+                return true;
+            }
+
+            // check if the video Id is a valid GUID format
+            // if it is a valid video id then generate the full URL
+            var isValidGuid = Guid.TryParse(link.Trim(']'), out var guidOutput);
+            if (isValidGuid)
+            {
+                block.QuoteType = QuoteSectionNoteType.DFMVideo;
+                block.VideoLink = $"{_learnVideoUrl}{link.Trim()}";
                 return true;
             }
         }

--- a/src/Microsoft.Docs.MarkdigExtensions/QuoteSectionNote/QuoteSectionNoteParser.cs
+++ b/src/Microsoft.Docs.MarkdigExtensions/QuoteSectionNote/QuoteSectionNoteParser.cs
@@ -192,7 +192,7 @@ public class QuoteSectionNoteParser : BlockParser
             if (isValidGuid)
             {
                 block.QuoteType = QuoteSectionNoteType.DFMVideo;
-                block.VideoLink = $"{_learnVideoUrl}{link.Trim()}";
+                block.VideoLink = $"{_learnVideoUrl}{guidOutput}";
                 return true;
             }
         }

--- a/src/Microsoft.Docs.MarkdigExtensions/ResolveLink/ResolveLinkExtension.cs
+++ b/src/Microsoft.Docs.MarkdigExtensions/ResolveLink/ResolveLinkExtension.cs
@@ -47,6 +47,33 @@ public class ResolveLinkExtension : IMarkdownExtension
                 autolinkInline.Url = _context.GetLink(autolinkInline.Url, autolinkInline);
                 break;
 
+            case QuoteSectionNoteBlock quoteSectionNoteBlock:
+                if (quoteSectionNoteBlock.QuoteType == QuoteSectionNoteType.DFMVideo)
+                {
+                    quoteSectionNoteBlock.VideoLink = _context.GetLink(quoteSectionNoteBlock.VideoLink, quoteSectionNoteBlock);
+                }
+                break;
+
+            case TripleColonBlock tripleColonBlock:
+                if (tripleColonBlock.GetType() == typeof(VideoExtension))
+                {
+                    foreach (var subBlock in tripleColonBlock)
+                    {
+                        UpdateLinks(subBlock);
+                    }
+                }
+                break;
+
+            case TripleColonInline tripleColonInline:
+                if (tripleColonInline.GetType() == typeof(VideoExtension))
+                {
+                    if (tripleColonInline.Attributes.TryGetValue("src", out var src))
+                    {
+                        tripleColonInline.Attributes["src"] = _context.GetLink(src, tripleColonInline);
+                    }
+                }
+                break;
+
             case ContainerBlock containerBlock:
                 foreach (var subBlock in containerBlock)
                 {

--- a/src/Microsoft.Docs.MarkdigExtensions/TripleColon/VideoExtension.cs
+++ b/src/Microsoft.Docs.MarkdigExtensions/TripleColon/VideoExtension.cs
@@ -11,6 +11,16 @@ public class VideoExtension : ITripleColonExtensionInfo
 {
     public string Name => "video";
 
+    private readonly string _learnVideoUrl = "https://learn-video.azurefd.net/vod/player?id=";
+
+    private readonly string[] _allowedVideoDomains = new[]
+    {
+        "channel9.msdn.com",
+        "youtube.com/embed",
+        "microsoft.com/en-us/videoplayer/embed",
+        "learn-video.azurefd.net",
+    };
+
     public bool SelfClosing => true;
 
     public bool IsInline => true;
@@ -79,11 +89,21 @@ public class VideoExtension : ITripleColonExtensionInfo
         {
             logError("upload-date is a required attribute. Please ensure you have specified a upload-date attribute.");
         }
-        if (!src.Contains("channel9.msdn.com") &&
-            !src.Contains("youtube.com/embed") &&
-            !src.Contains("microsoft.com/en-us/videoplayer/embed"))
+
+        var isValidGuid = Guid.TryParse(src.Trim(']'), out var guidOutput);
+        if (isValidGuid)
         {
-            logWarning($"Video source, '{src}', should be from https://channel9.msdn.com, https://www.youtube.com/embed, or https://www.microsoft.com/en-us/videoplayer/embed");
+            // check if the video Id is a valid GUID format
+            // if it is a valid video id then generate the full URL
+            src = $"{_learnVideoUrl}{guidOutput}";
+        }
+        else
+        {
+            var invalidVideoDomain = _allowedVideoDomains.All(x => !src.Contains(x));
+            if (invalidVideoDomain)
+            {
+                logWarning($"Video source, '{src}', should be from https://channel9.msdn.com, https://www.youtube.com/embed, https://learn-video.azurefd.net/vod/player, or https://www.microsoft.com/en-us/videoplayer/embed");
+            }
         }
         if (src.Contains("channel9.msdn.com") && !src.Contains("/player"))
         {

--- a/src/docfx/lib/markdown/MarkdigUtility.cs
+++ b/src/docfx/lib/markdown/MarkdigUtility.cs
@@ -241,6 +241,8 @@ internal static class MarkdigUtility
                 LeafBlock leafBlock when leafBlock.Inline is null || !leafBlock.Inline.Any() => false,
                 LinkInline linkInline when linkInline.IsImage => true,
                 TripleColonInline tripleColonInline when tripleColonInline.Extension is ImageExtension => true,
+                TripleColonBlock tripleColonBlock when tripleColonBlock.Extension is ImageExtension => true,
+                QuoteSectionNoteBlock quoteSectionNoteBlock when quoteSectionNoteBlock.QuoteType is QuoteSectionNoteType.DFMVideo => true,
                 LiteralInline literal when literal.Content.IsEmptyOrWhitespace() => false,
                 LeafInline => true,
                 _ => false,

--- a/src/docfx/lib/markdown/MarkdownEngine.cs
+++ b/src/docfx/lib/markdown/MarkdownEngine.cs
@@ -302,7 +302,7 @@ internal class MarkdownEngine
             HyperLinkType = link.MarkdownObject switch
             {
                 AutolinkInline => HyperLinkType.AutoLink,
-                HtmlBlock or HtmlInline or TripleColonInline or TripleColonBlock => HyperLinkType.HtmlAnchor,
+                HtmlBlock or HtmlInline or TripleColonInline or TripleColonBlock or QuoteSectionNoteBlock => HyperLinkType.HtmlAnchor,
                 _ => HyperLinkType.Default,
             },
         };

--- a/test/Microsoft.Docs.MarkdigExtensions.Tests/QuoteSectionNoteTest.cs
+++ b/test/Microsoft.Docs.MarkdigExtensions.Tests/QuoteSectionNoteTest.cs
@@ -461,4 +461,17 @@ We should support that.</p>
 ";
         TestUtility.VerifyMarkup(source, expected);
     }
+
+    [Fact]
+    [Trait("Related", "DfmMarkdown")]
+    public void TestVideoBlockWithGuid()
+    {
+        var source = @"# Article 2
+> [!VIDEO 0add8ade-e746-4bf3-932a-94413928d098]
+";
+        var expected = @"<h1 id=""article-2"">Article 2</h1>
+<div class=""embeddedvideo""><iframe src=""https://learn-video.azurefd.net/vod/player?id=0add8ade-e746-4bf3-932a-94413928d098"" frameborder=""0"" allowfullscreen=""true""></iframe></div>
+";
+        TestUtility.VerifyMarkup(source, expected);
+    }
 }

--- a/test/Microsoft.Docs.MarkdigExtensions.Tests/QuoteSectionNoteTest.cs
+++ b/test/Microsoft.Docs.MarkdigExtensions.Tests/QuoteSectionNoteTest.cs
@@ -474,4 +474,16 @@ We should support that.</p>
 ";
         TestUtility.VerifyMarkup(source, expected);
     }
+
+    [Fact]
+    [Trait("Related", "DfmMarkdown")]
+    public void TestVideoBlock_PreventsUnTrustedSourceUrl()
+    {
+        var source = @"# Article 2
+> [!VIDEO https://twitter.com/i/status/1532332451854536705]
+";
+        var expected = @"<h1 id=""article-2"">Article 2</h1>
+";
+        TestUtility.VerifyMarkup(source, expected);
+    }
 }

--- a/test/Microsoft.Docs.MarkdigExtensions.Tests/TestUtility.cs
+++ b/test/Microsoft.Docs.MarkdigExtensions.Tests/TestUtility.cs
@@ -33,6 +33,7 @@ public static class TestUtility
             logWarning: Log(),
             logError: Log(),
             readFile: ReadFile);
+            //getLink: GetLink);
 
         var pipelineBuilder = new MarkdownPipelineBuilder()
             .UseDocfxExtensions(markdownContext)
@@ -82,5 +83,24 @@ public static class TestUtility
             actualDependencies.Add(path);
             return files.TryGetValue(key, out var value) ? (value, key) : default;
         }
+
+        //string GetLink(LinkInfo link)
+        //{
+        //    var status = s_status.Value!.Peek();
+        //    var (linkErrors, result, _) =
+        //        _linkResolver.ResolveLink(link.Href, GetFilePath(link.Href), GetRootFilePath(), TransformLinkInfo(link), tagName: link.TagName);
+        //    status.Errors.AddRange(linkErrors);
+        //    return result;
+        //}
+
+        //string GetLink(string path, MarkdownObject origin)
+        //{
+        //    return GetLink(new()
+        //    {
+        //        Href = new(path, origin.GetSourceInfo()),
+        //        MarkdownObject = origin,
+        //    });
+        //}
+
     }
 }

--- a/test/Microsoft.Docs.MarkdigExtensions.Tests/VideoTest.cs
+++ b/test/Microsoft.Docs.MarkdigExtensions.Tests/VideoTest.cs
@@ -31,6 +31,9 @@ public class VideoTest
     [InlineData(@":::video source=""https://www.microsoft.com/en-us/videoplayer/embed/RE1XVQS"" title=""Introduction to Custom Vision Service"" thumbnail=""media/3-eclipse-install-button.png"" upload-date=""07/27/2020"":::", @"<p><div class=""embeddedvideo"">
 <iframe src=""https://www.microsoft.com/en-us/videoplayer/embed/RE1XVQS"" allowFullScreen=""true"" frameBorder=""0"" title=""Introduction to Custom Vision Service"" thumbnail=""media/3-eclipse-install-button.png"" upload-date=""07/27/2020""></iframe>
 </div></p>")]
+    [InlineData(@":::video source=""b63c2133-714a-48d7-9689-2120553664d4"" title=""Introduction to Custom Vision Service"" thumbnail=""media/3-eclipse-install-button.png"" upload-date=""07/27/2020"":::", @"<p><div class=""embeddedvideo"">
+<iframe src=""https://learn-video.azurefd.net/vod/player?id=b63c2133-714a-48d7-9689-2120553664d4"" allowFullScreen=""true"" frameBorder=""0"" title=""Introduction to Custom Vision Service"" thumbnail=""media/3-eclipse-install-button.png"" upload-date=""07/27/2020""></iframe>
+</div></p>")]
     public void VideoTestBlockGeneral(string source, string expected)
     {
         TestUtility.VerifyMarkup(source, expected);

--- a/test/Microsoft.Docs.MarkdigExtensions.Tests/VideoTest.cs
+++ b/test/Microsoft.Docs.MarkdigExtensions.Tests/VideoTest.cs
@@ -34,6 +34,8 @@ public class VideoTest
     [InlineData(@":::video source=""b63c2133-714a-48d7-9689-2120553664d4"" title=""Introduction to Custom Vision Service"" thumbnail=""media/3-eclipse-install-button.png"" upload-date=""07/27/2020"":::", @"<p><div class=""embeddedvideo"">
 <iframe src=""https://learn-video.azurefd.net/vod/player?id=b63c2133-714a-48d7-9689-2120553664d4"" allowFullScreen=""true"" frameBorder=""0"" title=""Introduction to Custom Vision Service"" thumbnail=""media/3-eclipse-install-button.png"" upload-date=""07/27/2020""></iframe>
 </div></p>")]
+    // This case is an untrusted domain (twitter), so we want to strip the output
+    [InlineData(@":::video source=""https://twitter.com/i/status/1532332451854536705"" title=""Introduction to Custom Vision Service"" thumbnail=""media/3-eclipse-install-button.png"" upload-date=""07/27/2020"":::", "")]
     public void VideoTestBlockGeneral(string source, string expected)
     {
         TestUtility.VerifyMarkup(source, expected);


### PR DESCRIPTION
Added code for running Video extensions through `ResolveLinkExtension`
 - Tried to setup Unit Test cases for running video extension through the `ResolveLinkExtension` but I dont believe the `GetLink` function is available in TestUtility `Markdown.ToHtml(markdown, pipeline)`

@yufeih can I setup some time to see how I can mock the `GetLink` in `Markdown.ToHtml` to write unit tests for this functionality? Or possibly something I am missing. 