### PR TITLE
ci: store and update snapshots in ubuntu

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -12,6 +12,7 @@ runs:
       dotnet-version: |
         6.x
         7.x
+
   - run: npm install
     shell: bash
     working-directory: templates

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,44 @@
+name: pr
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: khan/pull-request-comment-trigger@v1.1.0
+      id: update-snapshot
+      with:
+        trigger: '/update-snapshot'
+        reaction: rocket
+      env:
+        GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+
+    outputs:
+      update-snapshot: steps.check.update-snapshot.triggered == 'true'
+
+  update-snapshot:
+    runs-on: ubuntu-latest
+    needs: check
+    if: needs.check.outputs.update-snapshot
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+        lfs: true
+
+    - uses: ./.github/actions/build
+
+    - run: dotnet test -c Release --filter Stage=Snapshot --no-build
+      working-directory: test/docfx.Snapshot.Tests
+      env:
+        UPDATE_SNAPSHOT: true
+
+    - run: |
+        git config --global user.name docfx
+        git config --global user.email "docfx@users.noreply.github.com"
+        git commit -a -m "test(snapshot): update snapshots for $GITHUB_SHA"
+        git push
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/snapshot-test.yml
+++ b/.github/workflows/snapshot-test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   snapshot-test:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
       with:
@@ -15,13 +15,11 @@ jobs:
 
     - uses: ./.github/actions/build
 
-    - run: choco install wkhtmltopdf
-
     - run: dotnet test -c Release -f net7.0 --no-build
       working-directory: test/docfx.Snapshot.Tests
 
     - uses: actions/upload-artifact@v3
-      if: failure() && matrix.os == 'windows-latest'
+      if: failure()
       with:
         name: screenshots
         path: |

--- a/test/docfx.Snapshot.Tests/SamplesTest.cs
+++ b/test/docfx.Snapshot.Tests/SamplesTest.cs
@@ -25,6 +25,8 @@ namespace Microsoft.DocAsCode.Tests
     [Trait("Stage", "Snapshot")]
     public class SamplesTest
     {
+        private static readonly bool s_includeBuildServer = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("UPDATE_SNAPSHOT"));
+
         private static readonly string s_samplesDir = Path.GetFullPath("../../../../../samples");
 
         private static readonly string[] s_screenshotUrls = new[]
@@ -71,7 +73,7 @@ namespace Microsoft.DocAsCode.Tests
                 Assert.Equal(0, Exec(docfxPath, $"build {samplePath}/docfx.json"));
             }
 
-            await Verifier.VerifyDirectory($"{samplePath}/_site", IncludeFile, fileScrubber: ScrubFile).AutoVerify(includeBuildServer: false);
+            await Verifier.VerifyDirectory($"{samplePath}/_site", IncludeFile, fileScrubber: ScrubFile).AutoVerify(s_includeBuildServer);
         }
 
 #if NET7_0_OR_GREATER
@@ -133,11 +135,11 @@ namespace Microsoft.DocAsCode.Tests
                             .Verify(new Target("html", NormalizeHtml(html)))
                             .UseDirectory($"{nameof(SamplesTest)}.{nameof(SeedHtml)}/html")
                             .UseFileName(fileName)
-                            .AutoVerify(includeBuildServer: false);
+                            .AutoVerify(s_includeBuildServer);
                     }
 
-                    // Verify screenshots only on windows
-                    if (!OperatingSystem.IsWindows())
+                    // Verify screenshots only on linux
+                    if (!OperatingSystem.IsLinux())
                         continue;
 
                     var bytes = await page.ScreenshotAsync(new() { FullPage = fullPage });
@@ -146,7 +148,7 @@ namespace Microsoft.DocAsCode.Tests
                         .UseStreamComparer((received, verified, _) => CompareImage(received, verified, directory, fileName))
                         .UseDirectory(directory)
                         .UseFileName(fileName)
-                        .AutoVerify(includeBuildServer: false);
+                        .AutoVerify(s_includeBuildServer);
                 }
 
                 await page.CloseAsync();
@@ -218,7 +220,7 @@ namespace Microsoft.DocAsCode.Tests
                 Environment.SetEnvironmentVariable("DOCFX_SOURCE_BRANCH_NAME", null);
             }
 
-            await Verifier.VerifyDirectory($"{samplePath}/_site", IncludeFile).AutoVerify(includeBuildServer: false);
+            await Verifier.VerifyDirectory($"{samplePath}/_site", IncludeFile).AutoVerify(s_includeBuildServer);
         }
 #endif
 
@@ -234,7 +236,7 @@ namespace Microsoft.DocAsCode.Tests
             Assert.Equal(0, Exec("dotnet", "run -c Release --project build", workingDirectory: samplePath));
 #endif
 
-            return Verifier.VerifyDirectory($"{samplePath}/_site", IncludeFile).AutoVerify(includeBuildServer: false);
+            return Verifier.VerifyDirectory($"{samplePath}/_site", IncludeFile).AutoVerify(s_includeBuildServer);
         }
 
         private static int Exec(string filename, string args, string workingDirectory = null)


### PR DESCRIPTION
- Makes it easier to develop on Mac (and linux) by lifting snapshot updates to CI
- Makes CI faster by running on snapshot tests on ubuntu