### PR TITLE
pass variables to docs.validation for broken link validation

### DIFF
--- a/docs/specs/validation/broken-link-validation.yml
+++ b/docs/specs/validation/broken-link-validation.yml
@@ -1,0 +1,28 @@
+# Validate broken link
+inputs:
+  docfx.yml: |
+    markdownValidationRules: rules.json
+  rules.json: |
+    {
+      "links": {
+        "name": "BrokenLinks",
+        "description": "Validates code block content",
+        "aliases": null,
+        "rules": [
+          {
+            "type": "BrokenLinks",
+            "message": "Link '{0}' points to a page that doesn’t exist. Check the path or URL and update the link.",
+            "code": "link-broken",
+            "severity": "SUGGESTION",
+            "contentTypes": ["conceptual"]
+          }
+        ]
+      }
+    }
+  a.md: |
+    Link to [fake](https://fakelink.com)
+    Link to [real](https://reallink.com)
+outputs:
+  .errors.log: |
+    {"message_severity":"suggestion","log_item_type":"user","code":"link-broken","message":"Link 'https://fakelink.com' points to a page that doesn’t exist. Check the path or URL and update the link.","file":"a.md","line":1,"end_line":1,"column":9,"end_column":9}
+---

--- a/docs/specs/validation/broken-link-validation.yml
+++ b/docs/specs/validation/broken-link-validation.yml
@@ -23,6 +23,7 @@ inputs:
     Link to [fake](https://fakelink.com)
     Link to [real](https://reallink.com)
 outputs:
+  a.json:
   .errors.log: |
     {"message_severity":"suggestion","log_item_type":"user","code":"link-broken","message":"Link 'https://fakelink.com' points to a page that doesn’t exist. Check the path or URL and update the link.","file":"a.md","line":1,"end_line":1,"column":9,"end_column":9}
 ---

--- a/src/docfx/build/DocsetBuilder.cs
+++ b/src/docfx/build/DocsetBuilder.cs
@@ -83,7 +83,7 @@ internal class DocsetBuilder
         _publishUrlMap = new(_config, _errors, _buildScope, _redirectionProvider, _documentProvider, _monikerProvider);
         _customRuleProvider = _errors.CustomRuleProvider = new(_config, _errors, _fileResolver, _documentProvider, _publishUrlMap, _monikerProvider, _metadataProvider);
         _bookmarkValidator = new(_errors);
-        _fileLinkMapBuilder = new(_errors, _documentProvider, _monikerProvider, _contributionProvider);
+        _fileLinkMapBuilder = new(_errors, _documentProvider, _monikerProvider, _contributionProvider, _config.HostName);
         _dependencyMapBuilder = new(_sourceMap);
         _templateEngine = TemplateEngine.CreateTemplateEngine(_errors, _config, _packageResolver, _buildOptions.Locale, _bookmarkValidator);
         _zonePivotProvider = new(_errors, _documentProvider, _metadataProvider, _input, _publishUrlMap, () => Ensure(_contentValidator));

--- a/src/docfx/build/DocsetBuilder.cs
+++ b/src/docfx/build/DocsetBuilder.cs
@@ -91,7 +91,7 @@ internal class DocsetBuilder
         _xrefResolver = new(_config, _fileResolver, _buildOptions.Repository, _dependencyMapBuilder, _fileLinkMapBuilder, _errors, _documentProvider, _metadataProvider, _monikerProvider, _buildScope, _repositoryProvider, _input, _redirectionProvider, () => Ensure(_jsonSchemaTransformer));
         _linkResolver = new(_config, _buildOptions, _buildScope, _redirectionProvider, _documentProvider, _bookmarkValidator, _dependencyMapBuilder, _xrefResolver, _templateEngine, _fileLinkMapBuilder, _metadataProvider, _contentValidator);
         _htmlSanitizer = new(_config);
-        _markdownEngine = new(_input, _linkResolver, _xrefResolver, _documentProvider, _monikerProvider, _templateEngine, _contentValidator, _publishUrlMap, _htmlSanitizer);
+        _markdownEngine = new(_input, _linkResolver, _xrefResolver, _documentProvider, _monikerProvider, _templateEngine, _contentValidator, _publishUrlMap, _htmlSanitizer, _config.HostName);
         _jsonSchemaTransformer = new(_documentProvider, _markdownEngine, _linkResolver, _xrefResolver, _errors, _monikerProvider, _jsonSchemaProvider, _input);
         _metadataValidator = new MetadataValidator(_config, _microsoftGraphAccessor, _jsonSchemaLoader, _monikerProvider, _customRuleProvider);
         _tocParser = new(_input, _markdownEngine);

--- a/src/docfx/build/link/FileLinkMapBuilder.cs
+++ b/src/docfx/build/link/FileLinkMapBuilder.cs
@@ -54,6 +54,6 @@ internal class FileLinkMapBuilder
         var publishFiles = publishModel.Files.Where(item => !item.HasError && item.SourceFile != null).Select(item => item.SourceFile).ToHashSet();
         var links = _links.Value.Where(x => publishFiles.Contains(x.InclusionRoot)).OrderBy(x => x).ToArray();
 
-        return new { _hostName, links };
+        return new { hostName = _hostName, links };
     }
 }

--- a/src/docfx/build/link/FileLinkMapBuilder.cs
+++ b/src/docfx/build/link/FileLinkMapBuilder.cs
@@ -11,16 +11,18 @@ internal class FileLinkMapBuilder
     private readonly DocumentProvider _documentProvider;
     private readonly MonikerProvider _monikerProvider;
     private readonly ContributionProvider _contributionProvider;
+    private readonly string _hostName;
 
     private readonly Scoped<ConcurrentHashSet<FileLinkItem>> _links = new();
 
     public FileLinkMapBuilder(
-        ErrorBuilder errors, DocumentProvider documentProvider, MonikerProvider monikerProvider, ContributionProvider contributionProvider)
+        ErrorBuilder errors, DocumentProvider documentProvider, MonikerProvider monikerProvider, ContributionProvider contributionProvider, string hostName)
     {
         _errors = errors;
         _documentProvider = documentProvider;
         _monikerProvider = monikerProvider;
         _contributionProvider = contributionProvider;
+        _hostName = hostName;
     }
 
     public void AddFileLink(FilePath inclusionRoot, FilePath referencingFile, string targetUrl, SourceInfo? source)
@@ -52,6 +54,6 @@ internal class FileLinkMapBuilder
         var publishFiles = publishModel.Files.Where(item => !item.HasError && item.SourceFile != null).Select(item => item.SourceFile).ToHashSet();
         var links = _links.Value.Where(x => publishFiles.Contains(x.InclusionRoot)).OrderBy(x => x).ToArray();
 
-        return new { links };
+        return new { _hostName, links };
     }
 }

