### PR TITLE
Fix CS0612 and CS0618 and doc comment warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,16 +12,6 @@
   <PropertyGroup>
     <!--
       Suppress warnings similar to the following:
-          warning CS0612: 'StringHelper.LegacyEscapeMarkdown(string)' is obsolete
-     -->
-    <NoWarn>$(NoWarn);CS0612</NoWarn>
-    <!--
-      Suppress warnings similar to the following:
-          warning CS0618: 'MarkdownLHeadingBlockRule.LHeading' is obsolete: 'Please use LHeadingMatcher.'
-     -->
-    <NoWarn>$(NoWarn);CS0618</NoWarn>
-    <!--
-      Suppress warnings similar to the following:
           warning NU1507: There are 2 package sources defined in your configuration.
      -->
     <NoWarn>$(NoWarn);NU1507</NoWarn>

--- a/samples/seed/dotnet/assembly/Class1.cs
+++ b/samples/seed/dotnet/assembly/Class1.cs
@@ -7,8 +7,14 @@ namespace BuildFromAssembly;
 /// </summary>
 public class Class1
 {
+    /// <summary>
+    /// HelloWorld method.
+    /// </summary>
     public static void HelloWorld() { }
 
+    /// <summary>
+    /// HiddenAPI method.
+    /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public void HiddenAPI() { }
 }

--- a/src/Microsoft.DocAsCode.Build.Engine/ManifestUtility.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/ManifestUtility.cs
@@ -8,6 +8,9 @@ using Microsoft.DocAsCode.Plugins;
 
 namespace Microsoft.DocAsCode.Common;
 
+#pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+
 public static class ManifestUtility
 {
     public static void RemoveDuplicateOutputFiles(ManifestItemCollection manifestItems)

--- a/src/Microsoft.DocAsCode.Build.Engine/SingleDocumentBuilder.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/SingleDocumentBuilder.cs
@@ -7,6 +7,9 @@ using Microsoft.DocAsCode.Plugins;
 
 namespace Microsoft.DocAsCode.Build.Engine;
 
+#pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+
 public class SingleDocumentBuilder : IDisposable
 {
     private const string PhaseName = "Build Document";

--- a/src/Microsoft.DocAsCode.Common/JsonUtility.cs
+++ b/src/Microsoft.DocAsCode.Common/JsonUtility.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
 using Microsoft.DocAsCode.Plugins;
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.DocAsCode.Common;
 
@@ -17,7 +18,7 @@ public static class JsonUtility
             ReferenceLoopHandling = ReferenceLoopHandling.Serialize,
             Converters =
             {
-                new StringEnumConverter { CamelCaseText = true },
+                new StringEnumConverter { NamingStrategy = new CamelCaseNamingStrategy() },
             }
         });
 

--- a/src/Microsoft.DocAsCode.YamlSerialization/NodeDeserializers/EmitGenericCollectionNodeDeserializer.cs
+++ b/src/Microsoft.DocAsCode.YamlSerialization/NodeDeserializers/EmitGenericCollectionNodeDeserializer.cs
@@ -20,7 +20,7 @@ public class EmitGenericCollectionNodeDeserializer : INodeDeserializer
 {
     private static readonly MethodInfo DeserializeHelperMethod =
         typeof(EmitGenericCollectionNodeDeserializer).GetMethod(nameof(DeserializeHelper));
-        private readonly IObjectFactory _objectFactory;
+    private readonly IObjectFactory _objectFactory;
     private readonly Dictionary<Type, Type> _gpCache =
         new();
     private readonly Dictionary<Type, Action<IParser, Type, Func<IParser, Type, object>, object>> _actionCache =
@@ -81,8 +81,8 @@ public class EmitGenericCollectionNodeDeserializer : INodeDeserializer
     {
         var list = result as IList<TItem>;
 
-        reader.Expect<SequenceStart>();
-        while (!reader.Accept<SequenceEnd>())
+        reader.Consume<SequenceStart>();
+        while (!reader.Accept<SequenceEnd>(out _))
         {
             var current = reader.Current;
 
@@ -106,6 +106,6 @@ public class EmitGenericCollectionNodeDeserializer : INodeDeserializer
                 );
             }
         }
-        reader.Expect<SequenceEnd>();
+        reader.Consume<SequenceEnd>();
     }
 }

