### PR TITLE
fix: Remove SVG hover fill

### DIFF
--- a/templates/default/styles/docfx.css
+++ b/templates/default/styles/docfx.css
@@ -111,10 +111,6 @@ span.languagekeyword{
     font-weight: bold;
 }
 
-svg:hover path {
-    fill: #ffffff;
-}
-
 .hljs {
   display: inline;
   background-color: inherit;


### PR DESCRIPTION
This causes our company logo to turn white on hover: https://docs.unity3d.com/Packages/com.unity.render-pipelines.high-definition@12.1/api/UnityEngine.Rendering.HighDefinition.AmbientOcclusion.html

Our logo:
<img width="113" alt="image" src="https://github.com/dotnet/docfx/assets/28865984/cfdb85c3-f2de-49f3-a6d6-d31d49ee62b4">

Our logo with hover state:
![image](https://github.com/dotnet/docfx/assets/28865984/944286a7-7583-44b1-a4e8-90d405768bb4)

It's difficult to remove this fill by using main.css in a custom template.
