### PR TITLE
chore: Remove unused code

### DIFF
--- a/src/Docfx.Build.ConceptualDocuments/ConceptualDocumentProcessor.cs
+++ b/src/Docfx.Build.ConceptualDocuments/ConceptualDocumentProcessor.cs
@@ -19,7 +19,6 @@ public class ConceptualDocumentProcessor : DisposableDocumentProcessor
 {
     #region Fields
 
-    private readonly ResourcePoolManager<JsonSerializer> _serializerPool;
     private readonly string[] SystemKeys = {
         "conceptual",
         "type",
@@ -37,7 +36,6 @@ public class ConceptualDocumentProcessor : DisposableDocumentProcessor
 
     public ConceptualDocumentProcessor()
     {
-        _serializerPool = new ResourcePoolManager<JsonSerializer>(GetSerializer, 0x10);
     }
 
     #endregion
@@ -125,54 +123,6 @@ public class ConceptualDocumentProcessor : DisposableDocumentProcessor
         }
 
         return result;
-    }
-
-    #endregion
-
-    #region Protected Methods
-
-    protected virtual void SerializeModel(object model, Stream stream)
-    {
-        using var sw = new StreamWriter(stream, Encoding.UTF8, 0x100, true);
-        using var lease = _serializerPool.Rent();
-        lease.Resource.Serialize(sw, model);
-    }
-
-    protected virtual object DeserializeModel(Stream stream)
-    {
-        using var sr = new StreamReader(stream, Encoding.UTF8, false, 0x100, true);
-        using var jr = new JsonTextReader(sr);
-        using var lease = _serializerPool.Rent();
-        return lease.Resource.Deserialize(jr);
-    }
-
-    protected virtual void SerializeProperties(IDictionary<string, object> properties, Stream stream)
-    {
-        using var sw = new StreamWriter(stream, Encoding.UTF8, 0x100, true);
-        using var lease = _serializerPool.Rent();
-        lease.Resource.Serialize(sw, properties);
-    }
-
-    protected virtual IDictionary<string, object> DeserializeProperties(Stream stream)
-    {
-        using var sr = new StreamReader(stream, Encoding.UTF8, false, 0x100, true);
-        using var jr = new JsonTextReader(sr);
-        using var lease = _serializerPool.Rent();
-        return lease.Resource.Deserialize<Dictionary<string, object>>(jr);
-    }
-
-    protected virtual JsonSerializer GetSerializer()
-    {
-        return new JsonSerializer
-        {
-            NullValueHandling = NullValueHandling.Ignore,
-            ReferenceLoopHandling = ReferenceLoopHandling.Serialize,
-            Converters =
-            {
-                new Newtonsoft.Json.Converters.StringEnumConverter(),
-            },
-            TypeNameHandling = TypeNameHandling.All, // lgtm [cs/unsafe-type-name-handling]
-        };
     }
 
     #endregion

--- a/src/Docfx.Build.ManagedReference/ManagedReferenceDocumentProcessor.cs
+++ b/src/Docfx.Build.ManagedReference/ManagedReferenceDocumentProcessor.cs
@@ -20,7 +20,6 @@ namespace Docfx.Build.ManagedReference;
 public class ManagedReferenceDocumentProcessor : ReferenceDocumentProcessorBase
 {
     #region Fields
-    private readonly ResourcePoolManager<JsonSerializer> _serializerPool;
     private static readonly string[] SystemKeys = {
         "uid",
         "isEii",
@@ -63,7 +62,6 @@ public class ManagedReferenceDocumentProcessor : ReferenceDocumentProcessorBase
 
     public ManagedReferenceDocumentProcessor()
     {
-        _serializerPool = new ResourcePoolManager<JsonSerializer>(GetSerializer, 0x10);
     }
 
     #endregion
@@ -308,50 +306,6 @@ public class ManagedReferenceDocumentProcessor : ReferenceDocumentProcessorBase
             }
         }
         return result;
