### PR TITLE
fix CS0612 and CS0618 and doc comment warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,16 +12,6 @@
   <PropertyGroup>
     <!--
       Suppress warnings similar to the following:
-          warning CS0612: 'StringHelper.LegacyEscapeMarkdown(string)' is obsolete
-     -->
-    <NoWarn>$(NoWarn);CS0612</NoWarn>
-    <!--
-      Suppress warnings similar to the following:
-          warning CS0618: 'MarkdownLHeadingBlockRule.LHeading' is obsolete: 'Please use LHeadingMatcher.'
-     -->
-    <NoWarn>$(NoWarn);CS0618</NoWarn>
-    <!--
-      Suppress warnings similar to the following:
           warning NU1507: There are 2 package sources defined in your configuration.
      -->
     <NoWarn>$(NoWarn);NU1507</NoWarn>

--- a/samples/seed/dotnet/assembly/Class1.cs
+++ b/samples/seed/dotnet/assembly/Class1.cs
@@ -7,8 +7,14 @@ namespace BuildFromAssembly;
 /// </summary>
 public class Class1
 {
+    /// <summary>
+    /// HelloWorld method.
+    /// </summary>
     public static void HelloWorld() { }
 
+    /// <summary>
+    /// HiddenAPI method.
+    /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public void HiddenAPI() { }
 }

--- a/src/Microsoft.DocAsCode.Build.Engine/ManifestUtility.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/ManifestUtility.cs
@@ -8,6 +8,9 @@ using Microsoft.DocAsCode.Plugins;
 
 namespace Microsoft.DocAsCode.Common;
 
+#pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+
 public static class ManifestUtility
 {
     public static void RemoveDuplicateOutputFiles(ManifestItemCollection manifestItems)

--- a/src/Microsoft.DocAsCode.Build.Engine/SingleDocumentBuilder.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/SingleDocumentBuilder.cs
@@ -7,6 +7,9 @@ using Microsoft.DocAsCode.Plugins;
 
 namespace Microsoft.DocAsCode.Build.Engine;
 
+#pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+
 public class SingleDocumentBuilder : IDisposable
 {
     private const string PhaseName = "Build Document";


### PR DESCRIPTION
Change CS0612/CS0618‘ (`Type or member is obsolete`) warning suppression from to file-level.
and add doc comment to suppress `Unchanged files with check annotations`

**Example warnings for "Unchanged files with check annotations"**
https://github.com/dotnet/docfx/pull/8904/files