### PR TITLE
Require video title

### DIFF
--- a/src/Docfx.MarkdigEngine.Extensions/QuoteSectionNote/QuoteSectionNoteBlock.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/QuoteSectionNote/QuoteSectionNoteBlock.cs
@@ -21,6 +21,8 @@ public class QuoteSectionNoteBlock : ContainerBlock
     public string NoteTypeString { get; set; }
 
     public string VideoLink { get; set; }
+
+    public string VideoTitle { get; set; }
 }
 
 public enum QuoteSectionNoteType

--- a/src/Docfx.MarkdigEngine.Extensions/QuoteSectionNote/QuoteSectionNoteParser.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/QuoteSectionNote/QuoteSectionNoteParser.cs
@@ -177,19 +177,28 @@ public class QuoteSectionNoteParser : BlockParser
         if (infoString.StartsWith("[!Video", StringComparison.OrdinalIgnoreCase))
         {
             string data = infoString.Substring(7, infoString.Length - 8).Trim();
-            if ((data.StartsWith("http://") || data.StartsWith("https://")) && data.IndexOf(' ') != -1)
+            if (data.StartsWith("http://") || data.StartsWith("https://"))
             {
-                string link = data.Substring(0, data.IndexOf(' '));
-                string title = data.Trim().Substring(data.IndexOf(' ') + 1);
-                if (title.StartsWith("title=") && title.Length > 6)
+                string link = data;
+                string title = "";
+                if (data.IndexOf(' ') != -1)
                 {
-                    block.QuoteType = QuoteSectionNoteType.DFMVideo;
-                    block.VideoLink = link;
-                    block.VideoTitle = title.Substring(6);
-                    return true;
+                    link = data.Substring(0, data.IndexOf(' '));
+                    title = data.Trim().Substring(data.IndexOf(' ') + 1);
+                    if (title.StartsWith("title=") && title.Length > 6)
+                    {
+                        title = title.Substring(6);
+                    }
                 }
-            }
-            _context.LogWarning("invalid-note-section", "Video should have a valid url and title", block);
+
+                if (title == "") _context.LogWarning("inaccessible-video-section", "Video should have a valid url and title", block);
+
+                block.QuoteType = QuoteSectionNoteType.DFMVideo;
+                block.VideoLink = link;
+                block.VideoTitle = title;
+                return true;
+                
+            }  
         }
 
         processor.GoToColumn(originalColumn);

--- a/src/Docfx.MarkdigEngine.Extensions/QuoteSectionNote/QuoteSectionNoteParser.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/QuoteSectionNote/QuoteSectionNoteParser.cs
@@ -184,14 +184,14 @@ public class QuoteSectionNoteParser : BlockParser
                 if (data.IndexOf(' ') != -1)
                 {
                     link = data.Substring(0, data.IndexOf(' '));
-                    title = data.Trim().Substring(data.IndexOf(' ') + 1);
+                    title = data.Substring(data.IndexOf(' ') + 1);
                     if (title.StartsWith("title=") && title.Length > 6)
                     {
                         title = title.Substring(6);
                     }
                 }
 
-                if (title == "") _context.LogWarning("inaccessible-video-section", "Video should have a valid url and title", block);
+                if (title == "") _context.LogWarning("inaccessible-video-section", "Video title is missing. Please provide a video title.", block);
 
                 block.QuoteType = QuoteSectionNoteType.DFMVideo;
                 block.VideoLink = link;

--- a/src/Docfx.MarkdigEngine.Extensions/QuoteSectionNote/QuoteSectionNoteParser.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/QuoteSectionNote/QuoteSectionNoteParser.cs
@@ -176,13 +176,20 @@ public class QuoteSectionNoteParser : BlockParser
 
         if (infoString.StartsWith("[!Video", StringComparison.OrdinalIgnoreCase))
         {
-            string link = infoString.Substring(7, infoString.Length - 8);
-            if (link.StartsWith(" http://") || link.StartsWith(" https://"))
+            string data = infoString.Substring(7, infoString.Length - 8).Trim();
+            if ((data.StartsWith("http://") || data.StartsWith("https://")) && data.IndexOf(' ') != -1)
             {
-                block.QuoteType = QuoteSectionNoteType.DFMVideo;
-                block.VideoLink = link.Trim();
-                return true;
+                string link = data.Substring(0, data.IndexOf(' '));
+                string title = data.Trim().Substring(data.IndexOf(' ') + 1);
+                if (title.StartsWith("title=") && title.Length > 6)
+                {
+                    block.QuoteType = QuoteSectionNoteType.DFMVideo;
+                    block.VideoLink = link;
+                    block.VideoTitle = title.Substring(6);
+                    return true;
+                }
             }
+            _context.LogWarning("invalid-note-section", "Video should have a valid url and title", block);
         }
 
         processor.GoToColumn(originalColumn);

