### PR TITLE
Fix exception thrown when generating metadata for cast operators

### DIFF
--- a/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/Models/ReferenceItem.cs
+++ b/src/Microsoft.DocAsCode.Metadata.ManagedReference.Common/Models/ReferenceItem.cs
@@ -140,7 +140,6 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                             {
                                 for (int i = 0; i < sourceParts.Count; i++)
                                 {
-                                    Debug.Assert(sourceParts[i].Name == targetParts[i].Name);
                                     targetParts[i].IsExternalPath &= sourceParts[i].IsExternalPath;
                                     targetParts[i].Href = targetParts[i].Href ?? sourceParts[i].Href;
                                 }

--- a/test/docfx.Tests/Assets/test.cs.sample.1
+++ b/test/docfx.Tests/Assets/test.cs.sample.1
@@ -9,5 +9,11 @@ namespace Foo
         {
             return null;
         }
+
+        public static implicit operator Bar(uint value) => new();
+        public static implicit operator Bar(string value) => new();
+        
+        public static explicit operator uint(Bar value) => 0;
+        public static explicit operator string(Bar value) => "";
     }
 }

--- a/test/docfx.Tests/Assets/test.cs.sample.1
+++ b/test/docfx.Tests/Assets/test.cs.sample.1
@@ -12,7 +12,7 @@ namespace Foo
 
         public static implicit operator Bar(uint value) => new();
         public static implicit operator Bar(string value) => new();
-        
+
         public static explicit operator uint(Bar value) => 0;
         public static explicit operator string(Bar value) => "";
     }


### PR DESCRIPTION
Resolves #8381 

Removing this debug assertion fixes the above issue for implicit operators.
I have added tests for this case, I do however not know for certain whether removing this debug assertion is enough, or if there is desire for more structural changes.