### PR TITLE
Fix typo of open-file command option description

### DIFF
--- a/src/docfx/Models/BuildCommandOptions.cs
+++ b/src/docfx/Models/BuildCommandOptions.cs
@@ -52,7 +52,7 @@ internal class BuildCommandOptions : LogOptions
     [CommandOption("--open-browser")]
     public bool OpenBrowser { get; set; }
 
-    [Description("Open a file in a web browser When the hosted website starts,")]
+    [Description("Open a file in a web browser when the hosted website starts.")]
     [CommandOption("--open-file <RELATIVE_PATH>")]
     public string OpenFile { get; set; }
 

--- a/src/docfx/Models/ServeCommand.cs
+++ b/src/docfx/Models/ServeCommand.cs
@@ -28,7 +28,7 @@ internal class ServeCommand : Command<ServeCommand.Settings>
         [CommandOption("--open-browser")]
         public bool OpenBrowser { get; set; }
 
-        [Description("Open a file in a web browser When the hosted website starts,")]
+        [Description("Open a file in a web browser when the hosted website starts.")]
         [CommandOption("--open-file <RELATIVE_PATH>")]
         public string OpenFile { get; set; }
     }


### PR DESCRIPTION
This PR fix typo that is pointed out by following review comment.
- https://github.com/dotnet/docfx/pull/8934#discussion_r1252525653
- https://github.com/dotnet/docfx/pull/8934#discussion_r1252526159