### PR TITLE
fix: In page Namespaces keyword disappear

### DIFF
--- a/templates/common/ManagedReference.common.js
+++ b/templates/common/ManagedReference.common.js
@@ -20,7 +20,6 @@ exports.transform = function (model) {
       case 'namespace':
         model.isNamespace = true;
         if (model.children) groupChildren(model, namespaceCategory);
-        model[getTypePropertyName(model.type)] = true;
         break;
       case 'class':
       case 'interface':

--- a/templates/common/partials/namespaceSubtitle.tmpl.partial
+++ b/templates/common/partials/namespaceSubtitle.tmpl.partial
@@ -1,9 +1,8 @@
 {{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
-{{^isNamespace}}
+
 {{#inNamespace}}
 {{__global.namespacesInSubtitle}}
 {{/inNamespace}}
-{{/isNamespace}}
 {{#inClass}}
 {{__global.classesInSubtitle}}
 {{/inClass}}

--- a/templates/default/partials/title.tmpl.partial
+++ b/templates/default/partials/title.tmpl.partial
@@ -2,9 +2,9 @@
 {{#inPackage}}
 Package {{name.0.value}}
 {{/inPackage}}
-{{#inNamespace}}
+{{#isNamespace}}
 Namespace {{name.0.value}}
-{{/inNamespace}}
+{{/isNamespace}}
 {{#inClass}}
 Class {{name.0.value}}
 {{/inClass}}

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp10.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp10.html.view.verified.json
@@ -543,7 +543,6 @@
   "hideTitleType": false,
   "hideSubtitle": false,
   "isNamespace": true,
-  "inNamespace": true,
   "_disableToc": false,
   "_disableNextArticle": true
 }

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp11.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp11.html.view.verified.json
@@ -490,7 +490,6 @@
   "hideTitleType": false,
   "hideSubtitle": false,
   "isNamespace": true,
-  "inNamespace": true,
   "_disableToc": false,
   "_disableNextArticle": true
 }

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp8.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp8.html.view.verified.json
@@ -673,7 +673,6 @@
   "hideTitleType": false,
   "hideSubtitle": false,
   "isNamespace": true,
-  "inNamespace": true,
   "_disableToc": false,
   "_disableNextArticle": true
 }

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp9.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp9.html.view.verified.json
@@ -537,7 +537,6 @@
   "hideTitleType": false,
   "hideSubtitle": false,
   "isNamespace": true,
-  "inNamespace": true,
   "_disableToc": false,
   "_disableNextArticle": true
 }

--- a/test/docfx.Snapshot.Tests/SamplesTest.Extensions/api/MyExample.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Extensions/api/MyExample.html.view.verified.json
@@ -231,7 +231,6 @@
   "hideTitleType": false,
   "hideSubtitle": false,
   "isNamespace": true,
-  "inNamespace": true,
   "_disableToc": false,
   "_disableNextArticle": true
 }

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromAssembly.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromAssembly.html.view.verified.json
@@ -138,7 +138,6 @@
   "hideTitleType": false,
   "hideSubtitle": false,
   "isNamespace": true,
-  "inNamespace": true,
   "_disableToc": false,
   "_disableNextArticle": true
 }

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromCSharpSourceCode.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromCSharpSourceCode.html.view.verified.json
@@ -134,7 +134,6 @@
   "hideTitleType": false,
   "hideSubtitle": false,
   "isNamespace": true,
-  "inNamespace": true,
   "_disableToc": false,
   "_disableNextArticle": true
 }

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Issue8540.A.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Issue8540.A.html.view.verified.json
@@ -152,7 +152,6 @@
   "hideTitleType": false,
   "hideSubtitle": false,
   "isNamespace": true,
-  "inNamespace": true,
   "_disableToc": false,
   "_disableNextArticle": true
 }

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Issue8540.B.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Issue8540.B.html.view.verified.json
@@ -152,7 +152,6 @@
   "hideTitleType": false,
   "hideSubtitle": false,
   "isNamespace": true,
-  "inNamespace": true,
   "_disableToc": false,
   "_disableNextArticle": true
 }

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Issue8540.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Issue8540.html.view.verified.json
@@ -190,7 +190,6 @@
   "hideTitleType": false,
   "hideSubtitle": false,
   "isNamespace": true,
-  "inNamespace": true,
   "_disableToc": false,
   "_disableNextArticle": true
 }

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.html.view.verified.json
@@ -923,7 +923,6 @@
   "hideTitleType": false,
   "hideSubtitle": false,
   "isNamespace": true,
-  "inNamespace": true,
   "_disableToc": false,
   "_disableNextArticle": true
 }

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromVBSourceCode.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromVBSourceCode.html.view.verified.json
@@ -197,7 +197,6 @@
   "hideTitleType": false,
   "hideSubtitle": false,
   "isNamespace": true,
-  "inNamespace": true,
   "_disableToc": false,
   "_disableNextArticle": true
 }

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.Core.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.Core.html.view.verified.json
@@ -486,7 +486,6 @@
   "hideTitleType": false,
   "hideSubtitle": false,
   "isNamespace": true,
-  "inNamespace": true,
   "_disableToc": false,
   "_disableNextArticle": true
 }

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.html.view.verified.json
@@ -834,7 +834,6 @@
   "hideTitleType": false,
   "hideSubtitle": false,
   "isNamespace": true,
-  "inNamespace": true,
   "_disableToc": false,
   "_disableNextArticle": true
 }

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/MRef.Demo.Enumeration.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/MRef.Demo.Enumeration.html.view.verified.json
@@ -138,7 +138,6 @@
   "hideTitleType": false,
   "hideSubtitle": false,
   "isNamespace": true,
-  "inNamespace": true,
   "_disableToc": false,
   "_disableNextArticle": true
 }

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/index.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/index.verified.json
@@ -42,7 +42,7 @@
   "api/BuildFromProject.html": {
     "href": "api/BuildFromProject.html",
     "title": "Namespace BuildFromProject | docfx seed website",
-    "keywords": "Namespace BuildFromProject BuildFromProject.Issue8540 Classes Class1 Class1.Issue8665 Class1.Issue8696Attribute Class1.Test<T> Inheritdoc Inheritdoc.Issue6366 Inheritdoc.Issue6366.Class1<T> Inheritdoc.Issue6366.Class2 Inheritdoc.Issue7035 Inheritdoc.Issue7484 This is a test class to have something for DocFX to document. Inheritdoc.Issue8101 Structs Inheritdoc.Issue8129 Interfaces IInheritdoc"
+    "keywords": "Namespace BuildFromProject Namespaces BuildFromProject.Issue8540 Classes Class1 Class1.Issue8665 Class1.Issue8696Attribute Class1.Test<T> Inheritdoc Inheritdoc.Issue6366 Inheritdoc.Issue6366.Class1<T> Inheritdoc.Issue6366.Class2 Inheritdoc.Issue7035 Inheritdoc.Issue7484 This is a test class to have something for DocFX to document. Inheritdoc.Issue8101 Structs Inheritdoc.Issue8129 Interfaces IInheritdoc"
   },
   "api/BuildFromProject.IInheritdoc.html": {
     "href": "api/BuildFromProject.IInheritdoc.html",
@@ -112,7 +112,7 @@
   "api/BuildFromProject.Issue8540.html": {
     "href": "api/BuildFromProject.Issue8540.html",
     "title": "Namespace BuildFromProject.Issue8540 | docfx seed website",
-    "keywords": "Namespace BuildFromProject.Issue8540 BuildFromProject.Issue8540.A BuildFromProject.Issue8540.B"
+    "keywords": "Namespace BuildFromProject.Issue8540 Namespaces BuildFromProject.Issue8540.A BuildFromProject.Issue8540.B"
   },
   "api/BuildFromVBSourceCode.BaseClass1.html": {
     "href": "api/BuildFromVBSourceCode.BaseClass1.html",
@@ -187,7 +187,7 @@
   "api/CatLibrary.html": {
     "href": "api/CatLibrary.html",
     "title": "Namespace CatLibrary | docfx seed website",
-    "keywords": "Namespace CatLibrary CatLibrary.Core Classes CatException<T> Cat<T, K> Here's main class of this Demo. You can see mostly type of article within this class and you for more detail, please see the remarks. this class is a template class. It has two Generic parameter. they are: T and K. The extension method of this class can refer to ICatExtension class Complex<T, J> ICatExtension It's the class that contains ICat interface's extension method. This class must be public and static. Also it shouldn't be a geneic class Tom Tom class is only inherit from Object. Not any member inside itself. TomFromBaseClass TomFromBaseClass inherits from @ Interfaces IAnimal This is basic interface of all animal. ICat Cat's interface Delegates FakeDelegate<T> Fake delegate MRefDelegate<K, T, L> Generic delegate with many constrains. MRefNormalDelegate Delegate in the namespace"
+    "keywords": "Namespace CatLibrary Namespaces CatLibrary.Core Classes CatException<T> Cat<T, K> Here's main class of this Demo. You can see mostly type of article within this class and you for more detail, please see the remarks. this class is a template class. It has two Generic parameter. they are: T and K. The extension method of this class can refer to ICatExtension class Complex<T, J> ICatExtension It's the class that contains ICat interface's extension method. This class must be public and static. Also it shouldn't be a geneic class Tom Tom class is only inherit from Object. Not any member inside itself. TomFromBaseClass TomFromBaseClass inherits from @ Interfaces IAnimal This is basic interface of all animal. ICat Cat's interface Delegates FakeDelegate<T> Fake delegate MRefDelegate<K, T, L> Generic delegate with many constrains. MRefNormalDelegate Delegate in the namespace"
   },
   "api/CatLibrary.IAnimal.html": {
     "href": "api/CatLibrary.IAnimal.html",

--- a/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/1152x648/api-CatLibrary.html.verified.png
+++ b/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/1152x648/api-CatLibrary.html.verified.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82c6bdb0bb85a762081332d296db43db518da5998c4e9f173432c6f851d0d4c5
-size 89328
+oid sha256:b10dea504c4285013d0ac82724598a75190f4d95dff9c66c7b293a5d4e279ea0
+size 94810

--- a/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/1920x1080/api-CatLibrary.html.verified.png
+++ b/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/1920x1080/api-CatLibrary.html.verified.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:614a541e68c5c699135a194f3e457fe45a3aabdba1c1668ecf02eeb18c50d8fd
-size 167827
+oid sha256:9bca892281e2ae5a7c6b0d2bc5e0bc6eae0a4b8d92e4f275bb5a583b3867d2ac
+size 172892

--- a/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/375x812/api-CatLibrary.html.verified.png
+++ b/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/375x812/api-CatLibrary.html.verified.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:10ca47c8a3d6c8873f738838ac64a4df303314ee1fb4d79ced594916fac416a7
-size 127668
+oid sha256:5acea862ea48f0777751eccf2e682656a70c7eabaeeeb4595dbf4bcae231ba07
+size 131109

--- a/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/768x600/api-CatLibrary.html.verified.png
+++ b/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/768x600/api-CatLibrary.html.verified.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1427f481f27275db3c1b4df0c9b7c72932dc95660b7ee20415c6f27397e31bf0
-size 81254
+oid sha256:0629c3293a852c3e929cb0857f15ea94bb2a9c9fff7f679e2f82039abe520744
+size 85162

--- a/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/api-CatLibrary.html-term-cat.verified.html
+++ b/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/api-CatLibrary.html-term-cat.verified.html
@@ -521,7 +521,7 @@ mjx-container[jax="SVG"] path[data-c], mjx-container[jax="SVG"] use[data-c] {
   <div class="markdown level0 conceptual"></div>
   <div class="markdown level0 remarks"></div>
 
-    <h3 id="namespaces"><a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#namespaces" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
+    <h3 id="namespaces">Namespaces<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#namespaces" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
     <dl class="jumplist">
       <dt><a class="xref" href="CatLibrary.Core.html">Cat<wbr>Library.<wbr>Core</a></dt>
       <dd></dd>
@@ -601,7 +601,7 @@ mjx-container[jax="SVG"] path[data-c], mjx-container[jax="SVG"] use[data-c] {
       <div class="affix">
         <nav id="affix">
       <h5 class="border-bottom">In this article</h5>
-      <ul><li><a class="link-secondary" href="#namespaces"></a></li><li><a class="link-secondary" href="#classes">Classes</a></li><li><a class="link-secondary" href="#interfaces">Interfaces</a></li><li><a class="link-secondary" href="#delegates">Delegates</a></li></ul></nav>
+      <ul><li><a class="link-secondary" href="#namespaces">Namespaces</a></li><li><a class="link-secondary" href="#classes">Classes</a></li><li><a class="link-secondary" href="#interfaces">Interfaces</a></li><li><a class="link-secondary" href="#delegates">Delegates</a></li></ul></nav>
       </div>
     </main>
 

--- a/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/api-CatLibrary.html.verified.html
+++ b/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/api-CatLibrary.html.verified.html
@@ -521,7 +521,7 @@ mjx-container[jax="SVG"] path[data-c], mjx-container[jax="SVG"] use[data-c] {
   <div class="markdown level0 conceptual"></div>
   <div class="markdown level0 remarks"></div>
 
-    <h3 id="namespaces"><a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#namespaces" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
+    <h3 id="namespaces">Namespaces<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#namespaces" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
     <dl class="jumplist">
       <dt><a class="xref" href="CatLibrary.Core.html">Cat<wbr>Library.<wbr>Core</a></dt>
       <dd></dd>
@@ -601,7 +601,7 @@ mjx-container[jax="SVG"] path[data-c], mjx-container[jax="SVG"] use[data-c] {
       <div class="affix">
         <nav id="affix">
       <h5 class="border-bottom">In this article</h5>
-      <ul><li><a class="link-secondary" href="#namespaces"></a></li><li><a class="link-secondary" href="#classes">Classes</a></li><li><a class="link-secondary" href="#interfaces">Interfaces</a></li><li><a class="link-secondary" href="#delegates">Delegates</a></li></ul></nav>
+      <ul><li><a class="link-secondary" href="#namespaces">Namespaces</a></li><li><a class="link-secondary" href="#classes">Classes</a></li><li><a class="link-secondary" href="#interfaces">Interfaces</a></li><li><a class="link-secondary" href="#delegates">Delegates</a></li></ul></nav>
       </div>
     </main>
 


### PR DESCRIPTION
Caused by mustache parent variable lookup.

<img width="704" alt="Screenshot 2023-05-06 at 3 21 03 PM" src="https://user-images.githubusercontent.com/511355/236609591-ffc364cb-c552-4b94-be39-9b62fc8539b6.png">
