### PR TITLE
Add option for including explicit interface implementations

### DIFF
--- a/src/Microsoft.DocAsCode.Dotnet/DotnetApiCatalog.cs
+++ b/src/Microsoft.DocAsCode.Dotnet/DotnetApiCatalog.cs
@@ -110,6 +110,7 @@ namespace Microsoft.DocAsCode.Dotnet
                 ShouldSkipMarkup = configModel?.ShouldSkipMarkup ?? false,
                 FilterConfigFile = configModel?.FilterConfigFile is null ? null : Path.GetFullPath(Path.Combine(EnvironmentContext.BaseDirectory, configModel.FilterConfigFile)),
                 IncludePrivateMembers = configModel?.IncludePrivateMembers ?? false,
+                IncludeExplicitInterfaceImplementations = configModel?.IncludeExplicitInterfaceImplementations ?? false,
                 GlobalNamespaceId = configModel?.GlobalNamespaceId,
                 UseCompatibilityFileName = configModel?.UseCompatibilityFileName ?? false,
                 MSBuildProperties = configModel?.MSBuildProperties,

--- a/src/Microsoft.DocAsCode.Dotnet/ExtractMetadata/ExtractMetadataConfig.cs
+++ b/src/Microsoft.DocAsCode.Dotnet/ExtractMetadata/ExtractMetadataConfig.cs
@@ -21,6 +21,8 @@ namespace Microsoft.DocAsCode.Dotnet
 
         public bool IncludePrivateMembers { get; init; }
 
+        public bool IncludeExplicitInterfaceImplementations { get; init; }
+
         public bool UseCompatibilityFileName { get; init; }
 
         public string GlobalNamespaceId { get; init; }

--- a/src/Microsoft.DocAsCode.Dotnet/MetadataJsonItemConfig.cs
+++ b/src/Microsoft.DocAsCode.Dotnet/MetadataJsonItemConfig.cs
@@ -30,6 +30,9 @@ namespace Microsoft.DocAsCode
         [JsonProperty("includePrivateMembers")]
         public bool IncludePrivateMembers { get; set; }
 
+        [JsonProperty("includeExplicitInterfaceImplementations")]
+        public bool IncludeExplicitInterfaceImplementations { get; set; }
+
         [JsonProperty("globalNamespaceId")]
         public string GlobalNamespaceId { get; set; }
 

--- a/src/Microsoft.DocAsCode.Dotnet/SymbolFilter.cs
+++ b/src/Microsoft.DocAsCode.Dotnet/SymbolFilter.cs
@@ -94,29 +94,19 @@ namespace Microsoft.DocAsCode.Dotnet
             if (symbol.IsImplicitlyDeclared && symbol.Kind is not SymbolKind.Namespace)
                 return false;
 
-            if (_config.IncludeExplicitInterfaceImplementations)
+            if (_config.IncludeExplicitInterfaceImplementations &&
+                SymbolHelper.TryGetExplicitInterfaceImplementations(symbol, out var eiis) &&
+                IsEiiAndIncludesContainingSymbols(eiis))
             {
-                bool isEii = symbol.Kind switch
-                {
-                    SymbolKind.Method => IsEiiAndIncludesContainingSymbols(((IMethodSymbol)symbol).ExplicitInterfaceImplementations),
-                    SymbolKind.Property => IsEiiAndIncludesContainingSymbols(((IPropertySymbol)symbol).ExplicitInterfaceImplementations),
-                    SymbolKind.Event => IsEiiAndIncludesContainingSymbols(((IEventSymbol)symbol).ExplicitInterfaceImplementations),
-                    _ => false,
-                };
-
-                if (isEii)
                     return true;
             }
 
             if (_config.IncludePrivateMembers)
             {
-                return symbol.Kind switch
-                {
-                    SymbolKind.Method => IncludesContainingSymbols(((IMethodSymbol)symbol).ExplicitInterfaceImplementations),
-                    SymbolKind.Property => IncludesContainingSymbols(((IPropertySymbol)symbol).ExplicitInterfaceImplementations),
-                    SymbolKind.Event => IncludesContainingSymbols(((IEventSymbol)symbol).ExplicitInterfaceImplementations),
-                    _ => true,
-                };
+                if (SymbolHelper.TryGetExplicitInterfaceImplementations(symbol, out eiis))
+                    return IncludesContainingSymbols(eiis);
+
+                return true;
             }
 
             if (GetDisplayAccessibility(symbol) is null)

--- a/src/Microsoft.DocAsCode.Dotnet/SymbolFilter.cs
+++ b/src/Microsoft.DocAsCode.Dotnet/SymbolFilter.cs
@@ -94,6 +94,20 @@ namespace Microsoft.DocAsCode.Dotnet
             if (symbol.IsImplicitlyDeclared && symbol.Kind is not SymbolKind.Namespace)
                 return false;
 
+            if (_config.IncludeExplicitInterfaceImplementations)
+            {
+                bool isEii = symbol.Kind switch
+                {
+                    SymbolKind.Method => IsEiiAndIncludesContainingSymbols(((IMethodSymbol)symbol).ExplicitInterfaceImplementations),
+                    SymbolKind.Property => IsEiiAndIncludesContainingSymbols(((IPropertySymbol)symbol).ExplicitInterfaceImplementations),
+                    SymbolKind.Event => IsEiiAndIncludesContainingSymbols(((IEventSymbol)symbol).ExplicitInterfaceImplementations),
+                    _ => false,
+                };
+
+                if (isEii)
+                    return true;
+            }
+
             if (_config.IncludePrivateMembers)
             {
                 return symbol.Kind switch
@@ -113,6 +127,11 @@ namespace Microsoft.DocAsCode.Dotnet
             bool IncludesContainingSymbols(IEnumerable<ISymbol> symbols)
             {
                 return !symbols.Any() || symbols.All(s => IncludeApi(s.ContainingSymbol));
+            }
+
+            bool IsEiiAndIncludesContainingSymbols(IEnumerable<ISymbol> symbols)
+            {
+                return symbols.Any() && symbols.All(s => IncludeApi(s.ContainingSymbol));
             }
         }
     }

--- a/src/Microsoft.DocAsCode.Dotnet/SymbolHelper.cs
+++ b/src/Microsoft.DocAsCode.Dotnet/SymbolHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 
@@ -82,6 +83,19 @@ namespace Microsoft.DocAsCode.Dotnet
                     stack.Push(child);
                 }
             }
+        }
+
+        public static bool TryGetExplicitInterfaceImplementations(ISymbol symbol, [MaybeNullWhen(false)] out IEnumerable<ISymbol> eiis)
+        {
+            eiis = symbol.Kind switch
+            {
+                SymbolKind.Method => ((IMethodSymbol)symbol).ExplicitInterfaceImplementations,
+                SymbolKind.Property => ((IPropertySymbol)symbol).ExplicitInterfaceImplementations,
+                SymbolKind.Event => ((IEventSymbol)symbol).ExplicitInterfaceImplementations,
+                _ => null,
+            };
+
+            return eiis != null;
         }
     }
 }


### PR DESCRIPTION
Adds `includeExplicitInterfaceImplementations` metadata option which allows including explicit interface implementations without exposing all private members.