### PR TITLE
Upgrade to YamlDotNet version 12.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ docs/api
 *.cache
 .settings
 .DS_Store
+.idea
 launchSettings.json
 package-lock.json
 *.sublime-workspace

--- a/src/Microsoft.DocAsCode.Build.Common/MarkdownReader.cs
+++ b/src/Microsoft.DocAsCode.Build.Common/MarkdownReader.cs
@@ -128,7 +128,7 @@ namespace Microsoft.DocAsCode.Build.Common
         private static bool CheckRequiredProperties(ImmutableDictionary<string, object> properties, IEnumerable<string> requiredKeys, out string message)
         {
             var notExistsKeys = (from key in requiredKeys
-                                 where !properties.Keys.Contains(key)
+                                 where !properties.ContainsKey(key)
                                  select key).ToList();
             if (notExistsKeys.Count > 0)
             {

--- a/src/Microsoft.DocAsCode.Build.ManagedReference/BuildOutputs/ApiBuildOutput.cs
+++ b/src/Microsoft.DocAsCode.Build.ManagedReference/BuildOutputs/ApiBuildOutput.cs
@@ -242,7 +242,7 @@ namespace Microsoft.DocAsCode.Build.ManagedReference.BuildOutputs
                 Conceptual = model.Conceptual,
                 Platform = model.Platform,
                 Attributes = model.Attributes,
-                Metadata = model.Metadata.Concat(metadata.Where(p => !model.Metadata.Keys.Contains(p.Key))).ToDictionary(p => p.Key, p => p.Value),
+                Metadata = model.Metadata.Concat(metadata.Where(p => !model.Metadata.ContainsKey(p.Key))).ToDictionary(p => p.Key, p => p.Value),
             };
             output.DerivedClasses = GetReferenceList(model.DerivedClasses, references, model.SupportedLanguages, true, output.Level + 1);
             return output;

--- a/src/Microsoft.DocAsCode.Build.OverwriteDocuments/OverwriteDocumentModelCreater.cs
+++ b/src/Microsoft.DocAsCode.Build.OverwriteDocuments/OverwriteDocumentModelCreater.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DocAsCode.Build.OverwriteDocuments
             catch (Exception ex)
             {
                 throw new MarkdownFragmentsException(
-                    $"Encountered an invalid YAML code block: {ex.Message}",
+                    $"Encountered an invalid YAML code block: {ex.ToString()}",
                     yamlCodeBlockSource.Line,
                     ex);
             }
@@ -116,8 +116,8 @@ namespace Microsoft.DocAsCode.Build.OverwriteDocuments
                     {
                         object value;
                         var goodItems = (from item in listObject
-                                         where item is Dictionary<object, object> 
-                                            && ((Dictionary<object, object>)item).TryGetValue(segment.Key, out value) 
+                                         where item is Dictionary<object, object>
+                                            && ((Dictionary<object, object>)item).TryGetValue(segment.Key, out value)
                                             && ((string)value).Equals(segment.Value)
                                          select (Dictionary<object, object>)item).ToList();
                         if (goodItems.Count > 0)

--- a/src/Microsoft.DocAsCode.Build.TableOfContents/TocHelper.cs
+++ b/src/Microsoft.DocAsCode.Build.TableOfContents/TocHelper.cs
@@ -111,7 +111,7 @@ namespace Microsoft.DocAsCode.Build.TableOfContents
             }
             catch (Exception ex)
             {
-                throw new NotSupportedException($"{file} is not a valid TOC file, detail: {ex.Message}.", ex);
+                throw new NotSupportedException($"{file} is not a valid TOC file, detail: {ex.ToString()}.", ex);
             }
             if (obj is TocViewModel vm)
             {

--- a/src/Microsoft.DocAsCode.Build.UniversalReference/ModelConverter.cs
+++ b/src/Microsoft.DocAsCode.Build.UniversalReference/ModelConverter.cs
@@ -256,7 +256,7 @@ namespace Microsoft.DocAsCode.Build.UniversalReference
                     Conceptual = src.Conceptual,
 
                     Platform = ToApiListInDevLangs(src.Platform, src.PlatformInDevLangs, supportedLanguages),
-                    Metadata = model.Metadata?.Concat(src.Metadata.Where(p => !model.Metadata.Keys.Contains(p.Key))).ToDictionary(p => p.Key, p => p.Value) ?? src.Metadata,
+                    Metadata = model.Metadata?.Concat(src.Metadata.Where(p => !model.Metadata.ContainsKey(p.Key))).ToDictionary(p => p.Key, p => p.Value) ?? src.Metadata,
                 };
             }
 

