### PR TITLE
fix for broken tool page layout

### DIFF
--- a/Documentation/custom_template/dashboard.html.liquid
+++ b/Documentation/custom_template/dashboard.html.liquid
@@ -21,6 +21,8 @@
     padding: 16px;
   }
   .template-screenshot {
+    display: flex;
+    justify-content: center;
     position: relative;
     margin-bottom: 16px;
     padding-top: 60%;
@@ -29,8 +31,10 @@
   .template-screenshot-img {
     position: absolute;
     top: 0;
-    width: 100%;
+    width: auto;
     height: auto;
+    max-height: 100%;
+    max-width: 100%;
   }
   .template-title {
     font-weight: 600;

--- a/Documentation/templates-and-plugins/tools-dashboard.yml
+++ b/Documentation/templates-and-plugins/tools-dashboard.yml
@@ -8,7 +8,7 @@ items:
   - name: DocFxTocGenerator
     description: Generate a Table of Contents (TOC) in YAML format for DocFX. It has features like the ability to configure the order of files and the names of documents and folders. This tool is part of the DocFx Companion Tools set that can be installed using Chocolatey.
     type: External
-    thumbnail: ~/templates-and-plugins/images/docfstocgenerator.screenshot.png
+    thumbnail: ~/templates-and-plugins/images/docfxtocgenerator.screenshot.png
     homepage: https://github.com/Ellerbach/docfx-companion-tools
     repository:
       type: git


### PR DESCRIPTION
Issue #8093 shows some broken layout - this patch fixes these issues.

I think there might be some mileage is potentially looking at a nicer card template - but these tweaks will at least fix the issue on desktop (tested using Edge)