### PR TITLE
Group explicit interface implementations into their own section

### DIFF
--- a/plugins/Microsoft.DocAsCode.Build.MemberLevelManagedReference/templates/memberpage/toc.html.js
+++ b/plugins/Microsoft.DocAsCode.Build.MemberLevelManagedReference/templates/memberpage/toc.html.js
@@ -7,6 +7,7 @@ exports.transform = function (model) {
         "method":      { key: "methodsInSubtitle" },
         "event":       { key: "eventsInSubtitle" },
         "operator":    { key: "operatorsInSubtitle" },
+        "eii":         { key: "eiisInSubtitle" },
     };
 
     groupChildren(model);
@@ -22,7 +23,7 @@ exports.transform = function (model) {
         item.items.forEach(function (element) {
             groupChildren(element);
             if (element.type) {
-                var type = element.type.toLowerCase();
+                var type = element.isEii ? "eii" : element.type.toLowerCase();
                 if (!grouped.hasOwnProperty(type)) {
                     if (!groupNames.hasOwnProperty(type)) {
                         groupNames[type] = {


### PR DESCRIPTION
Puts explicit interface implementations into their own group when using `memberpage`:

![image](https://user-images.githubusercontent.com/1700111/221193841-950d607c-1220-48e9-a9cb-13ea2de3b9f7.png)