-    }
-
-    protected virtual void SerializeModel(object model, Stream stream)
-    {
-        using var sw = new StreamWriter(stream, Encoding.UTF8, 0x100, true);
-        using var lease = _serializerPool.Rent();
-        lease.Resource.Serialize(sw, model);
-    }
-
-    protected virtual object DeserializeModel(Stream stream)
-    {
-        using var sr = new StreamReader(stream, Encoding.UTF8, false, 0x100, true);
-        using var jr = new JsonTextReader(sr);
-        using var lease = _serializerPool.Rent();
-        return lease.Resource.Deserialize(jr);
-    }
-
-    protected virtual void SerializeProperties(IDictionary<string, object> properties, Stream stream)
-    {
-        using var sw = new StreamWriter(stream, Encoding.UTF8, 0x100, true);
-        using var lease = _serializerPool.Rent();
-        lease.Resource.Serialize(sw, properties);
-    }
-
-    protected virtual IDictionary<string, object> DeserializeProperties(Stream stream)
-    {
-        using var sr = new StreamReader(stream, Encoding.UTF8, false, 0x100, true);
-        using var jr = new JsonTextReader(sr);
-        using var lease = _serializerPool.Rent();
-        return (IDictionary<string, object>)lease.Resource.Deserialize<object>(jr);
-    }
-
-    protected virtual JsonSerializer GetSerializer()
-    {
-        return new JsonSerializer
-        {
-            NullValueHandling = NullValueHandling.Ignore,
-            ReferenceLoopHandling = ReferenceLoopHandling.Serialize,
-            Converters =
-            {
-                new Newtonsoft.Json.Converters.StringEnumConverter(),
-            },
-            TypeNameHandling = TypeNameHandling.All, // lgtm [cs/unsafe-type-name-handling]
-        };
     }
 
     #endregion

--- a/test/Docfx.Build.Engine.Tests/DocumentProcessors/YamlDocumentProcessor.cs
+++ b/test/Docfx.Build.Engine.Tests/DocumentProcessors/YamlDocumentProcessor.cs
@@ -23,15 +23,12 @@ public class YamlDocumentProcessor : DisposableDocumentProcessor
 
     public override string Name => nameof(YamlDocumentProcessor);
 
-    private readonly ResourcePoolManager<JsonSerializer> _serializerPool;
-
     #endregion
 
     #region Constructors
 
     public YamlDocumentProcessor()
     {
-        _serializerPool = new ResourcePoolManager<JsonSerializer>(GetSerializer, 0x10);
     }
 
     #endregion
@@ -94,54 +91,6 @@ public class YamlDocumentProcessor : DisposableDocumentProcessor
         {
             DocumentType = model.DocumentType,
             FileWithoutExtension = Path.ChangeExtension(model.File, null)
-        };
-    }
-
-    #endregion
-
-    #region Protected Methods
-
-    protected virtual void SerializeModel(object model, Stream stream)
-    {
-        using var sw = new StreamWriter(stream, Encoding.UTF8, 0x100, true);
-        using var lease = _serializerPool.Rent();
-        lease.Resource.Serialize(sw, model);
-    }
-
-    protected virtual object DeserializeModel(Stream stream)
-    {
-        using var sr = new StreamReader(stream, Encoding.UTF8, false, 0x100, true);
-        using var jr = new JsonTextReader(sr);
-        using var lease = _serializerPool.Rent();
-        return lease.Resource.Deserialize(jr);
-    }
-
-    protected virtual void SerializeProperties(IDictionary<string, object> properties, Stream stream)
-    {
-        using var sw = new StreamWriter(stream, Encoding.UTF8, 0x100, true);
-        using var lease = _serializerPool.Rent();
-        lease.Resource.Serialize(sw, properties);
-    }
-
-    protected virtual IDictionary<string, object> DeserializeProperties(Stream stream)
-    {
-        using var sr = new StreamReader(stream, Encoding.UTF8, false, 0x100, true);
-        using var jr = new JsonTextReader(sr);
-        using var lease = _serializerPool.Rent();
-        return lease.Resource.Deserialize<Dictionary<string, object>>(jr);
-    }
-
-    protected virtual JsonSerializer GetSerializer()
-    {
-        return new JsonSerializer
-        {
-            NullValueHandling = NullValueHandling.Ignore,
-            ReferenceLoopHandling = ReferenceLoopHandling.Serialize,
-            Converters =
-            {
-                new Newtonsoft.Json.Converters.StringEnumConverter(),
-            },
-            TypeNameHandling = TypeNameHandling.All, // lgtm [cs/unsafe-type-name-handling]
         };
     }
 


### PR DESCRIPTION
**What's included in this PR**
- Remove unused code from DocumentProcessors

It seems these code are not used.  and it can be replaced with `JsonUtility`'s methods.