### PR TITLE
chore: Update .NET SDK 8 to RC1 and fix node version

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -12,7 +12,7 @@ runs:
       dotnet-version: |
         6.x
         7.x
-        8.0.100-preview.7.23376.3
+        8.0.100-rc.1.23455.8
 
   - run: npm install
     shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,13 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
           6.x
           7.x
-          8.0.100-preview.6.23330.14
+          8.0.100-rc.1.23455.8
 
     - run: npm install
       working-directory: templates


### PR DESCRIPTION
**What's included in this PR**

- Update .NET 8 SDK to RC1.
- Update `release.yml`'s Node.js version to 18 (Node.js 16 is already EOS(at September 11th, 2023))