### PR TITLE
chore: Cleanup tests and fix spellings

### DIFF
--- a/src/Docfx.Build.Engine/ManifestProcessor.cs
+++ b/src/Docfx.Build.Engine/ManifestProcessor.cs
@@ -77,7 +77,7 @@ internal class ManifestProcessor
 
     private void NormalizeToObject()
     {
-        Logger.LogVerbose("Normalizing all the object to week type");
+        Logger.LogVerbose("Normalizing all the object to weak type");
 
         _manifestWithContext.RunAll(m =>
         {

--- a/src/Docfx.Build.SchemaDriven/OverwriteApplier.cs
+++ b/src/Docfx.Build.SchemaDriven/OverwriteApplier.cs
@@ -98,7 +98,7 @@ public class OverwriteApplier
             transformed["conceptual"] = context.ContentAnchorParser.Content;
         }
 
-        // add SourceDetail back to transformed, in week type
+        // add SourceDetail back to transformed, in weak type
         if (overwrite.Documentation != null)
         {
             transformed[Constants.PropertyName.Documentation] = new Dictionary<string, object>

--- a/test/Docfx.Build.Engine.Tests/XRefMapDownloaderTest.cs
+++ b/test/Docfx.Build.Engine.Tests/XRefMapDownloaderTest.cs
@@ -23,9 +23,6 @@ public class XRefMapDownloadTest
     [Fact]
     public async Task ReadLocalXRefMapWithFallback()
     {
-        // GitHub doesn't support TLS 1.1 since Feb 23, 2018. See: https://github.com/blog/2507-weak-cryptographic-standards-removed
-        ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-
         var basePath = Path.GetRandomFileName();
         var fallbackFolders = new List<string>() { Path.Combine(Directory.GetCurrentDirectory(), "TestData") };
         var xrefmaps = new List<string>() { "xrefmap.yml" };

--- a/test/Docfx.Build.ManagedReference.Tests/ManagedReferenceDocumentProcessorTest.cs
+++ b/test/Docfx.Build.ManagedReference.Tests/ManagedReferenceDocumentProcessorTest.cs
@@ -269,7 +269,7 @@ public class ManagedReferenceDocumentProcessorTest : TestBase
         }
     }
 
-    [Fact(Skip = "Markdig does not support multi-uid overwrite")]
+    [Fact]
     public void ProcessMrefWithMultiUidOverwriteShouldSucceed()
     {
         var files = new FileCollection(_defaultFiles);
@@ -281,7 +281,7 @@ public class ManagedReferenceDocumentProcessorTest : TestBase
             var model = JsonUtility.Deserialize<ApiBuildOutput>(outputRawModelPath);
             Assert.Equal("\n<p sourcefile=\"TestData/overwrite/mref.overwrite.multi.uid.md\" sourcestartlinenumber=\"6\">Overwrite content1</p>\n", model.Conceptual);
             Assert.Equal("\n<p sourcefile=\"TestData/overwrite/mref.overwrite.multi.uid.md\" sourcestartlinenumber=\"13\">Overwrite &quot;content2&quot;</p>\n", model.Summary);
-            Assert.Equal("\n<p sourcefile=\"TestData/overwrite/mref.overwrite.multi.uid.md\" sourcestartlinenumber=\"20\">Overwrite &#39;content3&#39;</p>\n", model.Metadata["not_defined_property"]);
+            Assert.Equal("\n<p sourcefile=\"TestData/overwrite/mref.overwrite.multi.uid.md\" sourcestartlinenumber=\"20\">Overwrite 'content3'</p>\n", model.Metadata["not_defined_property"]);
         }
     }
 

--- a/test/Docfx.Build.SchemaDriven.Tests/LimitationReachedTest.cs
+++ b/test/Docfx.Build.SchemaDriven.Tests/LimitationReachedTest.cs
@@ -42,39 +42,6 @@ public class LimitationReachedTest : TestBase
         _templateManager = new TemplateManager(new List<string> { "template" }, null, _templateFolder);
     }
 
