### PR TITLE
Expand active page when it has subpages on modern template

### DIFF
--- a/templates/modern/src/toc.ts
+++ b/templates/modern/src/toc.ts
@@ -56,6 +56,9 @@ export async function renderToc(): Promise<TocNode[]> {
       node.href = url.href
       active = normalizeUrlPath(url) === normalizeUrlPath(window.location)
       if (active) {
+        if (node.items) {
+          node.expanded = true
+        }
         selectedNodes.push(node)
       }
     }


### PR DESCRIPTION
The default template expands its contents in the table of contents (TOC) when the current page has subpages, but the modern template currently does not.

This PR adds an additional check to the modern template to verify whether the currently active page has subpages and expands them.