--- a/src/Microsoft.DocAsCode.YamlSerialization/Microsoft.DocAsCode.YamlSerialization.csproj
+++ b/src/Microsoft.DocAsCode.YamlSerialization/Microsoft.DocAsCode.YamlSerialization.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="YamlDotNet" Version="6.0.0" />
+    <PackageReference Include="YamlDotNet" Version="12.3.1" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DocAsCode.YamlSerialization/ObjectGraphVisitors/ExclusiveObjectGraphVisitor.cs
+++ b/src/Microsoft.DocAsCode.YamlSerialization/ObjectGraphVisitors/ExclusiveObjectGraphVisitor.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode.YamlSerialization.ObjectGraphVisitors
+{
+    using System;
+    using System.ComponentModel;
+    using YamlDotNet.Core;
+    using YamlDotNet.Serialization;
+    using YamlDotNet.Serialization.ObjectGraphVisitors;
+
+    /// <summary>
+    /// YamlDotNet behavior has changed since 6.x so a custom version which doesn't check on EnterMapping(IObjectDescriptor).
+    /// </summary>
+    internal sealed class ExclusiveObjectGraphVisitor : ChainedObjectGraphVisitor
+    {
+        public ExclusiveObjectGraphVisitor(IObjectGraphVisitor<IEmitter> nextVisitor)
+            : base(nextVisitor)
+        {
+        }
+
+        private static object GetDefault(Type type)
+        {
+            return type.IsValueType ? Activator.CreateInstance(type) : null;
+        }
+
+        public override bool EnterMapping(IPropertyDescriptor key, IObjectDescriptor value, IEmitter context)
+        {
+            var defaultValueAttribute = key.GetCustomAttribute<DefaultValueAttribute>();
+            object defaultValue = defaultValueAttribute != null
+                ? defaultValueAttribute.Value
+                : GetDefault(key.Type);
+
+            return !Equals(value.Value, defaultValue) && base.EnterMapping(key, value, context);
+        }
+    }
+}

--- a/src/Microsoft.DocAsCode.YamlSerialization/SerializationOptions.cs
+++ b/src/Microsoft.DocAsCode.YamlSerialization/SerializationOptions.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DocAsCode.YamlSerialization
+{
+    using System;
+
+    /// <summary>Options that control the serialization process.</summary>
+    [Flags]
+    public enum SerializationOptions
+    {
+        /// <summary>Serializes using the default options</summary>
+        None = 0,
+        /// <summary>
+        /// Ensures that it will be possible to deserialize the serialized objects.
+        /// </summary>
+        Roundtrip = 1,
+        /// <summary>
+        /// If this flag is specified, if the same object appears more than once in the
+        /// serialization graph, it will be serialized each time instead of just once.
+        /// </summary>
+        /// <remarks>
+        /// If the serialization graph contains circular references and this flag is set,
+        /// a StackOverflowException will be thrown.
+        /// If this flag is not set, there is a performance penalty because the entire
+        /// object graph must be walked twice.
+        /// </remarks>
+        DisableAliases = 2,
+        /// <summary>
+        /// Forces every value to be serialized, even if it is the default value for that type.
+        /// </summary>
+        EmitDefaults = 4,
+        /// <summary>
+        /// Ensures that the result of the serialization is valid JSON.
+        /// </summary>
+        JsonCompatible = 8,
+        /// <summary>
+        /// Use the static type of values instead of their actual type.
+        /// </summary>
+        DefaultToStaticType = 16, // 0x00000010
+    }
+}

