### PR TITLE
BREAKING CHANGE: Set markdig as default and deprecate dfm.

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -31,7 +31,6 @@
       "_appTitle": "docfx",
       "_appFooter": "Made with <a href='https://dotnet.github.io/docfx/'>docfx</a>"
     },
-    "markdownEngineName": "markdig",
     "dest": "_site",
     "template": [
       "default",

--- a/samples/extensions/docfx.json
+++ b/samples/extensions/docfx.json
@@ -38,7 +38,6 @@
       "memberpage"
     ],
     "postProcessors": [],
-    "markdownEngineName": "markdig",
     "noLangKeyword": false,
     "keepFileLink": false,
     "cleanupCacheHistory": false,

--- a/samples/seed/docfx.json
+++ b/samples/seed/docfx.json
@@ -32,7 +32,6 @@
       "_appTitle": "docfx seed website",
       "_enableSearch": true
     },
-    "markdownEngineName": "markdig",
     "dest": "_site",
     "xrefService": [ "https://xref.docs.microsoft.com/query?uid={uid}" ]
   },
@@ -55,7 +54,6 @@
       }
     ],
     "overwrite": "specs/*.md",
-    "markdownEngineName": "markdig",
     "wkhtmltopdf": {
       "filePath": "C:/Program Files/wkhtmltopdf/bin/wkhtmltopdf.exe",
       "additionalArguments": "--enable-local-file-access"

--- a/src/Microsoft.DocAsCode.App/Helpers/DocumentBuilderWrapper.cs
+++ b/src/Microsoft.DocAsCode.App/Helpers/DocumentBuilderWrapper.cs
@@ -218,9 +218,10 @@ namespace Microsoft.DocAsCode.SubCommands
                 parameters.MaxHttpParallelism = Math.Max(64, parameters.MaxParallelism * 2);
                 ServicePointManager.DefaultConnectionLimit = parameters.MaxHttpParallelism;
 
-                if (config.MarkdownEngineName != null)
+                parameters.MarkdownEngineName = config.MarkdownEngineName ?? "markdig";
+                if (parameters.MarkdownEngineName != "markdig")
                 {
-                    parameters.MarkdownEngineName = config.MarkdownEngineName;
+                    Logger.LogWarning($"Markdown engine {parameters.MarkdownEngineName} is deprecated and will be removed in future releases, please use markdig instead.");
                 }
                 if (config.MarkdownEngineProperties != null)
                 {

--- a/src/docfx/SubCommands/InitCommand.cs
+++ b/src/docfx/SubCommands/InitCommand.cs
@@ -234,7 +234,6 @@ namespace Microsoft.DocAsCode.SubCommands
                 {
                     question.Process(config, questionContext);
                 }
-                config.Build.MarkdownEngineName = "markdig";
 
                 if (_options.OnlyConfigFile)
                 {

--- a/test/docfx.Tests/BuildCommandTest.cs
+++ b/test/docfx.Tests/BuildCommandTest.cs
@@ -176,36 +176,38 @@ namespace Microsoft.DocAsCode.Tests
 
             var file = Path.Combine(_outputFolder, Path.ChangeExtension(conceptualFile1, ".html"));
             Assert.True(File.Exists(file));
-            Assert.Equal<string>(
-                new string[]
-                {
-                    "",
-                    "<h1 id=\"hello-test1\">Hello Test1</h1>",
-                    "<p>Test XRef: <a class=\"xref\" href=\"test2.html\">Hello World</a>",
-                    "Test XRef: @unknown_xref",
-                    "Test XRef: <a class=\"xref\" href=\"test2.html\"><img src=\".\"></a>",
-                    "Test link: <a href=\"test2.html\">link text</a>",
-                    "<p>",
-                    "test</p>",
-                    "",
-                },
-                File.ReadAllLines(file));
+            Assert.Equal(
+                """
+
+                <h1 id="hello-test1">Hello Test1</h1>
+                <p>Test XRef: <a class="xref" href="test2.html">Hello World</a>
+                Test XRef: @unknown_xref
+                Test XRef: <a class="xref" href="test2.html"><img src="."></a>
+                Test link: <a href="test2.html">link text</a></p>
+                <p>
+                test
+                </p>
+
+                """,
+                File.ReadAllText(file),
+                ignoreLineEndingDifferences: true);
 
             file = Path.Combine(_outputFolder, Path.ChangeExtension(conceptualFile2, ".html"));
             Assert.True(File.Exists(file));
-            Assert.Equal<string>(
-                new string[]
-                {
-                    "",
-                    "<h1 id=\"hello-world\">Hello World</h1>",
-                    "<p>Test XRef: <a class=\"xref\" href=\"test1.html\">Hello Test1</a>",
-                    "Test XRef auto link: <a class=\"xref\" href=\"test1.html\">Hello Test1</a>",
-                    "Test link: <a href=\"test1.html\">link text</a>",
-                    "<p>",
-                    "test</p>",
-                    ""
-                },
-                File.ReadAllLines(file));
+            Assert.Equal(
+                """
+                
+                <h1 id="hello-world">Hello World</h1>
+                <p>Test XRef: <a class="xref" href="test1.html">Hello Test1</a>
+                Test XRef auto link: <a class="xref" href="test1.html">Hello Test1</a>
+                Test link: <a href="test1.html">link text</a></p>
+                <p>
+                test
+                </p>
+
+                """,
+                File.ReadAllText(file),
+                ignoreLineEndingDifferences: true);
         }
 
         [Fact]

--- a/test/docfx.Tests/CompositeCommandTest.cs
+++ b/test/docfx.Tests/CompositeCommandTest.cs
@@ -97,7 +97,7 @@ public class HelloWorld(){}}
             var summary = html.DocumentNode.SelectSingleNode("//div[contains(@class, 'summary')]/p").InnerHtml;
             Assert.Equal("The class &lt; &gt; &gt; description goes here...", summary.Trim());
             var note = html.DocumentNode.SelectSingleNode("//div[@class='NOTE']").InnerHtml;
-            Assert.Equal("<h5>Note</h5><p>This is <em>note</em></p>", note.Trim());
+            Assert.Equal("<h5>Note</h5>\n<p>This is <em>note</em></p>", note.Trim());
             var code = html.DocumentNode.SelectNodes("//pre/code")[1].InnerHtml;
             Assert.Equal(@"var handler = DateTimeHandler();
 for (var i = 0; i &lt; 10; i++){


### PR DESCRIPTION
Changes the default markdown engine to `markdig` if not specified in `docfx.json`. 

Deprecate `dfm` and markdownlite. To use `dfm`, explicitly set `{ "markdigEngineName": "dfm" }` in `docfx.json` and consider migrate to `markdig` before `dfm` is fully retired in some future releases.