### PR TITLE
feat: specify global metadata with -m|--metadata arg

### DIFF
--- a/src/docfx/Models/BuildCommandOptions.cs
+++ b/src/docfx/Models/BuildCommandOptions.cs
@@ -17,6 +17,10 @@ internal class BuildCommandOptions : LogOptions
     [CommandArgument(0, "[config]")]
     public string ConfigFile { get; set; }
 
+    [Description("Specify a list of global metadata in key value pairs (e.g., --metadata _appTitle=\"My App\" --metadata _disableContribution)")]
+    [CommandOption("-m|--metadata")]
+    public string[] Metadata { get; set; }
+
     [Description("Specify the urls of xrefmap used by content files.")]
     [CommandOption("-x|--xref")]
     [TypeConverter(typeof(ArrayOptionConverter))]


### PR DESCRIPTION
Support specifying global metadata through the `-m` or `--metadata` command line argument, e.g., `docfx build --metadata _appTitle="My App 1"`:

- Set multiple metadata by passing multiple `--metadata` args
- `true` and `false` are parsed as boolean
- The value of `true` can be omitted, e.g, `docfx build --metadata _disableContribution`

fixes #8787