### PR TITLE
feat: use new hostname

### DIFF
--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -872,7 +872,7 @@ inputs:
 outputs:
   docs/a.json: |
     {
-       "conceptual": "<p><a href=\"/en-us/azure#bookmark\" data-linktype=\"absolute-path\">A link</a></p><p><a href=\"/zh-cn/azure?view=moniker-1\" data-linktype=\"absolute-path\">Another link</a></p>",
+       "conceptual": "<p><a href=\"/en-us/azure#bookmark\" data-linktype=\"absolute-path\">A link</a><a href=\"/zh-cn/azure?view=moniker-1\" data-linktype=\"absolute-path\">Another link</a></p>",
     }
 ---
 # keep domain for alternative hostname for absolute links when removeHostName is false
@@ -887,5 +887,5 @@ inputs:
 outputs:
   docs/a.json: |
     {
-       "conceptual": "<p><a href=\"https://docs.microsoft.com/en-us/azure#bookmark\" data-linktype=\"external\">A link</a></p><p><a href=\"https://docs.microsoft.com/zh-cn/azure?view=moniker-1\" data-linktype=\"external\">A link</a></p>",
+       "conceptual": "<p><a href=\"https://docs.microsoft.com/en-us/azure#bookmark\" data-linktype=\"external\">A link</a><a href=\"https://docs.microsoft.com/zh-cn/azure?view=moniker-1\" data-linktype=\"external\">A link</a></p>",
     }

--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -858,15 +858,32 @@ outputs:
       "no-loc": ["method", "SDK"]
     }
 ---
-# remove domain for alternative hostname for absolute links
+# remove domain for alternative hostname for absolute links when removeHostName is true
 inputs:
   docfx.yml: |
+    hostName: docs.microsoft.com
     alternativeHostname: new-docs.microsoft.com
     removeHostName: true
   docs/a.md: |
