### PR TITLE
Remove obsolete warning suppression. and fix deprecated APIs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,16 +12,6 @@
   <PropertyGroup>
     <!--
       Suppress warnings similar to the following:
-          warning CS0612: 'StringHelper.LegacyEscapeMarkdown(string)' is obsolete
-     -->
-    <NoWarn>$(NoWarn);CS0612</NoWarn>
-    <!--
-      Suppress warnings similar to the following:
-          warning CS0618: 'MarkdownLHeadingBlockRule.LHeading' is obsolete: 'Please use LHeadingMatcher.'
-     -->
-    <NoWarn>$(NoWarn);CS0618</NoWarn>
-    <!--
-      Suppress warnings similar to the following:
           warning NU1507: There are 2 package sources defined in your configuration.
      -->
     <NoWarn>$(NoWarn);NU1507</NoWarn>

--- a/src/Microsoft.DocAsCode.Build.Engine/ManifestUtility.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/ManifestUtility.cs
@@ -8,6 +8,9 @@ using Microsoft.DocAsCode.Plugins;
 
 namespace Microsoft.DocAsCode.Common;
 
+#pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+
 public static class ManifestUtility
 {
     public static void RemoveDuplicateOutputFiles(ManifestItemCollection manifestItems)

--- a/src/Microsoft.DocAsCode.Build.Engine/SingleDocumentBuilder.cs
+++ b/src/Microsoft.DocAsCode.Build.Engine/SingleDocumentBuilder.cs
@@ -7,6 +7,9 @@ using Microsoft.DocAsCode.Plugins;
 
 namespace Microsoft.DocAsCode.Build.Engine;
 
+#pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+
 public class SingleDocumentBuilder : IDisposable
 {
     private const string PhaseName = "Build Document";

--- a/src/Microsoft.DocAsCode.Common/JsonUtility.cs
+++ b/src/Microsoft.DocAsCode.Common/JsonUtility.cs
@@ -4,6 +4,7 @@
 using Microsoft.DocAsCode.Plugins;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.DocAsCode.Common;
 
@@ -16,7 +17,7 @@ public static class JsonUtility
             ReferenceLoopHandling = ReferenceLoopHandling.Serialize,
             Converters =
             {
-                new StringEnumConverter { CamelCaseText = true },
+                new StringEnumConverter { NamingStrategy = new CamelCaseNamingStrategy() },
             }
         });
 

--- a/src/Microsoft.DocAsCode.YamlSerialization/NodeDeserializers/EmitGenericCollectionNodeDeserializer.cs
+++ b/src/Microsoft.DocAsCode.YamlSerialization/NodeDeserializers/EmitGenericCollectionNodeDeserializer.cs
@@ -78,8 +78,8 @@ public class EmitGenericCollectionNodeDeserializer : INodeDeserializer
     {
         var list = result as IList<TItem>;
 
-        reader.Expect<SequenceStart>();
-        while (!reader.Accept<SequenceEnd>())
+        reader.Consume<SequenceStart>();
+        while (!reader.Accept<SequenceEnd>(out _))
         {
             var current = reader.Current;
 
@@ -103,6 +103,6 @@ public class EmitGenericCollectionNodeDeserializer : INodeDeserializer
                 );
             }
         }
-        reader.Expect<SequenceEnd>();
+        reader.Consume<SequenceEnd>();
     }
 }

--- a/src/Microsoft.DocAsCode.YamlSerialization/NodeDeserializers/EmitGenericDictionaryNodeDeserializer.cs
+++ b/src/Microsoft.DocAsCode.YamlSerialization/NodeDeserializers/EmitGenericDictionaryNodeDeserializer.cs
@@ -52,7 +52,7 @@ public class EmitGenericDictionaryNodeDeserializer : INodeDeserializer
             return false;
         }
 
-        reader.Expect<MappingStart>();
+        reader.Consume<MappingStart>();
 
         value = _objectFactory.Create(expectedType);
         var cacheKey = Tuple.Create(gp[0], gp[1]);
@@ -72,7 +72,7 @@ public class EmitGenericDictionaryNodeDeserializer : INodeDeserializer
         }
         action(reader, expectedType, nestedObjectDeserializer, value);
 