--- a/src/Docfx.MarkdigEngine.Extensions/QuoteSectionNote/QuoteSectionNoteRender.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/QuoteSectionNote/QuoteSectionNoteRender.cs
@@ -99,7 +99,7 @@ public class QuoteSectionNoteRender : HtmlObjectRenderer<QuoteSectionNoteBlock>
         }
 
         renderer.Write("<div class=\"embeddedvideo\"").WriteAttributes(obj).Write(">");
-        renderer.Write($"<iframe src=\"{modifiedLink}\" title=\"{modifiedTitle}\"frameborder=\"0\" allowfullscreen=\"true\"></iframe>");
+        renderer.Write($"<iframe src=\"{modifiedLink}\"{modifiedTitle} frameborder=\"0\" allowfullscreen=\"true\"></iframe>");
         renderer.WriteLine("</div>");
     }
 
@@ -113,7 +113,7 @@ public class QuoteSectionNoteRender : HtmlObjectRenderer<QuoteSectionNoteBlock>
         {
             title = title.Substring(0, title.Length - 1);
         }
-        return title;
+        return $" title=\"{title}\"";
     }
 
     public static string FixUpLink(string link)

--- a/src/Docfx.MarkdigEngine.Extensions/QuoteSectionNote/QuoteSectionNoteRender.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/QuoteSectionNote/QuoteSectionNoteRender.cs
@@ -87,15 +87,33 @@ public class QuoteSectionNoteRender : HtmlObjectRenderer<QuoteSectionNoteBlock>
     private void WriteVideo(HtmlRenderer renderer, QuoteSectionNoteBlock obj)
     {
         var modifiedLink = string.Empty;
+        var modifiedTitle = string.Empty;
 
         if (!string.IsNullOrWhiteSpace(obj?.VideoLink))
         {
             modifiedLink = FixUpLink(obj.VideoLink);
         }
+        if (!string.IsNullOrWhiteSpace(obj?.VideoTitle))
+        {
+            modifiedTitle = FixUpTitle(obj.VideoTitle);
+        }
 
         renderer.Write("<div class=\"embeddedvideo\"").WriteAttributes(obj).Write(">");
-        renderer.Write($"<iframe src=\"{modifiedLink}\" frameborder=\"0\" allowfullscreen=\"true\"></iframe>");
+        renderer.Write($"<iframe src=\"{modifiedLink}\" title=\"{modifiedTitle}\"frameborder=\"0\" allowfullscreen=\"true\"></iframe>");
         renderer.WriteLine("</div>");
+    }
+
+    public static string FixUpTitle(string title)
+    {
+        if (title.StartsWith("'") || title.StartsWith('"'))
+        {
+            title = title.Substring(1);
+        }
+        if (title.EndsWith("'") || title.EndsWith('"'))
+        {
+            title = title.Substring(0, title.Length - 1);
+        }
+        return title;
     }
 
     public static string FixUpLink(string link)

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/GeneralTest.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/GeneralTest.cs
@@ -401,7 +401,7 @@ http://your.company.abc, abc
 
 ### Video Sample
 
-> [!Video https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4]
+> [!Video https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4 title=Some Video]
 
 ## CommonMark sample
 
@@ -564,7 +564,7 @@ csr
 </ul>
 </div>
 <h3 id=""video-sample"">Video Sample</h3>
-<div class=""embeddedvideo""><iframe src=""https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4"" frameborder=""0"" allowfullscreen=""true""></iframe></div>
+<div class=""embeddedvideo""><iframe src=""https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4"" title=""Some Video"" frameborder=""0"" allowfullscreen=""true""></iframe></div>
 <h2 id=""commonmark-sample"">CommonMark sample</h2>
 <ul>
 <li><h1 id=""foo"">Foo</h1>

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/QuoteSectionNoteTest.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/QuoteSectionNoteTest.cs
@@ -28,7 +28,7 @@ public class QuoteSectionNoteTest
 <h5>WARNING</h5>
 </div>
 ";
-        TestUtility.VerifyMarkup(source, expected, new[] { "invalid-note-section" });
+        TestUtility.VerifyMarkup(source, expected, new[] { "invalid-note-section", "inaccessible-video-section" });
     }
 
     [Fact]
