### PR TITLE
refactor: Rewrite parameter null checks using helper methods

### DIFF
--- a/src/Docfx.Build.Common/ModelAttributeHandlers/Handlers/BaseModelAttributeHandler.cs
+++ b/src/Docfx.Build.Common/ModelAttributeHandlers/Handlers/BaseModelAttributeHandler.cs
@@ -13,15 +13,9 @@ public abstract class BaseModelAttributeHandler<T> : IModelAttributeHandler wher
     private Type _type;
     protected BaseModelAttributeHandler(Type type, IModelAttributeHandler handler)
     {
-        if (type == null)
-        {
-            throw new ArgumentNullException(nameof(type));
-        }
+        ArgumentNullException.ThrowIfNull(type);
+        ArgumentNullException.ThrowIfNull(handler);
 
-        if (handler == null)
-        {
-            throw new ArgumentNullException(nameof(handler));
-        }
         _type = type;
         _typeInfo = GetTypeInfo(type);
         Handler = handler;
@@ -37,10 +31,7 @@ public abstract class BaseModelAttributeHandler<T> : IModelAttributeHandler wher
             throw new InvalidOperationException($"Input type {type} is not the supported type {_type}");
         }
 
-        if (context == null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
+        ArgumentNullException.ThrowIfNull(context);
 
         if (obj == null)
         {

--- a/src/Docfx.Build.Common/ModelAttributeHandlers/Handlers/HandleGenericItemsHelper.cs
+++ b/src/Docfx.Build.Common/ModelAttributeHandlers/Handlers/HandleGenericItemsHelper.cs
@@ -7,85 +7,48 @@ public class HandleGenericItemsHelper
 {
     public static bool EnumerateIEnumerable(object currentObj, Func<object, object> handler)
     {
-        if (currentObj == null)
-        {
-            throw new ArgumentNullException(nameof(currentObj));
-        }
-
-        if (handler == null)
-        {
-            throw new ArgumentNullException(nameof(handler));
-        }
+        ArgumentNullException.ThrowIfNull(currentObj);
+        ArgumentNullException.ThrowIfNull(handler);
 
         return HandleItems(typeof(IEnumerable<>), typeof(EnumerateIEnumerableItems<>), currentObj, handler);
     }
 
     public static bool EnumerateIDictionary(object currentObj, Func<object, object> handler)
     {
-        if (currentObj == null)
-        {
-            throw new ArgumentNullException(nameof(currentObj));
-        }
-
-        if (handler == null)
-        {
-            throw new ArgumentNullException(nameof(handler));
-        }
+        ArgumentNullException.ThrowIfNull(currentObj);
+        ArgumentNullException.ThrowIfNull(handler);
 
         return HandleItems(typeof(IDictionary<,>), typeof(EnumerateIDictionaryItems<,>), currentObj, handler);
     }
 
     public static bool EnumerateIReadonlyDictionary(object currentObj, Func<object, object> handler)
     {
-        if (currentObj == null)
-        {
-            throw new ArgumentNullException(nameof(currentObj));
-        }
-
-        if (handler == null)
-        {
-            throw new ArgumentNullException(nameof(handler));
-        }
+        ArgumentNullException.ThrowIfNull(currentObj);
+        ArgumentNullException.ThrowIfNull(handler);
 
         return HandleItems(typeof(IReadOnlyDictionary<,>), typeof(EnumerateIReadonlyDictionaryItems<,>), currentObj, handler);
     }
 
     public static bool HandleIList(object currentObj, Func<object, object> handler)
     {
-        if (currentObj == null)
-        {
-            throw new ArgumentNullException(nameof(currentObj));
-        }
-
-        if (handler == null)
-        {
-            throw new ArgumentNullException(nameof(handler));
-        }
+        ArgumentNullException.ThrowIfNull(currentObj);
+        ArgumentNullException.ThrowIfNull(handler);
 
         return HandleItems(typeof(IList<>), typeof(HandleIListItems<>), currentObj, handler);
     }
 
     public static bool HandleIDictionary(object currentObj, Func<object, object> handler)
     {
-        if (currentObj == null)
-        {
-            throw new ArgumentNullException(nameof(currentObj));
-        }
-
-        if (handler == null)
-        {
-            throw new ArgumentNullException(nameof(handler));
-        }
+        ArgumentNullException.ThrowIfNull(currentObj);
+        ArgumentNullException.ThrowIfNull(handler);
 
         return HandleItems(typeof(IDictionary<,>), typeof(HandleIDictionaryItems<,>), currentObj, handler);
     }
 
     private static bool HandleItems(Type genericInterface, Type implHandlerType, object currentObj, Func<object, object> handler)
     {
-        if (currentObj == null)
-        {
-            throw new ArgumentNullException(nameof(currentObj));
-        }
+        ArgumentNullException.ThrowIfNull(currentObj);
+
         var type = currentObj.GetType();
         var genericType = ReflectionHelper.GetGenericType(type, genericInterface);
         if (genericType != null)

--- a/src/Docfx.Build.Common/ModelAttributeHandlers/Handlers/MarkdownContentHandler.cs
+++ b/src/Docfx.Build.Common/ModelAttributeHandlers/Handlers/MarkdownContentHandler.cs
@@ -21,15 +21,8 @@ public class MarkdownContentHandler : IModelAttributeHandler
             return null;
         }
 
-        if (context == null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
-
-        if (context.Host == null)
-        {
-            throw new ArgumentNullException(nameof(context.Host));
-        }
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(context.Host);
 
         if (context.SkipMarkup)
         {

--- a/src/Docfx.Build.Common/ModelAttributeHandlers/Handlers/UrlContentHandler.cs
+++ b/src/Docfx.Build.Common/ModelAttributeHandlers/Handlers/UrlContentHandler.cs
@@ -21,15 +21,8 @@ public class UrlContentHandler : IModelAttributeHandler
             return null;
         }
 
-        if (context == null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
-
-        if (context.Host == null)
-        {
-            throw new ArgumentNullException(nameof(context.Host));
-        }
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(context.Host);
 
         var type = obj.GetType();
         return _cache.GetOrAdd(type, t => new UrlContentHandlerImpl(t, this)).Handle(obj, context);

--- a/src/Docfx.Build.Common/ModelAttributeHandlers/ReflectionHelper.cs
+++ b/src/Docfx.Build.Common/ModelAttributeHandlers/ReflectionHelper.cs
@@ -31,18 +31,10 @@ public static class ReflectionHelper
 
     public static object CreateInstance(Type type, Type[] typeArguments, Type[] argumentTypes, object[] arguments)
     {
-        if (type == null)
-        {
-            throw new ArgumentNullException(nameof(type));
-        }
-        if (argumentTypes == null)
-        {
-            throw new ArgumentNullException(nameof(argumentTypes));
-        }
-        if (arguments == null)
-        {
-            throw new ArgumentNullException(nameof(arguments));
-        }
+        ArgumentNullException.ThrowIfNull(type);
+        ArgumentNullException.ThrowIfNull(argumentTypes);
+        ArgumentNullException.ThrowIfNull(arguments);
+
         var func = _createInstanceCache.GetOrAdd(
             Tuple.Create(type, typeArguments ?? Type.EmptyTypes, argumentTypes),
             GetCreateInstanceFunc);
@@ -142,20 +134,14 @@ public static class ReflectionHelper
 
     public static List<PropertyInfo> GetSettableProperties(Type type)
     {
-        if (type == null)
-        {
-            throw new ArgumentNullException(nameof(type));
-        }
+        ArgumentNullException.ThrowIfNull(type);
 
         return _settablePropertiesCache.GetOrAdd(type, _getSettableProperties);
     }
 
     public static List<PropertyInfo> GetGettableProperties(Type type)
     {
-        if (type == null)
-        {
-            throw new ArgumentNullException(nameof(type));
-        }
+        ArgumentNullException.ThrowIfNull(type);
 
         return _gettablePropertiesCache.GetOrAdd(type, _getGettableProperties);
     }
@@ -254,14 +240,9 @@ public static class ReflectionHelper
 
     public static object GetPropertyValue(object instance, PropertyInfo prop)
     {
-        if (instance == null)
-        {
-            throw new ArgumentNullException(nameof(instance));
-        }
-        if (prop == null)
-        {
-            throw new ArgumentNullException(nameof(prop));
-        }
+        ArgumentNullException.ThrowIfNull(instance);
+        ArgumentNullException.ThrowIfNull(prop);
+
         var func = _propertyGetterCache.GetOrAdd(prop, CreateGetPropertyFunc);
         return func(instance);
     }
@@ -291,14 +272,9 @@ public static class ReflectionHelper
 
     public static void SetPropertyValue(object instance, PropertyInfo prop, object value)
     {
-        if (instance == null)
-        {
-            throw new ArgumentNullException(nameof(instance));
-        }
-        if (prop == null)
-        {
-            throw new ArgumentNullException(nameof(prop));
-        }
+        ArgumentNullException.ThrowIfNull(instance);
+        ArgumentNullException.ThrowIfNull(prop);
+
         var action = _propertySetterCache.GetOrAdd(prop, CreateSetPropertyFunc);
         action(instance, value);
     }

--- a/src/Docfx.Build.Common/Reference/OverwriteDocumentReader.cs
+++ b/src/Docfx.Build.Common/Reference/OverwriteDocumentReader.cs
@@ -16,10 +16,7 @@ public class OverwriteDocumentReader
 {
     public static FileModel Read(FileAndType file)
     {
-        if (file == null)
-        {
-            throw new ArgumentNullException(nameof(file));
-        }
+        ArgumentNullException.ThrowIfNull(file);
 
         if (file.Type != DocumentType.Overwrite)
         {

--- a/src/Docfx.Build.ConceptualDocuments/CountWord.cs
+++ b/src/Docfx.Build.ConceptualDocuments/CountWord.cs
@@ -38,10 +38,7 @@ internal static class WordCounter
 
     public static long CountWord(string html)
     {
-        if (html == null)
-        {
-            throw new ArgumentNullException(nameof(html));
-        }
+        ArgumentNullException.ThrowIfNull(html);
 
         HtmlDocument document = new();
 

--- a/src/Docfx.Build.ConceptualDocuments/HtmlDocumentUtility.cs
+++ b/src/Docfx.Build.ConceptualDocuments/HtmlDocumentUtility.cs
@@ -10,10 +10,8 @@ public static class HtmlDocumentUtility
 {
     public static SeparatedHtmlInfo SeparateHtml(string contentHtml)
     {
-        if (contentHtml == null)
-        {
-            throw new ArgumentNullException();
-        }
+        ArgumentNullException.ThrowIfNull(contentHtml);
+
         var content = new SeparatedHtmlInfo();
 
         var document = new HtmlDocument();

--- a/src/Docfx.Build.Engine/CompositionContainer.cs
+++ b/src/Docfx.Build.Engine/CompositionContainer.cs
@@ -31,18 +31,9 @@ public class CompositionContainer : ICompositionContainer
 
     public static object GetExport(CompositionHost container, Type type, string name)
     {
-        if (container == null)
-        {
-            throw new ArgumentNullException(nameof(container));
-        }
-        if (type == null)
-        {
-            throw new ArgumentNullException(nameof(type));
-        }
-        if (name == null)
-        {
-            throw new ArgumentNullException(nameof(name));
-        }
+        ArgumentNullException.ThrowIfNull(container);
+        ArgumentNullException.ThrowIfNull(type);
+        ArgumentNullException.ThrowIfNull(name);
 
         object exportedObject = null;
         try
@@ -58,10 +49,7 @@ public class CompositionContainer : ICompositionContainer
 
     public static CompositionHost GetContainer(IEnumerable<Assembly> assemblies)
     {
-        if (assemblies == null)
-        {
-            throw new ArgumentNullException(nameof(assemblies));
-        }
+        ArgumentNullException.ThrowIfNull(assemblies);
 
         var configuration = new ContainerConfiguration();
         foreach (var assembly in assemblies)

--- a/src/Docfx.Build.Engine/DocumentBuildContext.cs
+++ b/src/Docfx.Build.Engine/DocumentBuildContext.cs
@@ -277,10 +277,8 @@ public sealed class DocumentBuildContext : IDocumentBuildContext
 
     public string GetFilePath(string key)
     {
-        if (key == null)
-        {
-            throw new ArgumentNullException(nameof(key));
-        }
+        ArgumentNullException.ThrowIfNull(key);
+
         if (key.Length == 0)
         {
             throw new ArgumentException("Key cannot be empty.", nameof(key));
@@ -301,19 +299,15 @@ public sealed class DocumentBuildContext : IDocumentBuildContext
 
     public string UpdateHref(string href)
     {
-        if (href == null)
-        {
-            throw new ArgumentNullException(nameof(href));
-        }
+        ArgumentNullException.ThrowIfNull(href);
+
         return UpdateHrefCore(href, null);
     }
 
     public string UpdateHref(string href, RelativePath fromFile)
     {
-        if (href == null)
-        {
-            throw new ArgumentNullException(nameof(href));
-        }
+        ArgumentNullException.ThrowIfNull(href);
+
         if (fromFile != null && !fromFile.IsFromWorkingFolder())
         {
             throw new ArgumentException("File must be from working folder (i.e. start with '~/').", nameof(fromFile));
@@ -357,10 +351,8 @@ public sealed class DocumentBuildContext : IDocumentBuildContext
     // TODO: use this method instead of directly accessing UidMap
     public void RegisterInternalXrefSpec(XRefSpec xrefSpec)
     {
-        if (xrefSpec == null)
-        {
-            throw new ArgumentNullException(nameof(xrefSpec));
-        }
+        ArgumentNullException.ThrowIfNull(xrefSpec);
+
         if (string.IsNullOrEmpty(xrefSpec.Href))
         {
             throw new ArgumentException("Href for xref spec must contain value");
@@ -382,18 +374,14 @@ public sealed class DocumentBuildContext : IDocumentBuildContext
 
     public void RegisterInternalXrefSpecBookmark(string uid, string bookmark)
     {
-        if (uid == null)
-        {
-            throw new ArgumentNullException(nameof(uid));
-        }
+        ArgumentNullException.ThrowIfNull(uid);
+
         if (uid.Length == 0)
         {
             throw new ArgumentException("Uid cannot be empty", nameof(uid));
         }
-        if (bookmark == null)
-        {
-            throw new ArgumentNullException(nameof(bookmark));
-        }
+
+        ArgumentNullException.ThrowIfNull(bookmark);
         if (bookmark.Length == 0)
         {
             return;
@@ -411,10 +399,7 @@ public sealed class DocumentBuildContext : IDocumentBuildContext
 
     public XRefSpec GetXrefSpec(string uid)
     {
-        if (uid == null)
-        {
-            throw new ArgumentNullException(nameof(uid));
-        }
+        ArgumentNullException.ThrowIfNull(uid);
 
         if (string.IsNullOrWhiteSpace(uid))
         {
@@ -463,10 +448,8 @@ public sealed class DocumentBuildContext : IDocumentBuildContext
 
     public IImmutableList<string> GetTocFileKeySet(string key)
     {
-        if (string.IsNullOrEmpty(key))
-        {
-            throw new ArgumentNullException(nameof(key));
-        }
+        ArgumentNullException.ThrowIfNull(key);
+
         if (TocMap.TryGetValue(key, out HashSet<string> sets))
         {
             return sets.ToImmutableArray();
@@ -477,9 +460,13 @@ public sealed class DocumentBuildContext : IDocumentBuildContext
 
     public void RegisterToc(string tocFileKey, string fileKey)
     {
+#if NET7_0_OR_GREATER
+        ArgumentNullException.ThrowIfNullOrEmpty(fileKey);
+        ArgumentNullException.ThrowIfNullOrEmpty(tocFileKey);
+#else
         if (string.IsNullOrEmpty(fileKey)) throw new ArgumentNullException(nameof(fileKey));
         if (string.IsNullOrEmpty(tocFileKey)) throw new ArgumentNullException(nameof(tocFileKey));
-
+#endif
         TocMap.AddOrUpdate(
             fileKey,
             new HashSet<string>(FilePathComparer.OSPlatformSensitiveRelativePathComparer) { tocFileKey },

--- a/src/Docfx.Build.Engine/DocumentBuilder.cs
+++ b/src/Docfx.Build.Engine/DocumentBuilder.cs
@@ -52,10 +52,8 @@ public class DocumentBuilder : IDisposable
 
     public void Build(IList<DocumentBuildParameters> parameters, string outputDirectory)
     {
-        if (parameters == null)
-        {
-            throw new ArgumentNullException(nameof(parameters));
-        }
+        ArgumentNullException.ThrowIfNull(parameters);
+
         if (parameters.Count == 0)
         {
             throw new ArgumentException("Parameters are empty.", nameof(parameters));

--- a/src/Docfx.Build.Engine/HostService.cs
+++ b/src/Docfx.Build.Engine/HostService.cs
@@ -83,10 +83,8 @@ internal sealed class HostService : IHostService, IDisposable
 
     public ImmutableList<FileModel> LookupByUid(string uid)
     {
-        if (uid == null)
-        {
-            throw new ArgumentNullException(nameof(uid));
-        }
+        ArgumentNullException.ThrowIfNull(uid);
+
         lock (_syncRoot)
         {
             if (_uidIndex.TryGetValue(uid, out List<FileModel> result))

--- a/src/Docfx.Build.Engine/ManifestProcessor.cs
+++ b/src/Docfx.Build.Engine/ManifestProcessor.cs
@@ -17,9 +17,13 @@ internal class ManifestProcessor
 
     public ManifestProcessor(List<ManifestItemWithContext> manifestWithContext, DocumentBuildContext context, TemplateProcessor templateProcessor)
     {
-        _context = context ?? throw new ArgumentNullException(nameof(context));
-        _templateProcessor = templateProcessor ?? throw new ArgumentNullException(nameof(templateProcessor));
-        _manifestWithContext = manifestWithContext ?? throw new ArgumentNullException(nameof(manifestWithContext));
+        ArgumentNullException.ThrowIfNull(manifestWithContext);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(templateProcessor);
+
+        _manifestWithContext = manifestWithContext;
+        _context = context;
+        _templateProcessor = templateProcessor;
 
         // E.g. we can set TOC model to be globally shared by every data model
         // Make sure it is single thread

--- a/src/Docfx.Build.Engine/ManifestUtility.cs
+++ b/src/Docfx.Build.Engine/ManifestUtility.cs
@@ -15,10 +15,7 @@ public static class ManifestUtility
 {
     public static void RemoveDuplicateOutputFiles(ManifestItemCollection manifestItems)
     {
-        if (manifestItems == null)
-        {
-            throw new ArgumentNullException(nameof(manifestItems));
-        }
+        ArgumentNullException.ThrowIfNull(manifestItems);
 
         var manifestItemGroups = (from item in manifestItems
                                   from output in item.OutputFiles.Values
@@ -44,10 +41,7 @@ public static class ManifestUtility
 
     public static Manifest MergeManifest(List<Manifest> manifests)
     {
-        if (manifests == null)
-        {
-            throw new ArgumentNullException(nameof(manifests));
-        }
+        ArgumentNullException.ThrowIfNull(manifests);
 
         var xrefMaps = (from manifest in manifests
                         where manifest.XRefMap != null
@@ -72,14 +66,9 @@ public static class ManifestUtility
 
     public static void ApplyLogCodes(ManifestItemCollection manifestItems, ConcurrentDictionary<string, ImmutableHashSet<string>> codes)
     {
-        if (manifestItems == null)
-        {
-            throw new ArgumentException(nameof(manifestItems));
-        }
-        if (codes == null)
-        {
-            throw new ArgumentException(nameof(codes));
-        }
+        ArgumentNullException.ThrowIfNull(manifestItems);
+        ArgumentNullException.ThrowIfNull(codes);
+
         foreach (var item in manifestItems)
         {
             if (codes.TryGetValue(item.SourceRelativePath, out var value))

--- a/src/Docfx.Build.Engine/MarkupResultUtility.cs
+++ b/src/Docfx.Build.Engine/MarkupResultUtility.cs
@@ -20,18 +20,10 @@ public static class MarkupUtility
 
     public static MarkupResult Parse(MarkupResult markupResult, string file, ImmutableDictionary<string, FileAndType> sourceFiles)
     {
-        if (markupResult == null)
-        {
-            throw new ArgumentNullException(nameof(markupResult));
-        }
-        if (file == null)
-        {
-            throw new ArgumentNullException(nameof(file));
-        }
-        if (sourceFiles == null)
-        {
-            throw new ArgumentNullException(nameof(sourceFiles));
-        }
+        ArgumentNullException.ThrowIfNull(markupResult);
+        ArgumentNullException.ThrowIfNull(file);
+        ArgumentNullException.ThrowIfNull(sourceFiles);
+
         return ParseCore(markupResult, file, sourceFiles);
     }
 

--- a/src/Docfx.Build.Engine/OSPlatformSensitiveDictionary.cs
+++ b/src/Docfx.Build.Engine/OSPlatformSensitiveDictionary.cs
@@ -17,10 +17,8 @@ public class OSPlatformSensitiveDictionary<V> : Dictionary<string, V>
 
     public OSPlatformSensitiveDictionary(IEnumerable<KeyValuePair<string, V>> list) : this()
     {
-        if (list == null)
-        {
-            throw new ArgumentNullException(nameof(list));
-        }
+        ArgumentNullException.ThrowIfNull(list);
+
         foreach (var item in list)
         {
             this[item.Key] = item.Value;

--- a/src/Docfx.Build.Engine/PostProcessors/HtmlPostProcessor.cs
+++ b/src/Docfx.Build.Engine/PostProcessors/HtmlPostProcessor.cs
@@ -41,14 +41,9 @@ internal sealed class HtmlPostProcessor : IPostProcessor
 
     public Manifest Process(Manifest manifest, string outputFolder)
     {
-        if (manifest == null)
-        {
-            throw new ArgumentNullException(nameof(manifest));
-        }
-        if (outputFolder == null)
-        {
-            throw new ArgumentNullException(nameof(outputFolder));
-        }
+        ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentNullException.ThrowIfNull(outputFolder);
+
         foreach (var handler in Handlers)
         {
             manifest = handler.PreHandle(manifest);

--- a/src/Docfx.Build.Engine/PostProcessors/PostProcessorsHandler.cs
+++ b/src/Docfx.Build.Engine/PostProcessors/PostProcessorsHandler.cs
@@ -11,18 +11,9 @@ internal class PostProcessorsHandler : IPostProcessorsHandler
 {
     public void Handle(List<PostProcessor> postProcessors, Manifest manifest, string outputFolder)
     {
-        if (postProcessors == null)
-        {
-            throw new ArgumentNullException(nameof(postProcessors));
-        }
-        if (manifest == null)
-        {
-            throw new ArgumentNullException(nameof(manifest));
-        }
-        if (outputFolder == null)
-        {
-            throw new ArgumentNullException(nameof(outputFolder));
-        }
+        ArgumentNullException.ThrowIfNull(postProcessors);
+        ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentNullException.ThrowIfNull(outputFolder);
 
         using (new LoggerPhaseScope("HandlePostProcessors", LogLevel.Verbose))
         {

--- a/src/Docfx.Build.Engine/PostProcessors/PostProcessorsManager.cs
+++ b/src/Docfx.Build.Engine/PostProcessors/PostProcessorsManager.cs
@@ -16,14 +16,9 @@ internal class PostProcessorsManager : IDisposable
 
     public PostProcessorsManager(CompositionHost container, ImmutableArray<string> postProcessorNames)
     {
-        if (container == null)
-        {
-            throw new ArgumentNullException(nameof(container));
-        }
-        if (postProcessorNames == null)
-        {
-            throw new ArgumentNullException(nameof(postProcessorNames));
-        }
+        ArgumentNullException.ThrowIfNull(container);
+        ArgumentNullException.ThrowIfNull(postProcessorNames);
+
         _postProcessors = GetPostProcessor(container, postProcessorNames);
         _postProcessorsHandler = new PostProcessorsHandler();
     }

--- a/src/Docfx.Build.Engine/ResourceFileReaders/ArchiveResourceReader.cs
+++ b/src/Docfx.Build.Engine/ResourceFileReaders/ArchiveResourceReader.cs
@@ -19,7 +19,7 @@ public sealed class ArchiveResourceReader : ResourceFileReader
 
     public ArchiveResourceReader(Stream stream, string name)
     {
-        if (stream == null) throw new ArgumentNullException(nameof(stream));
+        ArgumentNullException.ThrowIfNull(stream);
 
         _zipped = new ZipArchive(stream);
         Name = name;

--- a/src/Docfx.Build.Engine/SingleDocumentBuilder.cs
+++ b/src/Docfx.Build.Engine/SingleDocumentBuilder.cs
@@ -45,10 +45,8 @@ public class SingleDocumentBuilder : IDisposable
 
     public Manifest Build(DocumentBuildParameters parameters)
     {
-        if (parameters == null)
-        {
-            throw new ArgumentNullException(nameof(parameters));
-        }
+        ArgumentNullException.ThrowIfNull(parameters);
+
         if (parameters.OutputBaseDir == null)
         {
             throw new ArgumentException("Output folder cannot be null.", nameof(parameters) + "." + nameof(parameters.OutputBaseDir));

--- a/src/Docfx.Build.Engine/SystemMetadataGenerator.cs
+++ b/src/Docfx.Build.Engine/SystemMetadataGenerator.cs
@@ -15,7 +15,9 @@ internal sealed class SystemMetadataGenerator
 
     public SystemMetadataGenerator(IDocumentBuildContext context)
     {
-        _context = context ?? throw new ArgumentNullException(nameof(context));
+        ArgumentNullException.ThrowIfNull(context);
+
+        _context = context;
 
         // Order toc files by the output folder depth
         _toc = context.GetTocInfo()

--- a/src/Docfx.Build.Engine/TemplateProcessors/TemplateBundle.cs
+++ b/src/Docfx.Build.Engine/TemplateProcessors/TemplateBundle.cs
@@ -17,14 +17,8 @@ public class TemplateBundle
 
     public TemplateBundle(string documentType, IEnumerable<Template> templates)
     {
-        if (string.IsNullOrEmpty(documentType))
-        {
-            throw new ArgumentNullException(nameof(documentType));
-        }
-        if (templates == null)
-        {
-            throw new ArgumentNullException(nameof(templates));
-        }
+        ArgumentNullException.ThrowIfNull(documentType);
+        ArgumentNullException.ThrowIfNull(templates);
 
         DocumentType = documentType;
         Templates = templates.ToArray();

--- a/src/Docfx.Build.Engine/TemplateProcessors/TemplateManager.cs
+++ b/src/Docfx.Build.Engine/TemplateProcessors/TemplateManager.cs
@@ -74,8 +74,12 @@ public class TemplateManager
 
     private bool TryExportResourceFiles(IEnumerable<string> resourceNames, string outputDirectory, bool overwrite, string? regexFilter = null)
     {
+#if NET7_0_OR_GREATER
+        ArgumentNullException.ThrowIfNullOrEmpty(outputDirectory);
+#else
         if (string.IsNullOrEmpty(outputDirectory))
             throw new ArgumentNullException(nameof(outputDirectory));
+#endif
 
         if (!resourceNames.Any())
             return false;

--- a/src/Docfx.Build.Engine/TemplateProcessors/TemplateModelTransformer.cs
+++ b/src/Docfx.Build.Engine/TemplateProcessors/TemplateModelTransformer.cs
@@ -24,7 +24,9 @@ public class TemplateModelTransformer
 
     public TemplateModelTransformer(DocumentBuildContext context, TemplateCollection templateCollection, ApplyTemplateSettings settings, IDictionary<string, object> globals)
     {
-        _context = context ?? throw new ArgumentNullException(nameof(context));
+        ArgumentNullException.ThrowIfNull(context);
+
+        _context = context;
         _templateCollection = templateCollection;
         _settings = settings;
         _globalVariables = globals;

--- a/src/Docfx.Build.Engine/TemplateProcessors/TemplateProcessor.cs
+++ b/src/Docfx.Build.Engine/TemplateProcessors/TemplateProcessor.cs
@@ -44,13 +44,21 @@ public class TemplateProcessor : IDisposable
 
     public TemplateBundle GetTemplateBundle(string documentType)
     {
+#if NET7_0_OR_GREATER
+        ArgumentNullException.ThrowIfNullOrEmpty(documentType);
+#else
         if (string.IsNullOrEmpty(documentType)) throw new ArgumentNullException(nameof(documentType));
+#endif
         return _templateCollection[documentType];
     }
 
     public bool TryGetFileExtension(string documentType, out string fileExtension)
     {
+#if NET7_0_OR_GREATER
+        ArgumentNullException.ThrowIfNullOrEmpty(documentType);
+#else
         if (string.IsNullOrEmpty(documentType)) throw new ArgumentNullException(nameof(documentType));
+#endif
         fileExtension = string.Empty;
         if (_templateCollection.Count == 0) return false;
         var templateBundle = _templateCollection[documentType];

--- a/src/Docfx.Build.Engine/TemplateProcessors/ViewRenderers/MustacheTemplateRenderer.cs
+++ b/src/Docfx.Build.Engine/TemplateProcessors/ViewRenderers/MustacheTemplateRenderer.cs
@@ -21,20 +21,9 @@ internal class MustacheTemplateRenderer : ITemplateRenderer
 
     public MustacheTemplateRenderer(IResourceFileReader reader, ResourceInfo info, string name = null)
     {
-        if (info == null)
-        {
-            throw new ArgumentNullException(nameof(info));
-        }
-
-        if (info.Content == null)
-        {
-            throw new ArgumentNullException(nameof(info.Content));
-        }
-
-        if (info.Path == null)
-        {
-            throw new ArgumentNullException(nameof(info.Path));
-        }
+        ArgumentNullException.ThrowIfNull(info);
+        ArgumentNullException.ThrowIfNull(info.Content);
+        ArgumentNullException.ThrowIfNull(info.Path);
 
         Path = info.Path;
         Name = name ?? System.IO.Path.GetFileNameWithoutExtension(Path);

--- a/src/Docfx.Build.Engine/XRefMaps/BasicXRefMapReader.cs
+++ b/src/Docfx.Build.Engine/XRefMaps/BasicXRefMapReader.cs
@@ -11,7 +11,9 @@ public class BasicXRefMapReader : IXRefContainerReader
 
     public BasicXRefMapReader(XRefMap map)
     {
-        Map = map ?? throw new ArgumentNullException(nameof(map));
+        ArgumentNullException.ThrowIfNull(map);
+
+        Map = map;
         if (map.HrefUpdated != true &&
             map.BaseUrl != null)
         {

--- a/src/Docfx.Build.Engine/XRefMaps/XRefArchive.cs
+++ b/src/Docfx.Build.Engine/XRefMaps/XRefArchive.cs
@@ -35,10 +35,8 @@ public sealed class XRefArchive : IXRefContainer, IDisposable
 
     public static XRefArchive Open(string file, XRefArchiveMode mode)
     {
-        if (file == null)
-        {
-            throw new ArgumentNullException(nameof(file));
-        }
+        ArgumentNullException.ThrowIfNull(file);
+
         FileStream fs = null;
         ZipArchive archive = null;
         try
@@ -93,10 +91,8 @@ public sealed class XRefArchive : IXRefContainer, IDisposable
 
     public string CreateMajor(XRefMap map)
     {
-        if (map == null)
-        {
-            throw new ArgumentNullException(nameof(map));
-        }
+        ArgumentNullException.ThrowIfNull(map);
+
         if (_mode == XRefArchiveMode.Read)
         {
             throw new InvalidOperationException("Cannot create entry for readonly archive.");
@@ -110,10 +106,8 @@ public sealed class XRefArchive : IXRefContainer, IDisposable
 
     public string CreateMinor(XRefMap map, IEnumerable<string> names)
     {
-        if (map == null)
-        {
-            throw new ArgumentNullException(nameof(map));
-        }
+        ArgumentNullException.ThrowIfNull(map);
+
         if (_mode == XRefArchiveMode.Read)
         {
             throw new InvalidOperationException("Cannot create entry for readonly archive.");
@@ -144,10 +138,8 @@ public sealed class XRefArchive : IXRefContainer, IDisposable
 
     public XRefMap Get(string name)
     {
-        if (name == null)
-        {
-            throw new ArgumentNullException(nameof(name));
-        }
+        ArgumentNullException.ThrowIfNull(name);
+
         var entryName = GetEntry(name);
         if (entryName == null)
         {
@@ -160,14 +152,9 @@ public sealed class XRefArchive : IXRefContainer, IDisposable
 
     public void Update(string name, XRefMap map)
     {
-        if (name == null)
-        {
-            throw new ArgumentNullException(nameof(name));
-        }
-        if (map == null)
-        {
-            throw new ArgumentNullException(nameof(map));
-        }
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(map);
+
         if (_mode == XRefArchiveMode.Read)
         {
             throw new InvalidOperationException("Cannot create entry for readonly archive.");
@@ -184,10 +171,8 @@ public sealed class XRefArchive : IXRefContainer, IDisposable
 
     public void Delete(string name)
     {
-        if (name == null)
-        {
-            throw new ArgumentNullException(nameof(name));
-        }
+        ArgumentNullException.ThrowIfNull(name);
+
         if (_mode == XRefArchiveMode.Read)
         {
             throw new InvalidOperationException("Cannot create entry for readonly archive.");
@@ -202,10 +187,8 @@ public sealed class XRefArchive : IXRefContainer, IDisposable
 
     public bool HasEntry(string name)
     {
-        if (name == null)
-        {
-            throw new ArgumentNullException(nameof(name));
-        }
+        ArgumentNullException.ThrowIfNull(name);
+
         return HasEntryCore(name);
     }
 

--- a/src/Docfx.Build.Engine/XRefMaps/XRefArchiveBuilder.cs
+++ b/src/Docfx.Build.Engine/XRefMaps/XRefArchiveBuilder.cs
@@ -14,10 +14,8 @@ public class XRefArchiveBuilder
 
     public async Task<bool> DownloadAsync(Uri uri, string outputFile)
     {
-        if (uri == null)
-        {
-            throw new ArgumentNullException(nameof(uri));
-        }
+        ArgumentNullException.ThrowIfNull(uri);
+
         if (!uri.IsAbsoluteUri)
         {
             throw new ArgumentException("Relative path is not allowed.", nameof(uri));

--- a/src/Docfx.Build.Engine/XRefMaps/XRefArchiveReader.cs
+++ b/src/Docfx.Build.Engine/XRefMaps/XRefArchiveReader.cs
@@ -17,7 +17,9 @@ public class XRefArchiveReader : XRefRedirectionReader, IDisposable
     public XRefArchiveReader(XRefArchive archive)
         : base(XRefArchive.MajorFileName, new HashSet<string>(archive.Entries))
     {
-        _archive = archive ?? throw new ArgumentNullException(nameof(archive));
+        ArgumentNullException.ThrowIfNull(archive);
+
+        _archive = archive;
         _lru = LruList<Tuple<string, XRefMap>>.Create(0x10, comparer: new TupleComparer());
     }
 

--- a/src/Docfx.Build.Engine/XRefMaps/XRefCollection.cs
+++ b/src/Docfx.Build.Engine/XRefMaps/XRefCollection.cs
@@ -13,10 +13,8 @@ internal sealed class XRefCollection
 
     public XRefCollection(IEnumerable<Uri> uris)
     {
-        if (uris == null)
-        {
-            throw new ArgumentNullException(nameof(uris));
-        }
+        ArgumentNullException.ThrowIfNull(uris);
+
         Uris = uris.ToImmutableList();
     }
 

--- a/src/Docfx.Build.Engine/XRefMaps/XRefMapDownloader.cs
+++ b/src/Docfx.Build.Engine/XRefMaps/XRefMapDownloader.cs
@@ -37,10 +37,8 @@ public class XRefMapDownloader
     /// <threadsafety>This method is thread safe.</threadsafety>
     public async Task<IXRefContainer> DownloadAsync(Uri uri)
     {
-        if (uri == null)
-        {
-            throw new ArgumentNullException(nameof(uri));
-        }
+        ArgumentNullException.ThrowIfNull(uri);
+
         await _semaphore.WaitAsync();
         return await Task.Run(async () =>
         {

--- a/src/Docfx.Build.Engine/XRefMaps/XRefRedirectionReader.cs
+++ b/src/Docfx.Build.Engine/XRefMaps/XRefRedirectionReader.cs
@@ -11,7 +11,9 @@ public abstract class XRefRedirectionReader : IXRefContainerReader
 
     protected XRefRedirectionReader(string majorName, HashSet<string> mapNames)
     {
-        _majorName = majorName ?? throw new ArgumentNullException(nameof(majorName));
+        ArgumentNullException.ThrowIfNull(majorName);
+
+        _majorName = majorName;
         if (!mapNames.Contains(majorName))
         {
             throw new ArgumentException("Major map not found.");

--- a/src/Docfx.Build.OverwriteDocuments/MarkdownFragmentsCreator.cs
+++ b/src/Docfx.Build.OverwriteDocuments/MarkdownFragmentsCreator.cs
@@ -30,7 +30,9 @@ public class MarkdownFragmentsCreator
 
     public IEnumerable<MarkdownFragmentModel> Create(MarkdownDocument document)
     {
-        _document = document ?? throw new ArgumentNullException(nameof(document));
+        ArgumentNullException.ThrowIfNull(document);
+
+        _document = document;
         _position = 0;
 
         while (More())

--- a/src/Docfx.Build.OverwriteDocuments/OverwriteDocumentModelCreator.cs
+++ b/src/Docfx.Build.OverwriteDocuments/OverwriteDocumentModelCreator.cs
@@ -14,7 +14,9 @@ public class OverwriteDocumentModelCreator
 
     public OverwriteDocumentModelCreator(string file)
     {
-        _file = file ?? throw new ArgumentNullException(nameof(file));
+        ArgumentNullException.ThrowIfNull(file);
+
+        _file = file;
     }
 
     public OverwriteDocumentModel Create(MarkdownFragmentModel model)

--- a/src/Docfx.Build.OverwriteDocuments/Rules/InlineCodeHeadingRule.cs
+++ b/src/Docfx.Build.OverwriteDocuments/Rules/InlineCodeHeadingRule.cs
@@ -16,10 +16,7 @@ public class InlineCodeHeadingRule : IOverwriteBlockRule
 
     public bool Parse(Block block, out string value)
     {
-        if (block == null)
-        {
-            throw new ArgumentNullException(nameof(block));
-        }
+        ArgumentNullException.ThrowIfNull(block);
 
         var inline = ParseCore(block);
         value = inline?.Content;

--- a/src/Docfx.Build.OverwriteDocuments/Rules/YamlCodeBlockRule.cs
+++ b/src/Docfx.Build.OverwriteDocuments/Rules/YamlCodeBlockRule.cs
@@ -14,10 +14,7 @@ public sealed class YamlCodeBlockRule : IOverwriteBlockRule
 
     public bool Parse(Block block, out string value)
     {
-        if (block == null)
-        {
-            throw new ArgumentNullException(nameof(block));
-        }
+        ArgumentNullException.ThrowIfNull(block);
 
         var fenced = block as FencedCodeBlock;
         if (!string.IsNullOrEmpty(fenced?.Info) && !_allowedLanguages.Contains(fenced.Info.ToLower()))

--- a/src/Docfx.Build.RestApi/RestApiHelper.cs
+++ b/src/Docfx.Build.RestApi/RestApiHelper.cs
@@ -19,10 +19,8 @@ internal static class RestApiHelper
     /// <returns></returns>
     public static string FormatDefinitionSinglePath(string reference)
     {
-        if (reference == null)
-        {
-            throw new ArgumentNullException(nameof(reference));
-        }
+        ArgumentNullException.ThrowIfNull(reference);
+
         return reference.Replace("~", "~0").Replace("/", "~1");
     }
 
@@ -35,10 +33,7 @@ internal static class RestApiHelper
     /// <returns></returns>
     public static SwaggerFormattedReference FormatReferenceFullPath(string reference)
     {
-        if (reference == null)
-        {
-            throw new ArgumentNullException(nameof(reference));
-        }
+        ArgumentNullException.ThrowIfNull(reference);
 
         // Decode for URI Fragment Identifier Representation
         if (reference.StartsWith("#/", StringComparison.Ordinal))

--- a/src/Docfx.Build.SchemaDriven/Models/JsonPointer.cs
+++ b/src/Docfx.Build.SchemaDriven/Models/JsonPointer.cs
@@ -90,10 +90,7 @@ public class JsonPointer
 
     public void SetValue(ref object root, object value)
     {
-        if (root == null)
-        {
-            throw new ArgumentNullException(nameof(root));
-        }
+        ArgumentNullException.ThrowIfNull(root);
 
         if (_isRoot)
         {
@@ -121,10 +118,7 @@ public class JsonPointer
 
     public static object GetChild(object root, string part)
     {
-        if (part == null)
-        {
-            throw new ArgumentNullException(nameof(part));
-        }
+        ArgumentNullException.ThrowIfNull(part);
 
         if (root == null)
         {
@@ -159,15 +153,8 @@ public class JsonPointer
 
     public static void SetChild(object parent, string part, object value)
     {
-        if (part == null)
-        {
-            throw new ArgumentNullException(nameof(part));
-        }
-
-        if (parent == null)
-        {
-            throw new ArgumentNullException(nameof(parent));
-        }
+        ArgumentNullException.ThrowIfNull(part);
+        ArgumentNullException.ThrowIfNull(parent);
 
         var unescapedPart = UnescapeReference(part);
         if (int.TryParse(unescapedPart, out int index))
@@ -200,10 +187,7 @@ public class JsonPointer
 
     public static BaseSchema GetChildSchema(BaseSchema parent, string part)
     {
-        if (part == null)
-        {
-            throw new ArgumentNullException(nameof(part));
-        }
+        ArgumentNullException.ThrowIfNull(part);
 
         if (parent == null)
         {

--- a/src/Docfx.Build.SchemaDriven/OverwriteApplier.cs
+++ b/src/Docfx.Build.SchemaDriven/OverwriteApplier.cs
@@ -24,7 +24,9 @@ public class OverwriteApplier
 
     public OverwriteApplier(IHostService host, OverwriteModelType type)
     {
-        _host = host ?? throw new ArgumentNullException(nameof(host));
+        ArgumentNullException.ThrowIfNull(host);
+
+        _host = host;
         _overwriteModelType = type;
         _merger = new Merger
         {
@@ -61,10 +63,7 @@ public class OverwriteApplier
             return;
         }
 
-        if (schema == null)
-        {
-            throw new ArgumentNullException(nameof(schema));
-        }
+        ArgumentNullException.ThrowIfNull(schema);
 
         var context = new ProcessContext(_host, fileModel);
         _xrefSpecUpdater.Process(fileModel.Content, schema, context);
@@ -80,10 +79,7 @@ public class OverwriteApplier
             return null;
         }
 
-        if (schema == null)
-        {
-            throw new ArgumentNullException(nameof(schema));
-        }
+        ArgumentNullException.ThrowIfNull(schema);
 
         dynamic overwriteObject = ConvertToObjectHelper.ConvertToDynamic(overwrite.Metadata);
         overwriteObject.uid = overwrite.Uid;

--- a/src/Docfx.Build.SchemaDriven/Processors/SchemaProcessor.cs
+++ b/src/Docfx.Build.SchemaDriven/Processors/SchemaProcessor.cs
@@ -14,10 +14,7 @@ public class SchemaProcessor
 
     public object Process(object raw, BaseSchema schema, IProcessContext context)
     {
-        if (context == null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
+        ArgumentNullException.ThrowIfNull(context);
 
         return InterpretCore(raw, schema, string.Empty, context);
     }

--- a/src/Docfx.Build.SchemaDriven/SchemaDrivenDocumentProcessor.cs
+++ b/src/Docfx.Build.SchemaDriven/SchemaDrivenDocumentProcessor.cs
@@ -41,12 +41,14 @@ public class SchemaDrivenDocumentProcessor : DisposableDocumentProcessor
             throw new ArgumentException("Title for schema must not be empty");
         }
 
+        ArgumentNullException.ThrowIfNull(markdigMarkdownService);
+
         _schemaName = schema.Title;
         _schema = schema;
         SchemaValidator = schema.Validator;
         _allowOverwrite = schema.AllowOverwrite;
         _serializerPool = new ResourcePoolManager<JsonSerializer>(GetSerializer, 0x10);
-        _markdigMarkdownService = markdigMarkdownService ?? throw new ArgumentNullException(nameof(MarkdigMarkdownService));
+        _markdigMarkdownService = markdigMarkdownService;
         _folderRedirectionManager = folderRedirectionManager;
         if (container != null)
         {

--- a/src/Docfx.Build.SchemaDriven/SchemaFragmentsIterator.cs
+++ b/src/Docfx.Build.SchemaDriven/SchemaFragmentsIterator.cs
@@ -23,18 +23,9 @@ public class SchemaFragmentsIterator
         Dictionary<string, MarkdownFragment> fragments,
         BaseSchema schema)
     {
-        if (node == null)
-        {
-            throw new ArgumentNullException(nameof(node));
-        }
-        if (fragments == null)
-        {
-            throw new ArgumentNullException(nameof(fragments));
-        }
-        if (schema == null)
-        {
-            throw new ArgumentNullException(nameof(schema));
-        }
+        ArgumentNullException.ThrowIfNull(node);
+        ArgumentNullException.ThrowIfNull(fragments);
+        ArgumentNullException.ThrowIfNull(schema);
 
         TraverseCore(node, fragments, schema, string.Empty, string.Empty);
     }

--- a/src/Docfx.Build.TableOfContents/TocHelper.cs
+++ b/src/Docfx.Build.TableOfContents/TocHelper.cs
@@ -58,10 +58,14 @@ public static class TocHelper
 
     public static TocItemViewModel LoadSingleToc(string file)
     {
+#if NET7_0_OR_GREATER
+        ArgumentNullException.ThrowIfNullOrEmpty(file);
+#else
         if (string.IsNullOrEmpty(file))
         {
             throw new ArgumentNullException(nameof(file));
         }
+#endif
 
         if (!EnvironmentContext.FileAbstractLayer.Exists(file))
         {
@@ -95,10 +99,14 @@ public static class TocHelper
 
     public static TocItemViewModel LoadYamlToc(string file)
     {
+#if NET7_0_OR_GREATER
+        ArgumentNullException.ThrowIfNullOrEmpty(file);
+#else
         if (string.IsNullOrEmpty(file))
         {
             throw new ArgumentNullException(nameof(file));
         }
+#endif
 
         object obj;
         try

--- a/src/Docfx.Build.UniversalReference/ModelConverter.cs
+++ b/src/Docfx.Build.UniversalReference/ModelConverter.cs
@@ -14,10 +14,8 @@ public static class ModelConverter
 {
     public static ApiBuildOutput ToApiBuildOutput(PageViewModel model)
     {
-        if (model == null)
-        {
-            throw new ArgumentNullException(nameof(model));
-        }
+        ArgumentNullException.ThrowIfNull(model);
+
         if (model.Items == null || model.Items.Count == 0)
         {
             throw new ArgumentException($"{nameof(model)} must contain at least one item");

--- a/src/Docfx.Common/CollectionUtility.cs
+++ b/src/Docfx.Common/CollectionUtility.cs
@@ -9,10 +9,8 @@ public static class CollectionUtility
 {
     public static Dictionary<string, List<T>> Merge<T>(this IDictionary<string, List<T>> left, IEnumerable<KeyValuePair<string, IEnumerable<T>>> right)
     {
-        if (left == null)
-        {
-            throw new ArgumentNullException(nameof(left));
-        }
+        ArgumentNullException.ThrowIfNull(left);
+
         var result = new Dictionary<string, List<T>>(left);
         if (right == null)
         {

--- a/src/Docfx.Common/CommandUtility.cs
+++ b/src/Docfx.Common/CommandUtility.cs
@@ -9,10 +9,7 @@ public static class CommandUtility
 {
     public static int RunCommand(CommandInfo commandInfo, StreamWriter stdoutWriter = null, StreamWriter stderrWriter = null, int timeoutInMilliseconds = Timeout.Infinite)
     {
-        if (commandInfo == null)
-        {
-            throw new ArgumentNullException(nameof(commandInfo));
-        }
+        ArgumentNullException.ThrowIfNull(commandInfo);
 
         if (timeoutInMilliseconds < 0 && timeoutInMilliseconds != Timeout.Infinite)
         {

--- a/src/Docfx.Common/CompositeDictionary.cs
+++ b/src/Docfx.Common/CompositeDictionary.cs
@@ -25,10 +25,8 @@ public class CompositeDictionary
     {
         get
         {
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
+            ArgumentNullException.ThrowIfNull(key);
+
             foreach (var entry in _entries)
             {
                 if (key.StartsWith(entry.Prefix, StringComparison.Ordinal))
@@ -45,10 +43,8 @@ public class CompositeDictionary
         }
         set
         {
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
+            ArgumentNullException.ThrowIfNull(key);
+
             foreach (var entry in _entries)
             {
                 if (key.StartsWith(entry.Prefix, StringComparison.Ordinal))
@@ -106,19 +102,15 @@ public class CompositeDictionary
 
     public bool ContainsKey(string key)
     {
-        if (key == null)
-        {
-            throw new ArgumentNullException(nameof(key));
-        }
+        ArgumentNullException.ThrowIfNull(key);
+
         return TryGetValue(key, out _);
     }
 
     void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
     {
-        if (array == null)
-        {
-            throw new ArgumentNullException(nameof(array));
-        }
+        ArgumentNullException.ThrowIfNull(array);
+
         int count = 0;
         foreach (var item in this)
         {
@@ -149,10 +141,8 @@ public class CompositeDictionary
 
     public bool Remove(string key)
     {
-        if (key == null)
-        {
-            throw new ArgumentNullException(nameof(key));
-        }
+        ArgumentNullException.ThrowIfNull(key);
+
         foreach (var entry in _entries)
         {
             if (key.StartsWith(entry.Prefix))
@@ -165,10 +155,8 @@ public class CompositeDictionary
 
     public bool TryGetValue(string key, out object value)
     {
-        if (key == null)
-        {
-            throw new ArgumentNullException(nameof(key));
-        }
+        ArgumentNullException.ThrowIfNull(key);
+
         foreach (var entry in _entries)
         {
             if (key.StartsWith(entry.Prefix))
@@ -212,14 +200,9 @@ public class CompositeDictionary
 
         public Builder Add<TValue>(string prefix, IDictionary<string, TValue> dict, Func<object, TValue> valueConverter = null)
         {
-            if (prefix == null)
-            {
-                throw new ArgumentNullException(nameof(prefix));
-            }
-            if (dict == null)
-            {
-                throw new ArgumentNullException(nameof(dict));
-            }
+            ArgumentNullException.ThrowIfNull(prefix);
+            ArgumentNullException.ThrowIfNull(dict);
+
             valueConverter ??= o => (TValue)o;
             if (_entries.Exists(e => e.Prefix == prefix))
             {

--- a/src/Docfx.Common/EntityMergers/MergeOptionAttribute.cs
+++ b/src/Docfx.Common/EntityMergers/MergeOptionAttribute.cs
@@ -17,11 +17,9 @@ public sealed class MergeOptionAttribute : Attribute
     /// <param name="handlerType">the type of custom merge handler, it should implement <see cref="IMergeHandler"/>.</param>
     public MergeOptionAttribute(Type handlerType)
     {
+        ArgumentNullException.ThrowIfNull(handlerType);
+
         Option = MergeOption.Merge;
-        if (handlerType == null)
-        {
-            throw new ArgumentNullException(nameof(handlerType));
-        }
         Handler = (IMergeHandler)Activator.CreateInstance(handlerType);
     }
 

--- a/src/Docfx.Common/EntityMergers/MergerDecorator.cs
+++ b/src/Docfx.Common/EntityMergers/MergerDecorator.cs
@@ -9,7 +9,9 @@ public abstract class MergerDecorator : IMerger
 
     protected MergerDecorator(IMerger inner)
     {
-        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        ArgumentNullException.ThrowIfNull(inner);
+
+        _inner = inner;
     }
 
     public virtual void Merge(ref object source, object overrides, Type type, IMergeContext context)

--- a/src/Docfx.Common/FileAbstractLayer/FileAbstractLayer.cs
+++ b/src/Docfx.Common/FileAbstractLayer/FileAbstractLayer.cs
@@ -13,7 +13,9 @@ public class FileAbstractLayer : IFileAbstractLayer, IDisposable
 
     public FileAbstractLayer(IFileReader reader, IFileWriter writer)
     {
-        Reader = reader ?? throw new ArgumentNullException(nameof(reader));
+        ArgumentNullException.ThrowIfNull(reader);
+
+        Reader = reader;
         Writer = writer;
     }
 
@@ -37,20 +39,16 @@ public class FileAbstractLayer : IFileAbstractLayer, IDisposable
 
     public bool Exists(RelativePath file)
     {
-        if (file == null)
-        {
-            throw new ArgumentNullException(nameof(file));
-        }
+        ArgumentNullException.ThrowIfNull(file);
+
         EnsureNotDisposed();
         return Reader.FindFile(file) != null;
     }
 
     public Stream OpenRead(RelativePath file)
     {
-        if (file == null)
-        {
-            throw new ArgumentNullException(nameof(file));
-        }
+        ArgumentNullException.ThrowIfNull(file);
+
         EnsureNotDisposed();
         var pp = FindPhysicalPath(file);
         return File.OpenRead(Environment.ExpandEnvironmentVariables(pp.PhysicalPath));
@@ -58,10 +56,8 @@ public class FileAbstractLayer : IFileAbstractLayer, IDisposable
 
     public Stream Create(RelativePath file)
     {
-        if (file == null)
-        {
-            throw new ArgumentNullException(nameof(file));
-        }
+        ArgumentNullException.ThrowIfNull(file);
+
         EnsureNotDisposed();
         if (!CanWrite)
         {
@@ -72,14 +68,9 @@ public class FileAbstractLayer : IFileAbstractLayer, IDisposable
 
     public void Copy(RelativePath sourceFileName, RelativePath destFileName)
     {
-        if (sourceFileName == null)
-        {
-            throw new ArgumentNullException(nameof(sourceFileName));
-        }
-        if (destFileName == null)
-        {
-            throw new ArgumentNullException(nameof(destFileName));
-        }
+        ArgumentNullException.ThrowIfNull(sourceFileName);
+        ArgumentNullException.ThrowIfNull(destFileName);
+
         EnsureNotDisposed();
         if (!CanWrite)
         {
@@ -90,30 +81,24 @@ public class FileAbstractLayer : IFileAbstractLayer, IDisposable
 
     public ImmutableDictionary<string, string> GetProperties(RelativePath file)
     {
-        if (file == null)
-        {
-            throw new ArgumentNullException(nameof(file));
-        }
+        ArgumentNullException.ThrowIfNull(file);
+
         EnsureNotDisposed();
         return FindPhysicalPath(file).Properties;
     }
 
     public string GetPhysicalPath(RelativePath file)
     {
-        if (file == null)
-        {
-            throw new ArgumentNullException(nameof(file));
-        }
+        ArgumentNullException.ThrowIfNull(file);
+
         EnsureNotDisposed();
         return FindPhysicalPath(file).PhysicalPath;
     }
 
     public IEnumerable<string> GetExpectedPhysicalPath(RelativePath file)
     {
-        if (file == null)
-        {
-            throw new ArgumentNullException(nameof(file));
-        }
+        ArgumentNullException.ThrowIfNull(file);
+
         EnsureNotDisposed();
         return Reader.GetExpectedPhysicalPath(file);
     }

--- a/src/Docfx.Common/FileAbstractLayer/FileAbstractLayerBuilder.cs
+++ b/src/Docfx.Common/FileAbstractLayer/FileAbstractLayerBuilder.cs
@@ -24,49 +24,32 @@ public class FileAbstractLayerBuilder
 
     public FileAbstractLayerBuilder ReadFromRealFileSystem(string folder, ImmutableDictionary<string, string> properties)
     {
-        if (folder == null)
-        {
-            throw new ArgumentNullException(nameof(folder));
-        }
-        if (properties == null)
-        {
-            throw new ArgumentNullException(nameof(properties));
-        }
+        ArgumentNullException.ThrowIfNull(folder);
+        ArgumentNullException.ThrowIfNull(properties);
+
         return new FileAbstractLayerBuilder(new RealFileReader(folder, properties), _writer);
     }
 
     public FileAbstractLayerBuilder ReadFromManifest(Manifest manifest, string manifestFolder)
     {
-        if (manifest == null)
-        {
-            throw new ArgumentNullException(nameof(manifest));
-        }
-        if (manifestFolder == null)
-        {
-            throw new ArgumentNullException(nameof(manifestFolder));
-        }
+        ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentNullException.ThrowIfNull(manifestFolder);
+
         return new FileAbstractLayerBuilder(new ManifestFileReader(manifest, manifestFolder), _writer);
     }
 
     public FileAbstractLayerBuilder WriteToManifest(Manifest manifest, string manifestFolder, string outputFolder = null)
     {
-        if (manifest == null)
-        {
-            throw new ArgumentNullException(nameof(manifest));
-        }
-        if (manifestFolder == null)
-        {
-            throw new ArgumentNullException(nameof(manifestFolder));
-        }
+        ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentNullException.ThrowIfNull(manifestFolder);
+
         return new FileAbstractLayerBuilder(_reader, new ManifestFileWriter(manifest, manifestFolder, outputFolder));
     }
 
     public FileAbstractLayerBuilder ReadFromOutput(FileAbstractLayer fal)
     {
-        if (fal == null)
-        {
-            throw new ArgumentNullException(nameof(fal));
-        }
+        ArgumentNullException.ThrowIfNull(fal);
+
         if (!fal.CanWrite)
         {
             throw new ArgumentException("FileAbstractLayer cannot write.", nameof(fal));
@@ -76,10 +59,8 @@ public class FileAbstractLayerBuilder
 
     public FileAbstractLayerBuilder WriteToRealFileSystem(string folder)
     {
-        if (folder == null)
-        {
-            throw new ArgumentNullException(nameof(folder));
-        }
+        ArgumentNullException.ThrowIfNull(folder);
+
         return new FileAbstractLayerBuilder(_reader, new RealFileWriter(folder));
     }
 

--- a/src/Docfx.Common/FileAbstractLayer/ManifestFileHelper.cs
+++ b/src/Docfx.Common/FileAbstractLayer/ManifestFileHelper.cs
@@ -9,22 +9,11 @@ public static class ManifestFileHelper
 {
     public static bool AddFile(this Manifest manifest, string sourceFilePath, string extension, string targetRelativePath)
     {
-        if (manifest == null)
-        {
-            throw new ArgumentNullException(nameof(manifest));
-        }
-        if (sourceFilePath == null)
-        {
-            throw new ArgumentNullException(nameof(sourceFilePath));
-        }
-        if (extension == null)
-        {
-            throw new ArgumentNullException(nameof(extension));
-        }
-        if (targetRelativePath == null)
-        {
-            throw new ArgumentNullException(nameof(targetRelativePath));
-        }
+        ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentNullException.ThrowIfNull(sourceFilePath);
+        ArgumentNullException.ThrowIfNull(extension);
+        ArgumentNullException.ThrowIfNull(targetRelativePath);
+
         if (sourceFilePath.Length == 0)
         {
             throw new ArgumentException("Value cannot be empty.", nameof(sourceFilePath));
@@ -50,22 +39,11 @@ public static class ManifestFileHelper
 
     public static void AddFile(this Manifest manifest, ManifestItem item, string extension, string targetRelativePath)
     {
-        if (manifest == null)
-        {
-            throw new ArgumentNullException(nameof(manifest));
-        }
-        if (item == null)
-        {
-            throw new ArgumentNullException(nameof(item));
-        }
-        if (extension == null)
-        {
-            throw new ArgumentNullException(nameof(extension));
-        }
-        if (targetRelativePath == null)
-        {
-            throw new ArgumentNullException(nameof(targetRelativePath));
-        }
+        ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentNullException.ThrowIfNull(item);
+        ArgumentNullException.ThrowIfNull(extension);
+        ArgumentNullException.ThrowIfNull(targetRelativePath);
+
         if (targetRelativePath.Length == 0)
         {
             throw new ArgumentException("Value cannot be empty.", nameof(extension));
@@ -87,18 +65,10 @@ public static class ManifestFileHelper
 
     public static bool RemoveFile(this Manifest manifest, string sourceFilePath, string extension)
     {
-        if (manifest == null)
-        {
-            throw new ArgumentNullException(nameof(manifest));
-        }
-        if (sourceFilePath == null)
-        {
-            throw new ArgumentNullException(nameof(sourceFilePath));
-        }
-        if (extension == null)
-        {
-            throw new ArgumentNullException(nameof(extension));
-        }
+        ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentNullException.ThrowIfNull(sourceFilePath);
+        ArgumentNullException.ThrowIfNull(extension);
+
         if (sourceFilePath.Length == 0)
         {
             throw new ArgumentException("Value cannot be empty.", nameof(sourceFilePath));
@@ -119,18 +89,9 @@ public static class ManifestFileHelper
 
     public static bool RemoveFile(this Manifest manifest, ManifestItem item, string extension)
     {
-        if (manifest == null)
-        {
-            throw new ArgumentNullException(nameof(manifest));
-        }
-        if (item == null)
-        {
-            throw new ArgumentNullException(nameof(item));
-        }
-        if (extension == null)
-        {
-            throw new ArgumentNullException(nameof(extension));
-        }
+        ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentNullException.ThrowIfNull(item);
+        ArgumentNullException.ThrowIfNull(extension);
 
         lock (manifest)
         {
@@ -145,14 +106,8 @@ public static class ManifestFileHelper
 
     public static void Modify(this Manifest manifest, Action<Manifest> action)
     {
-        if (manifest == null)
-        {
-            throw new ArgumentNullException(nameof(manifest));
-        }
-        if (action == null)
-        {
-            throw new ArgumentNullException(nameof(action));
-        }
+        ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentNullException.ThrowIfNull(action);
 
         lock (manifest)
         {
@@ -162,14 +117,8 @@ public static class ManifestFileHelper
 
     public static T Modify<T>(this Manifest manifest, Func<Manifest, T> func)
     {
-        if (manifest == null)
-        {
-            throw new ArgumentNullException(nameof(manifest));
-        }
-        if (func == null)
-        {
-            throw new ArgumentNullException(nameof(func));
-        }
+        ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentNullException.ThrowIfNull(func);
 
         lock (manifest)
         {
@@ -179,14 +128,9 @@ public static class ManifestFileHelper
 
     public static void Dereference(this Manifest manifest, string manifestFolder, int parallelism)
     {
-        if (manifest == null)
-        {
-            throw new ArgumentNullException(nameof(manifest));
-        }
-        if (manifestFolder == null)
-        {
-            throw new ArgumentNullException(nameof(manifestFolder));
-        }
+        ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentNullException.ThrowIfNull(manifestFolder);
+
         FileWriterBase.EnsureFolder(manifestFolder);
         var fal = FileAbstractLayerBuilder.Default
             .ReadFromManifest(manifest, manifestFolder)

--- a/src/Docfx.Common/FileAbstractLayer/ManifestFileReader.cs
+++ b/src/Docfx.Common/FileAbstractLayer/ManifestFileReader.cs
@@ -13,7 +13,9 @@ public class ManifestFileReader : IFileReader
 
     public ManifestFileReader(Manifest manifest, string manifestFolder)
     {
-        Manifest = manifest ?? throw new ArgumentNullException(nameof(manifest));
+        ArgumentNullException.ThrowIfNull(manifest);
+
+        Manifest = manifest;
         ManifestFolder = manifestFolder;
     }
 

--- a/src/Docfx.Common/FileAbstractLayer/ManifestFileWriter.cs
+++ b/src/Docfx.Common/FileAbstractLayer/ManifestFileWriter.cs
@@ -16,8 +16,11 @@ public class ManifestFileWriter : FileWriterBase
     public ManifestFileWriter(Manifest manifest, string manifestFolder, string outputFolder)
         : base(outputFolder ?? manifestFolder)
     {
-        Manifest = manifest ?? throw new ArgumentNullException(nameof(manifest));
-        ManifestFolder = manifestFolder ?? throw new ArgumentNullException(nameof(manifestFolder));
+        ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentNullException.ThrowIfNull(manifestFolder);
+
+        Manifest = manifest;
+        ManifestFolder = manifestFolder;
         _noRandomFile = outputFolder == null;
     }
 

--- a/src/Docfx.Common/FileAbstractLayer/PathMapping.cs
+++ b/src/Docfx.Common/FileAbstractLayer/PathMapping.cs
@@ -9,12 +9,11 @@ public struct PathMapping
 {
     public PathMapping(RelativePath logicalPath, string physicalPath)
     {
-        if (logicalPath == null)
-        {
-            throw new ArgumentNullException(nameof(logicalPath));
-        }
+        ArgumentNullException.ThrowIfNull(logicalPath);
+        ArgumentNullException.ThrowIfNull(physicalPath);
+
         LogicalPath = logicalPath.GetPathFromWorkingFolder();
-        PhysicalPath = physicalPath ?? throw new ArgumentNullException(nameof(physicalPath));
+        PhysicalPath = physicalPath;
         AllowMoveOut = false;
         Properties = ImmutableDictionary<string, string>.Empty;
     }

--- a/src/Docfx.Common/FileAbstractLayer/RealFileReader.cs
+++ b/src/Docfx.Common/FileAbstractLayer/RealFileReader.cs
@@ -11,11 +11,10 @@ public class RealFileReader : IFileReader
 
     public RealFileReader(string inputFolder, ImmutableDictionary<string, string> properties)
     {
-        if (inputFolder == null)
-        {
-            throw new ArgumentNullException(nameof(inputFolder));
-        }
-        Properties = properties ?? throw new ArgumentNullException(nameof(properties));
+        ArgumentNullException.ThrowIfNull(inputFolder);
+        ArgumentNullException.ThrowIfNull(properties);
+
+        Properties = properties;
 
         _expandedInputFolder = Path.GetFullPath(Environment.ExpandEnvironmentVariables(inputFolder));
         if (!Directory.Exists(_expandedInputFolder))

--- a/src/Docfx.Common/FileLinkInfo.cs
+++ b/src/Docfx.Common/FileLinkInfo.cs
@@ -28,25 +28,14 @@ public struct FileLinkInfo
 
     public static FileLinkInfo Create(string fromFileInSource, string fromFileInDest, string href, IDocumentBuildContext context)
     {
-        if (fromFileInSource == null)
-        {
-            throw new ArgumentNullException(nameof(fromFileInSource));
-        }
-        if (fromFileInDest == null)
-        {
-            throw new ArgumentNullException(nameof(fromFileInDest));
-        }
-        if (href == null)
-        {
-            throw new ArgumentNullException(nameof(href));
-        }
+        ArgumentNullException.ThrowIfNull(fromFileInSource);
+        ArgumentNullException.ThrowIfNull(fromFileInDest);
+        ArgumentNullException.ThrowIfNull(href);
+        ArgumentNullException.ThrowIfNull(context);
+
         if (UriUtility.HasFragment(href) || UriUtility.HasQueryString(href))
         {
             throw new ArgumentException("fragment and query string is not supported", nameof(href));
-        }
-        if (context == null)
-        {
-            throw new ArgumentNullException(nameof(context));
         }
 
         var path = RelativePath.TryParse(href)?.UrlDecode();

--- a/src/Docfx.Common/FolderRedirection/FolderRedirectionManager.cs
+++ b/src/Docfx.Common/FolderRedirection/FolderRedirectionManager.cs
@@ -9,10 +9,7 @@ public class FolderRedirectionManager
 
     public FolderRedirectionManager(IEnumerable<FolderRedirectionRule> rules)
     {
-        if (rules == null)
-        {
-            throw new ArgumentException(nameof(rules));
-        }
+        ArgumentNullException.ThrowIfNull(rules);
 
         foreach (var rule in rules)
         {
@@ -22,14 +19,9 @@ public class FolderRedirectionManager
 
     private void AddFolderRedirectionRule(string from, string to)
     {
-        if (from == null)
-        {
-            throw new ArgumentNullException(nameof(from));
-        }
-        if (to == null)
-        {
-            throw new ArgumentNullException(nameof(to));
-        }
+        ArgumentNullException.ThrowIfNull(from);
+        ArgumentNullException.ThrowIfNull(to);
+
         var fromRel = (RelativePath)(from.TrimEnd('/', '\\') + "/");
         if (fromRel == null)
         {

--- a/src/Docfx.Common/FolderRedirection/FolderRedirectionRule.cs
+++ b/src/Docfx.Common/FolderRedirection/FolderRedirectionRule.cs
@@ -7,8 +7,11 @@ public class FolderRedirectionRule
 {
     public FolderRedirectionRule(string from, string to)
     {
-        From = from ?? throw new ArgumentNullException(nameof(from));
-        To = to ?? throw new ArgumentNullException(nameof(to));
+        ArgumentNullException.ThrowIfNull(from);
+        ArgumentNullException.ThrowIfNull(to);
+
+        From = from;
+        To = to;
     }
 
     public string From { get; set; }

--- a/src/Docfx.Common/Git/GitUtility.cs
+++ b/src/Docfx.Common/Git/GitUtility.cs
@@ -85,10 +85,14 @@ public static class GitUtility
     [Obsolete("Docfx parses repoUrl in template preprocessor. This method is never used.")]
     public static GitRepoInfo Parse(string repoUrl)
     {
+#if NET7_0_OR_GREATER
+        ArgumentNullException.ThrowIfNullOrEmpty(repoUrl);
+#else
         if (string.IsNullOrEmpty(repoUrl))
         {
             throw new ArgumentNullException(nameof(repoUrl));
         }
+#endif
 
         var githubMatch = GitHubRepoUrlRegex.Match(repoUrl);
         if (githubMatch.Success)

--- a/src/Docfx.Common/Loggers/CompositeLogListener.cs
+++ b/src/Docfx.Common/Loggers/CompositeLogListener.cs
@@ -21,10 +21,7 @@ public class CompositeLogListener : ILoggerListener
 
     public void AddListener(ILoggerListener listener)
     {
-        if (listener == null)
-        {
-            throw new ArgumentNullException(nameof(listener));
-        }
+        ArgumentNullException.ThrowIfNull(listener);
 
         lock (_sync)
         {
@@ -34,10 +31,7 @@ public class CompositeLogListener : ILoggerListener
 
     public void AddListeners(IEnumerable<ILoggerListener> listeners)
     {
-        if (listeners == null)
-        {
-            throw new ArgumentNullException(nameof(listeners));
-        }
+        ArgumentNullException.ThrowIfNull(listeners);
 
         lock (_sync)
         {
@@ -47,10 +41,7 @@ public class CompositeLogListener : ILoggerListener
 
     public ILoggerListener FindListener(Predicate<ILoggerListener> predicate)
     {
-        if (predicate == null)
-        {
-            throw new ArgumentNullException(nameof(predicate));
-        }
+        ArgumentNullException.ThrowIfNull(predicate);
 
         lock (_sync)
         {
@@ -60,10 +51,7 @@ public class CompositeLogListener : ILoggerListener
 
     public void RemoveListener(ILoggerListener listener)
     {
-        if (listener == null)
-        {
-            throw new ArgumentNullException(nameof(listener));
-        }
+        ArgumentNullException.ThrowIfNull(listener);
 
         lock (_sync)
         {
@@ -88,10 +76,7 @@ public class CompositeLogListener : ILoggerListener
 
     public void WriteLine(ILogItem item)
     {
-        if (item == null)
-        {
-            throw new ArgumentNullException(nameof(item));
-        }
+        ArgumentNullException.ThrowIfNull(item);
 
         lock (_sync)
         {

--- a/src/Docfx.Common/Loggers/LogCodesLogListener.cs
+++ b/src/Docfx.Common/Loggers/LogCodesLogListener.cs
@@ -21,10 +21,8 @@ public class LogCodesLogListener : ILoggerListener
 
     public void WriteLine(ILogItem item)
     {
-        if (item == null)
-        {
-            throw new ArgumentNullException(nameof(item));
-        }
+        ArgumentNullException.ThrowIfNull(item);
+
         if (string.IsNullOrEmpty(item.File) || string.IsNullOrEmpty(item.Code))
         {
             return;

--- a/src/Docfx.Common/Loggers/Logger.cs
+++ b/src/Docfx.Common/Loggers/Logger.cs
@@ -20,30 +20,21 @@ public static class Logger
 
     public static void RegisterListener(ILoggerListener listener)
     {
-        if (listener == null)
-        {
-            throw new ArgumentNullException(nameof(listener));
-        }
+        ArgumentNullException.ThrowIfNull(listener);
 
         _syncListener.AddListener(listener);
     }
 
     public static ILoggerListener FindListener(Predicate<ILoggerListener> predicate)
     {
-        if (predicate == null)
-        {
-            throw new ArgumentNullException(nameof(predicate));
-        }
+        ArgumentNullException.ThrowIfNull(predicate);
 
         return _syncListener.FindListener(predicate);
     }
 
     public static void UnregisterListener(ILoggerListener listener)
     {
-        if (listener == null)
-        {
-            throw new ArgumentNullException(nameof(listener));
-        }
+        ArgumentNullException.ThrowIfNull(listener);
 
         _syncListener.RemoveListener(listener);
     }
@@ -152,10 +143,8 @@ public static class Logger
 
     public static void Log(object result)
     {
-        if (result == null)
-        {
-            throw new ArgumentNullException(nameof(result));
-        }
+        ArgumentNullException.ThrowIfNull(result);
+
         Log(LogLevel.Info, result.ToString());
     }
 

--- a/src/Docfx.Common/Loggers/PerformanceScope.cs
+++ b/src/Docfx.Common/Loggers/PerformanceScope.cs
@@ -26,7 +26,9 @@ public sealed class PerformanceScope : IDisposable
 
     public PerformanceScope(Action<TimeSpan> logger = null)
     {
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _logger = logger;
         _stopwatch.Restart();
     }
 

--- a/src/Docfx.Common/Loggers/ReportLogListener.cs
+++ b/src/Docfx.Common/Loggers/ReportLogListener.cs
@@ -27,10 +27,8 @@ public sealed class ReportLogListener : ILoggerListener
 
     public void WriteLine(ILogItem item)
     {
-        if (item == null)
-        {
-            throw new ArgumentNullException(nameof(item));
-        }
+        ArgumentNullException.ThrowIfNull(item);
+
         var level = item.LogLevel;
         var message = item.Message;
         var phase = item.Phase;

--- a/src/Docfx.Common/LruList.cs
+++ b/src/Docfx.Common/LruList.cs
@@ -66,10 +66,8 @@ public class LruList<T>
 
     public void Access(T item)
     {
-        if (item == null)
-        {
-            throw new ArgumentNullException(nameof(item));
-        }
+        ArgumentNullException.ThrowIfNull(item);
+
         AccessNoCheck(item);
     }
 

--- a/src/Docfx.Common/Path/RelativePath.cs
+++ b/src/Docfx.Common/Path/RelativePath.cs
@@ -188,10 +188,14 @@ public sealed class RelativePath : IEquatable<RelativePath>
 
     public RelativePath ChangeFileName(string fileName)
     {
+#if NET7_0_OR_GREATER
+        ArgumentNullException.ThrowIfNullOrEmpty(fileName);
+#else
         if (string.IsNullOrEmpty(fileName))
         {
             throw new ArgumentNullException(nameof(fileName));
         }
+#endif
 
         if (fileName.Contains('\\') || fileName.Contains('/') || fileName == ".." || fileName == ".")
         {
@@ -318,10 +322,8 @@ public sealed class RelativePath : IEquatable<RelativePath>
     /// </summary>
     public bool InDirectory(RelativePath value)
     {
-        if (value == null)
-        {
-            throw new ArgumentNullException(nameof(value));
-        }
+        ArgumentNullException.ThrowIfNull(value);
+
         if (value._parts[value._parts.Length - 1] != "")
         {
             return false;

--- a/src/Docfx.Common/TaskHelper.cs
+++ b/src/Docfx.Common/TaskHelper.cs
@@ -15,10 +15,7 @@ public static class TaskHelper
     /// <returns>The task</returns>
     public static async Task ForEachInParallelAsync<T>(this IEnumerable<T> source, Func<T, Task> body, int maxParallelism)
     {
-        if (body == null)
-        {
-            throw new ArgumentNullException(nameof(body));
-        }
+        ArgumentNullException.ThrowIfNull(body);
 
         using var semaphore = new SemaphoreSlim(maxParallelism);
         // warning "access to disposed closure" around "semaphore" could be ignored as it is inside Task.WhenAll
@@ -62,10 +59,7 @@ public static class TaskHelper
     /// <returns>The task</returns>
     public static async Task<IReadOnlyList<TResult>> SelectInParallelAsync<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, Task<TResult>> body, int maxParallelism)
     {
-        if (body == null)
-        {
-            throw new ArgumentNullException(nameof(body));
-        }
+        ArgumentNullException.ThrowIfNull(body);
 
         using var semaphore = new SemaphoreSlim(maxParallelism);
         // warning "access to disposed closure" around "semaphore" could be ignored as it is inside Task.WhenAll

--- a/src/Docfx.Common/UriTemplates/UriTemplate.cs
+++ b/src/Docfx.Common/UriTemplates/UriTemplate.cs
@@ -25,18 +25,10 @@ public class UriTemplate<T>
     /// </summary>
     public static UriTemplate<T> Parse(string template, Func<string, T> func, Func<string, IUriTemplatePipeline<T>> pipelineProvider)
     {
-        if (template == null)
-        {
-            throw new ArgumentNullException(nameof(template));
-        }
-        if (func == null)
-        {
-            throw new ArgumentNullException(nameof(func));
-        }
-        if (pipelineProvider == null)
-        {
-            throw new ArgumentNullException(nameof(pipelineProvider));
-        }
+        ArgumentNullException.ThrowIfNull(template);
+        ArgumentNullException.ThrowIfNull(func);
+        ArgumentNullException.ThrowIfNull(pipelineProvider);
+
         var t = _marcoRegex.Replace(
             template,
             m => Environment.GetEnvironmentVariable(m.Groups[1].Value));
@@ -66,10 +58,8 @@ public class UriTemplate<T>
     /// </summary>
     public T Evaluate(IDictionary<string, string> variables)
     {
-        if (variables == null)
-        {
-            throw new ArgumentNullException(nameof(variables));
-        }
+        ArgumentNullException.ThrowIfNull(variables);
+
         var uri = EvaluateUri(variables);
         var value = _func(uri);
         return RunPostPipeline(value);

--- a/src/Docfx.Common/UriUtility.cs
+++ b/src/Docfx.Common/UriUtility.cs
@@ -13,68 +13,54 @@ public static class UriUtility
 
     public static bool HasFragment(string uriString)
     {
-        if (uriString == null)
-        {
-            throw new ArgumentNullException(nameof(uriString));
-        }
+        ArgumentNullException.ThrowIfNull(uriString);
+
         return uriString.IndexOf(FragmentMarker) != -1;
     }
 
     public static bool HasQueryString(string uriString)
     {
-        if (uriString == null)
-        {
-            throw new ArgumentNullException(nameof(uriString));
-        }
+        ArgumentNullException.ThrowIfNull(uriString);
+
         return uriString.IndexOf(QueryMarker) != -1;
     }
 
     public static string GetFragment(string uriString)
     {
-        if (uriString == null)
-        {
-            throw new ArgumentNullException(nameof(uriString));
-        }
+        ArgumentNullException.ThrowIfNull(uriString);
+
         var index = uriString.IndexOf(FragmentMarker);
         return index == -1 ? string.Empty : uriString.Substring(index);
     }
 
     public static string GetNonFragment(string uriString)
     {
-        if (uriString == null)
-        {
-            throw new ArgumentNullException(nameof(uriString));
-        }
+        ArgumentNullException.ThrowIfNull(uriString);
+
         var index = uriString.IndexOf(FragmentMarker);
         return index == -1 ? uriString : uriString.Remove(index);
     }
 
     public static string GetQueryString(string uriString)
     {
-        if (uriString == null)
-        {
-            throw new ArgumentNullException(nameof(uriString));
-        }
+        ArgumentNullException.ThrowIfNull(uriString);
+
         var index = uriString.IndexOf(QueryMarker);
         return index == -1 ? string.Empty : GetNonFragment(uriString.Substring(index));
     }
 
     public static string GetPath(string uriString)
     {
-        if (uriString == null)
-        {
-            throw new ArgumentNullException(nameof(uriString));
-        }
+        ArgumentNullException.ThrowIfNull(uriString);
+
         var index = uriString.IndexOfAny(QueryAndFragmentMarkers);
         return index == -1 ? uriString : uriString.Remove(index);
     }
 
     public static string GetQueryStringAndFragment(string uriString)
     {
-        if (uriString == null)
-        {
-            throw new ArgumentNullException(nameof(uriString));
-        }
+        ArgumentNullException.ThrowIfNull(uriString);
+
         var index = uriString.IndexOfAny(QueryAndFragmentMarkers);
         return index == -1 ? string.Empty : uriString.Substring(index);
     }
@@ -105,10 +91,8 @@ public static class UriUtility
 
     public static (string path, string query, string fragment) Split(string uri)
     {
-        if (uri == null)
-        {
-            throw new ArgumentNullException(nameof(uri));
-        }
+        ArgumentNullException.ThrowIfNull(uri);
+
         if (uri?.Length == 0)
         {
             return (string.Empty, string.Empty, string.Empty);

--- a/src/Docfx.Common/YamlMime.cs
+++ b/src/Docfx.Common/YamlMime.cs
@@ -14,10 +14,8 @@ public static class YamlMime
 
     public static string ReadMime(TextReader reader)
     {
-        if (reader == null)
-        {
-            throw new ArgumentNullException(nameof(reader));
-        }
+        ArgumentNullException.ThrowIfNull(reader);
+
         var line = reader.ReadLine();
         if (line == null || !line.StartsWith("#", StringComparison.Ordinal))
         {
@@ -33,10 +31,7 @@ public static class YamlMime
 
     public static string ReadMime(string file)
     {
-        if (file == null)
-        {
-            throw new ArgumentNullException(nameof(file));
-        }
+        ArgumentNullException.ThrowIfNull(file);
 
         using var stream = EnvironmentContext.FileAbstractLayer.OpenRead(file);
         using var reader = new StreamReader(stream);

--- a/src/Docfx.DataContracts.Common/ExternalReferences/ExternalReferencePackageCollection.cs
+++ b/src/Docfx.DataContracts.Common/ExternalReferences/ExternalReferencePackageCollection.cs
@@ -10,10 +10,8 @@ public class ExternalReferencePackageCollection : IDisposable
 
     public ExternalReferencePackageCollection(IEnumerable<string> packageFiles, int maxParallelism)
     {
-        if (packageFiles == null)
-        {
-            throw new ArgumentNullException(nameof(packageFiles));
-        }
+        ArgumentNullException.ThrowIfNull(packageFiles);
+
         Readers = (from file in packageFiles.AsParallel().WithDegreeOfParallelism(maxParallelism).AsOrdered()
                    let reader = ExternalReferencePackageReader.CreateNoThrow(file)
                    where reader != null

--- a/src/Docfx.DataContracts.Common/ExternalReferences/ExternalReferencePackageWriter.cs
+++ b/src/Docfx.DataContracts.Common/ExternalReferences/ExternalReferencePackageWriter.cs
@@ -37,14 +37,9 @@ public class ExternalReferencePackageWriter : IDisposable
 
     public void AddOrUpdateEntry(string entryName, List<ReferenceViewModel> vm)
     {
-        if (entryName == null)
-        {
-            throw new ArgumentNullException(nameof(entryName));
-        }
-        if (vm == null)
-        {
-            throw new ArgumentNullException(nameof(vm));
-        }
+        ArgumentNullException.ThrowIfNull(entryName);
+        ArgumentNullException.ThrowIfNull(vm);
+
         if (vm.Count == 0)
         {
             throw new ArgumentException("Empty collection is not allowed.", nameof(vm));

--- a/src/Docfx.Dotnet/ExtractMetadata/ReferenceItem.cs
+++ b/src/Docfx.Dotnet/ExtractMetadata/ReferenceItem.cs
@@ -94,10 +94,8 @@ internal class ReferenceItem
 
     internal void Merge(ReferenceItem other)
     {
-        if (other == null)
-        {
-            throw new ArgumentNullException(nameof(other));
-        }
+        ArgumentNullException.ThrowIfNull(other);
+
         IsDefinition = Merge(other.IsDefinition, IsDefinition);
         Definition = Merge(other.Definition, Definition);
         Parent = Merge(other.Parent, Parent);

--- a/src/Docfx.Dotnet/Filters/ConfigFilterRuleItem.cs
+++ b/src/Docfx.Dotnet/Filters/ConfigFilterRuleItem.cs
@@ -35,10 +35,8 @@ internal abstract class ConfigFilterRuleItem
 
     public bool IsMatch(SymbolFilterData symbol)
     {
-        if (symbol == null)
-        {
-            throw new ArgumentNullException("symbol");
-        }
+        ArgumentNullException.ThrowIfNull(symbol);
+
         var id = symbol.Id;
 
         return (_uidRegex == null || (id != null && _uidRegex.IsMatch(id))) &&

--- a/src/Docfx.Dotnet/SourceLink/SourceLinkMap.cs
+++ b/src/Docfx.Dotnet/SourceLink/SourceLinkMap.cs
@@ -82,10 +82,7 @@ namespace Microsoft.SourceLink.Tools
         /// <exception cref="JsonException"><paramref name="json"/> is not valid JSON string.</exception>
         public static SourceLinkMap Parse(string json)
         {
-            if (json is null)
-            {
-                throw new ArgumentNullException(nameof(json));
-            }
+            ArgumentNullException.ThrowIfNull(json);
 
             var list = new List<Entry>();
 
@@ -192,10 +189,7 @@ namespace Microsoft.SourceLink.Tools
 #endif
             out string? uri)
         {
-            if (path == null)
-            {
-                throw new ArgumentNullException(nameof(path));
-            }
+            ArgumentNullException.ThrowIfNull(path);
 
             if (path.IndexOf('*') >= 0)
             {

--- a/src/Docfx.Glob/GlobMatcher.cs
+++ b/src/Docfx.Glob/GlobMatcher.cs
@@ -51,7 +51,8 @@ public class GlobMatcher : IEquatable<GlobMatcher>
 
     public GlobMatcher(string pattern, GlobMatcherOptions options = DefaultOptions)
     {
-        if (pattern == null) throw new ArgumentNullException(nameof(pattern));
+        ArgumentNullException.ThrowIfNull(pattern);
+
         Options = options;
         Raw = pattern;
         _ignoreCase = Options.HasFlag(GlobMatcherOptions.IgnoreCase);
@@ -89,7 +90,8 @@ public class GlobMatcher : IEquatable<GlobMatcher>
 
     public bool Match(string file, bool partial = false)
     {
-        if (file == null) throw new ArgumentNullException(nameof(file));
+        ArgumentNullException.ThrowIfNull(file);
+
         var fileParts = Split(file, '/', '\\').ToArray();
         bool isMatch = false;
         foreach (var glob in _items)

--- a/src/Docfx.MarkdigEngine.Extensions/Rewriter/MarkdownDocumentVisitor.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/Rewriter/MarkdownDocumentVisitor.cs
@@ -17,10 +17,7 @@ public class MarkdownDocumentVisitor
 
     public void Visit(MarkdownDocument document)
     {
-        if (document == null)
-        {
-            throw new ArgumentNullException(nameof(document));
-        }
+        ArgumentNullException.ThrowIfNull(document);
 
         if (_rewriter == null)
         {

--- a/src/Docfx.MarkdigEngine/MarkdigMarkdownService.cs
+++ b/src/Docfx.MarkdigEngine/MarkdigMarkdownService.cs
@@ -43,15 +43,8 @@ public class MarkdigMarkdownService : IMarkdownService
 
     public MarkupResult Markup(string content, string filePath, bool multipleYamlHeader)
     {
-        if (content == null)
-        {
-            throw new ArgumentNullException(nameof(content));
-        }
-
-        if (filePath == null)
-        {
-            throw new ArgumentException("file path can't be null or empty.");
-        }
+        ArgumentNullException.ThrowIfNull(content);
+        ArgumentNullException.ThrowIfNull(filePath);
 
         var pipeline = CreateMarkdownPipeline(isInline: false, multipleYamlHeader);
 
@@ -72,10 +65,7 @@ public class MarkdigMarkdownService : IMarkdownService
 
     public MarkdownDocument Parse(string content, string filePath, bool isInline)
     {
-        if (content == null)
-        {
-            throw new ArgumentNullException(nameof(content));
-        }
+        ArgumentNullException.ThrowIfNull(content);
 
         if (string.IsNullOrEmpty(filePath))
         {
@@ -100,10 +90,7 @@ public class MarkdigMarkdownService : IMarkdownService
 
     public MarkupResult Render(MarkdownDocument document, bool isInline)
     {
-        if (document == null)
-        {
-            throw new ArgumentNullException(nameof(document));
-        }
+        ArgumentNullException.ThrowIfNull(document);
 
         if (!(document.GetData("filePath") is string filePath))
         {

--- a/src/Docfx.Plugins/DocumentException.cs
+++ b/src/Docfx.Plugins/DocumentException.cs
@@ -12,10 +12,8 @@ public class DocumentException : Exception
 
     public static void RunAll(params Action[] actions)
     {
-        if (actions == null)
-        {
-            throw new ArgumentNullException(nameof(actions));
-        }
+        ArgumentNullException.ThrowIfNull(actions);
+
         DocumentException firstException = null;
         foreach (var action in actions)
         {

--- a/src/Docfx.Plugins/DocumentExceptionExtensions.cs
+++ b/src/Docfx.Plugins/DocumentExceptionExtensions.cs
@@ -4,14 +4,9 @@ public static class DocumentExceptionExtensions
 {
     public static TResult[] RunAll<TElement, TResult>(this IReadOnlyList<TElement> elements, Func<TElement, TResult> func)
     {
-        if (elements == null)
-        {
-            throw new ArgumentNullException(nameof(elements));
-        }
-        if (func == null)
-        {
-            throw new ArgumentNullException(nameof(func));
-        }
+        ArgumentNullException.ThrowIfNull(elements);
+        ArgumentNullException.ThrowIfNull(func);
+
         var results = new TResult[elements.Count];
         DocumentException firstException = null;
         for (int i = 0; i < elements.Count; i++)
@@ -39,14 +34,9 @@ public static class DocumentExceptionExtensions
 
     public static void RunAll<TElement>(this IEnumerable<TElement> elements, Action<TElement> action)
     {
-        if (elements == null)
-        {
-            throw new ArgumentNullException(nameof(elements));
-        }
-        if (action == null)
-        {
-            throw new ArgumentNullException(nameof(action));
-        }
+        ArgumentNullException.ThrowIfNull(elements);
+        ArgumentNullException.ThrowIfNull(action);
+
         DocumentException firstException = null;
         foreach (var element in elements)
         {
@@ -72,14 +62,9 @@ public static class DocumentExceptionExtensions
 
     public static void RunAll<TElement>(this IEnumerable<TElement> elements, Action<TElement> action, int parallelism)
     {
-        if (elements == null)
-        {
-            throw new ArgumentNullException(nameof(elements));
-        }
-        if (action == null)
-        {
-            throw new ArgumentNullException(nameof(action));
-        }
+        ArgumentNullException.ThrowIfNull(elements);
+        ArgumentNullException.ThrowIfNull(action);
+
         if (parallelism <= 0)
         {
             throw new ArgumentOutOfRangeException(nameof(parallelism));

--- a/src/Docfx.Plugins/FileAndType.cs
+++ b/src/Docfx.Plugins/FileAndType.cs
@@ -11,14 +11,9 @@ public sealed class FileAndType
     [JsonConstructor]
     public FileAndType(string baseDir, string file, DocumentType type, string sourceDir = null, string destinationDir = null)
     {
-        if (baseDir == null)
-        {
-            throw new ArgumentNullException(nameof(baseDir));
-        }
-        if (file == null)
-        {
-            throw new ArgumentNullException(nameof(file));
-        }
+        ArgumentNullException.ThrowIfNull(baseDir);
+        ArgumentNullException.ThrowIfNull(file);
+
         if (!Path.IsPathRooted(baseDir))
         {
             throw new ArgumentException("Base directory must be rooted.", nameof(baseDir));

--- a/src/Docfx.Plugins/XRefSpec.cs
+++ b/src/Docfx.Plugins/XRefSpec.cs
@@ -20,10 +20,8 @@ public sealed class XRefSpec : IDictionary<string, object>
 
     public XRefSpec(IDictionary<string, object> dictionary)
     {
-        if (dictionary == null)
-        {
-            throw new ArgumentNullException(nameof(dictionary));
-        }
+        ArgumentNullException.ThrowIfNull(dictionary);
+
         _dict = new Dictionary<string, object>(dictionary);
     }
 

--- a/src/Docfx.YamlSerialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
+++ b/src/Docfx.YamlSerialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
@@ -40,9 +40,12 @@ public class FullObjectGraphTraversalStrategy : IObjectGraphTraversalStrategy
             throw new ArgumentOutOfRangeException("maxRecursion", maxRecursion, "maxRecursion must be greater than 1");
         }
 
+        ArgumentNullException.ThrowIfNull(typeDescriptor);
+        ArgumentNullException.ThrowIfNull(typeResolver);
+
         Serializer = serializer;
-        _typeDescriptor = typeDescriptor ?? throw new ArgumentNullException("typeDescriptor");
-        _typeResolver = typeResolver ?? throw new ArgumentNullException("typeResolver");
+        _typeDescriptor = typeDescriptor;
+        _typeResolver = typeResolver;
         _maxRecursion = maxRecursion;
         _namingConvention = namingConvention;
     }

--- a/src/Docfx.YamlSerialization/TypeInspectors/ExtensibleNamingConventionTypeInspector.cs
+++ b/src/Docfx.YamlSerialization/TypeInspectors/ExtensibleNamingConventionTypeInspector.cs
@@ -12,18 +12,10 @@ public sealed class ExtensibleNamingConventionTypeInspector : ExtensibleTypeInsp
 
     public ExtensibleNamingConventionTypeInspector(IExtensibleTypeInspector innerTypeDescriptor, INamingConvention namingConvention)
     {
-        if (innerTypeDescriptor == null)
-        {
-            throw new ArgumentNullException(nameof(innerTypeDescriptor));
-        }
+        ArgumentNullException.ThrowIfNull(innerTypeDescriptor);
+        ArgumentNullException.ThrowIfNull(namingConvention);
 
         this.innerTypeDescriptor = innerTypeDescriptor;
-
-        if (namingConvention == null)
-        {
-            throw new ArgumentNullException(nameof(namingConvention));
-        }
-
         this.namingConvention = namingConvention;
     }
 

--- a/src/Docfx.YamlSerialization/YamlDeserializer.cs
+++ b/src/Docfx.YamlSerialization/YamlDeserializer.cs
@@ -160,15 +160,8 @@ public sealed class YamlDeserializer
     /// <returns>Returns the deserialized object.</returns>
     public object Deserialize(IParser parser, Type type, IValueDeserializer deserializer = null)
     {
-        if (parser == null)
-        {
-            throw new ArgumentNullException("reader");
-        }
-
-        if (type == null)
-        {
-            throw new ArgumentNullException("type");
-        }
+        ArgumentNullException.ThrowIfNull(parser);
+        ArgumentNullException.ThrowIfNull(type);
 
         var hasStreamStart = parser.TryConsume<StreamStart>(out _);
 
@@ -201,7 +194,9 @@ public sealed class YamlDeserializer
 
         public LooseAliasValueDeserializer(IValueDeserializer innerDeserializer)
         {
-            _innerDeserializer = innerDeserializer ?? throw new ArgumentNullException("innerDeserializer");
+            ArgumentNullException.ThrowIfNull(innerDeserializer);
+
+            _innerDeserializer = innerDeserializer;
         }
 
         private sealed class AliasState : Dictionary<AnchorName, ValuePromise>, IPostDeserializationCallback

--- a/src/Docfx.YamlSerialization/YamlSerializer.cs
+++ b/src/Docfx.YamlSerialization/YamlSerializer.cs
@@ -52,10 +52,7 @@ public class YamlSerializer
 
     public void Serialize(IEmitter emitter, object graph)
     {
-        if (emitter == null)
-        {
-            throw new ArgumentNullException("emitter");
-        }
+        ArgumentNullException.ThrowIfNull(emitter);
 
         EmitDocument(emitter, new BetterObjectDescriptor(graph, graph != null ? graph.GetType() : typeof(object), typeof(object)));
     }

--- a/src/docfx/Models/InitCommand.cs
+++ b/src/docfx/Models/InitCommand.cs
@@ -372,8 +372,12 @@ TODO: Add .NET projects to the *src* folder and run `docfx` to generate **REAL**
         public SingleChoiceQuestion(string content, Action<T, DefaultConfigModel, QuestionContext> setter, Func<string, T> converter, params string[] options)
             : base(content, setter)
         {
-            if (options == null || options.Length == 0) throw new ArgumentNullException(nameof(options));
-            _converter = converter ?? throw new ArgumentNullException(nameof(converter));
+            ArgumentNullException.ThrowIfNull(options);
+            ArgumentNullException.ThrowIfNull(converter);
+
+            if (options.Length == 0) throw new ArgumentNullException(nameof(options));
+
+            _converter = converter;
             Options = options;
             DefaultAnswer = options[0];
             DefaultValue = converter(DefaultAnswer);
@@ -487,7 +491,8 @@ TODO: Add .NET projects to the *src* folder and run `docfx` to generate **REAL**
 
         public Question(string content, Action<T, DefaultConfigModel, QuestionContext> setter)
         {
-            if (setter == null) throw new ArgumentNullException(nameof(setter));
+            ArgumentNullException.ThrowIfNull(setter);
+
             Content = content;
             _setter = setter;
         }

--- a/test/Docfx.MarkdigEngine.Tests/TestUtility/TestLoggerListener.cs
+++ b/test/Docfx.MarkdigEngine.Tests/TestUtility/TestLoggerListener.cs
@@ -12,7 +12,9 @@ internal class TestLoggerListener : ILoggerListener
 
     public TestLoggerListener(Func<ILogItem, bool> filter)
     {
-        _filter = filter ?? throw new ArgumentNullException(nameof(filter));
+        ArgumentNullException.ThrowIfNull(filter);
+
+        _filter = filter;
     }
 
     public void Dispose()
@@ -25,10 +27,7 @@ internal class TestLoggerListener : ILoggerListener
 
     public void WriteLine(ILogItem item)
     {
-        if (item == null)
-        {
-            throw new ArgumentNullException(nameof(item));
-        }
+        ArgumentNullException.ThrowIfNull(item);
 
         if (_filter(item))
         {

--- a/test/Docfx.Tests.Common/TestBase.cs
+++ b/test/Docfx.Tests.Common/TestBase.cs
@@ -55,10 +55,8 @@ public class TestBase : IClassFixture<TestBase>, IDisposable
 
     protected static string CreateFile(string fileName, string[] lines, string baseFolder)
     {
-        if (lines == null)
-        {
-            throw new ArgumentNullException(nameof(lines));
-        }
+        ArgumentNullException.ThrowIfNull(lines);
+
         var dir = Path.GetDirectoryName(fileName);
         dir = CreateDirectory(dir, baseFolder);
         var file = Path.Combine(baseFolder, fileName);
@@ -68,18 +66,10 @@ public class TestBase : IClassFixture<TestBase>, IDisposable
 
     protected static string CreateFile(string fileName, string content, string baseFolder)
     {
-        if (fileName == null)
-        {
-            throw new ArgumentNullException(nameof(fileName));
-        }
-        if (content == null)
-        {
-            throw new ArgumentNullException(nameof(content));
-        }
-        if (baseFolder == null)
-        {
-            throw new ArgumentNullException(nameof(baseFolder));
-        }
+        ArgumentNullException.ThrowIfNull(fileName);
+        ArgumentNullException.ThrowIfNull(content);
+        ArgumentNullException.ThrowIfNull(baseFolder);
+
         var dir = Path.GetDirectoryName(fileName);
         dir = CreateDirectory(dir, baseFolder);
         var file = Path.Combine(baseFolder, fileName);
@@ -89,50 +79,29 @@ public class TestBase : IClassFixture<TestBase>, IDisposable
 
     protected static string UpdateFile(string fileName, string[] lines, string baseFolder)
     {
-        if (fileName == null)
-        {
-            throw new ArgumentNullException(nameof(fileName));
-        }
-        if (lines == null)
-        {
-            throw new ArgumentNullException(nameof(lines));
-        }
-        if (baseFolder == null)
-        {
-            throw new ArgumentNullException(nameof(baseFolder));
-        }
+        ArgumentNullException.ThrowIfNull(fileName);
+        ArgumentNullException.ThrowIfNull(lines);
+        ArgumentNullException.ThrowIfNull(baseFolder);
+
         File.Delete(Path.Combine(baseFolder, fileName));
         return CreateFile(fileName, lines, baseFolder);
     }
 
     protected static string UpdateFile(string fileName, string content, string baseFolder)
     {
-        if (fileName == null)
-        {
-            throw new ArgumentNullException(nameof(fileName));
-        }
-        if (content == null)
-        {
-            throw new ArgumentNullException(nameof(content));
-        }
-        if (baseFolder == null)
-        {
-            throw new ArgumentNullException(nameof(baseFolder));
-        }
+        ArgumentNullException.ThrowIfNull(fileName);
+        ArgumentNullException.ThrowIfNull(content);
+        ArgumentNullException.ThrowIfNull(baseFolder);
+
         File.Delete(Path.Combine(baseFolder, fileName));
         return CreateFile(fileName, content, baseFolder);
     }
 
     protected static string CreateDirectory(string dir, string baseFolder)
     {
-        if (string.IsNullOrEmpty(dir))
-        {
-            return string.Empty;
-        }
-        if (baseFolder == null)
-        {
-            throw new ArgumentNullException(nameof(baseFolder));
-        }
+        ArgumentNullException.ThrowIfNull(dir);
+        ArgumentNullException.ThrowIfNull(baseFolder);
+
         var subDirectory = Path.Combine(baseFolder, dir);
         Directory.CreateDirectory(subDirectory);
         return subDirectory;

--- a/test/Docfx.Tests.Common/TestLoggerListener.cs
+++ b/test/Docfx.Tests.Common/TestLoggerListener.cs
@@ -13,17 +13,17 @@ public class TestLoggerListener : ILoggerListener
 
     public TestLoggerListener(Func<ILogItem, bool> filter)
     {
-        _filter = filter ?? throw new ArgumentNullException(nameof(filter));
+        ArgumentNullException.ThrowIfNull(filter);
+
+        _filter = filter;
     }
 
     #region ILoggerListener
 
     public void WriteLine(ILogItem item)
     {
-        if (item == null)
-        {
-            throw new ArgumentNullException(nameof(item));
-        }
+        ArgumentNullException.ThrowIfNull(item);
+
         if (_filter(item))
         {
             Items.Add(item);


### PR DESCRIPTION
**What's included in this PR**
Rewrite parameter null check with following helper methods. 
  -  `ArgumentNullException.ThrowIfNull`(Require .NET 6 or later) 
  -  `ArgumentNullException.ThrowIfNullOrEmpty` (Require .NET 7)

These change will not affects application behaviors.
It's intended following purpose.
- Code readability
- Line coverage improvement.
- Better code size and code inlining.

**Related Roslyn Analyzer rules**

CA1510: Use ArgumentNullException throw helper

https://github.com/dotnet/roslyn-analyzers/blob/main/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.md#ca1510-use-argumentnullexception-throw-helper
