### PR TITLE
fix: see/seealso tag copies href when a child node exist

### DIFF
--- a/src/Docfx.Dotnet/Resources/XmlCommentTransform.xsl
+++ b/src/Docfx.Dotnet/Resources/XmlCommentTransform.xsl
@@ -28,7 +28,7 @@
   <xsl:template match="see[@href and not(parent::member)]">
     <a>
       <xsl:apply-templates select="@*|node()"/>
-      <xsl:if test="not(text())">
+      <xsl:if test="not(node())">
         <xsl:value-of select="@href"/>
       </xsl:if>
     </a>
@@ -37,7 +37,7 @@
   <xsl:template match="seealso[@href and not(parent::member)]">
     <a>
       <xsl:apply-templates select="@*|node()"/>
-      <xsl:if test="not(text())">
+      <xsl:if test="not(node())">
         <xsl:value-of select="@href"/>
       </xsl:if>
     </a>

--- a/test/Docfx.Dotnet.Tests/XmlCommentUnitTest.cs
+++ b/test/Docfx.Dotnet.Tests/XmlCommentUnitTest.cs
@@ -43,6 +43,13 @@ public class XmlCommentUnitTest
     }
 
     [Fact]
+    public static void Issue8965()
+    {
+        Verify("<seealso href=\"https://github.com\"><em>See also on MDN</em></seealso>", "<a href=\"https://github.com\">\n  <em>See also on MDN</em>\n</a>");
+        Verify("<see href=\"https://github.com\"><em>See also on MDN</em></see>", "<a href=\"https://github.com\">\n  <em>See also on MDN</em>\n</a>");
+    }
+
+    [Fact]
     public static void BasicCodeBlock()
     {
         var comment = XmlComment.Parse(


### PR DESCRIPTION
fixes #8965 