### PR TITLE
chore: Change output html file encoding to UTF-8 (No BOM)

### DIFF
--- a/src/Docfx.Build.Engine/PostProcessors/HtmlPostProcessor.cs
+++ b/src/Docfx.Build.Engine/PostProcessors/HtmlPostProcessor.cs
@@ -13,6 +13,8 @@ namespace Docfx.Build.Engine;
 
 internal sealed class HtmlPostProcessor : IPostProcessor
 {
+    private static readonly UTF8Encoding Utf8EncodingWithoutBom = new(false);
+
     public List<IHtmlDocumentHandler> Handlers { get; } = new List<IHtmlDocumentHandler>();
 
     private bool _handlerInitialized;
@@ -79,7 +81,7 @@ internal sealed class HtmlPostProcessor : IPostProcessor
             }
             using (var stream = EnvironmentContext.FileAbstractLayer.Create(tuple.OutputFile))
             {
-                document.Save(stream, Encoding.UTF8);
+                document.Save(stream, Utf8EncodingWithoutBom);
             }
         }
         foreach (var handler in Handlers)


### PR DESCRIPTION
**What's included in this PR**
- Change output HTML encoding from UTF-8(BOM) to UTF-8 (No BOM).

**Background**
Currently docfx output HTML files using UTF-8 (with BOM) encoding.
And other non-HTML files are using UTF-8 (No BOM).

Currently docfx output HTML with following meta tag. so it seems BOM is not required.

> <meta charset="utf-8">

If there is any reason to use `UTF-8(BOM)` close this PR.
(For example. Snapshot tests library requires BOM)