### PR TITLE
perf: Optimize read MIME operation

### DIFF
--- a/src/Docfx.Common/YamlMime.cs
+++ b/src/Docfx.Common/YamlMime.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
 using Docfx.Plugins;
 
 #nullable enable
@@ -15,8 +14,10 @@ public static class YamlMime
     public const string TableOfContent = YamlMimePrefix + nameof(TableOfContent);
     public const string XRefMap = YamlMimePrefix + nameof(XRefMap);
 
-    public static string? ReadMime([NotNull] TextReader reader)
+    public static string? ReadMime(TextReader reader)
     {
+        ArgumentNullException.ThrowIfNull(reader);
+
         var line = reader.ReadLine();
         if (line == null || !line.StartsWith("#", StringComparison.Ordinal))
         {
@@ -30,8 +31,10 @@ public static class YamlMime
         return content;
     }
 
-    public static string? ReadMime([NotNull] string file)
+    public static string? ReadMime(string file)
     {
+        ArgumentNullException.ThrowIfNull(file);
+
         var path = EnvironmentContext.FileAbstractLayer.GetPhysicalPath(file);
         using var stream = new FileStream(path, CustomFileReadOptions);
         using var reader = new StreamReader(stream, bufferSize: 128); // Min:128, Default:1024


### PR DESCRIPTION
**What included in this PR**
- Set FileStream's BufferSize to `0` (Default:4096)
- Set StreamReader's BufferSize to `128` (Default:1024, Min:128)
- Set `FileOptions.SequentialScan` hint for Windows (It seems don't affects actual performance thought)

**Background**
`YamlMime.ReadMime` API read file's first line only.
So it can reduce internal buffer allocations. and reduce Gen0 GC allocations.

**Benchmark results**

|              Method |     Mean |    Error |   StdDev | Ratio |   Gen0 |   Gen1 | Allocated | Alloc Ratio |
|-------------------- |---------:|---------:|---------:|------:|-------:|-------:|----------:|------------:|
|            ReadMime | 19.23 μs | 0.192 μs | 0.180 μs |  1.00 | 1.8616 | 0.0305 |   7.73 KB |        1.00 |
|  ReadMime_Optimized | 18.16 μs | 0.083 μs | 0.065 μs |  0.94 | 0.2441 | 0.0305 |   1.02 KB |        0.13 |
