### PR TITLE
Handle list items without either <term> or <description>

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/Transform/TripleSlashCommentTransform.xsl
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/Transform/TripleSlashCommentTransform.xsl
@@ -195,8 +195,15 @@
             <ul>
               <xsl:for-each select="item">
                 <li>
-                  <xsl:apply-templates select="term" />
-                  <xsl:apply-templates select="description" />
+                  <xsl:choose>
+                    <xsl:when test="self::node()[description|term]">
+                      <xsl:apply-templates select="term" />
+                      <xsl:apply-templates select="description" />
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <xsl:apply-templates />
+                    </xsl:otherwise>
+                  </xsl:choose>
                 </li>
               </xsl:for-each>
             </ul>
@@ -205,8 +212,15 @@
             <ol>
               <xsl:for-each select="item">
                 <li>
-                  <xsl:apply-templates select="term" />
-                  <xsl:apply-templates select="description" />
+                  <xsl:choose>
+                    <xsl:when test="self::node()[description|term]">
+                      <xsl:apply-templates select="term" />
+                      <xsl:apply-templates select="description" />
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <xsl:apply-templates />
+                    </xsl:otherwise>
+                  </xsl:choose>
                 </li>
               </xsl:for-each>
             </ol>

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/TripleSlashParserUnitTest.cs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/TripleSlashParserUnitTest.cs
@@ -77,6 +77,9 @@ namespace Example
         <item>
             <description>item2 in bullet list</description>
         </item>
+        <item>
+            loose text <i>not</i> wrapped in description
+        </item>
     </list>
     </remarks>
     <returns>Task<see cref='T:System.AccessViolationException'/> returns</returns>
@@ -163,7 +166,9 @@ Classes in assemblies are by definition complete.
             word inside list->listItem->list->listItem->para.>
             the second line.
 </li><li>item2 in numbered list</li></ol>
-</li><li>item2 in bullet list</li></ul>
+</li><li>item2 in bullet list</li><li>
+loose text <em>not</em> wrapped in description
+</li></ul>
 ".Replace("\r\n", "\n"),
 remarks);
 


### PR DESCRIPTION
Items in lists should be rendered even if they lack "term" and "description" tags.  This is needed for parity with SandCastle and IntelliSense.  This only impacts lists of type "bullet" and "number" -- tables are not affected.

The simplest way to implement this _would have been_ with a [single indiscriminate `<xsl:apply-templates />` inside `<li>`](https://gist.github.com/mstefarov/2134915ad38671ff3a519a25ceaf9513/revisions#diff-5abcc86a43ac8e6519682f8069fc76538ddb2f000d6a34ec501765cb5fe92ce7), but that would have changed rendered output for existing items that _do_ contain term/description tags.  Specifically, this would force preservation of insignificant whitespace around term/description tags in the rendered output.

So, I went with the slightly longer XSLT implementation that minimizes changes to output.

#5343