### PR TITLE
chore: remove sees from YAML output

### DIFF
--- a/src/Microsoft.DocAsCode.Build.ManagedReference/BuildOutputs/ApiBuildOutput.cs
+++ b/src/Microsoft.DocAsCode.Build.ManagedReference/BuildOutputs/ApiBuildOutput.cs
@@ -111,10 +111,6 @@ public class ApiBuildOutput
     [JsonProperty("seealso")]
     public List<ApiLinkInfoBuildOutput> SeeAlsos { get; set; }
 
-    [YamlMember(Alias = "see")]
-    [JsonProperty("see")]
-    public List<ApiLinkInfoBuildOutput> Sees { get; set; }
-
     [YamlMember(Alias = "inheritance")]
     [MergeOption(MergeOption.Ignore)]
     [JsonProperty("inheritance")]
@@ -230,7 +226,6 @@ public class ApiBuildOutput
             Overload = ApiBuildOutputUtility.GetApiNames(model.Overload, references, model.SupportedLanguages),
             Exceptions = GetCrefInfoList(model.Exceptions, references, model.SupportedLanguages),
             SeeAlsos = GetLinkInfoList(model.SeeAlsos, references, model.SupportedLanguages),
-            Sees = GetLinkInfoList(model.Sees, references, model.SupportedLanguages),
             Inheritance = GetReferenceList(model.Inheritance, references, model.SupportedLanguages, true),
             Implements = model.Implements?.Select(u => ApiBuildOutputUtility.GetApiNames(u, references, model.SupportedLanguages)).ToList(),
             InheritedMembers = GetReferenceList(model.InheritedMembers, references, model.SupportedLanguages),

--- a/src/Microsoft.DocAsCode.Build.ManagedReference/BuildOutputs/ApiReferenceBuildOutput.cs
+++ b/src/Microsoft.DocAsCode.Build.ManagedReference/BuildOutputs/ApiReferenceBuildOutput.cs
@@ -109,10 +109,6 @@ public class ApiReferenceBuildOutput
     [JsonProperty("seealso")]
     public List<ApiLinkInfoBuildOutput> SeeAlsos { get; set; }
 
-    [YamlMember(Alias = "see")]
-    [JsonProperty("see")]
-    public List<ApiLinkInfoBuildOutput> Sees { get; set; }
-
     [YamlMember(Alias = "inheritance")]
     [JsonProperty("inheritance")]
     public List<ApiReferenceBuildOutput> Inheritance { get; set; }
@@ -229,7 +225,6 @@ public class ApiReferenceBuildOutput
             Overridden = ApiNames.FromUid(vm.Overridden),
             Overload = ApiNames.FromUid(vm.Overload),
             SeeAlsos = vm.SeeAlsos?.Select(ApiLinkInfoBuildOutput.FromModel).ToList(),
-            Sees = vm.Sees?.Select(ApiLinkInfoBuildOutput.FromModel).ToList(),
             Inheritance = vm.Inheritance?.Select(FromUid).ToList(),
             Implements = vm.Implements?.Select(ApiNames.FromUid).ToList(),
             InheritedMembers = vm.InheritedMembers,
@@ -256,7 +251,6 @@ public class ApiReferenceBuildOutput
             Syntax?.Expand(references, supportedLanguages);
             Overridden = ApiBuildOutputUtility.GetApiNames(Overridden?.Uid, references, supportedLanguages);
             SeeAlsos?.ForEach(e => e.Expand(references, supportedLanguages));
-            Sees?.ForEach(e => e.Expand(references, supportedLanguages));
             Exceptions?.ForEach(e => e.Expand(references, supportedLanguages));
             Overload = ApiBuildOutputUtility.GetApiNames(Overload?.Uid, references, supportedLanguages);
         }

--- a/src/Microsoft.DocAsCode.Dotnet/ExtractMetadata/MetadataItem.cs
+++ b/src/Microsoft.DocAsCode.Dotnet/ExtractMetadata/MetadataItem.cs
@@ -100,10 +100,6 @@ internal class MetadataItem : ICloneable
     [JsonProperty("exceptions")]
     public List<ExceptionInfo> Exceptions { get; set; }
 
