### PR TITLE
feat: support multiple search languages

### DIFF
--- a/templates/modern/src/options.d.ts
+++ b/templates/modern/src/options.d.ts
@@ -36,6 +36,9 @@ export type DocfxOptions = {
   /** Configures mermaid diagram options */
   mermaid?: MermaidConfig,
 
+  /** A list of [lunr languages](https://github.com/MihaiValentin/lunr-languages#readme) such as fr, es for full text search */
+  lunrLanguages?: string[],
+
   /** Configures [hightlight.js](https://highlightjs.org/) */
   configureHljs?: (hljs: HLJSApi) => void,
 

--- a/templates/modern/src/search-worker.ts
+++ b/templates/modern/src/search-worker.ts
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import lunr from 'lunr'
+import stemmer from 'lunr-languages/lunr.stemmer.support'
+import multi from 'lunr-languages/lunr.multi'
 import { get, set, createStore } from 'idb-keyval'
 
 type SearchHit = {
@@ -31,14 +33,25 @@ async function loadIndexCore() {
     }
   }
 
-  const { configureLunr } = await import('./main.js').then(m => m.default) as DocfxOptions
+  const { lunrLanguages, configureLunr } = await import('./main.js').then(m => m.default) as DocfxOptions
+
+  if (lunrLanguages && lunrLanguages.length > 0) {
+    multi(lunr)
+    stemmer(lunr)
+    await Promise.all(lunrLanguages.map(initLanguage))
+  }
 
   const index = lunr(function() {
+    lunr.tokenizer.separator = /[\s\-.()]+/
+
     this.ref('href')
     this.field('title', { boost: 50 })
     this.field('keywords', { boost: 20 })
 
-    lunr.tokenizer.separator = /[\s\-.()]+/
+    if (lunrLanguages && lunrLanguages.length > 0) {
+      this.use(lunr.multiLanguage(...lunrLanguages))
+    }
+
     configureLunr?.(this)
 
     for (const key in data) {
@@ -58,5 +71,47 @@ loadIndex().catch(console.error)
 onmessage = function(e) {
   if (search) {
     postMessage({ e: 'query-ready', d: search(e.data.q) })
+  }
+}
+
+const langMap = {
+  ar: () => import('lunr-languages/lunr.ar.js'),
+  da: () => import('lunr-languages/lunr.da.js'),
+  de: () => import('lunr-languages/lunr.de.js'),
+  du: () => import('lunr-languages/lunr.du.js'),
+  el: () => import('lunr-languages/lunr.el.js'),
+  es: () => import('lunr-languages/lunr.es.js'),
+  fi: () => import('lunr-languages/lunr.fi.js'),
+  fr: () => import('lunr-languages/lunr.fr.js'),
+  he: () => import('lunr-languages/lunr.he.js'),
+  hi: () => import('lunr-languages/lunr.hi.js'),
+  hu: () => import('lunr-languages/lunr.hu.js'),
+  hy: () => import('lunr-languages/lunr.hy.js'),
+  it: () => import('lunr-languages/lunr.it.js'),
+  ja: () => import('lunr-languages/lunr.ja.js'),
+  jp: () => import('lunr-languages/lunr.jp.js'),
+  kn: () => import('lunr-languages/lunr.kn.js'),
+  ko: () => import('lunr-languages/lunr.ko.js'),
+  nl: () => import('lunr-languages/lunr.nl.js'),
+  no: () => import('lunr-languages/lunr.no.js'),
+  pt: () => import('lunr-languages/lunr.pt.js'),
+  ro: () => import('lunr-languages/lunr.ro.js'),
+  ru: () => import('lunr-languages/lunr.ru.js'),
+  sa: () => import('lunr-languages/lunr.sa.js'),
+  sv: () => import('lunr-languages/lunr.sv.js'),
+  ta: () => import('lunr-languages/lunr.ta.js'),
+  te: () => import('lunr-languages/lunr.te.js'),
+  th: () => import('lunr-languages/lunr.th.js'),
+  tr: () => import('lunr-languages/lunr.tr.js'),
+  vi: () => import('lunr-languages/lunr.vi.js')
+
+  // zh is currently not supported due to dependency on NodeJS.
+  // zh: () => import('lunr-languages/lunr.zh.js')
+}
+
+async function initLanguage(lang: string) {
+  if (lang !== 'en') {
+    const { default: init } = await langMap[lang]()
+    init(lunr)
   }
 }

--- a/templates/package-lock.json
+++ b/templates/package-lock.json
@@ -25,6 +25,7 @@
         "jquery": "3.7.0",
         "lit-html": "^3.0.0",
         "lunr": "2.3.9",
+        "lunr-languages": "^1.14.0",
         "mathjax": "^3.2.2",
         "mermaid": "^10.5.0"
       },
@@ -7083,6 +7084,11 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
+    },
+    "node_modules/lunr-languages": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/lunr-languages/-/lunr-languages-1.14.0.tgz",
+      "integrity": "sha512-hWUAb2KqM3L7J5bcrngszzISY4BxrXn/Xhbb9TTCJYEGqlR1nG67/M14sp09+PTIRklobrn57IAxcdcO/ZFyNA=="
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
@@ -15452,6 +15458,11 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
+    },
+    "lunr-languages": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/lunr-languages/-/lunr-languages-1.14.0.tgz",
+      "integrity": "sha512-hWUAb2KqM3L7J5bcrngszzISY4BxrXn/Xhbb9TTCJYEGqlR1nG67/M14sp09+PTIRklobrn57IAxcdcO/ZFyNA=="
     },
     "make-dir": {
       "version": "4.0.0",

--- a/templates/package.json
+++ b/templates/package.json
@@ -34,6 +34,7 @@
     "jquery": "3.7.0",
     "lit-html": "^3.0.0",
     "lunr": "2.3.9",
+    "lunr-languages": "^1.14.0",
     "mathjax": "^3.2.2",
     "mermaid": "^10.5.0"
   },


### PR DESCRIPTION
Supports additional search locales through the `lunrLanguages` config in `main.js`

Supports all locales in [lunr-languages](https://github.com/MihaiValentin/lunr-languages) except for `zh` due to dependency on NodeJS.

#8830