--- a/src/docfx/build/link/LinkResolver.cs
+++ b/src/docfx/build/link/LinkResolver.cs
@@ -139,7 +139,7 @@ internal class LinkResolver
             return (errors, "", fragment, linkType, null, false);
         }
 
-        ValidateLink(inclusionRoot, linkNode);
+        ValidateLink(inclusionRoot, linkNode, linkType == LinkType.External || linkType == LinkType.AbsolutePath);
         if (linkType == LinkType.External)
         {
             if (_config.TrustedDomains.TryGetValue(tagName, out var domains) && !domains.IsTrusted(href, out var untrustedDomain))
@@ -341,13 +341,13 @@ internal class LinkResolver
         return default;
     }
 
-    private void ValidateLink(FilePath file, LinkNode? node)
+    private void ValidateLink(FilePath file, LinkNode? node, bool validate404)
     {
         if (node is null)
         {
             return;
         }
 
-        _contentValidator.ValidateLink(file, node);
+        _contentValidator.ValidateLink(file, node, validate404);
     }
 }

--- a/src/docfx/build/link/LinkResolver.cs
+++ b/src/docfx/build/link/LinkResolver.cs
@@ -139,7 +139,11 @@ internal class LinkResolver
             return (errors, "", fragment, linkType, null, false);
         }
 
-        ValidateLink(inclusionRoot, linkNode, linkType == LinkType.External || linkType == LinkType.AbsolutePath);
+        ValidateLink(
+            inclusionRoot,
+            linkNode,
+            !IsPublicContributor() && (linkType == LinkType.External || linkType == LinkType.AbsolutePath));
+
         if (linkType == LinkType.External)
         {
             if (_config.TrustedDomains.TryGetValue(tagName, out var domains) && !domains.IsTrusted(href, out var untrustedDomain))
@@ -355,4 +359,7 @@ internal class LinkResolver
 
         _contentValidator.ValidateLink(file, node, validate404);
     }
