### PR TITLE
chore: Add code coverage excusions

### DIFF
--- a/src/Docfx.Common/Git/GitUtility.cs
+++ b/src/Docfx.Common/Git/GitUtility.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Web;
@@ -266,6 +267,7 @@ public static class GitUtility
         return repoInfo;
     }
 
+    [ExcludeFromCodeCoverage]
     private static Tuple<string, string> GetBranchNames(string repoRootPath)
     {
         // Use the branch name specified by the environment variable.


### PR DESCRIPTION
**What included in this PR**
Add `ExcludeFromCodeCoverage` attribute that randomly cause CodeCov coverage indirect diff. (See #9067)

I don't know what cause `detached branch` state (Checkout by commitId in some condition?)
But I though it's safe to exclude from code coverage.
