### PR TITLE
fix warning NU1701

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,8 +25,6 @@
           warning NU1507: There are 2 package sources defined in your configuration.
      -->
     <NoWarn>$(NoWarn);NU1507</NoWarn>
-
-    <NoWarn>$(NoWarn);NU1701</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,11 @@
     <PackageVersion Include="Jint" Version="3.0.0-beta-2049" />
     <PackageVersion Include="JsonSchema.Net" Version="4.1.5" />
     <PackageVersion Include="Markdig" Version="0.31.0" />
-    <PackageVersion Include="Microsoft.Build" Version="17.6.3" />
+
+     <!-- "17.3.2" is the latest compatible version for .NET 6 -->
+    <PackageVersion Include="Microsoft.Build" Version="[17.3.2]" Condition="'$(TargetFramework)' == 'net6.0'" />
+    <PackageVersion Include="Microsoft.Build" Version="17.6.3"   Condition="'$(TargetFramework)' != 'net6.0'" />
+
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.5.5" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.6.0" />


### PR DESCRIPTION
Fix warnings occurred when following conditions met.
- Using `Microsoft.DocAsCode.App` NuGet package
- TargetFramework is `net6.0`.

**Warnings Messages**
> Warning	NU1701	Package 'Microsoft.Build 17.6.3' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8, .NETFramework,Version=v4.8.1' instead of the project target framework 'net6.0'. This package may not be fully compatible with your project.
> 
> Warning	NU1701	Package 'Microsoft.IO.Redist 6.0.0' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8, .NETFramework,Version=v4.8.1' instead of the project target framework 'net6.0'. This package may not be fully compatible with your project.
