### PR TITLE
chore: Remove unused dependency

### DIFF
--- a/src/Docfx.HtmlToPdf/Docfx.HtmlToPdf.csproj
+++ b/src/Docfx.HtmlToPdf/Docfx.HtmlToPdf.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <Compile Remove="Manifest.cs" />
     <Compile Remove="ManifestItem.cs" />
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Docfx.Build.Common\Docfx.Build.Common.csproj" />
-    <ProjectReference Include="..\Docfx.Build.ConceptualDocuments\Docfx.Build.ConceptualDocuments.csproj" />
     <ProjectReference Include="..\Docfx.Common\Docfx.Common.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
**What included in this PR**
Remove `Docfx.Build.ConceptualDocuments` project reference from `Docfx.HtmlToPdf.csproj`.

**Background**
Currently `Docfx.HtmlToPdf.dll` is loaded as plugin DLL at following lines.
Because it transitively referencing `Docfx.Plugins` project.

https://github.com/dotnet/docfx/blob/fb4fe3f24438b39b22443763b5447be641b4139d/src/Docfx.App/Helpers/DocumentBuilderWrapper.cs#L76-L85

It seems `Docfx.Build.ConceptualDocuments`  is not used inside projects.
So It can safely removed.

