### PR TITLE
feat: support language attribute on C# documentation comment

### DIFF
--- a/src/Docfx.Dotnet/Parsers/XmlComment.cs
+++ b/src/Docfx.Dotnet/Parsers/XmlComment.cs
@@ -142,7 +142,18 @@ internal class XmlComment
             var (lang, value) = ResolveCodeSource(node, context);
             value = TrimEachLine(value ?? node.Value, new(' ', indent));
             var code = new XElement("code", value);
-            code.SetAttributeValue("class", $"lang-{lang ?? "csharp"}");
+
+            if (node.Attribute("language") is { } languageAttribute)
+            {
+                lang = languageAttribute.Value;
+            }
+
+            if (string.IsNullOrEmpty(lang))
+            {
+                lang = "csharp";
+            }
+
+            code.SetAttributeValue("class", $"lang-{lang}");
             node.ReplaceWith(new XElement("pre", code));
         }
     }

--- a/test/Docfx.Dotnet.Tests/XmlCommentUnitTest.cs
+++ b/test/Docfx.Dotnet.Tests/XmlCommentUnitTest.cs
@@ -325,7 +325,7 @@ public class XmlCommentUnitTest
             <a href="https://example.org">example</a>
             <p>This is <code class="paramref">ref</code> a sample of exception node</p>
             <ul><li>
-                        <pre><code class="lang-csharp">public class XmlElement
+                        <pre><code class="lang-c#">public class XmlElement
                             : XmlLinkedNode</code></pre>
                         <ol><li>
                                     word inside list-&gt;listItem-&gt;list-&gt;listItem-&gt;para.&gt;

--- a/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.Cat-2.html.view.verified.json
+++ b/test/docfx.Snapshot.Tests/SamplesTest.Seed/api/CatLibrary.Cat-2.html.view.verified.json
@@ -3693,7 +3693,7 @@
   "summary": "<p>Here's main class of this <i>Demo</i>.</p>\n<p>You can see mostly type of article within this class and you for more detail, please see the remarks.</p>\n<p></p>\n<p>this class is a template class. It has two Generic parameter. they are: <code class=\"typeparamref\">T</code> and <code class=\"typeparamref\">K</code>.</p>\n<p>The extension method of this class can refer to <xref href=\"CatLibrary.ICatExtension\" data-throw-if-not-resolved=\"false\"></xref> class</p>\n",
   "remarks": "<p sourcefile=\"specs/Cat.md\" sourcestartlinenumber=\"1\"><em sourcefile=\"specs/Cat.md\" sourcestartlinenumber=\"1\">THIS</em> is remarks overridden in <em sourcefile=\"specs/Cat.md\" sourcestartlinenumber=\"1\">MARKDWON</em> file</p>\n",
   "example": [
-    "<p>Here's example of how to create an instance of this class. As T is limited with <code>class</code> and K is limited with <code>struct</code>.</p>\n<pre><code class=\"lang-csharp\">var a = new Cat(object, int)();\nint catNumber = new int();\nunsafe\n{\n    a.GetFeetLength(catNumber);\n}</code></pre>\n<p>As you see, here we bring in <b>pointer</b> so we need to add <code class=\"languageKeyword\">unsafe</code> keyword.</p>\n"
+    "<p>Here's example of how to create an instance of this class. As T is limited with <code>class</code> and K is limited with <code>struct</code>.</p>\n<pre><code class=\"lang-c#\">var a = new Cat(object, int)();\nint catNumber = new int();\nunsafe\n{\n    a.GetFeetLength(catNumber);\n}</code></pre>\n<p>As you see, here we bring in <b>pointer</b> so we need to add <code class=\"languageKeyword\">unsafe</code> keyword.</p>\n"
   ],
   "syntax": {
     "content": [

--- a/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/1920x1080/api-CatLibrary.Cat-2.html-q-cat.verified.png
+++ b/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/1920x1080/api-CatLibrary.Cat-2.html-q-cat.verified.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d04890f4eaf9998cffbd4481f1a6961f6668ee26061c8ce2b24394c5a9e2d1ca
-size 833454
+oid sha256:c29d9342e3b4f0864c69cc39d180220ad9c23812f4c640e2c2e916f6a81648a5
+size 833585

--- a/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/375x812/api-CatLibrary.Cat-2.html-q-cat.verified.png
+++ b/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/375x812/api-CatLibrary.Cat-2.html-q-cat.verified.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3e64015b37c91f3e5b4c95ef54393014be1ab3e6ae8551cd0aab37c48a315fa3
-size 667755
+oid sha256:ef3fde1c7d93a26dcd5420bb8302efdaf6cff5d4adf7cfdb2c81804b9dd70992
+size 666999

--- a/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/api-CatLibrary.Cat-2.html-q-cat.verified.html
+++ b/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/api-CatLibrary.Cat-2.html-q-cat.verified.html
@@ -458,9 +458,9 @@ This is a CAT class</p>
 
   <h2 id="CatLibrary_Cat_2_examples">Examples<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="#" href="#CatLibrary_Cat_2_examples" style="margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h2>
   <p>Here's example of how to create an instance of this class. As T is limited with <code>class</code> and K is limited with <code>struct</code>.</p>
-<pre><code class="lang-csharp hljs language-csharp"><span class="hljs-keyword">var</span> a = <span class="hljs-keyword">new</span> Cat(<span class="hljs-built_in">object</span>, <span class="hljs-built_in">int</span>)();
-<span class="hljs-built_in">int</span> catNumber = <span class="hljs-keyword">new</span> <span class="hljs-built_in">int</span>();
-<span class="hljs-keyword">unsafe</span>
+<pre><code class="lang-c# hljs language-c">var a = new Cat(object, <span class="hljs-type">int</span>)();
+<span class="hljs-type">int</span> catNumber = new <span class="hljs-type">int</span>();
+unsafe
 {
     a.GetFeetLength(catNumber);
 }</code><a class="btn border-0 code-action" href="#" title="Copy"><i class="bi bi-clipboard"></i></a></pre>


### PR DESCRIPTION
Supports `language` attribute on `<code>` element in C# XML documentation comment. `<code>` elements uses `csharp` as the default language id, this can be overridden by the `language` attribute:

```
<code language="xml">
<![CDATA[
 <chart:Chart>
  <!-- ... Eliminated for simplicity-->
 </chart:Chart>
]]>
</code>
```

fixes #9156