### PR TITLE
Add default launchSettings.json

### DIFF
--- a/src/docfx/Properties/launchSettings.json
+++ b/src/docfx/Properties/launchSettings.json
@@ -1,0 +1,38 @@
+{
+  // Uncomment next line to enable intellisense.
+  // "$schema": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/launchsettings.json",
+  "profiles": {
+    // Run `docfx build` command.
+    "docfx build": {
+      "commandName": "Project",
+      "commandLineArgs": "build ../../docs/docfx.json",
+      "workingDirectory": ".",
+      "environmentVariables": {
+      }
+    },
+    // Run `docfx metadata` command.
+    "docfx metadata": {
+      "commandName": "Project",
+      "commandLineArgs": "metadata ../../docs/docfx.json",
+      "workingDirectory": ".",
+      "environmentVariables": {
+      }
+    },
+    // Run `docfx serve` command and launch browser.
+    "docfx serve": {
+      "commandName": "Project",
+      "commandLineArgs": "serve ../../docs/_site --open-browser",
+      "workingDirectory": ".",
+      "environmentVariables": {
+      }
+    },
+    // Run `docfx` command.
+    "docfx": {
+      "commandName": "Project",
+      "commandLineArgs": "../../docs/docfx.json",
+      "workingDirectory": ".",
+      "environmentVariables": {
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Purpose of this PR**
This PR add default `launchSettings.json` to `docfx` project.

These change can make the following work easier.
- Debugging `docfx.exe` project with default docs.
- Debug `docfx.exe` project with custom target.  (It need to modify `docfx.json` path in config)

**Defined Profiles**
Following profiles are defined.

| Profile Name     | Description         |
|-------------------|-------------------|
| docfx build        | (Default)             |
| docfx metadata |                            |
| docfx serve        | With `--open-browser` option |
| docfx                 |                            |

**Usage**
Launch profile's can be selected by Visual Studio navigation menu.
![image](https://github.com/dotnet/docfx/assets/103790468/b0691527-2e8d-4977-8533-f5fcb984550a)

When `docfx build` profile selected. `Ctrl+F5` starts `docfx build` command.
And `docfx serve` profile selected. `Ctrl+F5` starts `docfx serve --open-browser` command.

**Notes**
`launchSettings.json` is excluded by project's `.gitignore`. and considered as per-user settings. 
When this PR is merged. It may cause file conflicts if user already using custom `launchSettings.json`.
In that case. user needs to ignore updated content explicitly.

I thought this operation burden is acceptable.   
Because project's default `launchSettings.json` is rarely changed from now on.
.