### PR TITLE
fix(templates): modern template uses wrong rel

### DIFF
--- a/templates/modern/layout/_master.tmpl
+++ b/templates/modern/layout/_master.tmpl
@@ -30,8 +30,8 @@
 
   {{^redirect_url}}
   <script type="module">
-    import options from '{{_rel}}/public/main.js'
-    import { init } from '{{_rel}}/public/docfx.min.js'
+    import options from '{{_rel}}public/main.js'
+    import { init } from '{{_rel}}public/docfx.min.js'
     init(options)
   </script>
 

--- a/templates/modern/layout/_master.tmpl
+++ b/templates/modern/layout/_master.tmpl
@@ -30,8 +30,8 @@
 
   {{^redirect_url}}
   <script type="module">
-    import options from './{{_rel}}public/main.js'
-    import { init } from './{{_rel}}public/docfx.min.js'
+    import options from '{{_rel}}/public/main.js'
+    import { init } from '{{_rel}}/public/docfx.min.js'
     init(options)
   </script>
 


### PR DESCRIPTION
Fixes an issue introduced with #8751

Either I'm dumb rn or docfx, gotta check a few things. Getting weird cors errors