### PR TITLE
Add MSBuild target to check symlink existence for windows

### DIFF
--- a/src/Microsoft.DocAsCode.App/Microsoft.DocAsCode.App.csproj
+++ b/src/Microsoft.DocAsCode.App/Microsoft.DocAsCode.App.csproj
@@ -5,6 +5,13 @@
     <Description>Docfx published as a library for extensibility and advanced customization</Description>
   </PropertyGroup>
 
+  <Target Name="CheckSymbolicLinkExists"
+      BeforeTargets="PrepareForBuild"
+      Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <Warning Condition="!Exists('templates/default')"
+             Text="Symbolic link for `templates` directory is not configured." />
+  </Target>
+
   <ItemGroup>
     <Content Include="templates/**" CopyToOutputDirectory="PreserveNewest" PackageCopyToOutput="true" />
   </ItemGroup>


### PR DESCRIPTION
Related: #8844

**summary**
Add simple MSBuild target to check `templates\default`  path exists or not at pre-build timing (On Windows only). 
If `templates/default` path is not found. Report as warning and build continues.