### PR TITLE
build(deps): bump Microsoft.Build from 17.3.2 to 17.7.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
 
      <!-- "17.3.2" is the latest compatible version for .NET 6 -->
     <PackageVersion Include="Microsoft.Build" Version="[17.3.2]" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageVersion Include="Microsoft.Build" Version="17.6.3"   Condition="'$(TargetFramework)' != 'net6.0'" />
+    <PackageVersion Include="Microsoft.Build" Version="17.7.0"   Condition="'$(TargetFramework)' != 'net6.0'" />
 
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.5.5" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.6.0" />


### PR DESCRIPTION
**What's included in this PR**
Manually Update `Microsoft.Build` package from `17.3.2` to `17.7.0`.
Because PR (https://github.com/dotnet/docfx/pull/9062) created by dependabot ignore version range specifier.