### PR TITLE
feat: add overridable metadata output json config

### DIFF
--- a/docs/reference/docfx-json-reference.md
+++ b/docs/reference/docfx-json-reference.md
@@ -295,9 +295,13 @@ Configuration options that are applied for `docfx metadata` command:
 
 Specifies the source projects using [File Mappings](#file-mappings).
 
+### `output`
+
+Defines the output folder of the generated metadata files relative to `docfx.json` directory. The `docfx metadata --output <outdir>` command line argument overrides this value.
+
 ### `dest`
 
-Defines the output folder of the generated metadata files. Relative paths are relative to the docfx.json file being used. To go up a folder use `../`.
+Defines the output folder of the generated metadata files relative to `docfx.json` directory.  The `docfx metadata --output <outdir>` command line argument prepends this value.
 
 ### `shouldSkipMarkup`
 

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -1,5 +1,10 @@
 <Project>
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <!--
+      Suppress warnings similar to the following:
+          warning NU1507: There are 2 package sources defined in your configuration.
+     -->
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
 </Project>

--- a/samples/seed/docfx.json
+++ b/samples/seed/docfx.json
@@ -18,7 +18,7 @@
       ],
       "namespaceLayout": "nested",
       "enumSortOrder": "declaringOrder",
-      "dest": "obj/api"
+      "output": "obj/api"
     }
   ],
   "build": {

--- a/src/Docfx.App/Config/BuildJsonConfig.cs
+++ b/src/Docfx.App/Config/BuildJsonConfig.cs
@@ -41,6 +41,7 @@ internal class BuildJsonConfig
 
     /// <summary>
     /// Defines the output folder of the generated build files.
+    /// Command line --output argument prepends this value.
     /// </summary>
     [Obsolete("Use output instead.")]
     [JsonProperty("dest")]
@@ -48,6 +49,7 @@ internal class BuildJsonConfig
 
     /// <summary>
     /// Defines the output folder of the generated build files.
+    /// Command line --output argument override this value.
     /// </summary>
     [JsonProperty("output")]
     public string Output { get; set; }

--- a/src/Docfx.Dotnet/DotnetApiCatalog.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.cs
@@ -68,7 +68,7 @@ public static class DotnetApiCatalog
                     EnvironmentContext.SetGitFeaturesDisabled(item.DisableGitFeatures);
 
                     // TODO: Use plugin to generate metadata for files with different extension?
-                    using var worker = new ExtractMetadataWorker(ConvertConfig(item, outputDirectory ?? configDirectory), options);
+                    using var worker = new ExtractMetadataWorker(ConvertConfig(item, configDirectory, outputDirectory), options);
                     await worker.ExtractMetadataAsync();
                 }
 
@@ -103,11 +103,10 @@ public static class DotnetApiCatalog
         }
     }
 
