### PR TITLE
perf: Optimize templates resource loading peformance

### DIFF
--- a/src/Docfx.Build.Engine/DocumentBuilder.cs
+++ b/src/Docfx.Build.Engine/DocumentBuilder.cs
@@ -233,7 +233,7 @@ public class DocumentBuilder : IDisposable
                 }
 
                 var siteHostName = TryGetPublishTargetSiteHostNameFromEnvironment();
-                var markdigMarkdownService = CreateMarkdigMarkdownService(parameter);
+                var markdigMarkdownService = CreateMarkdigMarkdownService(parameter, resource);
                 foreach (var pair in resource.GetResources(@"^schemas/.*\.schema\.json"))
                 {
                     var fileName = Path.GetFileName(pair.Path);
@@ -262,10 +262,8 @@ public class DocumentBuilder : IDisposable
         }
     }
 
-    private MarkdigMarkdownService CreateMarkdigMarkdownService(DocumentBuildParameters parameters)
+    private MarkdigMarkdownService CreateMarkdigMarkdownService(DocumentBuildParameters parameters, CompositeResourceReader resourceProvider)
     {
-        var resourceProvider = parameters.TemplateManager?.CreateTemplateResource();
-
         return new MarkdigMarkdownService(
             new MarkdownServiceParameters
             {

--- a/src/Docfx.Build.Engine/ResourceFileReaders/CompositeResourceReader.cs
+++ b/src/Docfx.Build.Engine/ResourceFileReaders/CompositeResourceReader.cs
@@ -18,7 +18,7 @@ public sealed class CompositeResourceReader : ResourceFileReader, IEnumerable<Re
     {
         _readers = declaredReaders.ToArray();
         IsEmpty = _readers.Length == 0;
-        Names = _readers.SelectMany(s => s.Names).Distinct();
+        Names = _readers.SelectMany(s => s.Names).Distinct().ToArray();
     }
 
     public override Stream GetResourceStream(string name)


### PR DESCRIPTION
**What's included in this PR**
Small perf optimization related to templates resource loading.
- Remove unnecessary `CreateTemplateResource()` call.
- Call `ToArray()` before `IResourceFileReader::Names` property is set.  
  Because Names are enumerated multiple times.
- Add `HashSet<string>` for Names check. Because `ResourceFileReader::GetResourceStream` is called multiple times.
  For example. it is called about 443 times for `samples/seed` project.
  And Names contains 71/93 elements (For default/modern templates).


