### PR TITLE
fix: TOC word-break not being inserted in generic types

### DIFF
--- a/src/docfx.website.themes/default/styles/docfx.js
+++ b/src/docfx.website.themes/default/styles/docfx.js
@@ -1143,7 +1143,7 @@ $(function () {
      * If the jQuery element contains tags, this function will not change the element.
      */
     $.fn.breakWord = function () {
-      if (this.html() == this.text()) {
+      if (!this.html().match(/(<\w*)((\s\/>)|(.*<\/\w*>))/g)) {
         this.html(function (index, text) {
           return breakPlainText(text);
         })


### PR DESCRIPTION
Expected behavior: Word-break opportunities are inserted into the API references in the TOC.
Actual behavior: Word-break opportunities are not inserted if the reference is a generic type, causing that link to overflow its container.

### Before fix
![before](https://user-images.githubusercontent.com/44471531/196067378-a3055794-2c64-46ac-83f1-613ddd820799.png)

### After fix
![after](https://user-images.githubusercontent.com/44471531/196067406-ac8eee78-b3b8-4098-a3f2-540e573bf251.png)

These were taken from a template I am using. As shown in the before image, the second reference in the TOC on the left word-breaks correctly because it is non-generic, however the fourth and last references is generic and it overflows. I managed to fix it by overriding the docfx.js file in the template and applying the fix there. However, this is just a workaround and isn't an ideal one. It would be better if the fix was included in the default template so overriding this file becomes unnecessary. Also, for some more context, this issue is also present in DocFx's own API documentation site, not just the template I am using. As you can see below, there are quite a few generics in the TOC that overflow.

![docfx-site](https://user-images.githubusercontent.com/44471531/196068508-757406aa-63ea-4528-8b5c-2d7a1951ee9b.png)

This issue is caused because the function that inserts the `<wbr>` (word-break opportunity) tags only does so if `this.html()` has no html tags and is only text. It does this by comparing `this.html()` with `this.text()` to see if they are equal. This only works if the text is a non-generic reference. If it is generic, then `this.html()` returns the reference with the less-than and greater-than symbols encoded as `&lt;` and `&gt;` respectively. `this.text()` doesn't encode those symbols, so the check fails and the <wbr> tags are never inserted.

This fix replaces that check. Instead, it checks if `this.html()` doesn't match this regex: `/(<\w*)((\s\/>)|(.*<\/\w*>))/g`. This regex matches if there are any html tags. This regex has been tested with https://www.regextester.com/ and the following text:

```
<p>System.Collections.Generic.List&lt;string&gt;</p>
System.Collections.Generic.List&lt;string&gt;
```

The first line should match, the second one should not.