### PR TITLE
fix: related to #8653

### DIFF
--- a/src/Microsoft.DocAsCode.Dotnet/SymbolFormatter.Syntax.cs
+++ b/src/Microsoft.DocAsCode.Dotnet/SymbolFormatter.Syntax.cs
@@ -507,9 +507,16 @@ partial class SymbolFormatter
 
         private ImmutableArray<SymbolDisplayPart> GetDisplayParts(ISymbol symbol, SymbolDisplayFormat format)
         {
-            return Language is SyntaxLanguage.VB
-                ? VB.SymbolDisplay.ToDisplayParts(symbol, format)
-                : CS.SymbolDisplay.ToDisplayParts(symbol, format);
+            try
+            {
+                return Language is SyntaxLanguage.VB
+                    ? VB.SymbolDisplay.ToDisplayParts(symbol, format)
+                    : CS.SymbolDisplay.ToDisplayParts(symbol, format);
+            }
+            catch
+            {
+                return ImmutableArray<SymbolDisplayPart>.Empty;
+            }
         }
     }
 }


### PR DESCRIPTION
This is a follow up issue. With this fix, docfx generates docs. I hope it is not going to cause any side effects.

Also fixes #8653

https://github.com/dotnet/docfx/blob/463a4efc584dd3499905427e631b56eb33144849/src/Microsoft.DocAsCode.Dotnet/SymbolFormatter.cs#L152-L168