### PR TITLE
Fix affix max height size

### DIFF
--- a/templates/modern/src/layout.scss
+++ b/templates/modern/src/layout.scss
@@ -163,7 +163,7 @@ body[data-layout="landing"] {
         >.affix {
           display: block;
           width: 230px;
-          max-height: calc(100vh - #{$header-height});
+          max-height: calc(100vh - $header-height - $main-padding-top);
           overflow-x: hidden;
           overflow-y: auto;
 


### PR DESCRIPTION
Similar fix as #9035 for modern template `affix` element ("In this article" section).