### PR TITLE
fix: always copy template resources before build

### DIFF
--- a/src/Microsoft.DocAsCode.Build.Engine/SingleDocumentBuilder.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/SingleDocumentBuilder.cs
@@ -107,6 +107,8 @@ namespace Microsoft.DocAsCode.Build.Engine
                         hostServices = GetInnerContexts(parameters, Processors, templateProcessor, hostServiceCreator);
                     }
 
+                    templateProcessor.CopyTemplateResources(context.ApplyTemplateSettings);
+
                     BuildCore(phaseProcessor, hostServices, context);
 
                     var manifest = new Manifest(context.ManifestItems.Where(m => m.OutputFiles?.Count > 0))

--- a/test/Microsoft.DocAsCode.Build.Engine.Tests/TemplateManagerUnitTest.cs
+++ b/test/Microsoft.DocAsCode.Build.Engine.Tests/TemplateManagerUnitTest.cs
@@ -594,6 +594,7 @@ exports.transform = function (model){
             EnvironmentContext.SetOutputDirectory(outputFolder);
             try
             {
+                processor.CopyTemplateResources(settings);
                 processor.Process(items.ToList(), settings);
             }
             finally

--- a/test/docfx.Tests/DocsetTest.cs
+++ b/test/docfx.Tests/DocsetTest.cs
@@ -48,14 +48,12 @@ namespace Microsoft.DocAsCode.Tests
                     """
                     {
                         "build": {
-                            "content": [{ "files": [ "*.md" ] }],
                             "resource": [{ "files": [ "logo.svg" ] }],
                             "template": ["default"],
                             "dest": "_site"
                         }
                     }
                     """,
-                ["a.md"] = "",
                 ["logo.svg"] = "<svg>my svg</svg>"
             });
 


### PR DESCRIPTION
#8510 uses an unreliable way of fixing #8500 by ignoring files already on disk. It causes side effects such as template not updating when `_site` was built previously.

This PR attempts to fix #8500 by copy templates before building resources.