### PR TITLE
Add open browser options to docfx-serve command

### DIFF
--- a/src/Microsoft.DocAsCode.App/RunServe.cs
+++ b/src/Microsoft.DocAsCode.App/RunServe.cs
@@ -1,17 +1,21 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.DocAsCode.Common;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.DocAsCode.Plugins;
 
 namespace Microsoft.DocAsCode;
 
 internal static class RunServe
 {
-    public static void Exec(string folder, string host, int? port)
+    public static void Exec(string folder, string host, int? port, bool openBrowser, string openBrowserRelativePath)
     {
         if (string.IsNullOrEmpty(folder))
             folder = Directory.GetCurrentDirectory();
@@ -43,11 +47,104 @@ internal static class RunServe
             Console.WriteLine($"Serving \"{folder}\" on {url}. Press Ctrl+C to shut down.");
             using var app = builder.Build();
             app.UseFileServer(fileServerOptions);
-            app.Run();
+
+            if (openBrowser)
+            {
+                string relativePath = openBrowserRelativePath;
+                var launchUrl = string.IsNullOrEmpty(relativePath)
+                    ? url
+                    : Path.Combine(url, ResolveOutputHtmlRelativePath(folder, relativePath));
+
+                // Start web server.
+                app.Start();
+
+                // Launch browser process.
+
+                Console.WriteLine($"Launching browser with url: {url}.");
+                using var process = LaunchBrowser(launchUrl);
+
+                // Wait until server exited.
+                app.WaitForShutdown();
+
+                // process object is disposed. (Note:Launched process remain running.after dispose)
+            }
+            else
+            {
+                app.Run();
+            }
         }
         catch (System.Reflection.TargetInvocationException)
         {
             Logger.LogError($"Error serving \"{folder}\" on {url}, check if the port is already being in use.");
         }
+    }
+
+    /// <summary>
+    /// Resolve output HTML file path by `manifest.json` file.
+    /// </summary>
+    private static string ResolveOutputHtmlRelativePath(string folder, string relativePath)
+    {
+        var manifestPath = Path.GetFullPath(Path.Combine(folder, "manifest.json"));
+        if (!File.Exists(manifestPath))
+            return string.Empty;
+
+        try
+        {
+            Manifest manifest = JsonUtility.Deserialize<Manifest>(manifestPath);
+
+            // Try to find output html file (html->html)
+            OutputFileInfo outputFileInfo = manifest.FindOutputFileInfo(relativePath);
+            if (outputFileInfo != null)
+                return outputFileInfo.RelativePath;
+
+            // Try to resolve output HTML file. (md->html)
+            relativePath = relativePath.Replace('\\', '/'); // Normalize path.
+            var manifestFile = manifest.Files
+                                       .Where(x => FilePathComparer.OSPlatformSensitiveRelativePathComparer.Equals(x.SourceRelativePath, relativePath))
+                                       .FirstOrDefault(x => x.OutputFiles.TryGetValue(".html", out outputFileInfo));
+
+            if (outputFileInfo != null)
+                return outputFileInfo.RelativePath;
+        }
+        catch (Exception)
+        {
+            throw; // Unexpected exception occurred.(e.g. Failed to deserialize Manifest)
+        }
+
+        // Failed to resolve output HTML file.
+        Logger.LogError($"Failed to resolve output HTML file path. sourceRelativePath: {relativePath}");
+        return string.Empty;
+    }
+
+    private static Process LaunchBrowser(string url)
+    {
+        try
+        {
+            // Windows
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return Process.Start("cmd", new[] { "/C", "start", url });
+            }
+
+            // Linux
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return Process.Start("xdg-open", url);
+            }
+
+            // OSX
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return Process.Start("open", url);
+            }
+
+            Logger.LogError($"Could not launch the browser process. Unknown OS platform: {RuntimeInformation.OSDescription}");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError($"Could not launch the browser process, with error - {ex.Message}");
+        }
+
+        return null;
     }
 }

--- a/src/docfx/Models/BuildCommand.cs
+++ b/src/docfx/Models/BuildCommand.cs
@@ -19,7 +19,7 @@ internal class BuildCommand : Command<BuildCommandOptions>
             var serveDirectory = RunBuild.Exec(config.Item, new(), baseDirectory, settings.OutputFolder);
 
             if (settings.Serve)
