### PR TITLE
fix: projects in sln build twice

### DIFF
--- a/src/Microsoft.DocAsCode.Dotnet/FileInformation.cs
+++ b/src/Microsoft.DocAsCode.Dotnet/FileInformation.cs
@@ -50,7 +50,6 @@ namespace Microsoft.DocAsCode.Metadata.ManagedReference
                 case ".sln":
                     return FileType.Solution;
                 case ".csproj":
-                case ".fsproj":
                 case ".vbproj":
                     return FileType.Project;
                 case ".cs":

--- a/src/Microsoft.DocAsCode.Dotnet/Microsoft.DocAsCode.Dotnet.csproj
+++ b/src/Microsoft.DocAsCode.Dotnet/Microsoft.DocAsCode.Dotnet.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="ICSharpCode.Decompiler" Version="8.0.0.7246-preview3" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Build" Version="17.4.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.4.0" />


### PR DESCRIPTION
`OpenSolutionAsync` method triggers an MSBuild batch build for all projects in the solution, causing each project to build twice. Switch to `SolutionFile.Parse` to parse project list from `.sln`.