### PR TITLE
fix: updated highlight.js default themes to vs and vs2015 (dark-mode)

### DIFF
--- a/templates/modern/src/docfx.scss
+++ b/templates/modern/src/docfx.scss
@@ -11,10 +11,10 @@ $container-max-widths: (
 
 @import "bootstrap/scss/bootstrap.scss";
 
-@import "highlight.js/scss/github.scss";
+@import "highlight.js/scss/vs.scss";
 
 @include color-mode(dark) {
-  @import "highlight.js/scss/github-dark.scss";
+  @import "highlight.js/scss/vs2015.scss";
 }
 
 @import "highlight.scss";


### PR DESCRIPTION
As per discussion https://github.com/dotnet/docfx/discussions/8729, the highlight.js themes have been updated to `vs` and `vs2015` to improve presentation of C# code fragments.