--- a/src/Microsoft.DocAsCode.YamlSerialization/NodeDeserializers/ExtensibleObjectNodeDeserializer.cs
+++ b/src/Microsoft.DocAsCode.YamlSerialization/NodeDeserializers/ExtensibleObjectNodeDeserializer.cs
@@ -23,17 +23,16 @@ public sealed class ExtensibleObjectNodeDeserializer : INodeDeserializer
 
     bool INodeDeserializer.Deserialize(IParser reader, Type expectedType, Func<IParser, Type, object> nestedObjectDeserializer, out object value)
     {
-        var mapping = reader.Allow<MappingStart>();
-        if (mapping == null)
+        if (!reader.TryConsume<MappingStart>(out _))
         {
             value = null;
             return false;
         }
 
         value = _objectFactory.Create(expectedType);
-        while (!reader.Accept<MappingEnd>())
+        while (!reader.Accept<MappingEnd>(out _))
         {
-            var propertyName = reader.Expect<Scalar>();
+            var propertyName = reader.Consume<Scalar>();
             var property = _typeDescriptor.GetProperty(expectedType, value, propertyName.Value, _ignoreUnmatched);
             if (property == null)
             {
@@ -58,7 +57,7 @@ public sealed class ExtensibleObjectNodeDeserializer : INodeDeserializer
             }
         }
 
-        reader.Expect<MappingEnd>();
+        reader.Consume<MappingEnd>();
         return true;
     }
 }

--- a/src/Microsoft.DocAsCode.YamlSerialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
+++ b/src/Microsoft.DocAsCode.YamlSerialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
@@ -180,7 +180,7 @@ public class FullObjectGraphTraversalStrategy : IObjectGraphTraversalStrategy
             action = GetTraverseGenericDictionaryHelper(entryTypes[0], entryTypes[1], typeof(TContext));
             _traverseGenericDictionaryCache[key] = action;
         }
-        action(this, dictionary.Value, v, currentDepth, _namingConvention ?? new NullNamingConvention(), c);
+        action(this, dictionary.Value, v, currentDepth, _namingConvention ?? NullNamingConvention.Instance, c);
 
         v.VisitMappingEnd(dictionary, c);
     }

--- a/src/Microsoft.DocAsCode.YamlSerialization/YamlSerializer.cs
+++ b/src/Microsoft.DocAsCode.YamlSerialization/YamlSerializer.cs
@@ -29,7 +29,7 @@ public class YamlSerializer
     public YamlSerializer(SerializationOptions options = SerializationOptions.None, INamingConvention namingConvention = null)
     {
         _options = options;
-        _namingConvention = namingConvention ?? new NullNamingConvention();
+        _namingConvention = namingConvention ?? NullNamingConvention.Instance;
 
         Converters = new List<IYamlTypeConverter>();
         foreach (IYamlTypeConverter yamlTypeConverter in YamlTypeConverters.BuiltInConverters)

--- a/test/Microsoft.DocAsCode.Common.Tests/GitUtilityTest.cs
+++ b/test/Microsoft.DocAsCode.Common.Tests/GitUtilityTest.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DocAsCode.Common.Tests;
 #pragma warning disable CS0618 // Type or member is obsolete
 
 [Collection("docfx STA")]
-    public class GitUtilityTest : IDisposable
+public class GitUtilityTest : IDisposable
 {
     private string _originalBranchName;
     private const string envName = "DOCFX_SOURCE_BRANCH_NAME";

--- a/test/Microsoft.DocAsCode.Common.Tests/GitUtilityTest.cs
+++ b/test/Microsoft.DocAsCode.Common.Tests/GitUtilityTest.cs
@@ -7,6 +7,8 @@ using Microsoft.DocAsCode.Common.Git;
 
 namespace Microsoft.DocAsCode.Common.Tests;
 
+#pragma warning disable CS0618 // Type or member is obsolete
+
 [Collection("docfx STA")]
     public class GitUtilityTest : IDisposable
 {

--- a/test/Microsoft.DocAsCode.Plugins.Tests/JsonConverterTest.cs
+++ b/test/Microsoft.DocAsCode.Plugins.Tests/JsonConverterTest.cs
@@ -3,6 +3,7 @@
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
 using Xunit;
 
 namespace Microsoft.DocAsCode.Plugins.Tests;
@@ -33,7 +34,7 @@ public class JsonConverterTest
         {
             Converters =
             {
-                new StringEnumConverter { CamelCaseText = true },
+                new StringEnumConverter { NamingStrategy = new CamelCaseNamingStrategy() },
             }
         };
 


### PR DESCRIPTION
This PR contains following changes.
- Change CS0612/CS0618‘ (Type or member is obsolete) warning suppression from solution-wide to file level.
- Replace deprecated APIs (`Newtonsoft.Json` and `YamlDotNet`)
- Add doc comments to suppress warnings at PR `File changed` tab.  
  Displayed at **"Unchanged files with check annotations"**  
  https://github.com/dotnet/docfx/pull/8904/files
