### PR TITLE
fix: documentation of template.md

### DIFF
--- a/docs/docs/template.md
+++ b/docs/docs/template.md
@@ -4,12 +4,12 @@ Template defines the appearance of the website.
 
 Docfx ships several built-in templates. We recommend using the modern template that matches the look and feel of this site. It supports dark mode, more features, rich customization options and.
 
-Use the modern template by setting the `templates` property to `["default", "modern"]`:
+Use the modern template by setting the `template` property to `["default", "modern"]`:
 
 ```json
 {
   "build": {
-    "templates": [
+    "template": [
       "default",
       "modern"
     ]
@@ -77,14 +77,14 @@ Name         | Type    | Description
 
 ## Custom Template
 
-To build your own template, create a new folder and add it to `templates` config in `docfx.json`:
+To build your own template, create a new folder and add it to `template` config in `docfx.json`:
 
 # [Modern Template](#tab/modern)
 
 ```json
 {
   "build": {
-    "templates": [
+    "template": [
       "default",
       "modern",
       "my-template" // <-- Path to custom template


### PR DESCRIPTION
Documentation fix related to #8847

If `templates`  is specified instead of `template`  in `docfx.json` build config, 
It is ignored by deserializer and fallback to `default` template.

https://github.com/dotnet/docfx/blob/ffabd3dd419bf8c6819dbd9b5c2e13d1f8ba93de/src/Microsoft.DocAsCode.App/Config/BuildJsonConfig.cs#L68-L69

https://github.com/dotnet/docfx/blob/ffabd3dd419bf8c6819dbd9b5c2e13d1f8ba93de/src/Microsoft.DocAsCode.App/RunBuild.cs#L14-L17