### PR TITLE
test: stabilize visual test using reduced motion

### DIFF
--- a/test/docfx.Snapshot.Tests/SamplesTest.cs
+++ b/test/docfx.Snapshot.Tests/SamplesTest.cs
@@ -101,6 +101,7 @@ namespace Microsoft.DocAsCode.Tests
                     ViewportSize = new() { Width = width, Height = height },
                     IsMobile = isMobile,
                     HasTouch = isMobile,
+                    ReducedMotion = ReducedMotion.Reduce,
                 });
 
                 foreach (var url in s_screenshotUrls)
@@ -117,8 +118,6 @@ namespace Microsoft.DocAsCode.Tests
                         }
 
                         await (await page.QuerySelectorAsync("#search-query")).TypeAsync("cat");
-                        // Wait for input box focus animation
-                        await page.WaitForTimeoutAsync(200);
                         await page.WaitForFunctionAsync("window.docfx.searchResultReady");
                     }
 


### PR DESCRIPTION
Disables bootstrap transitions and smooth scrolls. Use `@media (prefers-reduced-motion)` to disable transitions and animations for custom styles.