### PR TITLE
feat: throw error if template branch isn't main or master or default

### DIFF
--- a/docs/specs/config.yml
+++ b/docs/specs/config.yml
@@ -547,3 +547,12 @@ outputs:
     {"document_id":"c871e0da-be84-d8ce-ce09-6d935e69b172","document_version_independent_id":"2c52aff4-0602-cfcd-e12f-269c5629bdd8"}
   src/dir1/a.json: |
     {"document_id":"b998d1b1-aaed-698d-7b82-0bc93b0b7ba5","document_version_independent_id":"2db8730f-5266-6c4f-6a6b-7db32fcff3b3"}
+---
+# template branch must be main or master or default when validation is enabled
+inputs:
+  docfx.yml: |
+    validateTemplateBranch: true
+    template: https://docs.com/template#test
+outputs:
+  .errors.log: |
+    {"message_severity":"error","code":"template-branch-invalid"}

--- a/docs/specs/config.yml
+++ b/docs/specs/config.yml
@@ -552,7 +552,23 @@ outputs:
 inputs:
   docfx.yml: |
     validateTemplateBranch: true
-    template: https://docs.com/template#test
+    template: https://docs.com/theme#test
 outputs:
   .errors.log: |
-    {"message_severity":"error","code":"template-branch-invalid"}
+    {"message_severity":"error","code":"template-branch-invalid","message":"Invalid template branch: 'test'. Template branch must be 'main' or 'master' or default."}
+---
+# template branch must be main or master or default when validation is enabled
+inputs:
+  docfx.yml: |
+    validateTemplateBranch: true
+    template: https://docs.com/template#main
+outputs:
+  .errors.log:
+---
+# template branch must be main or master or default when validation is enabled
+inputs:
+  docfx.yml: |
+    validateTemplateBranch: true
+    template: https://docs.com/template
+outputs:
+  .errors.log:

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -235,7 +235,7 @@ internal static class Errors
         /// </summary>
         /// Behavior: ❌ Message: ❌
         public static Error TemplateBranchInvalid(string templateBranch)
-            => new(ErrorLevel.Error, "template-branch-invalid", $"Invalid template branch: '{templateBranch}'. Template branch must be `main` or `master` or default.");
+            => new(ErrorLevel.Error, "template-branch-invalid", $"Invalid template branch: '{templateBranch}'. Template branch must be 'main' or 'master' or default.");
     }
 
     public static class Link

--- a/src/docfx/Errors.cs
+++ b/src/docfx/Errors.cs
@@ -229,6 +229,13 @@ internal static class Errors
         /// Behavior: ❌ Message: ✔️
         public static Error CommittishNotFound(string repo, string committish)
             => new(ErrorLevel.Error, "committish-not-found", $"Can't find branch, tag, or commit '{committish}' for repo {repo}.");
+
+        /// <summary>
+        /// Must use `main` or `master` or default for template branch.
+        /// </summary>
+        /// Behavior: ❌ Message: ❌
+        public static Error TemplateBranchInvalid(string templateBranch)
+            => new(ErrorLevel.Error, "template-branch-invalid", $"Invalid template branch: '{templateBranch}'. Template branch must be `main` or `master` or default.");
     }
 
     public static class Link

--- a/src/docfx/config/Config.cs
+++ b/src/docfx/config/Config.cs
@@ -353,6 +353,8 @@ internal class Config : PreloadConfig
 
     public bool IsCanonicalUrlWithMoniker { get; init; }
 
+    public bool ValidateTemplateBranch { get; init; }
+
     public IEnumerable<SourceInfo<string>> GetFileReferences()
     {
         foreach (var url in Xref)

--- a/src/docfx/config/ConfigLoader.cs
+++ b/src/docfx/config/ConfigLoader.cs
@@ -102,6 +102,11 @@ internal static class ConfigLoader
         JsonUtility.Merge(unionProperties, configObject, envConfig, globalConfig, extendConfig, opsConfig, docfxConfig, cliConfig);
         var config = JsonUtility.ToObject<Config>(errors, configObject);
 
+        if (config.ValidateTemplateBranch)
+        {
+            ValidateTemplateBranch(config.Template);
+        }
+
         Telemetry.TrackDocfxConfig(config.Name, docfxConfig);
         return (config, buildOptions, packageResolver, fileResolver, opsAccessor);
     }