@@ -167,12 +167,12 @@ this is also warning</p>
     {
         // 1. Prepare data
         var source = @"The following is two videos.
-> [!Video https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4]
-> [!Video https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4]";
+> [!Video https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4 title=Some Title]
+> [!Video https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4 title=Some Title]";
 
         var expected = @"<p>The following is two videos.</p>
-<div class=""embeddedvideo""><iframe src=""https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4"" frameborder=""0"" allowfullscreen=""true""></iframe></div>
-<div class=""embeddedvideo""><iframe src=""https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4"" frameborder=""0"" allowfullscreen=""true""></iframe></div>
+<div class=""embeddedvideo""><iframe src=""https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4"" title=""Some Title"" frameborder=""0"" allowfullscreen=""true""></iframe></div>
+<div class=""embeddedvideo""><iframe src=""https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4"" title=""Some Title"" frameborder=""0"" allowfullscreen=""true""></iframe></div>
 ";
 
         TestUtility.VerifyMarkup(source, expected);
@@ -184,11 +184,11 @@ this is also warning</p>
     {
         // 1. Prepare data
         var source = @"The following is video.
-> [!Video https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4]
+> [!Video https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4 title='Some Title' ]
 ";
 
         var expected = @"<p>The following is video.</p>
-<div class=""embeddedvideo""><iframe src=""https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4"" frameborder=""0"" allowfullscreen=""true""></iframe></div>
+<div class=""embeddedvideo""><iframe src=""https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4"" title=""Some Title"" frameborder=""0"" allowfullscreen=""true""></iframe></div>
 ";
 
         TestUtility.VerifyMarkup(source, expected);
@@ -200,18 +200,18 @@ this is also warning</p>
     {
         // 1. Prepare data
         var source = @"The following is video mixed with note.
-> [!Video https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4]
+> [!Video https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4 title=Some Title]
 > [!NOTE]
 > this is note text
-> [!Video https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4]";
+> [!Video https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4 title=""Some Title"" ]";
 
         var expected = @"<p>The following is video mixed with note.</p>
-<div class=""embeddedvideo""><iframe src=""https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4"" frameborder=""0"" allowfullscreen=""true""></iframe></div>
+<div class=""embeddedvideo""><iframe src=""https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4"" title=""Some Title"" frameborder=""0"" allowfullscreen=""true""></iframe></div>
 <div class=""NOTE"">
 <h5>NOTE</h5>
 <p>this is note text</p>
 </div>
-<div class=""embeddedvideo""><iframe src=""https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4"" frameborder=""0"" allowfullscreen=""true""></iframe></div>
+<div class=""embeddedvideo""><iframe src=""https://sec.ch9.ms/ch9/4393/7d7c7df7-3f15-4a65-a2f7-3e4d0bea4393/Episode208_mid.mp4"" title=""Some Title"" frameborder=""0"" allowfullscreen=""true""></iframe></div>
 ";
 
         TestUtility.VerifyMarkup(source, expected);
@@ -418,7 +418,7 @@ We should support that.</p>
         var expected = @"<h1 id=""article-2"">Article 2</h1>
 <div class=""embeddedvideo""><iframe src=""https://microsoft.com:8080/?query=value+A#bookmark"" frameborder=""0"" allowfullscreen=""true""></iframe></div>
 ";
-        TestUtility.VerifyMarkup(source, expected);
+        TestUtility.VerifyMarkup(source, expected, new[] { "inaccessible-video-section" });
     }
 
     [Fact]
@@ -431,7 +431,7 @@ We should support that.</p>
         var expected = @"<h1 id=""article-2"">Article 2</h1>
 <div class=""embeddedvideo""><iframe src=""https://channel9.msdn.com/?nocookie=true"" frameborder=""0"" allowfullscreen=""true""></iframe></div>
 ";
-        TestUtility.VerifyMarkup(source, expected);
+        TestUtility.VerifyMarkup(source, expected, new[] { "inaccessible-video-section" });
     }
 
     [Fact]
@@ -444,7 +444,7 @@ We should support that.</p>
         var expected = @"<h1 id=""article-2"">Article 2</h1>
 <div class=""embeddedvideo""><iframe src=""https://channel9.msdn.com/?query=value+A&nocookie=true"" frameborder=""0"" allowfullscreen=""true""></iframe></div>
 ";
-        TestUtility.VerifyMarkup(source, expected);
+        TestUtility.VerifyMarkup(source, expected, new[] { "inaccessible-video-section" });
     }
 
     [Fact]
@@ -457,6 +457,6 @@ We should support that.</p>
         var expected = @"<h1 id=""article-2"">Article 2</h1>
 <div class=""embeddedvideo""><iframe src=""https://www.youtube-nocookie.com/foo"" frameborder=""0"" allowfullscreen=""true""></iframe></div>
 ";
-        TestUtility.VerifyMarkup(source, expected);
+        TestUtility.VerifyMarkup(source, expected, new[] { "inaccessible-video-section" });
     }
 }


### PR DESCRIPTION
Adding video title and a warning when it is not present to resolve accessibility issues. 
[Bug #881457](https://dev.azure.com/ceapex/Engineering/_workitems/edit/881457/)

When the video gets converted to an iframe, they need to have a title attribute for the iframe to help screen readers. I added code to handle the expected title and to throw a warning if it is not given.