### PR TITLE
feat: improve metadata command diagnostics

### DIFF
--- a/samples/seed/docfx.json
+++ b/samples/seed/docfx.json
@@ -4,7 +4,7 @@
       "src": [
         {
           "files": [
-            "assembly/**/*.dll",
+            "assembly/bin/**/*.dll",
             "project/**/*.csproj",
             "solution/**/*.sln",
             "csharp/**/*.cs",

--- a/src/Microsoft.DocAsCode.App/RunMetadata.cs
+++ b/src/Microsoft.DocAsCode.App/RunMetadata.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DocAsCode
             var vs = MSBuildLocator.RegisterDefaults() ?? throw new DocfxException(
                 $"Cannot find a supported .NET Core SDK. Install .NET Core SDK {Environment.Version.Major}.{Environment.Version.Minor}.x to build .NET API docs.");
 
-            Logger.LogInfo($"Use {vs.Name} {vs.Version}");
+            Logger.LogInfo($"Using {vs.Name} {vs.Version}");
         }
 
         public static async Task Exec(MetadataJsonConfig config, string configDirectory, string outputDirectory = null)


### PR DESCRIPTION
- Log compilation errors and warnings
- Add console logger for msbuild to get diagnostics
- Remove unneeded `catch` statements