+
+    private static bool IsPublicContributor()
+        => EnvironmentVariable.RepositoryUrl != EnvironmentVariable.PublishRepositoryUrl;
 }

--- a/src/docfx/config/EnvironmentVariable.cs
+++ b/src/docfx/config/EnvironmentVariable.cs
@@ -30,6 +30,13 @@ public static class EnvironmentVariable
     // TODO: remove after switch complete
     public static string? PPEDefaultDomainHostName => GetValue("DOCFX_PPE_DEFAULT_DOMAIN_HOST_NAME");
 
+    public static DocsEnvironment GetDocsEnvironment()
+    {
+        return Enum.TryParse(GetValue("DOCS_ENVIRONMENT"), true, out DocsEnvironment docsEnvironment)
+            ? docsEnvironment
+            : DocsEnvironment.Prod;
+    }
+
     private static string? GetValue(string name)
     {
         var value = Environment.GetEnvironmentVariable(name);

--- a/src/docfx/config/ops/OpsAccessor.cs
+++ b/src/docfx/config/ops/OpsAccessor.cs
@@ -17,7 +17,7 @@ internal class OpsAccessor : ILearnServiceAccessor
 {
     private delegate Task<HttpResponseMessage> HttpMiddleware(HttpRequestMessage request, Func<HttpRequestMessage, Task<HttpResponseMessage>> next);
 
-    public static readonly DocsEnvironment DocsEnvironment = GetDocsEnvironment();
+    public static readonly DocsEnvironment DocsEnvironment = EnvironmentVariable.GetDocsEnvironment();
 
     private readonly CredentialHandler _credentialHandler;
     private readonly ErrorBuilder _errors;
@@ -345,12 +345,5 @@ internal class OpsAccessor : ILearnServiceAccessor
             DocsEnvironment.Prod => "https://taxonomy.docs.microsoft.com",
             _ => "https://taxonomy.ppe.docs.microsoft.com",
         };
-    }
-
-    private static DocsEnvironment GetDocsEnvironment()
-    {
-        return Enum.TryParse(Environment.GetEnvironmentVariable("DOCS_ENVIRONMENT"), true, out DocsEnvironment docsEnvironment)
-            ? docsEnvironment
-            : DocsEnvironment.Prod;
     }
 }

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.5.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.3.0" />
-    <PackageReference Include="docs.validation" Version="1.0.1-rc-00018-f8705ee" />
+    <PackageReference Include="docs.validation" Version="1.0.2-rc-00027-9f7d525" />
     <PackageReference Include="DotLiquid" Version="2.2.602" />
     <PackageReference Include="Glob" Version="1.1.9" />
     <PackageReference Include="HtmlReaderWriter" Version="1.0.0" />
@@ -49,6 +49,18 @@
   <ItemGroup>
     <ProjectReference Include="../Microsoft.Docs.MarkdigExtensions/Microsoft.Docs.MarkdigExtensions.csproj" />
     <ProjectReference Include="../Microsoft.Docs.Build.Specialized/Microsoft.Docs.Build.Specialized.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="validation\brokenLinkValidationUserSetting\config.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="validation\brokenLinkValidationUserSetting\config.ppe.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="validation\brokenLinkValidationUserSetting\config.prod.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.5.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.3.0" />
-    <PackageReference Include="docs.validation" Version="1.0.1-rc-00140-f8d62d5" />
+    <PackageReference Include="docs.validation" Version="1.0.1-rc-00018-f8705ee" />
     <PackageReference Include="DotLiquid" Version="2.2.602" />
     <PackageReference Include="Glob" Version="1.1.9" />
     <PackageReference Include="HtmlReaderWriter" Version="1.0.0" />

--- a/src/docfx/lib/markdown/MarkdownEngine.cs
+++ b/src/docfx/lib/markdown/MarkdownEngine.cs
@@ -32,6 +32,8 @@ internal class MarkdownEngine
     private readonly PublishUrlMap _publishUrlMap;
     private readonly HtmlSanitizer _htmlSanitizer;
 