-        reader.Expect<MappingEnd>();
+        reader.Consume<MappingEnd>();
 
         return true;
     }
@@ -80,7 +80,7 @@ public class EmitGenericDictionaryNodeDeserializer : INodeDeserializer
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static void DeserializeHelper<TKey, TValue>(IParser reader, Type expectedType, Func<IParser, Type, object> nestedObjectDeserializer, IDictionary<TKey, TValue> result)
     {
-        while (!reader.Accept<MappingEnd>())
+        while (!reader.Accept<MappingEnd>(out _))
         {
             var key = nestedObjectDeserializer(reader, typeof(TKey));
             var keyPromise = key as IValuePromise;

--- a/src/Microsoft.DocAsCode.YamlSerialization/NodeDeserializers/ExtensibleObjectNodeDeserializer.cs
+++ b/src/Microsoft.DocAsCode.YamlSerialization/NodeDeserializers/ExtensibleObjectNodeDeserializer.cs
@@ -23,17 +23,16 @@ public sealed class ExtensibleObjectNodeDeserializer : INodeDeserializer
 
     bool INodeDeserializer.Deserialize(IParser reader, Type expectedType, Func<IParser, Type, object> nestedObjectDeserializer, out object value)
     {
-        var mapping = reader.Allow<MappingStart>();
-        if (mapping == null)
+        if (!reader.TryConsume<MappingStart>(out _))
         {
             value = null;
             return false;
         }
 
         value = _objectFactory.Create(expectedType);
-        while (!reader.Accept<MappingEnd>())
+        while (!reader.Accept<MappingEnd>(out _))
         {
-            var propertyName = reader.Expect<Scalar>();
+            var propertyName = reader.Consume<Scalar>();
             var property = _typeDescriptor.GetProperty(expectedType, value, propertyName.Value, _ignoreUnmatched);
             if (property == null)
             {
@@ -58,7 +57,7 @@ public sealed class ExtensibleObjectNodeDeserializer : INodeDeserializer
             }
         }
 
-        reader.Expect<MappingEnd>();
+        reader.Consume<MappingEnd>();
         return true;
     }
 }

--- a/src/Microsoft.DocAsCode.YamlSerialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
+++ b/src/Microsoft.DocAsCode.YamlSerialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
@@ -177,7 +177,7 @@ public class FullObjectGraphTraversalStrategy : IObjectGraphTraversalStrategy
             action = GetTraverseGenericDictionaryHelper(entryTypes[0], entryTypes[1], typeof(TContext));
             _traverseGenericDictionaryCache[key] = action;
         }
-        action(this, dictionary.Value, v, currentDepth, _namingConvention ?? new NullNamingConvention(), c);
+        action(this, dictionary.Value, v, currentDepth, _namingConvention ?? NullNamingConvention.Instance, c);
 
         v.VisitMappingEnd(dictionary, c);
     }