-                RunServe.Exec(serveDirectory, settings.Host, settings.Port, settings.OpenBrowser, settings.OpenBrowserRelativePath);
+                RunServe.Exec(serveDirectory, settings.Host, settings.Port, settings.OpenBrowser, settings.OpenFile);
         });
     }
 

--- a/src/docfx/Models/BuildCommand.cs
+++ b/src/docfx/Models/BuildCommand.cs
@@ -19,7 +19,7 @@ internal class BuildCommand : Command<BuildCommandOptions>
             var serveDirectory = RunBuild.Exec(config.Item, new(), baseDirectory, settings.OutputFolder);
 
             if (settings.Serve)
-                RunServe.Exec(serveDirectory, settings.Host, settings.Port);
+                RunServe.Exec(serveDirectory, settings.Host, settings.Port, settings.OpenBrowser, settings.OpenBrowserRelativePath);
         });
     }
 

--- a/src/docfx/Models/BuildCommandOptions.cs
+++ b/src/docfx/Models/BuildCommandOptions.cs
@@ -48,6 +48,14 @@ internal class BuildCommandOptions : LogOptions
     [CommandOption("-p|--port")]
     public int? Port { get; set; }
 
+    [Description("Open a web browser when the hosted website starts.")]
+    [CommandOption("--open-browser")]
+    public bool OpenBrowser { get; set; }
+
+    [Description("Specify the relative path to open.")]
+    [CommandOption("--open-browser-relative-path")]
+    public string OpenBrowserRelativePath { get; set; }
+
     [Description("Run in debug mode. With debug mode, raw model and view model will be exported automatically when it encounters error when applying templates. If not specified, it is false.")]
     [CommandOption("--debug")]
     public bool EnableDebugMode { get; set; }

--- a/src/docfx/Models/BuildCommandOptions.cs
+++ b/src/docfx/Models/BuildCommandOptions.cs
@@ -52,9 +52,9 @@ internal class BuildCommandOptions : LogOptions
     [CommandOption("--open-browser")]
     public bool OpenBrowser { get; set; }
 
-    [Description("Specify the relative path to open.")]
-    [CommandOption("--open-browser-relative-path")]
-    public string OpenBrowserRelativePath { get; set; }
+    [Description("Open a file in a web browser When the hosted website starts,")]
+    [CommandOption("--open-file <RELATIVE_PATH>")]
+    public string OpenFile { get; set; }
 
     [Description("Run in debug mode. With debug mode, raw model and view model will be exported automatically when it encounters error when applying templates. If not specified, it is false.")]
     [CommandOption("--debug")]

--- a/src/docfx/Models/DefaultCommand.cs
+++ b/src/docfx/Models/DefaultCommand.cs
@@ -52,7 +52,7 @@ class DefaultCommand : Command<DefaultCommand.Options>
 
             if (options.Serve && serveDirectory is not null)
             {
-                RunServe.Exec(serveDirectory, options.Host, options.Port, options.OpenBrowser, options.OpenBrowserRelativePath);
+                RunServe.Exec(serveDirectory, options.Host, options.Port, options.OpenBrowser, options.OpenFile);
             }
         });
     }

--- a/src/docfx/Models/DefaultCommand.cs
+++ b/src/docfx/Models/DefaultCommand.cs
@@ -52,7 +52,7 @@ class DefaultCommand : Command<DefaultCommand.Options>
 
             if (options.Serve && serveDirectory is not null)
             {
-                RunServe.Exec(serveDirectory, options.Host, options.Port);
+                RunServe.Exec(serveDirectory, options.Host, options.Port, options.OpenBrowser, options.OpenBrowserRelativePath);
             }
         });
     }

--- a/src/docfx/Models/ServeCommand.cs
+++ b/src/docfx/Models/ServeCommand.cs
@@ -28,13 +28,13 @@ internal class ServeCommand : Command<ServeCommand.Settings>
         [CommandOption("--open-browser")]
         public bool OpenBrowser { get; set; }
 
