### PR TITLE
perf: Reduce lock wait when checking git command exists or not

### DIFF
--- a/src/Docfx.Common/Git/GitUtility.cs
+++ b/src/Docfx.Common/Git/GitUtility.cs
@@ -52,12 +52,20 @@ public static class GitUtility
     /// </summary>
     public static Lazy<bool> ExistGitCommand = new(() =>
     {
-        bool gitCommandExists = CommandUtility.ExistCommand(CommandName);
-        if (!gitCommandExists)
+        try
         {
-            Logger.LogInfo("Looks like Git is not installed globally. We depend on Git to extract repository information for source code and files.");
+            bool gitCommandExists = CommandUtility.ExistCommand(CommandName);
+            if (!gitCommandExists)
+            {
+                Logger.LogInfo("Looks like Git is not installed globally. We depend on Git to extract repository information for source code and files.");
+            }
+            return gitCommandExists;
         }
-        return gitCommandExists;
+        catch(Exception ex)
+        {
+            Logger.LogWarning("Failed to get Git command that installed globally. Exception: " + ex.ToString());
+            return false;
+        }
     }, LazyThreadSafetyMode.ExecutionAndPublication);
 
     public static GitDetail TryGetFileDetail(string filePath)

--- a/src/Docfx.Common/Git/GitUtility.cs
+++ b/src/Docfx.Common/Git/GitUtility.cs
@@ -47,8 +47,18 @@ public static class GitUtility
 
     private static readonly ConcurrentDictionary<string, GitRepoInfo> Cache = new();
 
-    private static bool? GitCommandExists = null;
-    private static object SyncRoot = new();
+    /// <summary>
+    /// Gets git is installed globally or not.
+    /// </summary>
+    public static Lazy<bool> ExistGitCommand = new(() =>
+    {
+        bool gitCommandExists = CommandUtility.ExistCommand(CommandName);
+        if (!gitCommandExists)
+        {
+            Logger.LogInfo("Looks like Git is not installed globally. We depend on Git to extract repository information for source code and files.");
+        }
+        return gitCommandExists;
+    }, LazyThreadSafetyMode.ExecutionAndPublication);
 
     public static GitDetail TryGetFileDetail(string filePath)
     {
@@ -160,7 +170,7 @@ public static class GitUtility
 
     private static GitDetail GetFileDetail(string filePath)
     {
-        if (string.IsNullOrEmpty(filePath) || !ExistGitCommand())
+        if (string.IsNullOrEmpty(filePath) || !ExistGitCommand.Value)
         {
             return null;
         }
@@ -365,26 +375,5 @@ public static class GitUtility
             }
         }
     }
-
-    private static bool ExistGitCommand()
-    {
-        if (GitCommandExists == null)
-        {
-            lock (SyncRoot)
-            {
-                if (GitCommandExists == null)
-                {
-                    GitCommandExists = CommandUtility.ExistCommand(CommandName);
-                    if (GitCommandExists != true)
-                    {
-                        Logger.LogInfo("Looks like Git is not installed globally. We depend on Git to extract repository information for source code and files.");
-                    }
-                }
-            }
-        }
-
-        return GitCommandExists.Value;
-    }
-
     #endregion
 }


### PR DESCRIPTION
**What's included in this PR**
Modify GitUtility's `ExistGitCommand` method to `Lazy<bool>` property.
And Initialize that property on startup phase.

**Background**
`ExistGitCommand()` takes about 70-100ms.
On Release build. About 3～6 threads are blocked by double-checked locking's  lock when worker thread's start operations.
To reduce lock wait. Add `Lazy<bool>` property initialize logic to `RunBuild.cs`.
