### PR TITLE
Add FluentAssertions nuget package to test projects

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,6 +37,7 @@
 
     <!-- Test only -->
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.11.0" />
     <PackageVersion Include="Magick.NET-Q16-AnyCPU" Version="13.1.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.35.0" />

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -14,6 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <!--
       The NuGet.Frameworks package is required to run csproj based tests targeting .NET 7.0.200.


### PR DESCRIPTION
This PR add [FluentAssertions](https://github.com/fluentassertions/fluentassertions) NuGet package to test projects.

**Background**
Currently xUnit's assertions are used for unit tests.
I want to write unit test assertions with `FluentAssertions` assertion helpers. when adding new tests.

`FluentAssertions` is published as `Apache License 2.0` and widely used in [`org:dotnet` repositories](https://github.com/search?q=org%3Adotnet+fluentassertions+language%3AXML&type=code&l=XML)
So I thought there is no major obstacles to adapt this assertion library.

If these changes aren't accepted. feel free to close this PR.