### PR TITLE
fix: add settings to include templates as linked content items

### DIFF
--- a/samples/extensions/build/build.csproj
+++ b/samples/extensions/build/build.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Microsoft.DocAsCode.App\Microsoft.DocAsCode.App.csproj" />
+    <Content Include="..\..\..\templates\dist\**" Exclude="..\..\..\templates\dist\.gitignore" LinkBase="templates" CopyToOutputDirectory="PreserveNewest" PackageCopyToOutput="true" />
   </ItemGroup>
 
   <!-- NOTE: Uncomment to use <PackageReference> for your own project. -->

--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Include="..\..\templates\dist\**" Exclude="..\..\templates\dist\.gitignore" LinkBase="templates" CopyToOutputDirectory="PreserveNewest" PackageCopyToOutput="true" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="docfx.Snapshot.Tests" />
   </ItemGroup>
 


### PR DESCRIPTION
**This PR resolve  following problem.**

When using `Microsoft.DocAsCode.App` project with `ProjectReference`.
`templates` content files are not copied to output dir. (#8610)

Currently it require manual operations like belows.
 - Copy `templates/dist` contents to exe's `templates` directory.  
 - Create symbolic link or directory junction.

---
This PR resolve  this problem by importing `templates/dist/**` as `linked contents` .
https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#linkbase

![image](https://github.com/dotnet/docfx/assets/103790468/9e137142-8b5c-4ca0-ada6-dcfbc75afc4e)

**Note**
It seems `LinkBase` approach is used before by `Microsoft.DocAsCode.App` project before.

- https://github.com/dotnet/docfx/issues/8354
- https://github.com/dotnet/docfx/commit/3ed3b86f8ed5e1e0a32d46e820436dee1f8d7dd6#diff-3408df1cfc343f8e7b145f18759311d2c1972f05da8b0be78798f43fd4

This PR set `LinkBase` inside `docfx` project, and  it is not published as NuGet package. 
So similar problems are not expected to happens.
