### PR TITLE
Fix `templates/dist/.gitignore` file

### DIFF
--- a/templates/dist/.gitignore
+++ b/templates/dist/.gitignore
@@ -1,5 +1,6 @@
 common
 default
 default(zh-cn)
+modern
 pdf.default
 statictoc


### PR DESCRIPTION
When I'm following this [build instructions](https://github.com/dotnet/docfx#build-and-test) to test project.
I get a git diff files under `templates/dist/modern` directory.