-    private static ExtractMetadataConfig ConvertConfig(MetadataJsonItemConfig configModel, string outputDirectory)
+    private static ExtractMetadataConfig ConvertConfig(MetadataJsonItemConfig configModel, string configDirectory, string outputDirectory)
     {
         var projects = configModel.Source;
         var references = configModel.References;
-        var outputFolder = configModel.Destination ?? "_api";
 
         var expandedFiles = GlobUtility.ExpandFileMapping(EnvironmentContext.BaseDirectory, projects);
         var expandedReferences = GlobUtility.ExpandFileMapping(EnvironmentContext.BaseDirectory, references);
@@ -120,7 +119,7 @@ public static class DotnetApiCatalog
             GlobalNamespaceId = configModel?.GlobalNamespaceId,
             MSBuildProperties = configModel?.MSBuildProperties,
             OutputFormat = configModel?.OutputFormat ?? default,
-            OutputFolder = Path.GetFullPath(Path.Combine(outputDirectory, outputFolder)),
+            OutputFolder = Path.GetFullPath(Path.Combine(configDirectory, outputDirectory ?? configModel.Output ?? "", configModel.Destination ?? "")),
             CodeSourceBasePath = configModel?.CodeSourceBasePath,
             DisableDefaultFilter = configModel?.DisableDefaultFilter ?? false,
             NoRestore = configModel?.NoRestore ?? false,

--- a/src/Docfx.Dotnet/DotnetApiCatalog.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.cs
@@ -108,6 +108,10 @@ public static class DotnetApiCatalog
         var projects = configModel.Source;
         var references = configModel.References;
 
+        var outputFolder = Path.GetFullPath(Path.Combine(
+            string.IsNullOrEmpty(outputDirectory) ? Path.Combine(configDirectory, configModel.Output ?? "") : outputDirectory,
+            configModel.Destination ?? ""));
+
         var expandedFiles = GlobUtility.ExpandFileMapping(EnvironmentContext.BaseDirectory, projects);
         var expandedReferences = GlobUtility.ExpandFileMapping(EnvironmentContext.BaseDirectory, references);
 
@@ -119,7 +123,7 @@ public static class DotnetApiCatalog
             GlobalNamespaceId = configModel?.GlobalNamespaceId,
             MSBuildProperties = configModel?.MSBuildProperties,
             OutputFormat = configModel?.OutputFormat ?? default,
-            OutputFolder = Path.GetFullPath(Path.Combine(configDirectory, outputDirectory ?? configModel.Output ?? "", configModel.Destination ?? "")),
+            OutputFolder = outputFolder,
             CodeSourceBasePath = configModel?.CodeSourceBasePath,
             DisableDefaultFilter = configModel?.DisableDefaultFilter ?? false,
             NoRestore = configModel?.NoRestore ?? false,

--- a/src/Docfx.Dotnet/MetadataJsonConfig.cs
+++ b/src/Docfx.Dotnet/MetadataJsonConfig.cs
@@ -83,9 +83,17 @@ internal class MetadataJsonItemConfig
 
     /// <summary>
     /// Defines the output folder of the generated metadata files.
+    /// Command line --output argument prepends this value.
     /// </summary>
     [JsonProperty("dest")]
     public string Destination { get; set; }
+
+    /// <summary>
+    /// Defines the output folder of the generated metadata files.
+    /// Command line --output argument override this value.
+    /// </summary>
+    [JsonProperty("output")]
+    public string Output { get; set; }
 
     /// <summary>
     /// Defines the output file format.

--- a/test/docfx.Snapshot.Tests/SamplesTest.cs
+++ b/test/docfx.Snapshot.Tests/SamplesTest.cs
@@ -180,15 +180,16 @@ public class SamplesTest
         }
     }
 
-    [SnapshotFact]
+    [Fact]
     public async Task SeedMarkdown()
     {
         var samplePath = $"{s_samplesDir}/seed";
+        var outputPath = nameof(SeedMarkdown);
         Clean(samplePath);
 
-        Program.Main(new[] { "metadata", $"{samplePath}/docfx.json", "--outputFormat", "markdown", "--output", nameof(SeedMarkdown) });
+        Program.Main(new[] { "metadata", $"{samplePath}/docfx.json", "--outputFormat", "markdown", "--output", outputPath });
 
-        await VerifyDirectory($"{nameof(SeedMarkdown)}", IncludeFile, fileScrubber: ScrubFile).AutoVerify(includeBuildServer: false);
+        await VerifyDirectory(outputPath, IncludeFile, fileScrubber: ScrubFile).AutoVerify(includeBuildServer: false);
     }
 
     [SnapshotFact]

--- a/test/docfx.Snapshot.Tests/SamplesTest.cs
+++ b/test/docfx.Snapshot.Tests/SamplesTest.cs
@@ -188,7 +188,7 @@ public class SamplesTest
 
         Program.Main(new[] { "metadata", $"{samplePath}/docfx.json", "--outputFormat", "markdown", "--output", nameof(SeedMarkdown) });
 
-        await VerifyDirectory($"{nameof(SeedMarkdown)}/obj/api", IncludeFile, fileScrubber: ScrubFile).AutoVerify(includeBuildServer: false);
+        await VerifyDirectory($"{nameof(SeedMarkdown)}", IncludeFile, fileScrubber: ScrubFile).AutoVerify(includeBuildServer: false);
     }
 
     [SnapshotFact]


### PR DESCRIPTION
Similar to `build --output <outdir>`, `metadata --output <outdir>` overrides the new `output` property in `docfx.json`:

```json
{
  "metadata": [
    {
      "output": "api"
    }
  ],
}
```