### PR TITLE
chore: Suppress messages generated by CodeAnalyzers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -111,9 +111,9 @@ csharp_style_prefer_null_check_over_type_check = true:suggestion                
 csharp_style_conditional_delegate_call = true:suggestion                           # IDE1005: Use conditional delegate call
 
 # 'var' preferences
-csharp_style_var_for_built_in_types = false:suggestion       # IDE0007: Use var instead of explicit type / IDE0008: Use explicit type instead of var
+csharp_style_var_for_built_in_types = false:silent           # IDE0007: Use var instead of explicit type / IDE0008: Use explicit type instead of var
 csharp_style_var_when_type_is_apparent = false:none          # IDE0007: Use var instead of explicit type / IDE0008: Use explicit type instead of var
-csharp_style_var_elsewhere = false:suggestion                # IDE0007: Use var instead of explicit type / IDE0008: Use explicit type instead of var
+csharp_style_var_elsewhere = true:silent                     # IDE0007: Use var instead of explicit type / IDE0008: Use explicit type instead of var
 
 # Expression-bodied-members
 csharp_style_expression_bodied_constructors = true:silent    # IDE0021: Use expression body for constructors

--- a/.editorconfig
+++ b/.editorconfig
@@ -240,7 +240,7 @@ dotnet_naming_symbols.constant_fields.required_modifiers = const
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
 # static fields should have s_ prefix
-dotnet_naming_rule.static_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.static_fields_should_have_prefix.severity = silent
 dotnet_naming_rule.static_fields_should_have_prefix.symbols  = static_fields
 dotnet_naming_rule.static_fields_should_have_prefix.style = static_prefix_style
 dotnet_naming_symbols.static_fields.applicable_kinds   = field
@@ -250,7 +250,7 @@ dotnet_naming_style.static_prefix_style.required_prefix = s_
 dotnet_naming_style.static_prefix_style.capitalization = camel_case
 
 # internal and private fields should be _camelCase
-dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = silent
 dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
 dotnet_naming_rule.camel_case_for_private_internal_fields.style = camel_case_underscore_style
 dotnet_naming_symbols.private_internal_fields.applicable_kinds = field

--- a/plugins/Docfx.Build.OperationLevelRestApi/SplitRestApiToOperationLevel.cs
+++ b/plugins/Docfx.Build.OperationLevelRestApi/SplitRestApiToOperationLevel.cs
@@ -88,7 +88,7 @@ public class SplitRestApiToOperationLevel : BaseDocumentBuildStep
         // Support both restructure by TopicHref and TopicUid
         var treeItemRestructions = new List<TreeItemRestructure>
         {
-            new TreeItemRestructure
+            new()
             {
                 ActionType = TreeItemActionType.AppendChild,
                 Key = model.Key,
@@ -96,7 +96,7 @@ public class SplitRestApiToOperationLevel : BaseDocumentBuildStep
                 RestructuredItems = treeItems.OrderBy(s => s.Metadata[Constants.PropertyName.Name]).ToImmutableList(),
                 SourceFiles = new FileAndType[] { model.OriginalFileAndType }.ToImmutableList(),
             },
-            new TreeItemRestructure
+            new()
             {
                 ActionType = TreeItemActionType.AppendChild,
                 Key = content.Uid,

--- a/plugins/Docfx.Build.OperationLevelRestApi/SplitRestApiToOperationLevel.cs
+++ b/plugins/Docfx.Build.OperationLevelRestApi/SplitRestApiToOperationLevel.cs
@@ -52,7 +52,7 @@ public class SplitRestApiToOperationLevel : BaseDocumentBuildStep
         return collection;
     }
 
-    private Tuple<List<FileModel>, List<TreeItemRestructure>> SplitModelToOperationGroup(FileModel model)
+    private static Tuple<List<FileModel>, List<TreeItemRestructure>> SplitModelToOperationGroup(FileModel model)
     {
         if (model.Type != DocumentType.Article)
         {
@@ -109,7 +109,7 @@ public class SplitRestApiToOperationLevel : BaseDocumentBuildStep
         return Tuple.Create(splittedModels, treeItemRestructions);
     }
 
-    private IEnumerable<RestApiRootItemViewModel> GenerateOperationModels(RestApiRootItemViewModel root)
+    private static IEnumerable<RestApiRootItemViewModel> GenerateOperationModels(RestApiRootItemViewModel root)
     {
         foreach (var child in root.Children)
         {
@@ -145,7 +145,7 @@ public class SplitRestApiToOperationLevel : BaseDocumentBuildStep
         }
     }
 
-    private FileModel GenerateNewFileModel(FileModel model, RestApiRootItemViewModel operationModel)
+    private static FileModel GenerateNewFileModel(FileModel model, RestApiRootItemViewModel operationModel)
     {
         var originalFile = model.FileAndType.File;
         var fileExtension = Path.GetExtension(originalFile);
@@ -167,7 +167,7 @@ public class SplitRestApiToOperationLevel : BaseDocumentBuildStep
         return newModel;
     }
 
-    private TreeItem ConvertToTreeItem(RestApiRootItemViewModel root, string fileKey)
+    private static TreeItem ConvertToTreeItem(RestApiRootItemViewModel root, string fileKey)
     {
         return new TreeItem
         {
@@ -179,7 +179,7 @@ public class SplitRestApiToOperationLevel : BaseDocumentBuildStep
         };
     }
 
-    private Dictionary<string, object> MergeChildMetadata(RestApiRootItemViewModel root, RestApiChildItemViewModel child)
+    private static Dictionary<string, object> MergeChildMetadata(RestApiRootItemViewModel root, RestApiChildItemViewModel child)
     {
         var result = new Dictionary<string, object>(child.Metadata);
         foreach (var pair in root.Metadata)

--- a/plugins/Docfx.Build.TagLevelRestApi/SplitRestApiToTagLevel.cs
+++ b/plugins/Docfx.Build.TagLevelRestApi/SplitRestApiToTagLevel.cs
@@ -50,7 +50,7 @@ public class SplitRestApiToTagLevel : BaseDocumentBuildStep
         return collection;
     }
 
-    private Tuple<List<FileModel>, TreeItemRestructure> SplitModelToOperationGroup(FileModel model)
+    private static Tuple<List<FileModel>, TreeItemRestructure> SplitModelToOperationGroup(FileModel model)
     {
         if (model.Type != DocumentType.Article)
         {
@@ -102,7 +102,7 @@ public class SplitRestApiToTagLevel : BaseDocumentBuildStep
         return Tuple.Create(splittedModels, treeItemRestruction);
     }
 
-    private IEnumerable<RestApiRootItemViewModel> GenerateTagModels(RestApiRootItemViewModel root)
+    private static IEnumerable<RestApiRootItemViewModel> GenerateTagModels(RestApiRootItemViewModel root)
     {
         foreach (var tag in root.Tags)
         {
@@ -125,7 +125,7 @@ public class SplitRestApiToTagLevel : BaseDocumentBuildStep
         }
     }
 
-    private IEnumerable<RestApiChildItemViewModel> GetChildrenByTag(RestApiRootItemViewModel root, string tagName)
+    private static IEnumerable<RestApiChildItemViewModel> GetChildrenByTag(RestApiRootItemViewModel root, string tagName)
     {
         // Only group children into first tag, to keep cross reference unique
         var children = root.Children.Where(child => child.Tags != null && tagName == child.Tags.FirstOrDefault());
@@ -136,7 +136,7 @@ public class SplitRestApiToTagLevel : BaseDocumentBuildStep
         }
     }
 
-    private FileModel GenerateNewFileModel(FileModel model, RestApiRootItemViewModel tagModel)
+    private static FileModel GenerateNewFileModel(FileModel model, RestApiRootItemViewModel tagModel)
     {
         var originalFile = model.FileAndType.File;
         var fileExtension = Path.GetExtension(originalFile);
@@ -158,7 +158,7 @@ public class SplitRestApiToTagLevel : BaseDocumentBuildStep
         return newModel;
     }
 
-    private IEnumerable<string> CalculateUids(RestApiRootItemViewModel root)
+    private static IEnumerable<string> CalculateUids(RestApiRootItemViewModel root)
     {
         if (!string.IsNullOrEmpty(root.Uid))
         {
@@ -173,7 +173,7 @@ public class SplitRestApiToTagLevel : BaseDocumentBuildStep
         }
     }
 
-    private TreeItem ConvertToTreeItem(RestApiRootItemViewModel root, string fileKey)
+    private static TreeItem ConvertToTreeItem(RestApiRootItemViewModel root, string fileKey)
     {
         return new TreeItem
         {
@@ -185,7 +185,7 @@ public class SplitRestApiToTagLevel : BaseDocumentBuildStep
         };
     }
 
-    private Dictionary<string, object> MergeTagMetadata(RestApiRootItemViewModel root, RestApiTagViewModel tag)
+    private static Dictionary<string, object> MergeTagMetadata(RestApiRootItemViewModel root, RestApiTagViewModel tag)
     {
         var result = new Dictionary<string, object>(tag.Metadata);
         foreach (var pair in root.Metadata)

--- a/src/Docfx.App/Config/BuildJsonConfig.cs
+++ b/src/Docfx.App/Config/BuildJsonConfig.cs
@@ -5,7 +5,6 @@ using Docfx.Common;
 using Docfx.Plugins;
 
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Docfx;
 

--- a/src/Docfx.App/Config/FileMetadataPairs.cs
+++ b/src/Docfx.App/Config/FileMetadataPairs.cs
@@ -15,7 +15,7 @@ namespace Docfx;
 internal class FileMetadataPairs
 {
     // Order matters, the latter one overrides the former one
-    private List<FileMetadataPairsItem> _items;
+    private readonly List<FileMetadataPairsItem> _items;
 
     /// <summary>
     /// Gets FileMetadataPairs items.

--- a/src/Docfx.App/Config/FileMetadataPairsConverter.cs
+++ b/src/Docfx.App/Config/FileMetadataPairsConverter.cs
@@ -28,7 +28,7 @@ internal class FileMetadataPairsConverter : JsonConverter
         {
             jItems = JContainer.Load(reader);
         }
-        else throw new JsonReaderException($"{reader.TokenType.ToString()} is not a valid {objectType.Name}.");
+        else throw new JsonReaderException($"{reader.TokenType} is not a valid {objectType.Name}.");
         return new FileMetadataPairs(jItems.Select(ParseItem).ToList());
     }
 

--- a/src/Docfx.App/Docset.cs
+++ b/src/Docfx.App/Docset.cs
@@ -59,7 +59,7 @@ public static class Docset
             configPath,
             options,
             "pdf",
-            (config, exeOptions, configDirectory, outputDirectory) => RunPdf.Exec(config, exeOptions, configDirectory, outputDirectory));
+            RunPdf.Exec);
     }
 
     private static Task Exec<TConfig>(

--- a/src/Docfx.App/Helpers/DocumentBuilderWrapper.cs
+++ b/src/Docfx.App/Helpers/DocumentBuilderWrapper.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
-using System.Net;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;

--- a/src/Docfx.App/Helpers/DocumentBuilderWrapper.cs
+++ b/src/Docfx.App/Helpers/DocumentBuilderWrapper.cs
@@ -134,10 +134,9 @@ internal static class DocumentBuilderWrapper
                 SitemapOptions = config.SitemapOptions,
                 DisableGitFeatures = config.DisableGitFeatures,
                 ConfigureMarkdig = options.ConfigureMarkdig,
+                Metadata = GetGlobalMetadata(config),
+                FileMetadata = GetFileMetadata(baseDirectory, config),
             };
-
-            parameters.Metadata = GetGlobalMetadata(config);
-            parameters.FileMetadata = GetFileMetadata(baseDirectory, config);
 
             if (config.PostProcessors != null)
             {

--- a/src/Docfx.App/Helpers/DocumentBuilderWrapper.cs
+++ b/src/Docfx.App/Helpers/DocumentBuilderWrapper.cs
@@ -11,8 +11,6 @@ using Docfx.Plugins;
 
 namespace Docfx;
 
-#pragma warning disable CS0618 // Type or member is obsolete
-
 internal static class DocumentBuilderWrapper
 {
     private static readonly Assembly[] s_pluginAssemblies = LoadPluginAssemblies(AppContext.BaseDirectory).ToArray();

--- a/src/Docfx.App/Helpers/MetadataMerger.cs
+++ b/src/Docfx.App/Helpers/MetadataMerger.cs
@@ -132,7 +132,7 @@ internal class MetadataMerger
         }
     }
 
-    private Dictionary<string, object> GetTableItem(IReadOnlyDictionary<string, object> metadata, ImmutableList<string> metaNames)
+    private static Dictionary<string, object> GetTableItem(IReadOnlyDictionary<string, object> metadata, ImmutableList<string> metaNames)
     {
         var tableItem = new Dictionary<string, object>();
         foreach (var metaName in metaNames)
@@ -163,7 +163,7 @@ internal class MetadataMerger
         ApplyTocMetadata(item, _propTable);
     }
 
