### PR TITLE
perf: Optimize JToken to Dictionary conversion performance

### DIFF
--- a/src/Docfx.Common/ConvertToObjectHelper.cs
+++ b/src/Docfx.Common/ConvertToObjectHelper.cs
@@ -39,7 +39,7 @@ public static class ConvertToObjectHelper
                 if (jToken is JValue jValue)
                     return jValue.Value;
                 else
-                    throw new ArgumentException($"Not expected object type passed. JTokenType: {jToken.Type}, JToken: {jToken}");
+                    throw new ArgumentException($"Not expected object type passed. JTokenType: {jToken.Type}, Text: {jToken}");
         }
     }
 

--- a/src/Docfx.Common/ConvertToObjectHelper.cs
+++ b/src/Docfx.Common/ConvertToObjectHelper.cs
@@ -1,35 +1,64 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
 
 using Newtonsoft.Json.Linq;
+using System.Runtime.CompilerServices;
 
 namespace Docfx.Common;
 
 public static class ConvertToObjectHelper
 {
-    public static object ConvertExpandoObjectToObject(object raw)
+#nullable enable
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    public static object? ConvertJObjectToObject(object raw)
     {
-        return ConvertExpandoObjectToObjectCore(raw, new Dictionary<object, object>());
+        switch (raw)
+        {
+            case null:
+                return null;
+            case JToken jToken:
+                return ConvertJTokenToObject(jToken);
+            default:
+                return raw; //  if other type object passed. Return object itself.
+        }
     }
 
-    public static object ConvertJObjectToObject(object raw)
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static object? ConvertJTokenToObject([NotNull] JToken jToken)
     {
-        if (raw is JValue jValue)
+        switch (jToken.Type)
         {
-            return jValue.Value;
+            case JTokenType.Array:
+                return ConvertJArrayToObjectArray((JArray)jToken);
+            case JTokenType.Object:
+                return ConvertJObjectToDictionary((JObject)jToken);
+            default:
+                if (jToken is not JValue jValue)
+                    goto default;
+                return jValue.Value;
+                throw new ArgumentException($"Not expected type passed. JTokenType: {jToken.Type}, JToken: {jToken}");
         }
-        if (raw is JArray jArray)
-        {
-            return jArray.Select(ConvertJObjectToObject).ToArray();
-        }
-        if (raw is JObject jObject)
-        {
-            return jObject.ToObject<Dictionary<string, object>>().ToDictionary(p => p.Key, p => ConvertJObjectToObject(p.Value));
-        }
-        return raw;
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static object?[] ConvertJArrayToObjectArray([NotNull] JArray jArray)
+    {
+        return jArray.Select(ConvertJTokenToObject).ToArray();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static IDictionary<string, object?> ConvertJObjectToDictionary(JObject jObject)
+    {
+        var dictionary = (IDictionary<string, JToken>)jObject;
+        return dictionary.ToDictionary(p => p.Key,
+                                       p => p.Value == null
+                                         ? null
+                                         : ConvertJTokenToObject(p.Value));
+    }
+#nullable restore
 
     public static object ConvertStrongTypeToObject(object raw)
     {
@@ -44,6 +73,11 @@ public static class ConvertToObjectHelper
         }
 
         return JToken.FromObject(raw, JsonUtility.DefaultSerializer.Value);
+    }
+
+    public static object ConvertExpandoObjectToObject(object raw)
+    {
+        return ConvertExpandoObjectToObjectCore(raw, new Dictionary<object, object>());
     }
 
     public static object ConvertToDynamic(object obj)

--- a/src/Docfx.Common/ConvertToObjectHelper.cs
+++ b/src/Docfx.Common/ConvertToObjectHelper.cs
@@ -36,10 +36,10 @@ public static class ConvertToObjectHelper
             case JTokenType.Object:
                 return ConvertJObjectToDictionary((JObject)jToken);
             default:
-                if (jToken is not JValue jValue)
-                    goto default;
-                return jValue.Value;
-                throw new ArgumentException($"Not expected type passed. JTokenType: {jToken.Type}, JToken: {jToken}");
+                if (jToken is JValue jValue)
+                    return jValue.Value;
+                else
+                    throw new ArgumentException($"Not expected object type passed. JTokenType: {jToken.Type}, JToken: {jToken}");
         }
     }
 

--- a/test/Docfx.Common.Tests/ConvertToObjectHelperTest.cs
+++ b/test/Docfx.Common.Tests/ConvertToObjectHelperTest.cs
@@ -1,7 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using FluentAssertions;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Docfx.Common.Tests;
@@ -67,6 +69,21 @@ public class ConvertToObjectHelperTest
         Dictionary<string, object> obj = ConvertToObjectHelper.ConvertExpandoObjectToObject(converted);
         Assert.True(ReferenceEquals(obj["key1"], obj));
         Assert.Equal("value", ((Dictionary<string, object>)obj["key1"])["key"]);
+    }
+
+    [Fact]
+    public void ConvertJObjectToObject_UnexpectedType()
+    {
+        // Arrange
+        var jToken = new JProperty("name", "dummy");
+
+        // Act
+        var action = () => { ConvertToObjectHelper.ConvertJObjectToObject(jToken); };
+
+        // Assert
+        action.Should()
+              .Throw<ArgumentException>()
+              .WithMessage("Not expected object type passed. JTokenType: Property, Text: \"name\": \"dummy\"");
     }
 
     private sealed class ComplexType

--- a/test/docfx.Tests/JsonConverterTest.cs
+++ b/test/docfx.Tests/JsonConverterTest.cs
@@ -136,22 +136,6 @@ public class JsonConverterTest
             "{\"files\":[{\"source_relative_path\":\"a\",\"output\":{}},{\"source_relative_path\":\"b\",\"output\":{}}]}",
             JsonUtility.Serialize(JsonUtility.FromJsonString<Manifest>(JsonUtility.Serialize(manifest))));
     }
-
-    private static object ConvertJObjectToObject(object raw)
-    {
-        if (raw is JValue jValue) { return jValue.Value; }
-
-        if (raw is JArray jArray)
-        {
-            return jArray.Select(ConvertJObjectToObject).ToArray();
-        }
-
-        if (raw is JObject jObject)
-        {
-            return jObject.ToObject<Dictionary<string, object>>().ToDictionary(p => p.Key, p => ConvertJObjectToObject(p.Value));
-        }
-        return raw;
-    }
 }
 
 internal class SkipEmptyOrNullContractResolver : DefaultContractResolver


### PR DESCRIPTION
*What's included in this PR*
- Optimize `ConvertToObjectHelper.ConvertJObjectToObject` method performance.
- Refactor code and append `AggressiveOptimization` attribute.
- Remove unused test code.

**Background**
When running Visual Studio profiler.
Sometimes `ConvertJObjectToObject` method is reported as Hot Path.
And this method is called about `64702` times when running docfx to `samples/seed` projecft.

It seems  `jObject.ToObject<Dictionary<string, object>>()` call can be safely removed.
Because `JObject` already implemented `IDictionary<string,JToken>` interface implicitly.

**Rewrite code from**
 > jObject.ToObject<Dictionary<string, object>>().ToDictionary(p => p.Key, p => ConvertJObjectToObject(p.Value));

**To**
> ((IDictionary<string,JToken>jObject).ToDictionary(p => p.Key, p => ConvertJObjectToObject(p.Value));

