### PR TITLE
Fix for modifying an enumerated collection while traversing it.

### DIFF
--- a/src/Docfx.Build.Engine/XRefMaps/XRefCollection.cs
+++ b/src/Docfx.Build.Engine/XRefMaps/XRefCollection.cs
@@ -45,13 +45,14 @@ internal sealed class XRefCollection
         {
             AddToDownloadList(_uris);
             var dict = new Dictionary<string, IXRefContainer>();
-            foreach (var item in _processing)
+            while (_processing.Any())
             {
-                var task = item.Key;
-                var uri = item.Value;
+                Task<IXRefContainer> task = await Task.WhenAny(_processing.Keys);
+                Uri uri = _processing[task];
+                _processing.Remove(task);
                 try
                 {
-                    var container = await task;
+                    IXRefContainer container = await task;
                     if (!container.IsEmbeddedRedirections)
                     {
                         AddToDownloadList(

--- a/src/Docfx.Build.Engine/XRefMaps/XRefMapDownloader.cs
+++ b/src/Docfx.Build.Engine/XRefMaps/XRefMapDownloader.cs
@@ -109,6 +109,7 @@ public class XRefMapDownloader
 
     private static IXRefContainer ReadLocalFile(string filePath)
     {
+        Logger.LogVerbose($"Reading from file: {filePath}");
         if (".zip".Equals(Path.GetExtension(filePath), StringComparison.OrdinalIgnoreCase))
         {
             return XRefArchive.Open(filePath, XRefArchiveMode.Read);
@@ -120,6 +121,7 @@ public class XRefMapDownloader
 
     protected static async Task<XRefMap> DownloadFromWebAsync(Uri uri)
     {
+        Logger.LogVerbose($"Reading from web: {uri.OriginalString}");
         var baseUrl = uri.GetLeftPart(UriPartial.Path);
         baseUrl = baseUrl.Substring(0, baseUrl.LastIndexOf('/') + 1);
 


### PR DESCRIPTION
The existing version of XRefCollection's ReaderCreator attempts to add items to a collection while it is traversing the same collection using foreach, causing an AggregateException. This error can be seen by having a simple xrefmap.yml file (referred to by "xref" in docfx.json) containing two redirections:

```
### YamlMime:XRefMap
redirections:
- uidPrefix: DocFx.PrefixOne
  href: https://example.com/folder1/xrefmap.yml
- uidPrefix: DocFx.PrefixTwo
  href: https://example.com/folder2/xrefmap.yml
```

This pull request reverts to a previous form of the loop, allowing the collection to be changed while processing it. Additionally, it adds a couple of log statements to XRefMapDownloader, enabled via `--logLevel verbose`, to allow the user to see which XRefMaps are being read.