### PR TITLE
feat: allow custom markdown extensions

### DIFF
--- a/samples/extensions/build/Program.cs
+++ b/samples/extensions/build/Program.cs
@@ -1,3 +1,10 @@
 ﻿using Microsoft.DocAsCode;
+using Markdig;
 
-await Docset.Build("docfx.json");
+var options = new BuildOptions
+{
+    // Enable citation markdown extension
+    ConfigureMarkdig = pipeline => pipeline.UseCitations(),
+};
+
+await Docset.Build("docfx.json", options);

--- a/samples/extensions/build/build.csproj
+++ b/samples/extensions/build/build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/extensions/index.md
+++ b/samples/extensions/index.md
@@ -1,4 +1,10 @@
 # This is the **HOMEPAGE**.
+
 Refer to [Markdown](http://daringfireball.net/projects/markdown/) for how to write markdown files.
+
 ## Quick Start Notes:
 1. Add images to the *images* folder if the file is referencing an image.
+
+## Markdown Extensions
+
+This is a ""citation of someone""

--- a/src/Microsoft.DocAsCode.App/BuildOptions.cs
+++ b/src/Microsoft.DocAsCode.App/BuildOptions.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Markdig;
+
+#nullable enable
+
+namespace Microsoft.DocAsCode
+{
+    /// <summary>
+    /// Provides options to be used with <see cref="Docset.Build(string, BuildOptions)"/>.
+    /// </summary>
+    public class BuildOptions
+    {
+        /// <summary>
+        /// Configures the markdig markdown pipeline.
+        /// </summary>
+        public Func<MarkdownPipelineBuilder, MarkdownPipelineBuilder>? ConfigureMarkdig { get; init; }
+    }
+}

--- a/src/Microsoft.DocAsCode.App/Docset.cs
+++ b/src/Microsoft.DocAsCode.App/Docset.cs
@@ -21,6 +21,17 @@ namespace Microsoft.DocAsCode
         /// <returns>A task to await for build completion.</returns>
         public static Task Build(string configPath)
         {
+            return Build(configPath, new());
+        }
+        
+        /// <summary>
+        /// Builds a docset specified by docfx.json config.
+        /// </summary>
+        /// <param name="configPath">The path to docfx.json config file.</param>
+        /// <param name="options">The build options.</param>
+        /// <returns>A task to await for build completion.</returns>
+        public static Task Build(string configPath, BuildOptions options)
+        {
             var consoleLogListener = new ConsoleLogListener();
             Logger.RegisterListener(consoleLogListener);
 
@@ -34,9 +45,9 @@ namespace Microsoft.DocAsCode
                 if (config.TryGetValue("merge", out value))
                     RunMerge.Exec(value.ToObject<MergeJsonConfig>(JsonUtility.DefaultSerializer.Value));
                 if (config.TryGetValue("pdf", out value))
-                    RunPdf.Exec(value.ToObject<PdfJsonConfig>(JsonUtility.DefaultSerializer.Value));
+                    RunPdf.Exec(value.ToObject<PdfJsonConfig>(JsonUtility.DefaultSerializer.Value), options);
                 if (config.TryGetValue("build", out value))
-                    RunBuild.Exec(value.ToObject<BuildJsonConfig>(JsonUtility.DefaultSerializer.Value));
+                    RunBuild.Exec(value.ToObject<BuildJsonConfig>(JsonUtility.DefaultSerializer.Value), options);
 
                 return Task.CompletedTask;
             }

--- a/src/Microsoft.DocAsCode.App/Microsoft.DocAsCode.App.csproj
+++ b/src/Microsoft.DocAsCode.App/Microsoft.DocAsCode.App.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>2.60.0</PackageValidationBaselineVersion>
     <Description>Docfx published as a library for extensibility and advanced customization</Description>
   </PropertyGroup>
 

--- a/src/Microsoft.DocAsCode.App/RunBuild.cs
+++ b/src/Microsoft.DocAsCode.App/RunBuild.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DocAsCode
 {
     internal static class RunBuild
     {
-        public static void Exec(BuildJsonConfig config)
+        public static void Exec(BuildJsonConfig config, BuildOptions options)
         {
             if (config.Templates == null || config.Templates.Count == 0)
             {
@@ -32,7 +32,7 @@ namespace Microsoft.DocAsCode
 
             try
             {
-                DocumentBuilderWrapper.BuildDocument(config, templateManager, baseDirectory, outputFolder, null, null);
+                DocumentBuilderWrapper.BuildDocument(config, options, templateManager, baseDirectory, outputFolder, null, null);
             }
             catch (AggregateException agg) when (agg.InnerException is DocfxException)
             {

--- a/src/Microsoft.DocAsCode.App/RunPdf.cs
+++ b/src/Microsoft.DocAsCode.App/RunPdf.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DocAsCode
 {
     internal static class RunPdf
     {
-        public static void Exec(PdfJsonConfig config)
+        public static void Exec(PdfJsonConfig config, BuildOptions buildOptions)
         {
             EnvironmentContext.SetBaseDirectory(Path.GetFullPath(string.IsNullOrEmpty(config.BaseDirectory) ? Directory.GetCurrentDirectory() : config.BaseDirectory));
             // TODO: remove BaseDirectory from Config, it may cause potential issue when abused
@@ -62,7 +62,7 @@ namespace Microsoft.DocAsCode
             // 1. call BuildCommand to generate html files first
             // Output build command exec result to temp folder
             config.OutputFolder = rawOutputFolder;
-            RunBuild.Exec(config);
+            RunBuild.Exec(config, buildOptions);
 
             // 2. call html2pdf converter
             var converter = new ConvertWrapper(options);

--- a/src/Microsoft.DocAsCode.Build.Engine/DocumentBuildParameters.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/DocumentBuildParameters.cs
@@ -6,7 +6,7 @@ namespace Microsoft.DocAsCode.Build.Engine
     using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
-
+    using Markdig;
     using Microsoft.DocAsCode.Build.Engine.Incrementals;
     using Microsoft.DocAsCode.Common;
     using Microsoft.DocAsCode.Plugins;
@@ -55,6 +55,9 @@ namespace Microsoft.DocAsCode.Build.Engine
 
         [IncrementalIgnore]
         public ImmutableDictionary<string, object> MarkdownEngineParameters { get; set; } = ImmutableDictionary<string, object>.Empty;
+
+        [IncrementalIgnore]
+        public Func<MarkdownPipelineBuilder, MarkdownPipelineBuilder> ConfigureMarkdig { get; set; }
 
         [IncrementalIgnore]
         public string VersionName { get; set; }

--- a/src/Microsoft.DocAsCode.MarkdigEngine/MarkdigMarkdownService.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine/MarkdigMarkdownService.cs
@@ -24,12 +24,15 @@ namespace Microsoft.DocAsCode.MarkdigEngine
         private readonly MarkdownServiceParameters _parameters;
         private readonly MarkdownValidatorBuilder _mvb;
         private readonly MarkdownContext _context;
+        private readonly Func<MarkdownPipelineBuilder, MarkdownPipelineBuilder> _configureMarkdig;
 
         public MarkdigMarkdownService(
             MarkdownServiceParameters parameters,
-            ICompositionContainer container = null)
+            ICompositionContainer container = null,
+            Func<MarkdownPipelineBuilder, MarkdownPipelineBuilder> configureMarkdig = null)
         {
             _parameters = parameters;
+            _configureMarkdig = configureMarkdig;
             _mvb = MarkdownValidatorBuilder.Create(parameters, container);
             _context = new MarkdownContext(
                 key => _parameters.Tokens.TryGetValue(key, out var value) ? value : null,
@@ -166,6 +169,11 @@ namespace Microsoft.DocAsCode.MarkdigEngine
                 && optionalExtensionsObj is IEnumerable<object> optionalExtensions)
             {
                 builder.UseOptionalExtensions(optionalExtensions.Select(e => e as string).Where(e => e != null));
+            }
+
+            if (_configureMarkdig != null)
+            {
+                builder = _configureMarkdig(builder);
             }
 
             return builder.Build();

--- a/src/Microsoft.DocAsCode.MarkdigEngine/MarkdigServiceProvider.cs
+++ b/src/Microsoft.DocAsCode.MarkdigEngine/MarkdigServiceProvider.cs
@@ -3,19 +3,18 @@
 
 namespace Microsoft.DocAsCode.MarkdigEngine
 {
-    using System.Composition;
-
+    using System;
+    using Markdig;
     using Microsoft.DocAsCode.Plugins;
 
-    [Export("markdig", typeof(IMarkdownServiceProvider))]
     public class MarkdigServiceProvider : IMarkdownServiceProvider
     {
-        [Import]
-        public ICompositionContainer Container { get; set; }
+        public ICompositionContainer Container { get; init; }
+        public Func<MarkdownPipelineBuilder, MarkdownPipelineBuilder> ConfigureMarkdig { get; init; }
 
         public IMarkdownService CreateMarkdownService(MarkdownServiceParameters parameters)
         {
-            return new MarkdigMarkdownService(parameters, Container);
+            return new MarkdigMarkdownService(parameters, Container, ConfigureMarkdig);
         }
     }
 }

--- a/src/docfx/SubCommands/BuildCommand.cs
+++ b/src/docfx/SubCommands/BuildCommand.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DocAsCode.SubCommands
 
         public void Exec(SubCommandRunningContext context)
         {
-            RunBuild.Exec(Config);
+            RunBuild.Exec(Config, new());
         }
 
         private static BuildJsonConfig ParseOptions(BuildCommandOptions options)

--- a/src/docfx/SubCommands/PdfCommand.cs
+++ b/src/docfx/SubCommands/PdfCommand.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DocAsCode.SubCommands
 
         public static void Exec(PdfJsonConfig config)
         {
-            RunPdf.Exec(config);
+            RunPdf.Exec(config, new());
         }
 
         private static PdfJsonConfig ParseOptions(PdfCommandOptions options)

--- a/test/docfx.Snapshot.Tests/SamplesTest.Extensions/index.raw.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Extensions/index.raw.verified.json
@@ -1,5 +1,5 @@
 ﻿{
-  "conceptual": "\n<p sourcefile=\"index.md\" sourcestartlinenumber=\"2\">Refer to <a href=\"http://daringfireball.net/projects/markdown/\" sourcefile=\"index.md\" sourcestartlinenumber=\"2\">Markdown</a> for how to write markdown files.</p>\n<h2 id=\"quick-start-notes\" sourcefile=\"index.md\" sourcestartlinenumber=\"3\">Quick Start Notes:</h2>\n<ol sourcefile=\"index.md\" sourcestartlinenumber=\"4\">\n<li sourcefile=\"index.md\" sourcestartlinenumber=\"4\">Add images to the <em sourcefile=\"index.md\" sourcestartlinenumber=\"4\">images</em> folder if the file is referencing an image.</li>\n</ol>\n",
+  "conceptual": "\n<p sourcefile=\"index.md\" sourcestartlinenumber=\"3\">Refer to <a href=\"http://daringfireball.net/projects/markdown/\" sourcefile=\"index.md\" sourcestartlinenumber=\"3\">Markdown</a> for how to write markdown files.</p>\n<h2 id=\"quick-start-notes\" sourcefile=\"index.md\" sourcestartlinenumber=\"5\">Quick Start Notes:</h2>\n<ol sourcefile=\"index.md\" sourcestartlinenumber=\"6\">\n<li sourcefile=\"index.md\" sourcestartlinenumber=\"6\">Add images to the <em sourcefile=\"index.md\" sourcestartlinenumber=\"6\">images</em> folder if the file is referencing an image.</li>\n</ol>\n<h2 id=\"markdown-extensions\" sourcefile=\"index.md\" sourcestartlinenumber=\"8\">Markdown Extensions</h2>\n<p sourcefile=\"index.md\" sourcestartlinenumber=\"10\">This is a <cite sourcefile=\"index.md\" sourcestartlinenumber=\"10\">citation of someone</cite></p>\n",
   "type": "Conceptual",
   "source": {
     "remote": {
@@ -34,7 +34,7 @@
   ],
   "rawTitle": "<h1 id=\"this-is-the-homepage\" sourcefile=\"index.md\" sourcestartlinenumber=\"1\">This is the <strong sourcefile=\"index.md\" sourcestartlinenumber=\"1\">HOMEPAGE</strong>.</h1>",
   "title": "This is the HOMEPAGE.",
-  "wordCount": 25,
+  "wordCount": 33,
   "_key": "index.md",
   "_lang": "csharp",
   "_navKey": "~/toc.yml",


### PR DESCRIPTION
Enable markdown customization using the `ConfigureMarkdig` API:

```csharp
var options = new BuildOptions
{
    // Enable citation markdown extension
    ConfigureMarkdig = pipeline => pipeline.UseCitations(),
};

await Docset.Build("docfx.json", options);
```


Fixes #3387