--- a/src/Microsoft.DocAsCode.YamlSerialization/YamlSerializer.cs
+++ b/src/Microsoft.DocAsCode.YamlSerialization/YamlSerializer.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.DocAsCode.YamlSerialization.ObjectGraphVisitors;
+
 namespace Microsoft.DocAsCode.YamlSerialization
 {
     using System;
@@ -90,14 +92,14 @@ namespace Microsoft.DocAsCode.YamlSerialization
             if (!IsOptionSet(SerializationOptions.DisableAliases))
             {
                 var anchorAssigner = new AnchorAssigner(Converters);
-                traversalStrategy.Traverse<Nothing>(graph, anchorAssigner, null);
+                traversalStrategy.Traverse<Nothing>(graph, anchorAssigner, default);
 
                 emittingVisitor = new AnchorAssigningObjectGraphVisitor(emittingVisitor, eventEmitter, anchorAssigner);
             }
 
             if (!IsOptionSet(SerializationOptions.EmitDefaults))
             {
-                emittingVisitor = new DefaultExclusiveObjectGraphVisitor(emittingVisitor);
+                emittingVisitor = new ExclusiveObjectGraphVisitor(emittingVisitor);
             }
 
             return emittingVisitor;
@@ -130,7 +132,7 @@ namespace Microsoft.DocAsCode.YamlSerialization
             }
             else
             {
-                return new TypeAssigningEventEmitter(writer, IsOptionSet(SerializationOptions.Roundtrip), new Dictionary<Type, string>());
+                return new TypeAssigningEventEmitter(writer, IsOptionSet(SerializationOptions.Roundtrip), new Dictionary<Type, TagName>());
             }
         }
 
@@ -156,3 +158,4 @@ namespace Microsoft.DocAsCode.YamlSerialization
         }
     }
 }
+

--- a/test/Microsoft.DocAsCode.Build.TableOfContents.Tests/TocDocumentProcessorTest.cs
+++ b/test/Microsoft.DocAsCode.Build.TableOfContents.Tests/TocDocumentProcessorTest.cs
@@ -771,7 +771,7 @@ items:
       href: x2.md";
             var toc = _fileCreator.CreateFile(content, FileType.YamlToc);
             var ex = Assert.Throws<DocumentException>(() => TocHelper.LoadSingleToc(toc));
-            Assert.Equal("toc.yml is not a valid TOC File: toc.yml is not a valid TOC file, detail: (Line: 3, Col: 10, Idx: 22) - (Line: 3, Col: 10, Idx: 22): Mapping values are not allowed in this context..", ex.Message);
+            Assert.Equal("toc.yml is not a valid TOC File: toc.yml is not a valid TOC file, detail: (Line: 3, Col: 10, Idx: 22) - (Line: 3, Col: 10, Idx: 22): While scanning a plain scalar value, found invalid mapping..", ex.Message);
         }
 
         [Fact]


### PR DESCRIPTION
This PR contains code changes required to get latest YamlDotNet version to compile and run.

* some `string` usage has changed to more typed, like `TagName` and `AnchorName`
* exception's `Message` does no longer contain the location, need to use `ToString()` to get same format as expected before
* `SerializationOptions` was removed, but as it's configuration data in docfx, easiest to copy old version to the project
* Custom `ExclusiveObjectGraphVisitor` which behaves like the one in 6.x library
* I also added extra caching layer to `EmitTypeInspector` when there are no property extension and can use statically calculated data, this almost halved the memory allocations for `PropertyDescriptor` in my testing project, from 516MB to 260MB