### PR TITLE
Set initial startup project to docfx.csproj

### DIFF
--- a/docfx.sln
+++ b/docfx.sln
@@ -22,6 +22,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "plugins", "plugins", "{DF2B
 		plugins\Directory.Build.props = plugins\Directory.Build.props
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "docfx", "src\docfx\docfx.csproj", "{EF53214F-BA98-4026-BEED-CF771865C312}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DocAsCode.Glob", "src\Microsoft.DocAsCode.Glob\Microsoft.DocAsCode.Glob.csproj", "{7E877810-DC13-4A6C-8DFC-184C00A20B7C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DocAsCode.Plugins", "src\Microsoft.DocAsCode.Plugins\Microsoft.DocAsCode.Plugins.csproj", "{B6B96738-C338-4904-B932-4C05DB7D4DDE}"
@@ -67,8 +69,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DocAsCode.Plugins.Tests", "test\Microsoft.DocAsCode.Plugins.Tests\Microsoft.DocAsCode.Plugins.Tests.csproj", "{B3EEB5FE-CF39-4CC7-9650-5709E71D2BA9}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DocAsCode.Build.ManagedReference.Tests", "test\Microsoft.DocAsCode.Build.ManagedReference.Tests\Microsoft.DocAsCode.Build.ManagedReference.Tests.csproj", "{958DF90F-0528-4C50-9AC2-E86C60971B7D}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "docfx", "src\docfx\docfx.csproj", "{EF53214F-BA98-4026-BEED-CF771865C312}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DocAsCode.Build.UniversalReference.Tests", "test\Microsoft.DocAsCode.Build.UniversalReference.Tests\Microsoft.DocAsCode.Build.UniversalReference.Tests.csproj", "{E9795C9A-1F98-4716-A0FC-843C6B000BE5}"
 EndProject


### PR DESCRIPTION
Initial VS startup project is determined by defined project order of `.sln`.
This PR set default startup project to `docfx.csproj`.