--- a/src/Microsoft.DocAsCode.YamlSerialization/YamlDeserializer.cs
+++ b/src/Microsoft.DocAsCode.YamlSerialization/YamlDeserializer.cs
@@ -65,7 +65,7 @@ public sealed class YamlDeserializer
         bool ignoreNotFoundAnchor = true)
     {
         objectFactory = objectFactory ?? new DefaultEmitObjectFactory();
-        namingConvention = namingConvention ?? new NullNamingConvention();
+        namingConvention = namingConvention ?? NullNamingConvention.Instance;
 
         _typeDescriptor.TypeDescriptor =
             new ExtensibleYamlAttributesTypeInspector(
@@ -170,12 +170,12 @@ public sealed class YamlDeserializer
             throw new ArgumentNullException("type");
         }
 
-        var hasStreamStart = parser.Allow<StreamStart>() != null;
+        var hasStreamStart = parser.TryConsume<StreamStart>(out _);
 
-        var hasDocumentStart = parser.Allow<DocumentStart>() != null;
+        var hasDocumentStart = parser.TryConsume<DocumentStart>(out _);
         deserializer = deserializer ?? _valueDeserializer;
         object result = null;
-        if (!parser.Accept<DocumentEnd>() && !parser.Accept<StreamEnd>())
+        if (!parser.Accept<DocumentEnd>(out _) && !parser.Accept<StreamEnd>(out _))
         {
             using var state = new SerializerState();
             result = deserializer.DeserializeValue(parser, type, state, deserializer);
@@ -184,12 +184,12 @@ public sealed class YamlDeserializer
 
         if (hasDocumentStart)
         {
-            parser.Expect<DocumentEnd>();
+            parser.Consume<DocumentEnd>();
         }
 
         if (hasStreamStart)
         {
-            parser.Expect<StreamEnd>();
+            parser.Consume<StreamEnd>();
         }
 
         return result;
@@ -267,8 +267,7 @@ public sealed class YamlDeserializer
         public object DeserializeValue(IParser reader, Type expectedType, SerializerState state, IValueDeserializer nestedObjectDeserializer)
         {
             object value;
-            var alias = reader.Allow<AnchorAlias>();
-            if (alias != null)
+            if (reader.TryConsume<AnchorAlias>(out var alias))
             {
                 var aliasState = state.Get<AliasState>();
                 if (!aliasState.TryGetValue(alias.Value, out ValuePromise valuePromise))
@@ -282,8 +281,7 @@ public sealed class YamlDeserializer
 
             AnchorName? anchor = null;
 
-            var nodeEvent = reader.Peek<NodeEvent>();
-            if (nodeEvent != null && !nodeEvent.Anchor.IsEmpty)
+            if (reader.Accept<NodeEvent>(out var nodeEvent) && !nodeEvent.Anchor.IsEmpty)
             {
                 anchor = nodeEvent.Anchor;
             }

--- a/src/Microsoft.DocAsCode.YamlSerialization/YamlSerializer.cs
+++ b/src/Microsoft.DocAsCode.YamlSerialization/YamlSerializer.cs
@@ -27,7 +27,7 @@ public class YamlSerializer
     public YamlSerializer(SerializationOptions options = SerializationOptions.None, INamingConvention namingConvention = null)
     {
         _options = options;
-        _namingConvention = namingConvention ?? new NullNamingConvention();
+        _namingConvention = namingConvention ?? NullNamingConvention.Instance;
 
         Converters = new List<IYamlTypeConverter>();
         foreach (IYamlTypeConverter yamlTypeConverter in YamlTypeConverters.BuiltInConverters)

--- a/test/Microsoft.DocAsCode.Common.Tests/GitUtilityTest.cs
+++ b/test/Microsoft.DocAsCode.Common.Tests/GitUtilityTest.cs
@@ -42,6 +42,7 @@ public class GitUtilityTest : IDisposable
         Assert.Equal(10_000, GitUtility.GetGitTimeout());
     }
 
+    [Obsolete]
     [Fact]
     public void TestParseGitRepoInfo()
     {
@@ -68,6 +69,7 @@ public class GitUtilityTest : IDisposable
         Assert.Equal(RepoType.Vso, repoInfo.RepoType);
     }
 
+    [Obsolete]
     [Fact]
     public void TestCombineGitUrl()
     {

--- a/test/Microsoft.DocAsCode.Plugins.Tests/JsonConverterTest.cs
+++ b/test/Microsoft.DocAsCode.Plugins.Tests/JsonConverterTest.cs
@@ -3,6 +3,7 @@
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
 using Xunit;
 
 namespace Microsoft.DocAsCode.Plugins.Tests;
@@ -33,7 +34,7 @@ public class JsonConverterTest
         {
             Converters =
             {
-                new StringEnumConverter { CamelCaseText = true },
+                new StringEnumConverter { NamingStrategy = new CamelCaseNamingStrategy() },
             }
         };
 


### PR DESCRIPTION
This PR contains following changes.
- Remove CS0612/CS0618 (Type or member is obsolete) solution-wide warning suppression.
- Replace deprecated APIs (`Newtonsoft.Json` and `YamlDotNet`) to supported API that is suggested by intellisense.  
- Set file-level warning suppression that need to use obsolete property for compatibility purpose.
- Set [Obsolete] attribute to test code that tests obsolete code.
