### PR TITLE
Add JSON schema for Microsoft Learn config

### DIFF
--- a/schemas/v1.0/.openpublishing.publish.config.schema.json
+++ b/schemas/v1.0/.openpublishing.publish.config.schema.json
@@ -1,0 +1,144 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "description": "JSON schema for .openpublishing.publish.config.json used for Microsoft Learn",
+    "type": "object",
+    "properties": {
+        "docsets_to_publish": {
+            "type": "array",
+            "description": "Specifies a list of docsets to publish",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "docset_name": {
+                        "type": "string",
+                        "description": "Specifies the name of the docset to publish"
+                    },
+                    "build_source_folder": {
+                        "type": "string",
+                        "description": "Directory path to docfx.json relative to the root of the repository"
+                    },
+                    "open_to_public_contributors": {
+                        "type":["boolean","string"],
+                        "description": "Whether or not to show the edit button to accept public contributions"
+                    },
+                    "xref_query_tags": {
+                        "type": "array",
+                        "description": "Specifies additional base path to include for xref resolution",
+                        "examples": [
+                            "https://github.com/MicrosoftDocs/azure-docs-pr/blob/7f9257ed2768a60687cdd668595aed6d5cd5e08e/.openpublishing.publish.config.json#L11"
+                        ],
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "customized_tasks": {
+                        "type": "object",
+                        "description": "Determines if it is a learn repository by checking if docset_postbuild contains TripleCrownValidation.ps1",
+                        "examples": [
+                            "https://github.com/MicrosoftDocs/learn-pr/blob/main/.openpublishing.publish.config.json#L23"
+                        ],
+                        "properties": {
+                            "docset_postbuild": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "split_toc": {
+                        "type": "array",
+                        "description": "Specifies a set of TOCs to split into a set of smaller TOCs in build",
+                        "examples": [
+                            "https://github.com/dotnet/dotnet-api-docs/blob/main/.openpublishing.publish.config.json#L44"
+                        ],
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "JoinTOCPlugin": {
+                        "type": "array",
+                        "description": "Configures fusion TOC and auto-generated service pages",
+                        "examples": [
+                            "https://github.com/MicrosoftDocs/azure-docs-sdk-node/blob/main/.openpublishing.publish.config.json#L93"
+                        ]
+                    },
+                    "ECMA2Yaml": {
+                        "type": "object",
+                        "description": "Configures the ECMA2Yaml tool to generate .NET API reference docs from XML files",
+                        "examples": [
+                            "https://github.com/dotnet/dotnet-api-docs/blob/main/.openpublishing.publish.config.json#L38"
+                        ]
+                    },
+                    "monikerPath": {
+                        "type": "array",
+                        "description": "Specifies the moniker definition file for PowerShell API reference docs",
+                        "examples": [
+                            "https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/.openpublishing.publish.config.json#L48"
+                        ],
+                        "items": {
+                            "type":"string"
+                        }
+                    }
+                }
+            }
+        },
+        "redirection_files": {
+            "type": "array",
+            "description": "Specifies a list of redirection files to include in build",
+            "examples": [
+                "https://github.com/MicrosoftDocs/azure-docs-pr/blob/7f9257ed2768a60687cdd668595aed6d5cd5e08e/.openpublishing.publish.config.json#L973"
+            ],
+            "items": {
+                "type": "string"
+            }
+        },
+        "dependent_repositories": {
+            "type": "array",
+            "description": "Specifies a list of dependency repositories with additional files to include in build",
+            "examples": [
+                "https://github.com/MicrosoftDocs/azure-docs-pr/blob/7f9257ed2768a60687cdd668595aed6d5cd5e08e/.openpublishing.publish.config.json#L34"
+            ],
+            "items": {
+                "type": "object",
+                "properties": {
+                    "path_to_root": {
+                        "type": "string",
+                        "description": "Path relative to repository root where the dependency repository is cloned"
+                    },
+                    "url":{
+                        "type": "string",
+                        "description": "Repository URL"
+                    },
+                    "branch":{
+                        "type": "string",
+                        "description": "Repository branch"
+                    },
+                    "branch_mapping": {
+                        "type": "object",
+                        "description": "Specifies a mapping from the branch name of the main repository to the dependency repository branch to check out",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "include_in_build": {
+                        "type": "boolean",
+                        "description": "When true, files in dependency repository that matches docfx.json content config are build and published to the site. When false, files in this dependency repository can only be included as markdown fragment or code snippet. The default is false."
+                    }
+                }
+            }
+        },
+        "git_repository_url_open_to_public_contributors": {
+            "type": "string",
+            "description": "Specifies the edit repository URL for private repositories"
+        },
+        "git_repository_branch_open_to_public_contributors": {
+            "type": "string",
+            "description": "Specifies the edit repository branch"
+        },
+        "need_generate_pdf_url_template": {
+            "type": "boolean",
+            "description": "Whether PDF is enabled for this repository"
+        }
+    }
+}

--- a/schemas/v1.0/.openpublishing.publish.config.schema.json
+++ b/schemas/v1.0/.openpublishing.publish.config.schema.json
@@ -2,12 +2,20 @@
     "$schema": "http://json-schema.org/draft-07/schema",
     "description": "JSON schema for .openpublishing.publish.config.json used for Microsoft Learn",
     "type": "object",
+    "required": [
+        "docsets_to_publish"
+    ],
     "properties": {
         "docsets_to_publish": {
             "type": "array",
             "description": "Specifies a list of docsets to publish",
+            "minLength": 1,
             "items": {
                 "type": "object",
+                "required": [
+                    "docset_name",
+                    "build_source_folder"
+                ],
                 "properties": {
                     "docset_name": {
                         "type": "string",
@@ -101,6 +109,10 @@
             ],
             "items": {
                 "type": "object",
+                "required": [
+                    "path_to_root",
+                    "url"
+                ],
                 "properties": {
                     "path_to_root": {
                         "type": "string",

--- a/schemas/v1.0/docs.docfx.schema.json
+++ b/schemas/v1.0/docs.docfx.schema.json
@@ -117,7 +117,7 @@
                         },
                         "folder_relative_path_in_docset": {
                             "type": "string",
-                            "description": "The original docfx.json directory path relative to repository root"
+                            "description": "The original source directory relative to docfx.json directory"
                         }
                     }
                 },

--- a/schemas/v1.0/docs.docfx.schema.json
+++ b/schemas/v1.0/docs.docfx.schema.json
@@ -1,0 +1,131 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "description": "JSON schema for docfx.json used for Microsoft Learn",
+    "type": "object",
+    "properties": {
+        "build": {
+            "type": "object",
+            "description": "Build configuration",
+            "properties": {
+                "content": {
+                    "type": "array",
+                    "description": "Specifies buildable content like markdown, YAML and TOC files",
+                    "items": {
+                        "$ref": "#/definitions/FileMapping"
+                    }
+                },
+                "resource": {
+                    "type": "array",
+                    "description": "Specifies resources copied to output as is like images",
+                    "items": {
+                        "$ref": "#/definitions/FileMapping"
+                    }
+                },
+                "groups": {
+                    "type": "object",
+                    "description": "Specifies groups to configure files using moniker range",
+                    "examples": [
+                        "https://github.com/MicrosoftDocs/azure-docs-pr/blob/7f9257ed2768a60687cdd668595aed6d5cd5e08e/docfx.json#L129"
+                    ],
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                            "moniker_range": {
+                                "type": "string",
+                                "description": "Specifies the moniker range for this group"
+                            }
+                        }
+                    }
+                },
+                "globalMetadata": {
+                    "$ref": "#/definitions/Metadata"
+                },
+                "fileMetadata": {
+                    "type": "object",
+                    "description": "Specifies metadata for files using glob patterns"
+                },
+                "xref": {
+                    "type":"array",
+                    "description": "Specifies additional xref map files to lookup in the repository",
+                    "examples": [
+                        "https://github.com/dotnet/dotnet-api-docs/blob/main/docfx.json#L142"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "FileMapping": {
+            "type": "object",
+            "properties": {
+                "src": {
+                    "type": ["string", "null"],
+                    "description": "Source directory of files included in build"
+                },
+                "dest": {
+                    "type": ["string", "null"],
+                    "description": "Destination base URL of files in this section"
+                },
+                "files": {
+                    "type": "array",
+                    "description": "List of file glob patterns to include in build",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "exclude": {
+                    "type": "array",
+                    "description": "List of file glob patterns to exclude in build",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "group": {
+                    "type": "string",
+                    "description": "An optional group name to lookup against in groups config to determine the version of files in this section"
+                },
+                "version": {
+                    "type": "string",
+                    "description": "An optional moniker name that determine the version of files in this section"
+                }
+            }
+        },
+        "Metadata": {
+            "type": "object",
+            "description": "A free-form key value pairs set on files, a mixture of content metadata and site features knobs. Due to the open nature of metadata, it has become a kitchen sink with no centralized governance, this is a non-comprehensive list of site feature knobs",
+            "additionalProperties": {
+                "contributors_to_exclude": {
+                    "type": "array",
+                    "description": "Specifies a list of GitHub aliases to exclude from the contributor list",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "_op_documentIdPathDepotMapping": {
+                    "type": "object",
+                    "description": "Specifies the mapping to ensure document ID stay the same for files moved to a different repository",
+                    "examples": [
+                        "https://github.com/MicrosoftDocs/azure-docs-pr/blob/7f9257ed2768a60687cdd668595aed6d5cd5e08e/docfx.json#L138"
+                    ],
+                    "additionalProperties": {
+                        "depot_name": {
+                            "type": "string",
+                            "description": "The original depot name found in OPS portal"
+                        },
+                        "folder_relative_path_in_docset": {
+                            "type": "string",
+                            "description": "The original docfx.json directory path relative to repository root"
+                        }
+                    }
+                },
+                "breadcrumb_path": {
+                    "type": "string",
+                    "description": "Specifies the breadcrumb source file or breadcrumb URL for this file"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add an initial version of `docfx.json` schema (a restricted set for Microsoft Learn only)  and `.openpublishing.publish.config.json` schema. 

These schema definitions contain all the configurations we intend to expose for mslearn:
- Configs not exposed here are system knobs that aren't meant for end users. 
- Configs today written in `docfx.json` and `.openpublishing.publish.config.json` but not appear in this schema are legacy, not recognized by the system and could be removed.