### PR TITLE
Fix serialization related property name problems

### DIFF
--- a/src/Microsoft.DocAsCode.DataContracts.Common/TocItemViewModel.cs
+++ b/src/Microsoft.DocAsCode.DataContracts.Common/TocItemViewModel.cs
@@ -88,8 +88,8 @@ public class TocItemViewModel
     [JsonProperty("homepage")]
     public string Homepage { get; set; }
 
-    [YamlMember(Alias = "originallHomepage")]
-    [JsonProperty("originallHomepage")]
+    [YamlMember(Alias = "originalHomepage")]
+    [JsonProperty("originalHomepage")]
     public string OriginalHomepage { get; set; }
 
     [YamlMember(Alias = "homepageUid")]

--- a/src/Microsoft.DocAsCode.Plugins/MarkdownServiceParameters.cs
+++ b/src/Microsoft.DocAsCode.Plugins/MarkdownServiceParameters.cs
@@ -11,7 +11,7 @@ public class MarkdownServiceProperties
     /// <summary>
     /// Enables line numbers.
     /// </summary>
-    [JsonProperty("EnableSourceInfo")]
+    [JsonProperty("enableSourceInfo")]
     public bool EnableSourceInfo { get; set; } = true;
 
     /// <summary>


### PR DESCRIPTION
This PR contains following changes.

**1.`OriginalHomepage` changes(https://github.com/dotnet/docfx/commit/88104f649f7b17a2f27e52411dd0784423341fe0)**

JSON/YAML Alias names use wrong spelling names. (`OriginallHomepage`)
There is compatibility problems. If these name are changed. 

But this property is added recently (about 4 month ago) and option is `undocumented`. (https://github.com/dotnet/docfx/issues/7736#issuecomment-984613407)

So there is almost no impact by changing these name settings. 

**2. `EnableSourceInfo` changes(https://github.com/dotnet/docfx/commit/88104f649f7b17a2f27e52411dd0784423341fe0)**

Change JSON property name to `enableSourceInfo`.
It seems there is no compatibility problems by this changes. 
