### PR TITLE
feat: drop compilation dependency on .NET Framework

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/ExtractMetadataWorker.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/ExtractMetadataWorker.cs
@@ -333,8 +333,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
 
             if (assemblyFiles.Count > 0)
             {
-                var assemblyCompilation = CompilationUtility.CreateCompilationFromAssembly(
-                    assemblyFiles.Concat(_references ?? Enumerable.Empty<string>()));
+                var assemblyCompilation = CompilationUtility.CreateCompilationFromAssembly(assemblyFiles, _references);
                 if (assemblyCompilation != null)
                 {
                     var commentFiles = (from file in assemblyFiles

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference/Microsoft.DocAsCode.Metadata.ManagedReference.csproj
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference/Microsoft.DocAsCode.Metadata.ManagedReference.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="ICSharpCode.Decompiler" Version="8.0.0.7246-preview3" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
   </ItemGroup>

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromAssemblyTest.cs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromAssemblyTest.cs
@@ -41,10 +41,11 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference.Tests
         public void TestGenerateMetadataFromAssembly()
         {
             var compilation = CompilationUtility.CreateCompilationFromAssembly(AssemblyFiles);
-            var referenceAssembly = CompilationUtility.GetAssemblyFromAssemblyComplation(compilation, AssemblyFiles).Select(s => s.assembly).ToList();
-
+            var referenceAssembly = CompilationUtility.GetAssemblyFromAssemblyComplation(compilation, AssemblyFiles)
+                .Select(s => s.assembly).OrderBy(s => s.Name).ToList();
+            
             {
-                var output = GenerateYamlMetadata(compilation, referenceAssembly[1]);
+                var output = GenerateYamlMetadata(compilation, referenceAssembly[2]);
                 var @class = output.Items[0].Items[2];
                 Assert.NotNull(@class);
                 Assert.Equal("Cat<T, K>", @class.DisplayNames.First().Value);
@@ -53,7 +54,7 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference.Tests
             }
 
             {
-                var output = GenerateYamlMetadata(compilation, referenceAssembly[2]);
+                var output = GenerateYamlMetadata(compilation, referenceAssembly[1]);
                 var @class = output.Items[0].Items[0];
                 Assert.NotNull(@class);
                 Assert.Equal("CarLibrary2.Cat2", @class.Name);

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromCSUnitTest.cs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromCSUnitTest.cs
@@ -2636,7 +2636,7 @@ namespace Test1
 [Test(new int[]{1, 2, 3})]
 [Test(new object[]{null, ""abc"", 'd', 1.1F, 1.2, (sbyte)2, (byte)3, (short)4, (ushort)5, 6, 7U, 8L, 9UL, new int[]{10, 11, 12}})]
 [Test(new Type[]{typeof(Func<>), typeof(Func<, >), typeof(Func<string, string>)})]
-public class TestAttribute : Attribute, _Attribute", @class.Syntax.Content[SyntaxLanguage.CSharp]);
+public class TestAttribute : Attribute", @class.Syntax.Content[SyntaxLanguage.CSharp]);
 
             Assert.NotNull(@class.Attributes);
             Assert.Equal(5, @class.Attributes.Count);

--- a/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromVBUnitTest.cs
+++ b/test/Microsoft.DocAsCode.Metadata.ManagedReference.Tests/GenerateMetadataFromVBUnitTest.cs
@@ -59,7 +59,7 @@ End Namespace
                 Assert.Equal("Test1.Class2`1", type.Name);
                 Assert.Equal(@"Public Class Class2(Of T)
     Inherits List(Of T)
-    Implements IList(Of T), ICollection(Of T), IList, ICollection, IReadOnlyList(Of T), IReadOnlyCollection(Of T), IEnumerable(Of T), IEnumerable", type.Syntax.Content[SyntaxLanguage.VB]);
+    Implements IList(Of T), ICollection(Of T), IReadOnlyList(Of T), IReadOnlyCollection(Of T), IEnumerable(Of T), IList, ICollection, IEnumerable", type.Syntax.Content[SyntaxLanguage.VB]);
                 Assert.Equal(new[] { "Public", "Class" }, type.Modifiers[SyntaxLanguage.VB]);
             }
             {
@@ -1474,8 +1474,7 @@ End Namespace
 <Test(New Object() {Nothing, ""abc"", ""d""c, 1.1F, 1.2, CType(2, SByte), CType(3, Byte), CType(4, Short), CType(5, UShort), 6, 8L, 9UL, New Integer() {10, 11, 12}})>
 <Test(New Type() {GetType(Func(Of )), GetType(Func(Of , )), GetType(Func(Of String, String))})>
 Public Class TestAttribute
-    Inherits Attribute
-    Implements _Attribute", type.Syntax.Content[SyntaxLanguage.VB]);
+    Inherits Attribute", type.Syntax.Content[SyntaxLanguage.VB]);
             var ctor = type.Items[0];
             Assert.NotNull(type);
             Assert.Equal(@"<Test(1)>


### PR DESCRIPTION
- For CS/VB source code, use the latest .NET Core SDK reference assembly list
- For DLL, resolve DLL referenced assemblies using ILSpy.