### PR TITLE
chore: Remove unused localsearch function from default template

### DIFF
--- a/templates/default/styles/docfx.js
+++ b/templates/default/styles/docfx.js
@@ -166,7 +166,7 @@ $(function () {
 
       var worker = new Worker(relHref + 'styles/search-worker.min.js');
       worker.onerror = function (oEvent) {
-        console.error('Error occurred at search-worker. message: ' + oEvent.message)
+        console.error('Error occurred at search-worker. message: ' + oEvent.message);
       }
 
       worker.onmessage = function (oEvent) {


### PR DESCRIPTION
Fix #9193.

- Delete `localsearch()` function.
- Modify `window.Worker` check code. (Original code checking `window.worker`. but it's always `undefined`)  
- Remove `!worker` check (Same as `modern template`)
- Add `worker.onerror` event handler that recently added to `modern` template.
- Remove `console.log("using local search");` log
