### PR TITLE
feat: update default template to allow google analytics from metadata

### DIFF
--- a/templates/default/partials/head.tmpl.partial
+++ b/templates/default/partials/head.tmpl.partial
@@ -2,6 +2,15 @@
 
 <head>
   <meta charset="utf-8">
+  {{#_googleTagId}}
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{_googleTagId}}"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', '{{_googleTagId}}');
+  </script>
+  {{/_googleTagId}}
   {{#redirect_url}}
     <meta http-equiv="refresh" content="0;URL='{{redirect_url}}'">
   {{/redirect_url}}


### PR DESCRIPTION
Bringing #8733 to the default template as well.

(let me know what additional docs etc. need to be updated and I'll be happy to do it.)