-    private void ApplyTocMetadata(TocItemViewModel item, Dictionary<string, Dictionary<string, object>> table)
+    private static void ApplyTocMetadata(TocItemViewModel item, Dictionary<string, Dictionary<string, object>> table)
     {
         if (table.TryGetValue(item.Uid, out Dictionary<string, object> metadata))
         {

--- a/src/Docfx.Build.Common/ModelAttributeHandlers/Handlers/BaseModelAttributeHandler.cs
+++ b/src/Docfx.Build.Common/ModelAttributeHandlers/Handlers/BaseModelAttributeHandler.cs
@@ -10,7 +10,7 @@ public abstract class BaseModelAttributeHandler<T> : IModelAttributeHandler wher
     private const int MaximumNestedLevel = 32;
     private readonly TypeInfo _typeInfo;
     protected readonly IModelAttributeHandler Handler;
-    private Type _type;
+    private readonly Type _type;
     protected BaseModelAttributeHandler(Type type, IModelAttributeHandler handler)
     {
         ArgumentNullException.ThrowIfNull(type);

--- a/src/Docfx.Build.Common/ModelAttributeHandlers/Handlers/BaseModelAttributeHandler.cs
+++ b/src/Docfx.Build.Common/ModelAttributeHandlers/Handlers/BaseModelAttributeHandler.cs
@@ -93,7 +93,7 @@ public abstract class BaseModelAttributeHandler<T> : IModelAttributeHandler wher
         {
             return null;
         }
-        Func<object, object> handler = s => Handler.Handle(s, context);
+        object handler(object s) => Handler.Handle(s, context);
         if (!HandleGenericItemsHelper.EnumerateIDictionary(currentObj, handler))
         {
             HandleGenericItemsHelper.EnumerateIReadonlyDictionary(currentObj, handler);
@@ -112,7 +112,7 @@ public abstract class BaseModelAttributeHandler<T> : IModelAttributeHandler wher
         {
             return null;
         }
-        Func<object, object> handler = s => Handler.Handle(s, context);
+
         HandleGenericItemsHelper.EnumerateIEnumerable(currentObj, s => Handler.Handle(s, context));
         return currentObj;
     }

--- a/src/Docfx.Build.Common/ModelAttributeHandlers/Handlers/BaseModelAttributeHandler.cs
+++ b/src/Docfx.Build.Common/ModelAttributeHandlers/Handlers/BaseModelAttributeHandler.cs
@@ -135,7 +135,7 @@ public abstract class BaseModelAttributeHandler<T> : IModelAttributeHandler wher
     protected virtual object ProcessNonPrimitiveType(object currentObj, HandleModelAttributesContext context)
     {
         // skip string type
-        if (currentObj != null && !(currentObj is string))
+        if (currentObj != null && currentObj is not string)
         {
             foreach (var prop in _typeInfo.PropInfos)
             {

--- a/src/Docfx.Build.Common/ModelAttributeHandlers/Handlers/CompositeModelAttributeHandler.cs
+++ b/src/Docfx.Build.Common/ModelAttributeHandlers/Handlers/CompositeModelAttributeHandler.cs
@@ -5,7 +5,7 @@ namespace Docfx.Build.Common;
 
 public class CompositeModelAttributeHandler : IModelAttributeHandler
 {
-    private IModelAttributeHandler[] _handlers;
+    private readonly IModelAttributeHandler[] _handlers;
     public CompositeModelAttributeHandler(params IModelAttributeHandler[] handlers)
     {
         _handlers = handlers;

--- a/src/Docfx.Build.Common/ModelAttributeHandlers/Handlers/HandleGenericItemsHelper.cs
+++ b/src/Docfx.Build.Common/ModelAttributeHandlers/Handlers/HandleGenericItemsHelper.cs
@@ -132,7 +132,7 @@ public class HandleGenericItemsHelper
 
         public void Handle(Func<object, object> handler)
         {
-            Handle(s => (T)handler((T)s));
+            Handle(s => (T)handler(s));
         }
 
         private void Handle(Func<T, T> handler)

--- a/src/Docfx.Build.Common/ModelAttributeHandlers/Handlers/MarkdownContentHandler.cs
+++ b/src/Docfx.Build.Common/ModelAttributeHandlers/Handlers/MarkdownContentHandler.cs
@@ -112,7 +112,7 @@ public class MarkdownContentHandler : IModelAttributeHandler
                    select prop;
         }
 
-        private string Markup(string content, HandleModelAttributesContext context)
+        private static string Markup(string content, HandleModelAttributesContext context)
         {
             if (string.IsNullOrEmpty(content))
             {
@@ -127,7 +127,7 @@ public class MarkdownContentHandler : IModelAttributeHandler
             return MarkupCore(content, context);
         }
 
-        private bool TryMarkupPlaceholderContent(string currentValue, HandleModelAttributesContext context, out string result)
+        private static bool TryMarkupPlaceholderContent(string currentValue, HandleModelAttributesContext context, out string result)
         {
             result = null;
             if (context.EnableContentPlaceholder && IsPlaceholderContent(currentValue))

--- a/src/Docfx.Build.Common/ModelAttributeHandlers/Handlers/UrlContentHandler.cs
+++ b/src/Docfx.Build.Common/ModelAttributeHandlers/Handlers/UrlContentHandler.cs
@@ -80,7 +80,7 @@ public class UrlContentHandler : IModelAttributeHandler
                    select prop;
         }
 
-        private string GetHrefFromRoot(string originalHref, HandleModelAttributesContext context)
+        private static string GetHrefFromRoot(string originalHref, HandleModelAttributesContext context)
         {
             if (context.FileAndType == null || string.IsNullOrEmpty(originalHref) || !RelativePath.IsRelativePath(originalHref))
             {

--- a/src/Docfx.Build.Common/ModelAttributeHandlers/ReflectionHelper.cs
+++ b/src/Docfx.Build.Common/ModelAttributeHandlers/ReflectionHelper.cs
@@ -48,7 +48,7 @@ public static class ReflectionHelper
         var argumentTypes = tuple.Item3;
         if (type == typeof(void))
         {
-            return _ => { throw new ArgumentException("Void is not allowed.", nameof(type)); };
+            return _ => { throw new ArgumentException("Void is not allowed for type.", nameof(tuple)); };
         }
         if (type.IsValueType)
         {
@@ -62,7 +62,7 @@ public static class ReflectionHelper
         }
         if (Array.IndexOf(typeArguments, typeof(void)) != -1)
         {
-            return _ => { throw new ArgumentException("Void is not allowed.", nameof(typeArguments)); };
+            return _ => { throw new ArgumentException("Void is not allowed for typeArguments.", nameof(tuple)); };
         }
         var typeArgument = Array.Find(typeArguments, t => !t.IsVisible);
         if (typeArgument != null)
@@ -111,7 +111,7 @@ public static class ReflectionHelper
         var ctor = finalType.GetConstructor(argumentTypes);
         if (ctor == null)
         {
-            return _ => { throw new ArgumentException(nameof(argumentTypes)); };
+            return _ => { throw new ArgumentException("Failed to get ctor of argumentTypes", nameof(tuple)); };
         }
         return GetCreateInstanceFuncCore(ctor, argumentTypes);
     }

--- a/src/Docfx.Build.ConceptualDocuments/ConceptualDocumentProcessor.cs
+++ b/src/Docfx.Build.ConceptualDocuments/ConceptualDocumentProcessor.cs
@@ -3,14 +3,11 @@
 
 using System.Collections.Immutable;
 using System.Composition;
-using System.Text;
 
 using Docfx.Build.Common;
 using Docfx.Common;
 using Docfx.DataContracts.Common;
 using Docfx.Plugins;
-
-using Newtonsoft.Json;
 
 namespace Docfx.Build.ConceptualDocuments;
 

--- a/src/Docfx.Build.Engine/CompilePhaseHandler.cs
+++ b/src/Docfx.Build.Engine/CompilePhaseHandler.cs
@@ -109,7 +109,7 @@ internal class CompilePhaseHandler : IPhaseHandler
                 using (new LoggerPhaseScope(buildStep.Name, LogLevel.Verbose))
                 {
                     var models = buildStep.Prebuild(hostService.Models, hostService);
-                    if (!object.ReferenceEquals(models, hostService.Models))
+                    if (!ReferenceEquals(models, hostService.Models))
                     {
                         Logger.LogVerbose($"Processor {hostService.Processor.Name}, step {buildStep.Name}: Reloading models...");
                         hostService.Reload(models);

--- a/src/Docfx.Build.Engine/DocumentBuildContext.cs
+++ b/src/Docfx.Build.Engine/DocumentBuildContext.cs
@@ -155,7 +155,7 @@ public sealed class DocumentBuildContext : IDocumentBuildContext
 
     internal void LoadExternalXRefSpec(TextReader reader)
     {
-        if (ExternalXRefSpec.Count > 0)
+        if (!ExternalXRefSpec.IsEmpty)
         {
             throw new InvalidOperationException("Cannot load after reporting external xref spec.");
         }

--- a/src/Docfx.Build.Engine/DocumentBuildContext.cs
+++ b/src/Docfx.Build.Engine/DocumentBuildContext.cs
@@ -482,7 +482,7 @@ public sealed class DocumentBuildContext : IDocumentBuildContext
         return _tableOfContents.Values.ToImmutableList();
     }
 
-    private ImmutableDictionary<string, FileAndType> GetAllSourceFiles(IEnumerable<FileAndType> allSourceFiles)
+    private static ImmutableDictionary<string, FileAndType> GetAllSourceFiles(IEnumerable<FileAndType> allSourceFiles)
     {
         var dict = new Dictionary<string, FileAndType>(FilePathComparer.OSPlatformSensitiveStringComparer);
         foreach (var item in allSourceFiles)

--- a/src/Docfx.Build.Engine/DocumentBuilder.cs
+++ b/src/Docfx.Build.Engine/DocumentBuilder.cs
@@ -261,7 +261,7 @@ public class DocumentBuilder : IDisposable
         }
     }
 
-    private MarkdigMarkdownService CreateMarkdigMarkdownService(DocumentBuildParameters parameters, CompositeResourceReader resourceProvider)
+    private static MarkdigMarkdownService CreateMarkdigMarkdownService(DocumentBuildParameters parameters, CompositeResourceReader resourceProvider)
     {
         return new MarkdigMarkdownService(
             new MarkdownServiceParameters

--- a/src/Docfx.Build.Engine/FileCollection.cs
+++ b/src/Docfx.Build.Engine/FileCollection.cs
@@ -78,7 +78,7 @@ public class FileCollection
         _files.RemoveAll(match);
     }
 
-    private string ToRelative(string file, string rootedBaseDir)
+    private static string ToRelative(string file, string rootedBaseDir)
     {
         if (!Path.IsPathRooted(file))
         {

--- a/src/Docfx.Build.Engine/FileMetadataConverter.cs
+++ b/src/Docfx.Build.Engine/FileMetadataConverter.cs
@@ -42,7 +42,7 @@ public class FileMetadataConverter : JsonConverter
         }
         else
         {
-            throw new JsonReaderException($"{reader.TokenType.ToString()} is not a valid {objectType.Name}.");
+            throw new JsonReaderException($"{reader.TokenType} is not a valid {objectType.Name}.");
         }
         var baseDir = (string)((JObject)token).GetValue(BaseDir);
         if (!(token[Dict] is JObject dict))

--- a/src/Docfx.Build.Engine/FileMetadataConverter.cs
+++ b/src/Docfx.Build.Engine/FileMetadataConverter.cs
@@ -45,7 +45,7 @@ public class FileMetadataConverter : JsonConverter
             throw new JsonReaderException($"{reader.TokenType} is not a valid {objectType.Name}.");
         }
         var baseDir = (string)((JObject)token).GetValue(BaseDir);
-        if (!(token[Dict] is JObject dict))
+        if (token[Dict] is not JObject dict)
         {
             throw new JsonReaderException($"Expect {token[Dict]} to be JObject.");
         }
@@ -95,13 +95,13 @@ public class FileMetadataConverter : JsonConverter
 
     private static ImmutableArray<FileMetadataItem> GetFileMetadataItemArray(JToken value)
     {
-        if (!(value is JArray arr))
+        if (value is not JArray arr)
         {
             throw new JsonReaderException($"Expect {value} to be JArray.");
         }
         return arr.Select(e =>
         {
-            if (!(e is JObject obj))
+            if (e is not JObject obj)
             {
                 throw new JsonReaderException($"Expect {e} to be JObject.");
             }

--- a/src/Docfx.Build.Engine/FileMetadataConverter.cs
+++ b/src/Docfx.Build.Engine/FileMetadataConverter.cs
@@ -93,7 +93,7 @@ public class FileMetadataConverter : JsonConverter
         writer.WriteEndObject();
     }
 
-    private ImmutableArray<FileMetadataItem> GetFileMetadataItemArray(JToken value)
+    private static ImmutableArray<FileMetadataItem> GetFileMetadataItemArray(JToken value)
     {
         if (!(value is JArray arr))
         {

--- a/src/Docfx.Build.Engine/FileMetadataItem.cs
+++ b/src/Docfx.Build.Engine/FileMetadataItem.cs
@@ -25,7 +25,7 @@ public sealed class FileMetadataItem : IEquatable<FileMetadataItem>
 
     public bool Equals(FileMetadataItem other)
     {
-        if (ReferenceEquals(null, other))
+        if (other is null)
         {
             return false;
         }

--- a/src/Docfx.Build.Engine/HostService.cs
+++ b/src/Docfx.Build.Engine/HostService.cs
@@ -236,7 +236,7 @@ internal sealed class HostService : IHostService, IDisposable
 
     private void HandleUidsChanged(object sender, PropertyChangedEventArgs<ImmutableArray<UidDefinition>> e)
     {
-        if (!(sender is FileModel m))
+        if (sender is not FileModel m)
         {
             return;
         }
@@ -268,7 +268,7 @@ internal sealed class HostService : IHostService, IDisposable
 
     private void HandleFileOrBaseDirChanged(object sender, EventArgs e)
     {
-        if (!(sender is FileModel m))
+        if (sender is not FileModel m)
         {
             return;
         }

--- a/src/Docfx.Build.Engine/HostServiceCreator.cs
+++ b/src/Docfx.Build.Engine/HostServiceCreator.cs
@@ -11,7 +11,7 @@ namespace Docfx.Build.Engine;
 
 internal class HostServiceCreator : IHostServiceCreator
 {
-    private DocumentBuildContext _context;
+    private readonly DocumentBuildContext _context;
 
     public HostServiceCreator(DocumentBuildContext context)
     {

--- a/src/Docfx.Build.Engine/HostServiceCreator.cs
+++ b/src/Docfx.Build.Engine/HostServiceCreator.cs
@@ -6,7 +6,6 @@ using System.Collections.Immutable;
 
 using Docfx.Common;
 using Docfx.Plugins;
-using Newtonsoft.Json.Linq;
 
 namespace Docfx.Build.Engine;
 

--- a/src/Docfx.Build.Engine/HostServiceCreator.cs
+++ b/src/Docfx.Build.Engine/HostServiceCreator.cs
@@ -62,7 +62,7 @@ internal class HostServiceCreator : IHostServiceCreator
             }
             catch (Exception e)
             {
-                if (!(e is DocumentException))
+                if (e is not DocumentException)
                 {
                     Logger.LogError(
                         $"Unable to load file '{file.File}' via processor '{processor.Name}': {e.Message}",

--- a/src/Docfx.Build.Engine/LinkPhaseHandler.cs
+++ b/src/Docfx.Build.Engine/LinkPhaseHandler.cs
@@ -49,7 +49,7 @@ internal class LinkPhaseHandler : IPhaseHandler
 
     #region Private Methods
 
-    private void Postbuild(List<HostService> hostServices, int maxParallelism)
+    private static void Postbuild(List<HostService> hostServices, int maxParallelism)
     {
         hostServices.RunAll(
             hostService =>
@@ -204,7 +204,7 @@ internal class LinkPhaseHandler : IPhaseHandler
         }
     }
 
-    private InternalManifestItem GetManifestItem(FileModel model, SaveResult result)
+    private static InternalManifestItem GetManifestItem(FileModel model, SaveResult result)
     {
         return new InternalManifestItem
         {

--- a/src/Docfx.Build.Engine/ManifestUtility.cs
+++ b/src/Docfx.Build.Engine/ManifestUtility.cs
@@ -9,7 +9,6 @@ using Docfx.Plugins;
 namespace Docfx.Common;
 
 #pragma warning disable CS0612 // Type or member is obsolete
-#pragma warning disable CS0618 // Type or member is obsolete
 
 public static class ManifestUtility
 {

--- a/src/Docfx.Build.Engine/PostProcessors/ExtractSearchIndex.cs
+++ b/src/Docfx.Build.Engine/PostProcessors/ExtractSearchIndex.cs
@@ -41,7 +41,7 @@ public class ExtractSearchIndex : IPostProcessor
     {
         if (outputFolder == null)
         {
-            throw new ArgumentNullException("Base directory can not be null");
+            throw new ArgumentNullException(nameof(outputFolder), "Base directory can not be null");
         }
         var indexData = new SortedDictionary<string, SearchIndexItem>();
         var indexDataFilePath = Path.Combine(outputFolder, IndexFileName);

--- a/src/Docfx.Build.Engine/PostProcessors/ExtractSearchIndex.cs
+++ b/src/Docfx.Build.Engine/PostProcessors/ExtractSearchIndex.cs
@@ -120,14 +120,14 @@ public class ExtractSearchIndex : IPostProcessor
         return new SearchIndexItem { Href = href, Title = title, Keywords = content };
     }
 
-    private string ExtractTitleFromHtml(HtmlDocument html)
+    private static string ExtractTitleFromHtml(HtmlDocument html)
     {
         var titleNode = html.DocumentNode.SelectSingleNode("//head/title");
         var originalTitle = titleNode?.InnerText;
         return NormalizeContent(originalTitle);
     }
 
-    private string NormalizeContent(string str)
+    private static string NormalizeContent(string str)
     {
         if (string.IsNullOrEmpty(str))
         {
@@ -137,7 +137,7 @@ public class ExtractSearchIndex : IPostProcessor
         return s_regexWhiteSpace.Replace(str, " ").Trim();
     }
 
-    private void ExtractTextFromNode(HtmlNode node, StringBuilder contentBuilder)
+    private static void ExtractTextFromNode(HtmlNode node, StringBuilder contentBuilder)
     {
         if (node == null)
         {

--- a/src/Docfx.Build.Engine/PostProcessors/PostProcessorsManager.cs
+++ b/src/Docfx.Build.Engine/PostProcessors/PostProcessorsManager.cs
@@ -12,7 +12,7 @@ namespace Docfx.Build.Engine;
 internal class PostProcessorsManager : IDisposable
 {
     private readonly List<PostProcessor> _postProcessors;
-    private IPostProcessorsHandler _postProcessorsHandler;
+    private readonly IPostProcessorsHandler _postProcessorsHandler;
 
     public PostProcessorsManager(CompositionHost container, ImmutableArray<string> postProcessorNames)
     {

--- a/src/Docfx.Build.Engine/PostProcessors/SearchIndexItem.cs
+++ b/src/Docfx.Build.Engine/PostProcessors/SearchIndexItem.cs
@@ -18,7 +18,7 @@ public class SearchIndexItem
 
     public override bool Equals(object obj)
     {
-        return this.Equals(obj as SearchIndexItem);
+        return Equals(obj as SearchIndexItem);
     }
 
     public bool Equals(SearchIndexItem other)
@@ -31,7 +31,7 @@ public class SearchIndexItem
         {
             return true;
         }
-        return string.Equals(this.Title, other.Title) && string.Equals(this.Href, other.Href) && string.Equals(this.Keywords, other.Keywords);
+        return string.Equals(Title, other.Title) && string.Equals(Href, other.Href) && string.Equals(Keywords, other.Keywords);
     }
 
     public override int GetHashCode()

--- a/src/Docfx.Build.Engine/PostProcessors/SitemapGenerator.cs
+++ b/src/Docfx.Build.Engine/PostProcessors/SitemapGenerator.cs
@@ -111,10 +111,10 @@ public class SitemapGenerator : IPostProcessor
             }
         }
 
-        options.BaseUrl = options.BaseUrl ?? rootOptions.BaseUrl;
-        options.ChangeFrequency = options.ChangeFrequency ?? rootOptions.ChangeFrequency;
-        options.Priority = options.Priority ?? rootOptions.Priority;
-        options.LastModified = options.LastModified ?? rootOptions.LastModified;
+        options.BaseUrl ??= rootOptions.BaseUrl;
+        options.ChangeFrequency ??= rootOptions.ChangeFrequency;
+        options.Priority ??= rootOptions.Priority;
+        options.LastModified ??= rootOptions.LastModified;
 
         if (options.Priority.HasValue && (options.Priority < 0 || options.Priority > 1))
         {

--- a/src/Docfx.Build.Engine/PostProcessors/ValidateBookmark.cs
+++ b/src/Docfx.Build.Engine/PostProcessors/ValidateBookmark.cs
@@ -23,7 +23,7 @@ public sealed class ValidateBookmark : HtmlDocumentHandler
     /// </summary>
     private readonly OSPlatformSensitiveDictionary<string> _fileMapping =
         new();
-    private OSPlatformSensitiveDictionary<List<LinkItem>> _linksWithBookmark =
+    private readonly OSPlatformSensitiveDictionary<List<LinkItem>> _linksWithBookmark =
         new();
 
     #region IHtmlDocumentHandler members

--- a/src/Docfx.Build.Engine/ResourceFileReaders/CompositeResourceReader.cs
+++ b/src/Docfx.Build.Engine/ResourceFileReaders/CompositeResourceReader.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
-using Docfx.Common;
 
 namespace Docfx.Build.Engine;
 

--- a/src/Docfx.Build.Engine/ResourceFileReaders/EmptyResourceReader.cs
+++ b/src/Docfx.Build.Engine/ResourceFileReaders/EmptyResourceReader.cs
@@ -5,7 +5,7 @@ namespace Docfx.Build.Engine;
 
 public sealed class EmptyResourceReader : ResourceFileReader
 {
-    private static readonly IEnumerable<string> Empty = new string[0];
+    private static readonly IEnumerable<string> Empty = Array.Empty<string>();
 
     public override bool IsEmpty => true;
     public override string Name => "Empty";

--- a/src/Docfx.Build.Engine/ResourceFileReaders/LocalFileResourceReader.cs
+++ b/src/Docfx.Build.Engine/ResourceFileReaders/LocalFileResourceReader.cs
@@ -9,8 +9,8 @@ public sealed class LocalFileResourceReader : ResourceFileReader
 {
     private const int MaxSearchLevel = 5;
     // keep comparer to be case sensitive as to be consistent with zip entries
-    private static StringComparer ResourceComparer = StringComparer.Ordinal;
-    private string _directory = null;
+    private static readonly StringComparer ResourceComparer = StringComparer.Ordinal;
+    private readonly string _directory = null;
     private readonly int _maxDepth;
     private readonly HashSet<string> NamesHashSet;
 

--- a/src/Docfx.Build.Engine/ResourceFileReaders/ResourceFileReader.cs
+++ b/src/Docfx.Build.Engine/ResourceFileReaders/ResourceFileReader.cs
@@ -32,7 +32,7 @@ public abstract class ResourceFileReader : IResourceFileReader, IDisposable
 
     public IEnumerable<KeyValuePair<string, Stream>> GetResourceStreams(string selector = null)
     {
-        Func<string, bool> filter = s =>
+        bool filter(string s)
         {
             if (selector != null)
             {
@@ -43,7 +43,7 @@ public abstract class ResourceFileReader : IResourceFileReader, IDisposable
             {
                 return true;
             }
-        };
+        }
         foreach (var name in Names)
         {
             if (filter(name))

--- a/src/Docfx.Build.Engine/SingleDocumentBuilder.cs
+++ b/src/Docfx.Build.Engine/SingleDocumentBuilder.cs
@@ -132,7 +132,7 @@ public class SingleDocumentBuilder : IDisposable
         }
     }
 
-    private void BuildCore(PhaseProcessor phaseProcessor, List<HostService> hostServices, DocumentBuildContext context)
+    private static void BuildCore(PhaseProcessor phaseProcessor, List<HostService> hostServices, DocumentBuildContext context)
     {
         phaseProcessor.Process(hostServices, context.MaxParallelism);
     }
@@ -191,7 +191,7 @@ public class SingleDocumentBuilder : IDisposable
         }
     }
 
-    private void Prepare(
+    private static void Prepare(
         DocumentBuildContext context,
         TemplateProcessor templateProcessor,
         out IHostServiceCreator hostServiceCreator,

--- a/src/Docfx.Build.Engine/SingleDocumentBuilder.cs
+++ b/src/Docfx.Build.Engine/SingleDocumentBuilder.cs
@@ -214,13 +214,14 @@ public class SingleDocumentBuilder : IDisposable
     private static string ExportXRefMap(DocumentBuildParameters parameters, DocumentBuildContext context)
     {
         Logger.LogVerbose("Exporting xref map...");
-        var xrefMap = new XRefMap();
-        xrefMap.References =
-            (from xref in context.XRefSpecMap.Values.AsParallel().WithDegreeOfParallelism(parameters.MaxParallelism)
+        var xrefMap = new XRefMap
+        {
+            References = (from xref in context.XRefSpecMap.Values.AsParallel().WithDegreeOfParallelism(parameters.MaxParallelism)
              select new XRefSpec(xref)
              {
                  Href = context.UpdateHref(xref.Href, RelativePath.WorkingFolder)
-             }).ToList();
+             }).ToList(),
+        };
         xrefMap.Sort();
         string xrefMapFileNameWithVersion = GetXrefMapFileNameWithGroup(parameters);
         YamlUtility.Serialize(

--- a/src/Docfx.Build.Engine/SingleDocumentBuilder.cs
+++ b/src/Docfx.Build.Engine/SingleDocumentBuilder.cs
@@ -111,7 +111,7 @@ public class SingleDocumentBuilder : IDisposable
                 };
                 manifest.Groups = new List<ManifestGroupInfo>
                 {
-                    new ManifestGroupInfo(parameters.GroupInfo)
+                    new(parameters.GroupInfo)
                     {
                         XRefmap = (string)manifest.XRefMap
                     }

--- a/src/Docfx.Build.Engine/SingleDocumentBuilder.cs
+++ b/src/Docfx.Build.Engine/SingleDocumentBuilder.cs
@@ -8,7 +8,6 @@ using Docfx.Plugins;
 namespace Docfx.Build.Engine;
 
 #pragma warning disable CS0612 // Type or member is obsolete
-#pragma warning disable CS0618 // Type or member is obsolete
 
 public class SingleDocumentBuilder : IDisposable
 {

--- a/src/Docfx.Build.Engine/TemplateProcessors/Template.cs
+++ b/src/Docfx.Build.Engine/TemplateProcessors/Template.cs
@@ -29,7 +29,7 @@ public class Template
     {
         if (renderer == null && preprocessor == null)
         {
-            throw new ArgumentNullException("Both renderer and preprocessor are null");
+            throw new ArgumentNullException(nameof(preprocessor), "Both renderer and preprocessor are null");
         }
 
         Renderer = renderer;

--- a/src/Docfx.Build.Engine/TemplateProcessors/TemplateBundle.cs
+++ b/src/Docfx.Build.Engine/TemplateProcessors/TemplateBundle.cs
@@ -35,7 +35,7 @@ public class TemplateBundle
         return MergeOptions(GetOptionsForEachTemplate(item, context));
     }
 
-    private TransformModelOptions MergeOptions(IEnumerable<TransformModelOptions> optionsList)
+    private static TransformModelOptions MergeOptions(IEnumerable<TransformModelOptions> optionsList)
     {
         var result = new TransformModelOptions();
         var bookmarks = new Dictionary<string, string>();

--- a/src/Docfx.Build.Engine/TemplateProcessors/TemplateCollection.cs
+++ b/src/Docfx.Build.Engine/TemplateProcessors/TemplateCollection.cs
@@ -32,7 +32,7 @@ public class TemplateCollection : Dictionary<string, TemplateBundle>
     {
         Reader = provider;
         MaxParallelism = maxParallelism;
-        base.TryGetValue("default", out _defaultTemplate);
+        TryGetValue("default", out _defaultTemplate);
     }
 
     private static Dictionary<string, TemplateBundle> ReadTemplate(ResourceFileReader reader, DocumentBuildContext context, int maxParallelism)

--- a/src/Docfx.Build.Engine/TemplateProcessors/TemplateCollection.cs
+++ b/src/Docfx.Build.Engine/TemplateProcessors/TemplateCollection.cs
@@ -5,7 +5,7 @@ namespace Docfx.Build.Engine;
 
 public class TemplateCollection : Dictionary<string, TemplateBundle>
 {
-    private TemplateBundle _defaultTemplate = null;
+    private readonly TemplateBundle _defaultTemplate = null;
 
     public IResourceFileReader Reader { get; }
 

--- a/src/Docfx.Build.Engine/TemplateProcessors/TemplateCollection.cs
+++ b/src/Docfx.Build.Engine/TemplateProcessors/TemplateCollection.cs
@@ -24,7 +24,7 @@ public class TemplateCollection : Dictionary<string, TemplateBundle>
         }
         set
         {
-            this[key] = value;
+            base[key] = value;
         }
     }
 

--- a/src/Docfx.Build.Engine/TemplateProcessors/TemplateModelTransformer.cs
+++ b/src/Docfx.Build.Engine/TemplateProcessors/TemplateModelTransformer.cs
@@ -250,7 +250,7 @@ public class TemplateModelTransformer
             return dictionary;
         }
 
-        if (!(ConvertToObjectHelper.ConvertStrongTypeToObject(model) is IDictionary<string, object> objectModel))
+        if (ConvertToObjectHelper.ConvertStrongTypeToObject(model) is not IDictionary<string, object> objectModel)
         {
             throw new ArgumentException("Only object model is supported for template transformation.");
         }

--- a/src/Docfx.Build.Engine/TemplateProcessors/TemplateModelTransformer.cs
+++ b/src/Docfx.Build.Engine/TemplateProcessors/TemplateModelTransformer.cs
@@ -184,7 +184,7 @@ public class TemplateModelTransformer
         foreach (var group in unresolvedXRefs.GroupBy(i => i.SourceFile))
         {
             // For each source file, print the first 10 invalid cross reference
-            var details = group.Take(MaxInvalidXrefMessagePerFile).Select(i => $"\"{HttpUtility.HtmlDecode(i.RawSource)}\" in line {i.SourceStartLineNumber.ToString()}").Distinct().ToList();
+            var details = group.Take(MaxInvalidXrefMessagePerFile).Select(i => $"\"{HttpUtility.HtmlDecode(i.RawSource)}\" in line {i.SourceStartLineNumber}").Distinct().ToList();
             var prefix = details.Count > MaxInvalidXrefMessagePerFile ? $"top {MaxInvalidXrefMessagePerFile} " : string.Empty;
             var message = $"Details for {prefix}invalid cross reference(s): {details.ToDelimitedString(", ")}";
 

--- a/src/Docfx.Build.Engine/TemplateProcessors/TemplateModelTransformer.cs
+++ b/src/Docfx.Build.Engine/TemplateProcessors/TemplateModelTransformer.cs
@@ -170,7 +170,7 @@ public class TemplateModelTransformer
         return manifestItem;
     }
 
-    private void LogInvalidXRefs(List<XRefDetails> unresolvedXRefs)
+    private static void LogInvalidXRefs(List<XRefDetails> unresolvedXRefs)
     {
         if (unresolvedXRefs == null || unresolvedXRefs.Count == 0)
         {

--- a/src/Docfx.Build.Engine/TemplateProcessors/TemplateModelTransformer.cs
+++ b/src/Docfx.Build.Engine/TemplateProcessors/TemplateModelTransformer.cs
@@ -40,7 +40,7 @@ public class TemplateModelTransformer
     {
         if (item == null || item.Content == null)
         {
-            throw new ArgumentNullException("Content for item.Model should not be null!");
+            throw new ArgumentNullException(nameof(item), "Content for item.Model should not be null!");
         }
 
         var model = ConvertObjectToDictionary(item.Content);

--- a/src/Docfx.Build.Engine/TemplateProcessors/TemplateProcessor.cs
+++ b/src/Docfx.Build.Engine/TemplateProcessors/TemplateProcessor.cs
@@ -119,7 +119,7 @@ public class TemplateProcessor : IDisposable
         }
     }
 
-    private void CopyTemplateResource(Stream stream, string outputDirectory, string filePath)
+    private static void CopyTemplateResource(Stream stream, string outputDirectory, string filePath)
     {
         if (stream != null)
         {

--- a/src/Docfx.Build.Engine/TemplateProcessors/TemplateProcessorUtility.cs
+++ b/src/Docfx.Build.Engine/TemplateProcessors/TemplateProcessorUtility.cs
@@ -16,7 +16,7 @@ public static class TemplateProcessorUtility
 
         return LoadTokensCore(resource);
 
-        Dictionary<string, string> LoadTokensCore(ResourceFileReader resource)
+        static Dictionary<string, string> LoadTokensCore(ResourceFileReader resource)
         {
             var tokenJson = resource.GetResource("token.json");
             if (string.IsNullOrEmpty(tokenJson))

--- a/src/Docfx.Build.Engine/TemplateProcessors/TemplateResourceInfo.cs
+++ b/src/Docfx.Build.Engine/TemplateProcessors/TemplateResourceInfo.cs
@@ -13,7 +13,7 @@ public sealed class TemplateResourceInfo
 
     public override bool Equals(object obj)
     {
-        if (!(obj is TemplateResourceInfo target))
+        if (obj is not TemplateResourceInfo target)
         {
             return false;
         }

--- a/src/Docfx.Build.Engine/XRefMaps/XRefArchive.cs
+++ b/src/Docfx.Build.Engine/XRefMaps/XRefArchive.cs
@@ -80,10 +80,7 @@ public sealed class XRefArchive : IXRefContainer, IDisposable
         }
         catch (Exception) when (fs != null)
         {
-            if (archive != null)
-            {
-                archive.Dispose();
-            }
+            archive?.Dispose();
             fs.Close();
             throw;
         }

--- a/src/Docfx.Build.Engine/XRefMaps/XRefArchiveBuilder.cs
+++ b/src/Docfx.Build.Engine/XRefMaps/XRefArchiveBuilder.cs
@@ -43,7 +43,7 @@ public class XRefArchiveBuilder
     {
         IXRefContainer container;
         container = await _downloader.DownloadAsync(uri);
-        if (!(container is XRefMap map))
+        if (container is not XRefMap map)
         {
             // not support download an xref archive, or reference to an xref archive
             return null;

--- a/src/Docfx.Build.Engine/XRefMaps/XRefMap.cs
+++ b/src/Docfx.Build.Engine/XRefMaps/XRefMap.cs
@@ -41,10 +41,7 @@ public class XRefMap : IXRefContainer
         {
             return;
         }
-        if (References != null)
-        {
-            References.Sort(XRefSpecUidComparer.Instance);
-        }
+        References?.Sort(XRefSpecUidComparer.Instance);
         Sorted = true;
     }
 

--- a/src/Docfx.Build.Engine/XRefMaps/XRefRedirectionReader.cs
+++ b/src/Docfx.Build.Engine/XRefMaps/XRefRedirectionReader.cs
@@ -54,7 +54,7 @@ public abstract class XRefRedirectionReader : IXRefContainerReader
         return null;
     }
 
-    private void AddRedirections(string uid, Stack<string> checkList, IXRefContainer current)
+    private static void AddRedirections(string uid, Stack<string> checkList, IXRefContainer current)
     {
         foreach (var r in current.GetRedirections().Reverse())
         {

--- a/src/Docfx.Build.Engine/XrefDetails.cs
+++ b/src/Docfx.Build.Engine/XrefDetails.cs
@@ -98,7 +98,7 @@ public sealed class XRefDetails
 
         return xref;
 
-        string ExtractValue(NameValueCollection collection, string properName)
+        static string ExtractValue(NameValueCollection collection, string properName)
         {
             var value = collection[properName];
             collection.Remove(properName);

--- a/src/Docfx.Build.ManagedReference/ApplyOverwriteDocumentForMREF.cs
+++ b/src/Docfx.Build.ManagedReference/ApplyOverwriteDocumentForMREF.cs
@@ -21,7 +21,7 @@ public class ApplyOverwriteDocumentForMref : ApplyOverwriteDocument
         return Transform<ItemViewModel>(fileModel, uid, host);
     }
 
-    public IEnumerable<ItemViewModel> GetItemsToOverwrite(FileModel fileModel, string uid, IHostService host)
+    public static IEnumerable<ItemViewModel> GetItemsToOverwrite(FileModel fileModel, string uid, IHostService host)
     {
         return ((PageViewModel)fileModel.Content).Items.Where(s => s.Uid == uid);
     }

--- a/src/Docfx.Build.ManagedReference/ApplyPlatformVersion.cs
+++ b/src/Docfx.Build.ManagedReference/ApplyPlatformVersion.cs
@@ -77,7 +77,7 @@ public class ApplyPlatformVersion : BaseDocumentBuildStep
             }
             catch (Exception)
             {
-                Logger.LogWarning($"Unknown platform-version metadata: {jArray.ToString()}");
+                Logger.LogWarning($"Unknown platform-version metadata: {jArray}");
             }
         }
 

--- a/src/Docfx.Build.ManagedReference/BuildOutputs/ApiBuildOutputUtility.cs
+++ b/src/Docfx.Build.ManagedReference/BuildOutputs/ApiBuildOutputUtility.cs
@@ -102,12 +102,12 @@ public static class ApiBuildOutputUtility
         var sb = new StringBuilder();
         sb.Append("<xref uid=\"")
             .Append(HttpUtility.HtmlEncode(uid))
-            .Append("\"");
+            .Append('"');
         if (!string.IsNullOrEmpty(text))
         {
             sb.Append(" text=\"")
                 .Append(HttpUtility.HtmlEncode(text))
-                .Append("\"");
+                .Append('"');
         }
         else
         {

--- a/src/Docfx.Build.ManagedReference/FillReferenceInformation.cs
+++ b/src/Docfx.Build.ManagedReference/FillReferenceInformation.cs
@@ -14,7 +14,7 @@ namespace Docfx.Build.ManagedReference;
 [Export(nameof(ManagedReferenceDocumentProcessor), typeof(IDocumentBuildStep))]
 public class FillReferenceInformation : BaseDocumentBuildStep
 {
-    private Dictionary<string, SourceInfo> _items = new();
+    private readonly Dictionary<string, SourceInfo> _items = new();
 
     public override string Name => nameof(FillReferenceInformation);
 

--- a/src/Docfx.Build.ManagedReference/FillReferenceInformation.cs
+++ b/src/Docfx.Build.ManagedReference/FillReferenceInformation.cs
@@ -70,7 +70,7 @@ public class FillReferenceInformation : BaseDocumentBuildStep
         }
     }
 
-    private void FillContent(ReferenceViewModel r, dynamic item)
+    private static void FillContent(ReferenceViewModel r, dynamic item)
     {
         if (item.Metadata != null)
         {
@@ -110,7 +110,7 @@ public class FillReferenceInformation : BaseDocumentBuildStep
         }
     }
 
-    private IEnumerable<string> GetUidsToFill(PageViewModel pageViewModel)
+    private static IEnumerable<string> GetUidsToFill(PageViewModel pageViewModel)
     {
         return (from i in pageViewModel.Items
                 from c in (i.Children ?? Enumerable.Empty<string>())

--- a/src/Docfx.Build.ManagedReference/ManagedReferenceDocumentProcessor.cs
+++ b/src/Docfx.Build.ManagedReference/ManagedReferenceDocumentProcessor.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Immutable;
 using System.Composition;
-using System.Text;
 
 using Docfx.Build.Common;
 using Docfx.Build.ManagedReference.BuildOutputs;
@@ -11,8 +10,6 @@ using Docfx.Common;
 using Docfx.DataContracts.Common;
 using Docfx.DataContracts.ManagedReference;
 using Docfx.Plugins;
-
-using Newtonsoft.Json;
 
 namespace Docfx.Build.ManagedReference;
 

--- a/src/Docfx.Build.ManagedReference/ManagedReferenceDocumentProcessor.cs
+++ b/src/Docfx.Build.ManagedReference/ManagedReferenceDocumentProcessor.cs
@@ -183,7 +183,7 @@ public class ManagedReferenceDocumentProcessor : ReferenceDocumentProcessorBase
         model.Content = apiModel;
     }
 
-    private IEnumerable<XRefSpec> GetXRefFromReference(PageViewModel vm)
+    private static IEnumerable<XRefSpec> GetXRefFromReference(PageViewModel vm)
     {
         if (vm.References == null)
         {

--- a/src/Docfx.Build.ManagedReference/MergeManagedReferenceDocument.cs
+++ b/src/Docfx.Build.ManagedReference/MergeManagedReferenceDocument.cs
@@ -148,7 +148,7 @@ public class MergeManagedReferenceDocument : BaseDocumentBuildStep
         }
     }
 
-    private void MergeReferences(MergeItem item, MergeItem otherItem)
+    private static void MergeReferences(MergeItem item, MergeItem otherItem)
     {
         if (item.References != null)
         {
@@ -163,7 +163,7 @@ public class MergeManagedReferenceDocument : BaseDocumentBuildStep
         }
     }
 
-    private void MergeReferencesCore(
+    private static void MergeReferencesCore(
         Dictionary<string, ReferenceViewModel> mergeTo,
         Dictionary<string, ReferenceViewModel> mergeFrom)
     {
@@ -176,7 +176,7 @@ public class MergeManagedReferenceDocument : BaseDocumentBuildStep
         }
     }
 
-    private PageViewModel ConvertToVM(MergeItem mergeItem)
+    private static PageViewModel ConvertToVM(MergeItem mergeItem)
     {
         var vm = new PageViewModel
         {
@@ -188,7 +188,7 @@ public class MergeManagedReferenceDocument : BaseDocumentBuildStep
         return vm;
     }
 
-    private void ConvertToVMCore(PageViewModel vm, MergeItem mergeItem)
+    private static void ConvertToVMCore(PageViewModel vm, MergeItem mergeItem)
     {
         if (mergeItem.AssemblyNameList.Count > 0)
         {

--- a/src/Docfx.Build.ManagedReference/SplitClassPageToMemberLevel.cs
+++ b/src/Docfx.Build.ManagedReference/SplitClassPageToMemberLevel.cs
@@ -611,7 +611,7 @@ public class SplitClassPageToMemberLevel : BaseDocumentBuildStep
             }
             catch (Exception)
             {
-                Logger.LogWarning($"Unknown version metadata: {jArray.ToString()}");
+                Logger.LogWarning($"Unknown version metadata: {jArray}");
             }
         }
 

--- a/src/Docfx.Build.ManagedReference/SplitClassPageToMemberLevel.cs
+++ b/src/Docfx.Build.ManagedReference/SplitClassPageToMemberLevel.cs
@@ -22,7 +22,7 @@ public class SplitClassPageToMemberLevel : BaseDocumentBuildStep
     private const string IsOverloadPropertyName = "_isOverload";
     private const int MaximumFileNameLength = 180;
     private static readonly List<string> EmptyList = new();
-    private static readonly string[] EmptyArray = new string[0];
+    private static readonly string[] EmptyArray = Array.Empty<string>();
 
     public override string Name => nameof(SplitClassPageToMemberLevel);
 

--- a/src/Docfx.Build.ManagedReference/SplitClassPageToMemberLevel.cs
+++ b/src/Docfx.Build.ManagedReference/SplitClassPageToMemberLevel.cs
@@ -88,7 +88,7 @@ public class SplitClassPageToMemberLevel : BaseDocumentBuildStep
         return modelsDict.Values;
     }
 
-    private void RenewDupeFileModels(FileModel dupeModel, Dictionary<string, int> newFilePaths, Dictionary<string, FileModel> modelsDict)
+    private static void RenewDupeFileModels(FileModel dupeModel, Dictionary<string, int> newFilePaths, Dictionary<string, FileModel> modelsDict)
     {
         var page = dupeModel.Content as PageViewModel;
         var memberType = page.Items[0]?.Type;
@@ -104,7 +104,7 @@ public class SplitClassPageToMemberLevel : BaseDocumentBuildStep
         modelsDict[newFilePath] = newModel;
     }
 
-    private string GetUniqueFilePath(string dupePath, string newFileName, Dictionary<string, int> newFilePaths, Dictionary<string, FileModel> modelsDict)
+    private static string GetUniqueFilePath(string dupePath, string newFileName, Dictionary<string, int> newFilePaths, Dictionary<string, FileModel> modelsDict)
     {
         var dir = Path.GetDirectoryName(dupePath);
         var extension = Path.GetExtension(dupePath);
@@ -198,7 +198,7 @@ public class SplitClassPageToMemberLevel : BaseDocumentBuildStep
         return new SplittedResult(primaryItem.Uid, children.OrderBy(GetDisplayName, StringComparer.Ordinal), splittedModels);
     }
 
-    private IEnumerable<PageViewModel> GetNewPages(PageViewModel page)
+    private static IEnumerable<PageViewModel> GetNewPages(PageViewModel page)
     {
         var primaryItem = page.Items[0];
         if (primaryItem.Type == MemberType.Enum)
@@ -229,13 +229,13 @@ public class SplitClassPageToMemberLevel : BaseDocumentBuildStep
         }
     }
 
-    private void AddToTree(ItemViewModel item, List<TreeItem> tree)
+    private static void AddToTree(ItemViewModel item, List<TreeItem> tree)
     {
         var treeItem = ConvertToTreeItem(item);
         tree.Add(treeItem);
     }
 
-    private ItemViewModel GenerateOverloadPage(PageViewModel page, IGrouping<string, ItemViewModel> overload)
+    private static ItemViewModel GenerateOverloadPage(PageViewModel page, IGrouping<string, ItemViewModel> overload)
     {
         var primaryItem = page.Items[0];
 
@@ -287,7 +287,7 @@ public class SplitClassPageToMemberLevel : BaseDocumentBuildStep
         return newPrimaryItem;
     }
 
-    private List<string> MergeList(IEnumerable<ItemViewModel> children, Func<ItemViewModel, IEnumerable<string>> selector)
+    private static List<string> MergeList(IEnumerable<ItemViewModel> children, Func<ItemViewModel, IEnumerable<string>> selector)
     {
         var items = children.SelectMany(selector).Distinct().OrderBy(s => s, StringComparer.Ordinal).ToList();
         if (items.Count == 0)
@@ -298,7 +298,7 @@ public class SplitClassPageToMemberLevel : BaseDocumentBuildStep
         return items;
     }
 
-    private List<string> GetVersionFromMetadata(object value)
+    private static List<string> GetVersionFromMetadata(object value)
     {
         if (value is string text)
         {
@@ -308,7 +308,7 @@ public class SplitClassPageToMemberLevel : BaseDocumentBuildStep
         return GetListFromObject(value);
     }
 
-    private string GetOverloadItemName(string overload, string parent, bool isCtor)
+    private static string GetOverloadItemName(string overload, string parent, bool isCtor)
     {
         if (string.IsNullOrEmpty(overload) || string.IsNullOrEmpty(parent))
         {
@@ -374,7 +374,7 @@ public class SplitClassPageToMemberLevel : BaseDocumentBuildStep
         return reference;
     }
 
-    private void MergeWithReference(ItemViewModel item, ReferenceViewModel reference)
+    private static void MergeWithReference(ItemViewModel item, ReferenceViewModel reference)
     {
         item.Name = reference.Name;
         item.NameWithType = reference.NameWithType;
@@ -458,7 +458,7 @@ public class SplitClassPageToMemberLevel : BaseDocumentBuildStep
         }
     }
 
-    private TreeItem ConvertToTreeItem(ItemViewModel item, Dictionary<string, object> overwriteMetadata = null)
+    private static TreeItem ConvertToTreeItem(ItemViewModel item, Dictionary<string, object> overwriteMetadata = null)
     {
         var result = new TreeItem
         {
@@ -514,7 +514,7 @@ public class SplitClassPageToMemberLevel : BaseDocumentBuildStep
         return result;
     }
 
-    private PageViewModel ExtractPageViewModel(PageViewModel page, List<ItemViewModel> items)
+    private static PageViewModel ExtractPageViewModel(PageViewModel page, List<ItemViewModel> items)
     {
         var newPage = new PageViewModel
         {
@@ -526,7 +526,7 @@ public class SplitClassPageToMemberLevel : BaseDocumentBuildStep
         return newPage;
     }
 
-    private FileModel GenerateNewFileModel(FileModel model, PageViewModel newPage, string fileNameWithoutExtension, Dictionary<string, int> existingFileNames)
+    private static FileModel GenerateNewFileModel(FileModel model, PageViewModel newPage, string fileNameWithoutExtension, Dictionary<string, int> existingFileNames)
     {
         var initialFile = model.FileAndType.File;
         var extension = Path.GetExtension(initialFile);
@@ -548,7 +548,7 @@ public class SplitClassPageToMemberLevel : BaseDocumentBuildStep
         };
     }
 
-    private string GetUniqueFileNameWithSuffix(string fileName, Dictionary<string, int> existingFileNames)
+    private static string GetUniqueFileNameWithSuffix(string fileName, Dictionary<string, int> existingFileNames)
     {
         if (existingFileNames.TryGetValue(fileName, out int suffix))
         {
@@ -562,7 +562,7 @@ public class SplitClassPageToMemberLevel : BaseDocumentBuildStep
         }
     }
 
-    private string GetNewFileName(string parentUid, ItemViewModel model)
+    private static string GetNewFileName(string parentUid, ItemViewModel model)
     {
         // For constructor, if the class is generic class e.g. ExpandedWrapper`11, class name can be pretty long
         // Use -ctor as file name
@@ -574,7 +574,7 @@ public class SplitClassPageToMemberLevel : BaseDocumentBuildStep
             );
     }
 
-    private string GetValidFileName(params string[] fileNames)
+    private static string GetValidFileName(params string[] fileNames)
     {
         foreach (var fileName in fileNames)
         {
@@ -589,14 +589,14 @@ public class SplitClassPageToMemberLevel : BaseDocumentBuildStep
         throw new DocumentException(message);
     }
 
-    private ImmutableArray<UidDefinition> CalculateUids(PageViewModel page, string file)
+    private static ImmutableArray<UidDefinition> CalculateUids(PageViewModel page, string file)
     {
         return (from item in page.Items
                 where !string.IsNullOrEmpty(item.Uid)
                 select new UidDefinition(item.Uid, file)).ToImmutableArray();
     }
 
-    private List<string> GetListFromObject(object value)
+    private static List<string> GetListFromObject(object value)
     {
         if (value is IEnumerable<object> collection)
         {
@@ -618,7 +618,7 @@ public class SplitClassPageToMemberLevel : BaseDocumentBuildStep
         return null;
     }
 
-    private T GetPropertyValue<T>(Dictionary<string, object> metadata, string key) where T : class
+    private static T GetPropertyValue<T>(Dictionary<string, object> metadata, string key) where T : class
     {
         if (metadata != null && metadata.TryGetValue(key, out object result))
         {
@@ -654,7 +654,7 @@ public class SplitClassPageToMemberLevel : BaseDocumentBuildStep
         }
     }
 
-    private void AddModelToDict(FileModel model, Dictionary<string, FileModel> models, List<FileModel> dupeModels)
+    private static void AddModelToDict(FileModel model, Dictionary<string, FileModel> models, List<FileModel> dupeModels)
     {
         if (!models.ContainsKey(model.File))
         {

--- a/src/Docfx.Build.ManagedReference/SplitClassPageToMemberLevel.cs
+++ b/src/Docfx.Build.ManagedReference/SplitClassPageToMemberLevel.cs
@@ -96,7 +96,7 @@ public class SplitClassPageToMemberLevel : BaseDocumentBuildStep
 
         if (memberType != null)
         {
-            newFileName = newFileName + $"({memberType})";
+            newFileName += $"({memberType})";
         }
 
         var newFilePath = GetUniqueFilePath(dupeModel.File, newFileName, newFilePaths, modelsDict);
@@ -115,13 +115,13 @@ public class SplitClassPageToMemberLevel : BaseDocumentBuildStep
             if (newFilePaths.TryGetValue(newFilePath, out int suffix))
             {
                 // new file path already exist and have suffix
-                newFileName = newFileName + $"_{suffix}";
+                newFileName += $"_{suffix}";
                 suffix++;
             }
             else
             {
                 // new file path already exist but doesn't have suffix (special case) 
-                newFileName = newFileName + "_1";
+                newFileName += "_1";
                 newFilePaths[newFilePath] = 2;
             }
 

--- a/src/Docfx.Build.OverwriteDocuments/MarkdownFragmentsCreator.cs
+++ b/src/Docfx.Build.OverwriteDocuments/MarkdownFragmentsCreator.cs
@@ -43,9 +43,11 @@ public class MarkdownFragmentsCreator
 
     private MarkdownFragmentModel MarkdownFragment()
     {
-        var result = new MarkdownFragmentModel();
-        result.UidSource = Eat(_l1InlineCodeHeadingRule, out var uid);
-        result.Uid = uid;
+        var result = new MarkdownFragmentModel
+        {
+            UidSource = Eat(_l1InlineCodeHeadingRule, out var uid),
+            Uid = uid,
+        };
 
         if (_yamlCodeBlockRule.Parse(Peek(), out var yamlCodeBlock))
         {

--- a/src/Docfx.Build.OverwriteDocuments/MarkdownFragmentsCreator.cs
+++ b/src/Docfx.Build.OverwriteDocuments/MarkdownFragmentsCreator.cs
@@ -20,13 +20,13 @@ public class MarkdownFragmentsCreator
 
     private int _position;
 
-    private InlineCodeHeadingRule _inlineCodeHeadingRule = new();
+    private readonly InlineCodeHeadingRule _inlineCodeHeadingRule = new();
 
-    private L1InlineCodeHeadingRule _l1InlineCodeHeadingRule = new();
+    private readonly L1InlineCodeHeadingRule _l1InlineCodeHeadingRule = new();
 
-    private L2InlineCodeHeadingRule _l2InlineCodeHeadingRule = new();
+    private readonly L2InlineCodeHeadingRule _l2InlineCodeHeadingRule = new();
 
-    private YamlCodeBlockRule _yamlCodeBlockRule = new();
+    private readonly YamlCodeBlockRule _yamlCodeBlockRule = new();
 
     public IEnumerable<MarkdownFragmentModel> Create(MarkdownDocument document)
     {

--- a/src/Docfx.Build.OverwriteDocuments/OverwriteDocumentModelCreator.cs
+++ b/src/Docfx.Build.OverwriteDocuments/OverwriteDocumentModelCreator.cs
@@ -9,7 +9,7 @@ namespace Docfx.Build.OverwriteDocuments;
 
 public class OverwriteDocumentModelCreator
 {
-    string _file;
+    private readonly string _file;
 
     public OverwriteDocumentModelCreator(string file)
     {

--- a/src/Docfx.Build.OverwriteDocuments/OverwriteDocumentModelCreator.cs
+++ b/src/Docfx.Build.OverwriteDocuments/OverwriteDocumentModelCreator.cs
@@ -110,10 +110,9 @@ public class OverwriteDocumentModelCreator
             {
                 if (childObject is List<object> listObject)
                 {
-                    object value;
                     var goodItems = (from item in listObject
                                      where item is Dictionary<object, object>
-                                        && ((Dictionary<object, object>)item).TryGetValue(segment.Key, out value)
+                                        && ((Dictionary<object, object>)item).TryGetValue(segment.Key, out object value)
                                         && ((string)value).Equals(segment.Value)
                                      select (Dictionary<object, object>)item).ToList();
                     if (goodItems.Count > 0)

--- a/src/Docfx.Build.OverwriteDocuments/OverwriteDocumentModelCreator.cs
+++ b/src/Docfx.Build.OverwriteDocuments/OverwriteDocumentModelCreator.cs
@@ -111,8 +111,8 @@ public class OverwriteDocumentModelCreator
                 if (childObject is List<object> listObject)
                 {
                     var goodItems = (from item in listObject
-                                     where item is Dictionary<object, object>
-                                        && ((Dictionary<object, object>)item).TryGetValue(segment.Key, out object value)
+                                     where item is Dictionary<object, object> dictionary
+                                        && dictionary.TryGetValue(segment.Key, out object value)
                                         && ((string)value).Equals(segment.Value)
                                      select (Dictionary<object, object>)item).ToList();
                     if (goodItems.Count > 0)

--- a/src/Docfx.Build.OverwriteDocuments/OverwriteDocumentModelCreator.cs
+++ b/src/Docfx.Build.OverwriteDocuments/OverwriteDocumentModelCreator.cs
@@ -48,7 +48,7 @@ public class OverwriteDocumentModelCreator
         catch (Exception ex)
         {
             throw new MarkdownFragmentsException(
-                $"Encountered an invalid YAML code block: {ex.ToString()}",
+                $"Encountered an invalid YAML code block: {ex}",
                 yamlCodeBlockSource.Line,
                 ex);
         }

--- a/src/Docfx.Build.OverwriteDocuments/OverwriteDocumentModelCreator.cs
+++ b/src/Docfx.Build.OverwriteDocuments/OverwriteDocumentModelCreator.cs
@@ -74,13 +74,13 @@ public class OverwriteDocumentModelCreator
         return currentMetadata.ToDictionary(k => k.Key.ToString(), k => k.Value);
     }
 
-    private void AppendNewObject(List<OPathSegment> OPathSegments, Block codeHeaderBlock, MarkdownDocument propertyValue, Dictionary<object, object> contentsMetadata)
+    private static void AppendNewObject(List<OPathSegment> OPathSegments, Block codeHeaderBlock, MarkdownDocument propertyValue, Dictionary<object, object> contentsMetadata)
     {
         FindOrCreateObject(contentsMetadata, codeHeaderBlock, OPathSegments, 0, propertyValue,
             string.Join("/", OPathSegments.Select(o => o.OriginalSegmentString)));
     }
 
-    private void FindOrCreateObject(Dictionary<object, object> currentObject, Block codeHeaderBlock, List<OPathSegment> OPathSegments, int index, MarkdownDocument propertyValue, string originalOPathString)
+    private static void FindOrCreateObject(Dictionary<object, object> currentObject, Block codeHeaderBlock, List<OPathSegment> OPathSegments, int index, MarkdownDocument propertyValue, string originalOPathString)
     {
         var segment = OPathSegments[index];
         if (index == OPathSegments.Count - 1)
@@ -153,7 +153,7 @@ public class OverwriteDocumentModelCreator
         }
     }
 
-    private void CreateCoreObject(OPathSegment lastSegment, Block codeHeaderBlock, Dictionary<object, object> currentObject, MarkdownDocument propertyValue, string originalOPathString)
+    private static void CreateCoreObject(OPathSegment lastSegment, Block codeHeaderBlock, Dictionary<object, object> currentObject, MarkdownDocument propertyValue, string originalOPathString)
     {
         if (currentObject.TryGetValue(lastSegment.SegmentName, out object value))
         {

--- a/src/Docfx.Build.OverwriteDocuments/Rules/InlineCodeHeadingRule.cs
+++ b/src/Docfx.Build.OverwriteDocuments/Rules/InlineCodeHeadingRule.cs
@@ -25,7 +25,7 @@ public class InlineCodeHeadingRule : IOverwriteBlockRule
 
     private CodeInline ParseCore(Block block)
     {
-        if (!(block is HeadingBlock heading)
+        if (block is not HeadingBlock heading
             || NeedCheckLevel && heading.Level != Level
             || heading.Inline.FirstChild != heading.Inline.LastChild)
         {

--- a/src/Docfx.Build.RestApi/ApplyOverwriteDocumentForRestApi.cs
+++ b/src/Docfx.Build.RestApi/ApplyOverwriteDocumentForRestApi.cs
@@ -25,7 +25,7 @@ public class ApplyOverwriteDocumentForRestApi : ApplyOverwriteDocument
                 base.GetMerger()));
     }
 
-    public IEnumerable<RestApiRootItemViewModel> GetRootItemsFromOverwriteDocument(FileModel overwriteModel, string uid, IHostService host)
+    public static IEnumerable<RestApiRootItemViewModel> GetRootItemsFromOverwriteDocument(FileModel overwriteModel, string uid, IHostService host)
     {
         return OverwriteDocumentReader.Transform<RestApiRootItemViewModel>(
             overwriteModel,
@@ -33,13 +33,13 @@ public class ApplyOverwriteDocumentForRestApi : ApplyOverwriteDocument
             s => (RestApiRootItemViewModel)BuildRestApiDocument.BuildItem(host, s, overwriteModel, content => content != null && content.Trim() == Constants.ContentPlaceholder));
     }
 
-    public IEnumerable<RestApiRootItemViewModel> GetRootItemsToOverwrite(FileModel articleModel, string uid,
+    public static IEnumerable<RestApiRootItemViewModel> GetRootItemsToOverwrite(FileModel articleModel, string uid,
         IHostService host)
     {
         return new[] { (RestApiRootItemViewModel)articleModel.Content };
     }
 
-    public IEnumerable<RestApiChildItemViewModel> GetChildItemsFromOverwriteDocument(FileModel overwriteModel, string uid, IHostService host)
+    public static IEnumerable<RestApiChildItemViewModel> GetChildItemsFromOverwriteDocument(FileModel overwriteModel, string uid, IHostService host)
     {
         return OverwriteDocumentReader.Transform<RestApiChildItemViewModel>(
                 overwriteModel,
@@ -47,12 +47,12 @@ public class ApplyOverwriteDocumentForRestApi : ApplyOverwriteDocument
                 s => (RestApiChildItemViewModel)BuildRestApiDocument.BuildItem(host, s, overwriteModel, content => content != null && content.Trim() == Constants.ContentPlaceholder));
     }
 
-    public IEnumerable<RestApiChildItemViewModel> GetChildItemsToOverwrite(FileModel articleModel, string uid, IHostService host)
+    public static IEnumerable<RestApiChildItemViewModel> GetChildItemsToOverwrite(FileModel articleModel, string uid, IHostService host)
     {
         return ((RestApiRootItemViewModel)articleModel.Content).Children.Where(c => c.Uid == uid);
     }
 
-    public IEnumerable<RestApiTagViewModel> GetTagsFromOverwriteDocument(FileModel overwriteModel, string uid, IHostService host)
+    public static IEnumerable<RestApiTagViewModel> GetTagsFromOverwriteDocument(FileModel overwriteModel, string uid, IHostService host)
     {
         return OverwriteDocumentReader.Transform<RestApiTagViewModel>(
             overwriteModel,
@@ -60,7 +60,7 @@ public class ApplyOverwriteDocumentForRestApi : ApplyOverwriteDocument
             s => BuildRestApiDocument.BuildTag(host, s, overwriteModel, content => content != null && content.Trim() == Constants.ContentPlaceholder));
     }
 
-    public IEnumerable<RestApiTagViewModel> GetTagItemsToOverwrite(FileModel articleModel, string uid, IHostService host)
+    public static IEnumerable<RestApiTagViewModel> GetTagItemsToOverwrite(FileModel articleModel, string uid, IHostService host)
     {
         return ((RestApiRootItemViewModel)articleModel.Content).Tags.Where(c => c.Uid == uid);
     }

--- a/src/Docfx.Build.RestApi/RestApiHelper.cs
+++ b/src/Docfx.Build.RestApi/RestApiHelper.cs
@@ -73,7 +73,7 @@ internal static class RestApiHelper
             }
 
             // For example "file.json#/definitions/reference"
-            if (reference.Contains("#"))
+            if (reference.Contains('#'))
             {
                 var values = reference.Split('#');
                 if (values.Length != 2)

--- a/src/Docfx.Build.RestApi/Swagger/Internals/JsonLocation/JsonLocationInfo.cs
+++ b/src/Docfx.Build.RestApi/Swagger/Internals/JsonLocation/JsonLocationInfo.cs
@@ -19,7 +19,7 @@ internal class JsonLocationInfo
 
     public override bool Equals(object obj)
     {
-        if (!(obj is JsonLocationInfo other))
+        if (obj is not JsonLocationInfo other)
         {
             return false;
         }

--- a/src/Docfx.Build.RestApi/SwaggerModelConverter.cs
+++ b/src/Docfx.Build.RestApi/SwaggerModelConverter.cs
@@ -53,7 +53,7 @@ public static class SwaggerModelConverter
                     // fetch operations from metadata
                     if (OperationNames.Contains(op.Key, StringComparer.OrdinalIgnoreCase))
                     {
-                        if (!(op.Value is JObject opJObject))
+                        if (op.Value is not JObject opJObject)
                         {
                             throw new InvalidOperationException($"Value of {op.Key} should be JObject");
                         }

--- a/src/Docfx.Build.SchemaDriven/ApplyOverwriteDocument.cs
+++ b/src/Docfx.Build.SchemaDriven/ApplyOverwriteDocument.cs
@@ -24,7 +24,7 @@ public class ApplyOverwriteDocument : BaseDocumentBuildStep
         host.GetAllUids().RunAll(uid => ApplyOverwriteToModel(overwriteApplier, uid, host));
     }
 
-    private void ApplyOverwriteToModel(OverwriteApplier overwriteApplier, string uid, IHostService host)
+    private static void ApplyOverwriteToModel(OverwriteApplier overwriteApplier, string uid, IHostService host)
     {
         var ms = host.LookupByUid(uid);
         var ods = ms.Where(m => m.Type == DocumentType.Overwrite).ToList();

--- a/src/Docfx.Build.SchemaDriven/ApplyOverwriteFragments.cs
+++ b/src/Docfx.Build.SchemaDriven/ApplyOverwriteFragments.cs
@@ -74,7 +74,7 @@ public class ApplyOverwriteFragments : BaseDocumentBuildStep
         }
     }
 
-    private void BuildCore(FileModel model, IHostService host)
+    private static void BuildCore(FileModel model, IHostService host)
     {
         var markdownService = (MarkdigMarkdownService)model.MarkdownFragmentsModel.Properties.MarkdigMarkdownService;
         var overwriteDocumentModelCreator = new OverwriteDocumentModelCreator(model.MarkdownFragmentsModel.OriginalFileAndType.File);
@@ -135,7 +135,7 @@ public class ApplyOverwriteFragments : BaseDocumentBuildStep
         model.MarkdownFragmentsModel.Content = overwriteDocumentModels;
     }
 
-    private void ValidateWithSchema(List<MarkdownFragmentModel> fragments, FileModel model)
+    private static void ValidateWithSchema(List<MarkdownFragmentModel> fragments, FileModel model)
     {
         var iterator = new SchemaFragmentsIterator(new ValidateFragmentsHandler());
         var yamlStream = new YamlStream();

--- a/src/Docfx.Build.SchemaDriven/ApplyOverwriteFragments.cs
+++ b/src/Docfx.Build.SchemaDriven/ApplyOverwriteFragments.cs
@@ -33,19 +33,19 @@ public class ApplyOverwriteFragments : BaseDocumentBuildStep
             return;
         }
 
-        if (!(model.MarkdownFragmentsModel.Content is string))
+        if (model.MarkdownFragmentsModel.Content is not string)
         {
             var message = "Unable to parse markdown fragments. Expect string content.";
             Logger.LogError(message);
             throw new DocfxException(message);
         }
-        if (model.MarkdownFragmentsModel.Properties.MarkdigMarkdownService == null || !(model.MarkdownFragmentsModel.Properties.MarkdigMarkdownService is MarkdigMarkdownService))
+        if (model.MarkdownFragmentsModel.Properties.MarkdigMarkdownService == null || model.MarkdownFragmentsModel.Properties.MarkdigMarkdownService is not MarkdigMarkdownService)
         {
             var message = "Unable to find markdig markdown service in file model.";
             Logger.LogError(message);
             throw new DocfxException(message);
         }
-        if (!(model.Properties.Schema is DocumentSchema))
+        if (model.Properties.Schema is not DocumentSchema)
         {
             var message = "Unable to find schema in file model.";
             Logger.LogError(message);

--- a/src/Docfx.Build.SchemaDriven/Models/JsonPointer.cs
+++ b/src/Docfx.Build.SchemaDriven/Models/JsonPointer.cs
@@ -17,7 +17,7 @@ public class JsonPointer
 
     public JsonPointer(string raw)
     {
-        raw = raw ?? string.Empty;
+        raw ??= string.Empty;
         _isRoot = raw.Length == 0;
         if (!_isRoot && raw[0] != Splitter[0])
         {

--- a/src/Docfx.Build.SchemaDriven/Models/JsonPointer.cs
+++ b/src/Docfx.Build.SchemaDriven/Models/JsonPointer.cs
@@ -24,7 +24,7 @@ public class JsonPointer
             throw new InvalidJsonPointerException($"Invalid json pointer \"{raw}\"");
         }
 
-        _parts = _isRoot ? new string[0] : raw.Substring(1).Split(Splitter[0]);
+        _parts = _isRoot ? Array.Empty<string>() : raw.Substring(1).Split(Splitter[0]);
 
         _raw = raw;
     }
@@ -32,7 +32,7 @@ public class JsonPointer
     public JsonPointer(string[] parts)
     {
         _isRoot = parts == null || parts.Length == 0;
-        _parts = parts == null ? new string[0] : parts;
+        _parts = parts == null ? Array.Empty<string>() : parts;
         _raw = Splitter + string.Join(Splitter, parts);
     }
 

--- a/src/Docfx.Build.SchemaDriven/Models/JsonPointer.cs
+++ b/src/Docfx.Build.SchemaDriven/Models/JsonPointer.cs
@@ -32,7 +32,7 @@ public class JsonPointer
     public JsonPointer(string[] parts)
     {
         _isRoot = parts == null || parts.Length == 0;
-        _parts = parts == null ? Array.Empty<string>() : parts;
+        _parts = parts ?? Array.Empty<string>();
         _raw = Splitter + string.Join(Splitter, parts);
     }
 

--- a/src/Docfx.Build.SchemaDriven/OverwriteApplier.cs
+++ b/src/Docfx.Build.SchemaDriven/OverwriteApplier.cs
@@ -130,7 +130,7 @@ public class OverwriteApplier
         _merger.Merge(ref source, overwrite, uid, path, schema);
     }
 
-    private void UpdateXRefSpecs(List<XRefSpec> original, List<XRefSpec> overwrite)
+    private static void UpdateXRefSpecs(List<XRefSpec> original, List<XRefSpec> overwrite)
     {
         foreach (var xref in overwrite)
         {

--- a/src/Docfx.Build.SchemaDriven/Processors/FileIncludeInterpreter.cs
+++ b/src/Docfx.Build.SchemaDriven/Processors/FileIncludeInterpreter.cs
@@ -20,7 +20,7 @@ public class FileIncludeInterpreter : IInterpreter
             return value;
         }
 
-        if (!(value is string val))
+        if (value is not string val)
         {
             throw new ArgumentException($"{value.GetType()} is not supported type string.");
         }

--- a/src/Docfx.Build.SchemaDriven/Processors/FileInterpreter.cs
+++ b/src/Docfx.Build.SchemaDriven/Processors/FileInterpreter.cs
@@ -29,7 +29,7 @@ public class FileInterpreter : IInterpreter
             return value;
         }
 
-        if (!(value is string val))
+        if (value is not string val)
         {
             throw new ArgumentException($"{value.GetType()} is not supported type string.");
         }

--- a/src/Docfx.Build.SchemaDriven/Processors/HrefInterpreter.cs
+++ b/src/Docfx.Build.SchemaDriven/Processors/HrefInterpreter.cs
@@ -31,7 +31,7 @@ public class HrefInterpreter : IInterpreter
             return value;
         }
 
-        if (!(value is string val))
+        if (value is not string val)
         {
             throw new ArgumentException($"{value.GetType()} is not supported type string.");
         }

--- a/src/Docfx.Build.SchemaDriven/Processors/MarkdownInterpreter.cs
+++ b/src/Docfx.Build.SchemaDriven/Processors/MarkdownInterpreter.cs
@@ -19,7 +19,7 @@ public class MarkdownInterpreter : IInterpreter
             return value;
         }
 
-        if (!(value is string val))
+        if (value is not string val)
         {
             throw new ArgumentException($"{value.GetType()} is not supported type string.");
         }

--- a/src/Docfx.Build.SchemaDriven/Processors/MarkdownWithContentAnchorInterpreter.cs
+++ b/src/Docfx.Build.SchemaDriven/Processors/MarkdownWithContentAnchorInterpreter.cs
@@ -18,7 +18,7 @@ public class MarkdownWithContentAnchorInterpreter : IInterpreter
 
     public object Interpret(BaseSchema schema, object value, IProcessContext context, string path)
     {
-        if (value == null || !CanInterpret(schema) || !(value is string val))
+        if (value == null || !CanInterpret(schema) || value is not string val)
         {
             return value;
         }

--- a/src/Docfx.Build.SchemaDriven/Processors/MergeTypeInterpreter.cs
+++ b/src/Docfx.Build.SchemaDriven/Processors/MergeTypeInterpreter.cs
@@ -18,7 +18,7 @@ public class MergeTypeInterpreter : IInterpreter
         return value;
     }
 
-    private object MergeCore(object value, IProcessContext context)
+    private static object MergeCore(object value, IProcessContext context)
     {
         return value;
     }

--- a/src/Docfx.Build.SchemaDriven/Processors/Merger.cs
+++ b/src/Docfx.Build.SchemaDriven/Processors/Merger.cs
@@ -123,13 +123,13 @@ internal sealed class Merger
         }
     }
 
-    private void ThrowError(string message)
+    private static void ThrowError(string message)
     {
         Logger.LogError(message);
         throw new InvalidOverwriteDocumentException(message);
     }
 
-    private bool TestKey(object source, object overrides, BaseSchema schema)
+    private static bool TestKey(object source, object overrides, BaseSchema schema)
     {
         if (overrides == null || overrides == null)
         {

--- a/src/Docfx.Build.SchemaDriven/Processors/XrefInterpreter.cs
+++ b/src/Docfx.Build.SchemaDriven/Processors/XrefInterpreter.cs
@@ -56,7 +56,7 @@ public class XrefInterpreter : IInterpreter
         return value;
     }
 
-    private void AddUidLinkSource(Dictionary<string, List<LinkSourceInfo>> uidLinkSources, LinkSourceInfo source)
+    private static void AddUidLinkSource(Dictionary<string, List<LinkSourceInfo>> uidLinkSources, LinkSourceInfo source)
     {
         var file = source.Target;
         if (!uidLinkSources.TryGetValue(file, out List<LinkSourceInfo> sources))

--- a/src/Docfx.Build.SchemaDriven/Processors/XrefInterpreter.cs
+++ b/src/Docfx.Build.SchemaDriven/Processors/XrefInterpreter.cs
@@ -29,7 +29,7 @@ public class XrefInterpreter : IInterpreter
             return value;
         }
 
-        if (!(value is string val))
+        if (value is not string val)
         {
             throw new ArgumentException($"{value.GetType()} is not supported type string.");
         }

--- a/src/Docfx.Build.SchemaDriven/Processors/XrefPropertiesInterpreter.cs
+++ b/src/Docfx.Build.SchemaDriven/Processors/XrefPropertiesInterpreter.cs
@@ -87,7 +87,7 @@ public class XrefPropertiesInterpreter : IInterpreter
         return value;
     }
 
-    private bool IsInternalXrefSpec(BaseSchema schema)
+    private static bool IsInternalXrefSpec(BaseSchema schema)
     {
         if (schema.Properties == null)
         {

--- a/src/Docfx.Build.SchemaDriven/Processors/XrefPropertiesInterpreter.cs
+++ b/src/Docfx.Build.SchemaDriven/Processors/XrefPropertiesInterpreter.cs
@@ -45,7 +45,7 @@ public class XrefPropertiesInterpreter : IInterpreter
             return value;
         }
 
-        if (!(JsonPointer.GetChild(value, "uid") is string uid))
+        if (JsonPointer.GetChild(value, "uid") is not string uid)
         {
             // schema validation threw error when uid is required, so here when uid is null, it must be optional, which is allowed
             return value;

--- a/src/Docfx.Build.SchemaDriven/SchemaDrivenDocumentProcessor.cs
+++ b/src/Docfx.Build.SchemaDriven/SchemaDrivenDocumentProcessor.cs
@@ -130,15 +130,15 @@ public class SchemaDrivenDocumentProcessor : DisposableDocumentProcessor
                     var fm = new FileModel(file, content)
                     {
                         LocalPathFromRoot = localPathFromRoot,
-                    };
-                    fm.MarkdownFragmentsModel = new FileModel(
+                        MarkdownFragmentsModel = new FileModel(
                         new FileAndType(
                             file.BaseDir,
                             markdownFragmentsFile,
                             DocumentType.MarkdownFragments,
                             file.SourceDir,
                             file.DestinationDir),
-                        markdownFragmentsContent);
+                        markdownFragmentsContent),
+                    };
                     fm.Properties.Schema = _schema;
                     fm.Properties.Metadata = pageMetadata;
                     fm.MarkdownFragmentsModel.Properties.MarkdigMarkdownService = _markdigMarkdownService;

--- a/src/Docfx.Build.SchemaDriven/SchemaDrivenDocumentProcessor.cs
+++ b/src/Docfx.Build.SchemaDriven/SchemaDrivenDocumentProcessor.cs
@@ -115,7 +115,7 @@ public class SchemaDrivenDocumentProcessor : DisposableDocumentProcessor
                     }
 
                     var content = ConvertToObjectHelper.ConvertToDynamic(obj);
-                    if (!(_schema.MetadataReference.GetValue(content) is IDictionary<string, object> pageMetadata))
+                    if (_schema.MetadataReference.GetValue(content) is not IDictionary<string, object> pageMetadata)
                     {
                         pageMetadata = new ExpandoObject();
                         _schema.MetadataReference.SetValue(ref content, pageMetadata);

--- a/src/Docfx.Build.SchemaDriven/SchemaDrivenDocumentProcessor.cs
+++ b/src/Docfx.Build.SchemaDriven/SchemaDrivenDocumentProcessor.cs
@@ -3,13 +3,11 @@
 
 using System.Collections.Immutable;
 using System.Dynamic;
-using System.Text;
 using Docfx.Build.Common;
 using Docfx.Build.SchemaDriven.Processors;
 using Docfx.Common;
 using Docfx.MarkdigEngine;
 using Docfx.Plugins;
-using Newtonsoft.Json;
 
 namespace Docfx.Build.SchemaDriven;
 

--- a/src/Docfx.Build.SchemaDriven/SchemaFragmentsIterator.cs
+++ b/src/Docfx.Build.SchemaDriven/SchemaFragmentsIterator.cs
@@ -90,7 +90,7 @@ public class SchemaFragmentsIterator
                     {
                         if (mapNode.Children.ContainsKey(mergeKey))
                         {
-                            var opath = $"{parentOPath}[{mergeKey}=\"{mapNode.Children[mergeKey].ToString()}\"]";
+                            var opath = $"{parentOPath}[{mergeKey}=\"{mapNode.Children[mergeKey]}\"]";
                             TraverseCore(item, fragments, schema.Items, opath, uid);
                         }
                         else

--- a/src/Docfx.Build.SchemaDriven/ValidateFragmentsHandler.cs
+++ b/src/Docfx.Build.SchemaDriven/ValidateFragmentsHandler.cs
@@ -10,7 +10,7 @@ namespace Docfx.Build.SchemaDriven;
 
 public class ValidateFragmentsHandler : ISchemaFragmentsHandler
 {
-    Dictionary<string, bool> _isMissingUidsLogged = new();
+    private readonly Dictionary<string, bool> _isMissingUidsLogged = new();
 
     public void HandleUid(string uidKey, YamlMappingNode node, Dictionary<string, MarkdownFragment> fragments, BaseSchema schema, string oPathPrefix, string uid)
     {

--- a/src/Docfx.Build.TableOfContents/BuildTocDocument.cs
+++ b/src/Docfx.Build.TableOfContents/BuildTocDocument.cs
@@ -37,7 +37,7 @@ public class BuildTocDocument : BuildTocDocumentStepBase
 
     #region Private methods
 
-    private void ReportPreBuildDependency(List<FileModel> models, IHostService host, int parallelism, HashSet<string> includedTocs)
+    private static void ReportPreBuildDependency(List<FileModel> models, IHostService host, int parallelism, HashSet<string> includedTocs)
     {
         var nearest = new ConcurrentDictionary<string, RelativeInfo>(FilePathComparer.OSPlatformSensitiveStringComparer);
         models.RunAll(model =>
@@ -51,7 +51,7 @@ public class BuildTocDocument : BuildTocDocumentStepBase
         UpdateNearestTocForNotInTocItem(models, host, nearest, parallelism);
     }
 
-    private void UpdateNearestToc(IHostService host, TocItemViewModel item, FileModel toc, ConcurrentDictionary<string, RelativeInfo> nearest)
+    private static void UpdateNearestToc(IHostService host, TocItemViewModel item, FileModel toc, ConcurrentDictionary<string, RelativeInfo> nearest)
     {
         var tocHref = item.TocHref;
         var type = Utility.GetHrefType(tocHref);
@@ -73,7 +73,7 @@ public class BuildTocDocument : BuildTocDocumentStepBase
         }
     }
 
-    private void UpdateNearestTocForNotInTocItem(List<FileModel> models, IHostService host, ConcurrentDictionary<string, RelativeInfo> nearest, int parallelism)
+    private static void UpdateNearestTocForNotInTocItem(List<FileModel> models, IHostService host, ConcurrentDictionary<string, RelativeInfo> nearest, int parallelism)
     {
         var allSourceFiles = host.SourceFiles;
         var tocInfos = models.Select(m => new TocInfo(m)).ToArray();
@@ -101,7 +101,7 @@ public class BuildTocDocument : BuildTocDocumentStepBase
         }
     }
 
-    private void UpdateNearestTocCore(IHostService host, string item, FileModel toc, ConcurrentDictionary<string, RelativeInfo> nearest)
+    private static void UpdateNearestTocCore(IHostService host, string item, FileModel toc, ConcurrentDictionary<string, RelativeInfo> nearest)
     {
         if (!host.SourceFiles.TryGetValue(item, out var itemSource))
         {

--- a/src/Docfx.Build.TableOfContents/BuildTocDocumentStepBase.cs
+++ b/src/Docfx.Build.TableOfContents/BuildTocDocumentStepBase.cs
@@ -26,7 +26,7 @@ public abstract class BuildTocDocumentStepBase : BaseDocumentBuildStep
 
     #region Private methods
 
-    private void BuildCore(TocItemViewModel item, FileModel model, IHostService hostService, string includedFrom = null)
+    private static void BuildCore(TocItemViewModel item, FileModel model, IHostService hostService, string includedFrom = null)
     {
         if (item == null)
         {

--- a/src/Docfx.Build.TableOfContents/TocDocumentProcessorBase.cs
+++ b/src/Docfx.Build.TableOfContents/TocDocumentProcessorBase.cs
@@ -99,7 +99,7 @@ public abstract class TocDocumentProcessorBase : DisposableDocumentProcessor
         toc.IsHrefUpdated = true;
     }
 
-    private void ResolveUid(TocItemViewModel item, FileModel model, IDocumentBuildContext context, string includedFrom)
+    private static void ResolveUid(TocItemViewModel item, FileModel model, IDocumentBuildContext context, string includedFrom)
     {
         if (item.TopicUid != null)
         {
@@ -124,7 +124,7 @@ public abstract class TocDocumentProcessorBase : DisposableDocumentProcessor
         }
     }
 
-    private XRefSpec GetXrefFromUid(string uid, FileModel model, IDocumentBuildContext context, string includedFrom)
+    private static XRefSpec GetXrefFromUid(string uid, FileModel model, IDocumentBuildContext context, string includedFrom)
     {
         var xref = context.GetXrefSpec(uid);
         if (xref == null)
@@ -137,7 +137,7 @@ public abstract class TocDocumentProcessorBase : DisposableDocumentProcessor
         return xref;
     }
 
-    private string ResolveHref(string pathToFile, string originalPathToFile, FileModel model, IDocumentBuildContext context, string propertyName)
+    private static string ResolveHref(string pathToFile, string originalPathToFile, FileModel model, IDocumentBuildContext context, string propertyName)
     {
         if (!Utility.IsSupportedRelativeHref(pathToFile))
         {

--- a/src/Docfx.Build.TableOfContents/TocHelper.cs
+++ b/src/Docfx.Build.TableOfContents/TocHelper.cs
@@ -108,7 +108,7 @@ public static class TocHelper
         }
         catch (Exception ex)
         {
-            throw new NotSupportedException($"{file} is not a valid TOC file, detail: {ex.ToString()}.", ex);
+            throw new NotSupportedException($"{file} is not a valid TOC file, detail: {ex}.", ex);
         }
         if (obj is TocViewModel vm)
         {

--- a/src/Docfx.Build.TableOfContents/TocResolver.cs
+++ b/src/Docfx.Build.TableOfContents/TocResolver.cs
@@ -87,7 +87,7 @@ internal sealed class TocResolver
         if (!isRoot && string.IsNullOrEmpty(item.Name) && string.IsNullOrEmpty(item.TopicUid))
         {
             Logger.LogWarning(
-                $"TOC item ({item.ToString()}) with empty name found. Missing a name?",
+                $"TOC item ({item}) with empty name found. Missing a name?",
                 code: WarningCodes.Build.EmptyTocItemName);
         }
 

--- a/src/Docfx.Build.TableOfContents/TocResolver.cs
+++ b/src/Docfx.Build.TableOfContents/TocResolver.cs
@@ -292,7 +292,7 @@ internal sealed class TocResolver
         }
     }
 
-    private TocViewModel UpdateOriginalHref(TocViewModel toc, RelativePath relativePath)
+    private static TocViewModel UpdateOriginalHref(TocViewModel toc, RelativePath relativePath)
     {
         if (toc == null || relativePath.SubdirectoryCount == 0)
         {
@@ -311,7 +311,7 @@ internal sealed class TocResolver
         return toc;
     }
 
-    private string GetRelativePath(string href, RelativePath rel)
+    private static string GetRelativePath(string href, RelativePath rel)
     {
         var type = Utility.GetHrefType(href);
         if (type == HrefType.RelativeFile)
@@ -321,7 +321,7 @@ internal sealed class TocResolver
         return href;
     }
 
-    private string NormalizeHref(string href, RelativePath relativeToFile)
+    private static string NormalizeHref(string href, RelativePath relativeToFile)
     {
         if (!Utility.IsSupportedRelativeHref(href))
         {
@@ -384,7 +384,7 @@ internal sealed class TocResolver
         return false;
     }
 
-    private void ValidateHref(TocItemViewModel item)
+    private static void ValidateHref(TocItemViewModel item)
     {
         if (item.Href == null)
         {

--- a/src/Docfx.Build.UniversalReference/ApplyOverwriteDocumentForUref.cs
+++ b/src/Docfx.Build.UniversalReference/ApplyOverwriteDocumentForUref.cs
@@ -24,7 +24,7 @@ public class ApplyOverwriteDocumentForUref : ApplyOverwriteDocument
             host);
     }
 
-    public IEnumerable<ItemViewModel> GetItemsToOverwrite(FileModel fileModel, string uid, IHostService host)
+    public static IEnumerable<ItemViewModel> GetItemsToOverwrite(FileModel fileModel, string uid, IHostService host)
     {
         return ((PageViewModel)fileModel.Content).Items.Where(s => s.Uid == uid);
     }

--- a/src/Docfx.Build.UniversalReference/FillReferenceInformation.cs
+++ b/src/Docfx.Build.UniversalReference/FillReferenceInformation.cs
@@ -35,7 +35,7 @@ public class FillReferenceInformation : BaseDocumentBuildStep
 
     #region Private methods
 
-    private void FillCore(PageViewModel model, IHostService host, string file)
+    private static void FillCore(PageViewModel model, IHostService host, string file)
     {
         if (model.References == null || model.References.Count == 0)
         {
@@ -58,7 +58,7 @@ public class FillReferenceInformation : BaseDocumentBuildStep
         }
     }
 
-    private void FillContent(ReferenceViewModel r, dynamic item)
+    private static void FillContent(ReferenceViewModel r, dynamic item)
     {
         if (item.Metadata != null)
         {

--- a/src/Docfx.Build.UniversalReference/ModelConverter.cs
+++ b/src/Docfx.Build.UniversalReference/ModelConverter.cs
@@ -388,7 +388,7 @@ public static class ModelConverter
         }
 
         var result = new List<ApiLanguageValuePair<T>>();
-        values = values ?? new SortedList<string, T>();
+        values ??= new SortedList<string, T>();
         foreach (var language in supportedLanguages)
         {
             result.Add(new ApiLanguageValuePair<T>

--- a/src/Docfx.Build.UniversalReference/UniversalReferenceDocumentProcessor.cs
+++ b/src/Docfx.Build.UniversalReference/UniversalReferenceDocumentProcessor.cs
@@ -132,7 +132,7 @@ public class UniversalReferenceDocumentProcessor : ReferenceDocumentProcessorBas
         model.Content = ModelConverter.ToApiBuildOutput((PageViewModel)model.Content);
     }
 
-    private IEnumerable<XRefSpec> GetXRefFromReference(PageViewModel vm)
+    private static IEnumerable<XRefSpec> GetXRefFromReference(PageViewModel vm)
     {
         if (vm.References == null)
         {

--- a/src/Docfx.Common/CollectionExtensions.cs
+++ b/src/Docfx.Common/CollectionExtensions.cs
@@ -70,7 +70,7 @@ public static class CollectionExtensions
         }
         if (indexes.Count == 0)
         {
-            result = default(TResult);
+            result = default;
             return false;
         }
         result = merger((from i in indexes select enumerators[i].Current).ToList());
@@ -100,7 +100,7 @@ public static class CollectionExtensions
 
         public bool Eof { get; private set; }
 
-        public T Current => Eof ? default(T) : Enumerator.Current;
+        public T Current => Eof ? default : Enumerator.Current;
 
         object IEnumerator.Current => Current;
 

--- a/src/Docfx.Common/CollectionUtility.cs
+++ b/src/Docfx.Common/CollectionUtility.cs
@@ -70,8 +70,8 @@ public static class CollectionUtility
             return results.ToImmutableArray();
         }
 
-        int leftItemCount = leftItems.Count();
-        int rightItemCount = rightItems.Count();
+        int leftItemCount = leftItems.Length;
+        int rightItemCount = rightItems.Length;
         int[,] dp = new int[leftItemCount + 1, rightItemCount + 1];
 
         for (int i = 0; i <= leftItemCount; i++)

--- a/src/Docfx.Common/ConvertToObjectHelper.cs
+++ b/src/Docfx.Common/ConvertToObjectHelper.cs
@@ -146,7 +146,7 @@ public static class ConvertToObjectHelper
                     throw new NotSupportedException("Only string key is supported.");
                 }
 
-                ((IDictionary<string, Object>)result).Add(key, ConvertToDynamicCore(pair.Value, cache));
+                ((IDictionary<string, object>)result).Add(key, ConvertToDynamicCore(pair.Value, cache));
             }
         }
         else if (obj is IDictionary<string, object> sDict)
@@ -155,7 +155,7 @@ public static class ConvertToObjectHelper
 
             foreach (var pair in sDict)
             {
-                ((IDictionary<string, Object>)result).Add(pair.Key, ConvertToDynamicCore(pair.Value, cache));
+                ((IDictionary<string, object>)result).Add(pair.Key, ConvertToDynamicCore(pair.Value, cache));
             }
         }
         else if (obj is IList<object> array)

--- a/src/Docfx.Common/ConvertToObjectHelper.cs
+++ b/src/Docfx.Common/ConvertToObjectHelper.cs
@@ -141,7 +141,7 @@ public static class ConvertToObjectHelper
 
             foreach (var pair in dict)
             {
-                if (!(pair.Key is string key))
+                if (pair.Key is not string key)
                 {
                     throw new NotSupportedException("Only string key is supported.");
                 }

--- a/src/Docfx.Common/EntityMergers/DictionaryMerger.cs
+++ b/src/Docfx.Common/EntityMergers/DictionaryMerger.cs
@@ -51,7 +51,7 @@ public class DictionaryMerger : MergerDecorator
             Merge((IDictionary<TKey, TValue>)source, (IDictionary<TKey, TValue>)overrides, context);
         }
 
-        public void Merge(IDictionary<TKey, TValue> source, IDictionary<TKey, TValue> overrides, IMergeContext context)
+        public static void Merge(IDictionary<TKey, TValue> source, IDictionary<TKey, TValue> overrides, IMergeContext context)
         {
             foreach (var oi in overrides)
             {

--- a/src/Docfx.Common/EntityMergers/KeyedListMerger.cs
+++ b/src/Docfx.Common/EntityMergers/KeyedListMerger.cs
@@ -14,7 +14,7 @@ public class KeyedListMerger : MergerDecorator
 
     public override void Merge(ref object source, object overrides, Type type, IMergeContext context)
     {
-        if (source is IEnumerable && type != typeof(string))
+        if (source is IEnumerable enumerable && type != typeof(string))
         {
             foreach (var it in type.GetInterfaces())
             {
@@ -27,7 +27,7 @@ public class KeyedListMerger : MergerDecorator
                     }
                     if (it.IsAssignableFrom(overrides.GetType()))
                     {
-                        new ListMergerImpl(it.GetGenericArguments()[0]).Merge((IEnumerable)source, (IEnumerable)overrides, context);
+                        new ListMergerImpl(it.GetGenericArguments()[0]).Merge(enumerable, (IEnumerable)overrides, context);
                         return;
                     }
                 }

--- a/src/Docfx.Common/FileItems.cs
+++ b/src/Docfx.Common/FileItems.cs
@@ -9,7 +9,7 @@ public class FileItems : List<string>
     private static IEnumerable<string> Empty = new List<string>();
     public FileItems(string file) : base()
     {
-        this.Add(file);
+        Add(file);
     }
 
     public FileItems(IEnumerable<string> files) : base(files ?? Empty)

--- a/src/Docfx.Common/FileItems.cs
+++ b/src/Docfx.Common/FileItems.cs
@@ -6,7 +6,7 @@ namespace Docfx;
 [Serializable]
 public class FileItems : List<string>
 {
-    private static IEnumerable<string> Empty = new List<string>();
+    private static readonly IEnumerable<string> Empty = new List<string>();
     public FileItems(string file) : base()
     {
         Add(file);

--- a/src/Docfx.Common/FileMapping.cs
+++ b/src/Docfx.Common/FileMapping.cs
@@ -55,7 +55,7 @@ public class FileMapping
     /// </summary>
     public FileMapping(IEnumerable<FileMappingItem> items)
     {
-        foreach (var item in items) this.Add(item);
+        foreach (var item in items) Add(item);
     }
 
     /// <summary>
@@ -63,7 +63,7 @@ public class FileMapping
     /// </summary>
     public FileMapping(FileMappingItem item)
     {
-        this.Add(item);
+        Add(item);
     }
 
     /// <summary>

--- a/src/Docfx.Common/FileMapping.cs
+++ b/src/Docfx.Common/FileMapping.cs
@@ -30,7 +30,7 @@ namespace Docfx;
 [Serializable]
 public class FileMapping
 {
-    private List<FileMappingItem> _items = new();
+    private readonly List<FileMappingItem> _items = new();
 
     /// <summary>
     /// Flags to distinguish items are expanded or not.

--- a/src/Docfx.Common/FileMappingItem.cs
+++ b/src/Docfx.Common/FileMappingItem.cs
@@ -55,7 +55,7 @@ public class FileMappingItem
     /// As discussed, `cwd` may lead to confusing and misunderstanding, so in version 1.3, `src` is introduced and `cwd` is kept for backward compatibility
     /// </summary>
     [JsonProperty("cwd")]
-    [Obsolete]
+    [Obsolete("Use src instead.")]
     public string CurrentWorkingDirectory
     {
         get

--- a/src/Docfx.Common/Git/GitDetail.cs
+++ b/src/Docfx.Common/Git/GitDetail.cs
@@ -38,9 +38,9 @@ public class GitDetail
     {
         if (obj == null) return false;
         if (ReferenceEquals(this, obj)) return true;
-        if (this.GetType() != obj.GetType()) return false;
+        if (GetType() != obj.GetType()) return false;
 
-        return Equals(this.ToString(), obj.ToString());
+        return Equals(ToString(), obj.ToString());
     }
 
     public override int GetHashCode()

--- a/src/Docfx.Common/HashUtility.cs
+++ b/src/Docfx.Common/HashUtility.cs
@@ -15,10 +15,7 @@ public static class HashUtility
     }
 
     public static byte[] GetSha256Hash(string content)
-    {
-        using var sha256 = SHA256.Create();
-        return sha256.ComputeHash(Encoding.UTF8.GetBytes(content));
-    }
+        => SHA256.HashData(Encoding.UTF8.GetBytes(content));
 
     public static string GetSha256HashString(string content)
         => Convert.ToBase64String(GetSha256Hash(content));

--- a/src/Docfx.Common/Loggers/ConsoleLogListener.cs
+++ b/src/Docfx.Common/Loggers/ConsoleLogListener.cs
@@ -55,7 +55,7 @@ public sealed class ConsoleLogListener : ILoggerListener
     {
     }
 
-    private ConsoleColor GetConsoleColor(LogLevel level)
+    private static ConsoleColor GetConsoleColor(LogLevel level)
     {
         return level switch
         {

--- a/src/Docfx.Common/Loggers/Logger.cs
+++ b/src/Docfx.Common/Loggers/Logger.cs
@@ -15,8 +15,8 @@ public static class Logger
     private static readonly CompositeLogListener _syncListener = new();
     private static int _warningCount = 0;
     private static int _errorCount = 0;
-    public volatile static LogLevel LogLevelThreshold = LogLevel.Info;
-    public volatile static bool WarningsAsErrors = false;
+    public static volatile LogLevel LogLevelThreshold = LogLevel.Info;
+    public static volatile bool WarningsAsErrors = false;
 
     public static void RegisterListener(ILoggerListener listener)
     {

--- a/src/Docfx.Common/Loggers/LoggerFileScope.cs
+++ b/src/Docfx.Common/Loggers/LoggerFileScope.cs
@@ -39,7 +39,7 @@ public sealed class LoggerFileScope : IDisposable
 
     public static LoggerFileScope Restore(object captured)
     {
-        if (!(captured is CapturedLoggerFileScope capturedScope))
+        if (captured is not CapturedLoggerFileScope capturedScope)
         {
             return null;
         }

--- a/src/Docfx.Common/Loggers/LoggerPhaseScope.cs
+++ b/src/Docfx.Common/Loggers/LoggerPhaseScope.cs
@@ -88,7 +88,7 @@ public sealed class LoggerPhaseScope : IDisposable
 
     private static LoggerPhaseScope Restore(object captured, LogLevel? perfLogLevel)
     {
-        if (!(captured is CapturedLoggerPhaseScope capturedScope))
+        if (captured is not CapturedLoggerPhaseScope capturedScope)
         {
             return null;
         }

--- a/src/Docfx.Common/Loggers/ReportLogListener.cs
+++ b/src/Docfx.Common/Loggers/ReportLogListener.cs
@@ -55,7 +55,7 @@ public sealed class ReportLogListener : ILoggerListener
         _writer.Dispose();
     }
 
-    private MessageSeverity GetSeverity(LogLevel level)
+    private static MessageSeverity GetSeverity(LogLevel level)
     {
         switch (level)
         {

--- a/src/Docfx.Common/LruList.cs
+++ b/src/Docfx.Common/LruList.cs
@@ -81,7 +81,7 @@ public class LruList<T>
                 return true;
             }
         }
-        item = default(T);
+        item = default;
         return false;
     }
 

--- a/src/Docfx.Common/Path/FilePathComparer.cs
+++ b/src/Docfx.Common/Path/FilePathComparer.cs
@@ -7,7 +7,7 @@ public class FilePathComparer
     : IEqualityComparer<string>
 {
     private readonly bool _ignoreToFullPath;
-    private readonly static StringComparer _stringComparer = GetStringComparer();
+    private static readonly StringComparer _stringComparer = GetStringComparer();
 
     public static readonly FilePathComparer OSPlatformSensitiveComparer = new();
     public static readonly FilePathComparer OSPlatformSensitiveRelativePathComparer = new(true);

--- a/src/Docfx.Common/Path/RelativePath.cs
+++ b/src/Docfx.Common/Path/RelativePath.cs
@@ -554,10 +554,10 @@ public sealed class RelativePath : IEquatable<RelativePath>
     }
 
     public static bool operator ==(RelativePath left, RelativePath right) =>
-        object.Equals(left, right);
+        Equals(left, right);
 
     public static bool operator !=(RelativePath left, RelativePath right) =>
-        !object.Equals(left, right);
+        !Equals(left, right);
 
     public static implicit operator string(RelativePath path)
     {

--- a/src/Docfx.Common/Path/RelativePath.cs
+++ b/src/Docfx.Common/Path/RelativePath.cs
@@ -209,7 +209,7 @@ public sealed class RelativePath : IEquatable<RelativePath>
     {
         if (_parts.Length == 0)
         {
-            throw new InvalidOperationException($"Unable to get directory path for {this.ToString()}");
+            throw new InvalidOperationException($"Unable to get directory path for {this}");
         }
 
         return ChangeFileNameWithNoCheck(string.Empty);

--- a/src/Docfx.Common/Path/RelativePath.cs
+++ b/src/Docfx.Common/Path/RelativePath.cs
@@ -116,11 +116,11 @@ public sealed class RelativePath : IEquatable<RelativePath>
         }
         if (ParentDirectoryCount >= path.SubdirectoryCount)
         {
-            return Create(path._isFromWorkingFolder, path.ParentDirectoryCount - path.SubdirectoryCount + this.ParentDirectoryCount, this._parts);
+            return Create(path._isFromWorkingFolder, path.ParentDirectoryCount - path.SubdirectoryCount + ParentDirectoryCount, _parts);
         }
         else
         {
-            return Create(path._isFromWorkingFolder, path.ParentDirectoryCount, path.GetSubdirectories(this.ParentDirectoryCount).Concat(this._parts));
+            return Create(path._isFromWorkingFolder, path.ParentDirectoryCount, path.GetSubdirectories(ParentDirectoryCount).Concat(_parts));
         }
     }
 

--- a/src/Docfx.Common/Path/RelativePath.cs
+++ b/src/Docfx.Common/Path/RelativePath.cs
@@ -499,7 +499,7 @@ public sealed class RelativePath : IEquatable<RelativePath>
                 var text = safe ? EncodedInvalidPartChars[chIndex] : EncodedUnsafeInvalidPartChars[chIndex];
                 var originIndex = origin.LastIndexOf(text, originLastIndex, StringComparison.OrdinalIgnoreCase);
                 originLastIndex = originIndex - 1;
-                sb.Insert(index, origin.Substring(originIndex, text.Length));
+                sb.Insert(index, origin.AsSpan(originIndex, text.Length));
             }
             parts[i] = modified ? sb.ToString() : value;
             if (sb != null)

--- a/src/Docfx.Common/TreeIterator.cs
+++ b/src/Docfx.Common/TreeIterator.cs
@@ -64,10 +64,10 @@ public static class TreeIterator
         if (predicate(current))
             return current;
         if (childrenGetter == null)
-            return default(T);
+            return default;
         var children = childrenGetter(current);
         if (children == null)
-            return default(T);
+            return default;
         foreach (var child in children)
         {
             var result = PreorderFirstOrDefault(child, childrenGetter, predicate);
@@ -77,6 +77,6 @@ public static class TreeIterator
             }
         }
 
-        return default(T);
+        return default;
     }
 }

--- a/src/Docfx.Common/UriUtility.cs
+++ b/src/Docfx.Common/UriUtility.cs
@@ -15,14 +15,14 @@ public static class UriUtility
     {
         ArgumentNullException.ThrowIfNull(uriString);
 
-        return uriString.IndexOf(FragmentMarker) != -1;
+        return uriString.Contains(FragmentMarker);
     }
 
     public static bool HasQueryString(string uriString)
     {
         ArgumentNullException.ThrowIfNull(uriString);
 
-        return uriString.IndexOf(QueryMarker) != -1;
+        return uriString.Contains(QueryMarker);
     }
 
     public static string GetFragment(string uriString)

--- a/src/Docfx.Common/UriUtility.cs
+++ b/src/Docfx.Common/UriUtility.cs
@@ -102,7 +102,7 @@ public static class UriUtility
         var (query, path) = SplitPart(remaining, QueryMarker);
         return (path, query, fragment);
 
-        (string result, string remaining) SplitPart(string partial, char marker)
+        static (string result, string remaining) SplitPart(string partial, char marker)
         {
             var index = partial.IndexOf(marker);
             var result = index == -1 ? string.Empty : partial.Substring(index);

--- a/src/Docfx.Common/XrefUtility.cs
+++ b/src/Docfx.Common/XrefUtility.cs
@@ -12,9 +12,9 @@ public static class XrefUtility
 
         if (spec.TryGetValue(key, out var objValue) && objValue != null)
         {
-            if (objValue is string)
+            if (objValue is string stringValue)
             {
-                value = (string)objValue;
+                value = stringValue;
                 return true;
             }
             else

--- a/src/Docfx.DataContracts.Common/ExternalReferences/ExternalReferencePackageWriter.cs
+++ b/src/Docfx.DataContracts.Common/ExternalReferences/ExternalReferencePackageWriter.cs
@@ -49,7 +49,7 @@ public class ExternalReferencePackageWriter : IDisposable
         {
             entry = _zip.GetEntry(entryName);
         }
-        entry = entry ?? _zip.CreateEntry(entryName);
+        entry ??= _zip.CreateEntry(entryName);
         using var stream = entry.Open();
         using var sw = new StreamWriter(stream);
         YamlUtility.Serialize(sw, vm);

--- a/src/Docfx.DataContracts.Common/JTokenConverter.cs
+++ b/src/Docfx.DataContracts.Common/JTokenConverter.cs
@@ -9,9 +9,9 @@ public static class JTokenConverter
 {
     public static T Convert<T>(object obj)
     {
-        if (obj is T)
+        if (obj is T tObj)
         {
-            return (T)obj;
+            return tObj;
         }
 
         if (obj is JToken jToken)

--- a/src/Docfx.DataContracts.Common/TocItemViewModel.cs
+++ b/src/Docfx.DataContracts.Common/TocItemViewModel.cs
@@ -147,7 +147,7 @@ public class TocItemViewModel
         result += PropertyInfo(nameof(TopicUid), TopicUid);
         return result;
 
-        string PropertyInfo(string name, string value)
+        static string PropertyInfo(string name, string value)
         {
             if (string.IsNullOrEmpty(value))
             {

--- a/src/Docfx.DataContracts.Common/TocItemViewModel.cs
+++ b/src/Docfx.DataContracts.Common/TocItemViewModel.cs
@@ -128,7 +128,7 @@ public class TocItemViewModel
 
     public TocItemViewModel Clone()
     {
-        var cloned = (TocItemViewModel)this.MemberwiseClone();
+        var cloned = (TocItemViewModel)MemberwiseClone();
         if (cloned.Items != null)
         {
             cloned.Items = Items.Clone();

--- a/src/Docfx.Dotnet/ExtractMetadata/ReferenceItem.cs
+++ b/src/Docfx.Dotnet/ExtractMetadata/ReferenceItem.cs
@@ -47,7 +47,7 @@ internal class ReferenceItem
         result.QualifiedNameParts = CloneParts(result.QualifiedNameParts);
         return result;
 
-        SortedList<SyntaxLanguage, List<LinkItem>> CloneParts(SortedList<SyntaxLanguage, List<LinkItem>> parts)
+        static SortedList<SyntaxLanguage, List<LinkItem>> CloneParts(SortedList<SyntaxLanguage, List<LinkItem>> parts)
         {
             if (parts is null)
                 return null;
@@ -108,7 +108,7 @@ internal class ReferenceItem
         NameWithTypeParts = MergeParts(NameWithTypeParts, other.NameWithTypeParts);
         QualifiedNameParts = MergeParts(QualifiedNameParts, other.QualifiedNameParts);
 
-        SortedList<SyntaxLanguage, List<LinkItem>> MergeParts(SortedList<SyntaxLanguage, List<LinkItem>> self, SortedList<SyntaxLanguage, List<LinkItem>> other)
+        static SortedList<SyntaxLanguage, List<LinkItem>> MergeParts(SortedList<SyntaxLanguage, List<LinkItem>> self, SortedList<SyntaxLanguage, List<LinkItem>> other)
         {
             if (other != null && self != null)
             {

--- a/src/Docfx.Dotnet/Filters/ConfigFilterRule.cs
+++ b/src/Docfx.Dotnet/Filters/ConfigFilterRule.cs
@@ -18,12 +18,12 @@ internal class ConfigFilterRule
 
     public bool CanVisitApi(SymbolFilterData symbol)
     {
-        return CanVisitCore(this.ApiRules, symbol);
+        return CanVisitCore(ApiRules, symbol);
     }
 
     public bool CanVisitAttribute(SymbolFilterData symbol)
     {
-        return CanVisitCore(this.AttributeRules, symbol);
+        return CanVisitCore(AttributeRules, symbol);
     }
 
     private static bool CanVisitCore(IEnumerable<ConfigFilterRuleItemUnion> ruleItems, SymbolFilterData symbol)

--- a/src/Docfx.Dotnet/Filters/ConfigFilterRule.cs
+++ b/src/Docfx.Dotnet/Filters/ConfigFilterRule.cs
@@ -18,15 +18,15 @@ internal class ConfigFilterRule
 
     public bool CanVisitApi(SymbolFilterData symbol)
     {
-        return this.CanVisitCore(this.ApiRules, symbol);
+        return CanVisitCore(this.ApiRules, symbol);
     }
 
     public bool CanVisitAttribute(SymbolFilterData symbol)
     {
-        return this.CanVisitCore(this.AttributeRules, symbol);
+        return CanVisitCore(this.AttributeRules, symbol);
     }
 
-    private bool CanVisitCore(IEnumerable<ConfigFilterRuleItemUnion> ruleItems, SymbolFilterData symbol)
+    private static bool CanVisitCore(IEnumerable<ConfigFilterRuleItemUnion> ruleItems, SymbolFilterData symbol)
     {
         foreach (var ruleUnion in ruleItems)
         {

--- a/src/Docfx.Dotnet/Parsers/XmlComment.cs
+++ b/src/Docfx.Dotnet/Parsers/XmlComment.cs
@@ -21,8 +21,8 @@ namespace Docfx.Dotnet;
 
 internal class XmlComment
 {
-    private const string idSelector = @"((?![0-9])[\w_])+[\w\(\)\.\{\}\[\]\|\*\^~#@!`,_<>:]*";
-    private static readonly Regex CommentIdRegex = new(@"^(?<type>N|T|M|P|F|E|Overload):(?<id>" + idSelector + ")$", RegexOptions.Compiled);
+    private const string IdSelector = @"((?![0-9])[\w_])+[\w\(\)\.\{\}\[\]\|\*\^~#@!`,_<>:]*";
+    private static readonly Regex CommentIdRegex = new(@"^(?<type>N|T|M|P|F|E|Overload):(?<id>" + IdSelector + ")$", RegexOptions.Compiled);
     private static readonly Regex RegionRegex = new(@"^\s*#region\s*(.*)$");
     private static readonly Regex XmlRegionRegex = new(@"^\s*<!--\s*<([^/\s].*)>\s*-->$");
     private static readonly Regex EndRegionRegex = new(@"^\s*#endregion\s*.*$");

--- a/src/Docfx.Dotnet/Parsers/XmlComment.cs
+++ b/src/Docfx.Dotnet/Parsers/XmlComment.cs
@@ -159,7 +159,7 @@ internal class XmlComment
         }
     }
 
-    private (string lang, string code) ResolveCodeSource(XElement node, XmlCommentParserContext context)
+    private static (string lang, string code) ResolveCodeSource(XElement node, XmlCommentParserContext context)
     {
         var source = node.Attribute("source")?.Value;
         if (string.IsNullOrEmpty(source))
@@ -276,7 +276,7 @@ internal class XmlComment
         return (RegionRegex, EndRegionRegex);
     }
 
-    private void ResolveLangword(XNode node)
+    private static void ResolveLangword(XNode node)
     {
         foreach (var item in node.XPathSelectElements("//see[@langword]").ToList())
         {
@@ -426,7 +426,7 @@ internal class XmlComment
         }
     }
 
-    private IEnumerable<LinkInfo> GetMultipleLinkInfo(XPathNavigator navigator, string selector)
+    private static IEnumerable<LinkInfo> GetMultipleLinkInfo(XPathNavigator navigator, string selector)
     {
         var iterator = navigator.Clone().Select(selector);
         if (iterator == null)

--- a/src/Docfx.Dotnet/Parsers/XmlComment.cs
+++ b/src/Docfx.Dotnet/Parsers/XmlComment.cs
@@ -260,7 +260,7 @@ internal class XmlComment
         return result;
     }
 
-    private static (Regex, Regex) GetRegionRegex(String source)
+    private static (Regex, Regex) GetRegionRegex(string source)
     {
         var ext = Path.GetExtension(source);
         switch (ext.ToUpper())

--- a/src/Docfx.Dotnet/Resolvers/LayoutCheckAndCleanup.cs
+++ b/src/Docfx.Dotnet/Resolvers/LayoutCheckAndCleanup.cs
@@ -50,7 +50,7 @@ internal class LayoutCheckAndCleanup : IResolverPipeline
             Debug.Assert(i.Type.IsPageLevel());
             if (!i.Type.IsPageLevel())
             {
-                Logger.Log(LogLevel.Error, $"Invalid item inside yaml metadata: {i.Type.ToString()} is not allowed inside {member.Type.ToString()}. Will be ignored.");
+                Logger.Log(LogLevel.Error, $"Invalid item inside yaml metadata: {i.Type} is not allowed inside {member.Type}. Will be ignored.");
                 message.AppendFormat("{0} is not allowed inside {1}.", i.Type.ToString(), member.Type.ToString());
                 i.IsInvalid = true;
             }

--- a/src/Docfx.Dotnet/Resolvers/LayoutCheckAndCleanup.cs
+++ b/src/Docfx.Dotnet/Resolvers/LayoutCheckAndCleanup.cs
@@ -35,7 +35,7 @@ internal class LayoutCheckAndCleanup : IResolverPipeline
         }
     }
 
-    private string CheckNamespaces(MetadataItem member)
+    private static string CheckNamespaces(MetadataItem member)
     {
         StringBuilder message = new();
 
@@ -72,7 +72,7 @@ internal class LayoutCheckAndCleanup : IResolverPipeline
     /// </summary>
     /// <param name="item"></param>
     /// <returns></returns>
-    private string CheckNamespaceMembers(MetadataItem member)
+    private static string CheckNamespaceMembers(MetadataItem member)
     {
         StringBuilder message = new();
 
@@ -99,7 +99,7 @@ internal class LayoutCheckAndCleanup : IResolverPipeline
     /// </summary>
     /// <param name="item"></param>
     /// <returns></returns>
-    private string CheckNamespaceMembersMembers(MetadataItem member)
+    private static string CheckNamespaceMembersMembers(MetadataItem member)
     {
         StringBuilder message = new();
         if (member.IsInvalid)

--- a/src/Docfx.Dotnet/Resolvers/ResolveReference.cs
+++ b/src/Docfx.Dotnet/Resolvers/ResolveReference.cs
@@ -63,7 +63,7 @@ internal class ResolveReference : IResolverPipeline
         }
     }
 
-    private void AddIndirectReference(ResolverContext context, MetadataItem page, List<ReferenceItem> addedReferences)
+    private static void AddIndirectReference(ResolverContext context, MetadataItem page, List<ReferenceItem> addedReferences)
     {
         while (addedReferences.Count > 0)
         {
@@ -79,7 +79,7 @@ internal class ResolveReference : IResolverPipeline
         }
     }
 
-    private IEnumerable<string> GetReferenceKeys(MetadataItem current)
+    private static IEnumerable<string> GetReferenceKeys(MetadataItem current)
     {
         if (current.NamespaceName != null)
         {
@@ -169,7 +169,7 @@ internal class ResolveReference : IResolverPipeline
         }
     }
 
-    private IEnumerable<string> GetReferenceKeys(ReferenceItem reference)
+    private static IEnumerable<string> GetReferenceKeys(ReferenceItem reference)
     {
         if (reference.Definition != null)
         {

--- a/src/Docfx.Dotnet/Resolvers/YamlMetadataResolver.cs
+++ b/src/Docfx.Dotnet/Resolvers/YamlMetadataResolver.cs
@@ -30,9 +30,11 @@ internal static class YamlMetadataResolver
         Dictionary<string, ReferenceItem> allReferences,
         NamespaceLayout namespaceLayout)
     {
-        MetadataModel viewModel = new();
-        viewModel.TocYamlViewModel = GenerateToc(allMembers, allReferences, namespaceLayout);
-        viewModel.Members = new List<MetadataItem>();
+        MetadataModel viewModel = new()
+        {
+            TocYamlViewModel = GenerateToc(allMembers, allReferences, namespaceLayout),
+            Members = new List<MetadataItem>(),
+        };
         ResolverContext context = new()
         {
             References = allReferences,

--- a/src/Docfx.Dotnet/SourceLink/PortableCustomDebugInfoKinds.cs
+++ b/src/Docfx.Dotnet/SourceLink/PortableCustomDebugInfoKinds.cs
@@ -4,8 +4,6 @@
 
 #nullable disable
 
-using System;
-
 namespace Microsoft.CodeAnalysis.Debugging
 {
     internal static class PortableCustomDebugInfoKinds

--- a/src/Docfx.Dotnet/SourceLink/PortableCustomDebugInfoKinds.cs
+++ b/src/Docfx.Dotnet/SourceLink/PortableCustomDebugInfoKinds.cs
@@ -2,24 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
+namespace Microsoft.CodeAnalysis.Debugging;
 
-namespace Microsoft.CodeAnalysis.Debugging
+internal static class PortableCustomDebugInfoKinds
 {
-    internal static class PortableCustomDebugInfoKinds
-    {
-        public static readonly Guid AsyncMethodSteppingInformationBlob = new("54FD2AC5-E925-401A-9C2A-F94F171072F8");
-        public static readonly Guid StateMachineHoistedLocalScopes = new("6DA9A61E-F8C7-4874-BE62-68BC5630DF71");
-        public static readonly Guid DynamicLocalVariables = new("83C563C4-B4F3-47D5-B824-BA5441477EA8");
-        public static readonly Guid TupleElementNames = new("ED9FDF71-8879-4747-8ED3-FE5EDE3CE710");
-        public static readonly Guid DefaultNamespace = new("58b2eab6-209f-4e4e-a22c-b2d0f910c782");
-        public static readonly Guid EncLocalSlotMap = new("755F52A8-91C5-45BE-B4B8-209571E552BD");
-        public static readonly Guid EncLambdaAndClosureMap = new("A643004C-0240-496F-A783-30D64F4979DE");
-        public static readonly Guid EncStateMachineStateMap = new("8B78CD68-2EDE-420B-980B-E15884B8AAA3");
-        public static readonly Guid SourceLink = new("CC110556-A091-4D38-9FEC-25AB9A351A6A");
-        public static readonly Guid EmbeddedSource = new("0E8A571B-6926-466E-B4AD-8AB04611F5FE");
-        public static readonly Guid CompilationMetadataReferences = new("7E4D4708-096E-4C5C-AEDA-CB10BA6A740D");
-        public static readonly Guid CompilationOptions = new("B5FEEC05-8CD0-4A83-96DA-466284BB4BD8");
-        public static readonly Guid TypeDefinitionDocuments = new("932E74BC-DBA9-4478-8D46-0F32A7BAB3D3");
-    }
+    public static readonly Guid AsyncMethodSteppingInformationBlob = new("54FD2AC5-E925-401A-9C2A-F94F171072F8");
+    public static readonly Guid StateMachineHoistedLocalScopes = new("6DA9A61E-F8C7-4874-BE62-68BC5630DF71");
+    public static readonly Guid DynamicLocalVariables = new("83C563C4-B4F3-47D5-B824-BA5441477EA8");
+    public static readonly Guid TupleElementNames = new("ED9FDF71-8879-4747-8ED3-FE5EDE3CE710");
+    public static readonly Guid DefaultNamespace = new("58b2eab6-209f-4e4e-a22c-b2d0f910c782");
+    public static readonly Guid EncLocalSlotMap = new("755F52A8-91C5-45BE-B4B8-209571E552BD");
+    public static readonly Guid EncLambdaAndClosureMap = new("A643004C-0240-496F-A783-30D64F4979DE");
+    public static readonly Guid EncStateMachineStateMap = new("8B78CD68-2EDE-420B-980B-E15884B8AAA3");
+    public static readonly Guid SourceLink = new("CC110556-A091-4D38-9FEC-25AB9A351A6A");
+    public static readonly Guid EmbeddedSource = new("0E8A571B-6926-466E-B4AD-8AB04611F5FE");
+    public static readonly Guid CompilationMetadataReferences = new("7E4D4708-096E-4C5C-AEDA-CB10BA6A740D");
+    public static readonly Guid CompilationOptions = new("B5FEEC05-8CD0-4A83-96DA-466284BB4BD8");
+    public static readonly Guid TypeDefinitionDocuments = new("932E74BC-DBA9-4478-8D46-0F32A7BAB3D3");
 }

--- a/src/Docfx.Dotnet/SourceLink/SourceLinkMap.cs
+++ b/src/Docfx.Dotnet/SourceLink/SourceLinkMap.cs
@@ -160,7 +160,7 @@ namespace Microsoft.SourceLink.Tools
                 uriPrefix = value[..uriStar];
                 uriSuffix = value[(uriStar + 1)..];
 
-                if (uriSuffix.IndexOf('*') >= 0)
+                if (uriSuffix.Contains('*'))
                 {
                     return false;
                 }
@@ -191,7 +191,7 @@ namespace Microsoft.SourceLink.Tools
         {
             ArgumentNullException.ThrowIfNull(path);
 
-            if (path.IndexOf('*') >= 0)
+            if (path.Contains('*'))
             {
                 uri = null;
                 return false;

--- a/src/Docfx.Dotnet/SourceLink/SourceLinkMap.cs
+++ b/src/Docfx.Dotnet/SourceLink/SourceLinkMap.cs
@@ -12,210 +12,209 @@ using System.Diagnostics.CodeAnalysis;
 
 #nullable enable
 
-namespace Microsoft.SourceLink.Tools
+namespace Microsoft.SourceLink.Tools;
+
+/// <summary>
+/// Source Link URL map. Maps file paths matching Source Link patterns to URLs.
+/// </summary>
+internal readonly struct SourceLinkMap
 {
-    /// <summary>
-    /// Source Link URL map. Maps file paths matching Source Link patterns to URLs.
-    /// </summary>
-    internal readonly struct SourceLinkMap
+    private readonly ReadOnlyCollection<Entry> _entries;
+
+    private SourceLinkMap(ReadOnlyCollection<Entry> mappings)
     {
-        private readonly ReadOnlyCollection<Entry> _entries;
+        _entries = mappings;
+    }
 
-        private SourceLinkMap(ReadOnlyCollection<Entry> mappings)
+    public readonly struct Entry
+    {
+        public readonly FilePathPattern FilePath;
+        public readonly UriPattern Uri;
+
+        public Entry(FilePathPattern filePath, UriPattern uri)
         {
-            _entries = mappings;
+            FilePath = filePath;
+            Uri = uri;
         }
 
-        public readonly struct Entry
+        public void Deconstruct(out FilePathPattern filePath, out UriPattern uri)
         {
-            public readonly FilePathPattern FilePath;
-            public readonly UriPattern Uri;
+            filePath = FilePath;
+            uri = Uri;
+        }
+    }
 
-            public Entry(FilePathPattern filePath, UriPattern uri)
-            {
-                FilePath = filePath;
-                Uri = uri;
-            }
+    public readonly struct FilePathPattern
+    {
+        public readonly string Path;
+        public readonly bool IsPrefix;
 
-            public void Deconstruct(out FilePathPattern filePath, out UriPattern uri)
-            {
-                filePath = FilePath;
-                uri = Uri;
-            }
+        public FilePathPattern(string path, bool isPrefix)
+        {
+            Path = path;
+            IsPrefix = isPrefix;
+        }
+    }
+
+    public readonly struct UriPattern
+    {
+        public readonly string Prefix;
+        public readonly string Suffix;
+
+        public UriPattern(string prefix, string suffix)
+        {
+            Prefix = prefix;
+            Suffix = suffix;
+        }
+    }
+
+    public IReadOnlyList<Entry> Entries => _entries;
+
+    /// <summary>
+    /// Parses Source Link JSON string.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="json"/> is null.</exception>
+    /// <exception cref="InvalidDataException">The JSON does not follow Source Link specification.</exception>
+    /// <exception cref="JsonException"><paramref name="json"/> is not valid JSON string.</exception>
+    public static SourceLinkMap Parse(string json)
+    {
+        ArgumentNullException.ThrowIfNull(json);
+
+        var list = new List<Entry>();
+
+        var root = JsonDocument.Parse(json, new JsonDocumentOptions() { AllowTrailingCommas = true }).RootElement;
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            throw new InvalidDataException();
         }
 
-        public readonly struct FilePathPattern
+        foreach (var rootEntry in root.EnumerateObject())
         {
-            public readonly string Path;
-            public readonly bool IsPrefix;
-
-            public FilePathPattern(string path, bool isPrefix)
+            if (!rootEntry.NameEquals("documents"))
             {
-                Path = path;
-                IsPrefix = isPrefix;
+                // potential future extensibility
+                continue;
             }
-        }
 
-        public readonly struct UriPattern
-        {
-            public readonly string Prefix;
-            public readonly string Suffix;
-
-            public UriPattern(string prefix, string suffix)
-            {
-                Prefix = prefix;
-                Suffix = suffix;
-            }
-        }
-
-        public IReadOnlyList<Entry> Entries => _entries;
-
-        /// <summary>
-        /// Parses Source Link JSON string.
-        /// </summary>
-        /// <exception cref="ArgumentNullException"><paramref name="json"/> is null.</exception>
-        /// <exception cref="InvalidDataException">The JSON does not follow Source Link specification.</exception>
-        /// <exception cref="JsonException"><paramref name="json"/> is not valid JSON string.</exception>
-        public static SourceLinkMap Parse(string json)
-        {
-            ArgumentNullException.ThrowIfNull(json);
-
-            var list = new List<Entry>();
-
-            var root = JsonDocument.Parse(json, new JsonDocumentOptions() { AllowTrailingCommas = true }).RootElement;
-            if (root.ValueKind != JsonValueKind.Object)
+            if (rootEntry.Value.ValueKind != JsonValueKind.Object)
             {
                 throw new InvalidDataException();
             }
 
-            foreach (var rootEntry in root.EnumerateObject())
+            foreach (var documentsEntry in rootEntry.Value.EnumerateObject())
             {
-                if (!rootEntry.NameEquals("documents"))
-                {
-                    // potential future extensibility
-                    continue;
-                }
-
-                if (rootEntry.Value.ValueKind != JsonValueKind.Object)
+                if (documentsEntry.Value.ValueKind != JsonValueKind.String ||
+                    !TryParseEntry(documentsEntry.Name, documentsEntry.Value.GetString()!, out var entry))
                 {
                     throw new InvalidDataException();
                 }
 
-                foreach (var documentsEntry in rootEntry.Value.EnumerateObject())
-                {
-                    if (documentsEntry.Value.ValueKind != JsonValueKind.String ||
-                        !TryParseEntry(documentsEntry.Name, documentsEntry.Value.GetString()!, out var entry))
-                    {
-                        throw new InvalidDataException();
-                    }
-
-                    list.Add(entry);
-                }
+                list.Add(entry);
             }
-
-            // Sort the map by decreasing file path length. This ensures that the most specific paths will checked before the least specific
-            // and that absolute paths will be checked before a wildcard path with a matching base
-            list.Sort((left, right) => -left.FilePath.Path.Length.CompareTo(right.FilePath.Path.Length));
-
-            return new SourceLinkMap(new ReadOnlyCollection<Entry>(list));
         }
 
-        private static bool TryParseEntry(string key, string value, out Entry entry)
+        // Sort the map by decreasing file path length. This ensures that the most specific paths will checked before the least specific
+        // and that absolute paths will be checked before a wildcard path with a matching base
+        list.Sort((left, right) => -left.FilePath.Path.Length.CompareTo(right.FilePath.Path.Length));
+
+        return new SourceLinkMap(new ReadOnlyCollection<Entry>(list));
+    }
+
+    private static bool TryParseEntry(string key, string value, out Entry entry)
+    {
+        entry = default;
+
+        // VALIDATION RULES
+        // 1. The only acceptable wildcard is one and only one '*', which if present will be replaced by a relative path
+        // 2. If the filepath does not contain a *, the uri cannot contain a * and if the filepath contains a * the uri must contain a *
+        // 3. If the filepath contains a *, it must be the final character
+        // 4. If the uri contains a *, it may be anywhere in the uri
+        if (key.Length == 0)
         {
-            entry = default;
-
-            // VALIDATION RULES
-            // 1. The only acceptable wildcard is one and only one '*', which if present will be replaced by a relative path
-            // 2. If the filepath does not contain a *, the uri cannot contain a * and if the filepath contains a * the uri must contain a *
-            // 3. If the filepath contains a *, it must be the final character
-            // 4. If the uri contains a *, it may be anywhere in the uri
-            if (key.Length == 0)
-            {
-                return false;
-            }
-
-            var filePathStar = key.IndexOf('*');
-            if (filePathStar == key.Length - 1)
-            {
-                key = key[..filePathStar];
-            }
-            else if (filePathStar >= 0)
-            {
-                return false;
-            }
-
-            string uriPrefix, uriSuffix;
-            var uriStar = value.IndexOf('*');
-            if (uriStar >= 0)
-            {
-                if (filePathStar < 0)
-                {
-                    return false;
-                }
-
-                uriPrefix = value[..uriStar];
-                uriSuffix = value[(uriStar + 1)..];
-
-                if (uriSuffix.Contains('*'))
-                {
-                    return false;
-                }
-            }
-            else
-            {
-                uriPrefix = value;
-                uriSuffix = "";
-            }
-
-            entry = new Entry(
-                new FilePathPattern(key, isPrefix: filePathStar >= 0),
-                new UriPattern(uriPrefix, uriSuffix));
-
-            return true;
+            return false;
         }
 
-        /// <summary>
-        /// Maps specified <paramref name="path"/> to the corresponding URL.
-        /// </summary>
-        /// <exception cref="ArgumentNullException"><paramref name="path"/> is null.</exception>
-        public bool TryGetUri(
-            string path,
+        var filePathStar = key.IndexOf('*');
+        if (filePathStar == key.Length - 1)
+        {
+            key = key[..filePathStar];
+        }
+        else if (filePathStar >= 0)
+        {
+            return false;
+        }
+
+        string uriPrefix, uriSuffix;
+        var uriStar = value.IndexOf('*');
+        if (uriStar >= 0)
+        {
+            if (filePathStar < 0)
+            {
+                return false;
+            }
+
+            uriPrefix = value[..uriStar];
+            uriSuffix = value[(uriStar + 1)..];
+
+            if (uriSuffix.Contains('*'))
+            {
+                return false;
+            }
+        }
+        else
+        {
+            uriPrefix = value;
+            uriSuffix = "";
+        }
+
+        entry = new Entry(
+            new FilePathPattern(key, isPrefix: filePathStar >= 0),
+            new UriPattern(uriPrefix, uriSuffix));
+
+        return true;
+    }
+
+    /// <summary>
+    /// Maps specified <paramref name="path"/> to the corresponding URL.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="path"/> is null.</exception>
+    public bool TryGetUri(
+        string path,
 #if NETCOREAPP
-            [NotNullWhen(true)]
+        [NotNullWhen(true)]
 #endif
-            out string? uri)
+        out string? uri)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+
+        if (path.Contains('*'))
         {
-            ArgumentNullException.ThrowIfNull(path);
-
-            if (path.Contains('*'))
-            {
-                uri = null;
-                return false;
-            }
-
-            // Note: the mapping function is case-insensitive.
-
-            foreach (var (file, mappedUri) in _entries)
-            {
-                if (file.IsPrefix)
-                {
-                    if (path.StartsWith(file.Path, StringComparison.OrdinalIgnoreCase))
-                    {
-                        var escapedPath = string.Join("/", path[file.Path.Length..].Split(new[] { '/', '\\' }).Select(Uri.EscapeDataString));
-                        uri = mappedUri.Prefix + escapedPath + mappedUri.Suffix;
-                        return true;
-                    }
-                }
-                else if (string.Equals(path, file.Path, StringComparison.OrdinalIgnoreCase))
-                {
-                    Debug.Assert(mappedUri.Suffix.Length == 0);
-                    uri = mappedUri.Prefix;
-                    return true;
-                }
-            }
-
             uri = null;
             return false;
         }
+
+        // Note: the mapping function is case-insensitive.
+
+        foreach (var (file, mappedUri) in _entries)
+        {
+            if (file.IsPrefix)
+            {
+                if (path.StartsWith(file.Path, StringComparison.OrdinalIgnoreCase))
+                {
+                    var escapedPath = string.Join("/", path[file.Path.Length..].Split(new[] { '/', '\\' }).Select(Uri.EscapeDataString));
+                    uri = mappedUri.Prefix + escapedPath + mappedUri.Suffix;
+                    return true;
+                }
+            }
+            else if (string.Equals(path, file.Path, StringComparison.OrdinalIgnoreCase))
+            {
+                Debug.Assert(mappedUri.Suffix.Length == 0);
+                uri = mappedUri.Prefix;
+                return true;
+            }
+        }
+
+        uri = null;
+        return false;
     }
 }

--- a/src/Docfx.Dotnet/SourceLink/SourceLinkMap.cs
+++ b/src/Docfx.Dotnet/SourceLink/SourceLinkMap.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Text.Json;
 
 #if NETCOREAPP

--- a/src/Docfx.Dotnet/SourceLink/SymbolSourceDocumentFinder.cs
+++ b/src/Docfx.Dotnet/SourceLink/SymbolSourceDocumentFinder.cs
@@ -6,166 +6,165 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using Microsoft.CodeAnalysis.Debugging;
 
-namespace Microsoft.CodeAnalysis.PdbSourceDocument
+namespace Microsoft.CodeAnalysis.PdbSourceDocument;
+
+internal static class SymbolSourceDocumentFinder
 {
-    internal static class SymbolSourceDocumentFinder
+    public static HashSet<DocumentHandle> FindDocumentHandles(EntityHandle handle, MetadataReader dllReader, MetadataReader pdbReader)
     {
-        public static HashSet<DocumentHandle> FindDocumentHandles(EntityHandle handle, MetadataReader dllReader, MetadataReader pdbReader)
+        var docList = new HashSet<DocumentHandle>();
+
+        switch (handle.Kind)
         {
-            var docList = new HashSet<DocumentHandle>();
-
-            switch (handle.Kind)
-            {
-                case HandleKind.MethodDefinition:
-                    ProcessMethodDef((MethodDefinitionHandle)handle, dllReader, pdbReader, docList, processDeclaringType: true);
-                    break;
-                case HandleKind.TypeDefinition:
-                    ProcessTypeDef((TypeDefinitionHandle)handle, dllReader, pdbReader, docList);
-                    break;
-                case HandleKind.FieldDefinition:
-                    ProcessFieldDef((FieldDefinitionHandle)handle, dllReader, pdbReader, docList);
-                    break;
-                case HandleKind.PropertyDefinition:
-                    ProcessPropertyDef((PropertyDefinitionHandle)handle, dllReader, pdbReader, docList);
-                    break;
-                case HandleKind.EventDefinition:
-                    ProcessEventDef((EventDefinitionHandle)handle, dllReader, pdbReader, docList);
-                    break;
-            }
-
-            return docList;
+            case HandleKind.MethodDefinition:
+                ProcessMethodDef((MethodDefinitionHandle)handle, dllReader, pdbReader, docList, processDeclaringType: true);
+                break;
+            case HandleKind.TypeDefinition:
+                ProcessTypeDef((TypeDefinitionHandle)handle, dllReader, pdbReader, docList);
+                break;
+            case HandleKind.FieldDefinition:
+                ProcessFieldDef((FieldDefinitionHandle)handle, dllReader, pdbReader, docList);
+                break;
+            case HandleKind.PropertyDefinition:
+                ProcessPropertyDef((PropertyDefinitionHandle)handle, dllReader, pdbReader, docList);
+                break;
+            case HandleKind.EventDefinition:
+                ProcessEventDef((EventDefinitionHandle)handle, dllReader, pdbReader, docList);
+                break;
         }
 
-        private static void ProcessMethodDef(MethodDefinitionHandle methodDefHandle, MetadataReader dllReader, MetadataReader pdbReader, HashSet<DocumentHandle> docList, bool processDeclaringType)
-        {
-            var mdi = pdbReader.GetMethodDebugInformation(methodDefHandle);
-            if (!mdi.Document.IsNil)
-            {
-                docList.Add(mdi.Document);
-                return;
-            }
+        return docList;
+    }
 
-            if (!mdi.SequencePointsBlob.IsNil)
+    private static void ProcessMethodDef(MethodDefinitionHandle methodDefHandle, MetadataReader dllReader, MetadataReader pdbReader, HashSet<DocumentHandle> docList, bool processDeclaringType)
+    {
+        var mdi = pdbReader.GetMethodDebugInformation(methodDefHandle);
+        if (!mdi.Document.IsNil)
+        {
+            docList.Add(mdi.Document);
+            return;
+        }
+
+        if (!mdi.SequencePointsBlob.IsNil)
+        {
+            foreach (var point in mdi.GetSequencePoints())
             {
-                foreach (var point in mdi.GetSequencePoints())
+                if (!point.Document.IsNil)
                 {
-                    if (!point.Document.IsNil)
-                    {
-                        docList.Add(point.Document);
-                        // No need to check the type if we found a document
-                        processDeclaringType = false;
-                    }
+                    docList.Add(point.Document);
+                    // No need to check the type if we found a document
+                    processDeclaringType = false;
                 }
             }
-
-            // Not all methods have document info, for example synthesized constructors, so we also want
-            // to get any documents from the declaring type
-            if (processDeclaringType)
-            {
-                var methodDef = dllReader.GetMethodDefinition(methodDefHandle);
-                var typeDefHandle = methodDef.GetDeclaringType();
-                ProcessTypeDef(typeDefHandle, dllReader, pdbReader, docList);
-            }
         }
 
-        private static void ProcessEventDef(EventDefinitionHandle eventDefHandle, MetadataReader dllReader, MetadataReader pdbReader, HashSet<DocumentHandle> docList)
+        // Not all methods have document info, for example synthesized constructors, so we also want
+        // to get any documents from the declaring type
+        if (processDeclaringType)
         {
-            var eventDef = dllReader.GetEventDefinition(eventDefHandle);
-            var accessors = eventDef.GetAccessors();
-            if (!accessors.Adder.IsNil)
-            {
-                ProcessMethodDef(accessors.Adder, dllReader, pdbReader, docList, processDeclaringType: true);
-            }
-
-            if (!accessors.Remover.IsNil)
-            {
-                ProcessMethodDef(accessors.Remover, dllReader, pdbReader, docList, processDeclaringType: true);
-            }
-
-            if (!accessors.Raiser.IsNil)
-            {
-                ProcessMethodDef(accessors.Raiser, dllReader, pdbReader, docList, processDeclaringType: true);
-            }
-
-            foreach (var other in accessors.Others)
-            {
-                ProcessMethodDef(other, dllReader, pdbReader, docList, processDeclaringType: true);
-            }
-        }
-
-        private static void ProcessPropertyDef(PropertyDefinitionHandle propertyDefHandle, MetadataReader dllReader, MetadataReader pdbReader, HashSet<DocumentHandle> docList)
-        {
-            var propertyDef = dllReader.GetPropertyDefinition(propertyDefHandle);
-            var accessors = propertyDef.GetAccessors();
-            if (!accessors.Getter.IsNil)
-            {
-                ProcessMethodDef(accessors.Getter, dllReader, pdbReader, docList, processDeclaringType: true);
-            }
-
-            if (!accessors.Setter.IsNil)
-            {
-                ProcessMethodDef(accessors.Setter, dllReader, pdbReader, docList, processDeclaringType: true);
-            }
-
-            foreach (var other in accessors.Others)
-            {
-                ProcessMethodDef(other, dllReader, pdbReader, docList, processDeclaringType: true);
-            }
-        }
-
-        private static void ProcessFieldDef(FieldDefinitionHandle fieldDefHandle, MetadataReader dllReader, MetadataReader pdbReader, HashSet<DocumentHandle> docList)
-        {
-            var fieldDef = dllReader.GetFieldDefinition(fieldDefHandle);
-            var typeDefHandle = fieldDef.GetDeclaringType();
+            var methodDef = dllReader.GetMethodDefinition(methodDefHandle);
+            var typeDefHandle = methodDef.GetDeclaringType();
             ProcessTypeDef(typeDefHandle, dllReader, pdbReader, docList);
         }
+    }
 
-        private static void ProcessTypeDef(TypeDefinitionHandle typeDefHandle, MetadataReader dllReader, MetadataReader pdbReader, HashSet<DocumentHandle> docList, bool processContainingType = true)
+    private static void ProcessEventDef(EventDefinitionHandle eventDefHandle, MetadataReader dllReader, MetadataReader pdbReader, HashSet<DocumentHandle> docList)
+    {
+        var eventDef = dllReader.GetEventDefinition(eventDefHandle);
+        var accessors = eventDef.GetAccessors();
+        if (!accessors.Adder.IsNil)
         {
-            AddDocumentsFromTypeDefinitionDocuments(typeDefHandle, pdbReader, docList);
+            ProcessMethodDef(accessors.Adder, dllReader, pdbReader, docList, processDeclaringType: true);
+        }
 
-            // We don't necessarily have all of the documents associated with the type
-            var typeDef = dllReader.GetTypeDefinition(typeDefHandle);
-            foreach (var methodDefHandle in typeDef.GetMethods())
-            {
-                ProcessMethodDef(methodDefHandle, dllReader, pdbReader, docList, processDeclaringType: false);
-            }
+        if (!accessors.Remover.IsNil)
+        {
+            ProcessMethodDef(accessors.Remover, dllReader, pdbReader, docList, processDeclaringType: true);
+        }
 
-            if (processContainingType && typeDef.IsNested)
-            {
-                // If this is a nested type, then we want to check the outer type too
-                var containingType = typeDef.GetDeclaringType();
-                if (!containingType.IsNil)
-                {
-                    ProcessTypeDef(containingType, dllReader, pdbReader, docList);
-                }
-            }
+        if (!accessors.Raiser.IsNil)
+        {
+            ProcessMethodDef(accessors.Raiser, dllReader, pdbReader, docList, processDeclaringType: true);
+        }
 
-            // And of course if this is an outer type, the only document info might be from methods in
-            // nested types
-            var nestedTypes = typeDef.GetNestedTypes();
-            foreach (var nestedType in nestedTypes)
+        foreach (var other in accessors.Others)
+        {
+            ProcessMethodDef(other, dllReader, pdbReader, docList, processDeclaringType: true);
+        }
+    }
+
+    private static void ProcessPropertyDef(PropertyDefinitionHandle propertyDefHandle, MetadataReader dllReader, MetadataReader pdbReader, HashSet<DocumentHandle> docList)
+    {
+        var propertyDef = dllReader.GetPropertyDefinition(propertyDefHandle);
+        var accessors = propertyDef.GetAccessors();
+        if (!accessors.Getter.IsNil)
+        {
+            ProcessMethodDef(accessors.Getter, dllReader, pdbReader, docList, processDeclaringType: true);
+        }
+
+        if (!accessors.Setter.IsNil)
+        {
+            ProcessMethodDef(accessors.Setter, dllReader, pdbReader, docList, processDeclaringType: true);
+        }
+
+        foreach (var other in accessors.Others)
+        {
+            ProcessMethodDef(other, dllReader, pdbReader, docList, processDeclaringType: true);
+        }
+    }
+
+    private static void ProcessFieldDef(FieldDefinitionHandle fieldDefHandle, MetadataReader dllReader, MetadataReader pdbReader, HashSet<DocumentHandle> docList)
+    {
+        var fieldDef = dllReader.GetFieldDefinition(fieldDefHandle);
+        var typeDefHandle = fieldDef.GetDeclaringType();
+        ProcessTypeDef(typeDefHandle, dllReader, pdbReader, docList);
+    }
+
+    private static void ProcessTypeDef(TypeDefinitionHandle typeDefHandle, MetadataReader dllReader, MetadataReader pdbReader, HashSet<DocumentHandle> docList, bool processContainingType = true)
+    {
+        AddDocumentsFromTypeDefinitionDocuments(typeDefHandle, pdbReader, docList);
+
+        // We don't necessarily have all of the documents associated with the type
+        var typeDef = dllReader.GetTypeDefinition(typeDefHandle);
+        foreach (var methodDefHandle in typeDef.GetMethods())
+        {
+            ProcessMethodDef(methodDefHandle, dllReader, pdbReader, docList, processDeclaringType: false);
+        }
+
+        if (processContainingType && typeDef.IsNested)
+        {
+            // If this is a nested type, then we want to check the outer type too
+            var containingType = typeDef.GetDeclaringType();
+            if (!containingType.IsNil)
             {
-                ProcessTypeDef(nestedType, dllReader, pdbReader, docList, processContainingType: false);
+                ProcessTypeDef(containingType, dllReader, pdbReader, docList);
             }
         }
 
-        private static void AddDocumentsFromTypeDefinitionDocuments(TypeDefinitionHandle typeDefHandle, MetadataReader pdbReader, HashSet<DocumentHandle> docList)
+        // And of course if this is an outer type, the only document info might be from methods in
+        // nested types
+        var nestedTypes = typeDef.GetNestedTypes();
+        foreach (var nestedType in nestedTypes)
         {
-            var handles = pdbReader.GetCustomDebugInformation(typeDefHandle);
-            foreach (var cdiHandle in handles)
+            ProcessTypeDef(nestedType, dllReader, pdbReader, docList, processContainingType: false);
+        }
+    }
+
+    private static void AddDocumentsFromTypeDefinitionDocuments(TypeDefinitionHandle typeDefHandle, MetadataReader pdbReader, HashSet<DocumentHandle> docList)
+    {
+        var handles = pdbReader.GetCustomDebugInformation(typeDefHandle);
+        foreach (var cdiHandle in handles)
+        {
+            var cdi = pdbReader.GetCustomDebugInformation(cdiHandle);
+            var guid = pdbReader.GetGuid(cdi.Kind);
+            if (guid == PortableCustomDebugInfoKinds.TypeDefinitionDocuments)
             {
-                var cdi = pdbReader.GetCustomDebugInformation(cdiHandle);
-                var guid = pdbReader.GetGuid(cdi.Kind);
-                if (guid == PortableCustomDebugInfoKinds.TypeDefinitionDocuments)
+                if (((TypeDefinitionHandle)cdi.Parent).Equals(typeDefHandle))
                 {
-                    if (((TypeDefinitionHandle)cdi.Parent).Equals(typeDefHandle))
+                    var reader = pdbReader.GetBlobReader(cdi.Value);
+                    while (reader.RemainingBytes > 0)
                     {
-                        var reader = pdbReader.GetBlobReader(cdi.Value);
-                        while (reader.RemainingBytes > 0)
-                        {
-                            docList.Add(MetadataTokens.DocumentHandle(reader.ReadCompressedInteger()));
-                        }
+                        docList.Add(MetadataTokens.DocumentHandle(reader.ReadCompressedInteger()));
                     }
                 }
             }

--- a/src/Docfx.Dotnet/SourceLink/SymbolSourceDocumentFinder.cs
+++ b/src/Docfx.Dotnet/SourceLink/SymbolSourceDocumentFinder.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using Microsoft.CodeAnalysis.Debugging;

--- a/src/Docfx.Dotnet/SymbolFormatter.Syntax.cs
+++ b/src/Docfx.Dotnet/SymbolFormatter.Syntax.cs
@@ -57,7 +57,7 @@ partial class SymbolFormatter
         public SyntaxLanguage Language { get; init; }
         public SymbolFilter Filter { get; init; } = default!;
 
-        private ImmutableArray<SymbolDisplayPart>.Builder _parts = ImmutableArray.CreateBuilder<SymbolDisplayPart>();
+        private readonly ImmutableArray<SymbolDisplayPart>.Builder _parts = ImmutableArray.CreateBuilder<SymbolDisplayPart>();
 
         public ImmutableArray<SymbolDisplayPart> GetSyntax(ISymbol symbol)
         {

--- a/src/Docfx.Dotnet/Visitors/SymbolVisitorAdapter.cs
+++ b/src/Docfx.Dotnet/Visitors/SymbolVisitorAdapter.cs
@@ -418,7 +418,7 @@ internal class SymbolVisitorAdapter : SymbolVisitor<MetadataItem>
         return _generator.AddSpecReference(symbol, typeGenericParameters, methodGenericParameters, _references, this);
     }
 
-    private MemberType GetMemberTypeFromSymbol(ISymbol symbol)
+    private static MemberType GetMemberTypeFromSymbol(ISymbol symbol)
     {
         switch (symbol.Kind)
         {
@@ -519,7 +519,7 @@ internal class SymbolVisitorAdapter : SymbolVisitor<MetadataItem>
         return result;
     }
 
-    private bool IsInheritable(ISymbol memberSymbol)
+    private static bool IsInheritable(ISymbol memberSymbol)
     {
         var kind = (memberSymbol as IMethodSymbol)?.MethodKind;
         if (kind != null)

--- a/src/Docfx.Dotnet/Visitors/SymbolVisitorAdapter.cs
+++ b/src/Docfx.Dotnet/Visitors/SymbolVisitorAdapter.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Text.RegularExpressions;
 using Docfx.Common;
 using Docfx.DataContracts.ManagedReference;
-using Docfx.Exceptions;
 using Docfx.Plugins;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Shared.Extensions;

--- a/src/Docfx.Dotnet/Visitors/SymbolVisitorAdapter.cs
+++ b/src/Docfx.Dotnet/Visitors/SymbolVisitorAdapter.cs
@@ -43,12 +43,11 @@ internal class SymbolVisitorAdapter : SymbolVisitor<MetadataItem>
         {
             Name = VisitorHelper.GetId(symbol),
             CommentId = VisitorHelper.GetCommentId(symbol),
+            DisplayNames = new SortedList<SyntaxLanguage, string>(),
+            DisplayNamesWithType = new SortedList<SyntaxLanguage, string>(),
+            DisplayQualifiedNames = new SortedList<SyntaxLanguage, string>(),
+            Source = VisitorHelper.GetSourceDetail(symbol, _compilation),
         };
-
-        item.DisplayNames = new SortedList<SyntaxLanguage, string>();
-        item.DisplayNamesWithType = new SortedList<SyntaxLanguage, string>();
-        item.DisplayQualifiedNames = new SortedList<SyntaxLanguage, string>();
-        item.Source = VisitorHelper.GetSourceDetail(symbol, _compilation);
         var assemblyName = symbol.ContainingAssembly?.Name;
         item.AssemblyNameList = string.IsNullOrEmpty(assemblyName) || assemblyName is "?" ? null : new List<string> { assemblyName };
         if (symbol is not INamespaceSymbol)
@@ -93,17 +92,16 @@ internal class SymbolVisitorAdapter : SymbolVisitor<MetadataItem>
         var item = new MetadataItem
         {
             Name = VisitorHelper.GetId(symbol),
+            DisplayNames = new SortedList<SyntaxLanguage, string>
+            {
+                { SyntaxLanguage.Default, symbol.MetadataName },
+            },
+                DisplayQualifiedNames = new SortedList<SyntaxLanguage, string>
+            {
+                { SyntaxLanguage.Default, symbol.MetadataName },
+            },
+            Type = MemberType.Assembly,
         };
-
-        item.DisplayNames = new SortedList<SyntaxLanguage, string>
-        {
-            { SyntaxLanguage.Default, symbol.MetadataName },
-        };
-        item.DisplayQualifiedNames = new SortedList<SyntaxLanguage, string>
-        {
-            { SyntaxLanguage.Default, symbol.MetadataName },
-        };
-        item.Type = MemberType.Assembly;
 
         IEnumerable<INamespaceSymbol> namespaces;
         if (!string.IsNullOrEmpty(VisitorHelper.GlobalNamespaceId))

--- a/src/Docfx.Dotnet/Visitors/SymbolVisitorAdapter.cs
+++ b/src/Docfx.Dotnet/Visitors/SymbolVisitorAdapter.cs
@@ -16,7 +16,7 @@ namespace Docfx.Dotnet;
 internal class SymbolVisitorAdapter : SymbolVisitor<MetadataItem>
 {
     private static readonly Regex MemberSigRegex = new(@"^([\w\{\}`]+\.)+", RegexOptions.Compiled);
-    private static readonly IReadOnlyList<string> EmptyListOfString = new string[0];
+    private static readonly IReadOnlyList<string> EmptyListOfString = Array.Empty<string>();
     private readonly Compilation _compilation;
     private readonly YamlModelGenerator _generator;
     private readonly Dictionary<string, ReferenceItem> _references = new();

--- a/src/Docfx.Dotnet/Visitors/SymbolVisitorAdapter.cs
+++ b/src/Docfx.Dotnet/Visitors/SymbolVisitorAdapter.cs
@@ -181,7 +181,7 @@ internal class SymbolVisitorAdapter : SymbolVisitor<MetadataItem>
         }
 
         item.Items = new List<MetadataItem>();
-        foreach (var member in symbol.GetMembers().Where(s => !(s is INamedTypeSymbol)))
+        foreach (var member in symbol.GetMembers().Where(s => s is not INamedTypeSymbol))
         {
             var memberItem = member.Accept(this);
             if (memberItem != null)
@@ -657,7 +657,7 @@ internal class SymbolVisitorAdapter : SymbolVisitor<MetadataItem>
     private void AddInheritedMembers(INamedTypeSymbol symbol, INamedTypeSymbol type, Dictionary<string, string> dict, IReadOnlyList<string> typeParameterNames)
     {
         foreach (var m in from m in type.GetMembers()
-                          where !(m is INamedTypeSymbol)
+                          where m is not INamedTypeSymbol
                           where _filter.IncludeApi(m)
                           where m.DeclaredAccessibility is Accessibility.Public || !(symbol.IsSealed || symbol.TypeKind is TypeKind.Struct)
                           where IsInheritable(m)
@@ -743,7 +743,7 @@ internal class SymbolVisitorAdapter : SymbolVisitor<MetadataItem>
         }
         var result =
             (from attr in attributes
-             where !(attr.AttributeClass is IErrorTypeSymbol)
+             where attr.AttributeClass is not IErrorTypeSymbol
              where attr.AttributeConstructor != null
              where _filter.IncludeAttribute(attr.AttributeConstructor)
              select new AttributeInfo

--- a/src/Docfx.Glob/FileGlob.cs
+++ b/src/Docfx.Glob/FileGlob.cs
@@ -18,7 +18,7 @@ public class FileGlob
         }
         var globArray = patterns.Select(s => new GlobMatcher(s, options)).ToArray();
         var excludeGlobArray = excludePatterns == null ?
-            new GlobMatcher[0] :
+            Array.Empty<GlobMatcher>() :
             excludePatterns.Select(s => new GlobMatcher(s, options)).ToArray();
         return GetFilesCore(cwd, globArray, excludeGlobArray);
     }

--- a/src/Docfx.Glob/GlobMatcher.cs
+++ b/src/Docfx.Glob/GlobMatcher.cs
@@ -127,7 +127,7 @@ public class GlobMatcher : IEquatable<GlobMatcher>
         return items;
     }
 
-    private IEnumerable<string> Split(string path, params char[] splitter)
+    private static IEnumerable<string> Split(string path, params char[] splitter)
     {
         var parts = path.Split(splitter, StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length == 0) yield break;
@@ -145,7 +145,7 @@ public class GlobMatcher : IEquatable<GlobMatcher>
         return string.Join(@"\/", items);
     }
 
-    private bool IsFolderPath(string path)
+    private static bool IsFolderPath(string path)
     {
         return path.EndsWith("/", StringComparison.Ordinal);
     }
@@ -323,7 +323,7 @@ public class GlobMatcher : IEquatable<GlobMatcher>
     /// </summary>
     /// <param name="globParts"></param>
     /// <returns></returns>
-    private IEnumerable<string> ExpandGlobStarShortcut(IEnumerable<string> globParts)
+    private static IEnumerable<string> ExpandGlobStarShortcut(IEnumerable<string> globParts)
     {
         foreach (var part in globParts)
         {

--- a/src/Docfx.Glob/GlobMatcher.cs
+++ b/src/Docfx.Glob/GlobMatcher.cs
@@ -723,7 +723,7 @@ public class GlobMatcher : IEquatable<GlobMatcher>
             {
                 _chars.Insert(0, "\\");
             }
-            return $"[{_chars.ToString()}]";
+            return $"[{_chars}]";
         }
     }
 

--- a/src/Docfx.Glob/GlobMatcher.cs
+++ b/src/Docfx.Glob/GlobMatcher.cs
@@ -523,11 +523,11 @@ public class GlobMatcher : IEquatable<GlobMatcher>
             {
                 _parent = parentNode ?? this;
             }
-            abstract public GlobNode AddChar(char c);
-            abstract public GlobNode StartLevel();
-            abstract public GlobNode AddGroup();
-            abstract public GlobNode FinishLevel();
-            abstract public List<StringBuilder> Flatten();
+            public abstract GlobNode AddChar(char c);
+            public abstract GlobNode StartLevel();
+            public abstract GlobNode AddGroup();
+            public abstract GlobNode FinishLevel();
+            public abstract List<StringBuilder> Flatten();
         }
         public class TextNode : GlobNode
         {

--- a/src/Docfx.Glob/GlobMatcher.cs
+++ b/src/Docfx.Glob/GlobMatcher.cs
@@ -13,7 +13,7 @@ public class GlobMatcher : IEquatable<GlobMatcher>
 {
     #region Private fields
     private static readonly StringComparer Comparer = FilePathComparer.OSPlatformSensitiveStringComparer;
-    private static readonly string[] EmptyString = new string[0];
+    private static readonly string[] EmptyString = Array.Empty<string>();
     private const char NegateChar = '!';
     private const string GlobStar = "**";
     private const string ReplacerGroupName = "replacer";

--- a/src/Docfx.Glob/GlobMatcher.cs
+++ b/src/Docfx.Glob/GlobMatcher.cs
@@ -646,7 +646,7 @@ public class GlobMatcher : IEquatable<GlobMatcher>
                         foreach (StringBuilder sb in result)
                         {
                             StringBuilder newSb = new(sb.ToString());
-                            newSb.Append(builder.ToString());
+                            newSb.Append(builder);
                             tmp.Add(newSb);
                         }
                     }

--- a/src/Docfx.Glob/GlobMatcher.cs
+++ b/src/Docfx.Glob/GlobMatcher.cs
@@ -768,7 +768,7 @@ public class GlobMatcher : IEquatable<GlobMatcher>
 
     public bool Equals(GlobMatcher other)
     {
-        if (ReferenceEquals(null, other))
+        if (other is null)
         {
             return false;
         }

--- a/src/Docfx.Glob/GlobMatcher.cs
+++ b/src/Docfx.Glob/GlobMatcher.cs
@@ -40,9 +40,9 @@ public class GlobMatcher : IEquatable<GlobMatcher>
 
     private static readonly Regex GlobStarRegex = new(@"^\*{2,}/?$", RegexOptions.Compiled);
 
-    private GlobRegexItem[][] _items;
-    private bool _negate = false;
-    private bool _ignoreCase = false;
+    private readonly GlobRegexItem[][] _items;
+    private readonly bool _negate = false;
+    private readonly bool _ignoreCase = false;
     #endregion
 
     public const GlobMatcherOptions DefaultOptions = GlobMatcherOptions.AllowNegate | GlobMatcherOptions.IgnoreCase | GlobMatcherOptions.AllowGlobStar | GlobMatcherOptions.AllowExpand | GlobMatcherOptions.AllowEscape;

--- a/src/Docfx.HtmlToPdf/ConvertWrapper.cs
+++ b/src/Docfx.HtmlToPdf/ConvertWrapper.cs
@@ -183,7 +183,7 @@ public class ConvertWrapper
                 }
                 catch (Exception ex)
                 {
-                    Logger.LogError($"Error happen when converting {tocJson} to Pdf. Details: {ex.ToString()}");
+                    Logger.LogError($"Error happen when converting {tocJson} to Pdf. Details: {ex}");
                 }
             });
 

--- a/src/Docfx.HtmlToPdf/ConvertWrapper.cs
+++ b/src/Docfx.HtmlToPdf/ConvertWrapper.cs
@@ -219,17 +219,17 @@ public class ConvertWrapper
         }
     }
 
-    private string NormalizeFilePath(string relativePath)
+    private static string NormalizeFilePath(string relativePath)
     {
         return relativePath.Replace('/', '\\').ToLower();
     }
 
-    private IList<ManifestItem> FindTocInManifest(Manifest manifest)
+    private static IList<ManifestItem> FindTocInManifest(Manifest manifest)
     {
         return manifest.Files.Where(f => IsType(f, ManifestItemType.Toc)).ToList();
     }
 
-    private ManifestItem FindSiblingCoverPageInManifest(Manifest manifest, ManifestItem tocFile)
+    private static ManifestItem FindSiblingCoverPageInManifest(Manifest manifest, ManifestItem tocFile)
     {
         return manifest.Files.SingleOrDefault(f =>
         {
@@ -238,7 +238,7 @@ public class ConvertWrapper
         });
     }
 
-    private void HtmlTransformer(string fullPath)
+    private static void HtmlTransformer(string fullPath)
     {
         var htmlFiles = Directory.GetFiles(fullPath, HtmlFilePattern, SearchOption.AllDirectories);
 
@@ -255,7 +255,7 @@ public class ConvertWrapper
         }
     }
 
-    private void RemoveQueryStringAndBookmarkTransformer(string tocPageFilePath)
+    private static void RemoveQueryStringAndBookmarkTransformer(string tocPageFilePath)
     {
         var transformer = new RemoveQueryStringTransformer();
         transformer.Transform(new List<string> { tocPageFilePath });
@@ -270,12 +270,12 @@ public class ConvertWrapper
         }
     }
 
-    private IList<TocModel> LoadTocModels(string basePath, ManifestItem tocFile)
+    private static IList<TocModel> LoadTocModels(string basePath, ManifestItem tocFile)
     {
         return JsonUtility.Deserialize<IList<TocModel>>(Path.Combine(basePath, ManifestUtility.GetRelativePath(tocFile, OutputType.TocJson)));
     }
 
-    private IEnumerable<string> GetManifestHtmls(Manifest manifest)
+    private static IEnumerable<string> GetManifestHtmls(Manifest manifest)
     {
         return from file in manifest.Files
                where file != null && IsType(file, ManifestItemType.Content)
@@ -284,7 +284,7 @@ public class ConvertWrapper
                select outputPath;
     }
 
-    private void ConvertTocModelToHtmlModel(IList<TocModel> tocModels, IList<HtmlModel> htmlModels, ConcurrentBag<string> tocHtmls)
+    private static void ConvertTocModelToHtmlModel(IList<TocModel> tocModels, IList<HtmlModel> htmlModels, ConcurrentBag<string> tocHtmls)
     {
         foreach (var tocModel in tocModels)
         {
@@ -309,14 +309,14 @@ public class ConvertWrapper
         }
     }
 
-    private IList<string> ManifestHtmlsExceptTocHtmls(Manifest manifest, ConcurrentBag<string> tocHtmls)
+    private static IList<string> ManifestHtmlsExceptTocHtmls(Manifest manifest, ConcurrentBag<string> tocHtmls)
     {
         var manifestConceptuals = GetManifestHtmls(manifest);
         var others = manifestConceptuals.Where(p => !tocHtmls.Contains(p)).Distinct().ToList();
         return others;
     }
 
-    private IList<HtmlModel> BuildHtmlModels(string basePath, IList<TocModel> tocModels, ConcurrentBag<string> tocHtmls)
+    private static IList<HtmlModel> BuildHtmlModels(string basePath, IList<TocModel> tocModels, ConcurrentBag<string> tocHtmls)
     {
         var htmlModels = new List<HtmlModel>();
         ConvertTocModelToHtmlModel(tocModels, htmlModels, tocHtmls);
@@ -342,7 +342,7 @@ public class ConvertWrapper
         converter.Save(Path.Combine(_pdfOptions.DestDirectory, pdfFileName));
     }
 
-    private bool IsType(ManifestItem item, ManifestItemType targetType)
+    private static bool IsType(ManifestItem item, ManifestItemType targetType)
     {
         return ManifestUtility.GetDocumentType(item) == targetType;
     }

--- a/src/Docfx.HtmlToPdf/HtmlToPdfConverter.cs
+++ b/src/Docfx.HtmlToPdf/HtmlToPdfConverter.cs
@@ -113,9 +113,9 @@ public class HtmlToPdfConverter
     {
         // In advanced scenarios where the user is passing additional arguments directly to the command line,
         // disable the quiet mode so problems can be diagnosed.
-        if (!string.IsNullOrEmpty(this._htmlToPdfOptions.AdditionalArguments))
+        if (!string.IsNullOrEmpty(_htmlToPdfOptions.AdditionalArguments))
         {
-            this._htmlToPdfOptions.IsQuiet = false;
+            _htmlToPdfOptions.IsQuiet = false;
         }
 
         using var process = new Process

--- a/src/Docfx.HtmlToPdf/HtmlToPdfConverter.cs
+++ b/src/Docfx.HtmlToPdf/HtmlToPdfConverter.cs
@@ -290,7 +290,7 @@ public class HtmlToPdfConverter
 
         builder.Bookmarks = new(GetOutlines());
 
-        PdfAction CopyLink(PdfAction action)
+        static PdfAction CopyLink(PdfAction action)
         {
             return action switch
             {

--- a/src/Docfx.HtmlToPdf/HtmlToPdfOptions.cs
+++ b/src/Docfx.HtmlToPdf/HtmlToPdfOptions.cs
@@ -100,21 +100,21 @@ public class HtmlToPdfOptions
         {
             if (File.Exists(DefaultStyleSheet))
             {
-                sb.Append(" --user-style-sheet \"").Append(DefaultStyleSheet).Append("\"");
+                sb.Append(" --user-style-sheet \"").Append(DefaultStyleSheet).Append('"');
             }
         }
         else
         {
-            sb.Append(" --user-style-sheet \"").Append(UserStyleSheet).Append("\"");
+            sb.Append(" --user-style-sheet \"").Append(UserStyleSheet).Append('"');
         }
 
         if (!string.IsNullOrEmpty(HeaderHtmlPath))
         {
-            sb.Append(" --header-html \"").Append(HeaderHtmlPath).Append("\"");
+            sb.Append(" --header-html \"").Append(HeaderHtmlPath).Append('"');
         }
         if (!string.IsNullOrEmpty(FooterHtmlPath))
         {
-            sb.Append(" --footer-html \"").Append(FooterHtmlPath).Append("\"");
+            sb.Append(" --footer-html \"").Append(FooterHtmlPath).Append('"');
         }
         if (!string.IsNullOrEmpty(LoadErrorHandling))
         {
@@ -126,7 +126,7 @@ public class HtmlToPdfOptions
         }
         if (!string.IsNullOrEmpty(AdditionalArguments))
         {
-            sb.Append(" ").Append(AdditionalArguments);
+            sb.Append(' ').Append(AdditionalArguments);
         }
 
         return sb.ToString();

--- a/src/Docfx.HtmlToPdf/PdfOptions.cs
+++ b/src/Docfx.HtmlToPdf/PdfOptions.cs
@@ -65,7 +65,7 @@ public class PdfOptions
     /// </summary>
     /// <param name="path">the path</param>
     /// <returns>the normalized path</returns>
-    private string Normalize(string path)
+    private static string Normalize(string path)
     {
         if (string.IsNullOrEmpty(path))
         {

--- a/src/Docfx.MarkdigEngine.Extensions/Aggregator/BlockAggregateContext.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/Aggregator/BlockAggregateContext.cs
@@ -7,7 +7,7 @@ namespace Docfx.MarkdigEngine.Extensions;
 
 public class BlockAggregateContext
 {
-    private ContainerBlock _blocks;
+    private readonly ContainerBlock _blocks;
     private int _currentBlockIndex = -1;
 
     public BlockAggregateContext(ContainerBlock blocks)

--- a/src/Docfx.MarkdigEngine.Extensions/Aggregator/TabGroupAggregator.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/Aggregator/TabGroupAggregator.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
-using System.Security.Cryptography;
-using System.Text;
 using System.Text.RegularExpressions;
 
 using Markdig.Syntax;

--- a/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/CodeSnippet.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/CodeSnippet.cs
@@ -84,19 +84,19 @@ public class CodeSnippet : LeafBlock
     {
         var sb = new StringBuilder();
 
-        if (!string.IsNullOrEmpty(this.Language))
+        if (!string.IsNullOrEmpty(Language))
         {
-            sb.Append($@" class=""lang-{this.Language}""");
+            sb.Append($@" class=""lang-{Language}""");
         }
 
-        if (!string.IsNullOrEmpty(this.Name))
+        if (!string.IsNullOrEmpty(Name))
         {
-            sb.Append($@" name=""{this.Name}""");
+            sb.Append($@" name=""{Name}""");
         }
 
-        if (!string.IsNullOrEmpty(this.Title))
+        if (!string.IsNullOrEmpty(Title))
         {
-            sb.Append($@" title=""{this.Title}""");
+            sb.Append($@" title=""{Title}""");
         }
 
         var highlightRangesString = GetHighlightLinesString();
@@ -111,9 +111,9 @@ public class CodeSnippet : LeafBlock
 
     public string GetHighlightLinesString()
     {
-        if (this.HighlightRanges != null && this.HighlightRanges.Any())
+        if (HighlightRanges != null && HighlightRanges.Any())
         {
-            return string.Join(",", this.HighlightRanges.Select(highlight =>
+            return string.Join(",", HighlightRanges.Select(highlight =>
             {
                 if (highlight.Start == highlight.End) return highlight.Start.ToString();
 

--- a/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/CodeSnippetExtractor.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/CodeSnippetExtractor.cs
@@ -17,9 +17,9 @@ public class CodeSnippetExtractor
 
     public CodeSnippetExtractor(string startLineTemplate, string endLineTemplate, bool isEndLineContainsTagName = true)
     {
-        this.StartLineTemplate = startLineTemplate;
-        this.EndLineTemplate = endLineTemplate;
-        this.IsEndLineContainsTagName = isEndLineContainsTagName;
+        StartLineTemplate = startLineTemplate;
+        EndLineTemplate = endLineTemplate;
+        IsEndLineContainsTagName = isEndLineContainsTagName;
     }
 
     public Dictionary<string, CodeRange> GetAllTags(string[] lines, ref HashSet<int> tagLines)

--- a/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/CodeSnippetExtractor.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/CodeSnippetExtractor.cs
@@ -63,7 +63,7 @@ public class CodeSnippetExtractor
         return result;
     }
 
-    private bool MatchTag(string line, string template, out string tagName, bool containTagName = true)
+    private static bool MatchTag(string line, string template, out string tagName, bool containTagName = true)
     {
         tagName = string.Empty;
         if (string.IsNullOrEmpty(line) || string.IsNullOrEmpty(template)) return false;

--- a/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/CodeSnippetParser.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/CodeSnippetParser.cs
@@ -83,7 +83,7 @@ public class CodeSnippetParser : BlockParser
         return BlockState.None;
     }
 
-    private bool MatchStart(ref StringSlice slice)
+    private static bool MatchStart(ref StringSlice slice)
     {
         var pc = slice.PeekCharExtra(-1);
         if (pc == '\\') return false;
@@ -100,7 +100,7 @@ public class CodeSnippetParser : BlockParser
         return index == StartString.Length;
     }
 
-    private bool MatchLanguage(BlockProcessor processor, ref StringSlice slice, ref CodeSnippet codeSnippet)
+    private static bool MatchLanguage(BlockProcessor processor, ref StringSlice slice, ref CodeSnippet codeSnippet)
     {
         if (slice.CurrentChar != '-') return false;
 
@@ -118,7 +118,7 @@ public class CodeSnippetParser : BlockParser
         return true;
     }
 
-    private bool MatchPath(BlockProcessor processor, ref StringSlice slice, ref CodeSnippet codeSnippet)
+    private static bool MatchPath(BlockProcessor processor, ref StringSlice slice, ref CodeSnippet codeSnippet)
     {
         ExtensionsHelper.SkipWhitespace(ref slice);
         if (slice.CurrentChar != '(') return false;
@@ -155,7 +155,7 @@ public class CodeSnippetParser : BlockParser
         return true;
     }
 
-    private bool MatchName(BlockProcessor processor, ref StringSlice slice, ref CodeSnippet codeSnippet)
+    private static bool MatchName(BlockProcessor processor, ref StringSlice slice, ref CodeSnippet codeSnippet)
     {
         if (slice.CurrentChar != '[') return false;
 
@@ -188,7 +188,7 @@ public class CodeSnippetParser : BlockParser
         return false;
     }
 
-    private bool MatchQuery(BlockProcessor processor, ref StringSlice slice, ref CodeSnippet codeSnippet)
+    private static bool MatchQuery(BlockProcessor processor, ref StringSlice slice, ref CodeSnippet codeSnippet)
     {
         var questionMarkMatched = MatchQuestionMarkQuery(processor, ref slice, ref codeSnippet);
 
@@ -197,7 +197,7 @@ public class CodeSnippetParser : BlockParser
         return questionMarkMatched || bookMarkMatched;
     }
 
-    private bool MatchQuestionMarkQuery(BlockProcessor processor, ref StringSlice slice, ref CodeSnippet codeSnippet)
+    private static bool MatchQuestionMarkQuery(BlockProcessor processor, ref StringSlice slice, ref CodeSnippet codeSnippet)
     {
         if (slice.CurrentChar != '?') return false;
 
@@ -216,7 +216,7 @@ public class CodeSnippetParser : BlockParser
         return TryParseQuery(queryString, ref codeSnippet);
     }
 
-    private bool MatchBookMarkQuery(BlockProcessor processor, ref StringSlice slice, ref CodeSnippet codeSnippet)
+    private static bool MatchBookMarkQuery(BlockProcessor processor, ref StringSlice slice, ref CodeSnippet codeSnippet)
     {
         if (slice.CurrentChar != '#') return false;
 
@@ -244,7 +244,7 @@ public class CodeSnippetParser : BlockParser
         return true;
     }
 
-    private bool MatchTitle(BlockProcessor processor, ref StringSlice slice, ref CodeSnippet codeSnippet)
+    private static bool MatchTitle(BlockProcessor processor, ref StringSlice slice, ref CodeSnippet codeSnippet)
     {
         if (slice.CurrentChar != '"') return false;
 
@@ -277,7 +277,7 @@ public class CodeSnippetParser : BlockParser
         return false;
     }
 
-    private bool TryParseQuery(string queryString, ref CodeSnippet codeSnippet)
+    private static bool TryParseQuery(string queryString, ref CodeSnippet codeSnippet)
     {
         if (string.IsNullOrEmpty(queryString)) return false;
 

--- a/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/CodeSnippetParser.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/CodeSnippetParser.cs
@@ -93,7 +93,7 @@ public class CodeSnippetParser : BlockParser
         var c = slice.CurrentChar;
         var index = 0;
 
-        while (c != '\0' && index < StartString.Length && Char.ToLower(c) == StartString[index])
+        while (c != '\0' && index < StartString.Length && char.ToLower(c) == StartString[index])
         {
             c = slice.NextChar();
             index++;

--- a/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/CodeSnippetParser.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/CodeSnippetParser.cs
@@ -37,8 +37,10 @@ public class CodeSnippetParser : BlockParser
             isNotebookCode = true;
         }
 
-        var codeSnippet = new CodeSnippet(this);
-        codeSnippet.IsNotebookCode = isNotebookCode;
+        var codeSnippet = new CodeSnippet(this)
+        {
+            IsNotebookCode = isNotebookCode,
+        };
         MatchLanguage(processor, ref slice, ref codeSnippet);
 
         if (!MatchName(processor, ref slice, ref codeSnippet))

--- a/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
@@ -356,8 +356,7 @@ public class HtmlCodeSnippetRenderer : HtmlObjectRenderer<CodeSnippet>
                 }
                 else
                 {
-                    int indentSpaces = 0;
-                    string rawCodeLine = CountAndReplaceIndentSpaces(allLines[lineNumber], out indentSpaces);
+                    string rawCodeLine = CountAndReplaceIndentSpaces(allLines[lineNumber], out int indentSpaces);
                     commonIndent = Math.Min(commonIndent, indentSpaces);
                     codeLines.Add(rawCodeLine);
                 }

--- a/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
@@ -322,7 +322,7 @@ public class HtmlCodeSnippetRenderer : HtmlObjectRenderer<CodeSnippet>
         }
         else
         {
-            return GetCodeLines(allLines, obj, new List<CodeRange> { new CodeRange { Start = 0, End = allLines.Length } });
+            return GetCodeLines(allLines, obj, new List<CodeRange> { new() { Start = 0, End = allLines.Length } });
         }
 
         return string.Empty;

--- a/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
@@ -445,7 +445,7 @@ public class HtmlCodeSnippetRenderer : HtmlObjectRenderer<CodeSnippet>
                 var c = line[column];
                 if (c != ' ')
                 {
-                    if (targetColumn >= tagLine.Length || tagLine[targetColumn] != Char.ToUpper(c))
+                    if (targetColumn >= tagLine.Length || tagLine[targetColumn] != char.ToUpper(c))
                     {
                         match = false;
                         break;
@@ -523,7 +523,7 @@ public class HtmlCodeSnippetRenderer : HtmlObjectRenderer<CodeSnippet>
         lineNumber = int.MaxValue;
         if (string.IsNullOrEmpty(lineNumberString)) return true;
 
-        if (withL && (lineNumberString.Length < 2 || Char.ToUpper(lineNumberString[0]) != 'L')) return false;
+        if (withL && (lineNumberString.Length < 2 || char.ToUpper(lineNumberString[0]) != 'L')) return false;
 
         return int.TryParse(withL ? lineNumberString.Substring(1) : lineNumberString, out lineNumber);
 

--- a/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
@@ -421,9 +421,9 @@ public class HtmlCodeSnippetRenderer : HtmlObjectRenderer<CodeSnippet>
 
     private static bool IsLineInRange(int lineNumber, List<CodeRange> allCodeRanges)
     {
-        if (allCodeRanges.Count() == 0) return true;
+        if (allCodeRanges.Count == 0) return true;
 
-        for (int rangeNumber = 0; rangeNumber < allCodeRanges.Count(); rangeNumber++)
+        for (int rangeNumber = 0; rangeNumber < allCodeRanges.Count; rangeNumber++)
         {
             var range = allCodeRanges[rangeNumber];
             if (lineNumber >= range.Start && lineNumber <= range.End)

--- a/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
@@ -338,7 +338,7 @@ public class HtmlCodeSnippetRenderer : HtmlObjectRenderer<CodeSnippet>
         }
     }
 
-    private string GetCodeLines(string[] allLines, CodeSnippet obj, List<CodeRange> codeRanges, HashSet<int> ignoreLines = null)
+    private static string GetCodeLines(string[] allLines, CodeSnippet obj, List<CodeRange> codeRanges, HashSet<int> ignoreLines = null)
     {
         List<string> codeLines = new();
         StringBuilder showCode = new();
@@ -374,7 +374,7 @@ public class HtmlCodeSnippetRenderer : HtmlObjectRenderer<CodeSnippet>
         return showCode.ToString();
     }
 
-    private string DedentString(string source, int dedent)
+    private static string DedentString(string source, int dedent)
     {
         int validDedent = Math.Min(dedent, source.Length);
         for (int i = 0; i < validDedent; i++)
@@ -384,12 +384,12 @@ public class HtmlCodeSnippetRenderer : HtmlObjectRenderer<CodeSnippet>
         return source.Substring(validDedent);
     }
 
-    private bool IsBlankLine(string line)
+    private static bool IsBlankLine(string line)
     {
         return line == "";
     }
 
-    private string CountAndReplaceIndentSpaces(string line, out int count)
+    private static string CountAndReplaceIndentSpaces(string line, out int count)
     {
         StringBuilder sb = new();
         count = 0;
@@ -419,7 +419,7 @@ public class HtmlCodeSnippetRenderer : HtmlObjectRenderer<CodeSnippet>
         return sb.ToString();
     }
 
-    private bool IsLineInRange(int lineNumber, List<CodeRange> allCodeRanges)
+    private static bool IsLineInRange(int lineNumber, List<CodeRange> allCodeRanges)
     {
         if (allCodeRanges.Count() == 0) return true;
 
@@ -433,7 +433,7 @@ public class HtmlCodeSnippetRenderer : HtmlObjectRenderer<CodeSnippet>
         return false;
     }
 
-    private int GetTagLineNumber(string[] lines, string tagLine)
+    private static int GetTagLineNumber(string[] lines, string tagLine)
     {
         for (int index = 0; index < lines.Length; index++)
         {

--- a/src/Docfx.MarkdigEngine.Extensions/ExtensionsHelper.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/ExtensionsHelper.cs
@@ -192,7 +192,7 @@ public static class ExtensionsHelper
 
     private static bool CharEqual(char ch1, char ch2, bool isCaseSensitive)
     {
-        return isCaseSensitive ? ch1 == ch2 : Char.ToLower(ch1) == Char.ToLower(ch2);
+        return isCaseSensitive ? ch1 == ch2 : char.ToLower(ch1) == char.ToLower(ch2);
     }
 
     private static bool MatchTitle(ref StringSlice slice, ref string title)

--- a/src/Docfx.MarkdigEngine.Extensions/HeadingId/HeadingIdExtension.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/HeadingId/HeadingIdExtension.cs
@@ -13,10 +13,7 @@ public class HeadingIdExtension : IMarkdownExtension
         var tokenRewriter = new HeadingIdRewriter();
         var visitor = new MarkdownDocumentVisitor(tokenRewriter);
 
-        pipeline.DocumentProcessed += document =>
-        {
-            visitor.Visit(document);
-        };
+        pipeline.DocumentProcessed += visitor.Visit;
     }
 
     public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)

--- a/src/Docfx.MarkdigEngine.Extensions/HeadingId/HeadingIdRewriter.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/HeadingId/HeadingIdRewriter.cs
@@ -61,7 +61,7 @@ public class HeadingIdRewriter : IMarkdownObjectRewriter
     private static string ParseHeading(HeadingBlock headBlock)
     {
         var tokens = headBlock.Inline.ToList();
-        if (!(tokens[0] is HtmlInline openATag) || !(tokens[1] is HtmlInline closeATag))
+        if (tokens[0] is not HtmlInline openATag || tokens[1] is not HtmlInline closeATag)
         {
             return null;
         }

--- a/src/Docfx.MarkdigEngine.Extensions/Inclusion/InclusionBlock/HtmlInclusionBlockRenderer.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/Inclusion/InclusionBlock/HtmlInclusionBlockRenderer.cs
@@ -10,7 +10,7 @@ namespace Docfx.MarkdigEngine.Extensions;
 public class HtmlInclusionBlockRenderer : HtmlObjectRenderer<InclusionBlock>
 {
     private readonly MarkdownContext _context;
-    private MarkdownPipeline _pipeline;
+    private readonly MarkdownPipeline _pipeline;
 
     public HtmlInclusionBlockRenderer(MarkdownContext context, MarkdownPipeline pipeline)
     {

--- a/src/Docfx.MarkdigEngine.Extensions/Inclusion/InclusionContext.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/Inclusion/InclusionContext.cs
@@ -61,7 +61,7 @@ public static class InclusionContext
         get
         {
             var markupStack = t_markupStacks.Value;
-            return markupStack.Count > 0 ? (IEnumerable<object>)markupStack.Peek().dependencies : Array.Empty<object>();
+            return markupStack.Count > 0 ? markupStack.Peek().dependencies : Array.Empty<object>();
         }
     }
 

--- a/src/Docfx.MarkdigEngine.Extensions/Interactive/CodeSnippetInteractiveRewriter.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/Interactive/CodeSnippetInteractiveRewriter.cs
@@ -29,7 +29,7 @@ public class CodeSnippetInteractiveRewriter : InteractiveBaseRewriter
         return markdownObject;
     }
 
-    private string GetGitUrl(CodeSnippet obj)
+    private static string GetGitUrl(CodeSnippet obj)
     {
         // TODO: Disable to get git URL of code snippet
         return null;

--- a/src/Docfx.MarkdigEngine.Extensions/Interactive/FencedCodeInteractiveRewriter.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/Interactive/FencedCodeInteractiveRewriter.cs
@@ -29,7 +29,7 @@ public class FencedCodeInteractiveRewriter : InteractiveBaseRewriter
         return markdownObject;
     }
 
-    private void UpdateFencedCodeLanguage(HtmlAttributes attributes, string originalLanguage, string updatedLanguage)
+    private static void UpdateFencedCodeLanguage(HtmlAttributes attributes, string originalLanguage, string updatedLanguage)
     {
         originalLanguage = Constants.FencedCodePrefix + originalLanguage;
         updatedLanguage = Constants.FencedCodePrefix + updatedLanguage;

--- a/src/Docfx.MarkdigEngine.Extensions/NestedColumn/NestedColumnParser.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/NestedColumn/NestedColumnParser.cs
@@ -73,7 +73,7 @@ public class NestedColumnParser : BlockParser
         }
         else
         {
-            columnWidth.Append("1"); // default span is one
+            columnWidth.Append('1'); // default span is one
         }
 
         while (c.IsSpace())

--- a/src/Docfx.MarkdigEngine.Extensions/Noloc/NolocParser.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/Noloc/NolocParser.cs
@@ -24,7 +24,7 @@ public class NolocParser : InlineParser
 
         var text = ExtensionsHelper.TryGetStringBeforeChars(new char[] { '\"', '\n' }, ref slice);
 
-        if (text == null || text.IndexOf('\n') != -1)
+        if (text == null || text.Contains('\n'))
         {
             return false;
         }

--- a/src/Docfx.MarkdigEngine.Extensions/QuoteSectionNote/QuoteSectionNoteRender.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/QuoteSectionNote/QuoteSectionNoteRender.cs
@@ -61,7 +61,7 @@ public class QuoteSectionNoteRender : HtmlObjectRenderer<QuoteSectionNoteBlock>
         renderer.WriteLine("</div>");
     }
 
-    private void WriteSection(HtmlRenderer renderer, QuoteSectionNoteBlock obj)
+    private static void WriteSection(HtmlRenderer renderer, QuoteSectionNoteBlock obj)
     {
         string attribute = string.IsNullOrEmpty(obj.SectionAttributeString) ?
                     string.Empty :
@@ -74,7 +74,7 @@ public class QuoteSectionNoteRender : HtmlObjectRenderer<QuoteSectionNoteBlock>
         renderer.WriteLine("</div>");
     }
 
-    private void WriteQuote(HtmlRenderer renderer, QuoteSectionNoteBlock obj)
+    private static void WriteQuote(HtmlRenderer renderer, QuoteSectionNoteBlock obj)
     {
         renderer.Write("<blockquote").WriteAttributes(obj).WriteLine(">");
         var savedImplicitParagraph = renderer.ImplicitParagraph;
@@ -84,7 +84,7 @@ public class QuoteSectionNoteRender : HtmlObjectRenderer<QuoteSectionNoteBlock>
         renderer.WriteLine("</blockquote>");
     }
 
-    private void WriteVideo(HtmlRenderer renderer, QuoteSectionNoteBlock obj)
+    private static void WriteVideo(HtmlRenderer renderer, QuoteSectionNoteBlock obj)
     {
         var modifiedLink = string.Empty;
 

--- a/src/Docfx.MarkdigEngine.Extensions/QuoteSectionNote/QuoteSectionNoteRender.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/QuoteSectionNote/QuoteSectionNoteRender.cs
@@ -122,7 +122,7 @@ public class QuoteSectionNoteRender : HtmlObjectRenderer<QuoteSectionNoteBlock>
                 }
                 else
                 {
-                    query = query + "&nocookie=true";
+                    query += "&nocookie=true";
                 }
             }
             else if (host.Equals("youtube.com", StringComparison.OrdinalIgnoreCase) || host.Equals("www.youtube.com", StringComparison.OrdinalIgnoreCase))

--- a/src/Docfx.MarkdigEngine.Extensions/ResolveLink/ResolveLinkExtension.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/ResolveLink/ResolveLinkExtension.cs
@@ -30,7 +30,7 @@ public class ResolveLinkExtension : IMarkdownExtension
     {
         switch (markdownObject)
         {
-            case TabTitleBlock _:
+            case TabTitleBlock:
                 break;
 
             case LinkInline linkInline:

--- a/src/Docfx.MarkdigEngine.Extensions/TabGroup/ActiveAndVisibleRewriter.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/TabGroup/ActiveAndVisibleRewriter.cs
@@ -49,7 +49,7 @@ public class ActiveAndVisibleRewriter : IMarkdownObjectRewriter
         return markdownObject;
     }
 
-    private int ApplyTabVisible(List<string[]> tabSelectionInfo, List<TabItemBlock> items)
+    private static int ApplyTabVisible(List<string[]> tabSelectionInfo, List<TabItemBlock> items)
     {
         var firstVisibleTab = -1;
 
@@ -70,7 +70,7 @@ public class ActiveAndVisibleRewriter : IMarkdownObjectRewriter
         return firstVisibleTab;
     }
 
-    private IEnumerable<Tuple<string, int>> GetTabIdAndCountList(List<TabItemBlock> items) =>
+    private static IEnumerable<Tuple<string, int>> GetTabIdAndCountList(List<TabItemBlock> items) =>
         from tab in items
         where tab.Visible
         from id in tab.Id.Split('+')
@@ -125,7 +125,7 @@ public class ActiveAndVisibleRewriter : IMarkdownObjectRewriter
         return active;
     }
 
-    private int FindActiveIndex(List<TabItemBlock> items, string[] info)
+    private static int FindActiveIndex(List<TabItemBlock> items, string[] info)
     {
         for (var i = 0; i < items.Count; i++)
         {

--- a/src/Docfx.MarkdigEngine.Extensions/TabGroup/ActiveAndVisibleRewriter.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/TabGroup/ActiveAndVisibleRewriter.cs
@@ -10,7 +10,7 @@ namespace Docfx.MarkdigEngine.Extensions;
 public class ActiveAndVisibleRewriter : IMarkdownObjectRewriter
 {
     private readonly MarkdownContext _context;
-    private List<string[]> tabSelectionInfo = new();
+    private readonly List<string[]> tabSelectionInfo = new();
 
     public ActiveAndVisibleRewriter(MarkdownContext context)
     {

--- a/src/Docfx.MarkdigEngine.Extensions/TabGroup/HtmlTabContentBlockRenderer.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/TabGroup/HtmlTabContentBlockRenderer.cs
@@ -13,7 +13,7 @@ class HtmlTabContentBlockRenderer : HtmlObjectRenderer<TabContentBlock>
     {
         foreach (var item in block)
         {
-            if (!(item is ThematicBreakBlock))
+            if (item is not ThematicBreakBlock)
             {
                 renderer.Render(item);
             }

--- a/src/Docfx.MarkdigEngine.Extensions/TabGroup/HtmlTabGroupBlockRenderer.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/TabGroup/HtmlTabGroupBlockRenderer.cs
@@ -23,7 +23,7 @@ public class HtmlTabGroupBlockRenderer : HtmlObjectRenderer<TabGroupBlock>
         renderer.Write("</div>\n");
     }
 
-    private void WriteTabHeaders(HtmlRenderer renderer, TabGroupBlock block, string groupId)
+    private static void WriteTabHeaders(HtmlRenderer renderer, TabGroupBlock block, string groupId)
     {
         renderer.Write("<ul role=\"tablist\">\n");
         for (var i = 0; i < block.Items.Length; i++)
@@ -63,7 +63,7 @@ public class HtmlTabGroupBlockRenderer : HtmlObjectRenderer<TabGroupBlock>
         renderer.Write("</ul>\n");
     }
 
-    private void WriteTabSections(HtmlRenderer renderer, TabGroupBlock block, string groupId)
+    private static void WriteTabSections(HtmlRenderer renderer, TabGroupBlock block, string groupId)
     {
         for (var i = 0; i < block.Items.Length; i++)
         {
@@ -92,7 +92,7 @@ public class HtmlTabGroupBlockRenderer : HtmlObjectRenderer<TabGroupBlock>
         }
     }
 
-    private void AppendGroupId(HtmlRenderer renderer, string groupId, TabItemBlock item)
+    private static void AppendGroupId(HtmlRenderer renderer, string groupId, TabItemBlock item)
     {
         renderer.Write(groupId);
         renderer.Write("_");

--- a/src/Docfx.MarkdigEngine.Extensions/TripleColon/TripleColonInline.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/TripleColon/TripleColonInline.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Markdig.Parsers;
 using Markdig.Syntax.Inlines;
 
 namespace Docfx.MarkdigEngine.Extensions;

--- a/src/Docfx.MarkdigEngine.Extensions/TripleColon/ZoneExtension.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/TripleColon/ZoneExtension.cs
@@ -89,7 +89,7 @@ public class ZoneExtension : ITripleColonExtensionInfo
     {
         while (container != null)
         {
-            if (container is TripleColonBlock && ((TripleColonBlock)container).Extension.Name == Name)
+            if (container is TripleColonBlock block && block.Extension.Name == Name)
             {
                 logError("Zones cannot be nested.");
                 return false;

--- a/src/Docfx.MarkdigEngine.Extensions/Xref/XrefInlineShortParser.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/Xref/XrefInlineShortParser.cs
@@ -39,7 +39,7 @@ class XrefInlineShortParser : InlineParser
         }
     }
 
-    private bool MatchXrefShortcut(InlineProcessor processor, ref StringSlice slice)
+    private static bool MatchXrefShortcut(InlineProcessor processor, ref StringSlice slice)
     {
         if (!slice.CurrentChar.IsAlpha()) return false;
 
@@ -84,7 +84,7 @@ class XrefInlineShortParser : InlineParser
         return true;
     }
 
-    private bool MatchXrefShortcutWithQuote(InlineProcessor processor, ref StringSlice slice)
+    private static bool MatchXrefShortcutWithQuote(InlineProcessor processor, ref StringSlice slice)
     {
         var saved = slice;
 

--- a/src/Docfx.MarkdigEngine/MarkdigMarkdownService.cs
+++ b/src/Docfx.MarkdigEngine/MarkdigMarkdownService.cs
@@ -185,9 +185,9 @@ public class MarkdigMarkdownService : IMarkdownService
         return path;
     }
 
-    private string GetImageLink(string href, MarkdownObject origin, string altText) => GetLink(href, origin);
+    private static string GetImageLink(string href, MarkdownObject origin, string altText) => GetLink(href, origin);
 
-    private void ReportDependency(RelativePath filePathToDocset, string parentFileDirectoryToDocset)
+    private static void ReportDependency(RelativePath filePathToDocset, string parentFileDirectoryToDocset)
     {
         var expectedPhysicalPath = EnvironmentContext.FileAbstractLayer.GetExpectedPhysicalPath(filePathToDocset);
         foreach (var physicalPath in expectedPhysicalPath)

--- a/src/Docfx.MarkdigEngine/MarkdigMarkdownService.cs
+++ b/src/Docfx.MarkdigEngine/MarkdigMarkdownService.cs
@@ -98,7 +98,7 @@ public class MarkdigMarkdownService : IMarkdownService
     {
         ArgumentNullException.ThrowIfNull(document);
 
-        if (!(document.GetData("filePath") is string filePath))
+        if (document.GetData("filePath") is not string filePath)
         {
             throw new ArgumentNullException(nameof(document), "file path can't be found in AST.");
         }

--- a/src/Docfx.MarkdigEngine/MarkdigMarkdownService.cs
+++ b/src/Docfx.MarkdigEngine/MarkdigMarkdownService.cs
@@ -100,7 +100,7 @@ public class MarkdigMarkdownService : IMarkdownService
 
         if (!(document.GetData("filePath") is string filePath))
         {
-            throw new ArgumentNullException("file path can't be found in AST.");
+            throw new ArgumentNullException(nameof(document), "file path can't be found in AST.");
         }
 
         var pipeline = CreateMarkdownPipeline(isInline);

--- a/src/Docfx.Plugins/DefaultFileAbstractLayer.cs
+++ b/src/Docfx.Plugins/DefaultFileAbstractLayer.cs
@@ -56,7 +56,7 @@ public class DefaultFileAbstractLayer : IFileAbstractLayer
             Environment.ExpandEnvironmentVariables(EnvironmentContext.BaseDirectory),
             file);
 
-    public string GetOutputPhysicalPath(string file) =>
+    public static string GetOutputPhysicalPath(string file) =>
         Path.Combine(
             Environment.ExpandEnvironmentVariables(EnvironmentContext.OutputDirectory),
             file);

--- a/src/Docfx.Plugins/DictionaryAsListJsonConverter.cs
+++ b/src/Docfx.Plugins/DictionaryAsListJsonConverter.cs
@@ -23,7 +23,7 @@ public class DictionaryAsListJsonConverter<T> : JsonConverter
         }
         else
         {
-            throw new JsonReaderException($"{reader.TokenType.ToString()} is not a valid {objectType.Name}.");
+            throw new JsonReaderException($"{reader.TokenType} is not a valid {objectType.Name}.");
         }
 
         return jItems.Select(s => ParseItem(s, serializer)).ToList();

--- a/src/Docfx.Plugins/DictionaryAsListJsonConverter.cs
+++ b/src/Docfx.Plugins/DictionaryAsListJsonConverter.cs
@@ -19,7 +19,7 @@ public class DictionaryAsListJsonConverter<T> : JsonConverter
         IEnumerable<JToken> jItems;
         if (reader.TokenType == JsonToken.StartObject)
         {
-            jItems = JContainer.Load(reader);
+            jItems = JToken.Load(reader);
         }
         else
         {

--- a/src/Docfx.Plugins/DictionaryAsListJsonConverter.cs
+++ b/src/Docfx.Plugins/DictionaryAsListJsonConverter.cs
@@ -40,7 +40,7 @@ public class DictionaryAsListJsonConverter<T> : JsonConverter
         writer.WriteEndObject();
     }
 
-    private KeyValuePair<string, T> ParseItem(JToken item, JsonSerializer serializer)
+    private static KeyValuePair<string, T> ParseItem(JToken item, JsonSerializer serializer)
     {
         if (item.Type == JTokenType.Property)
         {

--- a/src/Docfx.Plugins/FileAndType.cs
+++ b/src/Docfx.Plugins/FileAndType.cs
@@ -107,7 +107,7 @@ public sealed class FileAndType
         {
             return true;
         }
-        if (ReferenceEquals(left, null))
+        if (left is null)
         {
             return false;
         }

--- a/src/Docfx.Plugins/OutputFileCollection.cs
+++ b/src/Docfx.Plugins/OutputFileCollection.cs
@@ -35,5 +35,5 @@ public class OutputFileCollection : ObservableDictionary<string, OutputFileInfo>
 
     #endregion
 
-    public bool ContainsValue(OutputFileInfo value) => Values.Contains(value);
+    public bool ContainsValue(OutputFileInfo value) => ContainsValue(value);
 }

--- a/src/Docfx.Plugins/OutputFileCollection.cs
+++ b/src/Docfx.Plugins/OutputFileCollection.cs
@@ -35,5 +35,7 @@ public class OutputFileCollection : ObservableDictionary<string, OutputFileInfo>
 
     #endregion
 
-    public bool ContainsValue(OutputFileInfo value) => ContainsValue(value);
+#pragma warning disable CA1841 // Prefer Dictionary.Contains methods
+    public bool ContainsValue(OutputFileInfo value) => Values.Contains(value);
+#pragma warning restore CA1841 // Prefer Dictionary.Contains methods
 }

--- a/src/Docfx.Plugins/TreeNavigator.cs
+++ b/src/Docfx.Plugins/TreeNavigator.cs
@@ -5,7 +5,7 @@ namespace Docfx.Plugins;
 
 public class TreeNavigator
 {
-    private NavigatorTreeItem _tree;
+    private readonly NavigatorTreeItem _tree;
     private NavigatorTreeItem _current;
 
     public TreeNavigator(TreeItem tree)

--- a/src/Docfx.Plugins/TreeNavigator.cs
+++ b/src/Docfx.Plugins/TreeNavigator.cs
@@ -96,7 +96,7 @@ public class TreeNavigator
         return false;
     }
 
-    private NavigatorTreeItem Init(TreeItem current, NavigatorTreeItem parent)
+    private static NavigatorTreeItem Init(TreeItem current, NavigatorTreeItem parent)
     {
         var tree = new NavigatorTreeItem
         {

--- a/src/Docfx.YamlSerialization/ExtensibleMemberAttribute.cs
+++ b/src/Docfx.YamlSerialization/ExtensibleMemberAttribute.cs
@@ -3,6 +3,7 @@
 
 namespace Docfx.YamlSerialization;
 
+[AttributeUsage(AttributeTargets.Property)]
 public sealed class ExtensibleMemberAttribute : Attribute
 {
     public string Prefix { get; }

--- a/src/Docfx.YamlSerialization/NodeDeserializers/EmitArrayNodeDeserializer.cs
+++ b/src/Docfx.YamlSerialization/NodeDeserializers/EmitArrayNodeDeserializer.cs
@@ -12,7 +12,7 @@ namespace Docfx.YamlSerialization.NodeDeserializers;
 
 public class EmitArrayNodeDeserializer : INodeDeserializer
 {
-    private static MethodInfo DeserializeHelperMethod =
+    private static readonly MethodInfo DeserializeHelperMethod =
         typeof(EmitArrayNodeDeserializer).GetMethod(nameof(DeserializeHelper));
     private static readonly ConcurrentDictionary<Type, Func<IParser, Type, Func<IParser, Type, object>, object>> _funcCache =
         new();

--- a/src/Docfx.YamlSerialization/NodeDeserializers/EmitGenericCollectionNodeDeserializer.cs
+++ b/src/Docfx.YamlSerialization/NodeDeserializers/EmitGenericCollectionNodeDeserializer.cs
@@ -76,8 +76,6 @@ public class EmitGenericCollectionNodeDeserializer : INodeDeserializer
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static void DeserializeHelper<TItem>(IParser reader, Type expectedType, Func<IParser, Type, object> nestedObjectDeserializer, ICollection<TItem> result)
     {
-        var list = result as IList<TItem>;
-
         reader.Consume<SequenceStart>();
         while (!reader.Accept<SequenceEnd>(out _))
         {
@@ -88,7 +86,7 @@ public class EmitGenericCollectionNodeDeserializer : INodeDeserializer
             {
                 result.Add(TypeConverter.ChangeType<TItem>(value));
             }
-            else if (list != null)
+            else if (result is IList<TItem> list)
             {
                 var index = list.Count;
                 result.Add(default(TItem));

--- a/src/Docfx.YamlSerialization/NodeDeserializers/EmitGenericCollectionNodeDeserializer.cs
+++ b/src/Docfx.YamlSerialization/NodeDeserializers/EmitGenericCollectionNodeDeserializer.cs
@@ -89,7 +89,7 @@ public class EmitGenericCollectionNodeDeserializer : INodeDeserializer
             else if (result is IList<TItem> list)
             {
                 var index = list.Count;
-                result.Add(default(TItem));
+                result.Add(default);
                 promise.ValueAvailable += v => list[index] = TypeConverter.ChangeType<TItem>(v);
             }
             else

--- a/src/Docfx.YamlSerialization/NodeDeserializers/EmitGenericCollectionNodeDeserializer.cs
+++ b/src/Docfx.YamlSerialization/NodeDeserializers/EmitGenericCollectionNodeDeserializer.cs
@@ -82,7 +82,7 @@ public class EmitGenericCollectionNodeDeserializer : INodeDeserializer
             var current = reader.Current;
 
             var value = nestedObjectDeserializer(reader, typeof(TItem));
-            if (!(value is IValuePromise promise))
+            if (value is not IValuePromise promise)
             {
                 result.Add(TypeConverter.ChangeType<TItem>(value));
             }

--- a/src/Docfx.YamlSerialization/NodeDeserializers/EmitGenericDictionaryNodeDeserializer.cs
+++ b/src/Docfx.YamlSerialization/NodeDeserializers/EmitGenericDictionaryNodeDeserializer.cs
@@ -83,12 +83,11 @@ public class EmitGenericDictionaryNodeDeserializer : INodeDeserializer
         while (!reader.Accept<MappingEnd>(out _))
         {
             var key = nestedObjectDeserializer(reader, typeof(TKey));
-            var keyPromise = key as IValuePromise;
 
             var value = nestedObjectDeserializer(reader, typeof(TValue));
             var valuePromise = value as IValuePromise;
 
-            if (keyPromise == null)
+            if (key is not IValuePromise keyPromise)
             {
                 if (valuePromise == null)
                 {

--- a/src/Docfx.YamlSerialization/NodeDeserializers/ExtensibleObjectNodeDeserializer.cs
+++ b/src/Docfx.YamlSerialization/NodeDeserializers/ExtensibleObjectNodeDeserializer.cs
@@ -41,7 +41,7 @@ public sealed class ExtensibleObjectNodeDeserializer : INodeDeserializer
             }
 
             var propertyValue = nestedObjectDeserializer(reader, property.Type);
-            if (!(propertyValue is IValuePromise propertyValuePromise))
+            if (propertyValue is not IValuePromise propertyValuePromise)
             {
                 var convertedValue = TypeConverter.ChangeType(propertyValue, property.Type);
                 property.Write(value, convertedValue);

--- a/src/Docfx.YamlSerialization/ObjectDescriptors/BetterObjectDescriptor.cs
+++ b/src/Docfx.YamlSerialization/ObjectDescriptors/BetterObjectDescriptor.cs
@@ -23,7 +23,7 @@ public class BetterObjectDescriptor : IObjectDescriptor
 
         static bool NeedQuote(object val)
         {
-            if (!(val is string s))
+            if (val is not string s)
                 return false;
 
             return Regexes.BooleanLike.IsMatch(s)

--- a/src/Docfx.YamlSerialization/ObjectDescriptors/BetterObjectDescriptor.cs
+++ b/src/Docfx.YamlSerialization/ObjectDescriptors/BetterObjectDescriptor.cs
@@ -21,7 +21,7 @@ public class BetterObjectDescriptor : IObjectDescriptor
         StaticType = staticType;
         ScalarStyle = scalarStyle == ScalarStyle.Any && NeedQuote(value) ? ScalarStyle.DoubleQuoted : scalarStyle;
 
-        bool NeedQuote(object val)
+        static bool NeedQuote(object val)
         {
             if (!(val is string s))
                 return false;

--- a/src/Docfx.YamlSerialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
+++ b/src/Docfx.YamlSerialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
@@ -27,7 +27,7 @@ public class FullObjectGraphTraversalStrategy : IObjectGraphTraversalStrategy
     private readonly int _maxRecursion;
     private readonly ITypeInspector _typeDescriptor;
     private readonly ITypeResolver _typeResolver;
-    private INamingConvention _namingConvention;
+    private readonly INamingConvention _namingConvention;
     private readonly Dictionary<Tuple<Type, Type>, Action<IObjectDescriptor, IObjectGraphVisitor, int, IObjectGraphVisitorContext>> _behaviorCache =
         new();
     private readonly Dictionary<Tuple<Type, Type, Type>, Action<FullObjectGraphTraversalStrategy, object, IObjectGraphVisitor, int, INamingConvention, IObjectGraphVisitorContext>> _traverseGenericDictionaryCache =

--- a/src/Docfx.YamlSerialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
+++ b/src/Docfx.YamlSerialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
@@ -37,7 +37,7 @@ public class FullObjectGraphTraversalStrategy : IObjectGraphTraversalStrategy
     {
         if (maxRecursion <= 0)
         {
-            throw new ArgumentOutOfRangeException("maxRecursion", maxRecursion, "maxRecursion must be greater than 1");
+            throw new ArgumentOutOfRangeException(nameof(maxRecursion), maxRecursion, "maxRecursion must be greater than 1");
         }
 
         ArgumentNullException.ThrowIfNull(typeDescriptor);

--- a/src/Docfx.YamlSerialization/TypeInspectors/EmitTypeInspector.cs
+++ b/src/Docfx.YamlSerialization/TypeInspectors/EmitTypeInspector.cs
@@ -183,8 +183,7 @@ public class EmitTypeInspector : ExtensibleTypeInspectorSkeleton
             {
                 valueType = GetGenericValueTypeCore(propertyType);
             }
-            valueType = valueType ??
-                (from t in propertyType.GetInterfaces()
+            valueType ??= (from t in propertyType.GetInterfaces()
                  where t.IsVisible
                  select GetGenericValueTypeCore(t)).FirstOrDefault(x => x != null);
             return valueType;

--- a/src/Docfx.YamlSerialization/YamlDeserializer.cs
+++ b/src/Docfx.YamlSerialization/YamlDeserializer.cs
@@ -64,8 +64,8 @@ public sealed class YamlDeserializer
         bool ignoreUnmatched = false,
         bool ignoreNotFoundAnchor = true)
     {
-        objectFactory = objectFactory ?? new DefaultEmitObjectFactory();
-        namingConvention = namingConvention ?? NullNamingConvention.Instance;
+        objectFactory ??= new DefaultEmitObjectFactory();
+        namingConvention ??= NullNamingConvention.Instance;
 
         _typeDescriptor.TypeDescriptor =
             new ExtensibleYamlAttributesTypeInspector(
@@ -166,7 +166,7 @@ public sealed class YamlDeserializer
         var hasStreamStart = parser.TryConsume<StreamStart>(out _);
 
         var hasDocumentStart = parser.TryConsume<DocumentStart>(out _);
-        deserializer = deserializer ?? _valueDeserializer;
+        deserializer ??= _valueDeserializer;
         object result = null;
         if (!parser.Accept<DocumentEnd>(out _) && !parser.Accept<StreamEnd>(out _))
         {

--- a/src/Docfx.YamlSerialization/YamlDeserializer.cs
+++ b/src/Docfx.YamlSerialization/YamlDeserializer.cs
@@ -226,7 +226,7 @@ public sealed class YamlDeserializer
 
             public ValuePromise(AnchorAlias alias)
             {
-                this.Alias = alias;
+                Alias = alias;
             }
 
             public ValuePromise(object value)

--- a/src/Docfx.YamlSerialization/YamlSerializer.cs
+++ b/src/Docfx.YamlSerialization/YamlSerializer.cs
@@ -83,7 +83,7 @@ public class YamlSerializer
         if (!IsOptionSet(SerializationOptions.DisableAliases))
         {
             var anchorAssigner = new AnchorAssigner(Converters);
-            traversalStrategy.Traverse<Nothing>(graph, anchorAssigner, default);
+            traversalStrategy.Traverse(graph, anchorAssigner, default);
 
             emittingVisitor = new AnchorAssigningObjectGraphVisitor(emittingVisitor, eventEmitter, anchorAssigner);
         }

--- a/src/Docfx.YamlSerialization/YamlSerializer.cs
+++ b/src/Docfx.YamlSerialization/YamlSerializer.cs
@@ -36,8 +36,8 @@ public class YamlSerializer
         }
 
         _typeResolver = IsOptionSet(SerializationOptions.DefaultToStaticType)
-            ? (ITypeResolver)new StaticTypeResolver()
-            : (ITypeResolver)new DynamicTypeResolver();
+            ? new StaticTypeResolver()
+            : new DynamicTypeResolver();
     }
 
     private bool IsOptionSet(SerializationOptions option)

--- a/src/Docfx.YamlSerialization/YamlSerializer.cs
+++ b/src/Docfx.YamlSerialization/YamlSerializer.cs
@@ -76,7 +76,7 @@ public class YamlSerializer
     {
         IObjectGraphVisitor<IEmitter> emittingVisitor = new EmittingObjectGraphVisitor(eventEmitter);
 
-        ObjectSerializer nestedObjectSerializer = (v, t) => SerializeValue(emitter, v, t);
+        void nestedObjectSerializer(object v, Type t = null) => SerializeValue(emitter, v, t);
 
         emittingVisitor = new CustomSerializationObjectGraphVisitor(emittingVisitor, Converters, nestedObjectSerializer);
 

--- a/src/docfx/Models/InitCommand.cs
+++ b/src/docfx/Models/InitCommand.cs
@@ -364,7 +364,7 @@ TODO: Add .NET projects to the *src* folder and run `docfx` to generate **REAL**
 
     private class SingleChoiceQuestion<T> : Question<T>
     {
-        private Func<string, T> _converter;
+        private readonly Func<string, T> _converter;
         /// <summary>
         /// Options, the first one as the default one
         /// </summary>

--- a/src/docfx/Models/InitCommand.cs
+++ b/src/docfx/Models/InitCommand.cs
@@ -102,8 +102,9 @@ internal class InitCommand : Command<InitCommandOptions>
             new YesOrNoQuestion(
                 "Does the website contain .NET API documentation?", (s, m, c) =>
                 {
-                    m.Build = new BuildJsonConfig();
-                    m.Build.Output = "_site";
+                    m.Build = new BuildJsonConfig { 
+                        Output = "_site",
+                    };
                     m.Build.Templates.Add("default");
                     m.Build.Templates.Add("modern");
                     if (s)

--- a/src/docfx/Models/InitCommand.cs
+++ b/src/docfx/Models/InitCommand.cs
@@ -155,7 +155,7 @@ internal class InitCommand : Command<InitCommandOptions>
         return 0;
     }
 
-    private void GenerateConfigFile(string outputFolder, object config, bool quiet, bool overwrite)
+    private static void GenerateConfigFile(string outputFolder, object config, bool quiet, bool overwrite)
     {
         var path = Path.Combine(outputFolder ?? string.Empty, ConfigName).ToDisplayPath();
         if (File.Exists(path))
@@ -170,7 +170,7 @@ internal class InitCommand : Command<InitCommandOptions>
         $"Successfully generated default docfx config file to {path}".WriteLineToConsole(ConsoleColor.Green);
     }
 
-    private void GenerateSeedProject(string outputFolder, DefaultConfigModel config, bool quiet, bool overwrite)
+    private static void GenerateSeedProject(string outputFolder, DefaultConfigModel config, bool quiet, bool overwrite)
     {
         if (Directory.Exists(outputFolder))
         {

--- a/src/docfx/Models/MetadataCommand.cs
+++ b/src/docfx/Models/MetadataCommand.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
-using Docfx.DataContracts.Common;
 using Docfx.Dotnet;
 using Newtonsoft.Json;
 using Spectre.Console.Cli;

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -1,0 +1,6 @@
+# top-most EditorConfig file
+root = false
+
+[*.cs]
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent # IDE0058: Remove unnecessary expression value
+

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -3,4 +3,4 @@ root = false
 
 [*.cs]
 csharp_style_unused_value_expression_statement_preference = discard_variable:silent # IDE0058: Remove unnecessary expression value
-
+csharp_style_unused_value_assignment_preference           = discard_variable:silent # IDE0059: Remove unnecessary value assignment

--- a/test/Docfx.Build.Common.Tests/ModelAttributeHandlerTest.cs
+++ b/test/Docfx.Build.Common.Tests/ModelAttributeHandlerTest.cs
@@ -90,12 +90,12 @@ public class ModelAttributeHandlerTest
             OtherProperty = "others",
             InnerModels = new List<InnerModel>
             {
-                new InnerModel
+                new()
                 {
                      Identity = "2.1",
                      CrefType = TestCrefType.Cref
                 },
-                new InnerModel
+                new()
                 {
                      Identity = "2.2",
                      CrefType = TestCrefType.Href

--- a/test/Docfx.Build.ConceptualDocuments.Tests/ConceptualDocumentProcessorTest.cs
+++ b/test/Docfx.Build.ConceptualDocuments.Tests/ConceptualDocumentProcessorTest.cs
@@ -22,8 +22,8 @@ public class ConceptualDocumentProcessorTest : TestBase
     private readonly string _templateFolder;
     private readonly FileCollection _defaultFiles;
     private readonly FileCreator _fileCreator;
-    private ApplyTemplateSettings _applyTemplateSettings;
-    private TemplateManager _templateManager;
+    private readonly ApplyTemplateSettings _applyTemplateSettings;
+    private readonly TemplateManager _templateManager;
     private const string RawModelFileExtension = ".raw.json";
 
     public ConceptualDocumentProcessorTest()

--- a/test/Docfx.Build.ConceptualDocuments.Tests/ConceptualDocumentProcessorTest.cs
+++ b/test/Docfx.Build.ConceptualDocuments.Tests/ConceptualDocumentProcessorTest.cs
@@ -437,7 +437,7 @@ Some content";
 
         public string CreateFile(string content, string fileName = null, string folder = null)
         {
-            fileName = fileName ?? Path.GetRandomFileName() + ".md";
+            fileName ??= Path.GetRandomFileName() + ".md";
 
             fileName = Path.Combine(folder ?? string.Empty, fileName);
 

--- a/test/Docfx.Build.Engine.Tests/DocumentBuilderTest.cs
+++ b/test/Docfx.Build.Engine.Tests/DocumentBuilderTest.cs
@@ -769,7 +769,7 @@ exports.getOptions = function (){
         builder.Build(parameters);
     }
 
-    private IEnumerable<Assembly> LoadAssemblies()
+    private static IEnumerable<Assembly> LoadAssemblies()
     {
         yield return typeof(ConceptualDocumentProcessor).Assembly;
         yield return typeof(ManagedReferenceDocumentProcessor).Assembly;

--- a/test/Docfx.Build.Engine.Tests/DocumentBuilderTest.cs
+++ b/test/Docfx.Build.Engine.Tests/DocumentBuilderTest.cs
@@ -692,7 +692,7 @@ exports.getOptions = function (){
             _fakeResponses.Add(uri, responseMessage);
         }
 
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             if (_fakeResponses.ContainsKey(request.RequestUri))
             {

--- a/test/Docfx.Build.Engine.Tests/DocumentProcessors/YamlDocumentProcessor.cs
+++ b/test/Docfx.Build.Engine.Tests/DocumentProcessors/YamlDocumentProcessor.cs
@@ -3,13 +3,10 @@
 
 using System.Collections.Immutable;
 using System.Composition;
-using System.Text;
 
 using Docfx.Build.Common;
 using Docfx.Common;
 using Docfx.Plugins;
-
-using Newtonsoft.Json;
 
 namespace Docfx.Build.Engine.Tests;
 

--- a/test/Docfx.Build.Engine.Tests/ExtractSearchIndexFromHtmlTest.cs
+++ b/test/Docfx.Build.Engine.Tests/ExtractSearchIndexFromHtmlTest.cs
@@ -11,7 +11,7 @@ namespace Docfx.Build.Engine.Tests;
 [Collection("docfx STA")]
 public class ExtractSearchIndexFromHtmlTest
 {
-    private static ExtractSearchIndex _extractor = new();
+    private static readonly ExtractSearchIndex _extractor = new();
 
     [Fact]
     public void TestBasicFeature()

--- a/test/Docfx.Build.Engine.Tests/ExtractSearchIndexFromHtmlTest.cs
+++ b/test/Docfx.Build.Engine.Tests/ExtractSearchIndexFromHtmlTest.cs
@@ -207,8 +207,10 @@ public class ExtractSearchIndexFromHtmlTest
         File.WriteAllText(Path.Combine(tempTestFolder, "index.html"), rawHtml, new UTF8Encoding(false));
 
         // prepares fake manifest object
-        var outputFileInfo = new OutputFileInfo();
-        outputFileInfo.RelativePath = "index.html";
+        var outputFileInfo = new OutputFileInfo
+        {
+            RelativePath = "index.html",
+        };
 
         var manifestItem = new ManifestItem();
         manifestItem.OutputFiles.Add(".html", outputFileInfo);

--- a/test/Docfx.Build.Engine.Tests/FileMetadataHelperTest.cs
+++ b/test/Docfx.Build.Engine.Tests/FileMetadataHelperTest.cs
@@ -107,9 +107,9 @@ public class FileMetadataHelperTest
 
         var actualResults = FileMetadataHelper.GetChangedGlobs(left, right).ToList();
         Assert.NotNull(actualResults);
-        Assert.Equal(12, actualResults.Count());
+        Assert.Equal(12, actualResults.Count);
         var patterns = patternsA.Concat(patternsB).ToList();
-        for (var index = 0; index < patterns.Count(); index++)
+        for (var index = 0; index < patterns.Count; index++)
         {
             Assert.Equal(patterns[index], actualResults[index].Raw);
         }
@@ -138,7 +138,7 @@ public class FileMetadataHelperTest
 
         var actualResults = FileMetadataHelper.GetChangedGlobs(left, right).ToList();
         Assert.NotNull(actualResults);
-        Assert.Equal(2, actualResults.Count());
+        Assert.Equal(2, actualResults.Count);
         Assert.Equal(patterns[0], actualResults[0].Raw);
         Assert.Equal(patterns[2], actualResults[1].Raw);
     }
@@ -225,7 +225,7 @@ public class FileMetadataHelperTest
 
         var actualResults = FileMetadataHelper.GetChangedGlobs(left, right).ToList();
         Assert.NotNull(actualResults);
-        Assert.Equal(3, actualResults.Count());
+        Assert.Equal(3, actualResults.Count);
         Assert.Equal(patterns[5], actualResults[0].Raw);
         Assert.Equal(patterns[2], actualResults[1].Raw);
         Assert.Equal(patterns[4], actualResults[2].Raw);

--- a/test/Docfx.Build.Engine.Tests/JsonConverterTest.cs
+++ b/test/Docfx.Build.Engine.Tests/JsonConverterTest.cs
@@ -63,7 +63,7 @@ public class JsonConverterTest
         CompareFileMetadataItems(deserialized1, deserialized2);
     }
 
-    private void CompareFileMetadataItems(FileMetadata raw, FileMetadata actual)
+    private static void CompareFileMetadataItems(FileMetadata raw, FileMetadata actual)
     {
         Assert.Equal(raw.Count, actual.Count);
         foreach (var pair in raw)

--- a/test/Docfx.Build.Engine.Tests/PostProcessors/PostProcessorsHandlerTest.cs
+++ b/test/Docfx.Build.Engine.Tests/PostProcessors/PostProcessorsHandlerTest.cs
@@ -57,7 +57,7 @@ public class PostProcessorsHandlerTest : TestBase
         foreach (var type in types)
         {
             var instance = Activator.CreateInstance(type);
-            if (!(instance is IPostProcessor postProcessor))
+            if (instance is not IPostProcessor postProcessor)
             {
                 throw new InvalidOperationException($"{type} should implement {nameof(IPostProcessor)}.");
             }

--- a/test/Docfx.Build.Engine.Tests/TemplateManagerUnitTest.DotnetToolMode.cs
+++ b/test/Docfx.Build.Engine.Tests/TemplateManagerUnitTest.DotnetToolMode.cs
@@ -5,10 +5,9 @@ using Docfx.Common;
 using Docfx.Tests.Common;
 using FluentAssertions;
 using Xunit;
+using Switches = Docfx.DataContracts.Common.Constants.Switches;
 
 namespace Docfx.Build.Engine.Tests;
-
-using Switches = DataContracts.Common.Constants.Switches;
 
 public partial class TemplateManagerUnitTest
 {

--- a/test/Docfx.Build.Engine.Tests/ValidateBookmarkTest.cs
+++ b/test/Docfx.Build.Engine.Tests/ValidateBookmarkTest.cs
@@ -13,7 +13,7 @@ namespace Docfx.Build.Engine.Tests;
 public class ValidateBookmarkTest : TestBase
 {
     private readonly string _outputFolder;
-    private TestLoggerListener _listener = TestLoggerListener.CreateLoggerListenerWithPhaseEqualFilter("validate_bookmark.ValidateBookmark");
+    private readonly TestLoggerListener _listener = TestLoggerListener.CreateLoggerListenerWithPhaseEqualFilter("validate_bookmark.ValidateBookmark");
 
     public ValidateBookmarkTest()
     {

--- a/test/Docfx.Build.ManagedReference.Tests/ManagedReferenceDocumentProcessorTest.cs
+++ b/test/Docfx.Build.ManagedReference.Tests/ManagedReferenceDocumentProcessorTest.cs
@@ -17,11 +17,11 @@ namespace Docfx.Build.ManagedReference.Tests;
 
 public class ManagedReferenceDocumentProcessorTest : TestBase
 {
-    private string _outputFolder;
-    private string _inputFolder;
-    private FileCollection _defaultFiles;
-    private ApplyTemplateSettings _applyTemplateSettings;
-    private TemplateManager _templateManager;
+    private readonly string _outputFolder;
+    private readonly string _inputFolder;
+    private readonly FileCollection _defaultFiles;
+    private readonly ApplyTemplateSettings _applyTemplateSettings;
+    private readonly TemplateManager _templateManager;
 
     private const string RawModelFileExtension = ".raw.json";
     private const string MrefDirectory = "mref";

--- a/test/Docfx.Build.OverwriteDocuments.Tests/OverwriteDocumentModelCreatorTest.cs
+++ b/test/Docfx.Build.OverwriteDocuments.Tests/OverwriteDocumentModelCreatorTest.cs
@@ -228,12 +228,12 @@ definitions:
         Assert.Equal(0, ex.Position);
     }
 
-    private string ExtractDictionaryKeys(Dictionary<object, object> dict)
+    private static string ExtractDictionaryKeys(Dictionary<object, object> dict)
     {
         return string.Join(",", dict.Keys.ToArray());
     }
 
-    private string ExtractDictionaryKeys(Dictionary<string, object> dict)
+    private static string ExtractDictionaryKeys(Dictionary<string, object> dict)
     {
         return string.Join(",", dict.Keys.ToArray());
     }

--- a/test/Docfx.Build.OverwriteDocuments.Tests/OverwriteDocumentModelCreatorTest.cs
+++ b/test/Docfx.Build.OverwriteDocuments.Tests/OverwriteDocumentModelCreatorTest.cs
@@ -12,7 +12,7 @@ namespace Docfx.Build.OverwriteDocuments.Tests;
 
 public class OverwriteDocumentModelCreatorTest
 {
-    private TestLoggerListener _listener = TestLoggerListener.CreateLoggerListenerWithPhaseEqualFilter("overwrite_document_model_creator");
+    private readonly TestLoggerListener _listener = TestLoggerListener.CreateLoggerListenerWithPhaseEqualFilter("overwrite_document_model_creator");
 
     [Fact]
     public void YamlCodeBlockTest()

--- a/test/Docfx.Build.RestApi.Tests/RestApiDocumentProcessorTest.cs
+++ b/test/Docfx.Build.RestApi.Tests/RestApiDocumentProcessorTest.cs
@@ -18,10 +18,10 @@ namespace Docfx.Build.RestApi.Tests;
 [Collection("docfx STA")]
 public class RestApiDocumentProcessorTest : TestBase
 {
-    private string _outputFolder;
-    private string _inputFolder;
-    private FileCollection _defaultFiles;
-    private ApplyTemplateSettings _applyTemplateSettings;
+    private readonly string _outputFolder;
+    private readonly string _inputFolder;
+    private readonly FileCollection _defaultFiles;
+    private readonly ApplyTemplateSettings _applyTemplateSettings;
 
     private const string RawModelFileExtension = ".raw.json";
     private const string SwaggerDirectory = "swagger";

--- a/test/Docfx.Build.RestApi.WithPlugins.Tests/SplitRestApiToOperationLevelTest.cs
+++ b/test/Docfx.Build.RestApi.WithPlugins.Tests/SplitRestApiToOperationLevelTest.cs
@@ -19,11 +19,11 @@ namespace Docfx.Build.RestApi.WithPlugins.Tests;
 [Collection("docfx STA")]
 public class SplitRestApiToOperationLevelTest : TestBase
 {
-    private string _inputFolder;
-    private string _outputFolder;
-    private FileCollection _defaultFiles;
+    private readonly string _inputFolder;
+    private readonly string _outputFolder;
+    private readonly FileCollection _defaultFiles;
     private readonly ApplyTemplateSettings _applyTemplateSettings;
-    private TemplateManager _templateManager;
+    private readonly TemplateManager _templateManager;
 
     private const string RawModelFileExtension = ".raw.json";
 

--- a/test/Docfx.Build.RestApi.WithPlugins.Tests/SplitRestApiToTagLevelTest.cs
+++ b/test/Docfx.Build.RestApi.WithPlugins.Tests/SplitRestApiToTagLevelTest.cs
@@ -20,11 +20,11 @@ namespace Docfx.Build.RestApi.WithPlugins.Tests;
 [Collection("docfx STA")]
 public class SplitRestApiToTagLevelTest : TestBase
 {
-    private string _inputFolder;
-    private string _outputFolder;
-    private FileCollection _defaultFiles;
+    private readonly string _inputFolder;
+    private readonly string _outputFolder;
+    private readonly FileCollection _defaultFiles;
     private readonly ApplyTemplateSettings _applyTemplateSettings;
-    private TemplateManager _templateManager;
+    private readonly TemplateManager _templateManager;
 
     private const string RawModelFileExtension = ".raw.json";
 

--- a/test/Docfx.Build.SchemaDriven.Tests/LimitationReachedTest.cs
+++ b/test/Docfx.Build.SchemaDriven.Tests/LimitationReachedTest.cs
@@ -14,15 +14,15 @@ namespace Docfx.Build.SchemaDriven.Tests;
 [Collection("docfx STA")]
 public class LimitationReachedTest : TestBase
 {
-    private static Regex InputMatcher = new(@"```(yml|yaml)\s*(### YamlMime:[\s\S]*?)\s*```", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-    private static Regex SchemaMatcher = new(@"```json\s*(\{\s*""\$schema""[\s\S]*?)\s*```", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex InputMatcher = new(@"```(yml|yaml)\s*(### YamlMime:[\s\S]*?)\s*```", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex SchemaMatcher = new(@"```json\s*(\{\s*""\$schema""[\s\S]*?)\s*```", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-    private string _outputFolder;
-    private string _inputFolder;
-    private string _templateFolder;
-    private FileCollection _defaultFiles;
-    private ApplyTemplateSettings _applyTemplateSettings;
-    private TemplateManager _templateManager;
+    private readonly string _outputFolder;
+    private readonly string _inputFolder;
+    private readonly string _templateFolder;
+    private readonly FileCollection _defaultFiles;
+    private readonly ApplyTemplateSettings _applyTemplateSettings;
+    private readonly TemplateManager _templateManager;
 
     private const string RawModelFileExtension = ".raw.json";
 

--- a/test/Docfx.Build.SchemaDriven.Tests/LimitationReachedTest.cs
+++ b/test/Docfx.Build.SchemaDriven.Tests/LimitationReachedTest.cs
@@ -67,7 +67,7 @@ public class LimitationReachedTest : TestBase
         yield return typeof(SchemaDrivenProcessorTest).Assembly;
     }
 
-    private bool LimitationReached(TestListenerScope listener)
+    private static bool LimitationReached(TestListenerScope listener)
     {
         return listener.Items.SingleOrDefault(s => s.Message.StartsWith("Limitation reached when validating")) != null;
     }

--- a/test/Docfx.Build.SchemaDriven.Tests/LimitationReachedTest.cs
+++ b/test/Docfx.Build.SchemaDriven.Tests/LimitationReachedTest.cs
@@ -6,7 +6,6 @@ using System.Text.RegularExpressions;
 
 using Docfx.Build.Engine;
 using Docfx.Build.TableOfContents;
-using Docfx.Plugins;
 using Docfx.Tests.Common;
 using Xunit;
 

--- a/test/Docfx.Build.SchemaDriven.Tests/MarkdownFragmentsValidationTest.cs
+++ b/test/Docfx.Build.SchemaDriven.Tests/MarkdownFragmentsValidationTest.cs
@@ -61,7 +61,7 @@ public class MarkdownFragmentsValidationTest : TestBase
         var logs = _listener.Items;
         var warningLogs = logs.Where(l => l.Code == WarningCodes.Overwrite.InvalidMarkdownFragments).ToList();
         Assert.True(File.Exists(_rawModelFilePath));
-        Assert.Equal(5, warningLogs.Count());
+        Assert.Equal(5, warningLogs.Count);
         Assert.Equal(
             @"Markdown property `depot_name` is not allowed inside a YAML code block
 You cannot overwrite a readonly property: `site_name`, please add an `editable` tag on this property or mark its contentType as `markdown` in schema if you want to overwrite this property

--- a/test/Docfx.Build.SchemaDriven.Tests/MarkdownFragmentsValidationTest.cs
+++ b/test/Docfx.Build.SchemaDriven.Tests/MarkdownFragmentsValidationTest.cs
@@ -68,7 +68,7 @@ You cannot overwrite a readonly property: `site_name`, please add an `editable` 
 There is an invalid H2: `name`: the contentType of this property in schema must be `markdown`
 There is an invalid H2: `operations[id=""management.azure.com.advisor.fragmentsValidation.create""]/summary`: the contentType of this property in schema must be `markdown`
 ""/operations/1"" in overwrite object fails to overwrite ""/operations"" for ""management.azure.com.advisor.fragmentsValidation"" because it does not match any existing item.",
-            String.Join(Environment.NewLine, warningLogs.Select(x => x.Message)),
+            string.Join(Environment.NewLine, warningLogs.Select(x => x.Message)),
             ignoreLineEndingDifferences: true);
         Assert.Equal("14", warningLogs[2].Line);
         Assert.Equal("17", warningLogs[3].Line);

--- a/test/Docfx.Build.SchemaDriven.Tests/MergeMarkdownFragmentsTest.cs
+++ b/test/Docfx.Build.SchemaDriven.Tests/MergeMarkdownFragmentsTest.cs
@@ -12,16 +12,16 @@ namespace Docfx.Build.SchemaDriven.Tests;
 [Collection("docfx STA")]
 public class MergeMarkdownFragmentsTest : TestBase
 {
-    private string _outputFolder;
-    private string _inputFolder;
-    private string _templateFolder;
-    private FileCollection _defaultFiles;
-    private ApplyTemplateSettings _applyTemplateSettings;
-    private TemplateManager _templateManager;
-    private FileCollection _files;
+    private readonly string _outputFolder;
+    private readonly string _inputFolder;
+    private readonly string _templateFolder;
+    private readonly FileCollection _defaultFiles;
+    private readonly ApplyTemplateSettings _applyTemplateSettings;
+    private readonly TemplateManager _templateManager;
+    private readonly FileCollection _files;
 
-    private TestLoggerListener _listener;
-    private string _rawModelFilePath;
+    private readonly TestLoggerListener _listener;
+    private readonly string _rawModelFilePath;
 
     private const string RawModelFileExtension = ".raw.json";
 

--- a/test/Docfx.Build.SchemaDriven.Tests/MergeMarkdownFragmentsTest.cs
+++ b/test/Docfx.Build.SchemaDriven.Tests/MergeMarkdownFragmentsTest.cs
@@ -391,7 +391,7 @@ With [!include[invalid](invalid.md)]",
         Assert.True(messages.SequenceEqual(lastMessages));
     }
 
-    private List<string> ClearLog(List<ILogItem> items)
+    private static List<string> ClearLog(List<ILogItem> items)
     {
         var result = items.Select(i => i.Message).ToList();
         items.Clear();

--- a/test/Docfx.Build.SchemaDriven.Tests/SchemaDrivenProcessorTest.cs
+++ b/test/Docfx.Build.SchemaDriven.Tests/SchemaDrivenProcessorTest.cs
@@ -6,7 +6,6 @@ using System.Composition;
 using System.Text.RegularExpressions;
 
 using Docfx.Build.Engine;
-using Docfx.Build.SchemaDriven.Processors;
 using Docfx.Build.TableOfContents;
 using Docfx.Common;
 using Docfx.Exceptions;

--- a/test/Docfx.Build.SchemaDriven.Tests/SchemaDrivenProcessorTest.cs
+++ b/test/Docfx.Build.SchemaDriven.Tests/SchemaDrivenProcessorTest.cs
@@ -559,12 +559,12 @@ searchScope:
         {
             if (Path.GetFileNameWithoutExtension(model.File) == "page1")
             {
-                ((dynamic)model.Properties.Metadata).meta = "overwritten";
-                ((dynamic)model.Properties.Metadata).another = 1;
+                model.Properties.Metadata.meta = "overwritten";
+                model.Properties.Metadata.another = 1;
             }
             else
             {
-                ((dynamic)model.Properties.Metadata).another = 2;
+                model.Properties.Metadata.another = 2;
             }
         }
 
@@ -574,11 +574,11 @@ searchScope:
             {
                 if (Path.GetFileNameWithoutExtension(model.File) == "page1")
                 {
-                    ((dynamic)model.Properties.Metadata).postMeta = "postbuild1";
+                    model.Properties.Metadata.postMeta = "postbuild1";
                 }
                 else
                 {
-                    ((dynamic)model.Properties.Metadata).postMeta = "postbuild2";
+                    model.Properties.Metadata.postMeta = "postbuild2";
                 }
             }
         }

--- a/test/Docfx.Build.SchemaDriven.Tests/SchemaMergerTest.cs
+++ b/test/Docfx.Build.SchemaDriven.Tests/SchemaMergerTest.cs
@@ -16,12 +16,12 @@ namespace Docfx.Build.SchemaDriven.Tests;
 [Collection("docfx STA")]
 public class SchemaMergerTest : TestBase
 {
-    private string _outputFolder;
-    private string _inputFolder;
-    private string _templateFolder;
-    private FileCollection _defaultFiles;
-    private ApplyTemplateSettings _applyTemplateSettings;
-    private TemplateManager _templateManager;
+    private readonly string _outputFolder;
+    private readonly string _inputFolder;
+    private readonly string _templateFolder;
+    private readonly FileCollection _defaultFiles;
+    private readonly ApplyTemplateSettings _applyTemplateSettings;
+    private readonly TemplateManager _templateManager;
 
     private const string RawModelFileExtension = ".raw.json";
 

--- a/test/Docfx.Build.TableOfContents.Tests/TocDocumentProcessorTest.cs
+++ b/test/Docfx.Build.TableOfContents.Tests/TocDocumentProcessorTest.cs
@@ -18,10 +18,10 @@ namespace Docfx.Build.TableOfContents.Tests;
 [Collection("docfx STA")]
 public class TocDocumentProcessorTest : TestBase
 {
-    private string _outputFolder;
-    private string _inputFolder;
+    private readonly string _outputFolder;
+    private readonly string _inputFolder;
     private readonly FileCreator _fileCreator;
-    private ApplyTemplateSettings _applyTemplateSettings;
+    private readonly ApplyTemplateSettings _applyTemplateSettings;
 
     private const string RawModelFileExtension = ".raw.json";
 

--- a/test/Docfx.Build.TableOfContents.Tests/TocDocumentProcessorTest.cs
+++ b/test/Docfx.Build.TableOfContents.Tests/TocDocumentProcessorTest.cs
@@ -946,7 +946,7 @@ items:
         builder.Build(parameters);
     }
 
-    private IEnumerable<Assembly> LoadAssemblies()
+    private static IEnumerable<Assembly> LoadAssemblies()
     {
         yield return typeof(ConceptualDocumentProcessor).Assembly;
         yield return typeof(TocDocumentProcessor).Assembly;

--- a/test/Docfx.Build.UniversalReference.Tests/UniversalReferenceDocumentProcessorTest.cs
+++ b/test/Docfx.Build.UniversalReference.Tests/UniversalReferenceDocumentProcessorTest.cs
@@ -14,10 +14,10 @@ namespace Docfx.Build.UniversalReference.Tests;
 
 public class UniversalReferenceDocumentProcessorTest : TestBase
 {
-    private string _outputFolder;
-    private string _inputFolder;
-    private ApplyTemplateSettings _applyTemplateSettings;
-    private TemplateManager _templateManager;
+    private readonly string _outputFolder;
+    private readonly string _inputFolder;
+    private readonly ApplyTemplateSettings _applyTemplateSettings;
+    private readonly TemplateManager _templateManager;
 
     private const string RawModelFileExtension = ".raw.json";
     private const string TestDataDirectory = "TestData";

--- a/test/Docfx.Common.Tests/CollectionUtilityTest.cs
+++ b/test/Docfx.Common.Tests/CollectionUtilityTest.cs
@@ -17,7 +17,7 @@ public class CollectionUtilityTest
     {
         var inputArray = input1.ToImmutableArray();
         var actual = inputArray.GetLongestCommonSequence(input2.ToImmutableArray());
-        Assert.Equal(expected.Length, actual.Count());
+        Assert.Equal(expected.Length, actual.Length);
         for (int i = 0; i < expected.Length; i++)
         {
             Assert.Equal(expected[i], actual[i]);

--- a/test/Docfx.Common.Tests/GitUtilityTest.cs
+++ b/test/Docfx.Common.Tests/GitUtilityTest.cs
@@ -42,7 +42,7 @@ public class GitUtilityTest : IDisposable
         Assert.Equal(10_000, GitUtility.GetGitTimeout());
     }
 
-    [Obsolete]
+    [Obsolete("It will be removed in a future version.")]
     [Fact]
     public void TestParseGitRepoInfo()
     {
@@ -69,7 +69,7 @@ public class GitUtilityTest : IDisposable
         Assert.Equal(RepoType.Vso, repoInfo.RepoType);
     }
 
-    [Obsolete]
+    [Obsolete("It will be removed in a future version.")]
     [Fact]
     public void TestCombineGitUrl()
     {

--- a/test/Docfx.Common.Tests/GitUtilityTest.cs
+++ b/test/Docfx.Common.Tests/GitUtilityTest.cs
@@ -9,7 +9,7 @@ namespace Docfx.Common.Tests;
 [Collection("docfx STA")]
 public class GitUtilityTest : IDisposable
 {
-    private string _originalBranchName;
+    private readonly string _originalBranchName;
     private const string envName = "DOCFX_SOURCE_BRANCH_NAME";
     public GitUtilityTest()
     {

--- a/test/Docfx.Common.Tests/GitUtilityTest.cs
+++ b/test/Docfx.Common.Tests/GitUtilityTest.cs
@@ -10,16 +10,16 @@ namespace Docfx.Common.Tests;
 public class GitUtilityTest : IDisposable
 {
     private readonly string _originalBranchName;
-    private const string envName = "DOCFX_SOURCE_BRANCH_NAME";
+    private const string EnvName = "DOCFX_SOURCE_BRANCH_NAME";
     public GitUtilityTest()
     {
-        _originalBranchName = Environment.GetEnvironmentVariable(envName);
-        Environment.SetEnvironmentVariable(envName, "special-branch");
+        _originalBranchName = Environment.GetEnvironmentVariable(EnvName);
+        Environment.SetEnvironmentVariable(EnvName, "special-branch");
     }
 
     public void Dispose()
     {
-        Environment.SetEnvironmentVariable(envName, _originalBranchName);
+        Environment.SetEnvironmentVariable(EnvName, _originalBranchName);
     }
 
     [Fact]

--- a/test/Docfx.Common.Tests/ReflectionEntityMergerTest.cs
+++ b/test/Docfx.Common.Tests/ReflectionEntityMergerTest.cs
@@ -117,15 +117,15 @@ public class ReflectionEntityMergerTest
     {
         var sample = new List<ListItemSample>
         {
-            new ListItemSample { Key1 = "qwe", Key2 = 1, Text = "O1" },
-            new ListItemSample { Key1 = "asd", Key2 = 1, Text = "O2" },
-            new ListItemSample { Key1 = "asd", Key2 = 2, Text = "O3" },
+            new() { Key1 = "qwe", Key2 = 1, Text = "O1" },
+            new() { Key1 = "asd", Key2 = 1, Text = "O2" },
+            new() { Key1 = "asd", Key2 = 2, Text = "O3" },
         };
         var overrides = new List<ListItemSample>
         {
-            new ListItemSample { Key1 = "___", Key2 = 1, Text = "N1" },
-            new ListItemSample { Key1 = "asd", Key2 = 1, Text = "N2" },
-            new ListItemSample { Key1 = "asd", Key2 = 2, Text = "N3" },
+            new() { Key1 = "___", Key2 = 1, Text = "N1" },
+            new() { Key1 = "asd", Key2 = 1, Text = "N2" },
+            new() { Key1 = "asd", Key2 = 2, Text = "N3" },
         };
         new MergerFacade(
             new KeyedListMerger(

--- a/test/Docfx.Common.Tests/RelativePathTest.cs
+++ b/test/Docfx.Common.Tests/RelativePathTest.cs
@@ -138,7 +138,7 @@ public class RelativePathTest
     public void TestRelativePathGetDirectoryPathWithInvalidParentDirectoryShouldFail()
     {
         var relativePath = (RelativePath)"~/..";
-        Assert.Throws<InvalidOperationException>(() => relativePath.GetDirectoryPath());
+        Assert.Throws<InvalidOperationException>(relativePath.GetDirectoryPath);
     }
 
     [Fact]

--- a/test/Docfx.Common.Tests/ReportLoggerListenerTest.cs
+++ b/test/Docfx.Common.Tests/ReportLoggerListenerTest.cs
@@ -10,8 +10,8 @@ namespace Docfx.Common.Tests;
 [Collection("docfx STA")]
 public class ReportLoggerListenerTest : TestBase
 {
-    private string _workingDirectory;
-    private string _repoRoot;
+    private readonly string _workingDirectory;
+    private readonly string _repoRoot;
 
     public ReportLoggerListenerTest()
     {

--- a/test/Docfx.Common.Tests/ScopeTest.cs
+++ b/test/Docfx.Common.Tests/ScopeTest.cs
@@ -151,7 +151,7 @@ public class ScopeTest
         }
     }
 
-    internal ILogItem TakeFirstLogItemAndRemove(List<ILogItem> items)
+    internal static ILogItem TakeFirstLogItemAndRemove(List<ILogItem> items)
     {
         if (items.Count == 0)
         {

--- a/test/Docfx.Dotnet.Tests/SymbolUrlResolverUnitTest.cs
+++ b/test/Docfx.Dotnet.Tests/SymbolUrlResolverUnitTest.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Xunit;

--- a/test/Docfx.Dotnet.Tests/XmlCommentUnitTest.cs
+++ b/test/Docfx.Dotnet.Tests/XmlCommentUnitTest.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.RegularExpressions;
-using Docfx.DataContracts.Common;
 using Xunit;
 
 namespace Docfx.Dotnet.Tests;

--- a/test/Docfx.Glob.Tests/GlobFileTest.cs
+++ b/test/Docfx.Glob.Tests/GlobFileTest.cs
@@ -8,7 +8,7 @@ namespace Docfx.Glob.Tests;
 
 public class GlobFileTest : TestBase
 {
-    private string _workingDirectory;
+    private readonly string _workingDirectory;
 
     public GlobFileTest()
     {

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/AggregatorTest.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/AggregatorTest.cs
@@ -130,7 +130,7 @@ P4</p>
     {
         var visitor = new MarkdownDocumentAggregatorVisitor(blockAggregator);
         var pipelineBuilder = new MarkdownPipelineBuilder();
-        pipelineBuilder.DocumentProcessed += document => visitor.Visit(document);
+        pipelineBuilder.DocumentProcessed += visitor.Visit;
 
         var pipeline = pipelineBuilder.Build();
         var html = Markdown.ToHtml(content, pipeline);

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/AggregatorTest.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/AggregatorTest.cs
@@ -126,7 +126,7 @@ P4</p>
         }
     }
 
-    private void TestAggregator(string content, string expected, IBlockAggregator blockAggregator)
+    private static void TestAggregator(string content, string expected, IBlockAggregator blockAggregator)
     {
         var visitor = new MarkdownDocumentAggregatorVisitor(blockAggregator);
         var pipelineBuilder = new MarkdownPipelineBuilder();

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/ChromelessFormsTest.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/ChromelessFormsTest.cs
@@ -7,7 +7,7 @@ namespace Docfx.MarkdigEngine.Tests;
 
 public class ChromelessFormsTest
 {
-    static public string LoggerPhase = "ChromelessForms";
+    public static string LoggerPhase = "ChromelessForms";
 
     [Fact]
     public void ChromelessFormsTestWithoutModel()

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/CodeTest.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/CodeTest.cs
@@ -7,8 +7,8 @@ namespace Docfx.MarkdigEngine.Tests;
 
 public class CodeTest
 {
-    static public string LoggerPhase = "Code";
-    static public string contentCSharp = @"using System;
+    public static string LoggerPhase = "Code";
+    public static string contentCSharp = @"using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
@@ -217,7 +217,7 @@ namespace TableSnippets
         }
     }
 }";
-    static public string contentCSharp2 = @"using System;
+    public static string contentCSharp2 = @"using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -377,7 +377,7 @@ namespace ChangeFeedSample
         }
     }
 }";
-    static public string contentCSharpRegion = @"using Microsoft.AspNetCore.Builder;
+    public static string contentCSharpRegion = @"using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -447,7 +447,7 @@ namespace TagHelpersBuiltIn
         }
     }
 }";
-    static public string contentASPNet = @"@{
+    public static string contentASPNet = @"@{
     ViewData[""Title""] = ""Anchor Tag Helper"";
 }
 
@@ -651,7 +651,7 @@ namespace TagHelpersBuiltIn
         </tr>
     </tfoot>
 </table>";
-    static public string contentVB = @"'<Snippet1>
+    public static string contentVB = @"'<Snippet1>
 Class ADSetupInformation
 
     Shared Sub Main()
@@ -710,7 +710,7 @@ Class AppDomain2
 End Class
 '</snippet3>
 ";
-    static public string contentCPP = @"//<Snippet1>
+    public static string contentCPP = @"//<Snippet1>
 using namespace System;
 
 int main()
@@ -772,7 +772,7 @@ int main()
     AppDomain4::Main();
 }
 // </snippet2>";
-    static public string contentCPP2 = @"//<Snippet1>
+    public static string contentCPP2 = @"//<Snippet1>
 using namespace System;
 
 using namespace System::Collections::Generic;
@@ -948,7 +948,7 @@ Remove(""doc"")
 Key ""doc"" is not found.
  */
 //</ Snippet1  >";
-    static public string contentCrazy = @"//<Snippet1>
+    public static string contentCrazy = @"//<Snippet1>
 using namespace System;
 
 int main()
@@ -1010,7 +1010,7 @@ int main()
     AppDomain4::Main();
 }
 // </snippet2>";
-    static public string contentSQL = @"-- <everything>
+    public static string contentSQL = @"-- <everything>
 --<students>
 SELECT * FROM Students
 WHERE Grade = 12
@@ -1023,7 +1023,7 @@ WHERE Grade = 12
 AND Class = 'Math'
 --</teachers>
 --</everything>";
-    static public string contentPython = @"#<everything>
+    public static string contentPython = @"#<everything>
 #<first>
 from flask import Flask
 app = Flask(__name__)
@@ -1036,21 +1036,21 @@ def hello():
 #</second>
 #</everything>
 ";
-    static public string contentBatch = @"REM <snippet>
+    public static string contentBatch = @"REM <snippet>
 :Label1
 	:Label2
 :: Comment line 3
 REM </snippet>
 	:: Comment line 4
 IF EXIST C:\AUTOEXEC.BAT REM AUTOEXEC.BAT exists";
-    static public string contentErlang = @"-module(hello_world).
+    public static string contentErlang = @"-module(hello_world).
 -compile(export_all).
 
 % <snippet>
 hello() ->
     io:format(""hello world~n"").
 % </snippet>";
-    static public string contentLisp = @";<everything>
+    public static string contentLisp = @";<everything>
 USER(64): (member 'b '(perhaps today is a good day to die)) ; test fails
 NIL
 ;<inner>
@@ -1058,7 +1058,7 @@ USER(65): (member 'a '(perhaps today is a good day to die)) ; returns non-NIL
 '(a good day to die)
 ; </inner>
 ;</everything>";
-    static public string contentRuby = @"source 'https://rubygems.org'
+    public static string contentRuby = @"source 'https://rubygems.org'
 git_source(:github) { |repo| ""https://github.com/#{repo}.git"" }
 
 ruby '2.6.5'
@@ -1120,7 +1120,7 @@ gem 'httparty', '~> 0.17.1'
 gem 'activerecord-session_store', '~> 1.1'
 # </GemFileSnippet>
 ";
-    static public string contentCSS = @"body {
+    public static string contentCSS = @"body {
   padding-top: 70px;
 }
 

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/MonikerRangeTest.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/MonikerRangeTest.cs
@@ -7,7 +7,7 @@ namespace Docfx.MarkdigEngine.Tests;
 
 public class MonikerRangeTest
 {
-    static public string LoggerPhase = "MonikerRange";
+    public static string LoggerPhase = "MonikerRange";
 
     [Fact]
     public void MonikerRangeTestGeneral()

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/RenderZoneTest.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/RenderZoneTest.cs
@@ -7,7 +7,7 @@ namespace Docfx.MarkdigEngine.Tests;
 
 public class RenderZoneTest
 {
-    static public string LoggerPhase = "RenderZone";
+    public static string LoggerPhase = "RenderZone";
 
     [Fact]
     public void KitchenSink()

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/TestUtility.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/TestUtility.cs
@@ -22,10 +22,10 @@ public static class TestUtility
         Action<MarkdownObject> verifyAST = null,
         IEnumerable<string> optionalExtensions = null)
     {
-        errors = errors ?? Array.Empty<string>();
-        tokens = tokens ?? new Dictionary<string, string>();
-        files = files ?? new Dictionary<string, string>();
-        optionalExtensions = optionalExtensions ?? new List<string>();
+        errors ??= Array.Empty<string>();
+        tokens ??= new Dictionary<string, string>();
+        files ??= new Dictionary<string, string>();
+        optionalExtensions ??= new List<string>();
 
         var actualErrors = new List<string>();
         var actualDependencies = new HashSet<string>();

--- a/test/Docfx.Plugins.Tests/TreeNavigatorTest.cs
+++ b/test/Docfx.Plugins.Tests/TreeNavigatorTest.cs
@@ -57,7 +57,7 @@ public class TreeNavigatorTest
         Assert.Equal("root", GetName(nav.Current));
     }
 
-    private TreeItem GenerateLeaf(string name)
+    private static TreeItem GenerateLeaf(string name)
     {
         return new TreeItem
         {
@@ -65,7 +65,7 @@ public class TreeNavigatorTest
         };
     }
 
-    private Dictionary<string, object> GenerateName(string name)
+    private static Dictionary<string, object> GenerateName(string name)
     {
         return new Dictionary<string, object>
         {
@@ -73,7 +73,7 @@ public class TreeNavigatorTest
         };
     }
 
-    private string GetName(TreeItem item)
+    private static string GetName(TreeItem item)
     {
         object name = null;
         if (item?.Metadata?.TryGetValue("name", out name) == true && name is string)

--- a/test/Docfx.Plugins.Tests/TreeNavigatorTest.cs
+++ b/test/Docfx.Plugins.Tests/TreeNavigatorTest.cs
@@ -75,9 +75,9 @@ public class TreeNavigatorTest
 
     private static string GetName(TreeItem item)
     {
-        if (item?.Metadata?.TryGetValue("name", out object name) == true && name is string)
+        if (item?.Metadata?.TryGetValue("name", out object name) == true && name is string value)
         {
-            return (string)name;
+            return value;
         }
 
         return null;

--- a/test/Docfx.Plugins.Tests/TreeNavigatorTest.cs
+++ b/test/Docfx.Plugins.Tests/TreeNavigatorTest.cs
@@ -75,8 +75,7 @@ public class TreeNavigatorTest
 
     private static string GetName(TreeItem item)
     {
-        object name = null;
-        if (item?.Metadata?.TryGetValue("name", out name) == true && name is string)
+        if (item?.Metadata?.TryGetValue("name", out object name) == true && name is string)
         {
             return (string)name;
         }

--- a/test/Docfx.Tests.Common/TestBase.cs
+++ b/test/Docfx.Tests.Common/TestBase.cs
@@ -42,7 +42,7 @@ public class TestBase : IClassFixture<TestBase>, IDisposable
         var folder = Path.GetRandomFileName();
         if (Directory.Exists(folder))
         {
-            folder = folder + DateTime.Now.ToString("HHmmssffff");
+            folder += DateTime.Now.ToString("HHmmssffff");
             if (Directory.Exists(folder))
             {
                 throw new InvalidOperationException($"Random folder name collides {folder}");

--- a/test/Docfx.Tests.Common/TestBase.cs
+++ b/test/Docfx.Tests.Common/TestBase.cs
@@ -8,7 +8,7 @@ namespace Docfx.Tests.Common;
 public class TestBase : IClassFixture<TestBase>, IDisposable
 {
     private readonly List<string> _folderCollection = new();
-    private object _locker = new();
+    private readonly object _locker = new();
 
     protected string GetRandomFolder()
     {

--- a/test/Docfx.Tests.Common/TestBase.cs
+++ b/test/Docfx.Tests.Common/TestBase.cs
@@ -37,7 +37,7 @@ public class TestBase : IClassFixture<TestBase>, IDisposable
         return folder;
     }
 
-    private string GetFolder()
+    private static string GetFolder()
     {
         var folder = Path.GetRandomFileName();
         if (Directory.Exists(folder))

--- a/test/docfx.Snapshot.Tests/SamplesTest.cs
+++ b/test/docfx.Snapshot.Tests/SamplesTest.cs
@@ -160,7 +160,7 @@ public class SamplesTest
             await page.CloseAsync();
         });
 
-        Task<CompareResult> CompareImage(Stream received, Stream verified, string directory, string fileName)
+        static Task<CompareResult> CompareImage(Stream received, Stream verified, string directory, string fileName)
         {
             using var receivedImage = new MagickImage(received);
             using var verifiedImage = new MagickImage(verified);

--- a/test/docfx.Snapshot.Tests/SamplesTest.cs
+++ b/test/docfx.Snapshot.Tests/SamplesTest.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Net;
 using System.Net.NetworkInformation;
 using System.Text;
 using System.Text.Encodings.Web;

--- a/test/docfx.Tests/Assets/template/plugins/CustomPostProcessor.cs
+++ b/test/docfx.Tests/Assets/template/plugins/CustomPostProcessor.cs
@@ -2,6 +2,8 @@
 using System.Composition;
 using Docfx.Plugins;
 
+namespace docfx.Tests;
+
 [Export(nameof(CustomPostProcessor), typeof(IPostProcessor))]
 public class CustomPostProcessor : IPostProcessor
 {

--- a/test/docfx.Tests/Attributes/WindowsOnlyFactAttribute.cs
+++ b/test/docfx.Tests/Attributes/WindowsOnlyFactAttribute.cs
@@ -4,22 +4,21 @@
 using System.Runtime.InteropServices;
 using Xunit;
 
-namespace docfx.Tests.Attributes
+namespace docfx.Tests.Attributes;
+
+/// <summary>
+/// XUnit Fact attribute that skips the test if the OS is not Windows.
+/// </summary>
+/// <remarks>
+/// Taken from https://github.com/dotnet/sdk/blob/a30e465a2e2ea4e2550f319a2dc088daaafe5649/src/Tests/Microsoft.NET.TestFramework/Attributes/WindowsOnlyFactAttribute.cs
+/// </remarks>
+public class WindowsOnlyFactAttribute : FactAttribute
 {
-    /// <summary>
-    /// XUnit Fact attribute that skips the test if the OS is not Windows.
-    /// </summary>
-    /// <remarks>
-    /// Taken from https://github.com/dotnet/sdk/blob/a30e465a2e2ea4e2550f319a2dc088daaafe5649/src/Tests/Microsoft.NET.TestFramework/Attributes/WindowsOnlyFactAttribute.cs
-    /// </remarks>
-    public class WindowsOnlyFactAttribute : FactAttribute
+    public WindowsOnlyFactAttribute()
     {
-        public WindowsOnlyFactAttribute()
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                Skip = "This test requires Windows to run";
-            }
+            Skip = "This test requires Windows to run";
         }
     }
 }

--- a/test/docfx.Tests/Attributes/WindowsOnlyFactAttribute.cs
+++ b/test/docfx.Tests/Attributes/WindowsOnlyFactAttribute.cs
@@ -18,7 +18,7 @@ namespace docfx.Tests.Attributes
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                this.Skip = "This test requires Windows to run";
+                Skip = "This test requires Windows to run";
             }
         }
     }

--- a/test/docfx.Tests/CompositeCommandTest.cs
+++ b/test/docfx.Tests/CompositeCommandTest.cs
@@ -15,8 +15,8 @@ public class CompositeCommandTest : TestBase
     /// <summary>
     /// Use MetadataCommand to generate YAML files from a c# project and a VB project separately
     /// </summary>
-    private string _outputFolder;
-    private string _projectFolder;
+    private readonly string _outputFolder;
+    private readonly string _projectFolder;
 
     public CompositeCommandTest()
     {

--- a/test/docfx.Tests/DocsetBuildTest.cs
+++ b/test/docfx.Tests/DocsetBuildTest.cs
@@ -240,6 +240,6 @@ public class DocsetBuildTest : TestBase
         // Test redirect page.is excluded from sitemap.
         var sitemapXml = outputs["sitemap.xml"]();
         var urls = XDocument.Parse(sitemapXml).Root.Elements();
-        Assert.True(urls.Count() == 0);
+        Assert.True(!urls.Any());
     }
 }

--- a/test/docfx.Tests/JsonConverterTest.cs
+++ b/test/docfx.Tests/JsonConverterTest.cs
@@ -58,12 +58,12 @@ public class JsonConverterTest
         FileMetadataPairs item = new(
             new List<FileMetadataPairsItem>
             {
-                new FileMetadataPairsItem("*.md", 1L),
-                new FileMetadataPairsItem("*.m", true),
-                new FileMetadataPairsItem("abc", "string"),
-                new FileMetadataPairsItem("/[]\\*.cs", new Dictionary<string, object>{ ["key"] = "2" }),
-                new FileMetadataPairsItem("*/*.cs", new object[] { "1", "2" }),
-                new FileMetadataPairsItem("**", new Dictionary<string, object>{ ["key"] = new object[] {"1", "2" } }),
+                new("*.md", 1L),
+                new("*.m", true),
+                new("abc", "string"),
+                new("/[]\\*.cs", new Dictionary<string, object>{ ["key"] = "2" }),
+                new("*/*.cs", new object[] { "1", "2" }),
+                new("**", new Dictionary<string, object>{ ["key"] = new object[] {"1", "2" } }),
             });
         var result = JsonUtility.Serialize(item);
         Assert.Equal("{\"*.md\":1,\"*.m\":true,\"abc\":\"string\",\"/[]\\\\*.cs\":{\"key\":\"2\"},\"*/*.cs\":[\"1\",\"2\"],\"**\":{\"key\":[\"1\",\"2\"]}}", result);

--- a/test/docfx.Tests/JsonConverterTest.cs
+++ b/test/docfx.Tests/JsonConverterTest.cs
@@ -40,7 +40,7 @@ public class JsonConverterTest
 
         BuildJsonConfig buildOptions = JsonConvert.DeserializeObject<BuildJsonConfig>(jsonString);
 
-        Assert.Equal(7, buildOptions.GlobalMetadata.Count());
+        Assert.Equal(7, buildOptions.GlobalMetadata.Count);
 
         JsonSerializerSettings settings = new()
         {

--- a/test/docfx.Tests/JsonConverterTest.cs
+++ b/test/docfx.Tests/JsonConverterTest.cs
@@ -154,7 +154,7 @@ internal class SkipEmptyOrNullContractResolver : DefaultContractResolver
         {
             bool newShouldSerialize(object obj)
             {
-                return !(property.ValueProvider.GetValue(obj) is ICollection collection) || collection.Count != 0;
+                return property.ValueProvider.GetValue(obj) is not ICollection collection || collection.Count != 0;
             }
             Predicate<object> oldShouldSerialize = property.ShouldSerialize;
             property.ShouldSerialize = oldShouldSerialize != null

--- a/test/docfx.Tests/JsonConverterTest.cs
+++ b/test/docfx.Tests/JsonConverterTest.cs
@@ -152,10 +152,10 @@ internal class SkipEmptyOrNullContractResolver : DefaultContractResolver
             && !typeof(string).IsAssignableFrom(property.PropertyType)
             && typeof(IEnumerable).IsAssignableFrom(property.PropertyType))
         {
-            Predicate<object> newShouldSerialize = obj =>
+            bool newShouldSerialize(object obj)
             {
                 return !(property.ValueProvider.GetValue(obj) is ICollection collection) || collection.Count != 0;
-            };
+            }
             Predicate<object> oldShouldSerialize = property.ShouldSerialize;
             property.ShouldSerialize = oldShouldSerialize != null
                 ? o => oldShouldSerialize(o) && newShouldSerialize(o)

--- a/test/docfx.Tests/JsonConverterTest.cs
+++ b/test/docfx.Tests/JsonConverterTest.cs
@@ -6,7 +6,6 @@ using System.Reflection;
 using Docfx.Common;
 using Docfx.Plugins;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using Xunit;
 

--- a/test/docfx.Tests/MetadataCommandTest.cs
+++ b/test/docfx.Tests/MetadataCommandTest.cs
@@ -4,7 +4,6 @@
 using Docfx.Common;
 using Docfx.DataContracts.Common;
 using Docfx.DataContracts.ManagedReference;
-using Docfx.Dotnet;
 using Docfx.Tests.Common;
 using Xunit;
 

--- a/test/docfx.Tests/MetadataCommandTest.cs
+++ b/test/docfx.Tests/MetadataCommandTest.cs
@@ -15,8 +15,8 @@ public class MetadataCommandTest : TestBase
     /// <summary>
     /// Use MetadataCommand to generate YAML files from a c# project and a VB project separately
     /// </summary>
-    private string _outputFolder;
-    private string _projectFolder;
+    private readonly string _outputFolder;
+    private readonly string _projectFolder;
 
     public MetadataCommandTest()
     {


### PR DESCRIPTION
This PR aims to resolve some part of #9207 that can be fixed by Visual Studio's code fixer and handled with small code modifications.

Please review If there are changes that contains undesirable code changes.
Then I'll remove that changes.

| ID      |   Commit                                                                        | Description         |
|---------|---------------------------------------------------------------------------------|---------------------|
| CA1018  | https://github.com/dotnet/docfx/commit/51bbfa817dade6de2a7c645676ac7fd1091bc27e | [CA1018: Mark attributes with AttributeUsageAttribute](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1018)
| CA1041  | https://github.com/dotnet/docfx/commit/b614c9ece703a870d69a2f1e47d62d50ec09f1d3 | [CA1041: Provide ObsoleteAttribute message](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1041)
| CA1050  | https://github.com/dotnet/docfx/commit/c0f8515a3e1d6a89f837b1d866aadcf1f52eba7b | [CA1050: Declare types in namespaces](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1050)
| CA1507  | https://github.com/dotnet/docfx/commit/4dc6426de52f016db6b8f6e687e30289dfcf3d4d | [CA1507: Use nameof in place of string](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1507)
| CA1822  | https://github.com/dotnet/docfx/commit/591c6ed9a48e139ec6ad342273dfa21b759417b9 | [CA1822: Mark members as static](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1822)
| CA1825  | https://github.com/dotnet/docfx/commit/80d6c10c0aa15c15339e908db5e515543ba41372 | [CA1825: Avoid zero-length array allocations](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1825)
| CA1827  | https://github.com/dotnet/docfx/commit/a44bc8d9ed267754d820bd25acd5446c3521a7ab | [CA1827: Do not use Count()/LongCount() when Any() can be used](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1827)
| CA1829  | https://github.com/dotnet/docfx/commit/e758c9f620198e2a99510c66bb86a3bf0c08dbbe | [CA1829: Use Length/Count property instead of Enumerable.Count method](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1829)
| CA1830  | https://github.com/dotnet/docfx/commit/027807a722eaa2407e7375053661b4f3388bd4b9 | [CA1830: Prefer strongly-typed Append and Insert method overloads on StringBuilder](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1830)
| CA1834  | https://github.com/dotnet/docfx/commit/254d17291edc004ebcdae53232c713558a689327 | [CA1834: Use StringBuilder.Append(char) for single character strings](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1834)
| CA1836  | https://github.com/dotnet/docfx/commit/cac85d0348835fc52e33ba51db611a17614bc00c | [CA1836: Prefer IsEmpty over Count when available](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1836)
| CA1841  | https://github.com/dotnet/docfx/commit/27c0251cf3c771d25845285b82f30fc6164b91fc | [CA1841: Prefer Dictionary Contains methods](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1841)
| CA1846  | https://github.com/dotnet/docfx/commit/c78479944eaa19117abc8636292e497bedc6a7ad | [CA1846: Prefer AsSpan over Substring](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1846)
| CA1847  | https://github.com/dotnet/docfx/commit/cf3f1d47fd6d2a50a98851d014270eb677c9cf19 | [CA1847: Use string.Contains(char) instead of string.Contains(string) with single characters](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1847)
| CA1850  | https://github.com/dotnet/docfx/commit/12383b50cdc186f01545d475495b4ad1971ffb33 | [CA1850: Prefer static HashData method over ComputeHash](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1850)
| CA2208  | https://github.com/dotnet/docfx/commit/f7e57cd08554f6dc9c39516addf414b08e160d14 | [CA2208: Instantiate argument exceptions correctly](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/CA2208)
| CA2249  | https://github.com/dotnet/docfx/commit/fbbb5a1e32450f380edc3cc6e06758c3482a0694 | [CA2249: Consider using String.Contains instead of String.IndexOf](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2249)

| ID      | Commit                                                                          | Description         |
|---------|---------------------------------------------------------------------------------|---------------------|
| IDE0001 | https://github.com/dotnet/docfx/commit/99e2d8e0d28a28e0da5cbeb32f5c457e033c9eb5 | [Simplify name (IDE0001)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0001)
| IDE0002 | https://github.com/dotnet/docfx/commit/36242f158fc7be89ca076209535db26d078bfbe2 | [Simplify member access (IDE0002)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0002)
| IDE0003 | https://github.com/dotnet/docfx/commit/1df792525c104869b29539442dd138cab9449044 | [this preferences (IDE0003)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0003-ide0009)
| IDE0004 | https://github.com/dotnet/docfx/commit/073f67596a142d88ff798c74a62ee879f8218412 | [Remove unnecessary cast (IDE0004)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0004)
| IDE0005 | https://github.com/dotnet/docfx/commit/0fe71592c6d3b0c187dfbf92a67badb5e275ad74 | [Remove unnecessary using directives (IDE0005)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0005)
| IDE0007/IDE0008 | https://github.com/dotnet/docfx/commit/09181f4e84c9660cfdac9cced1e40562b4eaf645 | ['var' preferences (IDE0007 and IDE0008)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0007-ide0008)
| IDE0017 | https://github.com/dotnet/docfx/commit/27c2b045aba636cc206a0b866760039425ba7e28 | [Use object initializers (IDE0017)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0017)
| IDE0018 | https://github.com/dotnet/docfx/commit/6e57632d299436c9eb00f8bb881c51ca62a10bbf | [Inline variable declaration (IDE0018)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0018)
| IDE0019 | https://github.com/dotnet/docfx/commit/3b86b47f28bbe694a3bc57885ba53fe0942f6ed4 | [Use pattern matching to avoid 'as' followed by a 'null' check (IDE0019)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0019)
| IDE0029 | https://github.com/dotnet/docfx/commit/9dd355c05418f4d34fcbdd846954469787adbc1d | [Null check can be simplified (IDE0029)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0029-ide0030-ide0270)
| IDE0031 | https://github.com/dotnet/docfx/commit/22175e897f1e6482e29eb74320bae368272b2338 | [Use null propagation (IDE0031)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0031)
| IDE0034 | https://github.com/dotnet/docfx/commit/7523e16fc2c5f22cb4bec3ec17a84581137aa1e3 | [Simplify 'default' expression (IDE0034)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0034)
| IDE0036 | https://github.com/dotnet/docfx/commit/65da193d5dedba274dc34798f2d02321af5e7760 | [Order modifiers (IDE0036)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0036)
| IDE0038 | https://github.com/dotnet/docfx/commit/5f19db3a211a913d4b2be36a62e04235c4772568 | [Use pattern matching to avoid 'is' check followed by a cast (IDE0038)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0020-ide0038)
| IDE0039 | https://github.com/dotnet/docfx/commit/8446077eff9c54ba03c15218be9e2d375a9753d2 | [Use local function instead of lambda (IDE0039)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0039)
| IDE0041 | https://github.com/dotnet/docfx/commit/2ce102af31848cbe924d862a6f8f0397062dd670 | [Use 'is null' check (IDE0041)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0041)
| IDE0044 | https://github.com/dotnet/docfx/commit/a661ac1d0a2ae199026dac2b3366cd2c94c82f04 | [Add readonly modifier (IDE0044)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0044)
| IDE0049 | https://github.com/dotnet/docfx/commit/1bf1a9bbd66349ef9089ba5b26ffa18a2c1b290b | [Use language keywords instead of framework type names for type references (IDE0049)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0049)
| IDE0054 | https://github.com/dotnet/docfx/commit/99585f56e0afb38425c8ee54841323978f43fd13 | [Use compound assignment (IDE0054 and IDE0074)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0054-ide0074)
| IDE0058 | https://github.com/dotnet/docfx/commit/a425568b1d089379313714b2f378175228020b23 | [Remove unnecessary expression value (IDE0058)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0058) (For test projects)
| IDE0059 | https://github.com/dotnet/docfx/commit/f43c8621a18cb297ac8b0fd2d5d71b505ca66e8e | [Remove unnecessary value assignment (IDE0059)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0059) (For test projects)
| IDE0062 | https://github.com/dotnet/docfx/commit/3597d7a2c2f48440d9abe1ecd3c8c00b5ee99196 | [Make local function static (IDE0062)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0062)
| IDE0065 | https://github.com/dotnet/docfx/commit/c246e9e587660f50de422b413ff5c43bf7c8c677 | ['using' directive placement (IDE0065)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0065)
| IDE0071 | https://github.com/dotnet/docfx/commit/16686526f2ece55259238eeb70fe4b3ce4c8adc6 | [Simplify interpolation (IDE0071)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0071)
| IDE0079 | https://github.com/dotnet/docfx/commit/bcef7fce811a2a2b090c96d6bd38ec69d6706daa | [Remove unnecessary suppression (IDE0079)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0079)
| IDE0083 | https://github.com/dotnet/docfx/commit/f302cc6970bc15d62ea63b4d91fb9fa4c6e9bd57 | [Use pattern matching (not operator) (IDE0083)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0083)
| IDE0090 | https://github.com/dotnet/docfx/commit/22e4c7a65b922613b369a2e5462ebaef29781cdf | [Simplify new expression (IDE0090)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0090)
| IDE0110 | https://github.com/dotnet/docfx/commit/82511bff6f116b3b3fe8ea3e4898cca2e458bb6f | [Remove unnecessary discard (IDE0110)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0110)
| IDE0161 | https://github.com/dotnet/docfx/commit/e10d1d5e47fbc27b71baa1c3843d0cde498b3334 | [Namespace declaration preferences (IDE0160 and IDE0161)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0160-ide0161)
| IDE0200 | https://github.com/dotnet/docfx/commit/5e3df45818af8a331f3bfe82eb11fa348dc0449b | [Remove unnecessary lambda expression (IDE0200)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0200)
| IDE1006 | https://github.com/dotnet/docfx/commit/584c5ecc89db647e40dd9c2c06a8cda3d5420802 | Naming rules for static/internal/private fields


**TODO:**
Following tasks will be handled  by another PR.
- Suppress other code that require some code modification.
- Change resolved analyzer rules level from suggestion to warning.
- Try to using [more strict analyzer level](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview?tabs=net-7#enable-additional-rules) (`Default` -> `Recommended`) 
- Apply C#12 specific code analyzer rules. (It needs be compiled when targeting .NET 6 SDK)