-        [Description("Specify the relative path to open.")]
-        [CommandOption("--open-browser-relative-path")]
-        public string OpenBrowserRelativePath { get; set; }
+        [Description("Open a file in a web browser When the hosted website starts,")]
+        [CommandOption("--open-file <RELATIVE_PATH>")]
+        public string OpenFile { get; set; }
     }
 
     public override int Execute([NotNull] CommandContext context, [NotNull] Settings options)
     {
-        return CommandHelper.Run(() => RunServe.Exec(options.Folder, options.Host, options.Port, options.OpenBrowser, options.OpenBrowserRelativePath));
+        return CommandHelper.Run(() => RunServe.Exec(options.Folder, options.Host, options.Port, options.OpenBrowser, options.OpenFile));
     }
 }

--- a/src/docfx/Models/ServeCommand.cs
+++ b/src/docfx/Models/ServeCommand.cs
@@ -23,10 +23,18 @@ internal class ServeCommand : Command<ServeCommand.Settings>
         [Description("Specify the port of the hosted website")]
         [CommandOption("-p|--port")]
         public int? Port { get; set; }
+
+        [Description("Open a web browser when the hosted website starts.")]
+        [CommandOption("--open-browser")]
+        public bool OpenBrowser { get; set; }
+
+        [Description("Specify the relative path to open.")]
+        [CommandOption("--open-browser-relative-path")]
+        public string OpenBrowserRelativePath { get; set; }
     }
 
     public override int Execute([NotNull] CommandContext context, [NotNull] Settings options)
     {
-        return CommandHelper.Run(() => RunServe.Exec(options.Folder, options.Host, options.Port));
+        return CommandHelper.Run(() => RunServe.Exec(options.Folder, options.Host, options.Port, options.OpenBrowser, options.OpenBrowserRelativePath));
     }
 }


### PR DESCRIPTION
This PR implement feature described #8927.

**What's is added to docfx CLI command**

Following options are added for  `docfx build` and `docfx serve` commands.

```
--open-browser                Open a web browser when the hosted website starts
--open-browser-relative-path  Specify the relative path to open
```

#### Usage
To launch browser.  pass `--open-browser` switch option to command.
It launch browser with root site URL (e.g. http:localhost:8080).

When `--open-browser-relative-path` optional parameter is passed.  
It try to resolve **output HTML file** by using `manifest.json` file content.
If failed to resolve HTML path. then error log is recorded. and fallback to site root URL.

##### `docfx build --serve`

```pwsh
docfx build --serve --open-browser
docfx build --serve --open-browser --open-browser-relative-path docs/config.html
docfx build --serve --open-browser --open-browser-relative-path docs/config.md 
```

##### Launch with specific page.

```pwsh
docfx serve _site --open-browser
docfx serve _site --open-browser --open-browser-relative-path docs/config .html
docfx serve _site --open-browser --open-browser-relative-path docs/config .md
```

#### Unit Tests
This PR don't contains unit tests.
Because it's difficult to write unit tests that relating OS commands and launch browser.

Tests are executed manually that cover all execution paths.
Excepting `macOS` environment browser launch test.

This PR use same OS command(`open`) that is used by [`dotnet-serve` to open browser](https://github.com/natemcmaster/dotnet-serve/blob/main/src/dotnet-serve/SimpleServer.cs#L175-L203).
I thought, there is no problems on `macOS` environment.

#### Documentation

This PR don't contains documentation updates.
Currently there are few references about `docfx serve` and `docfx build --serve` command in the documentation.

It might be better to update following related docs later.
- https://dotnet.github.io/docfx/#create-a-new-website
- https://dotnet.github.io/docfx/reference/docfx-cli-reference.html

#### Additional Design Notes

**Composing Commands**
This PR add options  as simple options.
`Spectre.Console.Cli` supports [Composing Commands](https://spectreconsole.net/cli/composing).
It might be better to change `--serve` related options as `Composing Commands`.

**Redundant argument names**
`--open-browser-relative-path` is a bit redundant option name. 
`--open-browser:[url]` style option is preferred that is implemented by the `dotnet serve` command.

But It seems`Spectre.Console.Cli` can't handle this option styles.
