### PR TITLE
remove old package references

### DIFF
--- a/src/Microsoft.DocAsCode.Dfm/Microsoft.DocAsCode.Dfm.csproj
+++ b/src/Microsoft.DocAsCode.Dfm/Microsoft.DocAsCode.Dfm.csproj
@@ -8,6 +8,5 @@
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DocAsCode.MarkdigEngine/Microsoft.DocAsCode.MarkdigEngine.csproj
+++ b/src/Microsoft.DocAsCode.MarkdigEngine/Microsoft.DocAsCode.MarkdigEngine.csproj
@@ -4,7 +4,7 @@
     <PackageReference Include="System.Composition" Version="7.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
-    <PackageReference Include="YamlDotNet.Signed" Version="5.1.0" />
+    <PackageReference Include="YamlDotNet" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DocAsCode.MarkdownLite/Microsoft.DocAsCode.MarkdownLite.csproj
+++ b/src/Microsoft.DocAsCode.MarkdownLite/Microsoft.DocAsCode.MarkdownLite.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn.csproj
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn/Microsoft.DocAsCode.Metadata.ManagedReference.Roslyn.csproj
@@ -34,9 +34,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="System.Composition" Version="7.0.0" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
-    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="7.0.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Microsoft.VisualStudio.RemoteControl" Version="16.3.44" />
     <PackageReference Include="NuGet.ProjectModel" Version="6.3.1" />
     <PackageReference Include="NuGet.Packaging.Core" Version="6.4.0" />

--- a/src/Microsoft.DocAsCode.YamlSerialization/Microsoft.DocAsCode.YamlSerialization.csproj
+++ b/src/Microsoft.DocAsCode.YamlSerialization/Microsoft.DocAsCode.YamlSerialization.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
-    <PackageReference Include="YamlDotNet.Signed" Version="5.1.0" />
+    <PackageReference Include="YamlDotNet" Version="6.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Remove old package references that are not needed by .NET 6.0 anymore.