### PR TITLE
Update gen_doc_for_ts.md

### DIFF
--- a/Documentation/tutorial/universalreference/gen_doc_for_ts.md
+++ b/Documentation/tutorial/universalreference/gen_doc_for_ts.md
@@ -20,7 +20,7 @@ We use [typedoc](http://typedoc.org/) tool and [type2docfx](https://www.npmjs.co
 
 First, let's install the tools globally.
 ```
-npm install -g typedoc type2docfx
+npm install -g typedoc type2docfx@0.10.5
 ```
 
 #### 2.2.1 TypeDoc to parse source code into a JSON format output


### PR DESCRIPTION
Typescript example is broken as discussed here #6791 (https://github.com/dotnet/docfx/issues/6791). Re-verting to older npm package 0.10.5 for type2docfx fixes it for now.