### PR TITLE
Add API document generation target projects.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,0 @@
-Documentation project uses *docfx.console* nuget package to generate documentation for *docfx* project, along with conceputal files, with `docfx.json` to provide configuration for *docfx*.

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -4,8 +4,7 @@
       "src": [
         {
           "files": [
-            "src/Docfx.App/*.csproj",
-            "src/Docfx.Dotnet/*.csproj"
+            "src/**/*.csproj"
           ],
           "src": "../"
         }

--- a/src/Docfx.MarkdigEngine.Extensions/Inclusion/InclusionContext.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/Inclusion/InclusionContext.cs
@@ -66,7 +66,7 @@ public static class InclusionContext
     }
 
     /// <summary>
-    /// Creates a scope for calling <see cref="Markdig.Markdown.ToHtml(string, Markdig.MarkdownPipeline)"/>.
+    /// Creates a scope for calling <see cref="Markdig.Markdown.ToHtml(string, Markdig.MarkdownPipeline?, Markdig.MarkdownParserContext?)"/>.
     /// </summary>
     public static IDisposable PushFile(object file)
     {
@@ -79,7 +79,7 @@ public static class InclusionContext
     }
 
     /// <summary>
-    /// Creates a scope for calling <see cref="Markdig.Markdown.ToHtml(string, Markdig.MarkdownPipeline)"/>
+    /// Creates a scope for calling <see cref="Markdig.Markdown.ToHtml(string, Markdig.MarkdownPipeline?, Markdig.MarkdownParserContext?)"/>
     /// when processing a markdown inclusion inside <see cref="HtmlInclusionBlockRenderer"/> and <see cref="HtmlInclusionInlineRenderer"/>.
     /// </summary>
     public static IDisposable PushInclusion(object file)


### PR DESCRIPTION
This PR including following changes.

- Include all `.csproj` as extract metadata targets.  (To reference contents by  `xref:`)
  And fix related warnings occurred when running `docfx metadata` command.
- Remove `README.md` file from docs directory.    
  Because it' contents seems obsolete. and [published to site](https://dotnet.github.io/docfx/README.html)

**List of rarget projects to extract API metadata**
```
docfx.csproj
Docfx.App.csproj
Docfx.Build.Common.csproj
Docfx.Build.ConceptualDocuments.csproj
Docfx.Build.Engine.csproj
Docfx.Build.ManagedReference.csproj
Docfx.Build.OverwriteDocuments.csproj
Docfx.Build.ResourceFiles.csproj
Docfx.Build.RestApi.csproj
Docfx.Build.SchemaDriven.csproj
Docfx.Build.TableOfContents.csproj
Docfx.Build.UniversalReference.csproj
Docfx.Common.csproj
Docfx.DataContracts.Common.csproj
Docfx.DataContracts.RestApi.csproj
Docfx.DataContracts.UniversalReference.csproj
Docfx.Dotnet.csproj
Docfx.Glob.csproj
Docfx.HtmlToPdf.csproj
Docfx.MarkdigEngine.csproj
Docfx.MarkdigEngine.Extensions.csproj
Docfx.MarkdigEngine.Validators.csproj
Docfx.Plugins.csproj
Docfx.YamlSerialization.csproj
```