### PR TITLE
Fix CS0612 and CS0618 and doc comment warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,16 +12,6 @@
   <PropertyGroup>
     <!--
       Suppress warnings similar to the following:
-          warning CS0612: 'StringHelper.LegacyEscapeMarkdown(string)' is obsolete
-     -->
-    <NoWarn>$(NoWarn);CS0612</NoWarn>
-    <!--
-      Suppress warnings similar to the following:
-          warning CS0618: 'MarkdownLHeadingBlockRule.LHeading' is obsolete: 'Please use LHeadingMatcher.'
-     -->
-    <NoWarn>$(NoWarn);CS0618</NoWarn>
-    <!--
-      Suppress warnings similar to the following:
           warning NU1507: There are 2 package sources defined in your configuration.
      -->
     <NoWarn>$(NoWarn);NU1507</NoWarn>

--- a/samples/seed/dotnet/assembly/Class1.cs
+++ b/samples/seed/dotnet/assembly/Class1.cs
@@ -7,8 +7,14 @@ namespace BuildFromAssembly;
 /// </summary>
 public class Class1
 {
+    /// <summary>
+    /// HelloWorld method.
+    /// </summary>
     public static void HelloWorld() { }
 
+    /// <summary>
+    /// HiddenAPI method.
+    /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public void HiddenAPI() { }
 }

--- a/src/Microsoft.DocAsCode.Build.Engine/ManifestUtility.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/ManifestUtility.cs
@@ -8,6 +8,9 @@ using Microsoft.DocAsCode.Plugins;
 
 namespace Microsoft.DocAsCode.Common;
 
+#pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+
 public static class ManifestUtility
 {
     public static void RemoveDuplicateOutputFiles(ManifestItemCollection manifestItems)

--- a/src/Microsoft.DocAsCode.Build.Engine/SingleDocumentBuilder.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/SingleDocumentBuilder.cs
@@ -7,6 +7,9 @@ using Microsoft.DocAsCode.Plugins;
 
 namespace Microsoft.DocAsCode.Build.Engine;
 
+#pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+
 public class SingleDocumentBuilder : IDisposable
 {
     private const string PhaseName = "Build Document";

--- a/src/Microsoft.DocAsCode.Common/JsonUtility.cs
+++ b/src/Microsoft.DocAsCode.Common/JsonUtility.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
 using Microsoft.DocAsCode.Plugins;
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.DocAsCode.Common;
 
@@ -17,7 +18,7 @@ public static class JsonUtility
             ReferenceLoopHandling = ReferenceLoopHandling.Serialize,
             Converters =
             {
-                new StringEnumConverter { CamelCaseText = true },
+                new StringEnumConverter { NamingStrategy = new CamelCaseNamingStrategy() },
             }
         });
 

--- a/src/Microsoft.DocAsCode.YamlSerialization/NodeDeserializers/EmitGenericCollectionNodeDeserializer.cs
+++ b/src/Microsoft.DocAsCode.YamlSerialization/NodeDeserializers/EmitGenericCollectionNodeDeserializer.cs
@@ -20,7 +20,7 @@ public class EmitGenericCollectionNodeDeserializer : INodeDeserializer
 {
     private static readonly MethodInfo DeserializeHelperMethod =
         typeof(EmitGenericCollectionNodeDeserializer).GetMethod(nameof(DeserializeHelper));
-        private readonly IObjectFactory _objectFactory;
+    private readonly IObjectFactory _objectFactory;
     private readonly Dictionary<Type, Type> _gpCache =
         new();
     private readonly Dictionary<Type, Action<IParser, Type, Func<IParser, Type, object>, object>> _actionCache =
@@ -81,8 +81,8 @@ public class EmitGenericCollectionNodeDeserializer : INodeDeserializer
     {
         var list = result as IList<TItem>;
 
-        reader.Expect<SequenceStart>();
-        while (!reader.Accept<SequenceEnd>())
+        reader.Consume<SequenceStart>();
+        while (!reader.Accept<SequenceEnd>(out _))
         {
             var current = reader.Current;
 
@@ -106,6 +106,6 @@ public class EmitGenericCollectionNodeDeserializer : INodeDeserializer
                 );
             }
         }
-        reader.Expect<SequenceEnd>();
+        reader.Consume<SequenceEnd>();
     }
 }

--- a/src/Microsoft.DocAsCode.YamlSerialization/NodeDeserializers/ExtensibleObjectNodeDeserializer.cs
+++ b/src/Microsoft.DocAsCode.YamlSerialization/NodeDeserializers/ExtensibleObjectNodeDeserializer.cs
@@ -23,17 +23,16 @@ public sealed class ExtensibleObjectNodeDeserializer : INodeDeserializer
 
     bool INodeDeserializer.Deserialize(IParser reader, Type expectedType, Func<IParser, Type, object> nestedObjectDeserializer, out object value)
     {
-        var mapping = reader.Allow<MappingStart>();
-        if (mapping == null)
+        if (!reader.TryConsume<MappingStart>(out _))
         {
             value = null;
             return false;
         }
 
         value = _objectFactory.Create(expectedType);
-        while (!reader.Accept<MappingEnd>())
+        while (!reader.Accept<MappingEnd>(out _))
         {
-            var propertyName = reader.Expect<Scalar>();
+            var propertyName = reader.Consume<Scalar>();
             var property = _typeDescriptor.GetProperty(expectedType, value, propertyName.Value, _ignoreUnmatched);
             if (property == null)
             {
@@ -58,7 +57,7 @@ public sealed class ExtensibleObjectNodeDeserializer : INodeDeserializer
             }
         }
 
-        reader.Expect<MappingEnd>();
+        reader.Consume<MappingEnd>();
         return true;
     }
 }

--- a/src/Microsoft.DocAsCode.YamlSerialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
+++ b/src/Microsoft.DocAsCode.YamlSerialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
@@ -180,7 +180,7 @@ public class FullObjectGraphTraversalStrategy : IObjectGraphTraversalStrategy
             action = GetTraverseGenericDictionaryHelper(entryTypes[0], entryTypes[1], typeof(TContext));
             _traverseGenericDictionaryCache[key] = action;
         }
-        action(this, dictionary.Value, v, currentDepth, _namingConvention ?? new NullNamingConvention(), c);
+        action(this, dictionary.Value, v, currentDepth, _namingConvention ?? NullNamingConvention.Instance, c);
 
         v.VisitMappingEnd(dictionary, c);
     }