-    [A link](https://new-docs.microsoft.com/en-us/azure)
+    [A link](https://docs.microsoft.com/en-us/azure#bookmark)
+    [Another link](https://new-docs.microsoft.com/zh-cn/azure?view=moniker-1)
 outputs:
   docs/a.json: |
     {
-       "conceptual": "<p><a href=\"/en-us/azure\" data-linktype=\"absolute-path\">A link</a></p>",
+       "conceptual": "<p><a href=\"/en-us/azure#bookmark\" data-linktype=\"absolute-path\">A link</a></p><p><a href=\"/zh-cn/azure?view=moniker-1\" data-linktype=\"absolute-path\">A link</a></p>",
+    }
+---
+# replace domain for alternative hostname for absolute links when removeHostName is false
+inputs:
+  docfx.yml: |
+    hostName: docs.microsoft.com
+    alternativeHostname: new-docs.microsoft.com
+    removeHostName: false
+  docs/a.md: |
+    [A link](https://docs.microsoft.com/en-us/azure)
+    [Another link](https://new-docs.microsoft.com/zh-cn/azure?view=moniker-1)
+outputs:
+  docs/a.json: |
+    {
+       "conceptual": "<p><a href=\"https://docs.microsoft.com/en-us/azure#bookmark\" data-linktype=\"absolute-path\">A link</a></p><p><a href=\"https://docs.microsoft.com/zh-cn/azure?view=moniker-1\" data-linktype=\"absolute-path\">A link</a></p>",
     }

--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -410,6 +410,7 @@ outputs:
 inputs:
   docfx.yml: |
     removeHostName: true
+    hostName: docs.com
   docs/a.md: |
     [external link](https://docs.com/c)
 outputs:
@@ -699,6 +700,7 @@ outputs:
 inputs:
   docfx.yml: |
     removeHostName: true
+    hostName: docs.com
   a.md: |
     > [!TIP]
     > [![](./b.png)](https://docs.com)
@@ -870,10 +872,10 @@ inputs:
 outputs:
   docs/a.json: |
     {
-       "conceptual": "<p><a href=\"/en-us/azure#bookmark\" data-linktype=\"absolute-path\">A link</a></p><p><a href=\"/zh-cn/azure?view=moniker-1\" data-linktype=\"absolute-path\">A link</a></p>",
+       "conceptual": "<p><a href=\"/en-us/azure#bookmark\" data-linktype=\"absolute-path\">A link</a></p><p><a href=\"/zh-cn/azure?view=moniker-1\" data-linktype=\"absolute-path\">Another link</a></p>",
     }
 ---
-# replace domain for alternative hostname for absolute links when removeHostName is false
+# keep domain for alternative hostname for absolute links when removeHostName is false
 inputs:
   docfx.yml: |
     hostName: docs.microsoft.com
@@ -885,5 +887,5 @@ inputs:
 outputs:
   docs/a.json: |
     {
-       "conceptual": "<p><a href=\"https://docs.microsoft.com/en-us/azure#bookmark\" data-linktype=\"absolute-path\">A link</a></p><p><a href=\"https://docs.microsoft.com/zh-cn/azure?view=moniker-1\" data-linktype=\"absolute-path\">A link</a></p>",
+       "conceptual": "<p><a href=\"https://docs.microsoft.com/en-us/azure#bookmark\" data-linktype=\"external\">A link</a></p><p><a href=\"https://docs.microsoft.com/zh-cn/azure?view=moniker-1\" data-linktype=\"external\">A link</a></p>",
     }

--- a/docs/specs/markdown.yml
+++ b/docs/specs/markdown.yml
@@ -882,10 +882,10 @@ inputs:
     alternativeHostname: new-docs.microsoft.com
     removeHostName: false
   docs/a.md: |
-    [A link](https://docs.microsoft.com/en-us/azure)
+    [A link](https://docs.microsoft.com/en-us/azure#bookmark)
     [Another link](https://new-docs.microsoft.com/zh-cn/azure?view=moniker-1)
 outputs:
   docs/a.json: |
     {
-       "conceptual": "<p><a href=\"https://docs.microsoft.com/en-us/azure#bookmark\" data-linktype=\"external\">A link</a><a href=\"https://docs.microsoft.com/zh-cn/azure?view=moniker-1\" data-linktype=\"external\">A link</a></p>",
+       "conceptual": "<p><a href=\"https://docs.microsoft.com/en-us/azure#bookmark\" data-linktype=\"external\">A link</a><a href=\"https://new-docs.microsoft.com/zh-cn/azure?view=moniker-1\" data-linktype=\"external\">Another link</a></p>",
     }

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,0 +1,2 @@
+- name: Getting Started
+  href: getting-started.md

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,2 +1,0 @@
-- name: Getting Started
-  href: getting-started.md

--- a/src/docfx/build/link/LinkResolver.cs
+++ b/src/docfx/build/link/LinkResolver.cs
@@ -155,7 +155,7 @@ internal class LinkResolver
                 return (errors, "", fragment, LinkType.AbsolutePath, null, false);
             }
             var resolvedHref = _config.RemoveHostName ? UrlUtility.RemoveLeadingHostName(href, _config.HostName) : href;
-            if (!string.IsNullOrEmpty(_config.AlternativeHostName) && !_config.RemoveHostName)
+            if (!string.IsNullOrEmpty(_config.AlternativeHostName))
             {
                 var removedAlternativeHostNameHref = UrlUtility.RemoveLeadingHostName(href, _config.AlternativeHostName);
                 resolvedHref = _config.RemoveHostName

--- a/src/docfx/build/link/LinkResolver.cs
+++ b/src/docfx/build/link/LinkResolver.cs
@@ -154,13 +154,12 @@ internal class LinkResolver
                 }
                 return (errors, "", fragment, LinkType.AbsolutePath, null, false);
             }
-            var resolvedHref = _config.RemoveHostName ? UrlUtility.RemoveLeadingHostName(href, _config.HostName) : href;
-            if (!string.IsNullOrEmpty(_config.AlternativeHostName))
+
+            string resolvedHref = href;
+            if (_config.RemoveHostName)
             {
-                var removedAlternativeHostNameHref = UrlUtility.RemoveLeadingHostName(href, _config.AlternativeHostName);
-                resolvedHref = _config.RemoveHostName
-                    ? removedAlternativeHostNameHref
-                    : UrlUtility.Combine($"https://{_config.HostName}", removedAlternativeHostNameHref);
+                resolvedHref = UrlUtility.RemoveLeadingHostName(resolvedHref, _config.HostName);
+                resolvedHref = UrlUtility.RemoveLeadingHostName(resolvedHref, _config.AlternativeHostName);
             }
 
             return (errors, resolvedHref, fragment, LinkType.AbsolutePath, null, false);

--- a/src/docfx/build/link/LinkResolver.cs
+++ b/src/docfx/build/link/LinkResolver.cs
@@ -155,7 +155,13 @@ internal class LinkResolver
                 return (errors, "", fragment, LinkType.AbsolutePath, null, false);
             }
             var resolvedHref = _config.RemoveHostName ? UrlUtility.RemoveLeadingHostName(href, _config.HostName) : href;
-            resolvedHref = UrlUtility.RemoveLeadingHostName(resolvedHref, _config.AlternativeHostName);
+            if (!string.IsNullOrEmpty(_config.AlternativeHostName) && !_config.RemoveHostName)
+            {
+                var removedAlternativeHostNameHref = UrlUtility.RemoveLeadingHostName(href, _config.AlternativeHostName);
+                resolvedHref = _config.RemoveHostName
+                    ? removedAlternativeHostNameHref
+                    : UrlUtility.Combine($"https://{_config.HostName}", removedAlternativeHostNameHref);
+            }
 
             return (errors, resolvedHref, fragment, LinkType.AbsolutePath, null, false);
         }

--- a/src/docfx/config/EnvironmentVariable.cs
+++ b/src/docfx/config/EnvironmentVariable.cs
@@ -27,9 +27,6 @@ public static class EnvironmentVariable
 
     public static string? SessionId => GetValue("DOCFX_SESSION_ID");
 
-    // TODO: remove after switch complete
-    public static string? PPEDefaultDomainHostName => GetValue("DOCFX_PPE_DEFAULT_DOMAIN_HOST_NAME");
-
     private static string? GetValue(string name)
     {
         var value = Environment.GetEnvironmentVariable(name);

--- a/test/docfx.SpecTest/OpsConfigAdapterTest.cs
+++ b/test/docfx.SpecTest/OpsConfigAdapterTest.cs
@@ -13,15 +13,15 @@ public static class OpsConfigAdapterTest
     {
         {
             "https://ops/buildconfig/?name=e2eppe-azure-documents&repository_url=https://github.com/OPS-E2E-PPE/azure-docs-pr&branch=master",
-            "{'product':'MSDN','siteName':'Docs','hostName':'ppe.docs.microsoft.com','basePath':'/e2eppe-azure-documents','xrefHostName':'ppe.docs.microsoft.com'}"
+            "{'product':'MSDN','siteName':'Docs','hostName':'dev.learn.microsoft.com','alternativeHostName':'ppe.docs.microsoft.com','basePath':'/e2eppe-azure-documents','xrefHostName':'dev.learn.microsoft.com'}"
         },
         {
             "https://ops/buildconfig/?name=e2eppe-azure-documents&repository_url=https://github.com/OPS-E2E-PPE/azure-docs-pr&branch=live",
-            "{'product':'MSDN','siteName':'Docs','hostName':'ppe.docs.microsoft.com','basePath':'/e2eppe-azure-documents','xrefHostName':'ppe.docs.microsoft.com'}"
+            "{'product':'MSDN','siteName':'Docs','hostName':'dev.learn.microsoft.com','alternativeHostName':'ppe.docs.microsoft.com','basePath':'/e2eppe-azure-documents','xrefHostName':'dev.learn.microsoft.com'}"
         },
         {
             "https://ops/buildconfig/?name=E2E_DocFxV3&repository_url=https://github.com/OPS-E2E-PPE/E2E_DocFxV3/&branch=master",
-            "{'product':'MSDN','siteName':'Docs','hostName':'ppe.docs.microsoft.com','basePath':'/E2E_DocFxV3','xrefHostName':'ppe.docs.microsoft.com'}"
+            "{'product':'MSDN','siteName':'Docs','hostName':'dev.learn.microsoft.com','alternativeHostName':'ppe.docs.microsoft.com','basePath':'/E2E_DocFxV3','xrefHostName':'dev.learn.microsoft.com'}"
         },
     };
 


### PR DESCRIPTION
[AB#685989](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/685989)
[AB#680809](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/680809)
[AB#708846](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/708846)

This PR updates default host name for Docs as learn.microsoft.com. It also addresses two problems with original solution:
- Alternative host name should be per site.
- When `removeHostName` is false, keep alternative host name as it is in build output.