-    [YamlMember(Alias = "see")]
-    [JsonProperty("see")]
-    public List<LinkInfo> Sees { get; set; }
-
     [YamlMember(Alias = "seealso")]
     [JsonProperty("seealso")]
     public List<LinkInfo> SeeAlsos { get; set; }
@@ -171,8 +167,6 @@ internal class MetadataItem : ICloneable
 
         if (Exceptions == null && src.Exceptions != null)
             Exceptions = src.Exceptions.Select(e => e.Clone()).ToList();
-        if (Sees == null && src.Sees != null)
-            Sees = src.Sees.Select(s => s.Clone()).ToList();
         if (SeeAlsos == null && src.SeeAlsos != null)
             SeeAlsos = src.SeeAlsos.Select(s => s.Clone()).ToList();
         if (Examples == null && src.Examples != null)

--- a/src/Microsoft.DocAsCode.Dotnet/ManagedReference/ItemViewModel.cs
+++ b/src/Microsoft.DocAsCode.Dotnet/ManagedReference/ItemViewModel.cs
@@ -276,19 +276,10 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     [JsonProperty("seealso")]
     public List<LinkInfo> SeeAlsos { get; set; }
 
-    [YamlMember(Alias = "see")]
-    [JsonProperty("see")]
-    public List<LinkInfo> Sees { get; set; }
-
     [JsonIgnore]
     [YamlIgnore]
     [UniqueIdentityReference]
     public List<string> SeeAlsosUidReference => SeeAlsos?.Where(s => s.LinkType == LinkType.CRef)?.Select(s => s.LinkId).ToList();
-
-    [JsonIgnore]
-    [YamlIgnore]
-    [UniqueIdentityReference]
-    public List<string> SeesUidReference => Sees?.Where(s => s.LinkType == LinkType.CRef)?.Select(s => s.LinkId).ToList();
 
     [YamlMember(Alias = Constants.PropertyName.Inheritance)]
     [MergeOption(MergeOption.Ignore)]

--- a/src/Microsoft.DocAsCode.Dotnet/Parsers/XmlComment.cs
+++ b/src/Microsoft.DocAsCode.Dotnet/Parsers/XmlComment.cs
@@ -36,8 +36,6 @@ internal class XmlComment
 
     public List<ExceptionInfo> Exceptions { get; private set; }
 
-    public List<LinkInfo> Sees { get; private set; }
-
     public List<LinkInfo> SeeAlsos { get; private set; }
 
     public List<string> Examples { get; private set; }
@@ -74,7 +72,6 @@ internal class XmlComment
         Returns = GetReturns(nav, context);
 
         Exceptions = GetExceptions(nav, context);
-        Sees = GetSees(nav, context);
         SeeAlsos = GetSeeAlsos(nav, context);
         Examples = GetExamples(nav, context);
         Parameters = GetParameters(nav, context);
@@ -115,10 +112,6 @@ internal class XmlComment
         if (Exceptions == null && src.Exceptions != null)
         {
             Exceptions = src.Exceptions.Select(e => e.Clone()).ToList();
-        }
-        if (Sees == null && src.Sees != null)
-        {
-            Sees = src.Sees.Select(s => s.Clone()).ToList();
         }
         if (SeeAlsos == null && src.SeeAlsos != null)
         {
@@ -220,24 +213,6 @@ internal class XmlComment
     {
         string selector = "/member/exception";
         var result = GetMulitpleCrefInfo(nav, selector).ToList();
-        if (result.Count == 0)
-        {
-            return null;
-        }
-        return result;
-    }
-
-    /// <summary>
-    /// To get `see` tags out
-    /// </summary>
-    /// <param name="xml"></param>
-    /// <param name="context"></param>
-    /// <returns></returns>
-    /// <see cref="SpecIdHelper"/>
-    /// <see cref="SourceSwitch"/>
-    private List<LinkInfo> GetSees(XPathNavigator nav, XmlCommentParserContext context)
-    {
-        var result = GetMultipleLinkInfo(nav, "/member/see").ToList();
         if (result.Count == 0)
         {
             return null;

--- a/src/Microsoft.DocAsCode.Dotnet/Resolvers/ResolveReference.cs
+++ b/src/Microsoft.DocAsCode.Dotnet/Resolvers/ResolveReference.cs
@@ -144,14 +144,6 @@ internal class ResolveReference : IResolverPipeline
             }
         }
 
-        if (current.Sees?.Count > 0)
-        {
-            foreach (var item in current.Sees.Where(l => l.LinkType == LinkType.CRef))
-            {
-                yield return item.LinkId;
-            }
-        }
-
         if (current.SeeAlsos?.Count > 0)
         {
             foreach (var item in current.SeeAlsos.Where(l => l.LinkType == LinkType.CRef))

--- a/src/Microsoft.DocAsCode.Dotnet/Visitors/SymbolVisitorAdapter.cs
+++ b/src/Microsoft.DocAsCode.Dotnet/Visitors/SymbolVisitorAdapter.cs
@@ -67,14 +67,6 @@ internal class SymbolVisitorAdapter : SymbolVisitor<MetadataItem>
             }
         }
 
