### PR TITLE
Adds expander class to modern theme TOC <li> elements with children

### DIFF
--- a/templates/modern/src/toc.ts
+++ b/templates/modern/src/toc.ts
@@ -114,7 +114,7 @@ export async function renderToc(): Promise<TocNode[]> {
       const isExpanded = (tocFilter !== '' && expanded !== false && children != null) || expanded === true
 
       return html`
-        <li class=${classMap({ expanded: isExpanded, active: activeNodes.includes(node) })}>
+        <li class=${classMap({ expander: !isLeaf, expanded: isExpanded, active: activeNodes.includes(node) })}>
           ${isLeaf ? null : html`<span class='expand-stub' @click=${toggleExpand}></span>`}
           ${dom}
           ${children}


### PR DESCRIPTION
Adds `expander` class to modern theme TOC `<li>` elements with children to allow for additional styling via CSS.