### PR TITLE
Fix TOC max height size

### DIFF
--- a/templates/modern/src/layout.scss
+++ b/templates/modern/src/layout.scss
@@ -124,7 +124,7 @@ body[data-layout="landing"] {
           overflow-x: hidden;
           overflow-y: auto;
           max-width: 360px;
-          max-height: calc(100vh - #{$header-height});
+          max-height: calc(100vh - $header-height - $main-padding-top);
 
           @include stick-to-header;
 


### PR DESCRIPTION
Max height of `toc-offcanvas` is calculated by only subtracting header height from viewport size:

https://github.com/dotnet/docfx/blob/a8d1438c20ce62c68d0cb26b687731d3e42a4643/templates/modern/src/layout.scss#L121-L127

This causes a portion of TOC to expand out of the viewport if main part of the page isn't scrolled all the way down:
![image](https://github.com/dotnet/docfx/assets/11288915/be03ba24-ba7b-4623-8fea-4f07428101c9)

Proposed solution is to also subtract main elements top padding size from viewport height:
![image](https://github.com/dotnet/docfx/assets/11288915/2b03494e-4555-4677-bcf5-608d98e74786)

