### PR TITLE
chore: update .NET SDK for CI

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -12,7 +12,7 @@ runs:
       dotnet-version: |
         6.x
         7.x
-        8.0.100-preview.6.23330.14
+        8.0.100-preview.7.23376.3
 
   - run: npm install
     shell: bash

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ We welcome code contributions through pull requests, issues tagged as **[`help-w
 
 - Install [Visual Studio 2022 (Community or higher)](https://www.visualstudio.com/) and make sure you have the latest updates.
 - Install [.NET Core SDK](https://dotnet.microsoft.com/download/dotnet-core) 6.x and 7.x.
-- Install NodeJS (16.x.x).
+- Install NodeJS (18.x.x).
 - Optional: Install wkhtmltopdf on Windows to test PDF using `choco install wkhtmltopdf`.
 
 ### Build and Test

--- a/test/docfx.Tests/ModuleInitializer.cs
+++ b/test/docfx.Tests/ModuleInitializer.cs
@@ -11,13 +11,13 @@ public static class ModuleInitializer
     [ModuleInitializer]
     public static void Initialize()
     {
+        // Workaround code to avoid `NuGet.Frameworks` package related errror.
         RegisterNonPreviewSdkInstance();
     }
 
     /// <summary>
     /// Try to register non-preview version .NET SDK to avoid `NuGet.Frameworks` package related problems.
     /// </summary>
-    /// <remarks>
     private static void RegisterNonPreviewSdkInstance()
     {
         if (MSBuildLocator.IsRegistered)
@@ -29,7 +29,8 @@ public static class ModuleInitializer
 
         // Gets non-preview .NET SDKs.
         var vsInstances = MSBuildLocator.QueryVisualStudioInstances(VisualStudioInstanceQueryOptions.Default)
-                                        .Where(x => !x.MSBuildPath.Contains("-preview."));
+                                        .Where(x => !x.MSBuildPath.Contains("-preview."))
+                                        .Where(x => !x.MSBuildPath.Contains("-rc."));
 
         var vs = vsInstances.FirstOrDefault();
         if (vs == null)


### PR DESCRIPTION
**What's included in this PR**
- Update CI environment's .NET 8 SDK from `preview.6` to `preview.7`
- Fix Node.js version of README.md
- Add `-rc.` version filter for `docfx.Tests` project.   
  It can be removed when `NuGet.Frameworks`  `6.8.x` RC version is released to NuGet.
