### PR TITLE
Add Require Powershell 7 directive to UpdateTemplate.ps1

### DIFF
--- a/UpdateTemplate.ps1
+++ b/UpdateTemplate.ps1
@@ -1,3 +1,4 @@
+#Requires -Version 7.0
 $ErrorActionPreference = "Stop"
 
 # Check if node exists globally

--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,4 @@
 @ECHO OFF
 PUSHD %~dp0
-PowerShell -NoProfile -ExecutionPolicy Bypass -Command ".\build.ps1 %*; exit $LastExitCode;"
+pwsh -NoProfile -ExecutionPolicy Bypass -Command ".\build.ps1 %*; exit $LastExitCode;"
 POPD


### PR DESCRIPTION
UpdateTemplate.ps1 contains null coalescing operator that was introduced in powershell 7. More here https://docs.microsoft.com/en-us/powershell/scripting/whats-new/What-s-New-in-PowerShell-70?view=powershell-7.2


closes #8130 