### PR TITLE
Update NuGet package version of ICSharpCode.Decompiler

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageVersion Include="HtmlAgilityPack" Version="1.11.49" />
-    <PackageVersion Include="ICSharpCode.Decompiler" Version="8.0.0.7246-preview3" />
+    <PackageVersion Include="ICSharpCode.Decompiler" Version="8.0.0.7345" />
     <PackageVersion Include="IgnoresAccessChecksToGenerator" Version="0.6.0" />
     <PackageVersion Include="Jint" Version="3.0.0-beta-2049" />
     <PackageVersion Include="JsonSchema.Net" Version="4.1.6" />


### PR DESCRIPTION
Try manually update `ICSharpCode.Decompiler` NuGet package.

This update PR is created before (https://github.com/dotnet/docfx/pull/8834) and closed without merge.
Update this package. If there are no compatibility problems