-        if (item.Sees != null)
-        {
-            foreach (var i in item.Sees.Where(l => l.LinkType == LinkType.CRef))
-            {
-                AddReference(i.LinkId, i.CommentId);
-            }
-        }
-
         if (item.SeeAlsos != null)
         {
             foreach (var i in item.SeeAlsos.Where(l => l.LinkType == LinkType.CRef))

--- a/src/Microsoft.DocAsCode.Dotnet/Visitors/VisitorHelper.cs
+++ b/src/Microsoft.DocAsCode.Dotnet/Visitors/VisitorHelper.cs
@@ -28,7 +28,6 @@ internal static class VisitorHelper
             item.Summary = commentModel.Summary;
             item.Remarks = commentModel.Remarks;
             item.Exceptions = commentModel.Exceptions;
-            item.Sees = commentModel.Sees;
             item.SeeAlsos = commentModel.SeeAlsos;
             item.Examples = commentModel.Examples;
             item.InheritDoc = commentModel.InheritDoc;

--- a/src/Microsoft.DocAsCode.Dotnet/YamlViewModelExtensions.cs
+++ b/src/Microsoft.DocAsCode.Dotnet/YamlViewModelExtensions.cs
@@ -263,7 +263,6 @@ internal static class YamlViewModelExtensions
             Overridden = model.Overridden,
             Overload = model.Overload,
             Exceptions = model.Exceptions,
-            Sees = model.Sees,
             SeeAlsos = model.SeeAlsos,
             DerivedClasses = model.DerivedClasses,
             Inheritance = model.Inheritance,

--- a/test/Microsoft.DocAsCode.Dotnet.Tests/XmlCommentUnitTest.cs
+++ b/test/Microsoft.DocAsCode.Dotnet.Tests/XmlCommentUnitTest.cs
@@ -255,17 +255,6 @@ public class XmlCommentUnitTest
         context.PreserveRawInlineComments = true;
         commentModel = XmlComment.Parse(input, context);
 
-        var sees = commentModel.Sees;
-        Assert.Equal(5, sees.Count);
-        Assert.Equal("Microsoft.DocAsCode.EntityModel.SpecIdHelper", sees[0].LinkId);
-        Assert.Null(sees[0].AltText);
-        Assert.Equal("System.String.Compare*", sees[2].LinkId);
-        Assert.Null(sees[1].AltText);
-        Assert.Equal("http://exception.com", sees[3].LinkId);
-        Assert.Equal("Global See section", sees[3].AltText);
-        Assert.Equal("http://exception.com", sees[4].AltText);
-        Assert.Equal("http://exception.com", sees[4].LinkId);
-
         var seeAlsos = commentModel.SeeAlsos;
         Assert.Equal(3, seeAlsos.Count);
         Assert.Equal("System.IO.WaitForChangedResult", seeAlsos[0].LinkId);


### PR DESCRIPTION
Unlike `<seealso>` that will be aggregated to the "See Alsos" section, `<see>` is only an inline token that gets transformed to a link.

#8558