### PR TITLE
Fix package path to reduce nupkg size

### DIFF
--- a/src/Microsoft.DocAsCode.App/Microsoft.DocAsCode.App.csproj
+++ b/src/Microsoft.DocAsCode.App/Microsoft.DocAsCode.App.csproj
@@ -13,7 +13,7 @@
   </Target>
 
   <ItemGroup>
-    <Content Include="templates/**" CopyToOutputDirectory="PreserveNewest" PackageCopyToOutput="true" />
+    <Content Include="templates/**" CopyToOutputDirectory="PreserveNewest" PackageCopyToOutput="true" PackagePath="contentFiles/any/any/templates"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Currently build-in templates don't contains target framework dependent plugin DLLs.
But `Microsoft.DocAsCode.App.nupkg` contains duplicated content files as below.

```
/contentFiles/any/net6.0/templates/**
/contentFiles/any/net7.0/templates/**
/contentFiles/any/net8.0/templates/**
```

This PR set `PackagePath` as [Language- and framework-agnostic](https://learn.microsoft.com/en-us/nuget/reference/nuspec#package-folder-structure)
and `templates`  resources are packed to following shared path.

```
/contentFiles/any/any/templates/**
```

This PR reduce `Microsoft.DocAsCode.App.nupkg` package size.
`docfx.nupkg` package size issue described at #8691 needs additional works.
