### PR TITLE
Update SpellingExclusions.dic

### DIFF
--- a/SpellingExclusions.dic
+++ b/SpellingExclusions.dic
@@ -342,9 +342,3 @@ yamlheader
 youtube
 yyyy
 zoneinfo
-ãâáà
-êé
-í
-õôó
-Типы
-шрифтов


### PR DESCRIPTION
**What changed in this PR**
Visual Studio Spell checker configs are added by this PR (#8940)
It works when these settings added. but after reloading projects. All settings are silently ignored.

It seems SpellCheker don't works as expected.
when spellcheck file contains non-ascii characters. (Need to separate dictionary?)

This PR temporary remove non-ascii chars from dictionary. 
(These word is used by `ExtractSearchIndexFromHtmlTest.cs`)
