### PR TITLE
Fix scroll into view in TOC

### DIFF
--- a/templates/modern/src/toc.ts
+++ b/templates/modern/src/toc.ts
@@ -99,7 +99,7 @@ export async function renderToc(): Promise<TocNode[]> {
       const isExpanded = (tocFilter !== '' && expanded !== false && children != null) || expanded === true
 
       return html`
-        <li class=${classMap({ expanded: isExpanded })}>
+        <li class=${classMap({ expanded: isExpanded, active: activeNodes.includes(node) })}>
           ${isLeaf ? null : html`<span class='expand-stub' @click=${toggleExpand}></span>`}
           ${dom}
           ${children}


### PR DESCRIPTION
Modern template should scroll last active list item into view: https://github.com/dotnet/docfx/blob/e0f8953c587966476b46a365b3b964725103e69a/templates/modern/src/toc.ts#L39-L43

But currently, list items do not get the class "active" assigned. This PR fixes this.