### PR TITLE
build(deps): bump Microsoft.Build from 17.3.2 to 17.7.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
 
      <!-- "17.3.2" is the latest compatible version for .NET 6 -->
     <PackageVersion Include="Microsoft.Build" Version="[17.3.2]" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageVersion Include="Microsoft.Build" Version="17.7.0"   Condition="'$(TargetFramework)' != 'net6.0'" />
+    <PackageVersion Include="Microsoft.Build" Version="17.7.2"   Condition="'$(TargetFramework)' != 'net6.0'" />
 
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.5.5" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.7.0" />


### PR DESCRIPTION
This PR manually update `Microsoft.Build` nuget package dependency.
It override PR #9134 that created by dependabot.




