### PR TITLE
feat: add output config overridable by --output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,9 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
 
     - run: dotnet run -c Release --no-build -f net7.0 --project src/docfx -- docs/docfx.json
-    - run: dotnet run -c Release --no-build -f net7.0 --project src/docfx -- samples/seed/docfx.json --output docs/_site/seed
+
+    - run: dotnet run -c Release --no-build -f net7.0 --project src/docfx -- metadata samples/seed/docfx.json
+    - run: dotnet run -c Release --no-build -f net7.0 --project src/docfx -- build samples/seed/docfx.json --output docs/_site/seed
 
     - uses: actions/upload-artifact@v3
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
 
     - run: dotnet run -c Release --no-build -f net7.0 --project src/docfx -- docs/docfx.json
+    - run: dotnet run -c Release --no-build -f net7.0 --project src/docfx -- samples/seed/docfx.json --output docs/_site/seed
 
     - uses: actions/upload-artifact@v3
       if: matrix.os == 'ubuntu-latest'

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -32,7 +32,7 @@
       "_appName": "docfx",
       "_appFooter": "<span>Supported by the <a href=\"https://dotnetfoundation.org\">.NET Foundation</a>. Made with <a href=\"https://dotnet.github.io/docfx\">docfx</a></span>"
     },
-    "dest": "_site",
+    "output": "_site",
     "template": [
       "default",
       "modern",

--- a/docs/docs/basic-concepts.md
+++ b/docs/docs/basic-concepts.md
@@ -133,7 +133,7 @@ Template and theme processing is the one part of Docfx that is not coded in C#; 
 {
   "build": {
     //...
-    "dest": "_site",
+    "output": "_site",
     "template": [
       "default",
       "modern",

--- a/samples/seed/docfx.json
+++ b/samples/seed/docfx.json
@@ -42,7 +42,7 @@
       "_appName": "Seed",
       "_enableSearch": true
     },
-    "dest": "_site",
+    "output": "_site",
     "exportViewModel": true,
     "template": ["default", "modern", "template"]
   },
@@ -69,6 +69,6 @@
       "filePath": "C:/Program Files/wkhtmltopdf/bin/wkhtmltopdf.exe",
       "additionalArguments": "--enable-local-file-access"
     },
-    "dest": "_site_pdf"
+    "output": "_site_pdf"
   }
 }

--- a/src/Microsoft.DocAsCode.App/Config/BuildJsonConfig.cs
+++ b/src/Microsoft.DocAsCode.App/Config/BuildJsonConfig.cs
@@ -39,6 +39,9 @@ internal class BuildJsonConfig
     [JsonProperty("dest")]
     public string Destination { get; set; }
 
+    [JsonProperty("output")]
+    public string Output { get; set; }
+
     [JsonProperty("globalMetadata")]
     [JsonConverter(typeof(JObjectDictionaryToObjectDictionaryConverter))]
     public Dictionary<string, object> GlobalMetadata { get; set; }

--- a/src/Microsoft.DocAsCode.App/Helpers/Constants.cs
+++ b/src/Microsoft.DocAsCode.App/Helpers/Constants.cs
@@ -6,7 +6,6 @@ namespace Microsoft.DocAsCode;
 internal static class Constants
 {
     public const string ConfigFileName = "docfx.json";
-    public const string DefaultRootOutputFolderPath = "_site";
     public const string DefaultTemplateName = "default";
     public const string EmbeddedTemplateFolderName = "Template";
 }

--- a/src/Microsoft.DocAsCode.App/RunBuild.cs
+++ b/src/Microsoft.DocAsCode.App/RunBuild.cs
@@ -23,7 +23,9 @@ internal static class RunBuild
         EnvironmentContext.SetBaseDirectory(Path.GetFullPath(string.IsNullOrEmpty(configDirectory) ? Directory.GetCurrentDirectory() : configDirectory));
         // TODO: remove BaseDirectory from Config, it may cause potential issue when abused
         var baseDirectory = EnvironmentContext.BaseDirectory;
-        var outputFolder = Path.GetFullPath(Path.Combine(string.IsNullOrEmpty(outputDirectory) ? baseDirectory : outputDirectory, config.Destination ?? string.Empty));
+        var outputFolder = Path.GetFullPath(Path.Combine(
+            string.IsNullOrEmpty(outputDirectory) ? Path.Combine(baseDirectory, config.Output ?? "") : outputDirectory, 
+            config.Destination ?? ""));
 
         try
         {

--- a/src/Microsoft.DocAsCode.App/RunPdf.cs
+++ b/src/Microsoft.DocAsCode.App/RunPdf.cs
@@ -24,7 +24,10 @@ internal static class RunPdf
             config.Templates = new ListWithStringFallback(new List<string> { "pdf.default" });
         }
 
-        var outputFolder = Path.GetFullPath(Path.Combine(string.IsNullOrEmpty(outputDirectory) ? baseDirectory : outputDirectory, config.Destination ?? string.Empty));
+        var outputFolder = Path.GetFullPath(Path.Combine(
+            string.IsNullOrEmpty(outputDirectory) ? Path.Combine(baseDirectory, config.Output ?? "") : outputDirectory, 
+            config.Destination ?? ""));
+
         var rawOutputFolder = string.IsNullOrEmpty(config.RawOutputFolder) ? Path.Combine(outputFolder, "_raw") : config.RawOutputFolder;
         var options = new PdfOptions
         {

--- a/src/docfx/Models/InitCommand.cs
+++ b/src/docfx/Models/InitCommand.cs
@@ -103,7 +103,7 @@ internal class InitCommand : Command<InitCommandOptions>
                 "Does the website contain .NET API documentation?", (s, m, c) =>
                 {
                     m.Build = new BuildJsonConfig();
-                    m.Build.Destination = "_site";
+                    m.Build.Output = "_site";
                     m.Build.Templates.Add("default");
                     m.Build.Templates.Add("modern");
                     if (s)


### PR DESCRIPTION
- add a new `output` JSON config to `build` and `pdf` command overridable by `--output` command line args
- make `docfx init` generate `output` as `_site` and `dest` as empty
- publish seed project to https://dotnet.github.io/docfx/seed

fixes #8339