### PR TITLE
Update .NET8 SDK version for CI 

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -12,7 +12,7 @@ runs:
       dotnet-version: |
         6.x
         7.x
-        8.0.100-preview.2.23157.25
+        8.0.100-preview.6.23330.14
 
   - run: npm install
     shell: bash

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
         dotnet-version: |
           6.x
           7.x
-          8.0.100-preview.2.23157.25
+          8.0.100-preview.6.23330.14
 
     - uses: github/codeql-action/init@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         dotnet-version: |
           6.x
           7.x
-          8.0.100-preview.2.23157.25
+          8.0.100-preview.6.23330.14
 
     - run: npm install
       working-directory: templates
@@ -67,7 +67,7 @@ jobs:
         name: nuget
         path: drop/nuget
 
-    - run: dotnet tool install --tool-path . sign --version 0.9.1-beta.23274.1
+    - run: dotnet tool install --tool-path . sign --version 0.9.1-beta.23356.1
 
     - run: >
         ./sign code azure-key-vault

--- a/src/Docfx.Dotnet/DotnetApiCatalog.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.cs
@@ -91,24 +91,8 @@ public static class DotnetApiCatalog
         {
             if (!MSBuildLocator.IsRegistered)
             {
-                // Gets non-preview .NET SDKs.
-                var vsInstances = MSBuildLocator.QueryVisualStudioInstances(VisualStudioInstanceQueryOptions.Default)
-                                                .Where(x => !x.MSBuildPath.Contains("-preview."));
-
-                var vs = vsInstances.FirstOrDefault();
-
-                if (vs != null)
-                {
-                    MSBuildLocator.RegisterInstance(vs);
-                }
-                else
-                {
-                    // If failed to resolve non-preview .NET SDK. Fallback to default resolver.
-                    vs = MSBuildLocator.RegisterDefaults();
-
-                    if (vs == null)
-                        throw new ExtractMetadataException($"Cannot find a supported .NET Core SDK. Install .NET Core SDK {Environment.Version.Major}.{Environment.Version.Minor}.x to build .NET API docs.");
-                }
+                var vs = MSBuildLocator.RegisterDefaults() ?? throw new ExtractMetadataException(
+                    $"Cannot find a supported .NET Core SDK. Install .NET Core SDK {Environment.Version.Major}.{Environment.Version.Minor}.x to build .NET API docs.");
 
                 Logger.LogInfo($"Using {vs.Name} {vs.Version}");
             }

--- a/test/Docfx.Dotnet.Tests/GenerateMetadataFromCSUnitTest.cs
+++ b/test/Docfx.Dotnet.Tests/GenerateMetadataFromCSUnitTest.cs
@@ -2566,7 +2566,7 @@ namespace Test1
     public class Test
     {
         public void Defined(ConsoleSpecialKey key = ConsoleSpecialKey.ControlC) { }
-        public void Undefined(ConsoleKey key = (ConsoleKey)0) { }
+        public void Undefined(ConsoleKey key = ConsoleKey.None) { }
     }
 }
 ";
@@ -2578,7 +2578,7 @@ namespace Test1
 
         var undefined = output.Items[0].Items[0].Items[1];
         Assert.NotNull(undefined);
-        Assert.Equal(@"public void Undefined(ConsoleKey key = (ConsoleKey)0)", undefined.Syntax.Content[SyntaxLanguage.CSharp]);
+        Assert.Equal(@"public void Undefined(ConsoleKey key = ConsoleKey.None)", undefined.Syntax.Content[SyntaxLanguage.CSharp]);
     }
 
     [Fact]
@@ -2625,7 +2625,7 @@ namespace Test1
         public void EnumNull(ConsoleSpecialKey? key = null) { }
         public void EnumDefault(ConsoleSpecialKey? key = ConsoleSpecialKey.ControlC) { }
         public void EnumValue(ConsoleSpecialKey? key = ConsoleSpecialKey.ControlBreak) { }
-        public void EnumUndefinedDefault(ConsoleKey? key = (ConsoleKey)0) { }
+        public void EnumUndefinedDefault(ConsoleKey? key = ConsoleKey.None) { }
         public void EnumUndefinedValue(ConsoleKey? key = (ConsoleKey)999) { }
     }
 }
@@ -2646,7 +2646,7 @@ namespace Test1
 
         var enumUndefinedDefault = output.Items[0].Items[0].Items[3];
         Assert.NotNull(enumUndefinedDefault);
-        Assert.Equal(@"public void EnumUndefinedDefault(ConsoleKey? key = (ConsoleKey)0)", enumUndefinedDefault.Syntax.Content[SyntaxLanguage.CSharp]);
+        Assert.Equal(@"public void EnumUndefinedDefault(ConsoleKey? key = ConsoleKey.None)", enumUndefinedDefault.Syntax.Content[SyntaxLanguage.CSharp]);
 
         var enumUndefinedValue = output.Items[0].Items[0].Items[4];
         Assert.NotNull(enumUndefinedValue);

--- a/test/docfx.Tests/ModuleInitializer.cs
+++ b/test/docfx.Tests/ModuleInitializer.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.Build.Locator;
+
+namespace Docfx.Tests;
+
+public static class ModuleInitializer
+{
+    [ModuleInitializer]
+    public static void Initialize()
+    {
+        RegisterNonPreviewSdkInstance();
+    }
+
+    /// <summary>
+    /// Try to register non-preview version .NET SDK to avoid `NuGet.Frameworks` package related problems.
+    /// </summary>
+    /// <remarks>
+    private static void RegisterNonPreviewSdkInstance()
+    {
+        if (MSBuildLocator.IsRegistered)
+        {
+            // `DotnetApiCatalog.Exec` is called before ModuleInitializer execution.
+            MSBuildLocator.Unregister();
+            Console.WriteLine($"Execute: MSBuildLocator.Unregister()");
+        }
+
+        // Gets non-preview .NET SDKs.
+        var vsInstances = MSBuildLocator.QueryVisualStudioInstances(VisualStudioInstanceQueryOptions.Default)
+                                        .Where(x => !x.MSBuildPath.Contains("-preview."));
+
+        var vs = vsInstances.FirstOrDefault();
+        if (vs == null)
+            return;
+
+        MSBuildLocator.RegisterInstance(vs);
+        Console.WriteLine($"Using {vs.Name} {vs.Version}");
+    }
+}


### PR DESCRIPTION
**What's included in this PR**

- Update .NET SDK version from `preview.2` to `preview.6`.
- Update `sign` tool version to `0.9.1-beta.23356.1`. 