+    private readonly string _hostName;
+
     private static readonly ThreadLocal<Stack<Status>> s_status = new(() => new());
 
     public MarkdownEngine(
@@ -43,7 +45,8 @@ internal class MarkdownEngine
         TemplateEngine templateEngine,
         ContentValidator contentValidator,
         PublishUrlMap publishUrlMap,
-        HtmlSanitizer htmlSanitizer)
+        HtmlSanitizer htmlSanitizer,
+        string hostName)
     {
         _input = input;
         _linkResolver = linkResolver;
@@ -54,6 +57,7 @@ internal class MarkdownEngine
         _contentValidator = contentValidator;
         _publishUrlMap = publishUrlMap;
         _htmlSanitizer = htmlSanitizer;
+        _hostName = hostName;
 
         _markdownContext = new(GetToken, LogInfo, LogSuggestion, LogWarning, LogError, ReadFile, GetLink, GetImageLink);
         _pipelines = new[]
@@ -282,7 +286,7 @@ internal class MarkdownEngine
         return s_status.Value!.Peek().Conceptual;
     }
 
-    private static LinkNode? TransformLinkInfo(LinkInfo link)
+    private LinkNode? TransformLinkInfo(LinkInfo link)
     {
         if (link.MarkdownObject is null)
         {
@@ -315,6 +319,7 @@ internal class MarkdownEngine
             Monikers = link.MarkdownObject.GetZoneLevelMonikers(),
             ZonePivots = link.MarkdownObject.GetZonePivots(),
             TabbedConceptualHeader = link.MarkdownObject.GetTabId(),
+            HostName = _hostName,
         };
     }
 

--- a/src/docfx/validation/brokenLinkValidationUserSetting/config.json
+++ b/src/docfx/validation/brokenLinkValidationUserSetting/config.json
@@ -1,0 +1,57 @@
+{
+  "RequestTimeoutInSeconds": 5,
+  "SkipTooManyRequests": true,
+  "RetryOptions": {
+    "RetryUserAgent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0",
+    "GithubEntityRetryCodes": [ 404, 429, 502 ],
+    "ExternalLinkRetryCodes": [ 429, 403, 408 ],
+    "InternalLinkRetryCodes": [ 408 ]
+  },
+  "RequestThrottlers": [
+    {
+      "Prefix": "go.microsoft.com",
+      "Limit": 2,
+      "Period": "1s"
+    },
+    {
+      "Prefix": "www.microsoft.com/download",
+      "Limit": 5,
+      "Period": "5s"
+    },
+    {
+      "Prefix": "msdn.microsoft.com",
+      "Limit": 5,
+      "Period": "1s"
+    },
+    {
+      "Prefix": "github.com",
+      "Limit": 1,
+      "Period": "1.5s"
+    },
+    {
+      "Prefix": "www.nuget.org",
+      "Limit": 4,
+      "Period": "2.5s"
+    },
+    {
+      "Prefix": "docs.microsoft.com/dotnet/api",
+      "Limit": 45,
+      "Period": "1s"
+    },
+    {
+      "Prefix": "learn.microsoft.com/dotnet/api",
+      "Limit": 45,
+      "Period": "1s"
+    },
+    {
+      "Prefix": "www.linkedin.com",
+      "Limit": 1,
+      "Period": "1s"
+    },
+    {
+      "Prefix": "www.youtube.com",
+      "Limit": 1,
+      "Period": "1s"
+    }
+  ]
+}

--- a/src/docfx/validation/brokenLinkValidationUserSetting/config.ppe.json
+++ b/src/docfx/validation/brokenLinkValidationUserSetting/config.ppe.json
@@ -1,0 +1,4 @@
+{
+  // For now, user settings for PubDev and Public are almost the same.
+  "Environment": "PudDev"
+}

--- a/src/docfx/validation/brokenLinkValidationUserSetting/config.prod.json
+++ b/src/docfx/validation/brokenLinkValidationUserSetting/config.prod.json
@@ -1,0 +1,3 @@
+{
+  "Environment": "Public"
+}


### PR DESCRIPTION
[AB#702233](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/702233)

**Changes**
- Update the contract between docfx and docs.validation for broken link validation. Now, we pass `UserSetting` to docs.validation which will be passed to broken link lib eventually. The setting is controlled in docfx, so we don't bother upgrading docs.validation/ broken link lib each time we want to change the settings.
- Add conditions to decide whether we want to validate broken link. The link needs to be external or in absolute path and the pr is not created by public contributor.
- Add host name into `.links.json` and `LinkNode.cs`.

**Test**
For now, we are mocking up docs.validation for testing purpose that we will throw broken-link suggestion when the link is `https://fakelink.com`.
- Spec test
- Local test on PPE repo.
![image](https://user-images.githubusercontent.com/74176112/192488962-b7f9f74d-659a-409b-ac3f-6ef108e92366.png)