@@ -260,5 +265,13 @@ internal static class ConfigLoader
         }
 
         return null;
+    }
+
+    private static void ValidateTemplateBranch(PackagePath template)
+    {
+        if (!template.IsMainOrMasterOrDefault)
+        {
+            throw Errors.Config.TemplateBranchInvalid(template.Branch).ToException();
+        }
     }
 }

--- a/src/docfx/config/ops/OpsConfigLoader.cs
+++ b/src/docfx/config/ops/OpsConfigLoader.cs
@@ -59,16 +59,8 @@ internal static class OpsConfigLoader
                   !dep.name.StartsWith("_dependentPackages", StringComparison.OrdinalIgnoreCase)
             select new JProperty(dep.path, dep.obj));
 
-        var template = dependencies.FirstOrDefault(
+        result["template"] = dependencies.FirstOrDefault(
             dep => dep.name.Equals("_themes", StringComparison.OrdinalIgnoreCase)).obj;
-
-        // override template branch to main for live branch build
-        if (template != null && branch == "live")
-        {
-            template["branch"] = "main";
-        }
-
-        result["template"] = template;
 
         result["outputPdf"] = opsConfig.NeedGeneratePdfUrlTemplate;
 

--- a/src/docfx/config/ops/OpsConfigLoader.cs
+++ b/src/docfx/config/ops/OpsConfigLoader.cs
@@ -59,8 +59,16 @@ internal static class OpsConfigLoader
                   !dep.name.StartsWith("_dependentPackages", StringComparison.OrdinalIgnoreCase)
             select new JProperty(dep.path, dep.obj));
 
-        result["template"] = dependencies.FirstOrDefault(
+        var template = dependencies.FirstOrDefault(
             dep => dep.name.Equals("_themes", StringComparison.OrdinalIgnoreCase)).obj;
+
+        // override template branch to main for live branch build
+        if (template != null && branch == "live")
+        {
+            template["branch"] = "main";
+        }
+
+        result["template"] = template;
 
         result["outputPdf"] = opsConfig.NeedGeneratePdfUrlTemplate;
 

--- a/src/docfx/lib/path/PackagePath.cs
+++ b/src/docfx/lib/path/PackagePath.cs
@@ -28,7 +28,7 @@ internal record PackagePath
 
     public bool IsMainOrMaster => Branch == "main" || Branch == "master";
 
-    public bool IsMainOrMasterOrDefault => Branch == "main" || Branch == "master" || Branch == "";
+    public bool IsMainOrMasterOrDefault => Branch == "main" || Branch == "master" || string.IsNullOrEmpty(Branch);
 
     public PackagePath()
     {

--- a/src/docfx/lib/path/PackagePath.cs
+++ b/src/docfx/lib/path/PackagePath.cs
@@ -28,6 +28,8 @@ internal record PackagePath
 
     public bool IsMainOrMaster => Branch == "main" || Branch == "master";
 
+    public bool IsMainOrMasterOrDefault => Branch == "main" || Branch == "master" || Branch == "";
+
     public PackagePath()
     {
     }


### PR DESCRIPTION
[AB#713280](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/713280)

Design considerations:
- Override with `main` vs. throwing error: Prefer throwing error so that content team will be fully aware of this change. They will then open a PR for fix and during the PR they can double check whether the rendered results are expected.
- Why do we need to pass in a flag: Local run of DocFX for developers and DocFX run in learn-validation extension will still want to have the flexibility to be able to use non-`main` branch template. Thus, a flag is invented and will only be set to `true` for real server build for `live` branch build and PR builds towards `live` branch.