### PR TITLE
Change dependabot schedule to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,12 @@ updates:
   target-branch: main
   directory: "/"
   schedule:
-    interval: weekly
+    interval: daily
 - package-ecosystem: npm
   target-branch: main
   directory: "/templates"
   schedule:
-    interval: weekly
+    interval: daily
   ignore:
      # Ignore default template dependency update due to missing tests
   - dependency-name: '@default/*'
@@ -17,5 +17,5 @@ updates:
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule: 
-    interval: weekly
+    interval: daily
   target-branch: main


### PR DESCRIPTION
I've created this PR from by following reason.

- When dependabot's created PR count reach `open-pull-requests-limit` (default: `5`).
   Remaining PR is not created until next schedule (?)  
   (I don't confirm behaviors. but currently `semver 6.3.1`  package update PR is not created.   
  and occurs `moderate severity vulnerability` message when running `npm install` command)
- [GitHub hosted runner's pre-installed software](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#preinstalled-software) is frequently updated.  
  If software is updated before PR created & merged. It might lead to CI error (e.g. `NuGet.Framewroks` update) 
