### PR TITLE
perf: Change JsonSerializerOptions instance to static

### DIFF
--- a/src/Docfx.Build.SchemaDriven/Models/DocumentSchema.cs
+++ b/src/Docfx.Build.SchemaDriven/Models/DocumentSchema.cs
@@ -11,6 +11,17 @@ namespace Docfx.Build.SchemaDriven;
 
 public class DocumentSchema : BaseSchema
 {
+    // JsonSerializerOptions should be reused.
+    // https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/configure-options#reuse-jsonserializeroptions-instances
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        AllowTrailingCommas = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = {
+                        new JsonStringEnumConverter()
+                     },
+    };
+
     public string Metadata { get; set; }
 
     public JsonPointer MetadataReference { get; private set; }
@@ -30,14 +41,7 @@ public class DocumentSchema : BaseSchema
         {
             schema = JsonSerializer.Deserialize<DocumentSchema>(
                 content,
-                new JsonSerializerOptions()
-                {
-                    AllowTrailingCommas = true,
-                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                    Converters = {
-                        new JsonStringEnumConverter()
-                    }
-                });
+                SerializerOptions);
         }
         catch (Exception e)
         {


### PR DESCRIPTION
**What's included in this PR**
- Change `JsonSerializerOptions` to static and reuse instance.

**Background**
`JsonSerializerOptions` is recommended to be reused.

- https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/configure-options#reuse-jsonserializeroptions-instances
- Benchmark: https://devblogs.microsoft.com/dotnet/performance_improvements_in_net_7/#json

If project are using multiple SDP(`SchemaDrivenProcessor`) schemas.
It's expected to improve performance improvement.