### PR TITLE
fix: incorrect type name for unresolved generic types

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/XrefDetails.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/XrefDetails.cs
@@ -173,6 +173,10 @@ namespace Microsoft.DocAsCode.Build.Engine
                 {
                     return (GetDefaultPlainTextNode(InnerHtml), false);
                 }
+                if (!string.IsNullOrEmpty(Text))
+                {
+                    return (GetDefaultPlainTextNode(Text), false);
+                }
                 if (!string.IsNullOrEmpty(Alt))
                 {
                     return (GetDefaultPlainTextNode(Alt), false);


### PR DESCRIPTION
When an xref is not resolved, we failed to convert `<xref uid="" text="Dictionary">` to `<a>Dictionary</a>` because `text` isn't treated the same way in the resolved code path.

Fixes #8488 

