### PR TITLE
temp disable regression test for azure-docs-pr

### DIFF
--- a/azure-pipelines-v3.yml
+++ b/azure-pipelines-v3.yml
@@ -231,8 +231,8 @@ parameters:
       params: https://github.com/dotnet/EntityFramework.ApiDocs --timeout 120
     azure-docs-rest-apis:
       params: https://github.com/Azure/azure-docs-rest-apis --timeout 130 --error-level Warning
-#    powerapps-docs-web-api-ref-pr:
-#      params: https://github.com/MicrosoftDocs/powerapps-docs-web-api-ref-pr --timeout 25
+    powerapps-docs-web-api-ref-pr:
+      params: https://github.com/MicrosoftDocs/powerapps-docs-web-api-ref-pr --timeout 25
     mc-docs-pr:
       params: https://github.com/MicrosoftDocs/mc-docs-pr --timeout 70
     dynamics365smb-devitpro:

--- a/azure-pipelines-v3.yml
+++ b/azure-pipelines-v3.yml
@@ -207,8 +207,8 @@ parameters:
 - name: repos
   type: object
   default:
-    azure-docs-pr:
-      params: https://github.com/MicrosoftDocs/azure-docs-pr --profile --timeout 115 --regression-rules
+#    azure-docs-pr:
+#      params: https://github.com/MicrosoftDocs/azure-docs-pr --profile --timeout 115 --regression-rules
     sql-docs-pr:
       params: https://github.com/MicrosoftDocs/sql-docs-pr --profile --timeout 120 --regression-rules
     docs:
@@ -221,8 +221,8 @@ parameters:
       params: https://github.com/MicrosoftDocs/VBA-Docs --timeout 80 --regression-rules
     azure-devops-docs-pr:
       params: https://github.com/MicrosoftDocs/azure-devops-docs-pr --timeout 30 --regression-rules
-    microsoft-365-docs-pr.zh-CN:
-      params: https://github.com/MicrosoftDocs/microsoft-365-docs-pr.zh-CN --branch live --profile --timeout 25
+#    microsoft-365-docs-pr.zh-CN:
+#      params: https://github.com/MicrosoftDocs/microsoft-365-docs-pr.zh-CN --branch live --profile --timeout 25
     PowerShell-Docs:
       params: https://github.com/MicrosoftDocs/PowerShell-Docs --timeout 90 --branch live
     roslyn-api-docs:
@@ -231,8 +231,8 @@ parameters:
       params: https://github.com/dotnet/EntityFramework.ApiDocs --timeout 120
     azure-docs-rest-apis:
       params: https://github.com/Azure/azure-docs-rest-apis --timeout 130 --error-level Warning
-    powerapps-docs-web-api-ref-pr:
-      params: https://github.com/MicrosoftDocs/powerapps-docs-web-api-ref-pr --timeout 25
+#    powerapps-docs-web-api-ref-pr:
+#      params: https://github.com/MicrosoftDocs/powerapps-docs-web-api-ref-pr --timeout 25
     mc-docs-pr:
       params: https://github.com/MicrosoftDocs/mc-docs-pr --timeout 70
     dynamics365smb-devitpro:

--- a/azure-pipelines-v3.yml
+++ b/azure-pipelines-v3.yml
@@ -221,8 +221,8 @@ parameters:
       params: https://github.com/MicrosoftDocs/VBA-Docs --timeout 80 --regression-rules
     azure-devops-docs-pr:
       params: https://github.com/MicrosoftDocs/azure-devops-docs-pr --timeout 30 --regression-rules
-#    microsoft-365-docs-pr.zh-CN:
-#      params: https://github.com/MicrosoftDocs/microsoft-365-docs-pr.zh-CN --branch live --profile --timeout 25
+    microsoft-365-docs-pr.zh-CN:
+      params: https://github.com/MicrosoftDocs/microsoft-365-docs-pr.zh-CN --branch live --profile --timeout 25
     PowerShell-Docs:
       params: https://github.com/MicrosoftDocs/PowerShell-Docs --timeout 90 --branch live
     roslyn-api-docs:


### PR DESCRIPTION
- azure-docs-pr: the testing result state is too large to download during test
- powerapps-docs-web-api-ref-pr: repo is removed 