### PR TITLE
Add try catch and needed logging for a actionable message to the user.

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/CompilePhaseHandler.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/CompilePhaseHandler.cs
@@ -140,7 +140,15 @@ namespace Microsoft.DocAsCode.Build.Engine
                                 Logger.LogDiagnostic($"Processor {hostService.Processor.Name}, step {buildStep.Name}: Building...");
                                 using (new LoggerPhaseScope(buildStep.Name, LogLevel.Diagnostic, aggregatedPerformanceScope))
                                 {
-                                    buildStep.Build(m, hostService);
+                                    try
+                                    {
+                                        buildStep.Build(m, hostService);
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        Logger.LogError($"Trouble processing file - {m.FileAndType.FullPath}, with error - {ex.Message}");
+                                        throw;
+                                    }
                                 }
                             });
                     }

--- a/src/Microsoft.DocAsCode.Build.Engine/CompilePhaseHandler.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/CompilePhaseHandler.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.DocAsCode.Build.Engine
 {
+    using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.IO;


### PR DESCRIPTION
This change is for the issue - https://github.com/dotnet/docfx/issues/8128

It adds a try catch to help log the name file which is causing issue when parsing pipe based table parser or any other parser. The reason for this logging is to help our customers be able to debug the issue themselves.