-    [Fact(Skip = "Manually run this testcase, as it will influence the result of other test cases")]
-    public void TestSchemaReachedLimits()
-    {
-        // Json.NET schema has limitation of 1000 calls per hour
-        using var listener = new TestListenerScope("TestInvalidMetadataReference");
-        var schemaFile = CreateFile("template/schemas/limit.test.schema.json", @"
-{
-  ""$schema"": ""http://dotnet.github.io/docfx/schemas/v1.0/schema.json#"",
-  ""version"": ""1.0.0"",
-  ""title"": ""LimitTest"",
-  ""description"": ""A simple test schema for sdp"",
-  ""type"": ""object"",
-  ""properties"": {
-      ""metadata"": {
-            ""type"": ""string""
-      }
-  }
-}
-", _templateFolder);
-
-        var inputFiles = Enumerable.Range(0, 2000)
-            .Select(s => CreateFile($"normal{s}.yml", @"### YamlMime:LimitTest
-metadata: Web Apps Documentation
-", _inputFolder)).ToArray();
-
-        FileCollection files = new(_defaultFiles);
-        files.Add(DocumentType.Article, inputFiles, _inputFolder);
-        BuildDocument(files);
-        Assert.Equal(2, listener.Items.Count);
-        Assert.Single(listener.Items.Where(s => s.Message == "There is no template processing document type(s): LimitTest"));
-        Assert.True(LimitationReached(listener));
-    }
-
     private void BuildDocument(FileCollection files)
     {
         var parameters = new DocumentBuildParameters

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/CodeSnippetTest.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/CodeSnippetTest.cs
@@ -264,8 +264,8 @@ public class MyClass
     }
 
     [Fact]
-    [Trait("Related", "DfmMarkdown")]
-    public void TestDfmFencesBlockLevel()
+    [Trait("Related", "Markdown")]
+    public void TestFencesBlockLevel()
     {
         var root = @"
 [!code-FakeREST[REST](api.json)]
@@ -292,7 +292,7 @@ public class MyClass
     }
 
     [Theory]
-    [Trait("Related", "DfmMarkdown")]
+    [Trait("Related", "Markdown")]
     #region Inline Data
     [InlineData(@"[!code-csharp[Main](Program.cs)]", @"<pre><code class=""lang-csharp"" name=""Main"">namespace ConsoleApplication1
 {
@@ -540,7 +540,7 @@ public static void Foo()
 }
 </code></pre>")]
     #endregion
-    public void TestDfmFencesBlockLevelWithQueryString(string fencesPath, string expectedContent)
+    public void TestFencesBlockLevelWithQueryString(string fencesPath, string expectedContent)
     {
         // arrange
         var content = @"namespace ConsoleApplication1
@@ -581,8 +581,8 @@ public static void Foo()
     }
 
     [Fact]
-    [Trait("Related", "DfmMarkdown")]
-    public void TestDfmFencesBlockLevelWithWhitespaceLeading()
+    [Trait("Related", "Markdown")]
+    public void TestFencesBlockLevelWithWhitespaceLeading()
     {
         var root = @"
  [!code-FakeREST[REST](api.json)]
@@ -655,8 +655,8 @@ public static void Foo()
     }
 
     [Fact]
-    [Trait("Related", "DfmMarkdown")]
-    public void TestDfmFencesBlockLevelWithWorkingFolder()
+    [Trait("Related", "Markdown")]
+    public void TestFencesBlockLevelWithWorkingFolder()
     {
         var root = @"[!code-REST[REST](~/api.json)]";
         var apiJsonContent = @"
@@ -687,6 +687,7 @@ public static void Foo()
     }
 
     [Fact]
+    [Trait("Related", "Markdown")]
     public void CodeSnippetShouldVerifyTagname()
     {
         //arrange

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/MathematicsTest.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/MathematicsTest.cs
@@ -7,20 +7,20 @@ namespace Docfx.MarkdigEngine.Tests;
 
 public class MathematicsTest
 {
-    [Fact(Skip = "Disable math support")]
+    [Fact]
     public void Test_Mathematics_Support_0()
     {
         var source = "$ math inline $";
-        var expected = @"<p><span class=""math"">math inline</span></p>";
+        var expected = """<p><span class="math">\(math inline\)</span></p>""";
 
         TestUtility.VerifyMarkup(source, expected);
     }
 
-    [Fact(Skip = "Disable math support")]
+    [Fact]
     public void Test_Mathematics_Support_1()
     {
         var source = "$ math^0 **inline** $";
-        var expected = @"<p><span class=""math"">math^0 **inline**</span></p>";
+        var expected = """<p><span class="math">\(math^0 **inline**\)</span></p>""";
 
         TestUtility.VerifyMarkup(source, expected);
     }

--- a/test/docfx.Tests/MetadataCommandTest.cs
+++ b/test/docfx.Tests/MetadataCommandTest.cs
@@ -45,24 +45,6 @@ public class MetadataCommandTest : TestBase
 
     [Fact]
     [Trait("Related", "docfx")]
-    public void TestMetadataCommandFromCSProjectWithVsinstalldirEnvSet()
-    {
-        var envName = "VSINSTALLDIR";
-        var originalValue = Environment.GetEnvironmentVariable(envName);
-        Environment.SetEnvironmentVariable(envName, "c:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise");
-
-        try
-        {
-            TestMetadataCommandFromCSProject();
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(envName, originalValue);
-        }
-    }
-
-    [Fact]
-    [Trait("Related", "docfx")]
     public void TestMetadataCommandFromDll()
     {
         var dllFile = Path.Combine(_projectFolder, "test.dll");
@@ -261,7 +243,7 @@ public class MetadataCommandTest : TestBase
         Assert.NotNull(memberViewModel.References.Find(s => s.Uid.Equals("Foo")));
     }
 
-    [Fact(Skip = "Don't know why this fails.")]
+    [Fact]
     [Trait("Related", "docfx")]
     public void TestMetadataCommandFromCSProjectWithDuplicateProjectReference()
     {


### PR DESCRIPTION
**What's included in this PR**
- Fix spelling miss in verbose log message from `week type` to `weak type".
- Remove code that explicitly setting `ServicePointManager.SecurityProtocol` to `Tls12`  
   Because there are no supported OS/.NET versions that require this settings.
- Remove `TestSchemaReachedLimits` tests. Because `Json.NET schema` is not used anymore.
- Rename test method signature and traits that using Markdig. 
- Modify skipped tests. that pass tests with small modifications.
- Remove `TestMetadataCommandFromCSProjectWithVsinstalldirEnvSet` test because it's not actually used.