--- a/src/Microsoft.DocAsCode.YamlSerialization/YamlSerializer.cs
+++ b/src/Microsoft.DocAsCode.YamlSerialization/YamlSerializer.cs
@@ -29,7 +29,7 @@ public class YamlSerializer
     public YamlSerializer(SerializationOptions options = SerializationOptions.None, INamingConvention namingConvention = null)
     {
         _options = options;
-        _namingConvention = namingConvention ?? new NullNamingConvention();
+        _namingConvention = namingConvention ?? NullNamingConvention.Instance;
 
         Converters = new List<IYamlTypeConverter>();
         foreach (IYamlTypeConverter yamlTypeConverter in YamlTypeConverters.BuiltInConverters)

--- a/test/Microsoft.DocAsCode.Common.Tests/GitUtilityTest.cs
+++ b/test/Microsoft.DocAsCode.Common.Tests/GitUtilityTest.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DocAsCode.Common.Tests;
 #pragma warning disable CS0618 // Type or member is obsolete
 
 [Collection("docfx STA")]
-    public class GitUtilityTest : IDisposable
+public class GitUtilityTest : IDisposable
 {
     private string _originalBranchName;
     private const string envName = "DOCFX_SOURCE_BRANCH_NAME";

--- a/test/Microsoft.DocAsCode.Common.Tests/GitUtilityTest.cs
+++ b/test/Microsoft.DocAsCode.Common.Tests/GitUtilityTest.cs
@@ -7,6 +7,8 @@ using Microsoft.DocAsCode.Common.Git;
 
 namespace Microsoft.DocAsCode.Common.Tests;
 
+#pragma warning disable CS0618 // Type or member is obsolete
+
 [Collection("docfx STA")]
     public class GitUtilityTest : IDisposable
 {

--- a/test/Microsoft.DocAsCode.Plugins.Tests/JsonConverterTest.cs
+++ b/test/Microsoft.DocAsCode.Plugins.Tests/JsonConverterTest.cs
@@ -3,6 +3,7 @@
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
 using Xunit;
 
 namespace Microsoft.DocAsCode.Plugins.Tests;
@@ -33,7 +34,7 @@ public class JsonConverterTest
         {
             Converters =
             {
-                new StringEnumConverter { CamelCaseText = true },
+                new StringEnumConverter { NamingStrategy = new CamelCaseNamingStrategy() },
             }
         };
 

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp10.ConstantInterpolatedStrings.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp10.ConstantInterpolatedStrings.html.view.verified.json
@@ -163,7 +163,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp10.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "S1",
             "path": "src/CSharp10.cs",
@@ -179,8 +179,8 @@
           "type": "field",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_ConstantInterpolatedStrings_S1.md&value=---%0Auid%3A%20CSharp10.ConstantInterpolatedStrings.S1%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L23",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_ConstantInterpolatedStrings_S1.md&value=---%0Auid%3A%20CSharp10.ConstantInterpolatedStrings.S1%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L23",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -298,7 +298,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp10.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "S2",
             "path": "src/CSharp10.cs",
@@ -314,8 +314,8 @@
           "type": "field",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_ConstantInterpolatedStrings_S2.md&value=---%0Auid%3A%20CSharp10.ConstantInterpolatedStrings.S2%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L24",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_ConstantInterpolatedStrings_S2.md&value=---%0Auid%3A%20CSharp10.ConstantInterpolatedStrings.S2%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L24",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -433,7 +433,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp10.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "S3",
             "path": "src/CSharp10.cs",
@@ -449,8 +449,8 @@
           "type": "field",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_ConstantInterpolatedStrings_S3.md&value=---%0Auid%3A%20CSharp10.ConstantInterpolatedStrings.S3%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L25",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_ConstantInterpolatedStrings_S3.md&value=---%0Auid%3A%20CSharp10.ConstantInterpolatedStrings.S3%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L25",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -502,7 +502,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp10.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "ConstantInterpolatedStrings",
     "path": "src/CSharp10.cs",
@@ -1077,8 +1077,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_ConstantInterpolatedStrings.md&value=---%0Auid%3A%20CSharp10.ConstantInterpolatedStrings%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L21",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_ConstantInterpolatedStrings.md&value=---%0Auid%3A%20CSharp10.ConstantInterpolatedStrings%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L21",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp10.Issue7737.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp10.Issue7737.html.view.verified.json
@@ -117,7 +117,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp10.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Foo",
             "path": "src/CSharp10.cs",
@@ -178,8 +178,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"api/CSharp10.Issue7737.yml\" sourcestartlinenumber=\"1\"><xref href=\"System.Exception\" data-throw-if-not-resolved=\"false\"></xref></p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_Issue7737_Foo.md&value=---%0Auid%3A%20CSharp10.Issue7737.Foo%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L33",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_Issue7737_Foo.md&value=---%0Auid%3A%20CSharp10.Issue7737.Foo%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L33",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -230,7 +230,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp10.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "Issue7737",
     "path": "src/CSharp10.cs",
@@ -805,8 +805,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_Issue7737.md&value=---%0Auid%3A%20CSharp10.Issue7737%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L28",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_Issue7737.md&value=---%0Auid%3A%20CSharp10.Issue7737%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L28",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp10.ParameterlessStructConstructors.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp10.ParameterlessStructConstructors.html.view.verified.json
@@ -117,7 +117,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp10.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": ".ctor",
             "path": "src/CSharp10.cs",
@@ -177,8 +177,8 @@
           "type": "constructor",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_ParameterlessStructConstructors__ctor.md&value=---%0Auid%3A%20CSharp10.ParameterlessStructConstructors.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L15",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_ParameterlessStructConstructors__ctor.md&value=---%0Auid%3A%20CSharp10.ParameterlessStructConstructors.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L15",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -303,7 +303,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp10.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "X",
             "path": "src/CSharp10.cs",
@@ -319,8 +319,8 @@
           "type": "field",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_ParameterlessStructConstructors_X.md&value=---%0Auid%3A%20CSharp10.ParameterlessStructConstructors.X%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L11",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_ParameterlessStructConstructors_X.md&value=---%0Auid%3A%20CSharp10.ParameterlessStructConstructors.X%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L11",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -446,7 +446,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp10.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Description",
             "path": "src/CSharp10.cs",
@@ -506,8 +506,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_ParameterlessStructConstructors_Description.md&value=---%0Auid%3A%20CSharp10.ParameterlessStructConstructors.Description%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L13",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_ParameterlessStructConstructors_Description.md&value=---%0Auid%3A%20CSharp10.ParameterlessStructConstructors.Description%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L13",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -626,7 +626,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp10.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Y",
             "path": "src/CSharp10.cs",
@@ -686,8 +686,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_ParameterlessStructConstructors_Y.md&value=---%0Auid%3A%20CSharp10.ParameterlessStructConstructors.Y%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L12",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_ParameterlessStructConstructors_Y.md&value=---%0Auid%3A%20CSharp10.ParameterlessStructConstructors.Y%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L12",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -739,7 +739,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp10.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "ParameterlessStructConstructors",
     "path": "src/CSharp10.cs",
@@ -1213,8 +1213,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_ParameterlessStructConstructors.md&value=---%0Auid%3A%20CSharp10.ParameterlessStructConstructors%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L9",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_ParameterlessStructConstructors.md&value=---%0Auid%3A%20CSharp10.ParameterlessStructConstructors%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L9",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp10.ReadOnlyRecordStruct.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp10.ReadOnlyRecordStruct.html.view.verified.json
@@ -257,7 +257,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp10.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": ".ctor",
             "path": "src/CSharp10.cs",
@@ -317,8 +317,8 @@
           "type": "constructor",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_ReadOnlyRecordStruct__ctor_System_Double_System_Double_System_Double_.md&value=---%0Auid%3A%20CSharp10.ReadOnlyRecordStruct.%23ctor(System.Double%2CSystem.Double%2CSystem.Double)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L3",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_ReadOnlyRecordStruct__ctor_System_Double_System_Double_System_Double_.md&value=---%0Auid%3A%20CSharp10.ReadOnlyRecordStruct.%23ctor(System.Double%2CSystem.Double%2CSystem.Double)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L3",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -444,7 +444,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp10.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "X",
             "path": "src/CSharp10.cs",
@@ -504,8 +504,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_ReadOnlyRecordStruct_X.md&value=---%0Auid%3A%20CSharp10.ReadOnlyRecordStruct.X%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L3",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_ReadOnlyRecordStruct_X.md&value=---%0Auid%3A%20CSharp10.ReadOnlyRecordStruct.X%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L3",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -624,7 +624,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp10.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Y",
             "path": "src/CSharp10.cs",
@@ -684,8 +684,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_ReadOnlyRecordStruct_Y.md&value=---%0Auid%3A%20CSharp10.ReadOnlyRecordStruct.Y%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L3",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_ReadOnlyRecordStruct_Y.md&value=---%0Auid%3A%20CSharp10.ReadOnlyRecordStruct.Y%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L3",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -804,7 +804,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp10.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Z",
             "path": "src/CSharp10.cs",
@@ -864,8 +864,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_ReadOnlyRecordStruct_Z.md&value=---%0Auid%3A%20CSharp10.ReadOnlyRecordStruct.Z%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L3",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_ReadOnlyRecordStruct_Z.md&value=---%0Auid%3A%20CSharp10.ReadOnlyRecordStruct.Z%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L3",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -917,7 +917,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp10.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "ReadOnlyRecordStruct",
     "path": "src/CSharp10.cs",
@@ -1437,8 +1437,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_ReadOnlyRecordStruct.md&value=---%0Auid%3A%20CSharp10.ReadOnlyRecordStruct%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L3",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_ReadOnlyRecordStruct.md&value=---%0Auid%3A%20CSharp10.ReadOnlyRecordStruct%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L3",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp10.RecordClass.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp10.RecordClass.html.view.verified.json
@@ -211,7 +211,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp10.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": ".ctor",
             "path": "src/CSharp10.cs",
@@ -271,8 +271,8 @@
           "type": "constructor",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_RecordClass__ctor_System_String_System_String_.md&value=---%0Auid%3A%20CSharp10.RecordClass.%23ctor(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L7",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_RecordClass__ctor_System_String_System_String_.md&value=---%0Auid%3A%20CSharp10.RecordClass.%23ctor(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L7",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -398,7 +398,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp10.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "FirstName",
             "path": "src/CSharp10.cs",
@@ -458,8 +458,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_RecordClass_FirstName.md&value=---%0Auid%3A%20CSharp10.RecordClass.FirstName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L7",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_RecordClass_FirstName.md&value=---%0Auid%3A%20CSharp10.RecordClass.FirstName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L7",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -578,7 +578,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp10.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "LastName",
             "path": "src/CSharp10.cs",
@@ -638,8 +638,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_RecordClass_LastName.md&value=---%0Auid%3A%20CSharp10.RecordClass.LastName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L7",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_RecordClass_LastName.md&value=---%0Auid%3A%20CSharp10.RecordClass.LastName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L7",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -691,7 +691,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp10.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "RecordClass",
     "path": "src/CSharp10.cs",
@@ -1312,8 +1312,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_RecordClass.md&value=---%0Auid%3A%20CSharp10.RecordClass%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L7",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_RecordClass.md&value=---%0Auid%3A%20CSharp10.RecordClass%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L7",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp10.RecordStruct.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp10.RecordStruct.html.view.verified.json
@@ -211,7 +211,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp10.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": ".ctor",
             "path": "src/CSharp10.cs",
@@ -271,8 +271,8 @@
           "type": "constructor",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_RecordStruct__ctor_System_DateTime_System_Double_.md&value=---%0Auid%3A%20CSharp10.RecordStruct.%23ctor(System.DateTime%2CSystem.Double)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L5",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_RecordStruct__ctor_System_DateTime_System_Double_.md&value=---%0Auid%3A%20CSharp10.RecordStruct.%23ctor(System.DateTime%2CSystem.Double)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L5",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -398,7 +398,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp10.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Measurement",
             "path": "src/CSharp10.cs",
@@ -458,8 +458,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_RecordStruct_Measurement.md&value=---%0Auid%3A%20CSharp10.RecordStruct.Measurement%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L5",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_RecordStruct_Measurement.md&value=---%0Auid%3A%20CSharp10.RecordStruct.Measurement%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L5",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -578,7 +578,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp10.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "TakenAt",
             "path": "src/CSharp10.cs",
@@ -638,8 +638,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_RecordStruct_TakenAt.md&value=---%0Auid%3A%20CSharp10.RecordStruct.TakenAt%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L5",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_RecordStruct_TakenAt.md&value=---%0Auid%3A%20CSharp10.RecordStruct.TakenAt%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L5",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -691,7 +691,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp10.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "RecordStruct",
     "path": "src/CSharp10.cs",
@@ -1211,8 +1211,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp10_RecordStruct.md&value=---%0Auid%3A%20CSharp10.RecordStruct%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L5",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp10_RecordStruct.md&value=---%0Auid%3A%20CSharp10.RecordStruct%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp10.cs/#L5",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp11.CheckedUserDefinedOperators-1.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp11.CheckedUserDefinedOperators-1.html.view.verified.json
@@ -259,7 +259,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "op_Addition",
             "path": "src/CSharp11.cs",
@@ -315,8 +315,8 @@
           "type": "operator",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_Addition__0__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_Addition(%600%2C%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L29",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_Addition__0__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_Addition(%600%2C%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L29",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -530,7 +530,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "op_CheckedAddition",
             "path": "src/CSharp11.cs",
@@ -586,8 +586,8 @@
           "type": "operator",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_CheckedAddition__0__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_CheckedAddition(%600%2C%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L38",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_CheckedAddition__0__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_CheckedAddition(%600%2C%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L38",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -754,7 +754,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "op_CheckedDecrement",
             "path": "src/CSharp11.cs",
@@ -810,8 +810,8 @@
           "type": "operator",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_CheckedDecrement__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_CheckedDecrement(%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L36",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_CheckedDecrement__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_CheckedDecrement(%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L36",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -1025,7 +1025,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "op_CheckedDivision",
             "path": "src/CSharp11.cs",
@@ -1081,8 +1081,8 @@
           "type": "operator",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_CheckedDivision__0__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_CheckedDivision(%600%2C%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L41",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_CheckedDivision__0__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_CheckedDivision(%600%2C%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L41",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -1248,7 +1248,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "op_CheckedExplicit",
             "path": "src/CSharp11.cs",
@@ -1304,8 +1304,8 @@
           "type": "operator",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_CheckedExplicit__0__System_Int32.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_CheckedExplicit(%600)~System.Int32%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L42",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_CheckedExplicit__0__System_Int32.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_CheckedExplicit(%600)~System.Int32%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L42",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -1472,7 +1472,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "op_CheckedIncrement",
             "path": "src/CSharp11.cs",
@@ -1528,8 +1528,8 @@
           "type": "operator",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_CheckedIncrement__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_CheckedIncrement(%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L35",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_CheckedIncrement__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_CheckedIncrement(%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L35",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -1743,7 +1743,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "op_CheckedMultiply",
             "path": "src/CSharp11.cs",
@@ -1799,8 +1799,8 @@
           "type": "operator",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_CheckedMultiply__0__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_CheckedMultiply(%600%2C%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L40",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_CheckedMultiply__0__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_CheckedMultiply(%600%2C%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L40",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -2014,7 +2014,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "op_CheckedSubtraction",
             "path": "src/CSharp11.cs",
@@ -2070,8 +2070,8 @@
           "type": "operator",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_CheckedSubtraction__0__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_CheckedSubtraction(%600%2C%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L39",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_CheckedSubtraction__0__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_CheckedSubtraction(%600%2C%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L39",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -2238,7 +2238,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "op_CheckedUnaryNegation",
             "path": "src/CSharp11.cs",
@@ -2294,8 +2294,8 @@
           "type": "operator",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_CheckedUnaryNegation__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_CheckedUnaryNegation(%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L37",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_CheckedUnaryNegation__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_CheckedUnaryNegation(%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L37",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -2462,7 +2462,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "op_Decrement",
             "path": "src/CSharp11.cs",
@@ -2518,8 +2518,8 @@
           "type": "operator",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_Decrement__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_Decrement(%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L27",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_Decrement__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_Decrement(%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L27",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -2733,7 +2733,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "op_Division",
             "path": "src/CSharp11.cs",
@@ -2789,8 +2789,8 @@
           "type": "operator",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_Division__0__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_Division(%600%2C%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L32",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_Division__0__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_Division(%600%2C%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L32",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -2956,7 +2956,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "op_Explicit",
             "path": "src/CSharp11.cs",
@@ -3012,8 +3012,8 @@
           "type": "operator",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_Explicit__0__System_Int32.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_Explicit(%600)~System.Int32%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L33",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_Explicit__0__System_Int32.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_Explicit(%600)~System.Int32%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L33",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -3180,7 +3180,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "op_Increment",
             "path": "src/CSharp11.cs",
@@ -3236,8 +3236,8 @@
           "type": "operator",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_Increment__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_Increment(%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L26",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_Increment__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_Increment(%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L26",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -3451,7 +3451,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "op_Multiply",
             "path": "src/CSharp11.cs",
@@ -3507,8 +3507,8 @@
           "type": "operator",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_Multiply__0__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_Multiply(%600%2C%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L31",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_Multiply__0__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_Multiply(%600%2C%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L31",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -3722,7 +3722,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "op_Subtraction",
             "path": "src/CSharp11.cs",
@@ -3778,8 +3778,8 @@
           "type": "operator",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_Subtraction__0__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_Subtraction(%600%2C%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L30",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_Subtraction__0__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_Subtraction(%600%2C%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L30",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -3946,7 +3946,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "op_UnaryNegation",
             "path": "src/CSharp11.cs",
@@ -4002,8 +4002,8 @@
           "type": "operator",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_UnaryNegation__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_UnaryNegation(%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L28",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1_op_UnaryNegation__0_.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601.op_UnaryNegation(%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L28",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -4055,7 +4055,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp11.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "CheckedUserDefinedOperators",
     "path": "src/CSharp11.cs",
@@ -4238,8 +4238,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L24",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_CheckedUserDefinedOperators_1.md&value=---%0Auid%3A%20CSharp11.CheckedUserDefinedOperators%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L24",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp11.RequiredModifier.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp11.RequiredModifier.html.view.verified.json
@@ -164,7 +164,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "FirstName",
             "path": "src/CSharp11.cs",
@@ -224,8 +224,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_RequiredModifier_FirstName.md&value=---%0Auid%3A%20CSharp11.RequiredModifier.FirstName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L47",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_RequiredModifier_FirstName.md&value=---%0Auid%3A%20CSharp11.RequiredModifier.FirstName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L47",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -344,7 +344,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "LastName",
             "path": "src/CSharp11.cs",
@@ -404,8 +404,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_RequiredModifier_LastName.md&value=---%0Auid%3A%20CSharp11.RequiredModifier.LastName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L49",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_RequiredModifier_LastName.md&value=---%0Auid%3A%20CSharp11.RequiredModifier.LastName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L49",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -524,7 +524,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "MiddleName",
             "path": "src/CSharp11.cs",
@@ -584,8 +584,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_RequiredModifier_MiddleName.md&value=---%0Auid%3A%20CSharp11.RequiredModifier.MiddleName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L48",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_RequiredModifier_MiddleName.md&value=---%0Auid%3A%20CSharp11.RequiredModifier.MiddleName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L48",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -637,7 +637,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp11.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "RequiredModifier",
     "path": "src/CSharp11.cs",
@@ -1212,8 +1212,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_RequiredModifier.md&value=---%0Auid%3A%20CSharp11.RequiredModifier%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L45",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_RequiredModifier.md&value=---%0Auid%3A%20CSharp11.RequiredModifier%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L45",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp11.ScopedModifier.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp11.ScopedModifier.html.view.verified.json
@@ -211,7 +211,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "CreateSpan",
             "path": "src/CSharp11.cs",
@@ -271,8 +271,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_ScopedModifier_CreateSpan_System_Int32__.md&value=---%0Auid%3A%20CSharp11.ScopedModifier.CreateSpan(System.Int32%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L59",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_ScopedModifier_CreateSpan_System_Int32__.md&value=---%0Auid%3A%20CSharp11.ScopedModifier.CreateSpan(System.Int32%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L59",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -324,7 +324,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp11.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "ScopedModifier",
     "path": "src/CSharp11.cs",
@@ -899,8 +899,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_ScopedModifier.md&value=---%0Auid%3A%20CSharp11.ScopedModifier%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L57",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_ScopedModifier.md&value=---%0Auid%3A%20CSharp11.ScopedModifier%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L57",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp11.StaticAbstractMembersInInterfaces.IGetNext-1.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp11.StaticAbstractMembersInInterfaces.IGetNext-1.html.view.verified.json
@@ -212,7 +212,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "op_Increment",
             "path": "src/CSharp11.cs",
@@ -268,8 +268,8 @@
           "type": "operator",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_StaticAbstractMembersInInterfaces_IGetNext_1_op_Increment__0_.md&value=---%0Auid%3A%20CSharp11.StaticAbstractMembersInInterfaces.IGetNext%601.op_Increment(%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L7",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_StaticAbstractMembersInInterfaces_IGetNext_1_op_Increment__0_.md&value=---%0Auid%3A%20CSharp11.StaticAbstractMembersInInterfaces.IGetNext%601.op_Increment(%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L7",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -321,7 +321,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp11.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "IGetNext",
     "path": "src/CSharp11.cs",
@@ -504,8 +504,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_StaticAbstractMembersInInterfaces_IGetNext_1.md&value=---%0Auid%3A%20CSharp11.StaticAbstractMembersInInterfaces.IGetNext%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L5",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_StaticAbstractMembersInInterfaces_IGetNext_1.md&value=---%0Auid%3A%20CSharp11.StaticAbstractMembersInInterfaces.IGetNext%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L5",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp11.StaticAbstractMembersInInterfaces.RepeatSequence.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp11.StaticAbstractMembersInInterfaces.RepeatSequence.html.view.verified.json
@@ -117,7 +117,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": ".ctor",
             "path": "src/CSharp11.cs",
@@ -177,8 +177,8 @@
           "type": "constructor",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_StaticAbstractMembersInInterfaces_RepeatSequence__ctor.md&value=---%0Auid%3A%20CSharp11.StaticAbstractMembersInInterfaces.RepeatSequence.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L15",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_StaticAbstractMembersInInterfaces_RepeatSequence__ctor.md&value=---%0Auid%3A%20CSharp11.StaticAbstractMembersInInterfaces.RepeatSequence.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L15",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -303,7 +303,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Text",
             "path": "src/CSharp11.cs",
@@ -319,8 +319,8 @@
           "type": "field",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_StaticAbstractMembersInInterfaces_RepeatSequence_Text.md&value=---%0Auid%3A%20CSharp11.StaticAbstractMembersInInterfaces.RepeatSequence.Text%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L13",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_StaticAbstractMembersInInterfaces_RepeatSequence_Text.md&value=---%0Auid%3A%20CSharp11.StaticAbstractMembersInInterfaces.RepeatSequence.Text%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L13",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -445,7 +445,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "ToString",
             "path": "src/CSharp11.cs",
@@ -549,8 +549,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"api/CSharp11.StaticAbstractMembersInInterfaces.RepeatSequence.yml\" sourcestartlinenumber=\"1\">Returns the fully qualified type name of this instance.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_StaticAbstractMembersInInterfaces_RepeatSequence_ToString.md&value=---%0Auid%3A%20CSharp11.StaticAbstractMembersInInterfaces.RepeatSequence.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L20",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_StaticAbstractMembersInInterfaces_RepeatSequence_ToString.md&value=---%0Auid%3A%20CSharp11.StaticAbstractMembersInInterfaces.RepeatSequence.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L20",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -721,7 +721,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp11.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "op_Increment",
             "path": "src/CSharp11.cs",
@@ -824,8 +824,8 @@
           "type": "operator",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_StaticAbstractMembersInInterfaces_RepeatSequence_op_Increment_CSharp11_StaticAbstractMembersInInterfaces_RepeatSequence_.md&value=---%0Auid%3A%20CSharp11.StaticAbstractMembersInInterfaces.RepeatSequence.op_Increment(CSharp11.StaticAbstractMembersInInterfaces.RepeatSequence)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L17",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_StaticAbstractMembersInInterfaces_RepeatSequence_op_Increment_CSharp11_StaticAbstractMembersInInterfaces_RepeatSequence_.md&value=---%0Auid%3A%20CSharp11.StaticAbstractMembersInInterfaces.RepeatSequence.op_Increment(CSharp11.StaticAbstractMembersInInterfaces.RepeatSequence)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L17",
           "remarks": "",
           "conceptual": "",
           "seealso": null,
@@ -875,7 +875,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp11.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "RepeatSequence",
     "path": "src/CSharp11.cs",
@@ -1346,8 +1346,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_StaticAbstractMembersInInterfaces_RepeatSequence.md&value=---%0Auid%3A%20CSharp11.StaticAbstractMembersInInterfaces.RepeatSequence%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L10",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_StaticAbstractMembersInInterfaces_RepeatSequence.md&value=---%0Auid%3A%20CSharp11.StaticAbstractMembersInInterfaces.RepeatSequence%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L10",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp11.StaticAbstractMembersInInterfaces.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp11.StaticAbstractMembersInInterfaces.html.view.verified.json
@@ -89,7 +89,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp11.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "StaticAbstractMembersInInterfaces",
     "path": "src/CSharp11.cs",
@@ -664,8 +664,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp11_StaticAbstractMembersInInterfaces.md&value=---%0Auid%3A%20CSharp11.StaticAbstractMembersInInterfaces%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L3",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp11_StaticAbstractMembersInInterfaces.md&value=---%0Auid%3A%20CSharp11.StaticAbstractMembersInInterfaces%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp11.cs/#L3",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp8.DefaultInterfaceMembers.IA.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp8.DefaultInterfaceMembers.IA.html.view.verified.json
@@ -117,7 +117,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "M",
             "path": "src/CSharp8.cs",
@@ -177,8 +177,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_DefaultInterfaceMembers_IA_M.md&value=---%0Auid%3A%20CSharp8.DefaultInterfaceMembers.IA.M%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L51",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_DefaultInterfaceMembers_IA_M.md&value=---%0Auid%3A%20CSharp8.DefaultInterfaceMembers.IA.M%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L51",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -230,7 +230,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp8.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "IA",
     "path": "src/CSharp8.cs",
@@ -408,8 +408,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_DefaultInterfaceMembers_IA.md&value=---%0Auid%3A%20CSharp8.DefaultInterfaceMembers.IA%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L49",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_DefaultInterfaceMembers_IA.md&value=---%0Auid%3A%20CSharp8.DefaultInterfaceMembers.IA%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L49",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp8.DefaultInterfaceMembers.Nested.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp8.DefaultInterfaceMembers.Nested.html.view.verified.json
@@ -89,7 +89,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp8.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "Nested",
     "path": "src/CSharp8.cs",
@@ -664,8 +664,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_DefaultInterfaceMembers_Nested.md&value=---%0Auid%3A%20CSharp8.DefaultInterfaceMembers.Nested%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L41",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_DefaultInterfaceMembers_Nested.md&value=---%0Auid%3A%20CSharp8.DefaultInterfaceMembers.Nested%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L41",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp8.DefaultInterfaceMembers.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp8.DefaultInterfaceMembers.html.view.verified.json
@@ -163,7 +163,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "GravitationalConstant",
             "path": "src/CSharp8.cs",
@@ -179,8 +179,8 @@
           "type": "field",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_DefaultInterfaceMembers_GravitationalConstant.md&value=---%0Auid%3A%20CSharp8.DefaultInterfaceMembers.GravitationalConstant%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L31",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_DefaultInterfaceMembers_GravitationalConstant.md&value=---%0Auid%3A%20CSharp8.DefaultInterfaceMembers.GravitationalConstant%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L31",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -298,7 +298,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "X",
             "path": "src/CSharp8.cs",
@@ -314,8 +314,8 @@
           "type": "field",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_DefaultInterfaceMembers_X.md&value=---%0Auid%3A%20CSharp8.DefaultInterfaceMembers.X%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L30",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_DefaultInterfaceMembers_X.md&value=---%0Auid%3A%20CSharp8.DefaultInterfaceMembers.X%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L30",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -394,7 +394,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "DoSomething",
             "path": "src/CSharp8.cs",
@@ -454,8 +454,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_DefaultInterfaceMembers_DoSomething.md&value=---%0Auid%3A%20CSharp8.DefaultInterfaceMembers.DoSomething%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L46",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_DefaultInterfaceMembers_DoSomething.md&value=---%0Auid%3A%20CSharp8.DefaultInterfaceMembers.DoSomething%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L46",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -527,7 +527,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "DoSomethingElse",
             "path": "src/CSharp8.cs",
@@ -587,8 +587,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_DefaultInterfaceMembers_DoSomethingElse.md&value=---%0Auid%3A%20CSharp8.DefaultInterfaceMembers.DoSomethingElse%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L47",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_DefaultInterfaceMembers_DoSomethingElse.md&value=---%0Auid%3A%20CSharp8.DefaultInterfaceMembers.DoSomethingElse%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L47",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -760,7 +760,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "op_UnaryPlus",
             "path": "src/CSharp8.cs",
@@ -816,8 +816,8 @@
           "type": "operator",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_DefaultInterfaceMembers_op_UnaryPlus_CSharp8_DefaultInterfaceMembers_.md&value=---%0Auid%3A%20CSharp8.DefaultInterfaceMembers.op_UnaryPlus(CSharp8.DefaultInterfaceMembers)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L34",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_DefaultInterfaceMembers_op_UnaryPlus_CSharp8_DefaultInterfaceMembers_.md&value=---%0Auid%3A%20CSharp8.DefaultInterfaceMembers.op_UnaryPlus(CSharp8.DefaultInterfaceMembers)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L34",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -869,7 +869,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp8.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "DefaultInterfaceMembers",
     "path": "src/CSharp8.cs",
@@ -1047,8 +1047,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_DefaultInterfaceMembers.md&value=---%0Auid%3A%20CSharp8.DefaultInterfaceMembers%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L28",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_DefaultInterfaceMembers.md&value=---%0Auid%3A%20CSharp8.DefaultInterfaceMembers%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L28",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp8.DisposableRefStructs.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp8.DisposableRefStructs.html.view.verified.json
@@ -117,7 +117,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Dispose",
             "path": "src/CSharp8.cs",
@@ -177,8 +177,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_DisposableRefStructs_Dispose.md&value=---%0Auid%3A%20CSharp8.DisposableRefStructs.Dispose%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L57",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_DisposableRefStructs_Dispose.md&value=---%0Auid%3A%20CSharp8.DisposableRefStructs.Dispose%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L57",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -250,7 +250,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "DoSomething",
             "path": "src/CSharp8.cs",
@@ -310,8 +310,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_DisposableRefStructs_DoSomething.md&value=---%0Auid%3A%20CSharp8.DisposableRefStructs.DoSomething%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L61",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_DisposableRefStructs_DoSomething.md&value=---%0Auid%3A%20CSharp8.DisposableRefStructs.DoSomething%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L61",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -363,7 +363,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp8.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "DisposableRefStructs",
     "path": "src/CSharp8.cs",
@@ -837,8 +837,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_DisposableRefStructs.md&value=---%0Auid%3A%20CSharp8.DisposableRefStructs%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L55",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_DisposableRefStructs.md&value=---%0Auid%3A%20CSharp8.DisposableRefStructs%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L55",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp8.Issue4007.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp8.Issue4007.html.view.verified.json
@@ -165,7 +165,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "SomeMethod",
             "path": "src/CSharp8.cs",
@@ -225,8 +225,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_Issue4007_SomeMethod_System_Int32_.md&value=---%0Auid%3A%20CSharp8.Issue4007.SomeMethod(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L148",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_Issue4007_SomeMethod_System_Int32_.md&value=---%0Auid%3A%20CSharp8.Issue4007.SomeMethod(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L148",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -298,7 +298,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "SomeOtherMethod",
             "path": "src/CSharp8.cs",
@@ -358,8 +358,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_Issue4007_SomeOtherMethod.md&value=---%0Auid%3A%20CSharp8.Issue4007.SomeOtherMethod%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L158",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_Issue4007_SomeOtherMethod.md&value=---%0Auid%3A%20CSharp8.Issue4007.SomeOtherMethod%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L158",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -411,7 +411,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp8.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "Issue4007",
     "path": "src/CSharp8.cs",
@@ -988,8 +988,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_Issue4007.md&value=---%0Auid%3A%20CSharp8.Issue4007%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L146",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_Issue4007.md&value=---%0Auid%3A%20CSharp8.Issue4007%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L146",
   "remarks": "",
   "conceptual": "",
   "implements": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp8.Misc.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp8.Misc.html.view.verified.json
@@ -162,7 +162,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "AsynchronousStreams",
             "path": "src/CSharp8.cs",
@@ -222,8 +222,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_Misc_AsynchronousStreams.md&value=---%0Auid%3A%20CSharp8.Misc.AsynchronousStreams%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L98",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_Misc_AsynchronousStreams.md&value=---%0Auid%3A%20CSharp8.Misc.AsynchronousStreams%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L98",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -341,7 +341,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "GenerateSequence",
             "path": "src/CSharp8.cs",
@@ -401,8 +401,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_Misc_GenerateSequence.md&value=---%0Auid%3A%20CSharp8.Misc.GenerateSequence%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L106",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_Misc_GenerateSequence.md&value=---%0Auid%3A%20CSharp8.Misc.GenerateSequence%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L106",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -474,7 +474,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "IndicesAndRanges",
             "path": "src/CSharp8.cs",
@@ -534,8 +534,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_Misc_IndicesAndRanges.md&value=---%0Auid%3A%20CSharp8.Misc.IndicesAndRanges%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L120",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_Misc_IndicesAndRanges.md&value=---%0Auid%3A%20CSharp8.Misc.IndicesAndRanges%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L120",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -700,7 +700,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "IsExpression",
             "path": "src/CSharp8.cs",
@@ -760,8 +760,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_Misc_IsExpression_System_DateTime_.md&value=---%0Auid%3A%20CSharp8.Misc.IsExpression(System.DateTime)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L78",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_Misc_IsExpression_System_DateTime_.md&value=---%0Auid%3A%20CSharp8.Misc.IsExpression(System.DateTime)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L78",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -833,7 +833,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "NullCoalescingAssignment",
             "path": "src/CSharp8.cs",
@@ -893,8 +893,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_Misc_NullCoalescingAssignment.md&value=---%0Auid%3A%20CSharp8.Misc.NullCoalescingAssignment%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L128",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_Misc_NullCoalescingAssignment.md&value=---%0Auid%3A%20CSharp8.Misc.NullCoalescingAssignment%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L128",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -966,7 +966,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "StackallocInNestedExpressions",
             "path": "src/CSharp8.cs",
@@ -1026,8 +1026,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_Misc_StackallocInNestedExpressions.md&value=---%0Auid%3A%20CSharp8.Misc.StackallocInNestedExpressions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L134",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_Misc_StackallocInNestedExpressions.md&value=---%0Auid%3A%20CSharp8.Misc.StackallocInNestedExpressions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L134",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -1192,7 +1192,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "StaticLocalFunctions",
             "path": "src/CSharp8.cs",
@@ -1252,8 +1252,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_Misc_StaticLocalFunctions_System_Int32_.md&value=---%0Auid%3A%20CSharp8.Misc.StaticLocalFunctions(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L89",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_Misc_StaticLocalFunctions_System_Int32_.md&value=---%0Auid%3A%20CSharp8.Misc.StaticLocalFunctions(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L89",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -1418,7 +1418,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "SwitchExpression",
             "path": "src/CSharp8.cs",
@@ -1478,8 +1478,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_Misc_SwitchExpression_System_ConsoleColor_.md&value=---%0Auid%3A%20CSharp8.Misc.SwitchExpression(System.ConsoleColor)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L81",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_Misc_SwitchExpression_System_ConsoleColor_.md&value=---%0Auid%3A%20CSharp8.Misc.SwitchExpression(System.ConsoleColor)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L81",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -1551,7 +1551,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "UsingDeclaration",
             "path": "src/CSharp8.cs",
@@ -1611,8 +1611,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_Misc_UsingDeclaration.md&value=---%0Auid%3A%20CSharp8.Misc.UsingDeclaration%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L115",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_Misc_UsingDeclaration.md&value=---%0Auid%3A%20CSharp8.Misc.UsingDeclaration%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L115",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -1664,7 +1664,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp8.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "Misc",
     "path": "src/CSharp8.cs",
@@ -2239,8 +2239,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_Misc.md&value=---%0Auid%3A%20CSharp8.Misc%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L76",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_Misc.md&value=---%0Auid%3A%20CSharp8.Misc%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L76",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp8.NullableReferenceTypes.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp8.NullableReferenceTypes.html.view.verified.json
@@ -163,7 +163,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Field",
             "path": "src/CSharp8.cs",
@@ -179,8 +179,8 @@
           "type": "field",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_NullableReferenceTypes_Field.md&value=---%0Auid%3A%20CSharp8.NullableReferenceTypes.Field%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L71",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_NullableReferenceTypes_Field.md&value=---%0Auid%3A%20CSharp8.NullableReferenceTypes.Field%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L71",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -306,7 +306,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Property",
             "path": "src/CSharp8.cs",
@@ -366,8 +366,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_NullableReferenceTypes_Property.md&value=---%0Auid%3A%20CSharp8.NullableReferenceTypes.Property%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L69",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_NullableReferenceTypes_Property.md&value=---%0Auid%3A%20CSharp8.NullableReferenceTypes.Property%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L69",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -541,7 +541,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "DoSomething",
             "path": "src/CSharp8.cs",
@@ -601,8 +601,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_NullableReferenceTypes_DoSomething_System_Collections_Generic_List_System_String__.md&value=---%0Auid%3A%20CSharp8.NullableReferenceTypes.DoSomething(System.Collections.Generic.List%7BSystem.String%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L73",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_NullableReferenceTypes_DoSomething_System_Collections_Generic_List_System_String__.md&value=---%0Auid%3A%20CSharp8.NullableReferenceTypes.DoSomething(System.Collections.Generic.List%7BSystem.String%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L73",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -654,7 +654,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp8.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "NullableReferenceTypes",
     "path": "src/CSharp8.cs",
@@ -1229,8 +1229,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_NullableReferenceTypes.md&value=---%0Auid%3A%20CSharp8.NullableReferenceTypes%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L67",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_NullableReferenceTypes.md&value=---%0Auid%3A%20CSharp8.NullableReferenceTypes%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L67",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp8.ReadOnlyMembers.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp8.ReadOnlyMembers.html.view.verified.json
@@ -164,7 +164,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Counter",
             "path": "src/CSharp8.cs",
@@ -224,8 +224,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_ReadOnlyMembers_Counter.md&value=---%0Auid%3A%20CSharp8.ReadOnlyMembers.Counter%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L21",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_ReadOnlyMembers_Counter.md&value=---%0Auid%3A%20CSharp8.ReadOnlyMembers.Counter%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L21",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -344,7 +344,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "X",
             "path": "src/CSharp8.cs",
@@ -404,8 +404,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_ReadOnlyMembers_X.md&value=---%0Auid%3A%20CSharp8.ReadOnlyMembers.X%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L10",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_ReadOnlyMembers_X.md&value=---%0Auid%3A%20CSharp8.ReadOnlyMembers.X%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L10",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -524,7 +524,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Y",
             "path": "src/CSharp8.cs",
@@ -584,8 +584,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_ReadOnlyMembers_Y.md&value=---%0Auid%3A%20CSharp8.ReadOnlyMembers.Y%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L11",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_ReadOnlyMembers_Y.md&value=---%0Auid%3A%20CSharp8.ReadOnlyMembers.Y%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L11",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -709,7 +709,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Sum",
             "path": "src/CSharp8.cs",
@@ -769,8 +769,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_ReadOnlyMembers_Sum.md&value=---%0Auid%3A%20CSharp8.ReadOnlyMembers.Sum%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L13",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_ReadOnlyMembers_Sum.md&value=---%0Auid%3A%20CSharp8.ReadOnlyMembers.Sum%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L13",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -888,7 +888,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp8.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "ToString",
             "path": "src/CSharp8.cs",
@@ -992,8 +992,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"api/CSharp8.ReadOnlyMembers.yml\" sourcestartlinenumber=\"1\">Returns the fully qualified type name of this instance.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_ReadOnlyMembers_ToString.md&value=---%0Auid%3A%20CSharp8.ReadOnlyMembers.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L18",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_ReadOnlyMembers_ToString.md&value=---%0Auid%3A%20CSharp8.ReadOnlyMembers.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L18",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -1044,7 +1044,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp8.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "ReadOnlyMembers",
     "path": "src/CSharp8.cs",
@@ -1469,8 +1469,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp8_ReadOnlyMembers.md&value=---%0Auid%3A%20CSharp8.ReadOnlyMembers%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L8",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp8_ReadOnlyMembers.md&value=---%0Auid%3A%20CSharp8.ReadOnlyMembers%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp8.cs/#L8",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp9.FunctionPointers.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp9.FunctionPointers.html.view.verified.json
@@ -376,7 +376,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp9.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Example",
             "path": "src/CSharp9.cs",
@@ -436,8 +436,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp9_FunctionPointers_Example_System_Action_System_Int32_______.md&value=---%0Auid%3A%20CSharp9.FunctionPointers.Example(System.Action%7BSystem.Int32%7D%2C%2C%2C%2C%2C)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L30",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp9_FunctionPointers_Example_System_Action_System_Int32_______.md&value=---%0Auid%3A%20CSharp9.FunctionPointers.Example(System.Action%7BSystem.Int32%7D%2C%2C%2C%2C%2C)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L30",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -489,7 +489,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp9.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "FunctionPointers",
     "path": "src/CSharp9.cs",
@@ -1064,8 +1064,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp9_FunctionPointers.md&value=---%0Auid%3A%20CSharp9.FunctionPointers%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L28",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp9_FunctionPointers.md&value=---%0Auid%3A%20CSharp9.FunctionPointers%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L28",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp9.InitOnlySetters.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp9.InitOnlySetters.html.view.verified.json
@@ -164,7 +164,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp9.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "PressureInMillibars",
             "path": "src/CSharp9.cs",
@@ -224,8 +224,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp9_InitOnlySetters_PressureInMillibars.md&value=---%0Auid%3A%20CSharp9.InitOnlySetters.PressureInMillibars%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L19",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp9_InitOnlySetters_PressureInMillibars.md&value=---%0Auid%3A%20CSharp9.InitOnlySetters.PressureInMillibars%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L19",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -344,7 +344,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp9.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "RecordedAt",
             "path": "src/CSharp9.cs",
@@ -404,8 +404,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp9_InitOnlySetters_RecordedAt.md&value=---%0Auid%3A%20CSharp9.InitOnlySetters.RecordedAt%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L17",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp9_InitOnlySetters_RecordedAt.md&value=---%0Auid%3A%20CSharp9.InitOnlySetters.RecordedAt%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L17",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -524,7 +524,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp9.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "TemperatureInCelsius",
             "path": "src/CSharp9.cs",
@@ -584,8 +584,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp9_InitOnlySetters_TemperatureInCelsius.md&value=---%0Auid%3A%20CSharp9.InitOnlySetters.TemperatureInCelsius%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L18",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp9_InitOnlySetters_TemperatureInCelsius.md&value=---%0Auid%3A%20CSharp9.InitOnlySetters.TemperatureInCelsius%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L18",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -637,7 +637,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp9.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "InitOnlySetters",
     "path": "src/CSharp9.cs",
@@ -1212,8 +1212,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp9_InitOnlySetters.md&value=---%0Auid%3A%20CSharp9.InitOnlySetters%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L15",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp9_InitOnlySetters.md&value=---%0Auid%3A%20CSharp9.InitOnlySetters%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L15",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp9.NativeSizedIntegers.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp9.NativeSizedIntegers.html.view.verified.json
@@ -163,7 +163,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp9.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "X",
             "path": "src/CSharp9.cs",
@@ -179,8 +179,8 @@
           "type": "field",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp9_NativeSizedIntegers_X.md&value=---%0Auid%3A%20CSharp9.NativeSizedIntegers.X%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L24",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp9_NativeSizedIntegers_X.md&value=---%0Auid%3A%20CSharp9.NativeSizedIntegers.X%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L24",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -298,7 +298,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp9.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Y",
             "path": "src/CSharp9.cs",
@@ -314,8 +314,8 @@
           "type": "field",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp9_NativeSizedIntegers_Y.md&value=---%0Auid%3A%20CSharp9.NativeSizedIntegers.Y%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L25",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp9_NativeSizedIntegers_Y.md&value=---%0Auid%3A%20CSharp9.NativeSizedIntegers.Y%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L25",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -367,7 +367,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp9.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "NativeSizedIntegers",
     "path": "src/CSharp9.cs",
@@ -942,8 +942,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp9_NativeSizedIntegers.md&value=---%0Auid%3A%20CSharp9.NativeSizedIntegers%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L22",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp9_NativeSizedIntegers.md&value=---%0Auid%3A%20CSharp9.NativeSizedIntegers%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L22",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp9.RecordTypes.Person.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp9.RecordTypes.Person.html.view.verified.json
@@ -211,7 +211,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp9.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": ".ctor",
             "path": "src/CSharp9.cs",
@@ -271,8 +271,8 @@
           "type": "constructor",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp9_RecordTypes_Person__ctor_System_String_System_String_.md&value=---%0Auid%3A%20CSharp9.RecordTypes.Person.%23ctor(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L10",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp9_RecordTypes_Person__ctor_System_String_System_String_.md&value=---%0Auid%3A%20CSharp9.RecordTypes.Person.%23ctor(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L10",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -398,7 +398,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp9.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "FirstName",
             "path": "src/CSharp9.cs",
@@ -458,8 +458,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp9_RecordTypes_Person_FirstName.md&value=---%0Auid%3A%20CSharp9.RecordTypes.Person.FirstName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L10",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp9_RecordTypes_Person_FirstName.md&value=---%0Auid%3A%20CSharp9.RecordTypes.Person.FirstName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L10",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -578,7 +578,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp9.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "LastName",
             "path": "src/CSharp9.cs",
@@ -638,8 +638,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp9_RecordTypes_Person_LastName.md&value=---%0Auid%3A%20CSharp9.RecordTypes.Person.LastName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L10",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp9_RecordTypes_Person_LastName.md&value=---%0Auid%3A%20CSharp9.RecordTypes.Person.LastName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L10",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -691,7 +691,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp9.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "Person",
     "path": "src/CSharp9.cs",
@@ -1330,8 +1330,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp9_RecordTypes_Person.md&value=---%0Auid%3A%20CSharp9.RecordTypes.Person%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L10",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp9_RecordTypes_Person.md&value=---%0Auid%3A%20CSharp9.RecordTypes.Person%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L10",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp9.RecordTypes.Teacher.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp9.RecordTypes.Teacher.html.view.verified.json
@@ -257,7 +257,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp9.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": ".ctor",
             "path": "src/CSharp9.cs",
@@ -317,8 +317,8 @@
           "type": "constructor",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp9_RecordTypes_Teacher__ctor_System_String_System_String_System_Int32_.md&value=---%0Auid%3A%20CSharp9.RecordTypes.Teacher.%23ctor(System.String%2CSystem.String%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L12",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp9_RecordTypes_Teacher__ctor_System_String_System_String_System_Int32_.md&value=---%0Auid%3A%20CSharp9.RecordTypes.Teacher.%23ctor(System.String%2CSystem.String%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L12",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -444,7 +444,7 @@
             "remote": {
               "path": "samples/csharp/src/CSharp9.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Grade",
             "path": "src/CSharp9.cs",
@@ -504,8 +504,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp9_RecordTypes_Teacher_Grade.md&value=---%0Auid%3A%20CSharp9.RecordTypes.Teacher.Grade%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L12",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp9_RecordTypes_Teacher_Grade.md&value=---%0Auid%3A%20CSharp9.RecordTypes.Teacher.Grade%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L12",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -557,7 +557,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp9.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "Teacher",
     "path": "src/CSharp9.cs",
@@ -1373,8 +1373,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp9_RecordTypes_Teacher.md&value=---%0Auid%3A%20CSharp9.RecordTypes.Teacher%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L12",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp9_RecordTypes_Teacher.md&value=---%0Auid%3A%20CSharp9.RecordTypes.Teacher%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L12",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp9.RecordTypes.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.CSharp/api/CSharp9.RecordTypes.html.view.verified.json
@@ -89,7 +89,7 @@
     "remote": {
       "path": "samples/csharp/src/CSharp9.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "RecordTypes",
     "path": "src/CSharp9.cs",
@@ -664,8 +664,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CSharp9_RecordTypes.md&value=---%0Auid%3A%20CSharp9.RecordTypes%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L8",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CSharp9_RecordTypes.md&value=---%0Auid%3A%20CSharp9.RecordTypes%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/csharp/src/CSharp9.cs/#L8",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Extensions/api/MyExample.ExampleClass.-ctor.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Extensions/api/MyExample.ExampleClass.-ctor.html.view.verified.json
@@ -70,7 +70,7 @@
             "remote": {
               "path": "samples/extensions/src/ExampleClass.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": ".ctor",
             "path": "src/ExampleClass.cs",
@@ -127,8 +127,8 @@
           "type": "constructor",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=MyExample_ExampleClass__ctor.md&value=---%0Auid%3A%20MyExample.ExampleClass.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/extensions/src/ExampleClass.cs/#L13",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=MyExample_ExampleClass__ctor.md&value=---%0Auid%3A%20MyExample.ExampleClass.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/extensions/src/ExampleClass.cs/#L13",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -180,7 +180,7 @@
     "remote": {
       "path": "samples/extensions/src/ExampleClass.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": ".ctor",
     "path": "src/ExampleClass.cs",
@@ -348,8 +348,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=MyExample_ExampleClass__ctor_.md&value=---%0Auid%3A%20MyExample.ExampleClass.%23ctor*%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/extensions/src/ExampleClass.cs/#L13",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=MyExample_ExampleClass__ctor_.md&value=---%0Auid%3A%20MyExample.ExampleClass.%23ctor*%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/extensions/src/ExampleClass.cs/#L13",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Extensions/api/MyExample.ExampleClass.MyEvent.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Extensions/api/MyExample.ExampleClass.MyEvent.html.view.verified.json
@@ -56,7 +56,7 @@
     "remote": {
       "path": "samples/extensions/src/ExampleClass.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "MyEvent",
     "path": "src/ExampleClass.cs",
@@ -281,8 +281,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=MyExample_ExampleClass_MyEvent.md&value=---%0Auid%3A%20MyExample.ExampleClass.MyEvent%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/extensions/src/ExampleClass.cs/#L7",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=MyExample_ExampleClass_MyEvent.md&value=---%0Auid%3A%20MyExample.ExampleClass.MyEvent%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/extensions/src/ExampleClass.cs/#L7",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Extensions/api/MyExample.ExampleClass.MyMethod.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Extensions/api/MyExample.ExampleClass.MyMethod.html.view.verified.json
@@ -115,7 +115,7 @@
             "remote": {
               "path": "samples/extensions/src/ExampleClass.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "MyMethod",
             "path": "src/ExampleClass.cs",
@@ -172,8 +172,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=MyExample_ExampleClass_MyMethod.md&value=---%0Auid%3A%20MyExample.ExampleClass.MyMethod%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/extensions/src/ExampleClass.cs/#L18",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=MyExample_ExampleClass_MyMethod.md&value=---%0Auid%3A%20MyExample.ExampleClass.MyMethod%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/extensions/src/ExampleClass.cs/#L18",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -225,7 +225,7 @@
     "remote": {
       "path": "samples/extensions/src/ExampleClass.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "MyMethod",
     "path": "src/ExampleClass.cs",
@@ -393,8 +393,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=MyExample_ExampleClass_MyMethod_.md&value=---%0Auid%3A%20MyExample.ExampleClass.MyMethod*%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/extensions/src/ExampleClass.cs/#L18",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=MyExample_ExampleClass_MyMethod_.md&value=---%0Auid%3A%20MyExample.ExampleClass.MyMethod*%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/extensions/src/ExampleClass.cs/#L18",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Extensions/api/MyExample.ExampleClass.MyProperty.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Extensions/api/MyExample.ExampleClass.MyProperty.html.view.verified.json
@@ -117,7 +117,7 @@
             "remote": {
               "path": "samples/extensions/src/ExampleClass.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "MyProperty",
             "path": "src/ExampleClass.cs",
@@ -174,8 +174,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=MyExample_ExampleClass_MyProperty.md&value=---%0Auid%3A%20MyExample.ExampleClass.MyProperty%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/extensions/src/ExampleClass.cs/#L11",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=MyExample_ExampleClass_MyProperty.md&value=---%0Auid%3A%20MyExample.ExampleClass.MyProperty%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/extensions/src/ExampleClass.cs/#L11",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -227,7 +227,7 @@
     "remote": {
       "path": "samples/extensions/src/ExampleClass.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "MyProperty",
     "path": "src/ExampleClass.cs",
@@ -395,8 +395,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=MyExample_ExampleClass_MyProperty_.md&value=---%0Auid%3A%20MyExample.ExampleClass.MyProperty*%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/extensions/src/ExampleClass.cs/#L11",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=MyExample_ExampleClass_MyProperty_.md&value=---%0Auid%3A%20MyExample.ExampleClass.MyProperty*%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/extensions/src/ExampleClass.cs/#L11",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Extensions/api/MyExample.ExampleClass.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Extensions/api/MyExample.ExampleClass.html.view.verified.json
@@ -362,7 +362,7 @@
     "remote": {
       "path": "samples/extensions/src/ExampleClass.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "ExampleClass",
     "path": "src/ExampleClass.cs",
@@ -939,8 +939,8 @@
     "_shared": {}
   },
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=MyExample_ExampleClass.md&value=---%0Auid%3A%20MyExample.ExampleClass%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/extensions/src/ExampleClass.cs/#L5",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=MyExample_ExampleClass.md&value=---%0Auid%3A%20MyExample.ExampleClass%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/extensions/src/ExampleClass.cs/#L5",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Extensions/index.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Extensions/index.html.view.verified.json
@@ -5,7 +5,7 @@
     "remote": {
       "path": "samples/extensions/index.md",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "startLine": 0.0,
     "endLine": 0.0,
@@ -16,7 +16,7 @@
     "remote": {
       "path": "samples/extensions/index.md",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "startLine": 0.0,
     "endLine": 0.0,
@@ -109,5 +109,5 @@
     "_shared": {}
   },
   "_disableToc": true,
-  "docurl": "https://github.com/dotnet/docfx/blob/main/samples/extensions/index.md/#L1"
+  "docurl": "https://github.com/filzrev/docfx/blob/main/samples/extensions/index.md/#L1"
 }

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromAssembly.Class1.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromAssembly.Class1.html.view.verified.json
@@ -115,7 +115,7 @@
             ]
           },
           "source": {
-            "href": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/assembly/Class1.cs",
+            "href": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/assembly/Class1.cs",
             "startLine": 0.0,
             "endLine": 0.0,
             "isExternal": false
@@ -173,7 +173,7 @@
           "summary": "",
           "platform": null,
           "docurl": "",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/assembly/Class1.cs",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/assembly/Class1.cs",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -249,7 +249,7 @@
             ]
           },
           "source": {
-            "href": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/assembly/Class1.cs",
+            "href": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/assembly/Class1.cs",
             "startLine": 0.0,
             "endLine": 0.0,
             "isExternal": false
@@ -258,6 +258,7 @@
             "BuildFromAssembly"
           ],
           "namespace": "BuildFromAssembly",
+          "example": [],
           "overload": {
             "uid": "BuildFromAssembly.Class1.HelloWorld*",
             "name": [
@@ -304,14 +305,13 @@
           },
           "level": 0.0,
           "type": "method",
-          "summary": "",
+          "summary": "<p sourcefile=\"obj/api/BuildFromAssembly.Class1.yml\" sourcestartlinenumber=\"1\">HelloWorld method.</p>\n",
           "platform": null,
           "docurl": "",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/assembly/Class1.cs",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/assembly/Class1.cs",
           "remarks": "",
           "conceptual": "",
           "implements": "",
-          "example": "",
           "seealso": null,
           "id": "BuildFromAssembly_Class1_HelloWorld",
           "hideTitleType": false,
@@ -356,7 +356,7 @@
   ],
   "type": "class",
   "source": {
-    "href": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/assembly/Class1.cs",
+    "href": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/assembly/Class1.cs",
     "startLine": 0.0,
     "endLine": 0.0,
     "isExternal": false
@@ -838,7 +838,7 @@
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
   "docurl": "",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/assembly/Class1.cs",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/assembly/Class1.cs",
   "remarks": "",
   "conceptual": "",
   "implements": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromCSharpSourceCode.CSharp.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromCSharpSourceCode.CSharp.html.view.verified.json
@@ -165,7 +165,7 @@
             "remote": {
               "path": "samples/seed/dotnet/csharp/CSharp.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Main",
             "path": "dotnet/csharp/CSharp.cs",
@@ -222,8 +222,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromCSharpSourceCode_CSharp_Main_System_String___.md&value=---%0Auid%3A%20BuildFromCSharpSourceCode.CSharp.Main(System.String%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/csharp/CSharp.cs/#L10",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromCSharpSourceCode_CSharp_Main_System_String___.md&value=---%0Auid%3A%20BuildFromCSharpSourceCode.CSharp.Main(System.String%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/csharp/CSharp.cs/#L10",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -275,7 +275,7 @@
     "remote": {
       "path": "samples/seed/dotnet/csharp/CSharp.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "CSharp",
     "path": "dotnet/csharp/CSharp.cs",
@@ -753,8 +753,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromCSharpSourceCode_CSharp.md&value=---%0Auid%3A%20BuildFromCSharpSourceCode.CSharp%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/csharp/CSharp.cs/#L8",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromCSharpSourceCode_CSharp.md&value=---%0Auid%3A%20BuildFromCSharpSourceCode.CSharp%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/csharp/CSharp.cs/#L8",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Class1.Issue8665.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Class1.Issue8665.html.view.verified.json
@@ -117,7 +117,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": ".ctor",
             "path": "dotnet/project/Project/Class1.cs",
@@ -177,8 +177,8 @@
           "type": "constructor",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue8665__ctor.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue8665.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L111",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue8665__ctor.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue8665.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L111",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -298,7 +298,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": ".ctor",
             "path": "dotnet/project/Project/Class1.cs",
@@ -358,8 +358,8 @@
           "type": "constructor",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue8665__ctor_System_Int32_.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue8665.%23ctor(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L113",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue8665__ctor_System_Int32_.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue8665.%23ctor(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L113",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -525,7 +525,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": ".ctor",
             "path": "dotnet/project/Project/Class1.cs",
@@ -585,8 +585,8 @@
           "type": "constructor",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue8665__ctor_System_Int32_System_Char_.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue8665.%23ctor(System.Int32%2CSystem.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L115",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue8665__ctor_System_Int32_System_Char_.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue8665.%23ctor(System.Int32%2CSystem.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L115",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -798,7 +798,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": ".ctor",
             "path": "dotnet/project/Project/Class1.cs",
@@ -858,8 +858,8 @@
           "type": "constructor",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue8665__ctor_System_Int32_System_Char_System_String_.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue8665.%23ctor(System.Int32%2CSystem.Char%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L117",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue8665__ctor_System_Int32_System_Char_System_String_.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue8665.%23ctor(System.Int32%2CSystem.Char%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L117",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -985,7 +985,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Bar",
             "path": "dotnet/project/Project/Class1.cs",
@@ -1045,8 +1045,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue8665_Bar.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue8665.Bar%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L108",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue8665_Bar.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue8665.Bar%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L108",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -1165,7 +1165,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Baz",
             "path": "dotnet/project/Project/Class1.cs",
@@ -1225,8 +1225,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue8665_Baz.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue8665.Baz%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L109",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue8665_Baz.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue8665.Baz%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L109",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -1345,7 +1345,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Foo",
             "path": "dotnet/project/Project/Class1.cs",
@@ -1405,8 +1405,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue8665_Foo.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue8665.Foo%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L107",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue8665_Foo.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue8665.Foo%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L107",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -1458,7 +1458,7 @@
     "remote": {
       "path": "samples/seed/dotnet/project/Project/Class1.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "Issue8665",
     "path": "dotnet/project/Project/Class1.cs",
@@ -1939,8 +1939,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue8665.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue8665%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L105",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue8665.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue8665%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L105",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Class1.Issue8696Attribute.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Class1.Issue8696Attribute.html.view.verified.json
@@ -395,7 +395,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": ".ctor",
             "path": "dotnet/project/Project/Class1.cs",
@@ -455,8 +455,8 @@
           "type": "constructor",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue8696Attribute__ctor_System_String_System_Int32_System_Int32_System_String___System_Boolean_System_Type_.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue8696Attribute.%23ctor(System.String%2CSystem.Int32%2CSystem.Int32%2CSystem.String%5B%5D%2CSystem.Boolean%2CSystem.Type)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L127",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue8696Attribute__ctor_System_String_System_Int32_System_Int32_System_String___System_Boolean_System_Type_.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue8696Attribute.%23ctor(System.String%2CSystem.Int32%2CSystem.Int32%2CSystem.String%5B%5D%2CSystem.Boolean%2CSystem.Type)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L127",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -508,7 +508,7 @@
     "remote": {
       "path": "samples/seed/dotnet/project/Project/Class1.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "Issue8696Attribute",
     "path": "dotnet/project/Project/Class1.cs",
@@ -2754,8 +2754,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue8696Attribute.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue8696Attribute%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L125",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue8696Attribute.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue8696Attribute%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L125",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Class1.Test-1.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Class1.Test-1.html.view.verified.json
@@ -89,7 +89,7 @@
     "remote": {
       "path": "samples/seed/dotnet/project/Project/Class1.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "Test",
     "path": "dotnet/project/Project/Class1.cs",
@@ -575,8 +575,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Test_1.md&value=---%0Auid%3A%20BuildFromProject.Class1.Test%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L5",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Test_1.md&value=---%0Auid%3A%20BuildFromProject.Class1.Test%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L5",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Class1.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Class1.html.view.verified.json
@@ -117,7 +117,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Issue1651",
             "path": "dotnet/project/Project/Class1.cs",
@@ -178,8 +178,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/BuildFromProject.Class1.yml\" sourcestartlinenumber=\"1\">Pricing models are used to calculate theoretical option values</p>\n<ul><li><span class=\"term\">1</span>Black Scholes</li><li><span class=\"term\">2</span>Black76</li><li><span class=\"term\">3</span>Black76Fut</li><li><span class=\"term\">4</span>Equity Tree</li><li><span class=\"term\">5</span>Variance Swap</li><li><span class=\"term\">6</span>Dividend Forecast</li></ul>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue1651.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue1651%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L32",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue1651.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue1651%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L32",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -250,7 +250,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Issue2623",
             "path": "dotnet/project/Project/Class1.cs",
@@ -314,8 +314,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue2623.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue2623%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L77",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue2623.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue2623%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L77",
           "conceptual": "",
           "implements": "",
           "seealso": null,
@@ -385,7 +385,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Issue2723",
             "path": "dotnet/project/Project/Class1.cs",
@@ -447,8 +447,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue2723.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue2723%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L96",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue2723.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue2723%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L96",
           "conceptual": "",
           "implements": "",
           "seealso": null,
@@ -518,7 +518,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Issue4017",
             "path": "dotnet/project/Project/Class1.cs",
@@ -582,8 +582,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue4017.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue4017%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L55",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue4017.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue4017%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L55",
           "conceptual": "",
           "implements": "",
           "seealso": null,
@@ -653,7 +653,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Issue4392",
             "path": "dotnet/project/Project/Class1.cs",
@@ -715,8 +715,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue4392.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue4392%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L101",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue4392.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue4392%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L101",
           "conceptual": "",
           "implements": "",
           "seealso": null,
@@ -786,7 +786,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Issue7484",
             "path": "dotnet/project/Project/Class1.cs",
@@ -848,8 +848,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue7484.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue7484%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L42",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue7484.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue7484%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L42",
           "conceptual": "",
           "implements": "",
           "seealso": null,
@@ -924,7 +924,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Issue8764",
             "path": "dotnet/project/Project/Class1.cs",
@@ -984,8 +984,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue8764__1.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue8764%60%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L103",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue8764__1.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue8764%60%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L103",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -1057,7 +1057,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Issue896",
             "path": "dotnet/project/Project/Class1.cs",
@@ -1214,8 +1214,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/BuildFromProject.Class1.yml\" sourcestartlinenumber=\"1\">Test</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue896.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue896%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L19",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_Issue896.md&value=---%0Auid%3A%20BuildFromProject.Class1.Issue896%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L19",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -1285,7 +1285,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "XmlCommentIncludeTag",
             "path": "dotnet/project/Project/Class1.cs",
@@ -1392,8 +1392,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/BuildFromProject.Class1.yml\" sourcestartlinenumber=\"1\">This method should do something...</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_XmlCommentIncludeTag.md&value=---%0Auid%3A%20BuildFromProject.Class1.XmlCommentIncludeTag%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L11",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1_XmlCommentIncludeTag.md&value=---%0Auid%3A%20BuildFromProject.Class1.XmlCommentIncludeTag%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L11",
           "conceptual": "",
           "seealso": null,
           "id": "BuildFromProject_Class1_XmlCommentIncludeTag",
@@ -1442,7 +1442,7 @@
     "remote": {
       "path": "samples/seed/dotnet/project/Project/Class1.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "Class1",
     "path": "dotnet/project/Project/Class1.cs",
@@ -1968,8 +1968,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1.md&value=---%0Auid%3A%20BuildFromProject.Class1%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L3",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1.md&value=---%0Auid%3A%20BuildFromProject.Class1%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L3",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.IInheritdoc.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.IInheritdoc.html.view.verified.json
@@ -117,7 +117,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Inheritdoc.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Issue7629",
             "path": "dotnet/project/Project/Inheritdoc.cs",
@@ -178,8 +178,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/BuildFromProject.IInheritdoc.yml\" sourcestartlinenumber=\"1\">This method should do something...</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_IInheritdoc_Issue7629.md&value=---%0Auid%3A%20BuildFromProject.IInheritdoc.Issue7629%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L8",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_IInheritdoc_Issue7629.md&value=---%0Auid%3A%20BuildFromProject.IInheritdoc.Issue7629%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L8",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -230,7 +230,7 @@
     "remote": {
       "path": "samples/seed/dotnet/project/Project/Inheritdoc.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "IInheritdoc",
     "path": "dotnet/project/Project/Inheritdoc.cs",
@@ -314,8 +314,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_IInheritdoc.md&value=---%0Auid%3A%20BuildFromProject.IInheritdoc%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L3",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_IInheritdoc.md&value=---%0Auid%3A%20BuildFromProject.IInheritdoc%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L3",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Inheritdoc.Issue6366.Class1-1.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Inheritdoc.Issue6366.Class1-1.html.view.verified.json
@@ -261,7 +261,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Inheritdoc.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "TestMethod1",
             "path": "dotnet/project/Project/Inheritdoc.cs",
@@ -322,8 +322,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/BuildFromProject.Inheritdoc.Issue6366.Class1-1.yml\" sourcestartlinenumber=\"1\">This text inherited.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue6366_Class1_1_TestMethod1__0_System_Int32_.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue6366.Class1%601.TestMethod1(%600%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L102",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue6366_Class1_1_TestMethod1__0_System_Int32_.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue6366.Class1%601.TestMethod1(%600%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L102",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -374,7 +374,7 @@
     "remote": {
       "path": "samples/seed/dotnet/project/Project/Inheritdoc.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "Class1",
     "path": "dotnet/project/Project/Inheritdoc.cs",
@@ -878,8 +878,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue6366_Class1_1.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue6366.Class1%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L94",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue6366_Class1_1.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue6366.Class1%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L94",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Inheritdoc.Issue6366.Class2.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Inheritdoc.Issue6366.Class2.html.view.verified.json
@@ -259,7 +259,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Inheritdoc.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "TestMethod1",
             "path": "dotnet/project/Project/Inheritdoc.cs",
@@ -364,8 +364,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/BuildFromProject.Inheritdoc.Issue6366.Class2.yml\" sourcestartlinenumber=\"1\">This text inherited.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue6366_Class2_TestMethod1_System_Boolean_System_Int32_.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue6366.Class2.TestMethod1(System.Boolean%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L108",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue6366_Class2_TestMethod1_System_Boolean_System_Int32_.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue6366.Class2.TestMethod1(System.Boolean%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L108",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -416,7 +416,7 @@
     "remote": {
       "path": "samples/seed/dotnet/project/Project/Inheritdoc.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "Class2",
     "path": "dotnet/project/Project/Inheritdoc.cs",
@@ -947,8 +947,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue6366_Class2.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue6366.Class2%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L105",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue6366_Class2.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue6366.Class2%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L105",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Inheritdoc.Issue6366.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Inheritdoc.Issue6366.html.view.verified.json
@@ -89,7 +89,7 @@
     "remote": {
       "path": "samples/seed/dotnet/project/Project/Inheritdoc.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "Issue6366",
     "path": "dotnet/project/Project/Inheritdoc.cs",
@@ -570,8 +570,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue6366.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue6366%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L92",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue6366.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue6366%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L92",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Inheritdoc.Issue7035.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Inheritdoc.Issue7035.html.view.verified.json
@@ -117,7 +117,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Inheritdoc.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "A",
             "path": "dotnet/project/Project/Inheritdoc.cs",
@@ -178,8 +178,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue7035_A.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue7035.A%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L86",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue7035_A.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue7035.A%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L86",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -250,7 +250,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Inheritdoc.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "B",
             "path": "dotnet/project/Project/Inheritdoc.cs",
@@ -311,8 +311,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue7035_B.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue7035.B%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L89",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue7035_B.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue7035.B%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L89",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -363,7 +363,7 @@
     "remote": {
       "path": "samples/seed/dotnet/project/Project/Inheritdoc.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "Issue7035",
     "path": "dotnet/project/Project/Inheritdoc.cs",
@@ -844,8 +844,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue7035.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue7035%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L83",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue7035.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue7035%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L83",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Inheritdoc.Issue7484.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Inheritdoc.Issue7484.html.view.verified.json
@@ -117,7 +117,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Inheritdoc.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": ".ctor",
             "path": "dotnet/project/Project/Inheritdoc.cs",
@@ -178,8 +178,8 @@
           "type": "constructor",
           "summary": "<p sourcefile=\"obj/api/BuildFromProject.Inheritdoc.Issue7484.yml\" sourcestartlinenumber=\"1\">This is a constructor to document.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue7484__ctor.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue7484.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L64",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue7484__ctor.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue7484.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L64",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -304,7 +304,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Inheritdoc.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "DoDad",
             "path": "dotnet/project/Project/Inheritdoc.cs",
@@ -365,8 +365,8 @@
           "type": "property",
           "summary": "<p sourcefile=\"obj/api/BuildFromProject.Inheritdoc.Issue7484.yml\" sourcestartlinenumber=\"1\">A string that could have something.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue7484_DoDad.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue7484.DoDad%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L69",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue7484_DoDad.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue7484.DoDad%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L69",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -539,7 +539,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Inheritdoc.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "BoolReturningMethod",
             "path": "dotnet/project/Project/Inheritdoc.cs",
@@ -601,8 +601,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/BuildFromProject.Inheritdoc.Issue7484.yml\" sourcestartlinenumber=\"1\">Simple method to generate docs for.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue7484_BoolReturningMethod_System_Boolean_.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue7484.BoolReturningMethod(System.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L80",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue7484_BoolReturningMethod_System_Boolean_.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue7484.BoolReturningMethod(System.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L80",
           "conceptual": "",
           "implements": "",
           "seealso": null,
@@ -652,7 +652,7 @@
     "remote": {
       "path": "samples/seed/dotnet/project/Project/Inheritdoc.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "Issue7484",
     "path": "dotnet/project/Project/Inheritdoc.cs",
@@ -1136,8 +1136,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue7484.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue7484%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L59",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue7484.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue7484%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L59",
   "conceptual": "",
   "implements": "",
   "seealso": null,

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Inheritdoc.Issue8101.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Inheritdoc.Issue8101.html.view.verified.json
@@ -354,7 +354,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Inheritdoc.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Tween",
             "path": "dotnet/project/Project/Inheritdoc.cs",
@@ -415,8 +415,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/BuildFromProject.Inheritdoc.Issue8101.yml\" sourcestartlinenumber=\"1\">Create a new tween.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue8101_Tween_System_Int32_System_Int32_System_Single_System_Action_System_Int32__.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue8101.Tween(System.Int32%2CSystem.Int32%2CSystem.Single%2CSystem.Action%7BSystem.Int32%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L33",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue8101_Tween_System_Int32_System_Int32_System_Single_System_Action_System_Int32__.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue8101.Tween(System.Int32%2CSystem.Int32%2CSystem.Single%2CSystem.Action%7BSystem.Int32%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L33",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -724,7 +724,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Inheritdoc.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Tween",
             "path": "dotnet/project/Project/Inheritdoc.cs",
@@ -785,8 +785,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/BuildFromProject.Inheritdoc.Issue8101.yml\" sourcestartlinenumber=\"1\">Create a new tween.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue8101_Tween_System_Single_System_Single_System_Single_System_Action_System_Single__.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue8101.Tween(System.Single%2CSystem.Single%2CSystem.Single%2CSystem.Action%7BSystem.Single%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L30",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue8101_Tween_System_Single_System_Single_System_Single_System_Action_System_Single__.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue8101.Tween(System.Single%2CSystem.Single%2CSystem.Single%2CSystem.Action%7BSystem.Single%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L30",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -837,7 +837,7 @@
     "remote": {
       "path": "samples/seed/dotnet/project/Project/Inheritdoc.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "Issue8101",
     "path": "dotnet/project/Project/Inheritdoc.cs",
@@ -1318,8 +1318,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue8101.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue8101%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L20",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue8101.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue8101%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L20",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Inheritdoc.Issue8129.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Inheritdoc.Issue8129.html.view.verified.json
@@ -165,7 +165,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Inheritdoc.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": ".ctor",
             "path": "dotnet/project/Project/Inheritdoc.cs",
@@ -226,8 +226,8 @@
           "type": "constructor",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue8129__ctor_System_String_.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue8129.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L39",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue8129__ctor_System_String_.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue8129.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L39",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -278,7 +278,7 @@
     "remote": {
       "path": "samples/seed/dotnet/project/Project/Inheritdoc.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "Issue8129",
     "path": "dotnet/project/Project/Inheritdoc.cs",
@@ -658,8 +658,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue8129.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue8129%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L36",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue8129.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue8129%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L36",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Inheritdoc.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Inheritdoc.html.view.verified.json
@@ -117,7 +117,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Inheritdoc.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Dispose",
             "path": "dotnet/project/Project/Inheritdoc.cs",
@@ -223,8 +223,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/BuildFromProject.Inheritdoc.yml\" sourcestartlinenumber=\"1\">Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Dispose.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Dispose%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L13",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Dispose.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Dispose%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L13",
           "remarks": "",
           "conceptual": "",
           "seealso": null,
@@ -294,7 +294,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Inheritdoc.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Issue7628",
             "path": "dotnet/project/Project/Inheritdoc.cs",
@@ -355,8 +355,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/BuildFromProject.Inheritdoc.yml\" sourcestartlinenumber=\"1\">This method should do something...</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue7628.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue7628%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L18",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue7628.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue7628%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L18",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -427,7 +427,7 @@
             "remote": {
               "path": "samples/seed/dotnet/project/Project/Inheritdoc.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Issue7629",
             "path": "dotnet/project/Project/Inheritdoc.cs",
@@ -533,8 +533,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/BuildFromProject.Inheritdoc.yml\" sourcestartlinenumber=\"1\">This method should do something...</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue7629.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue7629%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L15",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc_Issue7629.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc.Issue7629%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L15",
           "remarks": "",
           "conceptual": "",
           "seealso": null,
@@ -584,7 +584,7 @@
     "remote": {
       "path": "samples/seed/dotnet/project/Project/Inheritdoc.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "Inheritdoc",
     "path": "dotnet/project/Project/Inheritdoc.cs",
@@ -1153,8 +1153,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L11",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Inheritdoc.md&value=---%0Auid%3A%20BuildFromProject.Inheritdoc%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Inheritdoc.cs/#L11",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Issue8540.A.A.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Issue8540.A.A.html.view.verified.json
@@ -89,7 +89,7 @@
     "remote": {
       "path": "samples/seed/dotnet/project/Project/Namespace.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "A",
     "path": "dotnet/project/Project/Namespace.cs",
@@ -570,8 +570,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Issue8540_A_A.md&value=---%0Auid%3A%20BuildFromProject.Issue8540.A.A%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Namespace.cs/#L3",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Issue8540_A_A.md&value=---%0Auid%3A%20BuildFromProject.Issue8540.A.A%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Namespace.cs/#L3",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Issue8540.B.B.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromProject.Issue8540.B.B.html.view.verified.json
@@ -89,7 +89,7 @@
     "remote": {
       "path": "samples/seed/dotnet/project/Project/Namespace.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "B",
     "path": "dotnet/project/Project/Namespace.cs",
@@ -570,8 +570,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Issue8540_B_B.md&value=---%0Auid%3A%20BuildFromProject.Issue8540.B.B%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Namespace.cs/#L8",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Issue8540_B_B.md&value=---%0Auid%3A%20BuildFromProject.Issue8540.B.B%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Namespace.cs/#L8",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromVBSourceCode.BaseClass1.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromVBSourceCode.BaseClass1.html.view.verified.json
@@ -210,7 +210,7 @@
             "remote": {
               "path": "samples/seed/dotnet/vb/Class1.vb",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "WithDeclarationKeyword",
             "path": "dotnet/vb/Class1.vb",
@@ -267,8 +267,8 @@
           "type": "method",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromVBSourceCode_BaseClass1_WithDeclarationKeyword_BuildFromVBSourceCode_Class1_.md&value=---%0Auid%3A%20BuildFromVBSourceCode.BaseClass1.WithDeclarationKeyword(BuildFromVBSourceCode.Class1)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/vb/Class1.vb/#L46",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromVBSourceCode_BaseClass1_WithDeclarationKeyword_BuildFromVBSourceCode_Class1_.md&value=---%0Auid%3A%20BuildFromVBSourceCode.BaseClass1.WithDeclarationKeyword(BuildFromVBSourceCode.Class1)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/vb/Class1.vb/#L46",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -320,7 +320,7 @@
     "remote": {
       "path": "samples/seed/dotnet/vb/Class1.vb",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "BaseClass1",
     "path": "dotnet/vb/Class1.vb",
@@ -900,8 +900,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromVBSourceCode_BaseClass1.md&value=---%0Auid%3A%20BuildFromVBSourceCode.BaseClass1%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/vb/Class1.vb/#L45",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromVBSourceCode_BaseClass1.md&value=---%0Auid%3A%20BuildFromVBSourceCode.BaseClass1%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/vb/Class1.vb/#L45",
   "remarks": "",
   "conceptual": "",
   "implements": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromVBSourceCode.Class1.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/BuildFromVBSourceCode.Class1.html.view.verified.json
@@ -163,7 +163,7 @@
             "remote": {
               "path": "samples/seed/dotnet/vb/Class1.vb",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "ValueClass",
             "path": "dotnet/vb/Class1.vb",
@@ -177,8 +177,8 @@
           "type": "field",
           "summary": "<p sourcefile=\"obj/api/BuildFromVBSourceCode.Class1.yml\" sourcestartlinenumber=\"1\">This is a <em sourcefile=\"obj/api/BuildFromVBSourceCode.Class1.yml\" sourcestartlinenumber=\"1\">Value</em> type</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromVBSourceCode_Class1_ValueClass.md&value=---%0Auid%3A%20BuildFromVBSourceCode.Class1.ValueClass%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/vb/Class1.vb/#L14",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromVBSourceCode_Class1_ValueClass.md&value=---%0Auid%3A%20BuildFromVBSourceCode.Class1.ValueClass%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/vb/Class1.vb/#L14",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -303,7 +303,7 @@
             "remote": {
               "path": "samples/seed/dotnet/vb/Class1.vb",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Keyword",
             "path": "dotnet/vb/Class1.vb",
@@ -376,8 +376,8 @@
           "type": "property",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromVBSourceCode_Class1_Keyword.md&value=---%0Auid%3A%20BuildFromVBSourceCode.Class1.Keyword%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/vb/Class1.vb/#L16",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromVBSourceCode_Class1_Keyword.md&value=---%0Auid%3A%20BuildFromVBSourceCode.Class1.Keyword%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/vb/Class1.vb/#L16",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -551,7 +551,7 @@
             "remote": {
               "path": "samples/seed/dotnet/vb/Class1.vb",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Value",
             "path": "dotnet/vb/Class1.vb",
@@ -609,8 +609,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/BuildFromVBSourceCode.Class1.yml\" sourcestartlinenumber=\"1\">This is a <em sourcefile=\"obj/api/BuildFromVBSourceCode.Class1.yml\" sourcestartlinenumber=\"1\">Function</em></p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromVBSourceCode_Class1_Value_System_String_.md&value=---%0Auid%3A%20BuildFromVBSourceCode.Class1.Value(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/vb/Class1.vb/#L37",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromVBSourceCode_Class1_Value_System_String_.md&value=---%0Auid%3A%20BuildFromVBSourceCode.Class1.Value(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/vb/Class1.vb/#L37",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -774,7 +774,7 @@
             "remote": {
               "path": "samples/seed/dotnet/vb/Class1.vb",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "WithDeclarationKeyword",
             "path": "dotnet/vb/Class1.vb",
@@ -875,8 +875,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/BuildFromVBSourceCode.Class1.yml\" sourcestartlinenumber=\"1\">What is <strong sourcefile=\"obj/api/BuildFromVBSourceCode.Class1.yml\" sourcestartlinenumber=\"1\">Sub</strong>?</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromVBSourceCode_Class1_WithDeclarationKeyword_BuildFromVBSourceCode_Class1_.md&value=---%0Auid%3A%20BuildFromVBSourceCode.Class1.WithDeclarationKeyword(BuildFromVBSourceCode.Class1)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/vb/Class1.vb/#L26",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromVBSourceCode_Class1_WithDeclarationKeyword_BuildFromVBSourceCode_Class1_.md&value=---%0Auid%3A%20BuildFromVBSourceCode.Class1.WithDeclarationKeyword(BuildFromVBSourceCode.Class1)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/vb/Class1.vb/#L26",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -927,7 +927,7 @@
     "remote": {
       "path": "samples/seed/dotnet/vb/Class1.vb",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "Class1",
     "path": "dotnet/vb/Class1.vb",
@@ -1505,8 +1505,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromVBSourceCode_Class1.md&value=---%0Auid%3A%20BuildFromVBSourceCode.Class1%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/vb/Class1.vb/#L6",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromVBSourceCode_Class1.md&value=---%0Auid%3A%20BuildFromVBSourceCode.Class1%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/vb/Class1.vb/#L6",
   "remarks": "",
   "conceptual": "",
   "implements": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.Cat-2.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.Cat-2.html.view.verified.json
@@ -117,7 +117,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": ".ctor",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -178,8 +178,8 @@
           "type": "constructor",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.Cat-2.yml\" sourcestartlinenumber=\"1\">Default constructor.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2__ctor.md&value=---%0Auid%3A%20CatLibrary.Cat%602.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L122",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2__ctor.md&value=---%0Auid%3A%20CatLibrary.Cat%602.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L122",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -440,7 +440,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": ".ctor",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -501,8 +501,8 @@
           "type": "constructor",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.Cat-2.yml\" sourcestartlinenumber=\"1\">It's a complex constructor. The parameter will have some attributes.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2__ctor_System_String_System_Int32__System_String_System_Boolean_.md&value=---%0Auid%3A%20CatLibrary.Cat%602.%23ctor(System.String%2CSystem.Int32%40%2CSystem.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L137",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2__ctor_System_String_System_Int32__System_String_System_Boolean_.md&value=---%0Auid%3A%20CatLibrary.Cat%602.%23ctor(System.String%2CSystem.Int32%40%2CSystem.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L137",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -623,7 +623,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": ".ctor",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -684,8 +684,8 @@
           "type": "constructor",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.Cat-2.yml\" sourcestartlinenumber=\"1\">Constructor with one generic parameter.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2__ctor__0_.md&value=---%0Auid%3A%20CatLibrary.Cat%602.%23ctor(%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L128",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2__ctor__0_.md&value=---%0Auid%3A%20CatLibrary.Cat%602.%23ctor(%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L128",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -809,7 +809,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "isHealthy",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -838,8 +838,8 @@
           "type": "field",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.Cat-2.yml\" sourcestartlinenumber=\"1\">Field with attribute.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2_isHealthy.md&value=---%0Auid%3A%20CatLibrary.Cat%602.isHealthy%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L231",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2_isHealthy.md&value=---%0Auid%3A%20CatLibrary.Cat%602.isHealthy%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L231",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -964,7 +964,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Age",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -1025,8 +1025,8 @@
           "type": "property",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.Cat-2.yml\" sourcestartlinenumber=\"1\">Hint cat's age.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2_Age.md&value=---%0Auid%3A%20CatLibrary.Cat%602.Age%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L213",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2_Age.md&value=---%0Auid%3A%20CatLibrary.Cat%602.Age%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L213",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -1193,7 +1193,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "this[]",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -1254,8 +1254,8 @@
           "type": "property",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.Cat-2.yml\" sourcestartlinenumber=\"1\">This is index property of Cat. You can see that the visibility is different between <code>get</code> and <code>set</code> method.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2_Item_System_String_.md&value=---%0Auid%3A%20CatLibrary.Cat%602.Item(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L204",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2_Item_System_String_.md&value=---%0Auid%3A%20CatLibrary.Cat%602.Item(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L204",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -1373,7 +1373,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Name",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -1479,8 +1479,8 @@
           "type": "property",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.Cat-2.yml\" sourcestartlinenumber=\"1\">EII property.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2_Name.md&value=---%0Auid%3A%20CatLibrary.Cat%602.Name%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L255",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2_Name.md&value=---%0Auid%3A%20CatLibrary.Cat%602.Name%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L255",
           "remarks": "",
           "conceptual": "",
           "seealso": null,
@@ -1653,7 +1653,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "CalculateFood",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -1665,7 +1665,7 @@
             "remote": {
               "path": "samples/seed/specs/Cat.CalculateFood.md",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "path": "specs/Cat.CalculateFood.md",
             "startLine": 1.0,
@@ -1774,8 +1774,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"specs/Cat.CalculateFood.md\" sourcestartlinenumber=\"1\">It's an overridden summary in <code sourcefile=\"specs/Cat.CalculateFood.md\" sourcestartlinenumber=\"1\">markdown</code> format</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/specs/Cat.CalculateFood.md/#L2",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L145",
+          "docurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/specs/Cat.CalculateFood.md/#L2",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L145",
           "remarks": "",
           "implements": "",
           "seealso": null,
@@ -1940,7 +1940,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Equals",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -2044,8 +2044,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.Cat-2.yml\" sourcestartlinenumber=\"1\">Override the method of <code>Object.Equals(object obj).</code></p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2_Equals_System_Object_.md&value=---%0Auid%3A%20CatLibrary.Cat%602.Equals(System.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L165",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2_Equals_System_Object_.md&value=---%0Auid%3A%20CatLibrary.Cat%602.Equals(System.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L165",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -2258,7 +2258,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "GetTailLength",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -2319,8 +2319,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.Cat-2.yml\" sourcestartlinenumber=\"1\">It's an <code>unsafe</code> method.\nAs you see, <code class=\"paramref\">catName</code> is a <b>pointer</b>, so we need to add <code class=\"languageKeyword\">unsafe</code> keyword.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2_GetTailLength_System_Int32__System_Object___.md&value=---%0Auid%3A%20CatLibrary.Cat%602.GetTailLength(System.Int32*%2CSystem.Object%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L174",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2_GetTailLength_System_Int32__System_Object___.md&value=---%0Auid%3A%20CatLibrary.Cat%602.GetTailLength(System.Int32*%2CSystem.Object%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L174",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -2536,7 +2536,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Jump",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -2657,8 +2657,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.Cat-2.yml\" sourcestartlinenumber=\"1\">This method have attribute above it.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2_Jump__0__1_System_Boolean__.md&value=---%0Auid%3A%20CatLibrary.Cat%602.Jump(%600%2C%601%2CSystem.Boolean%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L154",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2_Jump__0__1_System_Boolean__.md&value=---%0Auid%3A%20CatLibrary.Cat%602.Jump(%600%2C%601%2CSystem.Boolean%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L154",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -2782,7 +2782,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "ownEat",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -2799,8 +2799,8 @@
           "type": "event",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.Cat-2.yml\" sourcestartlinenumber=\"1\">Eat event of this cat</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2_ownEat.md&value=---%0Auid%3A%20CatLibrary.Cat%602.ownEat%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L223",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2_ownEat.md&value=---%0Auid%3A%20CatLibrary.Cat%602.ownEat%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L223",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -3020,7 +3020,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "op_Addition",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -3077,8 +3077,8 @@
           "type": "operator",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.Cat-2.yml\" sourcestartlinenumber=\"1\">Addition operator of this class.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2_op_Addition_CatLibrary_Cat__0__1__System_Int32_.md&value=---%0Auid%3A%20CatLibrary.Cat%602.op_Addition(CatLibrary.Cat%7B%600%2C%601%7D%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L183",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2_op_Addition_CatLibrary_Cat__0__1__System_Int32_.md&value=---%0Auid%3A%20CatLibrary.Cat%602.op_Addition(CatLibrary.Cat%7B%600%2C%601%7D%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L183",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -3244,7 +3244,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "op_Explicit",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -3301,8 +3301,8 @@
           "type": "operator",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.Cat-2.yml\" sourcestartlinenumber=\"1\">Expilicit operator of this class.</p>\n<p>It means this cat can evolve to change to Tom. Tom and Jerry.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2_op_Explicit_CatLibrary_Cat__0__1___CatLibrary_Tom.md&value=---%0Auid%3A%20CatLibrary.Cat%602.op_Explicit(CatLibrary.Cat%7B%600%2C%601%7D)~CatLibrary.Tom%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L196",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2_op_Explicit_CatLibrary_Cat__0__1___CatLibrary_Tom.md&value=---%0Auid%3A%20CatLibrary.Cat%602.op_Explicit(CatLibrary.Cat%7B%600%2C%601%7D)~CatLibrary.Tom%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L196",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -3512,7 +3512,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "op_Subtraction",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -3569,8 +3569,8 @@
           "type": "operator",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.Cat-2.yml\" sourcestartlinenumber=\"1\">Similar with operaotr +, refer to that topic.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2_op_Subtraction_CatLibrary_Cat__0__1__System_Int32_.md&value=---%0Auid%3A%20CatLibrary.Cat%602.op_Subtraction(CatLibrary.Cat%7B%600%2C%601%7D%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L188",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Cat_2_op_Subtraction_CatLibrary_Cat__0__1__System_Int32_.md&value=---%0Auid%3A%20CatLibrary.Cat%602.op_Subtraction(CatLibrary.Cat%7B%600%2C%601%7D%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L188",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -3621,7 +3621,7 @@
     "remote": {
       "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "Cat",
     "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -3633,7 +3633,7 @@
     "remote": {
       "path": "samples/seed/specs/Cat.md",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "path": "specs/Cat.md",
     "startLine": 1.0,
@@ -4275,8 +4275,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/specs/Cat.md/#L2",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L113",
+  "docurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/specs/Cat.md/#L2",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L113",
   "seealso": null,
   "id": "CatLibrary_Cat_2",
   "hideTitleType": false,

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.CatException-1.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.CatException-1.html.view.verified.json
@@ -89,7 +89,7 @@
     "remote": {
       "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "CatException",
     "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -1209,8 +1209,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_CatException_1.md&value=---%0Auid%3A%20CatLibrary.CatException%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L317",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_CatException_1.md&value=---%0Auid%3A%20CatLibrary.CatException%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L317",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.Complex-2.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.Complex-2.html.view.verified.json
@@ -89,7 +89,7 @@
     "remote": {
       "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "Complex",
     "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -578,8 +578,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Complex_2.md&value=---%0Auid%3A%20CatLibrary.Complex%602%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L275",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Complex_2.md&value=---%0Auid%3A%20CatLibrary.Complex%602%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L275",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.Core.ContainersRefType.ColorType.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.Core.ContainersRefType.ColorType.html.view.verified.json
@@ -163,7 +163,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Blue",
             "path": "dotnet/solution/CatLibrary.Core/BaseClass.cs",
@@ -180,8 +180,8 @@
           "type": "field",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.Core.ContainersRefType.ColorType.yml\" sourcestartlinenumber=\"1\">blue</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType_ColorType_Blue.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType.ColorType.Blue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L33",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType_ColorType_Blue.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType.ColorType.Blue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L33",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -298,7 +298,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Red",
             "path": "dotnet/solution/CatLibrary.Core/BaseClass.cs",
@@ -315,8 +315,8 @@
           "type": "field",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.Core.ContainersRefType.ColorType.yml\" sourcestartlinenumber=\"1\">red</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType_ColorType_Red.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType.ColorType.Red%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L29",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType_ColorType_Red.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType.ColorType.Red%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L29",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -433,7 +433,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Yellow",
             "path": "dotnet/solution/CatLibrary.Core/BaseClass.cs",
@@ -450,8 +450,8 @@
           "type": "field",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.Core.ContainersRefType.ColorType.yml\" sourcestartlinenumber=\"1\">yellow</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType_ColorType_Yellow.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType.ColorType.Yellow%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L37",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType_ColorType_Yellow.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType.ColorType.Yellow%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L37",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -502,7 +502,7 @@
     "remote": {
       "path": "samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "ColorType",
     "path": "dotnet/solution/CatLibrary.Core/BaseClass.cs",
@@ -588,8 +588,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType_ColorType.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType.ColorType%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L24",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType_ColorType.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType.ColorType%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L24",
   "remarks": "",
   "conceptual": "",
   "implements": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.Core.ContainersRefType.ContainersRefTypeChild.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.Core.ContainersRefType.ContainersRefTypeChild.html.view.verified.json
@@ -89,7 +89,7 @@
     "remote": {
       "path": "samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "ContainersRefTypeChild",
     "path": "dotnet/solution/CatLibrary.Core/BaseClass.cs",
@@ -570,8 +570,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType_ContainersRefTypeChild.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType.ContainersRefTypeChild%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L80",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType_ContainersRefTypeChild.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType.ContainersRefTypeChild%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L80",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.Core.ContainersRefType.ContainersRefTypeChildInterface.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.Core.ContainersRefType.ContainersRefTypeChildInterface.html.view.verified.json
@@ -89,7 +89,7 @@
     "remote": {
       "path": "samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "ContainersRefTypeChildInterface",
     "path": "dotnet/solution/CatLibrary.Core/BaseClass.cs",
@@ -173,8 +173,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType_ContainersRefTypeChildInterface.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType.ContainersRefTypeChildInterface%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L74",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType_ContainersRefTypeChildInterface.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType.ContainersRefTypeChildInterface%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L74",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.Core.ContainersRefType.ContainersRefTypeDelegate.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.Core.ContainersRefType.ContainersRefTypeDelegate.html.view.verified.json
@@ -89,7 +89,7 @@
     "remote": {
       "path": "samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "ContainersRefTypeDelegate",
     "path": "dotnet/solution/CatLibrary.Core/BaseClass.cs",
@@ -175,8 +175,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType_ContainersRefTypeDelegate.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType.ContainersRefTypeDelegate%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L44",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType_ContainersRefTypeDelegate.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType.ContainersRefTypeDelegate%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L44",
   "remarks": "",
   "conceptual": "",
   "implements": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.Core.ContainersRefType.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.Core.ContainersRefType.html.view.verified.json
@@ -163,7 +163,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "ColorCount",
             "path": "dotnet/solution/CatLibrary.Core/BaseClass.cs",
@@ -180,8 +180,8 @@
           "type": "field",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.Core.ContainersRefType.yml\" sourcestartlinenumber=\"1\">ColorCount</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType_ColorCount.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType.ColorCount%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L18",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType_ColorCount.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType.ColorCount%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L18",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -306,7 +306,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "GetColorCount",
             "path": "dotnet/solution/CatLibrary.Core/BaseClass.cs",
@@ -367,8 +367,8 @@
           "type": "property",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.Core.ContainersRefType.yml\" sourcestartlinenumber=\"1\">GetColorCount</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType_GetColorCount.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType.GetColorCount%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L50",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType_GetColorCount.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType.GetColorCount%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L50",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -539,7 +539,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "ContainersRefTypeNonRefMethod",
             "path": "dotnet/solution/CatLibrary.Core/BaseClass.cs",
@@ -600,8 +600,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.Core.ContainersRefType.yml\" sourcestartlinenumber=\"1\">ContainersRefTypeNonRefMethod</p>\n<param name=\"parmsArray\">array\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType_ContainersRefTypeNonRefMethod_System_Object___.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType.ContainersRefTypeNonRefMethod(System.Object%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L68",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType_ContainersRefTypeNonRefMethod_System_Object___.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType.ContainersRefTypeNonRefMethod(System.Object%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L68",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -725,7 +725,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "ContainersRefTypeEventHandler",
             "path": "dotnet/solution/CatLibrary.Core/BaseClass.cs",
@@ -741,8 +741,8 @@
           "type": "event",
           "summary": "",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType_ContainersRefTypeEventHandler.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType.ContainersRefTypeEventHandler%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L86",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType_ContainersRefTypeEventHandler.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType.ContainersRefTypeEventHandler%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L86",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -794,7 +794,7 @@
     "remote": {
       "path": "samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "ContainersRefType",
     "path": "dotnet/solution/CatLibrary.Core/BaseClass.cs",
@@ -1176,8 +1176,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L12",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ContainersRefType.md&value=---%0Auid%3A%20CatLibrary.Core.ContainersRefType%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L12",
   "remarks": "",
   "conceptual": "",
   "implements": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.Core.ExplicitLayoutClass.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.Core.ExplicitLayoutClass.html.view.verified.json
@@ -89,7 +89,7 @@
     "remote": {
       "path": "samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "ExplicitLayoutClass",
     "path": "dotnet/solution/CatLibrary.Core/BaseClass.cs",
@@ -570,8 +570,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ExplicitLayoutClass.md&value=---%0Auid%3A%20CatLibrary.Core.ExplicitLayoutClass%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L94",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Core_ExplicitLayoutClass.md&value=---%0Auid%3A%20CatLibrary.Core.ExplicitLayoutClass%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary.Core/BaseClass.cs/#L94",
   "summary": "",
   "remarks": "",
   "conceptual": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.FakeDelegate-1.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.FakeDelegate-1.html.view.verified.json
@@ -89,7 +89,7 @@
     "remote": {
       "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "FakeDelegate",
     "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -370,8 +370,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_FakeDelegate_1.md&value=---%0Auid%3A%20CatLibrary.FakeDelegate%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L374",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_FakeDelegate_1.md&value=---%0Auid%3A%20CatLibrary.FakeDelegate%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L374",
   "remarks": "",
   "conceptual": "",
   "implements": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.IAnimal.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.IAnimal.html.view.verified.json
@@ -213,7 +213,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "this[]",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -274,8 +274,8 @@
           "type": "property",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.IAnimal.yml\" sourcestartlinenumber=\"1\">Return specific number animal's name.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_IAnimal_Item_System_Int32_.md&value=---%0Auid%3A%20CatLibrary.IAnimal.Item(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L29",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_IAnimal_Item_System_Int32_.md&value=---%0Auid%3A%20CatLibrary.IAnimal.Item(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L29",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -393,7 +393,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Name",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -454,8 +454,8 @@
           "type": "property",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.IAnimal.yml\" sourcestartlinenumber=\"1\">Name of Animal.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_IAnimal_Name.md&value=---%0Auid%3A%20CatLibrary.IAnimal.Name%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L22",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_IAnimal_Name.md&value=---%0Auid%3A%20CatLibrary.IAnimal.Name%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L22",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -533,7 +533,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Eat",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -594,8 +594,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.IAnimal.yml\" sourcestartlinenumber=\"1\">Animal's eat method.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_IAnimal_Eat.md&value=---%0Auid%3A%20CatLibrary.IAnimal.Eat%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L34",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_IAnimal_Eat.md&value=---%0Auid%3A%20CatLibrary.IAnimal.Eat%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L34",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -715,7 +715,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Eat",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -776,8 +776,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.IAnimal.yml\" sourcestartlinenumber=\"1\">Feed the animal with some food</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_IAnimal_Eat_System_String_.md&value=---%0Auid%3A%20CatLibrary.IAnimal.Eat(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L48",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_IAnimal_Eat_System_String_.md&value=---%0Auid%3A%20CatLibrary.IAnimal.Eat(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L48",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -904,7 +904,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Eat",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -965,8 +965,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.IAnimal.yml\" sourcestartlinenumber=\"1\">Overload method of eat. This define the animal eat by which tool.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_IAnimal_Eat__1___0_.md&value=---%0Auid%3A%20CatLibrary.IAnimal.Eat%60%601(%60%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L41",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_IAnimal_Eat__1___0_.md&value=---%0Auid%3A%20CatLibrary.IAnimal.Eat%60%601(%60%600)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L41",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -1017,7 +1017,7 @@
     "remote": {
       "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "IAnimal",
     "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -1029,7 +1029,7 @@
     "remote": {
       "path": "samples/seed/specs/CatLibrary.IAnimal.md",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "path": "specs/CatLibrary.IAnimal.md",
     "startLine": 1.0,
@@ -1116,8 +1116,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/specs/CatLibrary.IAnimal.md/#L2",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L16",
+  "docurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/specs/CatLibrary.IAnimal.md/#L2",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L16",
   "implements": "",
   "seealso": null,
   "id": "CatLibrary_IAnimal",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.ICat.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.ICat.html.view.verified.json
@@ -163,7 +163,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "eat",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -180,8 +180,8 @@
           "type": "event",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.ICat.yml\" sourcestartlinenumber=\"1\">eat event of cat. Every cat must implement this event.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_ICat_eat.md&value=---%0Auid%3A%20CatLibrary.ICat.eat%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L60",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_ICat_eat.md&value=---%0Auid%3A%20CatLibrary.ICat.eat%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L60",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -232,7 +232,7 @@
     "remote": {
       "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "ICat",
     "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -675,8 +675,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_ICat.md&value=---%0Auid%3A%20CatLibrary.ICat%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L54",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_ICat.md&value=---%0Auid%3A%20CatLibrary.ICat%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L54",
   "remarks": "",
   "conceptual": "",
   "implements": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.ICatExtension.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.ICatExtension.html.view.verified.json
@@ -213,7 +213,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Play",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -274,8 +274,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.ICatExtension.yml\" sourcestartlinenumber=\"1\">Extension method to let cat play</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_ICatExtension_Play_CatLibrary_ICat_CatLibrary_Core_ContainersRefType_ColorType_.md&value=---%0Auid%3A%20CatLibrary.ICatExtension.Play(CatLibrary.ICat%2CCatLibrary.Core.ContainersRefType.ColorType)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L341",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_ICatExtension_Play_CatLibrary_ICat_CatLibrary_Core_ContainersRefType_ColorType_.md&value=---%0Auid%3A%20CatLibrary.ICatExtension.Play(CatLibrary.ICat%2CCatLibrary.Core.ContainersRefType.ColorType)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L341",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -442,7 +442,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Sleep",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -503,8 +503,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.ICatExtension.yml\" sourcestartlinenumber=\"1\">Extension method hint that how long the cat can sleep.</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_ICatExtension_Sleep_CatLibrary_ICat_System_Int64_.md&value=---%0Auid%3A%20CatLibrary.ICatExtension.Sleep(CatLibrary.ICat%2CSystem.Int64)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L334",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_ICatExtension_Sleep_CatLibrary_ICat_System_Int64_.md&value=---%0Auid%3A%20CatLibrary.ICatExtension.Sleep(CatLibrary.ICat%2CSystem.Int64)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L334",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -555,7 +555,7 @@
     "remote": {
       "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "ICatExtension",
     "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -1038,8 +1038,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_ICatExtension.md&value=---%0Auid%3A%20CatLibrary.ICatExtension%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L327",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_ICatExtension.md&value=---%0Auid%3A%20CatLibrary.ICatExtension%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L327",
   "remarks": "",
   "conceptual": "",
   "implements": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.MRefDelegate-3.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.MRefDelegate-3.html.view.verified.json
@@ -89,7 +89,7 @@
     "remote": {
       "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "MRefDelegate",
     "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -335,8 +335,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_MRefDelegate_3.md&value=---%0Auid%3A%20CatLibrary.MRefDelegate%603%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L361",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_MRefDelegate_3.md&value=---%0Auid%3A%20CatLibrary.MRefDelegate%603%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L361",
   "remarks": "",
   "conceptual": "",
   "implements": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.MRefNormalDelegate.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.MRefNormalDelegate.html.view.verified.json
@@ -89,7 +89,7 @@
     "remote": {
       "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "MRefNormalDelegate",
     "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -272,8 +272,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_MRefNormalDelegate.md&value=---%0Auid%3A%20CatLibrary.MRefNormalDelegate%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L350",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_MRefNormalDelegate.md&value=---%0Auid%3A%20CatLibrary.MRefNormalDelegate%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L350",
   "remarks": "",
   "conceptual": "",
   "implements": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.Tom.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.Tom.html.view.verified.json
@@ -262,7 +262,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "TomMethod",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -463,8 +463,8 @@
           "type": "method",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.Tom.yml\" sourcestartlinenumber=\"1\">This is a Tom Method with complex type as return</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Tom_TomMethod_CatLibrary_Complex_CatLibrary_TomFromBaseClass_CatLibrary_TomFromBaseClass__System_Tuple_System_String_CatLibrary_Tom__.md&value=---%0Auid%3A%20CatLibrary.Tom.TomMethod(CatLibrary.Complex%7BCatLibrary.TomFromBaseClass%2CCatLibrary.TomFromBaseClass%7D%2CSystem.Tuple%7BSystem.String%2CCatLibrary.Tom%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L294",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Tom_TomMethod_CatLibrary_Complex_CatLibrary_TomFromBaseClass_CatLibrary_TomFromBaseClass__System_Tuple_System_String_CatLibrary_Tom__.md&value=---%0Auid%3A%20CatLibrary.Tom.TomMethod(CatLibrary.Complex%7BCatLibrary.TomFromBaseClass%2CCatLibrary.TomFromBaseClass%7D%2CSystem.Tuple%7BSystem.String%2CCatLibrary.Tom%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L294",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -515,7 +515,7 @@
     "remote": {
       "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "Tom",
     "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -1016,8 +1016,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_Tom.md&value=---%0Auid%3A%20CatLibrary.Tom%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L283",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_Tom.md&value=---%0Auid%3A%20CatLibrary.Tom%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L283",
   "remarks": "",
   "conceptual": "",
   "implements": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.TomFromBaseClass.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.TomFromBaseClass.html.view.verified.json
@@ -166,7 +166,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": ".ctor",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -227,8 +227,8 @@
           "type": "constructor",
           "summary": "<p sourcefile=\"obj/api/CatLibrary.TomFromBaseClass.yml\" sourcestartlinenumber=\"1\">This is a #ctor with parameter</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_TomFromBaseClass__ctor_System_Int32_.md&value=---%0Auid%3A%20CatLibrary.TomFromBaseClass.%23ctor(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L310",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_TomFromBaseClass__ctor_System_Int32_.md&value=---%0Auid%3A%20CatLibrary.TomFromBaseClass.%23ctor(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L310",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -279,7 +279,7 @@
     "remote": {
       "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "TomFromBaseClass",
     "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -863,8 +863,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=CatLibrary_TomFromBaseClass.md&value=---%0Auid%3A%20CatLibrary.TomFromBaseClass%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L303",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=CatLibrary_TomFromBaseClass.md&value=---%0Auid%3A%20CatLibrary.TomFromBaseClass%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L303",
   "remarks": "",
   "conceptual": "",
   "implements": "",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/MRef.Demo.Enumeration.ColorType.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/MRef.Demo.Enumeration.ColorType.html.view.verified.json
@@ -163,7 +163,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Blue",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -180,8 +180,8 @@
           "type": "field",
           "summary": "<p sourcefile=\"obj/api/MRef.Demo.Enumeration.ColorType.yml\" sourcestartlinenumber=\"1\">blue like river</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=MRef_Demo_Enumeration_ColorType_Blue.md&value=---%0Auid%3A%20MRef.Demo.Enumeration.ColorType.Blue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L409",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=MRef_Demo_Enumeration_ColorType_Blue.md&value=---%0Auid%3A%20MRef.Demo.Enumeration.ColorType.Blue%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L409",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -298,7 +298,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Red",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -315,8 +315,8 @@
           "type": "field",
           "summary": "<p sourcefile=\"obj/api/MRef.Demo.Enumeration.ColorType.yml\" sourcestartlinenumber=\"1\">this color is red</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=MRef_Demo_Enumeration_ColorType_Red.md&value=---%0Auid%3A%20MRef.Demo.Enumeration.ColorType.Red%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L405",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=MRef_Demo_Enumeration_ColorType_Red.md&value=---%0Auid%3A%20MRef.Demo.Enumeration.ColorType.Red%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L405",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -433,7 +433,7 @@
             "remote": {
               "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "id": "Yellow",
             "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -450,8 +450,8 @@
           "type": "field",
           "summary": "<p sourcefile=\"obj/api/MRef.Demo.Enumeration.ColorType.yml\" sourcestartlinenumber=\"1\">yellow comes from desert</p>\n",
           "platform": null,
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=MRef_Demo_Enumeration_ColorType_Yellow.md&value=---%0Auid%3A%20MRef.Demo.Enumeration.ColorType.Yellow%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L413",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=MRef_Demo_Enumeration_ColorType_Yellow.md&value=---%0Auid%3A%20MRef.Demo.Enumeration.ColorType.Yellow%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L413",
           "remarks": "",
           "conceptual": "",
           "implements": "",
@@ -502,7 +502,7 @@
     "remote": {
       "path": "samples/seed/dotnet/solution/CatLibrary/Class1.cs",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "id": "ColorType",
     "path": "dotnet/solution/CatLibrary/Class1.cs",
@@ -638,8 +638,8 @@
   "_tocPath": "api/toc.html",
   "_tocRel": "toc.html",
   "yamlmime": "ManagedReference",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=MRef_Demo_Enumeration_ColorType.md&value=---%0Auid%3A%20MRef.Demo.Enumeration.ColorType%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L400",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=MRef_Demo_Enumeration_ColorType.md&value=---%0Auid%3A%20MRef.Demo.Enumeration.ColorType%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L400",
   "conceptual": "",
   "implements": "",
   "id": "MRef_Demo_Enumeration_ColorType",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/articles/csharp_coding_standards.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/articles/csharp_coding_standards.html.view.verified.json
@@ -5,7 +5,7 @@
     "remote": {
       "path": "samples/seed/articles/csharp_coding_standards.md",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "startLine": 0.0,
     "endLine": 0.0,
@@ -16,7 +16,7 @@
     "remote": {
       "path": "samples/seed/articles/csharp_coding_standards.md",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "startLine": 0.0,
     "endLine": 0.0,
@@ -38,5 +38,5 @@
   "_tocPath": "articles/toc.html",
   "_tocRel": "toc.html",
   "_disableToc": false,
-  "docurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/articles/csharp_coding_standards.md/#L1"
+  "docurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/articles/csharp_coding_standards.md/#L1"
 }

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/articles/docfx_getting_started.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/articles/docfx_getting_started.html.view.verified.json
@@ -5,7 +5,7 @@
     "remote": {
       "path": "samples/seed/articles/docfx_getting_started.md",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "startLine": 0.0,
     "endLine": 0.0,
@@ -16,7 +16,7 @@
     "remote": {
       "path": "samples/seed/articles/docfx_getting_started.md",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "startLine": 0.0,
     "endLine": 0.0,
@@ -38,5 +38,5 @@
   "_tocPath": "articles/toc.html",
   "_tocRel": "toc.html",
   "_disableToc": false,
-  "docurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/articles/docfx_getting_started.md/#L1"
+  "docurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/articles/docfx_getting_started.md/#L1"
 }

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/articles/engineering_guidelines.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/articles/engineering_guidelines.html.view.verified.json
@@ -5,7 +5,7 @@
     "remote": {
       "path": "samples/seed/articles/engineering_guidelines.md",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "startLine": 0.0,
     "endLine": 0.0,
@@ -16,7 +16,7 @@
     "remote": {
       "path": "samples/seed/articles/engineering_guidelines.md",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "startLine": 0.0,
     "endLine": 0.0,
@@ -38,5 +38,5 @@
   "_tocPath": "articles/toc.html",
   "_tocRel": "toc.html",
   "_disableToc": false,
-  "docurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/articles/engineering_guidelines.md/#L1"
+  "docurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/articles/engineering_guidelines.md/#L1"
 }

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/articles/markdown.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/articles/markdown.html.view.verified.json
@@ -5,7 +5,7 @@
     "remote": {
       "path": "samples/seed/articles/markdown.md",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "startLine": 0.0,
     "endLine": 0.0,
@@ -16,7 +16,7 @@
     "remote": {
       "path": "samples/seed/articles/markdown.md",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "startLine": 0.0,
     "endLine": 0.0,
@@ -38,5 +38,5 @@
   "_tocPath": "articles/toc.html",
   "_tocRel": "toc.html",
   "_disableToc": false,
-  "docurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/articles/markdown.md/#L1"
+  "docurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/articles/markdown.md/#L1"
 }

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/index.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/index.html.view.verified.json
@@ -5,7 +5,7 @@
     "remote": {
       "path": "samples/seed/index.md",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "startLine": 0.0,
     "endLine": 0.0,
@@ -16,7 +16,7 @@
     "remote": {
       "path": "samples/seed/index.md",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "startLine": 0.0,
     "endLine": 0.0,
@@ -42,5 +42,5 @@
   "_tocPath": "toc.html",
   "_tocRel": "toc.html",
   "_disableToc": true,
-  "docurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/index.md/#L1"
+  "docurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/index.md/#L1"
 }

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/index.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/index.verified.json
@@ -2,7 +2,7 @@
   "api/BuildFromAssembly.Class1.html": {
     "href": "api/BuildFromAssembly.Class1.html",
     "title": "Class Class1 | docfx seed website",
-    "keywords": "Class Class1 Namespace BuildFromAssembly Assembly BuildFromAssembly.dll This is a test class. public class Class1 Inheritance object Class1 Inherited Members object.GetType() object.MemberwiseClone() object.ToString() object.Equals(object) object.Equals(object, object) object.ReferenceEquals(object, object) object.GetHashCode() Constructors Class1() public Class1() Methods HelloWorld() public static void HelloWorld()"
+    "keywords": "Class Class1 Namespace BuildFromAssembly Assembly BuildFromAssembly.dll This is a test class. public class Class1 Inheritance object Class1 Inherited Members object.GetType() object.MemberwiseClone() object.ToString() object.Equals(object) object.Equals(object, object) object.ReferenceEquals(object, object) object.GetHashCode() Constructors Class1() public Class1() Methods HelloWorld() HelloWorld method. public static void HelloWorld()"
   },
   "api/BuildFromAssembly.html": {
     "href": "api/BuildFromAssembly.html",

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/restapi/contacts.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/restapi/contacts.html.view.verified.json
@@ -40,14 +40,14 @@
         "remote": {
           "path": "samples/seed/restapi/contacts_swagger2.json",
           "branch": "main",
-          "repo": "https://github.com/dotnet/docfx"
+          "repo": "https://github.com/filzrev/docfx"
         },
         "startLine": 0.0,
         "endLine": 0.0,
         "isExternal": false
       },
-      "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=graph_windows_net_myorganization_Contacts_1_6_get_contacts.md&value=---%0Auid%3A%20graph.windows.net%2Fmyorganization%2FContacts%2F1.6%2Fget%20contacts%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-      "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/contacts_swagger2.json/#L1",
+      "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=graph_windows_net_myorganization_Contacts_1_6_get_contacts.md&value=---%0Auid%3A%20graph.windows.net%2Fmyorganization%2FContacts%2F1.6%2Fget%20contacts%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+      "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/contacts_swagger2.json/#L1",
       "conceptual": "",
       "footer": "",
       "remarks": ""
@@ -98,14 +98,14 @@
         "remote": {
           "path": "samples/seed/restapi/contacts_swagger2.json",
           "branch": "main",
-          "repo": "https://github.com/dotnet/docfx"
+          "repo": "https://github.com/filzrev/docfx"
         },
         "startLine": 0.0,
         "endLine": 0.0,
         "isExternal": false
       },
-      "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=graph_windows_net_myorganization_Contacts_1_6_get_contact_by_id.md&value=---%0Auid%3A%20graph.windows.net%2Fmyorganization%2FContacts%2F1.6%2Fget%20contact%20by%20id%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-      "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/contacts_swagger2.json/#L1",
+      "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=graph_windows_net_myorganization_Contacts_1_6_get_contact_by_id.md&value=---%0Auid%3A%20graph.windows.net%2Fmyorganization%2FContacts%2F1.6%2Fget%20contact%20by%20id%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+      "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/contacts_swagger2.json/#L1",
       "conceptual": "",
       "footer": "",
       "remarks": ""
@@ -400,14 +400,14 @@
         "remote": {
           "path": "samples/seed/restapi/contacts_swagger2.json",
           "branch": "main",
-          "repo": "https://github.com/dotnet/docfx"
+          "repo": "https://github.com/filzrev/docfx"
         },
         "startLine": 0.0,
         "endLine": 0.0,
         "isExternal": false
       },
-      "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=graph_windows_net_myorganization_Contacts_1_6_update_contact.md&value=---%0Auid%3A%20graph.windows.net%2Fmyorganization%2FContacts%2F1.6%2Fupdate%20contact%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-      "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/contacts_swagger2.json/#L1",
+      "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=graph_windows_net_myorganization_Contacts_1_6_update_contact.md&value=---%0Auid%3A%20graph.windows.net%2Fmyorganization%2FContacts%2F1.6%2Fupdate%20contact%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+      "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/contacts_swagger2.json/#L1",
       "conceptual": "",
       "footer": "",
       "remarks": ""
@@ -452,14 +452,14 @@
         "remote": {
           "path": "samples/seed/restapi/contacts_swagger2.json",
           "branch": "main",
-          "repo": "https://github.com/dotnet/docfx"
+          "repo": "https://github.com/filzrev/docfx"
         },
         "startLine": 0.0,
         "endLine": 0.0,
         "isExternal": false
       },
-      "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=graph_windows_net_myorganization_Contacts_1_6_delete_contact.md&value=---%0Auid%3A%20graph.windows.net%2Fmyorganization%2FContacts%2F1.6%2Fdelete%20contact%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-      "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/contacts_swagger2.json/#L1",
+      "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=graph_windows_net_myorganization_Contacts_1_6_delete_contact.md&value=---%0Auid%3A%20graph.windows.net%2Fmyorganization%2FContacts%2F1.6%2Fdelete%20contact%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+      "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/contacts_swagger2.json/#L1",
       "conceptual": "",
       "footer": "",
       "remarks": ""
@@ -520,14 +520,14 @@
         "remote": {
           "path": "samples/seed/restapi/contacts_swagger2.json",
           "branch": "main",
-          "repo": "https://github.com/dotnet/docfx"
+          "repo": "https://github.com/filzrev/docfx"
         },
         "startLine": 0.0,
         "endLine": 0.0,
         "isExternal": false
       },
-      "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=graph_windows_net_myorganization_Contacts_1_6_get_contact_manager_link.md&value=---%0Auid%3A%20graph.windows.net%2Fmyorganization%2FContacts%2F1.6%2Fget%20contact%20manager%20link%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-      "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/contacts_swagger2.json/#L1",
+      "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=graph_windows_net_myorganization_Contacts_1_6_get_contact_manager_link.md&value=---%0Auid%3A%20graph.windows.net%2Fmyorganization%2FContacts%2F1.6%2Fget%20contact%20manager%20link%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+      "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/contacts_swagger2.json/#L1",
       "conceptual": "",
       "footer": "",
       "remarks": ""
@@ -593,14 +593,14 @@
         "remote": {
           "path": "samples/seed/restapi/contacts_swagger2.json",
           "branch": "main",
-          "repo": "https://github.com/dotnet/docfx"
+          "repo": "https://github.com/filzrev/docfx"
         },
         "startLine": 0.0,
         "endLine": 0.0,
         "isExternal": false
       },
-      "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=graph_windows_net_myorganization_Contacts_1_6_update_contact_manager.md&value=---%0Auid%3A%20graph.windows.net%2Fmyorganization%2FContacts%2F1.6%2Fupdate%20contact%20manager%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-      "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/contacts_swagger2.json/#L1",
+      "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=graph_windows_net_myorganization_Contacts_1_6_update_contact_manager.md&value=---%0Auid%3A%20graph.windows.net%2Fmyorganization%2FContacts%2F1.6%2Fupdate%20contact%20manager%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+      "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/contacts_swagger2.json/#L1",
       "conceptual": "",
       "footer": "",
       "remarks": ""
@@ -645,14 +645,14 @@
         "remote": {
           "path": "samples/seed/restapi/contacts_swagger2.json",
           "branch": "main",
-          "repo": "https://github.com/dotnet/docfx"
+          "repo": "https://github.com/filzrev/docfx"
         },
         "startLine": 0.0,
         "endLine": 0.0,
         "isExternal": false
       },
-      "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=graph_windows_net_myorganization_Contacts_1_6_delete_contact_manager_by_id.md&value=---%0Auid%3A%20graph.windows.net%2Fmyorganization%2FContacts%2F1.6%2Fdelete%20contact%20manager%20by%20id%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-      "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/contacts_swagger2.json/#L1",
+      "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=graph_windows_net_myorganization_Contacts_1_6_delete_contact_manager_by_id.md&value=---%0Auid%3A%20graph.windows.net%2Fmyorganization%2FContacts%2F1.6%2Fdelete%20contact%20manager%20by%20id%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+      "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/contacts_swagger2.json/#L1",
       "conceptual": "",
       "footer": "",
       "remarks": ""
@@ -703,14 +703,14 @@
         "remote": {
           "path": "samples/seed/restapi/contacts_swagger2.json",
           "branch": "main",
-          "repo": "https://github.com/dotnet/docfx"
+          "repo": "https://github.com/filzrev/docfx"
         },
         "startLine": 0.0,
         "endLine": 0.0,
         "isExternal": false
       },
-      "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=graph_windows_net_myorganization_Contacts_1_6_get_contact_direct_reports_links.md&value=---%0Auid%3A%20graph.windows.net%2Fmyorganization%2FContacts%2F1.6%2Fget%20contact%20direct%20reports%20links%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-      "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/contacts_swagger2.json/#L1",
+      "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=graph_windows_net_myorganization_Contacts_1_6_get_contact_direct_reports_links.md&value=---%0Auid%3A%20graph.windows.net%2Fmyorganization%2FContacts%2F1.6%2Fget%20contact%20direct%20reports%20links%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+      "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/contacts_swagger2.json/#L1",
       "conceptual": "",
       "footer": "",
       "remarks": ""
@@ -761,14 +761,14 @@
         "remote": {
           "path": "samples/seed/restapi/contacts_swagger2.json",
           "branch": "main",
-          "repo": "https://github.com/dotnet/docfx"
+          "repo": "https://github.com/filzrev/docfx"
         },
         "startLine": 0.0,
         "endLine": 0.0,
         "isExternal": false
       },
-      "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=graph_windows_net_myorganization_Contacts_1_6_get_contact_memberOf_links.md&value=---%0Auid%3A%20graph.windows.net%2Fmyorganization%2FContacts%2F1.6%2Fget%20contact%20memberOf%20links%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-      "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/contacts_swagger2.json/#L1",
+      "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=graph_windows_net_myorganization_Contacts_1_6_get_contact_memberOf_links.md&value=---%0Auid%3A%20graph.windows.net%2Fmyorganization%2FContacts%2F1.6%2Fget%20contact%20memberOf%20links%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+      "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/contacts_swagger2.json/#L1",
       "conceptual": "",
       "footer": "",
       "remarks": ""
@@ -786,7 +786,7 @@
     "remote": {
       "path": "samples/seed/restapi/contacts_swagger2.json",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "startLine": 0.0,
     "endLine": 0.0,
@@ -806,8 +806,8 @@
   "_tocRel": "toc.html",
   "_jsonPath": "contacts.swagger.json",
   "title": "Contacts",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=graph_windows_net_myorganization_Contacts_1_6.md&value=---%0Auid%3A%20graph.windows.net%2Fmyorganization%2FContacts%2F1.6%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/contacts_swagger2.json/#L1",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=graph_windows_net_myorganization_Contacts_1_6.md&value=---%0Auid%3A%20graph.windows.net%2Fmyorganization%2FContacts%2F1.6%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/contacts_swagger2.json/#L1",
   "_disableToc": false,
   "_disableNextArticle": true
 }

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/restapi/petstore.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/restapi/petstore.html.view.verified.json
@@ -181,15 +181,15 @@
             "remote": {
               "path": "samples/seed/restapi/petstore.swagger.json",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "startLine": 0.0,
             "endLine": 0.0,
             "isExternal": false
           },
           "footer": "\n<blockquote sourcefile=\"specs/petstore-operations.addPet.footer.md\" sourcestartlinenumber=\"5\">\n<p sourcefile=\"specs/petstore-operations.addPet.footer.md\" sourcestartlinenumber=\"5\">NOTE: Add pet only when you needs.</p>\n</blockquote>\n",
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_addPet.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FaddPet%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_addPet.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FaddPet%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
           "conceptual": "",
           "remarks": "",
           "includedInTags": true
@@ -371,14 +371,14 @@
             "remote": {
               "path": "samples/seed/restapi/petstore.swagger.json",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "startLine": 0.0,
             "endLine": 0.0,
             "isExternal": false
           },
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_updatePet.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FupdatePet%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_updatePet.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FupdatePet%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
           "conceptual": "",
           "footer": "",
           "remarks": "",
@@ -522,14 +522,14 @@
             "remote": {
               "path": "samples/seed/restapi/petstore.swagger.json",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "startLine": 0.0,
             "endLine": 0.0,
             "isExternal": false
           },
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_findPetsByStatus.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FfindPetsByStatus%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_findPetsByStatus.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FfindPetsByStatus%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
           "conceptual": "",
           "footer": "",
           "remarks": "",
@@ -668,14 +668,14 @@
             "remote": {
               "path": "samples/seed/restapi/petstore.swagger.json",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "startLine": 0.0,
             "endLine": 0.0,
             "isExternal": false
           },
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_findPetsByTags.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FfindPetsByTags%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_findPetsByTags.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FfindPetsByTags%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
           "conceptual": "",
           "footer": "",
           "remarks": "",
@@ -734,14 +734,14 @@
             "remote": {
               "path": "samples/seed/restapi/petstore.swagger.json",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "startLine": 0.0,
             "endLine": 0.0,
             "isExternal": false
           },
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_deletePet.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FdeletePet%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_deletePet.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FdeletePet%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
           "conceptual": "",
           "footer": "",
           "remarks": "",
@@ -919,14 +919,14 @@
             "remote": {
               "path": "samples/seed/restapi/petstore.swagger.json",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "startLine": 0.0,
             "endLine": 0.0,
             "isExternal": false
           },
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getPetById.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FgetPetById%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getPetById.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FgetPetById%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
           "conceptual": "",
           "footer": "",
           "remarks": "",
@@ -992,14 +992,14 @@
             "remote": {
               "path": "samples/seed/restapi/petstore.swagger.json",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "startLine": 0.0,
             "endLine": 0.0,
             "isExternal": false
           },
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_updatePetWithForm.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FupdatePetWithForm%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_updatePetWithForm.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FupdatePetWithForm%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
           "conceptual": "",
           "footer": "",
           "remarks": "",
@@ -1092,14 +1092,14 @@
             "remote": {
               "path": "samples/seed/restapi/petstore.swagger.json",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "startLine": 0.0,
             "endLine": 0.0,
             "isExternal": false
           },
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_uploadFile.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FuploadFile%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_uploadFile.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FuploadFile%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
           "conceptual": "",
           "footer": "",
           "remarks": "",
@@ -1285,15 +1285,15 @@
             "remote": {
               "path": "samples/seed/restapi/petstore.swagger.json",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "startLine": 0.0,
             "endLine": 0.0,
             "isExternal": false
           },
           "footer": "\n<blockquote sourcefile=\"specs/petstore-operations.addPet.footer.md\" sourcestartlinenumber=\"5\">\n<p sourcefile=\"specs/petstore-operations.addPet.footer.md\" sourcestartlinenumber=\"5\">NOTE: Add pet only when you needs.</p>\n</blockquote>\n",
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_addPet.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FaddPet%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_addPet.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FaddPet%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
           "conceptual": "",
           "remarks": "",
           "includedInTags": true
@@ -1335,14 +1335,14 @@
             "remote": {
               "path": "samples/seed/restapi/petstore.swagger.json",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "startLine": 0.0,
             "endLine": 0.0,
             "isExternal": false
           },
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getInventory.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FgetInventory%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getInventory.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FgetInventory%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
           "conceptual": "",
           "footer": "",
           "remarks": "",
@@ -1507,14 +1507,14 @@
             "remote": {
               "path": "samples/seed/restapi/petstore.swagger.json",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "startLine": 0.0,
             "endLine": 0.0,
             "isExternal": false
           },
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_placeOrder.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FplaceOrder%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_placeOrder.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FplaceOrder%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
           "conceptual": "",
           "footer": "",
           "remarks": "",
@@ -1560,14 +1560,14 @@
             "remote": {
               "path": "samples/seed/restapi/petstore.swagger.json",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "startLine": 0.0,
             "endLine": 0.0,
             "isExternal": false
           },
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_deleteOrder.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FdeleteOrder%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_deleteOrder.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FdeleteOrder%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
           "conceptual": "",
           "footer": "",
           "remarks": "",
@@ -1679,14 +1679,14 @@
             "remote": {
               "path": "samples/seed/restapi/petstore.swagger.json",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "startLine": 0.0,
             "endLine": 0.0,
             "isExternal": false
           },
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getOrderById.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FgetOrderById%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getOrderById.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FgetOrderById%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
           "conceptual": "",
           "footer": "",
           "remarks": "",
@@ -1804,14 +1804,14 @@
             "remote": {
               "path": "samples/seed/restapi/petstore.swagger.json",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "startLine": 0.0,
             "endLine": 0.0,
             "isExternal": false
           },
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_createUser.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FcreateUser%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_createUser.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FcreateUser%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
           "conceptual": "",
           "footer": "",
           "remarks": "",
@@ -1889,14 +1889,14 @@
             "remote": {
               "path": "samples/seed/restapi/petstore.swagger.json",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "startLine": 0.0,
             "endLine": 0.0,
             "isExternal": false
           },
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_createUsersWithArrayInput.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FcreateUsersWithArrayInput%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_createUsersWithArrayInput.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FcreateUsersWithArrayInput%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
           "conceptual": "",
           "footer": "",
           "remarks": "",
@@ -1974,14 +1974,14 @@
             "remote": {
               "path": "samples/seed/restapi/petstore.swagger.json",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "startLine": 0.0,
             "endLine": 0.0,
             "isExternal": false
           },
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_createUsersWithListInput.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FcreateUsersWithListInput%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_createUsersWithListInput.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FcreateUsersWithListInput%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
           "conceptual": "",
           "footer": "",
           "remarks": "",
@@ -2047,14 +2047,14 @@
             "remote": {
               "path": "samples/seed/restapi/petstore.swagger.json",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "startLine": 0.0,
             "endLine": 0.0,
             "isExternal": false
           },
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_loginUser.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FloginUser%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_loginUser.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FloginUser%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
           "conceptual": "",
           "footer": "",
           "remarks": "",
@@ -2086,14 +2086,14 @@
             "remote": {
               "path": "samples/seed/restapi/petstore.swagger.json",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "startLine": 0.0,
             "endLine": 0.0,
             "isExternal": false
           },
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_logoutUser.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FlogoutUser%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_logoutUser.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FlogoutUser%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
           "conceptual": "",
           "footer": "",
           "remarks": "",
@@ -2137,14 +2137,14 @@
             "remote": {
               "path": "samples/seed/restapi/petstore.swagger.json",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "startLine": 0.0,
             "endLine": 0.0,
             "isExternal": false
           },
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_deleteUser.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FdeleteUser%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_deleteUser.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FdeleteUser%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
           "conceptual": "",
           "footer": "",
           "remarks": "",
@@ -2259,14 +2259,14 @@
             "remote": {
               "path": "samples/seed/restapi/petstore.swagger.json",
               "branch": "main",
-              "repo": "https://github.com/dotnet/docfx"
+              "repo": "https://github.com/filzrev/docfx"
             },
             "startLine": 0.0,
             "endLine": 0.0,
             "isExternal": false
           },
-          "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getUserByName.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FgetUserByName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-          "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
+          "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getUserByName.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FgetUserByName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+          "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
           "conceptual": "",
           "footer": "",
           "remarks": "",
@@ -2386,14 +2386,14 @@
         "remote": {
           "path": "samples/seed/restapi/petstore.swagger.json",
           "branch": "main",
-          "repo": "https://github.com/dotnet/docfx"
+          "repo": "https://github.com/filzrev/docfx"
         },
         "startLine": 0.0,
         "endLine": 0.0,
         "isExternal": false
       },
-      "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_updateUser.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FupdateUser%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-      "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
+      "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_updateUser.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FupdateUser%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+      "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
       "conceptual": "",
       "footer": "",
       "remarks": ""
@@ -2432,7 +2432,7 @@
     "remote": {
       "path": "samples/seed/restapi/petstore.swagger.json",
       "branch": "main",
-      "repo": "https://github.com/dotnet/docfx"
+      "repo": "https://github.com/filzrev/docfx"
     },
     "startLine": 0.0,
     "endLine": 0.0,
@@ -2453,8 +2453,8 @@
   "_tocPath": "restapi/toc.html",
   "_tocRel": "toc.html",
   "_jsonPath": "petstore.swagger.json",
-  "docurl": "https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
-  "sourceurl": "https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
+  "docurl": "https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0.md&value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A",
+  "sourceurl": "https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1",
   "isTagLayout": true,
   "_disableToc": false,
   "_disableNextArticle": true

--- a/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/api-BuildFromProject.Class1.html.verified.html
+++ b/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/api-BuildFromProject.Class1.html.verified.html
@@ -15,7 +15,7 @@
       <meta name="docfx:rel" content="../">
       
       
-      <meta name="docfx:docurl" content="https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1.md&amp;value=---%0Auid%3A%20BuildFromProject.Class1%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">
+      <meta name="docfx:docurl" content="https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=BuildFromProject_Class1.md&amp;value=---%0Auid%3A%20BuildFromProject.Class1%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">
   <script type="module">
     import options from './../public/main.js'
     import { init } from './../public/docfx.min.js'
@@ -344,7 +344,7 @@
 
   <h1 id="BuildFromProject_Class1" data-uid="BuildFromProject.Class1" class="text-break">
     Class Class1
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L3"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L3"><i class="bi bi-code-slash"></i></a>
   </h1>
 
   <div class="facts text-secondary">
@@ -416,7 +416,7 @@
 
   <h3 id="BuildFromProject_Class1_Issue1651" data-uid="BuildFromProject.Class1.Issue1651">
   Issue1651()
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L32"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L32"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#BuildFromProject_Class1_Issue1651" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"><p>Pricing models are used to calculate theoretical option values</p>
@@ -444,7 +444,7 @@
 
   <h3 id="BuildFromProject_Class1_Issue2623" data-uid="BuildFromProject.Class1.Issue2623">
   Issue2623()
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L77"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L77"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#BuildFromProject_Class1_Issue2623" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"></div>
@@ -489,7 +489,7 @@
 
   <h3 id="BuildFromProject_Class1_Issue2723" data-uid="BuildFromProject.Class1.Issue2723">
   Issue2723()
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L96"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L96"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#BuildFromProject_Class1_Issue2723" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"></div>
@@ -527,7 +527,7 @@
 
   <h3 id="BuildFromProject_Class1_Issue4017" data-uid="BuildFromProject.Class1.Issue4017">
   Issue4017()
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L55"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L55"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#BuildFromProject_Class1_Issue4017" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"></div>
@@ -576,7 +576,7 @@
 
   <h3 id="BuildFromProject_Class1_Issue4392" data-uid="BuildFromProject.Class1.Issue4392">
   Issue4392()
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L101"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L101"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#BuildFromProject_Class1_Issue4392" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"></div>
@@ -605,7 +605,7 @@
 
   <h3 id="BuildFromProject_Class1_Issue7484" data-uid="BuildFromProject.Class1.Issue7484">
   Issue7484()
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L42"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L42"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#BuildFromProject_Class1_Issue7484" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"></div>
@@ -635,7 +635,7 @@
 
   <h3 id="BuildFromProject_Class1_Issue8764__1" data-uid="BuildFromProject.Class1.Issue8764``1">
   Issue8764&lt;T&gt;()
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L103"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L103"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#BuildFromProject_Class1_Issue8764__1" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"></div>
@@ -666,7 +666,7 @@
 
   <h3 id="BuildFromProject_Class1_Issue896" data-uid="BuildFromProject.Class1.Issue896">
   Issue896()
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L19"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L19"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#BuildFromProject_Class1_Issue896" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"><p>Test</p>
@@ -700,7 +700,7 @@
 
   <h3 id="BuildFromProject_Class1_XmlCommentIncludeTag" data-uid="BuildFromProject.Class1.XmlCommentIncludeTag">
   XmlCommentIncludeTag()
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L11"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L11"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#BuildFromProject_Class1_XmlCommentIncludeTag" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"><p>This method should do something...</p>
@@ -730,7 +730,7 @@
 </article>
 
         <div class="contribution d-print-none">
-          <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L3" class="edit-link">Edit this page</a>
+          <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/project/Project/Class1.cs/#L3" class="edit-link">Edit this page</a>
         </div>
 
         

--- a/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/api-CatLibrary.Cat-2.html-q-cat.verified.html
+++ b/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/api-CatLibrary.Cat-2.html-q-cat.verified.html
@@ -15,7 +15,7 @@
       <meta name="docfx:rel" content="../">
       
       
-      <meta name="docfx:docurl" content="https://github.com/dotnet/docfx/blob/main/samples/seed/specs/Cat.md/#L2">
+      <meta name="docfx:docurl" content="https://github.com/filzrev/docfx/blob/main/samples/seed/specs/Cat.md/#L2">
   <script type="module">
     import options from './../public/main.js'
     import { init } from './../public/docfx.min.js'
@@ -344,7 +344,7 @@
 
   <h1 id="CatLibrary_Cat_2" data-uid="CatLibrary.Cat`2" class="text-break">
     Class Cat&lt;T, K&gt;
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L113"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L113"><i class="bi bi-code-slash"></i></a>
   </h1>
 
   <div class="facts text-secondary">
@@ -459,7 +459,7 @@ This is a CAT class</p>
 
   <h3 id="CatLibrary_Cat_2__ctor" data-uid="CatLibrary.Cat`2.#ctor">
   Cat()
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L122"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L122"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#CatLibrary_Cat_2__ctor" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"><p>Default constructor.</p>
@@ -486,7 +486,7 @@ This is a CAT class</p>
 
   <h3 id="CatLibrary_Cat_2__ctor_System_String_System_Int32__System_String_System_Boolean_" data-uid="CatLibrary.Cat`2.#ctor(System.String,System.Int32@,System.String,System.Boolean)">
   Cat(string, out int, string, bool)
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L137"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L137"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#CatLibrary_Cat_2__ctor_System_String_System_Int32__System_String_System_Boolean_" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"><p>It's a complex constructor. The parameter will have some attributes.</p>
@@ -528,7 +528,7 @@ This is a CAT class</p>
 
   <h3 id="CatLibrary_Cat_2__ctor__0_" data-uid="CatLibrary.Cat`2.#ctor(`0)">
   Cat(T)
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L128"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L128"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#CatLibrary_Cat_2__ctor__0_" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"><p>Constructor with one generic parameter.</p>
@@ -563,7 +563,7 @@ This is a CAT class</p>
 
   <h3 id="CatLibrary_Cat_2_isHealthy" data-uid="CatLibrary.Cat`2.isHealthy">
   isHealthy
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L231"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L231"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#CatLibrary_Cat_2_isHealthy" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"><p>Field with attribute.</p>
@@ -600,7 +600,7 @@ This is a CAT class</p>
 
   <h3 id="CatLibrary_Cat_2_Age" data-uid="CatLibrary.Cat`2.Age">
   Age
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L213"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L213"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#CatLibrary_Cat_2_Age" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"><p>Hint cat's age.</p>
@@ -632,7 +632,7 @@ This is a CAT class</p>
 
   <h3 id="CatLibrary_Cat_2_Item_System_String_" data-uid="CatLibrary.Cat`2.Item(System.String)">
   this[string]
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L204"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L204"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#CatLibrary_Cat_2_Item_System_String_" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"><p>This is index property of Cat. You can see that the visibility is different between <code>get</code> and <code>set</code> method.</p>
@@ -671,7 +671,7 @@ This is a CAT class</p>
 
   <h3 id="CatLibrary_Cat_2_Name" data-uid="CatLibrary.Cat`2.Name">
   Name
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L255"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L255"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#CatLibrary_Cat_2_Name" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"><p>EII property.</p>
@@ -706,7 +706,7 @@ This is a CAT class</p>
 
   <h3 id="CatLibrary_Cat_2_CalculateFood_System_DateTime_" data-uid="CatLibrary.Cat`2.CalculateFood(System.DateTime)">
   Override CalculateFood Name
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L145"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L145"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#CatLibrary_Cat_2_CalculateFood_System_DateTime_" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"><p>It's an overridden summary in <code>markdown</code> format</p>
@@ -753,7 +753,7 @@ This is a CAT class</p>
 
   <h3 id="CatLibrary_Cat_2_Equals_System_Object_" data-uid="CatLibrary.Cat`2.Equals(System.Object)">
   Equals(object)
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L165"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L165"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#CatLibrary_Cat_2_Equals_System_Object_" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"><p>Override the method of <code>Object.Equals(object obj).</code></p>
@@ -792,7 +792,7 @@ This is a CAT class</p>
 
   <h3 id="CatLibrary_Cat_2_GetTailLength_System_Int32__System_Object___" data-uid="CatLibrary.Cat`2.GetTailLength(System.Int32*,System.Object[])">
   GetTailLength(int*, params object[])
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L174"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L174"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#CatLibrary_Cat_2_GetTailLength_System_Int32__System_Object___" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"><p>It's an <code>unsafe</code> method.
@@ -835,7 +835,7 @@ As you see, <code class="paramref">catName</code> is a <b>pointer</b>, so we nee
 
   <h3 id="CatLibrary_Cat_2_Jump__0__1_System_Boolean__" data-uid="CatLibrary.Cat`2.Jump(`0,`1,System.Boolean@)">
   Jump(T, K, ref bool)
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L154"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L154"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#CatLibrary_Cat_2_Jump__0__1_System_Boolean__" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"><p>This method have attribute above it.</p>
@@ -883,7 +883,7 @@ As you see, <code class="paramref">catName</code> is a <b>pointer</b>, so we nee
 
   <h3 id="CatLibrary_Cat_2_ownEat" data-uid="CatLibrary.Cat`2.ownEat">
   ownEat
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L223"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L223"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#CatLibrary_Cat_2_ownEat" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"><p>Eat event of this cat</p>
@@ -918,7 +918,7 @@ As you see, <code class="paramref">catName</code> is a <b>pointer</b>, so we nee
 
   <h3 id="CatLibrary_Cat_2_op_Addition_CatLibrary_Cat__0__1__System_Int32_" data-uid="CatLibrary.Cat`2.op_Addition(CatLibrary.Cat{`0,`1},System.Int32)">
   operator +(Cat&lt;T, K&gt;, int)
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L183"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L183"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#CatLibrary_Cat_2_op_Addition_CatLibrary_Cat__0__1__System_Int32_" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"><p>Addition operator of this class.</p>
@@ -960,7 +960,7 @@ As you see, <code class="paramref">catName</code> is a <b>pointer</b>, so we nee
 
   <h3 id="CatLibrary_Cat_2_op_Explicit_CatLibrary_Cat__0__1___CatLibrary_Tom" data-uid="CatLibrary.Cat`2.op_Explicit(CatLibrary.Cat{`0,`1})~CatLibrary.Tom">
   explicit operator Tom(Cat&lt;T, K&gt;)
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L196"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L196"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#CatLibrary_Cat_2_op_Explicit_CatLibrary_Cat__0__1___CatLibrary_Tom" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"><p>Expilicit operator of this class.</p>
@@ -1000,7 +1000,7 @@ As you see, <code class="paramref">catName</code> is a <b>pointer</b>, so we nee
 
   <h3 id="CatLibrary_Cat_2_op_Subtraction_CatLibrary_Cat__0__1__System_Int32_" data-uid="CatLibrary.Cat`2.op_Subtraction(CatLibrary.Cat{`0,`1},System.Int32)">
   operator -(Cat&lt;T, K&gt;, int)
-  <a class="header-action link-secondary" title="View source" href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L188"><i class="bi bi-code-slash"></i></a>
+  <a class="header-action link-secondary" title="View source" href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L188"><i class="bi bi-code-slash"></i></a>
   <a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#CatLibrary_Cat_2_op_Subtraction_CatLibrary_Cat__0__1__System_Int32_" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
 
   <div class="markdown level1 summary"><p>Similar with operaotr +, refer to that topic.</p>
@@ -1039,7 +1039,7 @@ As you see, <code class="paramref">catName</code> is a <b>pointer</b>, so we nee
 </article>
 
         <div class="contribution d-print-none">
-          <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L113" class="edit-link">Edit this page</a>
+          <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/dotnet/solution/CatLibrary/Class1.cs/#L113" class="edit-link">Edit this page</a>
         </div>
 
         

--- a/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/articles-csharp_coding_standards.html.verified.html
+++ b/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/articles-csharp_coding_standards.html.verified.html
@@ -13,7 +13,7 @@
       <meta name="docfx:rel" content="../">
       
       
-      <meta name="docfx:docurl" content="https://github.com/dotnet/docfx/blob/main/samples/seed/articles/csharp_coding_standards.md/#L1">
+      <meta name="docfx:docurl" content="https://github.com/filzrev/docfx/blob/main/samples/seed/articles/csharp_coding_standards.md/#L1">
   <script type="module">
     import options from './../public/main.js'
     import { init } from './../public/docfx.min.js'
@@ -320,7 +320,7 @@ Assert.Equal(list1, list2, StringComparer.OrdinalIgnoreCase);
 </article>
 
         <div class="contribution d-print-none">
-          <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/articles/csharp_coding_standards.md/#L1" class="edit-link">Edit this page</a>
+          <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/articles/csharp_coding_standards.md/#L1" class="edit-link">Edit this page</a>
         </div>
 
         <div class="next-article d-print-none border-top" id="nextArticle"><div class="prev"><span><i class="bi bi-chevron-left"></i> Previous</span> <a rel="prev" href="http://localhost:8089/articles/engineering_guidelines.html">Engineering Guidelines</a></div> <div class="next"><span>Next <i class="bi bi-chevron-right"></i></span> <a rel="next" href="http://localhost:8089/articles/markdown.html">Markdown</a></div></div>

--- a/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/articles-markdown.html-tabs-windows-2Ctypescript-markdown-extensions.verified.html
+++ b/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/articles-markdown.html-tabs-windows-2Ctypescript-markdown-extensions.verified.html
@@ -13,7 +13,7 @@
       <meta name="docfx:rel" content="../">
       
       
-      <meta name="docfx:docurl" content="https://github.com/dotnet/docfx/blob/main/samples/seed/articles/markdown.md/#L1">
+      <meta name="docfx:docurl" content="https://github.com/filzrev/docfx/blob/main/samples/seed/articles/markdown.md/#L1">
   <script type="module">
     import options from './../public/main.js'
     import { init } from './../public/docfx.min.js'
@@ -497,7 +497,7 @@ REST API content, independent of platform...
 </article>
 
         <div class="contribution d-print-none">
-          <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/articles/markdown.md/#L1" class="edit-link">Edit this page</a>
+          <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/articles/markdown.md/#L1" class="edit-link">Edit this page</a>
         </div>
 
         <div class="next-article d-print-none border-top" id="nextArticle"><div class="prev"><span><i class="bi bi-chevron-left"></i> Previous</span> <a rel="prev" href="http://localhost:8089/articles/csharp_coding_standards.html">CSharp Coding Standards</a></div> </div>

--- a/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/index.html.verified.html
+++ b/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/index.html.verified.html
@@ -13,7 +13,7 @@
       <meta name="docfx:rel" content="">
       <meta name="docfx:disablenewtab" content="true">
       
-      <meta name="docfx:docurl" content="https://github.com/dotnet/docfx/blob/main/samples/seed/index.md/#L1">
+      <meta name="docfx:docurl" content="https://github.com/filzrev/docfx/blob/main/samples/seed/index.md/#L1">
   <script type="module">
     import options from './public/main.js'
     import { init } from './public/docfx.min.js'
@@ -167,7 +167,7 @@
 </article>
 
         <div class="contribution d-print-none">
-          <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/index.md/#L1" class="edit-link">Edit this page</a>
+          <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/index.md/#L1" class="edit-link">Edit this page</a>
         </div>
 
         <div class="next-article d-print-none border-top" id="nextArticle"> <div class="next"><span>Next <i class="bi bi-chevron-right"></i></span> <a rel="next" href="http://localhost:8089/articles/docfx_getting_started.html">Articles</a></div></div>

--- a/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/restapi-petstore.html.verified.html
+++ b/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/restapi-petstore.html.verified.html
@@ -13,7 +13,7 @@
       <meta name="docfx:rel" content="../">
       
       
-      <meta name="docfx:docurl" content="https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">
+      <meta name="docfx:docurl" content="https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">
   <script type="module">
     import options from './../public/main.js'
     import { init } from './../public/docfx.min.js'
@@ -123,10 +123,10 @@
 
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_addPet.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FaddPet%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
+    <a href="https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_addPet.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FaddPet%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
+    <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
   </span>
    <h3 id="petstore_swagger_io_v2_Swagger_Petstore_1_0_0_addPet" data-uid="petstore.swagger.io/v2/Swagger Petstore/1.0.0/addPet" class="text-capitalize">addPet<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#petstore_swagger_io_v2_Swagger_Petstore_1_0_0_addPet" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
   <div class="markdown level1 summary"><p>Add a new pet to the store</p>
@@ -184,10 +184,10 @@
 
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_updatePet.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FupdatePet%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
+    <a href="https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_updatePet.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FupdatePet%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
+    <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
   </span>
    <h3 id="petstore_swagger_io_v2_Swagger_Petstore_1_0_0_updatePet" data-uid="petstore.swagger.io/v2/Swagger Petstore/1.0.0/updatePet" class="text-capitalize">updatePet<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#petstore_swagger_io_v2_Swagger_Petstore_1_0_0_updatePet" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
   <div class="markdown level1 summary"><p>Update an existing pet</p>
@@ -254,10 +254,10 @@
 
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_findPetsByStatus.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FfindPetsByStatus%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
+    <a href="https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_findPetsByStatus.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FfindPetsByStatus%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
+    <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
   </span>
    <h3 id="petstore_swagger_io_v2_Swagger_Petstore_1_0_0_findPetsByStatus" data-uid="petstore.swagger.io/v2/Swagger Petstore/1.0.0/findPetsByStatus" class="text-capitalize">findPetsByStatus<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#petstore_swagger_io_v2_Swagger_Petstore_1_0_0_findPetsByStatus" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
   <div class="markdown level1 summary"><p>Finds Pets by status</p>
@@ -319,10 +319,10 @@
 
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_findPetsByTags.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FfindPetsByTags%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
+    <a href="https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_findPetsByTags.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FfindPetsByTags%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
+    <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
   </span>
    <h3 id="petstore_swagger_io_v2_Swagger_Petstore_1_0_0_findPetsByTags" data-uid="petstore.swagger.io/v2/Swagger Petstore/1.0.0/findPetsByTags" class="text-capitalize">findPetsByTags<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#petstore_swagger_io_v2_Swagger_Petstore_1_0_0_findPetsByTags" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
   <div class="markdown level1 summary"><p>Finds Pets by tags</p>
@@ -384,10 +384,10 @@
 
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_deletePet.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FdeletePet%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
+    <a href="https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_deletePet.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FdeletePet%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
+    <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
   </span>
    <h3 id="petstore_swagger_io_v2_Swagger_Petstore_1_0_0_deletePet" data-uid="petstore.swagger.io/v2/Swagger Petstore/1.0.0/deletePet" class="text-capitalize">deletePet<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#petstore_swagger_io_v2_Swagger_Petstore_1_0_0_deletePet" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
   <div class="markdown level1 summary"><p>Deletes a pet</p>
@@ -453,10 +453,10 @@
 
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getPetById.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FgetPetById%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
+    <a href="https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getPetById.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FgetPetById%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
+    <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
   </span>
    <h3 id="petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getPetById" data-uid="petstore.swagger.io/v2/Swagger Petstore/1.0.0/getPetById" class="text-capitalize">getPetById<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getPetById" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
   <div class="markdown level1 summary"><p>Find pet by ID</p>
@@ -525,10 +525,10 @@
 
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_updatePetWithForm.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FupdatePetWithForm%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
+    <a href="https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_updatePetWithForm.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FupdatePetWithForm%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
+    <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
   </span>
    <h3 id="petstore_swagger_io_v2_Swagger_Petstore_1_0_0_updatePetWithForm" data-uid="petstore.swagger.io/v2/Swagger Petstore/1.0.0/updatePetWithForm" class="text-capitalize">updatePetWithForm<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#petstore_swagger_io_v2_Swagger_Petstore_1_0_0_updatePetWithForm" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
   <div class="markdown level1 summary"><p>Updates a pet in the store with form data</p>
@@ -595,10 +595,10 @@
 
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_uploadFile.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FuploadFile%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
+    <a href="https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_uploadFile.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FuploadFile%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
+    <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
   </span>
    <h3 id="petstore_swagger_io_v2_Swagger_Petstore_1_0_0_uploadFile" data-uid="petstore.swagger.io/v2/Swagger Petstore/1.0.0/uploadFile" class="text-capitalize">uploadFile<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#petstore_swagger_io_v2_Swagger_Petstore_1_0_0_uploadFile" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
   <div class="markdown level1 summary"><p>uploads an image</p>
@@ -670,10 +670,10 @@
 
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_addPet.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FaddPet%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
+    <a href="https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_addPet.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FaddPet%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
+    <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
   </span>
    <h3 id="petstore_swagger_io_v2_Swagger_Petstore_1_0_0_addPet" data-uid="petstore.swagger.io/v2/Swagger Petstore/1.0.0/addPet" class="text-capitalize">addPet<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#petstore_swagger_io_v2_Swagger_Petstore_1_0_0_addPet" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
   <div class="markdown level1 summary"><p>Add a new pet to the store</p>
@@ -731,10 +731,10 @@
 
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getInventory.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FgetInventory%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
+    <a href="https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getInventory.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FgetInventory%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
+    <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
   </span>
    <h3 id="petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getInventory" data-uid="petstore.swagger.io/v2/Swagger Petstore/1.0.0/getInventory" class="text-capitalize">getInventory<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getInventory" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
   <div class="markdown level1 summary"><p>Returns pet inventories by status</p>
@@ -769,10 +769,10 @@
 
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_placeOrder.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FplaceOrder%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
+    <a href="https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_placeOrder.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FplaceOrder%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
+    <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
   </span>
    <h3 id="petstore_swagger_io_v2_Swagger_Petstore_1_0_0_placeOrder" data-uid="petstore.swagger.io/v2/Swagger Petstore/1.0.0/placeOrder" class="text-capitalize">placeOrder<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#petstore_swagger_io_v2_Swagger_Petstore_1_0_0_placeOrder" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
   <div class="markdown level1 summary"><p>Place an order for a pet</p>
@@ -832,10 +832,10 @@
 
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_deleteOrder.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FdeleteOrder%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
+    <a href="https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_deleteOrder.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FdeleteOrder%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
+    <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
   </span>
    <h3 id="petstore_swagger_io_v2_Swagger_Petstore_1_0_0_deleteOrder" data-uid="petstore.swagger.io/v2/Swagger Petstore/1.0.0/deleteOrder" class="text-capitalize">deleteOrder<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#petstore_swagger_io_v2_Swagger_Petstore_1_0_0_deleteOrder" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
   <div class="markdown level1 summary"><p>Delete purchase order by ID</p>
@@ -897,10 +897,10 @@
 
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getOrderById.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FgetOrderById%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
+    <a href="https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getOrderById.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FgetOrderById%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
+    <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
   </span>
    <h3 id="petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getOrderById" data-uid="petstore.swagger.io/v2/Swagger Petstore/1.0.0/getOrderById" class="text-capitalize">getOrderById<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getOrderById" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
   <div class="markdown level1 summary"><p>Find purchase order by ID</p>
@@ -972,10 +972,10 @@
 
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_createUser.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FcreateUser%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
+    <a href="https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_createUser.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FcreateUser%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
+    <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
   </span>
    <h3 id="petstore_swagger_io_v2_Swagger_Petstore_1_0_0_createUser" data-uid="petstore.swagger.io/v2/Swagger Petstore/1.0.0/createUser" class="text-capitalize">createUser<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#petstore_swagger_io_v2_Swagger_Petstore_1_0_0_createUser" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
   <div class="markdown level1 summary"><p>Create user</p>
@@ -1030,10 +1030,10 @@
 
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_createUsersWithArrayInput.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FcreateUsersWithArrayInput%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
+    <a href="https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_createUsersWithArrayInput.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FcreateUsersWithArrayInput%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
+    <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
   </span>
    <h3 id="petstore_swagger_io_v2_Swagger_Petstore_1_0_0_createUsersWithArrayInput" data-uid="petstore.swagger.io/v2/Swagger Petstore/1.0.0/createUsersWithArrayInput" class="text-capitalize">createUsersWithArrayInput<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#petstore_swagger_io_v2_Swagger_Petstore_1_0_0_createUsersWithArrayInput" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
   <div class="markdown level1 summary"><p>Creates list of users with given input array</p>
@@ -1086,10 +1086,10 @@
 
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_createUsersWithListInput.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FcreateUsersWithListInput%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
+    <a href="https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_createUsersWithListInput.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FcreateUsersWithListInput%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
+    <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
   </span>
    <h3 id="petstore_swagger_io_v2_Swagger_Petstore_1_0_0_createUsersWithListInput" data-uid="petstore.swagger.io/v2/Swagger Petstore/1.0.0/createUsersWithListInput" class="text-capitalize">createUsersWithListInput<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#petstore_swagger_io_v2_Swagger_Petstore_1_0_0_createUsersWithListInput" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
   <div class="markdown level1 summary"><p>Creates list of users with given input array</p>
@@ -1142,10 +1142,10 @@
 
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_loginUser.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FloginUser%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
+    <a href="https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_loginUser.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FloginUser%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
+    <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
   </span>
    <h3 id="petstore_swagger_io_v2_Swagger_Petstore_1_0_0_loginUser" data-uid="petstore.swagger.io/v2/Swagger Petstore/1.0.0/loginUser" class="text-capitalize">loginUser<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#petstore_swagger_io_v2_Swagger_Petstore_1_0_0_loginUser" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
   <div class="markdown level1 summary"><p>Logs user into the system</p>
@@ -1212,10 +1212,10 @@
 
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_logoutUser.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FlogoutUser%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
+    <a href="https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_logoutUser.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FlogoutUser%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
+    <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
   </span>
    <h3 id="petstore_swagger_io_v2_Swagger_Petstore_1_0_0_logoutUser" data-uid="petstore.swagger.io/v2/Swagger Petstore/1.0.0/logoutUser" class="text-capitalize">logoutUser<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#petstore_swagger_io_v2_Swagger_Petstore_1_0_0_logoutUser" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
   <div class="markdown level1 summary"><p>Logs out current logged in user session</p>
@@ -1248,10 +1248,10 @@
 
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_deleteUser.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FdeleteUser%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
+    <a href="https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_deleteUser.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FdeleteUser%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
+    <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
   </span>
    <h3 id="petstore_swagger_io_v2_Swagger_Petstore_1_0_0_deleteUser" data-uid="petstore.swagger.io/v2/Swagger Petstore/1.0.0/deleteUser" class="text-capitalize">deleteUser<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#petstore_swagger_io_v2_Swagger_Petstore_1_0_0_deleteUser" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
   <div class="markdown level1 summary"><p>Delete user</p>
@@ -1313,10 +1313,10 @@
 
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getUserByName.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FgetUserByName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
+    <a href="https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getUserByName.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FgetUserByName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
+    <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
   </span>
    <h3 id="petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getUserByName" data-uid="petstore.swagger.io/v2/Swagger Petstore/1.0.0/getUserByName" class="text-capitalize">getUserByName<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#petstore_swagger_io_v2_Swagger_Petstore_1_0_0_getUserByName" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
   <div class="markdown level1 summary"><p>Get user by user name</p>
@@ -1384,10 +1384,10 @@
 
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/dotnet/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_updateUser.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FupdateUser%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
+    <a href="https://github.com/filzrev/docfx/new/main/apiSpec/new?filename=petstore_swagger_io_v2_Swagger_Petstore_1_0_0_updateUser.md&amp;value=---%0Auid%3A%20petstore.swagger.io%2Fv2%2FSwagger%20Petstore%2F1.0.0%2FupdateUser%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" target="_blank" rel="noopener noreferrer nofollow" class="external">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
+    <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" target="_blank" rel="noopener noreferrer nofollow" class="external">View Source</a>
   </span>
    <h3 id="petstore_swagger_io_v2_Swagger_Petstore_1_0_0_updateUser" data-uid="petstore.swagger.io/v2/Swagger Petstore/1.0.0/updateUser" class="text-capitalize">updateUser<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#petstore_swagger_io_v2_Swagger_Petstore_1_0_0_updateUser" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h3>
   <div class="markdown level1 summary"><p>Updated user</p>
@@ -1463,7 +1463,7 @@
 </article>
 
         <div class="contribution d-print-none">
-          <a href="https://github.com/dotnet/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" class="edit-link">Edit this page</a>
+          <a href="https://github.com/filzrev/docfx/blob/main/samples/seed/restapi/petstore.swagger.json/#L1" class="edit-link">Edit this page</a>
         </div>
 
         


### PR DESCRIPTION
This PR is same as #8906

---

This PR contains following changes.

- Change CS0612/CS0618‘ (Type or member is obsolete) warning suppression from solution-wide to file level.
- Replace deprecated APIs (Newtonsoft.Json and YamlDotNet)
- Add doc comments to suppress warnings at PR File changed tab.
- Displayed at "Unchanged files with check annotations"  
  https://github.com/dotnet/docfx/pull/8904/files