### PR TITLE
chore: Change search start condition & add onerror handler

### DIFF
--- a/templates/default/styles/docfx.js
+++ b/templates/default/styles/docfx.js
@@ -252,7 +252,7 @@ $(function () {
 
         $('#search-query').keyup(function () {
           query = $(this).val();
-          if (query.length < 3) {
+          if (query === '') {
             flipContents("show");
           } else {
             flipContents("hide");

--- a/templates/modern/src/search.ts
+++ b/templates/modern/src/search.ts
@@ -48,7 +48,7 @@ export function enableSearch() {
   function onSearchQueryInput() {
     query = searchQuery.value
 
-    if (!query || (query.length < 3 && textEncoder.encode(query).length < 3)) {
+    if (query.length < 3 && textEncoder.encode(query).length < 3) {
       document.body.removeAttribute('data-search')
     } else {
       worker.postMessage({ q: query })

--- a/templates/modern/src/search.ts
+++ b/templates/modern/src/search.ts
@@ -11,6 +11,7 @@ type SearchHit = {
   keywords: string
 }
 
+const textEncoder = new TextEncoder()
 let query
 
 /**
@@ -24,6 +25,11 @@ export function enableSearch() {
 
   const relHref = meta('docfx:rel') || ''
   const worker = new Worker(relHref + 'public/search-worker.min.js', { type: 'module' })
+
+  worker.onerror = event => {
+    console.error("Error occurred at search-worker. message: " + event.message);
+  }
+
   worker.onmessage = function(oEvent) {
     switch (oEvent.data.e) {
       case 'index-ready':
@@ -41,7 +47,8 @@ export function enableSearch() {
 
   function onSearchQueryInput() {
     query = searchQuery.value
-    if (query.length < 3) {
+
+    if (!query || (query.length < 3 && textEncoder.encode(query).length < 3)) {
       document.body.removeAttribute('data-search')
     } else {
       worker.postMessage({ q: query })

--- a/templates/modern/src/search.ts
+++ b/templates/modern/src/search.ts
@@ -27,7 +27,7 @@ export function enableSearch() {
   const worker = new Worker(relHref + 'public/search-worker.min.js', { type: 'module' })
 
   worker.onerror = event => {
-    console.error("Error occurred at search-worker. message: " + event.message);
+    console.error('Error occurred at search-worker. message: ' + event.message)
   }
 
   worker.onmessage = function(oEvent) {

--- a/templates/modern/src/search.ts
+++ b/templates/modern/src/search.ts
@@ -11,7 +11,6 @@ type SearchHit = {
   keywords: string
 }
 
-const textEncoder = new TextEncoder()
 let query
 
 /**
@@ -41,6 +40,9 @@ export function enableSearch() {
         document.body.setAttribute('data-search', 'true')
         renderSearchResults(oEvent.data.d, 0)
         window.docfx.searchResultReady = true
+        if (searchQuery.value.length == 0) {
+          document.body.removeAttribute('data-search')
+        }
         break
     }
   }
@@ -48,7 +50,7 @@ export function enableSearch() {
   function onSearchQueryInput() {
     query = searchQuery.value
 
-    if (query.length < 3 && textEncoder.encode(query).length < 3) {
+    if (query.length == 0) {
       document.body.removeAttribute('data-search')
     } else {
       worker.postMessage({ q: query })

--- a/templates/modern/src/search.ts
+++ b/templates/modern/src/search.ts
@@ -40,7 +40,7 @@ export function enableSearch() {
         document.body.setAttribute('data-search', 'true')
         renderSearchResults(oEvent.data.d, 0)
         window.docfx.searchResultReady = true
-        if (searchQuery.value.length == 0) {
+        if (searchQuery.value === '') {
           document.body.removeAttribute('data-search')
         }
         break
@@ -50,7 +50,7 @@ export function enableSearch() {
   function onSearchQueryInput() {
     query = searchQuery.value
 
-    if (query.length == 0) {
+    if (query === '') {
       document.body.removeAttribute('data-search')
     } else {
       worker.postMessage({ q: query })


### PR DESCRIPTION
**What's included in this PR**
- Add search `start condition` based on query string's UTF-8 byte count.
- Add `onerror` log handler for worker.

**Background**
I'm trying to replace `search-worker.min.js` from [Lunr.js](https://lunrjs.com) to [Fuse.js](https://www.fusejs.io) based.
`Fuse.js` supports non-ascii text search by default. so I want to change default condition to start search operation.  
(Currently at least  3-chars required)

And when modifying custom `search-worker.min.js` file.
Sometimes unhandled error is not logged when failed to load `search-worker.min.js` itself. 
(It occurs when using Chrome/Edge browser. When using Firefox. error log is recorded always)
So I've added `onerror` handler.  
(On Chrome/Edge environment `event.message` might be undefined thought).

**Tested Environments**
I've tested on Chrome/Edge/Firefox browsers(on Windows environment)
And confirmed `TextEncoder` API is available on all major platforms.
https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder#browser_compatibility

**Additional Info**
To replacing `Fuse.js` based search. use following  `search-worker.min.js` file.
https://gist.github.com/filzrev/9a046c40f6df63d01f40018d8a19bd47
 