### PR TITLE
feat: add allowCompilationErrors option

### DIFF
--- a/src/Microsoft.DocAsCode.Dotnet/CompilationHelper.cs
+++ b/src/Microsoft.DocAsCode.Dotnet/CompilationHelper.cs
@@ -25,7 +25,7 @@ internal static class CompilationHelper
                 """),
     };
 
-    public static bool CheckDiagnostics(this Compilation compilation)
+    public static bool CheckDiagnostics(this Compilation compilation, bool errorAsWarning)
     {
         var errorCount = 0;
 
@@ -34,7 +34,8 @@ internal static class CompilationHelper
             if (diagnostic.IsSuppressed)
                 continue;
 
-            if (diagnostic.Severity is DiagnosticSeverity.Warning)
+            if (diagnostic.Severity is DiagnosticSeverity.Warning ||
+                (diagnostic.Severity is DiagnosticSeverity.Error && errorAsWarning))
             {
                 Logger.LogWarning(diagnostic.ToString());
                 continue;

--- a/src/Microsoft.DocAsCode.Dotnet/DotnetApiCatalog.cs
+++ b/src/Microsoft.DocAsCode.Dotnet/DotnetApiCatalog.cs
@@ -126,6 +126,7 @@ public static class DotnetApiCatalog
             DisableDefaultFilter = configModel?.DisableDefaultFilter ?? false,
             NoRestore = configModel?.NoRestore ?? false,
             NamespaceLayout = configModel?.NamespaceLayout ?? NamespaceLayout.Flattened,
+            AllowCompilationErrors = configModel?.AllowCompilationErrors ?? false,
             Files = expandedFiles.Items.SelectMany(s => s.Files).ToList(),
             References = expandedReferences?.Items.SelectMany(s => s.Files).ToList(),
         };

--- a/src/Microsoft.DocAsCode.Dotnet/ExtractMetadata/ExtractMetadataConfig.cs
+++ b/src/Microsoft.DocAsCode.Dotnet/ExtractMetadata/ExtractMetadataConfig.cs
@@ -32,4 +32,6 @@ internal class ExtractMetadataConfig
     public NamespaceLayout NamespaceLayout { get; init; }
 
     public Dictionary<string, string> MSBuildProperties { get; init; }
+
+    public bool AllowCompilationErrors { get; init; }
 }

--- a/src/Microsoft.DocAsCode.Dotnet/ExtractMetadata/ExtractMetadataWorker.cs
+++ b/src/Microsoft.DocAsCode.Dotnet/ExtractMetadata/ExtractMetadataWorker.cs
@@ -101,21 +101,21 @@ internal class ExtractMetadataWorker : IDisposable
 
         foreach (var compilation in projectCompilations)
         {
-            hasCompilationError |= compilation.CheckDiagnostics();
+            hasCompilationError |= compilation.CheckDiagnostics(_config.AllowCompilationErrors);
             assemblies.Add((compilation.Assembly, compilation));
         }
 
         if (_files.TryGetValue(FileType.CSSourceCode, out var csFiles))
         {
             var compilation = CompilationHelper.CreateCompilationFromCSharpFiles(csFiles.Select(f => f.NormalizedPath));
-            hasCompilationError |= compilation.CheckDiagnostics();
+            hasCompilationError |= compilation.CheckDiagnostics(_config.AllowCompilationErrors);
             assemblies.Add((compilation.Assembly, compilation));
         }
 
         if (_files.TryGetValue(FileType.VBSourceCode, out var vbFiles))
         {
             var compilation = CompilationHelper.CreateCompilationFromVBFiles(vbFiles.Select(f => f.NormalizedPath));
-            hasCompilationError |= compilation.CheckDiagnostics();
+            hasCompilationError |= compilation.CheckDiagnostics(_config.AllowCompilationErrors);
             assemblies.Add((compilation.Assembly, compilation));
         }
 
@@ -125,7 +125,7 @@ internal class ExtractMetadataWorker : IDisposable
             {
                 Logger.LogInfo($"Loading assembly {assemblyFile.NormalizedPath}");
                 var (compilation, assembly) = CompilationHelper.CreateCompilationFromAssembly(assemblyFile.NormalizedPath, _config.References);
-                hasCompilationError |= compilation.CheckDiagnostics();
+                hasCompilationError |= compilation.CheckDiagnostics(_config.AllowCompilationErrors);
                 assemblies.Add((assembly, compilation));
             }
         }

--- a/src/Microsoft.DocAsCode.Dotnet/MetadataJsonItemConfig.cs
+++ b/src/Microsoft.DocAsCode.Dotnet/MetadataJsonItemConfig.cs
@@ -57,4 +57,7 @@ internal class MetadataJsonItemConfig
 
     [JsonProperty("namespaceLayout")]
     public NamespaceLayout NamespaceLayout{  get; set; }
+
+    [JsonProperty("allowCompilationErrors")]
+    public bool AllowCompilationErrors { get; set; }
 }

--- a/test/Microsoft.DocAsCode.Dotnet.Tests/GenerateMetadataFromCSUnitTest.cs
+++ b/test/Microsoft.DocAsCode.Dotnet.Tests/GenerateMetadataFromCSUnitTest.cs
@@ -3656,19 +3656,19 @@ namespace Test1
     {
         var code =
             """
-                namespace Test
+            namespace Test
+            {
+                internal class Foo : IFoo
                 {
-                    internal class Foo : IFoo
-                    {
-                        internal void M1();
-                        protected internal void M2();
-                        private protected void M3();
-                        private void M4();
-                    }
-
-                    internal interface IFoo { }
+                    internal void M1();
+                    protected internal void M2();
+                    private protected void M3();
+                    private void M4();
                 }
-                """;
+
+                internal interface IFoo { }
+            }
+            """;
 
         var output = Verify(code, new() { IncludePrivateMembers = true });
         var foo = output.Items[0].Items[0];
@@ -3680,5 +3680,21 @@ namespace Test1
             "private protected void M3()",
             "private void M4()",
         }, foo.Items.Select(item => item.Syntax.Content[SyntaxLanguage.CSharp]));
+    }
+
+    [Fact]
+    public void TestAllowCompilationErrors()
+    {
+        var code =
+            """
+            namespace Test
+            {
+                public class Foo : Bar {}
+            }
+            """;
+
+        var output = Verify(code, new() { AllowCompilationErrors = true });
+        var foo = output.Items[0].Items[0];
+        Assert.Equal("public class Foo : Bar", foo.Syntax.Content[SyntaxLanguage.CSharp]);
     }
 }


### PR DESCRIPTION
Add an `allowCompilationErrors` option to report compilation errors as warnings. Enabling this option may address some edge use cases, but could also result in crashes or undefined behaviors.

fixes #8429