### PR TITLE
chore: add System.Text.Json attributes

### DIFF
--- a/src/Docfx.App/Config/BuildJsonConfig.cs
+++ b/src/Docfx.App/Config/BuildJsonConfig.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.Common;
 using Docfx.Plugins;
 
@@ -18,24 +19,28 @@ internal class BuildJsonConfig
     /// Contains all the files to generate documentation, including metadata yml files and conceptual md files.
     /// </summary>
     [JsonProperty("content")]
+    [JsonPropertyName("content")]
     public FileMapping Content { get; set; }
 
     /// <summary>
     /// Contains all the resource files that conceptual and metadata files dependent on, e.g. image files.
     /// </summary>
     [JsonProperty("resource")]
+    [JsonPropertyName("resource")]
     public FileMapping Resource { get; set; }
 
     /// <summary>
     /// Contains all the conceptual files which contains yaml header with uid and is intended to override the existing metadata yml files.
     /// </summary>
     [JsonProperty("overwrite")]
+    [JsonPropertyName("overwrite")]
     public FileMapping Overwrite { get; set; }
 
     /// <summary>
     /// Specifies the urls of xrefmap used by content files. Supports local file path and HTTP/HTTPS urls.
     /// </summary>
     [JsonProperty("xref")]
+    [JsonPropertyName("xref")]
     public ListWithStringFallback Xref { get; set; }
 
     /// <summary>
@@ -44,6 +49,7 @@ internal class BuildJsonConfig
     /// </summary>
     [Obsolete("Use output instead.")]
     [JsonProperty("dest")]
+    [JsonPropertyName("dest")]
     public string Dest { get; set; }
 
     /// <summary>
@@ -51,12 +57,14 @@ internal class BuildJsonConfig
     /// Command line --output argument override this value.
     /// </summary>
     [JsonProperty("output")]
+    [JsonPropertyName("output")]
     public string Output { get; set; }
 
     /// <summary>
     /// Contains metadata that will be applied to every file, in key-value pair format.
     /// </summary>
     [JsonProperty("globalMetadata")]
+    [JsonPropertyName("globalMetadata")]
     [Newtonsoft.Json.JsonConverter(typeof(JObjectDictionaryToObjectDictionaryConverter))]
     public Dictionary<string, object> GlobalMetadata { get; set; }
 
@@ -64,6 +72,7 @@ internal class BuildJsonConfig
     /// Specify a list of JSON file path containing globalMetadata settings.
     /// </summary>
     [JsonProperty("globalMetadataFiles")]
+    [JsonPropertyName("globalMetadataFiles")]
     public ListWithStringFallback GlobalMetadataFiles { get; set; } = new ListWithStringFallback();
 
     /// <summary>
@@ -74,12 +83,14 @@ internal class BuildJsonConfig
     ///     The value is the value of the metadata.
     /// </summary>
     [JsonProperty("fileMetadata")]
+    [JsonPropertyName("fileMetadata")]
     public Dictionary<string, FileMetadataPairs> FileMetadata { get; set; }
 
     /// <summary>
     /// Specify a list of JSON file path containing fileMetadata settings.
     /// </summary>
     [JsonProperty("fileMetadataFiles")]
+    [JsonPropertyName("fileMetadataFiles")]
     public ListWithStringFallback FileMetadataFiles { get; set; } = new ListWithStringFallback();
 
     /// <summary>
@@ -88,6 +99,7 @@ internal class BuildJsonConfig
     /// If omitted, embedded default template will be used.
     /// </summary>
     [JsonProperty("template")]
+    [JsonPropertyName("template")]
     public ListWithStringFallback Template { get; set; } = new ListWithStringFallback();
 
     /// <summary>
@@ -98,6 +110,7 @@ internal class BuildJsonConfig
     /// If omitted, no theme will be applied, the default theme inside the template will be used.
     /// </summary>
     [JsonProperty("theme")]
+    [JsonPropertyName("theme")]
     public ListWithStringFallback Theme { get; set; }
 
     /// <summary>
@@ -110,6 +123,7 @@ internal class BuildJsonConfig
     ///  </code>
     ///  </example>
     [JsonProperty("postProcessors")]
+    [JsonPropertyName("postProcessors")]
     public ListWithStringFallback PostProcessors { get; set; } = new ListWithStringFallback();
 
     /// <summary>
@@ -118,6 +132,7 @@ internal class BuildJsonConfig
     /// If not specified, it is false
     /// </summary>
     [JsonProperty("debug")]
+    [JsonPropertyName("debug")]
     public bool? Debug { get; set; }
 
     /// <summary>
@@ -125,12 +140,14 @@ internal class BuildJsonConfig
     /// If not specified, it is ${TempPath}/docfx
     /// </summary>
     [JsonProperty("debugOutput")]
+    [JsonPropertyName("debugOutput")]
     public string DebugOutput { get; set; }
 
     /// <summary>
     /// If set to true, data model to run template script will be extracted in .raw.model.json extension.
     /// </summary>
     [JsonProperty("exportRawModel")]
+    [JsonPropertyName("exportRawModel")]
     public bool? ExportRawModel { get; set; }
 
     /// <summary>
@@ -138,12 +155,14 @@ internal class BuildJsonConfig
     /// If not set, the raw model will be generated to the same folder as the output documentation.
     /// </summary>
     [JsonProperty("rawModelOutputFolder")]
+    [JsonPropertyName("rawModelOutputFolder")]
     public string RawModelOutputFolder { get; set; }
 
     /// <summary>
     /// If set to true, data model to apply template will be extracted in .view.model.json extension.
     /// </summary>
     [JsonProperty("exportViewModel")]
+    [JsonPropertyName("exportViewModel")]
     public bool? ExportViewModel { get; set; }
 
     /// <summary>
@@ -151,6 +170,7 @@ internal class BuildJsonConfig
     /// If not set, the view model will be generated to the same folder as the output documentation.
     /// </summary>
     [JsonProperty("viewModelOutputFolder")]
+    [JsonPropertyName("viewModelOutputFolder")]
     public string ViewModelOutputFolder { get; set; }
 
     /// <summary>
@@ -158,24 +178,28 @@ internal class BuildJsonConfig
     /// This option is always used with --exportRawModel or --exportViewModel is set so that only raw model files or view model files are generated.
     /// </summary>
     [JsonProperty("dryRun")]
+    [JsonPropertyName("dryRun")]
     public bool? DryRun { get; set; }
 
     /// <summary>
     /// Set the max parallelism, 0 is auto.
     /// </summary>
     [JsonProperty("maxParallelism")]
+    [JsonPropertyName("maxParallelism")]
     public int? MaxParallelism { get; set; }
 
     /// <summary>
     /// Set the parameters for markdown engine, value should be a JSON string.
     /// </summary>
     [JsonProperty("markdownEngineProperties")]
+    [JsonPropertyName("markdownEngineProperties")]
     public MarkdownServiceProperties MarkdownEngineProperties { get; set; }
 
     /// <summary>
     /// Set the name of ICustomHrefGenerator derived class.
     /// </summary>
     [JsonProperty("customLinkResolver")]
+    [JsonPropertyName("customLinkResolver")]
     public string CustomLinkResolver { get; set; }
 
     /// <summary>
@@ -192,6 +216,7 @@ internal class BuildJsonConfig
     /// </code>
     /// </example>
     [JsonProperty("groups")]
+    [JsonPropertyName("groups")]
     public Dictionary<string, GroupConfig> Groups { get; set; }
 
     /// <summary>
@@ -199,12 +224,14 @@ internal class BuildJsonConfig
     /// Instead, it saves a link_to_path property inside manifest.json to indicate the physical location of that file.
     /// </summary>
     [JsonProperty("keepFileLink")]
+    [JsonPropertyName("keepFileLink")]
     public bool KeepFileLink { get; set; }
 
     /// <summary>
     /// Specifies the options for the sitemap.xml file.
     /// </summary>
     [JsonProperty("sitemap")]
+    [JsonPropertyName("sitemap")]
     public SitemapOptions Sitemap { get; set; }
 
     /// <summary>
@@ -212,5 +239,6 @@ internal class BuildJsonConfig
     /// By default it is enabled and may have side effect on performance when the repo is large.
     /// </summary>
     [JsonProperty("disableGitFeatures")]
+    [JsonPropertyName("disableGitFeatures")]
     public bool DisableGitFeatures { get; set; }
 }

--- a/src/Docfx.App/Config/BuildJsonConfig.cs
+++ b/src/Docfx.App/Config/BuildJsonConfig.cs
@@ -57,7 +57,7 @@ internal class BuildJsonConfig
     /// Contains metadata that will be applied to every file, in key-value pair format.
     /// </summary>
     [JsonProperty("globalMetadata")]
-    [JsonConverter(typeof(JObjectDictionaryToObjectDictionaryConverter))]
+    [Newtonsoft.Json.JsonConverter(typeof(JObjectDictionaryToObjectDictionaryConverter))]
     public Dictionary<string, object> GlobalMetadata { get; set; }
 
     /// <summary>

--- a/src/Docfx.App/Config/FileMetadataPairs.cs
+++ b/src/Docfx.App/Config/FileMetadataPairs.cs
@@ -10,7 +10,7 @@ namespace Docfx;
 /// </summary>
 /// <see cref="BuildJsonConfig.FileMetadata"/>
 /// <see cref="MergeJsonItemConfig.FileMetadata"/>
-[JsonConverter(typeof(FileMetadataPairsConverter))]
+[Newtonsoft.Json.JsonConverter(typeof(FileMetadataPairsConverter))]
 internal class FileMetadataPairs
 {
     // Order matters, the latter one overrides the former one

--- a/src/Docfx.App/Config/GroupConfig.cs
+++ b/src/Docfx.App/Config/GroupConfig.cs
@@ -19,6 +19,7 @@ internal class GroupConfig
     /// <summary>
     /// Extension metadata.
     /// </summary>
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.App/Config/GroupConfig.cs
+++ b/src/Docfx.App/Config/GroupConfig.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Docfx;
@@ -14,6 +15,7 @@ internal class GroupConfig
     /// Defines the output folder of the generated build files.
     /// </summary>
     [JsonProperty("dest")]
+    [JsonPropertyName("dest")]
     public string Destination { get; set; }
 
     /// <summary>

--- a/src/Docfx.App/Config/ListWithStringFallback.cs
+++ b/src/Docfx.App/Config/ListWithStringFallback.cs
@@ -8,7 +8,7 @@ namespace Docfx;
 /// <summary>
 /// ListWithStringFallback.
 /// </summary>
-[JsonConverter(typeof(ListWithStringFallbackConverter))]
+[Newtonsoft.Json.JsonConverter(typeof(ListWithStringFallbackConverter))]
 internal class ListWithStringFallback : List<string>
 {
     /// <summary>

--- a/src/Docfx.App/Config/MergeJsonConfig.cs
+++ b/src/Docfx.App/Config/MergeJsonConfig.cs
@@ -8,7 +8,7 @@ namespace Docfx;
 /// <summary>
 /// MergeJsonConfig.
 /// </summary>
-[JsonConverter(typeof(MergeJsonConfigConverter))]
+[Newtonsoft.Json.JsonConverter(typeof(MergeJsonConfigConverter))]
 internal class MergeJsonConfig : List<MergeJsonItemConfig>
 {
     /// <summary>

--- a/src/Docfx.App/Config/MergeJsonItemConfig.cs
+++ b/src/Docfx.App/Config/MergeJsonItemConfig.cs
@@ -28,7 +28,7 @@ internal class MergeJsonItemConfig
     /// Contains metadata that will be applied to every file, in key-value pair format.
     /// </summary>
     [JsonProperty("globalMetadata")]
-    [JsonConverter(typeof(JObjectDictionaryToObjectDictionaryConverter))]
+    [Newtonsoft.Json.JsonConverter(typeof(JObjectDictionaryToObjectDictionaryConverter))]
     public Dictionary<string, object> GlobalMetadata { get; set; }
 
     /// <summary>

--- a/src/Docfx.App/Config/MergeJsonItemConfig.cs
+++ b/src/Docfx.App/Config/MergeJsonItemConfig.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.Common;
 
 using Newtonsoft.Json;
@@ -16,18 +17,21 @@ internal class MergeJsonItemConfig
     /// Defines the files to merge.
     /// </summary>
     [JsonProperty("content")]
+    [JsonPropertyName("content")]
     public FileMapping Content { get; set; }
 
     /// <summary>
     /// Defines the output folder of the generated merge files.
     /// </summary>
     [JsonProperty("dest")]
+    [JsonPropertyName("dest")]
     public string Destination { get; set; }
 
     /// <summary>
     /// Contains metadata that will be applied to every file, in key-value pair format.
     /// </summary>
     [JsonProperty("globalMetadata")]
+    [JsonPropertyName("globalMetadata")]
     [Newtonsoft.Json.JsonConverter(typeof(JObjectDictionaryToObjectDictionaryConverter))]
     public Dictionary<string, object> GlobalMetadata { get; set; }
 
@@ -39,11 +43,13 @@ internal class MergeJsonItemConfig
     ///     The value is the value of the metadata.
     /// </summary>
     [JsonProperty("fileMetadata")]
+    [JsonPropertyName("fileMetadata")]
     public Dictionary<string, FileMetadataPairs> FileMetadata { get; set; }
 
     /// <summary>
     /// Metadata that applies to toc files.
     /// </summary>
     [JsonProperty("tocMetadata")]
+    [JsonPropertyName("tocMetadata")]
     public ListWithStringFallback TocMetadata { get; set; }
 }

--- a/src/Docfx.App/Config/PdfJsonConfig.cs
+++ b/src/Docfx.App/Config/PdfJsonConfig.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.HtmlToPdf;
 using Newtonsoft.Json;
 
@@ -16,36 +17,42 @@ internal class PdfJsonConfig : BuildJsonConfig
     /// Specifies the prefix of the generated PDF files.
     /// </summary>
     [JsonProperty("name")]
+    [JsonPropertyName("name")]
     public string Name { get; set; }
 
     /// <summary>
     /// Specify the hostname to link not-in-TOC articles.
     /// </summary>
     [JsonProperty("host")]
+    [JsonPropertyName("host")]
     public string Host { get; set; }
 
     /// <summary>
     /// Specify the locale of the pdf file.
     /// </summary>
     [JsonProperty("locale")]
+    [JsonPropertyName("locale")]
     public string Locale { get; set; }
 
     /// <summary>
     /// If specified, an appendices.pdf file is generated containing all the not-in-TOC articles.
     /// </summary>
     [JsonProperty("generatesAppendices")]
+    [JsonPropertyName("generatesAppendices")]
     public bool GeneratesAppendices { get; set; }
 
     /// <summary>
     /// Specify whether or not to generate external links for PDF.
     /// </summary>
     [JsonProperty("generatesExternalLink")]
+    [JsonPropertyName("generatesExternalLink")]
     public bool GeneratesExternalLink { get; set; }
 
     /// <summary>
     /// If specified, the intermediate html files used to generate the PDF are not deleted after the PDF has been generated.
     /// </summary>
     [JsonProperty("keepRawFiles")]
+    [JsonPropertyName("keepRawFiles")]
     public bool KeepRawFiles { get; set; }
 
     /// <summary>
@@ -53,6 +60,7 @@ internal class PdfJsonConfig : BuildJsonConfig
     /// By default the value is false.
     /// </summary>
     [JsonProperty("excludeDefaultToc")]
+    [JsonPropertyName("excludeDefaultToc")]
     public bool ExcludeDefaultToc { get; set; }
 
     /// <summary>
@@ -60,6 +68,7 @@ internal class PdfJsonConfig : BuildJsonConfig
     /// default be saved to _raw subfolder under output folder if keepRawFiles is set to true
     /// </summary>
     [JsonProperty("rawOutputFolder")]
+    [JsonPropertyName("rawOutputFolder")]
     public string RawOutputFolder { get; set; }
 
     /// <summary>
@@ -67,53 +76,62 @@ internal class PdfJsonConfig : BuildJsonConfig
     /// By default the value is false.
     /// </summary>
     [JsonProperty("excludedTocs")]
+    [JsonPropertyName("excludedTocs")]
     public List<string> ExcludedTocs { get; set; }
 
     /// <summary>
     /// Specify the path for the css to generate pdf, default value is styles/default.css.
     /// </summary>
     [JsonProperty("css")]
+    [JsonPropertyName("css")]
     public string Css { get; set; }
 
     /// <summary>
     /// Specify the base path for ExternalLinkFormat.
     /// </summary>
     [JsonProperty("base")]
+    [JsonPropertyName("base")]
     public string Base { get; set; }
 
     /// <summary>
     /// Specify how to handle pages that fail to load: abort, ignore or skip(default abort)
     /// </summary>
     [JsonProperty("errorHandling")]
+    [JsonPropertyName("errorHandling")]
     public string ErrorHandling { get; set; }
 
     /// <summary>
     /// Specify options specific to the wkhtmltopdf tooling used by the pdf command.
     /// </summary>
     [JsonProperty("wkhtmltopdf")]
+    [JsonPropertyName("wkhtmltopdf")]
     public WkhtmltopdfJsonConfig Wkhtmltopdf { get; set; }
 
     /// <summary>
     /// Gets or sets the "Table of Contents" bookmark title.
     /// </summary>
     [JsonProperty("tocTitle")]
+    [JsonPropertyName("tocTitle")]
     public string TocTitle { get; set; } = "Table of Contents";
 
     /// <summary>
     /// Gets or sets the outline option.
     /// </summary>
     [JsonProperty("outline")]
+    [JsonPropertyName("outline")]
     public OutlineOption Outline { get; set; } = OutlineOption.DefaultOutline;
 
     /// <summary>
     /// Gets or sets the cover page title.
     /// </summary>
     [JsonProperty("coverTitle")]
+    [JsonPropertyName("coverTitle")]
     public string CoverTitle { get; set; } = "Cover Page";
 
     /// <summary>
     /// Are input arguments set using command line
     /// </summary>
     [JsonProperty("noStdin")]
+    [JsonPropertyName("noStdin")]
     public bool NoStdin { get; set; }
 }

--- a/src/Docfx.App/Config/WkhtmltopdfJsonConfig.cs
+++ b/src/Docfx.App/Config/WkhtmltopdfJsonConfig.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Docfx;
@@ -14,11 +15,13 @@ internal class WkhtmltopdfJsonConfig
     /// Gets or sets the path and file name of a wkhtmltopdf.exe compatible executable.
     /// </summary>
     [JsonProperty("filePath")]
+    [JsonPropertyName("filePath")]
     public string FilePath { get; set; }
 
     /// <summary>
     /// Specify additional command line arguments that should be passed to the wkhtmltopdf executable.
     /// </summary>
     [JsonProperty("additionalArguments")]
+    [JsonPropertyName("additionalArguments")]
     public string AdditionalArguments { get; set; }
 }

--- a/src/Docfx.Build.Common/Reference/OverwriteDocumentModel.cs
+++ b/src/Docfx.Build.Common/Reference/OverwriteDocumentModel.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using System.Text.Json.Serialization;
 using Docfx.Common;
 using Docfx.DataContracts.Common;
 using Docfx.Plugins;
@@ -23,6 +24,7 @@ public class OverwriteDocumentModel
     /// </summary>
     [YamlMember(Alias = Constants.PropertyName.Uid)]
     [JsonProperty(Constants.PropertyName.Uid)]
+    [JsonPropertyName(Constants.PropertyName.Uid)]
     public string Uid { get; set; }
 
     /// <summary>
@@ -30,6 +32,7 @@ public class OverwriteDocumentModel
     /// </summary>
     [YamlMember(Alias = Constants.PropertyName.Conceptual)]
     [JsonProperty(Constants.PropertyName.Conceptual)]
+    [JsonPropertyName(Constants.PropertyName.Conceptual)]
     public string Conceptual { get; set; }
 
     /// <summary>
@@ -37,6 +40,7 @@ public class OverwriteDocumentModel
     /// </summary>
     [YamlMember(Alias = Constants.PropertyName.Documentation)]
     [JsonProperty(Constants.PropertyName.Documentation)]
+    [JsonPropertyName(Constants.PropertyName.Documentation)]
     public SourceDetail Documentation { get; set; }
 
     /// <summary>

--- a/src/Docfx.Build.Common/Reference/OverwriteDocumentModel.cs
+++ b/src/Docfx.Build.Common/Reference/OverwriteDocumentModel.cs
@@ -14,7 +14,8 @@ namespace Docfx.Build.Common;
 public class OverwriteDocumentModel
 {
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 
     /// <summary>

--- a/src/Docfx.Build.Common/Reference/OverwriteDocumentModel.cs
+++ b/src/Docfx.Build.Common/Reference/OverwriteDocumentModel.cs
@@ -43,35 +43,40 @@ public class OverwriteDocumentModel
     /// Links to other files
     /// </summary>
     [YamlIgnore]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public HashSet<string> LinkToFiles { get; set; } = new HashSet<string>();
 
     /// <summary>
     /// Links to other Uids
     /// </summary>
     [YamlIgnore]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public HashSet<string> LinkToUids { get; set; } = new HashSet<string>();
 
     /// <summary>
     /// Link sources information for file
     /// </summary>
     [YamlIgnore]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public Dictionary<string, List<LinkSourceInfo>> FileLinkSources { get; set; } = new Dictionary<string, List<LinkSourceInfo>>();
 
     /// <summary>
     /// Link sources information for Uid
     /// </summary>
     [YamlIgnore]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public Dictionary<string, List<LinkSourceInfo>> UidLinkSources { get; set; } = new Dictionary<string, List<LinkSourceInfo>>();
 
     /// <summary>
     /// Dependencies extracted from the markdown content
     /// </summary>
     [YamlIgnore]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public ImmutableArray<string> Dependency { get; set; } = ImmutableArray<string>.Empty;
 
     public T ConvertTo<T>() where T : class

--- a/src/Docfx.Build.ManagedReference/BuildOutputs/ApiBuildOutput.cs
+++ b/src/Docfx.Build.ManagedReference/BuildOutputs/ApiBuildOutput.cs
@@ -148,7 +148,8 @@ public class ApiBuildOutput
     public List<AttributeInfo> Attributes { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 
     public static ApiBuildOutput FromModel(PageViewModel model)

--- a/src/Docfx.Build.ManagedReference/BuildOutputs/ApiBuildOutput.cs
+++ b/src/Docfx.Build.ManagedReference/BuildOutputs/ApiBuildOutput.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.Common;
 using Docfx.Common.EntityMergers;
 using Docfx.DataContracts.Common;
@@ -15,136 +16,169 @@ public class ApiBuildOutput
 {
     [YamlMember(Alias = "uid")]
     [JsonProperty("uid")]
+    [JsonPropertyName("uid")]
     public string Uid { get; set; }
 
     [YamlMember(Alias = "isEii")]
     [JsonProperty("isEii")]
+    [JsonPropertyName("isEii")]
     public bool IsExplicitInterfaceImplementation { get; set; }
 
     [YamlMember(Alias = "isExtensionMethod")]
     [JsonProperty("isExtensionMethod")]
+    [JsonPropertyName("isExtensionMethod")]
     public bool IsExtensionMethod { get; set; }
 
     [YamlMember(Alias = "parent")]
     [JsonProperty("parent")]
+    [JsonPropertyName("parent")]
     public ApiReferenceBuildOutput Parent { get; set; }
 
     [YamlMember(Alias = "children")]
     [JsonProperty("children")]
+    [JsonPropertyName("children")]
     public List<ApiReferenceBuildOutput> Children { get; set; }
 
     [YamlMember(Alias = "href")]
     [JsonProperty("href")]
+    [JsonPropertyName("href")]
     public string Href { get; set; }
 
     [YamlMember(Alias = "langs")]
     [JsonProperty("langs")]
+    [JsonPropertyName("langs")]
     public string[] SupportedLanguages { get; set; } = new string[] { "csharp", "vb" };
 
     [YamlMember(Alias = "name")]
     [JsonProperty("name")]
+    [JsonPropertyName("name")]
     public List<ApiLanguageValuePair> Name { get; set; }
 
     [YamlMember(Alias = "nameWithType")]
     [JsonProperty("nameWithType")]
+    [JsonPropertyName("nameWithType")]
     public List<ApiLanguageValuePair> NameWithType { get; set; }
 
     [YamlMember(Alias = "fullName")]
     [JsonProperty("fullName")]
+    [JsonPropertyName("fullName")]
     public List<ApiLanguageValuePair> FullName { get; set; }
 
     [YamlMember(Alias = "type")]
     [JsonProperty("type")]
+    [JsonPropertyName("type")]
     public MemberType? Type { get; set; }
 
     [YamlMember(Alias = "source")]
     [JsonProperty("source")]
+    [JsonPropertyName("source")]
     public SourceDetail Source { get; set; }
 
     [YamlMember(Alias = "documentation")]
     [JsonProperty("documentation")]
+    [JsonPropertyName("documentation")]
     public SourceDetail Documentation { get; set; }
 
     [YamlMember(Alias = "assemblies")]
     [JsonProperty("assemblies")]
+    [JsonPropertyName("assemblies")]
     public List<string> AssemblyNameList { get; set; }
 
     [YamlMember(Alias = "namespace")]
     [JsonProperty("namespace")]
+    [JsonPropertyName("namespace")]
     public ApiReferenceBuildOutput NamespaceName { get; set; }
 
     [YamlMember(Alias = "summary")]
     [JsonProperty("summary")]
+    [JsonPropertyName("summary")]
     public string Summary { get; set; } = null;
 
     [YamlMember(Alias = "remarks")]
     [JsonProperty("remarks")]
+    [JsonPropertyName("remarks")]
     public string Remarks { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.AdditionalNotes)]
     [JsonProperty(Constants.PropertyName.AdditionalNotes)]
+    [JsonPropertyName(Constants.PropertyName.AdditionalNotes)]
     public AdditionalNotes AdditionalNotes { get; set; }
 
     [YamlMember(Alias = "example")]
     [JsonProperty("example")]
+    [JsonPropertyName("example")]
     public List<string> Examples { get; set; }
 
     [YamlMember(Alias = "syntax")]
     [JsonProperty("syntax")]
+    [JsonPropertyName("syntax")]
     public ApiSyntaxBuildOutput Syntax { get; set; }
 
     [YamlMember(Alias = "overridden")]
     [JsonProperty("overridden")]
+    [JsonPropertyName("overridden")]
     public ApiNames Overridden { get; set; }
 
     [YamlMember(Alias = "overload")]
     [JsonProperty("overload")]
+    [JsonPropertyName("overload")]
     public ApiNames Overload { get; set; }
 
     [YamlMember(Alias = "exceptions")]
     [JsonProperty("exceptions")]
+    [JsonPropertyName("exceptions")]
     public List<ApiExceptionInfoBuildOutput> Exceptions { get; set; }
 
     [YamlMember(Alias = "seealso")]
     [JsonProperty("seealso")]
+    [JsonPropertyName("seealso")]
     public List<ApiLinkInfoBuildOutput> SeeAlsos { get; set; }
 
     [YamlMember(Alias = "inheritance")]
     [MergeOption(MergeOption.Ignore)]
     [JsonProperty("inheritance")]
+    [JsonPropertyName("inheritance")]
     public List<ApiReferenceBuildOutput> Inheritance { get; set; }
 
     [YamlMember(Alias = "derivedClasses")]
     [MergeOption(MergeOption.Ignore)]
     [JsonProperty("derivedClasses")]
+    [JsonPropertyName("derivedClasses")]
     public List<ApiReferenceBuildOutput> DerivedClasses { get; set; }
 
     [YamlMember(Alias = "level")]
     [JsonProperty("level")]
+    [JsonPropertyName("level")]
     public int Level { get { return Inheritance != null ? Inheritance.Count : 0; } }
 
     [YamlMember(Alias = "implements")]
     [JsonProperty("implements")]
+    [JsonPropertyName("implements")]
     public List<ApiNames> Implements { get; set; }
 
     [YamlMember(Alias = "inheritedMembers")]
     [JsonProperty("inheritedMembers")]
+    [JsonPropertyName("inheritedMembers")]
     public List<ApiReferenceBuildOutput> InheritedMembers { get; set; }
 
     [YamlMember(Alias = "extensionMethods")]
     [JsonProperty("extensionMethods")]
+    [JsonPropertyName("extensionMethods")]
     public List<ApiReferenceBuildOutput> ExtensionMethods { get; set; }
 
     [YamlMember(Alias = "conceptual")]
     [JsonProperty("conceptual")]
+    [JsonPropertyName("conceptual")]
     public string Conceptual { get; set; }
 
     [YamlMember(Alias = "platform")]
     [JsonProperty("platform")]
+    [JsonPropertyName("platform")]
     public List<string> Platform { get; set; }
 
     [YamlMember(Alias = "attributes")]
     [JsonProperty("attributes")]
+    [JsonPropertyName("attributes")]
     public List<AttributeInfo> Attributes { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.Build.ManagedReference/BuildOutputs/ApiExceptionInfoBuildOutput.cs
+++ b/src/Docfx.Build.ManagedReference/BuildOutputs/ApiExceptionInfoBuildOutput.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.DataContracts.ManagedReference;
 using Newtonsoft.Json;
 using YamlDotNet.Serialization;
@@ -11,10 +12,12 @@ public class ApiExceptionInfoBuildOutput
 {
     [YamlMember(Alias = "type")]
     [JsonProperty("type")]
+    [JsonPropertyName("type")]
     public ApiNames Type { get; set; }
 
     [YamlMember(Alias = "description")]
     [JsonProperty("description")]
+    [JsonPropertyName("description")]
     public string Description { get; set; }
 
     private bool _needExpand = true;

--- a/src/Docfx.Build.ManagedReference/BuildOutputs/ApiLanguageValuePair.cs
+++ b/src/Docfx.Build.ManagedReference/BuildOutputs/ApiLanguageValuePair.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 using YamlDotNet.Serialization;
 
@@ -10,9 +11,11 @@ public class ApiLanguageValuePair
 {
     [YamlMember(Alias = "lang")]
     [JsonProperty("lang")]
+    [JsonPropertyName("lang")]
     public string Language { get; set; }
 
     [YamlMember(Alias = "value")]
     [JsonProperty("value")]
+    [JsonPropertyName("value")]
     public string Value { get; set; }
 }

--- a/src/Docfx.Build.ManagedReference/BuildOutputs/ApiLinkInfoBuildOutput.cs
+++ b/src/Docfx.Build.ManagedReference/BuildOutputs/ApiLinkInfoBuildOutput.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.DataContracts.ManagedReference;
 using Newtonsoft.Json;
 using YamlDotNet.Serialization;
@@ -11,14 +12,17 @@ public class ApiLinkInfoBuildOutput
 {
     [YamlMember(Alias = "linkType")]
     [JsonProperty("linkType")]
+    [JsonPropertyName("linkType")]
     public LinkType LinkType { get; set; }
 
     [YamlMember(Alias = "type")]
     [JsonProperty("type")]
+    [JsonPropertyName("type")]
     public ApiNames Type { get; set; }
 
     [YamlMember(Alias = "url")]
     [JsonProperty("url")]
+    [JsonPropertyName("url")]
     public string Url { get; set; }
 
     private bool _needExpand = true;

--- a/src/Docfx.Build.ManagedReference/BuildOutputs/ApiNames.cs
+++ b/src/Docfx.Build.ManagedReference/BuildOutputs/ApiNames.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 using YamlDotNet.Serialization;
 
@@ -10,30 +11,37 @@ public class ApiNames
 {
     [YamlMember(Alias = "uid")]
     [JsonProperty("uid")]
+    [JsonPropertyName("uid")]
     public string Uid { get; set; }
 
     [YamlMember(Alias = "id")]
     [JsonProperty("id")]
+    [JsonPropertyName("id")]
     public string Id { get; set; }
 
     [YamlMember(Alias = "definition")]
     [JsonProperty("definition")]
+    [JsonPropertyName("definition")]
     public string Definition { get; set; }
 
     [YamlMember(Alias = "name")]
     [JsonProperty("name")]
+    [JsonPropertyName("name")]
     public List<ApiLanguageValuePair> Name { get; set; }
 
     [YamlMember(Alias = "nameWithType")]
     [JsonProperty("nameWithType")]
+    [JsonPropertyName("nameWithType")]
     public List<ApiLanguageValuePair> NameWithType { get; set; }
 
     [YamlMember(Alias = "fullName")]
     [JsonProperty("fullName")]
+    [JsonPropertyName("fullName")]
     public List<ApiLanguageValuePair> FullName { get; set; }
 
     [YamlMember(Alias = "specName")]
     [JsonProperty("specName")]
+    [JsonPropertyName("specName")]
     public List<ApiLanguageValuePair> Spec { get; set; }
 
     public static ApiNames FromUid(string uid)

--- a/src/Docfx.Build.ManagedReference/BuildOutputs/ApiParameterBuildOutput.cs
+++ b/src/Docfx.Build.ManagedReference/BuildOutputs/ApiParameterBuildOutput.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.DataContracts.ManagedReference;
 using Newtonsoft.Json;
 using YamlDotNet.Serialization;
@@ -11,14 +12,17 @@ public class ApiParameterBuildOutput
 {
     [YamlMember(Alias = "id")]
     [JsonProperty("id")]
+    [JsonPropertyName("id")]
     public string Name { get; set; }
 
     [YamlMember(Alias = "type")]
     [JsonProperty("type")]
+    [JsonPropertyName("type")]
     public ApiNames Type { get; set; }
 
     [YamlMember(Alias = "description")]
     [JsonProperty("description")]
+    [JsonPropertyName("description")]
     public string Description { get; set; }
 
     private bool _needExpand = true;

--- a/src/Docfx.Build.ManagedReference/BuildOutputs/ApiReferenceBuildOutput.cs
+++ b/src/Docfx.Build.ManagedReference/BuildOutputs/ApiReferenceBuildOutput.cs
@@ -139,7 +139,8 @@ public class ApiReferenceBuildOutput
     public int? Index { get; set; }
 
     [ExtensibleMember]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Docfx.Build.ManagedReference/BuildOutputs/ApiReferenceBuildOutput.cs
+++ b/src/Docfx.Build.ManagedReference/BuildOutputs/ApiReferenceBuildOutput.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
+using System.Text.Json.Serialization;
 using System.Web;
 using Docfx.Common;
 using Docfx.DataContracts.Common;
@@ -16,126 +17,157 @@ public class ApiReferenceBuildOutput
 {
     [YamlMember(Alias = "uid")]
     [JsonProperty("uid")]
+    [JsonPropertyName("uid")]
     public string Uid { get; set; }
 
     [YamlMember(Alias = "isEii")]
     [JsonProperty("isEii")]
+    [JsonPropertyName("isEii")]
     public bool IsExplicitInterfaceImplementation { get; set; }
 
     [YamlMember(Alias = "isExtensionMethod")]
     [JsonProperty("isExtensionMethod")]
+    [JsonPropertyName("isExtensionMethod")]
     public bool IsExtensionMethod { get; set; }
 
     [YamlMember(Alias = "parent")]
     [JsonProperty("parent")]
+    [JsonPropertyName("parent")]
     public string Parent { get; set; }
 
     [YamlMember(Alias = "definition")]
     [JsonProperty("definition")]
+    [JsonPropertyName("definition")]
     public string Definition { get; set; }
-
-    [JsonProperty("isExternal")]
+      
     [YamlMember(Alias = "isExternal")]
+    [JsonProperty("isExternal")]
+    [JsonPropertyName("isExternal")]
     public bool? IsExternal { get; set; }
 
     [YamlMember(Alias = "href")]
     [JsonProperty("href")]
+    [JsonPropertyName("href")]
     public string Href { get; set; }
 
     [YamlMember(Alias = "name")]
     [JsonProperty("name")]
+    [JsonPropertyName("name")]
     public List<ApiLanguageValuePair> Name { get; set; }
 
     [YamlMember(Alias = "nameWithType")]
     [JsonProperty("nameWithType")]
+    [JsonPropertyName("nameWithType")]
     public List<ApiLanguageValuePair> NameWithType { get; set; }
 
     [YamlMember(Alias = "fullName")]
     [JsonProperty("fullName")]
+    [JsonPropertyName("fullName")]
     public List<ApiLanguageValuePair> FullName { get; set; }
 
     [YamlMember(Alias = "specName")]
     [JsonProperty("specName")]
+    [JsonPropertyName("specName")]
     public List<ApiLanguageValuePair> Spec { get; set; }
 
     [YamlMember(Alias = "syntax")]
     [JsonProperty("syntax")]
+    [JsonPropertyName("syntax")]
     public ApiSyntaxBuildOutput Syntax { get; set; }
 
     [YamlMember(Alias = "source")]
     [JsonProperty("source")]
+    [JsonPropertyName("source")]
     public SourceDetail Source { get; set; }
 
     [YamlMember(Alias = "documentation")]
     [JsonProperty("documentation")]
+    [JsonPropertyName("documentation")]
     public SourceDetail Documentation { get; set; }
 
     [YamlMember(Alias = "assemblies")]
     [JsonProperty("assemblies")]
+    [JsonPropertyName("assemblies")]
     public List<string> AssemblyNameList { get; set; }
 
     [YamlMember(Alias = "namespace")]
     [JsonProperty("namespace")]
+    [JsonPropertyName("namespace")]
     public string NamespaceName { get; set; }
 
     [YamlMember(Alias = "remarks")]
     [JsonProperty("remarks")]
+    [JsonPropertyName("remarks")]
     public string Remarks { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.AdditionalNotes)]
     [JsonProperty(Constants.PropertyName.AdditionalNotes)]
+    [JsonPropertyName(Constants.PropertyName.AdditionalNotes)]
     public AdditionalNotes AdditionalNotes { get; set; }
 
     [YamlMember(Alias = "example")]
     [JsonProperty("example")]
+    [JsonPropertyName("example")]
     public List<string> Examples { get; set; }
 
     [YamlMember(Alias = "overridden")]
     [JsonProperty("overridden")]
+    [JsonPropertyName("overridden")]
     public ApiNames Overridden { get; set; }
 
     [YamlMember(Alias = "overload")]
     [JsonProperty("overload")]
+    [JsonPropertyName("overload")]
     public ApiNames Overload { get; set; }
 
     [YamlMember(Alias = "exceptions")]
     [JsonProperty("exceptions")]
+    [JsonPropertyName("exceptions")]
     public List<ApiExceptionInfoBuildOutput> Exceptions { get; set; }
 
     [YamlMember(Alias = "seealso")]
     [JsonProperty("seealso")]
+    [JsonPropertyName("seealso")]
     public List<ApiLinkInfoBuildOutput> SeeAlsos { get; set; }
 
     [YamlMember(Alias = "inheritance")]
     [JsonProperty("inheritance")]
+    [JsonPropertyName("inheritance")]
     public List<ApiReferenceBuildOutput> Inheritance { get; set; }
 
     [YamlMember(Alias = "level")]
     [JsonProperty("level")]
+    [JsonPropertyName("level")]
     public int Level => Inheritance != null ? Inheritance.Count : 0;
 
     [YamlMember(Alias = "implements")]
     [JsonProperty("implements")]
+    [JsonPropertyName("implements")]
     public List<ApiNames> Implements { get; set; }
 
     [YamlMember(Alias = "inheritedMembers")]
     [JsonProperty("inheritedMembers")]
+    [JsonPropertyName("inheritedMembers")]
     public List<string> InheritedMembers { get; set; }
 
     [YamlMember(Alias = "extensionMethods")]
     [JsonProperty("extensionMethods")]
+    [JsonPropertyName("extensionMethods")]
     public List<string> ExtensionMethods { get; set; }
 
     [YamlMember(Alias = "conceptual")]
     [JsonProperty("conceptual")]
+    [JsonPropertyName("conceptual")]
     public string Conceptual { get; set; }
 
     [YamlMember(Alias = "attributes")]
     [JsonProperty("attributes")]
+    [JsonPropertyName("attributes")]
     public List<AttributeInfo> Attributes { get; set; }
 
     [YamlMember(Alias = "index")]
     [JsonProperty("index")]
+    [JsonPropertyName("index")]
     public int? Index { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.Build.ManagedReference/BuildOutputs/ApiReferenceBuildOutput.cs
+++ b/src/Docfx.Build.ManagedReference/BuildOutputs/ApiReferenceBuildOutput.cs
@@ -144,7 +144,8 @@ public class ApiReferenceBuildOutput
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     [YamlIgnore]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public CompositeDictionary MetadataJson =>
         CompositeDictionary
             .CreateBuilder()

--- a/src/Docfx.Build.ManagedReference/BuildOutputs/ApiSyntaxBuildOutput.cs
+++ b/src/Docfx.Build.ManagedReference/BuildOutputs/ApiSyntaxBuildOutput.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.DataContracts.ManagedReference;
 using Newtonsoft.Json;
 using YamlDotNet.Serialization;
@@ -11,18 +12,22 @@ public class ApiSyntaxBuildOutput
 {
     [YamlMember(Alias = "content")]
     [JsonProperty("content")]
+    [JsonPropertyName("content")]
     public List<ApiLanguageValuePair> Content { get; set; } = new List<ApiLanguageValuePair>();
 
     [YamlMember(Alias = "parameters")]
     [JsonProperty("parameters")]
+    [JsonPropertyName("parameters")]
     public List<ApiParameterBuildOutput> Parameters { get; set; }
 
     [YamlMember(Alias = "typeParameters")]
     [JsonProperty("typeParameters")]
+    [JsonPropertyName("typeParameters")]
     public List<ApiParameterBuildOutput> TypeParameters { get; set; }
 
     [YamlMember(Alias = "return")]
     [JsonProperty("return")]
+    [JsonPropertyName("return")]
     public ApiParameterBuildOutput Return { get; set; }
 
     private bool _needExpand = true;

--- a/src/Docfx.Build.RestApi/Swagger/InfoObject.cs
+++ b/src/Docfx.Build.RestApi/Swagger/InfoObject.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.YamlSerialization;
 using Newtonsoft.Json;
 using YamlDotNet.Serialization;
@@ -17,6 +18,7 @@ public class InfoObject
     /// </summary>
     [YamlMember(Alias = "title")]
     [JsonProperty("title")]
+    [JsonPropertyName("title")]
     public string Title { get; set; }
 
     /// <summary>
@@ -24,6 +26,7 @@ public class InfoObject
     /// </summary>
     [YamlMember(Alias = "version")]
     [JsonProperty("version")]
+    [JsonPropertyName("version")]
     public string Version { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.Build.RestApi/Swagger/InfoObject.cs
+++ b/src/Docfx.Build.RestApi/Swagger/InfoObject.cs
@@ -27,6 +27,7 @@ public class InfoObject
     public string Version { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> PatternedObjects { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.Build.RestApi/Swagger/OperationObject.cs
+++ b/src/Docfx.Build.RestApi/Swagger/OperationObject.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.YamlSerialization;
 using Newtonsoft.Json;
 using YamlDotNet.Serialization;
@@ -14,22 +15,27 @@ public class OperationObject
     /// </summary>
     [YamlMember(Alias = "operationId")]
     [JsonProperty("operationId")]
+    [JsonPropertyName("operationId")]
     public string OperationId { get; set; }
 
     [YamlMember(Alias = "description")]
     [JsonProperty("description")]
+    [JsonPropertyName("description")]
     public string Description { get; set; }
 
     [YamlMember(Alias = "summary")]
     [JsonProperty("summary")]
+    [JsonPropertyName("summary")]
     public string Summary { get; set; }
 
     [YamlMember(Alias = "tags")]
     [JsonProperty("tags")]
+    [JsonPropertyName("tags")]
     public List<string> Tags { get; set; }
 
     [YamlMember(Alias = "parameters")]
     [JsonProperty("parameters")]
+    [JsonPropertyName("parameters")]
     public List<ParameterObject> Parameters { get; set; }
 
     /// <summary>
@@ -37,6 +43,7 @@ public class OperationObject
     /// </summary>
     [YamlMember(Alias = "responses")]
     [JsonProperty("responses")]
+    [JsonPropertyName("responses")]
     public Dictionary<string, ResponseObject> Responses { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.Build.RestApi/Swagger/OperationObject.cs
+++ b/src/Docfx.Build.RestApi/Swagger/OperationObject.cs
@@ -40,6 +40,7 @@ public class OperationObject
     public Dictionary<string, ResponseObject> Responses { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.Build.RestApi/Swagger/ParameterObject.cs
+++ b/src/Docfx.Build.RestApi/Swagger/ParameterObject.cs
@@ -18,6 +18,7 @@ public class ParameterObject
     public string Name { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.Build.RestApi/Swagger/ParameterObject.cs
+++ b/src/Docfx.Build.RestApi/Swagger/ParameterObject.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.YamlSerialization;
 using Newtonsoft.Json;
 using YamlDotNet.Serialization;
@@ -11,10 +12,12 @@ public class ParameterObject
 {
     [YamlMember(Alias = "description")]
     [JsonProperty("description")]
+    [JsonPropertyName("description")]
     public string Description { get; set; }
 
     [YamlMember(Alias = "name")]
     [JsonProperty("name")]
+    [JsonPropertyName("name")]
     public string Name { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.Build.RestApi/Swagger/PathItemObject.cs
+++ b/src/Docfx.Build.RestApi/Swagger/PathItemObject.cs
@@ -21,6 +21,7 @@ public class PathItemObject
     public List<ParameterObject> Parameters { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.Build.RestApi/Swagger/PathItemObject.cs
+++ b/src/Docfx.Build.RestApi/Swagger/PathItemObject.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.YamlSerialization;
 using Newtonsoft.Json;
 using YamlDotNet.Serialization;
@@ -18,6 +19,7 @@ public class PathItemObject
     /// </summary>
     [YamlMember(Alias = "parameters")]
     [JsonProperty("parameters")]
+    [JsonPropertyName("parameters")]
     public List<ParameterObject> Parameters { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.Build.RestApi/Swagger/ResponseObject.cs
+++ b/src/Docfx.Build.RestApi/Swagger/ResponseObject.cs
@@ -25,6 +25,7 @@ public class ResponseObject
     public Dictionary<string, object> Examples { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.Build.RestApi/Swagger/ResponseObject.cs
+++ b/src/Docfx.Build.RestApi/Swagger/ResponseObject.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.YamlSerialization;
 using Newtonsoft.Json;
 using YamlDotNet.Serialization;
@@ -11,10 +12,12 @@ public class ResponseObject
 {
     [YamlMember(Alias = "description")]
     [JsonProperty("description")]
+    [JsonPropertyName("description")]
     public string Description { get; set; }
 
     [YamlMember(Alias = "summary")]
     [JsonProperty("summary")]
+    [JsonPropertyName("summary")]
     public string Summary { get; set; }
 
     /// <summary>
@@ -22,6 +25,7 @@ public class ResponseObject
     /// </summary>
     [YamlMember(Alias = "examples")]
     [JsonProperty("examples")]
+    [JsonPropertyName("examples")]
     public Dictionary<string, object> Examples { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.Build.RestApi/Swagger/SwaggerModel.cs
+++ b/src/Docfx.Build.RestApi/Swagger/SwaggerModel.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.YamlSerialization;
 using Newtonsoft.Json;
 using YamlDotNet.Serialization;
@@ -22,6 +23,7 @@ public class SwaggerModel
     /// </summary>
     [YamlMember(Alias = "info")]
     [JsonProperty("info")]
+    [JsonPropertyName("info")]
     public InfoObject Info { get; set; }
 
     /// <summary>
@@ -29,6 +31,7 @@ public class SwaggerModel
     /// </summary>
     [YamlMember(Alias = "host")]
     [JsonProperty("host")]
+    [JsonPropertyName("host")]
     public string Host { get; set; }
 
     /// <summary>
@@ -36,6 +39,7 @@ public class SwaggerModel
     /// </summary>
     [YamlMember(Alias = "basePath")]
     [JsonProperty("basePath")]
+    [JsonPropertyName("basePath")]
     public string BasePath { get; set; }
 
     /// <summary>
@@ -43,14 +47,17 @@ public class SwaggerModel
     /// </summary>
     [YamlMember(Alias = "paths")]
     [JsonProperty("paths")]
+    [JsonPropertyName("paths")]
     public PathsObject Paths { get; set; }
 
     [YamlMember(Alias = "description")]
     [JsonProperty("description")]
+    [JsonPropertyName("description")]
     public string Description { get; set; }
 
     [YamlMember(Alias = "summary")]
     [JsonProperty("summary")]
+    [JsonPropertyName("summary")]
     public string Summary { get; set; }
 
     /// <summary>
@@ -58,6 +65,7 @@ public class SwaggerModel
     /// </summary>
     [YamlMember(Alias = "definitions")]
     [JsonProperty("definitions")]
+    [JsonPropertyName("definitions")]
     public object Definitions { get; set; }
 
     /// <summary>
@@ -65,6 +73,7 @@ public class SwaggerModel
     /// </summary>
     [YamlMember(Alias = "parameters")]
     [JsonProperty("parameters")]
+    [JsonPropertyName("parameters")]
     public object Parameters { get; set; }
 
     /// <summary>
@@ -72,6 +81,7 @@ public class SwaggerModel
     /// </summary>
     [YamlMember(Alias = "responses")]
     [JsonProperty("responses")]
+    [JsonPropertyName("responses")]
     public object Responses { get; set; }
 
     /// <summary>
@@ -79,6 +89,7 @@ public class SwaggerModel
     /// </summary>
     [YamlMember(Alias = "tags")]
     [JsonProperty("tags")]
+    [JsonPropertyName("tags")]
     public List<TagItemObject> Tags { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.Build.RestApi/Swagger/SwaggerModel.cs
+++ b/src/Docfx.Build.RestApi/Swagger/SwaggerModel.cs
@@ -13,7 +13,8 @@ public class SwaggerModel
     /// The original swagger.json content
     /// </summary>
     [YamlIgnore]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public string Raw { get; set; }
 
     /// <summary>

--- a/src/Docfx.Build.RestApi/Swagger/SwaggerModel.cs
+++ b/src/Docfx.Build.RestApi/Swagger/SwaggerModel.cs
@@ -81,6 +81,7 @@ public class SwaggerModel
     public List<TagItemObject> Tags { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.Build.RestApi/Swagger/TagItemObject.cs
+++ b/src/Docfx.Build.RestApi/Swagger/TagItemObject.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.YamlSerialization;
 using Newtonsoft.Json;
 using YamlDotNet.Serialization;
@@ -14,6 +15,7 @@ public class TagItemObject
     /// </summary>
     [YamlMember(Alias = "name")]
     [JsonProperty("name")]
+    [JsonPropertyName("name")]
     public string Name { get; set; }
 
     /// <summary>
@@ -21,6 +23,7 @@ public class TagItemObject
     /// </summary>
     [YamlMember(Alias = "description")]
     [JsonProperty("description")]
+    [JsonPropertyName("description")]
     public string Description { get; set; }
 
     /// <summary>
@@ -28,6 +31,7 @@ public class TagItemObject
     /// </summary>
     [YamlMember(Alias = "x-bookmark-id")]
     [JsonProperty("x-bookmark-id")]
+    [JsonPropertyName("x-bookmark-id")]
     public string BookmarkId { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.Build.RestApi/Swagger/TagItemObject.cs
+++ b/src/Docfx.Build.RestApi/Swagger/TagItemObject.cs
@@ -31,6 +31,7 @@ public class TagItemObject
     public string BookmarkId { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.Build.UniversalReference/BuildOutputs/ApiBuildOutput.cs
+++ b/src/Docfx.Build.UniversalReference/BuildOutputs/ApiBuildOutput.cs
@@ -140,6 +140,7 @@ public class ApiBuildOutput
     public List<ApiLanguageValuePair<List<string>>> Platform { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.Build.UniversalReference/BuildOutputs/ApiBuildOutput.cs
+++ b/src/Docfx.Build.UniversalReference/BuildOutputs/ApiBuildOutput.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.DataContracts.Common;
 using Docfx.YamlSerialization;
 
@@ -13,130 +14,162 @@ public class ApiBuildOutput
 {
     [YamlMember(Alias = Constants.PropertyName.Uid)]
     [JsonProperty(Constants.PropertyName.Uid)]
+    [JsonPropertyName(Constants.PropertyName.Uid)]
     public string Uid { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.CommentId)]
     [JsonProperty(Constants.PropertyName.CommentId)]
+    [JsonPropertyName(Constants.PropertyName.CommentId)]
     public string CommentId { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Parent)]
     [JsonProperty(Constants.PropertyName.Parent)]
+    [JsonPropertyName(Constants.PropertyName.Parent)]
     public List<ApiLanguageValuePair<ApiNames>> Parent { get; set; }
 
     [YamlMember(Alias = "package")]
     [JsonProperty("package")]
+    [JsonPropertyName("package")]
     public List<ApiLanguageValuePair<ApiNames>> Package { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Children)]
     [JsonProperty(Constants.PropertyName.Children)]
+    [JsonPropertyName(Constants.PropertyName.Children)]
     public List<ApiLanguageValuePair<List<ApiBuildOutput>>> Children { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Href)]
     [JsonProperty(Constants.PropertyName.Href)]
+    [JsonPropertyName(Constants.PropertyName.Href)]
     public string Href { get; set; }
 
     [YamlMember(Alias = "langs")]
     [JsonProperty("langs")]
+    [JsonPropertyName("langs")]
     public string[] SupportedLanguages { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Name)]
     [JsonProperty(Constants.PropertyName.Name)]
+    [JsonPropertyName(Constants.PropertyName.Name)]
     public List<ApiLanguageValuePair<string>> Name { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.NameWithType)]
     [JsonProperty(Constants.PropertyName.NameWithType)]
+    [JsonPropertyName(Constants.PropertyName.NameWithType)]
     public List<ApiLanguageValuePair<string>> NameWithType { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.FullName)]
     [JsonProperty(Constants.PropertyName.FullName)]
+    [JsonPropertyName(Constants.PropertyName.FullName)]
     public List<ApiLanguageValuePair<string>> FullName { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Type)]
     [JsonProperty(Constants.PropertyName.Type)]
+    [JsonPropertyName(Constants.PropertyName.Type)]
     public string Type { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Source)]
     [JsonProperty(Constants.PropertyName.Source)]
+    [JsonPropertyName(Constants.PropertyName.Source)]
     public List<ApiLanguageValuePair<SourceDetail>> Source { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Documentation)]
     [JsonProperty(Constants.PropertyName.Documentation)]
+    [JsonPropertyName(Constants.PropertyName.Documentation)]
     public SourceDetail Documentation { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Assemblies)]
     [JsonProperty(Constants.PropertyName.Assemblies)]
+    [JsonPropertyName(Constants.PropertyName.Assemblies)]
     public List<ApiLanguageValuePair<List<string>>> AssemblyNameList { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Namespace)]
     [JsonProperty(Constants.PropertyName.Namespace)]
+    [JsonPropertyName(Constants.PropertyName.Namespace)]
     public List<ApiLanguageValuePair<ApiNames>> NamespaceName { get; set; }
 
     [YamlMember(Alias = "summary")]
     [JsonProperty("summary")]
+    [JsonPropertyName("summary")]
     public string Summary { get; set; } = null;
 
     [YamlMember(Alias = "remarks")]
     [JsonProperty("remarks")]
+    [JsonPropertyName("remarks")]
     public string Remarks { get; set; }
 
     [YamlMember(Alias = "example")]
     [JsonProperty("example")]
+    [JsonPropertyName("example")]
     public List<string> Examples { get; set; }
 
     [YamlMember(Alias = "syntax")]
     [JsonProperty("syntax")]
+    [JsonPropertyName("syntax")]
     public ApiSyntaxBuildOutput Syntax { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Overridden)]
     [JsonProperty(Constants.PropertyName.Overridden)]
+    [JsonPropertyName(Constants.PropertyName.Overridden)]
     public List<ApiLanguageValuePair<ApiNames>> Overridden { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Overload)]
     [JsonProperty(Constants.PropertyName.Overload)]
+    [JsonPropertyName(Constants.PropertyName.Overload)]
     public List<ApiLanguageValuePair<ApiNames>> Overload { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Exceptions)]
     [JsonProperty(Constants.PropertyName.Exceptions)]
+    [JsonPropertyName(Constants.PropertyName.Exceptions)]
     public List<ApiLanguageValuePair<List<ApiExceptionInfoBuildOutput>>> Exceptions { get; set; }
 
     [YamlMember(Alias = "seealso")]
     [JsonProperty("seealso")]
+    [JsonPropertyName("seealso")]
     public List<ApiLinkInfoBuildOutput> SeeAlsos { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.SeeAlsoContent)]
     [JsonProperty(Constants.PropertyName.SeeAlsoContent)]
+    [JsonPropertyName(Constants.PropertyName.SeeAlsoContent)]
     public string SeeAlsoContent { get; set; }
 
     [YamlMember(Alias = "see")]
     [JsonProperty("see")]
+    [JsonPropertyName("see")]
     public List<ApiLinkInfoBuildOutput> Sees { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Inheritance)]
     [JsonProperty(Constants.PropertyName.Inheritance)]
+    [JsonPropertyName(Constants.PropertyName.Inheritance)]
     public List<ApiLanguageValuePairWithLevel<List<ApiInheritanceTreeBuildOutput>>> Inheritance { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.DerivedClasses)]
     [JsonProperty(Constants.PropertyName.DerivedClasses)]
+    [JsonPropertyName(Constants.PropertyName.DerivedClasses)]
     public List<ApiLanguageValuePair<List<ApiNames>>> DerivedClasses { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Implements)]
     [JsonProperty(Constants.PropertyName.Implements)]
+    [JsonPropertyName(Constants.PropertyName.Implements)]
     public List<ApiLanguageValuePair<List<ApiNames>>> Implements { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.InheritedMembers)]
     [JsonProperty(Constants.PropertyName.InheritedMembers)]
+    [JsonPropertyName(Constants.PropertyName.InheritedMembers)]
     public List<ApiLanguageValuePair<List<ApiNames>>> InheritedMembers { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.ExtensionMethods)]
     [JsonProperty(Constants.PropertyName.ExtensionMethods)]
+    [JsonPropertyName(Constants.PropertyName.ExtensionMethods)]
     public List<ApiLanguageValuePair<List<ApiNames>>> ExtensionMethods { get; set; }
 
     [YamlMember(Alias = "conceptual")]
     [JsonProperty("conceptual")]
+    [JsonPropertyName("conceptual")]
     public string Conceptual { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Platform)]
     [JsonProperty(Constants.PropertyName.Platform)]
+    [JsonPropertyName(Constants.PropertyName.Platform)]
     public List<ApiLanguageValuePair<List<string>>> Platform { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.Build.UniversalReference/BuildOutputs/ApiExceptionInfoBuildOutput.cs
+++ b/src/Docfx.Build.UniversalReference/BuildOutputs/ApiExceptionInfoBuildOutput.cs
@@ -19,6 +19,7 @@ public class ApiExceptionInfoBuildOutput
     public string Description { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.Build.UniversalReference/BuildOutputs/ApiExceptionInfoBuildOutput.cs
+++ b/src/Docfx.Build.UniversalReference/BuildOutputs/ApiExceptionInfoBuildOutput.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.YamlSerialization;
 
 using Newtonsoft.Json;
@@ -12,10 +13,12 @@ public class ApiExceptionInfoBuildOutput
 {
     [YamlMember(Alias = "type")]
     [JsonProperty("type")]
+    [JsonPropertyName("type")]
     public ApiNames Type { get; set; }
 
     [YamlMember(Alias = "description")]
     [JsonProperty("description")]
+    [JsonPropertyName("description")]
     public string Description { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.Build.UniversalReference/BuildOutputs/ApiInheritanceTreeBuildOutput.cs
+++ b/src/Docfx.Build.UniversalReference/BuildOutputs/ApiInheritanceTreeBuildOutput.cs
@@ -24,6 +24,7 @@ public class ApiInheritanceTreeBuildOutput
     public int Level { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.Build.UniversalReference/BuildOutputs/ApiInheritanceTreeBuildOutput.cs
+++ b/src/Docfx.Build.UniversalReference/BuildOutputs/ApiInheritanceTreeBuildOutput.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.DataContracts.Common;
 using Docfx.YamlSerialization;
 
@@ -13,14 +14,17 @@ public class ApiInheritanceTreeBuildOutput
 {
     [YamlMember(Alias = Constants.PropertyName.Type)]
     [JsonProperty(Constants.PropertyName.Type)]
+    [JsonPropertyName(Constants.PropertyName.Type)]
     public ApiNames Type { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Inheritance)]
     [JsonProperty(Constants.PropertyName.Inheritance)]
+    [JsonPropertyName(Constants.PropertyName.Inheritance)]
     public List<ApiInheritanceTreeBuildOutput> Inheritance { get; set; }
 
     [YamlMember(Alias = "level")]
     [JsonProperty("level")]
+    [JsonPropertyName("level")]
     public int Level { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.Build.UniversalReference/BuildOutputs/ApiLanguageValuePair.cs
+++ b/src/Docfx.Build.UniversalReference/BuildOutputs/ApiLanguageValuePair.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 using YamlDotNet.Serialization;
 
@@ -10,9 +11,11 @@ public class ApiLanguageValuePair<T>
 {
     [YamlMember(Alias = "lang")]
     [JsonProperty("lang")]
+    [JsonPropertyName("lang")]
     public string Language { get; set; }
 
     [YamlMember(Alias = "value")]
     [JsonProperty("value")]
+    [JsonPropertyName("value")]
     public T Value { get; set; }
 }

--- a/src/Docfx.Build.UniversalReference/BuildOutputs/ApiLanguageValuePairWithLevel.cs
+++ b/src/Docfx.Build.UniversalReference/BuildOutputs/ApiLanguageValuePairWithLevel.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 using YamlDotNet.Serialization;
 
@@ -10,5 +11,6 @@ public class ApiLanguageValuePairWithLevel<T> : ApiLanguageValuePair<T>
 {
     [YamlMember(Alias = "level")]
     [JsonProperty("level")]
+    [JsonPropertyName("level")]
     public int Level { get; set; }
 }

--- a/src/Docfx.Build.UniversalReference/BuildOutputs/ApiLinkInfoBuildOutput.cs
+++ b/src/Docfx.Build.UniversalReference/BuildOutputs/ApiLinkInfoBuildOutput.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.DataContracts.UniversalReference;
 
 using Newtonsoft.Json;
@@ -12,13 +13,16 @@ public class ApiLinkInfoBuildOutput
 {
     [YamlMember(Alias = "linkType")]
     [JsonProperty("linkType")]
+    [JsonPropertyName("linkType")]
     public LinkType LinkType { get; set; }
 
     [YamlMember(Alias = "type")]
     [JsonProperty("type")]
+    [JsonPropertyName("type")]
     public ApiNames Type { get; set; }
 
     [YamlMember(Alias = "url")]
     [JsonProperty("url")]
+    [JsonPropertyName("url")]
     public string Url { get; set; }
 }

--- a/src/Docfx.Build.UniversalReference/BuildOutputs/ApiNames.cs
+++ b/src/Docfx.Build.UniversalReference/BuildOutputs/ApiNames.cs
@@ -36,6 +36,7 @@ public class ApiNames
     public List<ApiLanguageValuePair<string>> Spec { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.Build.UniversalReference/BuildOutputs/ApiNames.cs
+++ b/src/Docfx.Build.UniversalReference/BuildOutputs/ApiNames.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.DataContracts.Common;
 using Docfx.YamlSerialization;
 
@@ -13,26 +14,32 @@ public class ApiNames
 {
     [YamlMember(Alias = Constants.PropertyName.Uid)]
     [JsonProperty(Constants.PropertyName.Uid)]
+    [JsonPropertyName(Constants.PropertyName.Uid)]
     public string Uid { get; set; }
 
     [YamlMember(Alias = "definition")]
     [JsonProperty("definition")]
+    [JsonPropertyName("definition")]
     public string Definition { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Name)]
     [JsonProperty(Constants.PropertyName.Name)]
+    [JsonPropertyName(Constants.PropertyName.Name)]
     public List<ApiLanguageValuePair<string>> Name { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.NameWithType)]
     [JsonProperty(Constants.PropertyName.NameWithType)]
+    [JsonPropertyName(Constants.PropertyName.NameWithType)]
     public List<ApiLanguageValuePair<string>> NameWithType { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.FullName)]
     [JsonProperty(Constants.PropertyName.FullName)]
+    [JsonPropertyName(Constants.PropertyName.FullName)]
     public List<ApiLanguageValuePair<string>> FullName { get; set; }
 
     [YamlMember(Alias = "specName")]
     [JsonProperty("specName")]
+    [JsonPropertyName("specName")]
     public List<ApiLanguageValuePair<string>> Spec { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.Build.UniversalReference/BuildOutputs/ApiParameterBuildOutput.cs
+++ b/src/Docfx.Build.UniversalReference/BuildOutputs/ApiParameterBuildOutput.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.YamlSerialization;
 
 using Newtonsoft.Json;
@@ -12,22 +13,27 @@ public class ApiParameterBuildOutput
 {
     [YamlMember(Alias = "id")]
     [JsonProperty("id")]
+    [JsonPropertyName("id")]
     public string Name { get; set; }
 
     [YamlMember(Alias = "type")]
     [JsonProperty("type")]
+    [JsonPropertyName("type")]
     public List<ApiNames> Type { get; set; }
 
     [YamlMember(Alias = "description")]
     [JsonProperty("description")]
+    [JsonPropertyName("description")]
     public string Description { get; set; }
 
     [YamlMember(Alias = "optional")]
     [JsonProperty("optional")]
+    [JsonPropertyName("optional")]
     public bool Optional { get; set; }
 
     [YamlMember(Alias = "defaultValue")]
     [JsonProperty("defaultValue")]
+    [JsonPropertyName("defaultValue")]
     public string DefaultValue { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.Build.UniversalReference/BuildOutputs/ApiParameterBuildOutput.cs
+++ b/src/Docfx.Build.UniversalReference/BuildOutputs/ApiParameterBuildOutput.cs
@@ -31,6 +31,7 @@ public class ApiParameterBuildOutput
     public string DefaultValue { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.Build.UniversalReference/BuildOutputs/ApiSyntaxBuildOutput.cs
+++ b/src/Docfx.Build.UniversalReference/BuildOutputs/ApiSyntaxBuildOutput.cs
@@ -28,6 +28,7 @@ public class ApiSyntaxBuildOutput
     public List<ApiLanguageValuePair<ApiParameterBuildOutput>> Return { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.Build.UniversalReference/BuildOutputs/ApiSyntaxBuildOutput.cs
+++ b/src/Docfx.Build.UniversalReference/BuildOutputs/ApiSyntaxBuildOutput.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.DataContracts.Common;
 using Docfx.YamlSerialization;
 
@@ -13,18 +14,22 @@ public class ApiSyntaxBuildOutput
 {
     [YamlMember(Alias = Constants.PropertyName.Content)]
     [JsonProperty(Constants.PropertyName.Content)]
+    [JsonPropertyName(Constants.PropertyName.Content)]
     public List<ApiLanguageValuePair<string>> Content { get; set; }
 
     [YamlMember(Alias = "parameters")]
     [JsonProperty("parameters")]
+    [JsonPropertyName("parameters")]
     public List<ApiParameterBuildOutput> Parameters { get; set; }
 
     [YamlMember(Alias = "typeParameters")]
     [JsonProperty("typeParameters")]
+    [JsonPropertyName("typeParameters")]
     public List<ApiParameterBuildOutput> TypeParameters { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Return)]
     [JsonProperty(Constants.PropertyName.Return)]
+    [JsonPropertyName(Constants.PropertyName.Return)]
     public List<ApiLanguageValuePair<ApiParameterBuildOutput>> Return { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.Build/PostProcessors/SearchIndexItem.cs
+++ b/src/Docfx.Build/PostProcessors/SearchIndexItem.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Docfx.Build.Engine;
@@ -8,12 +9,15 @@ namespace Docfx.Build.Engine;
 public class SearchIndexItem
 {
     [JsonProperty("href")]
+    [JsonPropertyName("href")]
     public string Href { get; set; }
 
     [JsonProperty("title")]
+    [JsonPropertyName("title")]
     public string Title { get; set; }
 
     [JsonProperty("keywords")]
+    [JsonPropertyName("keywords")]
     public string Keywords { get; set; }
 
     public override bool Equals(object obj)

--- a/src/Docfx.Build/SystemMetadata.cs
+++ b/src/Docfx.Build/SystemMetadata.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Docfx.Build.Engine;
@@ -8,77 +9,95 @@ namespace Docfx.Build.Engine;
 internal sealed class SystemMetadata
 {
     [JsonProperty("_title")]
+    [JsonPropertyName("_title")]
     public string Title { get; set; }
+
     [JsonProperty("_tocTitle")]
+    [JsonPropertyName("_tocTitle")]
     public string TocTitle { get; set; }
+
     [JsonProperty("_name")]
+    [JsonPropertyName("_name")]
     public string Name { get; set; }
+
     [JsonProperty("_description")]
+    [JsonPropertyName("_description")]
     public string Description { get; set; }
 
     /// <summary>
     /// TOC PATH from ~ ROOT
     /// </summary>
     [JsonProperty("_tocPath")]
+    [JsonPropertyName("_tocPath")]
     public string TocPath { get; set; }
 
     /// <summary>
     /// ROOT TOC PATH from ~ ROOT
     /// </summary>
     [JsonProperty("_navPath")]
+    [JsonPropertyName("_navPath")]
     public string RootTocPath { get; set; }
 
     /// <summary>
     /// Current file's relative path to ROOT, e.g. file is ~/A/B.md, relative path to ROOT is ../
     /// </summary>
     [JsonProperty("_rel")]
+    [JsonPropertyName("_rel")]
     public string RelativePathToRoot { get; set; }
 
     /// <summary>
     /// Current file's path from ~ ROOT
     /// </summary>
     [JsonProperty("_path")]
+    [JsonPropertyName("_path")]
     public string Path { get; set; }
 
     /// <summary>
     /// Current file's key from ~ ROOT
     /// </summary>
     [JsonProperty("_key")]
+    [JsonPropertyName("_key")]
     public string Key { get; set; }
 
     /// <summary>
     /// Current file's relative path to ROOT TOC file
     /// </summary>
     [JsonProperty("_navRel")]
+    [JsonPropertyName("_navRel")]
     public string RelativePathToRootToc { get; set; }
 
     /// <summary>
     /// Current file's relative path to current file's TOC file
     /// </summary>
     [JsonProperty("_tocRel")]
+    [JsonPropertyName("_tocRel")]
     public string RelativePathToToc { get; set; }
 
     /// <summary>
     /// The file key for Root TOC file, starting with `~`
     /// </summary>
     [JsonProperty("_navKey")]
+    [JsonPropertyName("_navKey")]
     public string RootTocKey { get; set; }
 
     /// <summary>
     /// The file key for current file's TOC file, starting with `~`
     /// </summary>
     [JsonProperty("_tocKey")]
+    [JsonPropertyName("_tocKey")]
     public string TocKey { get; set; }
 
     /// <summary>
     /// Current file's version name
     /// </summary>
     [JsonProperty("_version")]
+    [JsonPropertyName("_version")]
     public string VersionName { get; set; }
 
     /// <summary>
     /// Current file's version root path from ~ ROOT
     /// </summary>
     [JsonProperty("_versionPath")]
+    [JsonPropertyName("_versionPath")]
     public string VersionFolder { get; set; }
 }

--- a/src/Docfx.Build/TransformModelOptions.cs
+++ b/src/Docfx.Build/TransformModelOptions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Docfx.Build.Engine;
@@ -8,8 +9,10 @@ namespace Docfx.Build.Engine;
 public class TransformModelOptions
 {
     [JsonProperty(PropertyName = "isShared")]
+    [JsonPropertyName("isShared")]
     public bool IsShared { get; set; }
 
     [JsonProperty(PropertyName = "bookmarks")]
+    [JsonPropertyName("bookmarks")]
     public Dictionary<string, string> Bookmarks { get; set; }
 }

--- a/src/Docfx.Build/XRefMaps/XRefMap.cs
+++ b/src/Docfx.Build/XRefMaps/XRefMap.cs
@@ -78,7 +78,8 @@ public class XRefMap : IXRefContainer
     }
 
     [YamlIgnore]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public bool IsEmbeddedRedirections => false;
 
     public IEnumerable<XRefMapRedirection> GetRedirections() =>

--- a/src/Docfx.Build/XRefMaps/XRefMap.cs
+++ b/src/Docfx.Build/XRefMaps/XRefMap.cs
@@ -32,7 +32,8 @@ public class XRefMap : IXRefContainer
     public List<XRefSpec> References { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Others { get; set; } = new Dictionary<string, object>();
 
     public void Sort()

--- a/src/Docfx.Build/XRefMaps/XRefMap.cs
+++ b/src/Docfx.Build/XRefMaps/XRefMap.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.Common;
 using Docfx.Plugins;
 using Docfx.YamlSerialization;
@@ -13,22 +14,27 @@ public class XRefMap : IXRefContainer
 {
     [YamlMember(Alias = "sorted")]
     [JsonProperty("sorted")]
+    [JsonPropertyName("sorted")]
     public bool? Sorted { get; set; }
 
     [YamlMember(Alias = "hrefUpdated")]
     [JsonProperty("hrefUpdated")]
+    [JsonPropertyName("hrefUpdated")]
     public bool? HrefUpdated { get; set; }
 
     [YamlMember(Alias = "baseUrl")]
     [JsonProperty("baseUrl")]
+    [JsonPropertyName("baseUrl")]
     public string BaseUrl { get; set; }
 
     [YamlMember(Alias = "redirections")]
     [JsonProperty("redirections")]
+    [JsonPropertyName("redirections")]
     public List<XRefMapRedirection> Redirections { get; set; }
 
     [YamlMember(Alias = "references")]
     [JsonProperty("references")]
+    [JsonPropertyName("references")]
     public List<XRefSpec> References { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.Common/FileMapping.cs
+++ b/src/Docfx.Common/FileMapping.cs
@@ -26,7 +26,7 @@ namespace Docfx;
 ///     If the Array form contains only one item, it can be shortened to an object
 ///     e.g. <code>projects: ["file1", "file2"]</code>
 /// </summary>
-[JsonConverter(typeof(FileMappingConverter))]
+[Newtonsoft.Json.JsonConverter(typeof(FileMappingConverter))]
 public class FileMapping
 {
     private readonly List<FileMappingItem> _items = new();

--- a/src/Docfx.Common/FileMappingItem.cs
+++ b/src/Docfx.Common/FileMappingItem.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Docfx;
@@ -14,30 +15,35 @@ public class FileMappingItem
     /// The name of current item, the value is not used for now
     /// </summary>
     [JsonProperty("name")]
+    [JsonPropertyName("name")]
     public string Name { get; set; }
 
     /// <summary>
     /// The file glob pattern collection, with path relative to property `src`/`cwd` is value is set
     /// </summary>
     [JsonProperty("files")]
+    [JsonPropertyName("files")]
     public FileItems Files { get; set; }
 
     /// <summary>
     /// The file glob pattern collection for files that should be excluded, with path relative to property `src`/`cwd` is value is set
     /// </summary>
     [JsonProperty("exclude")]
+    [JsonPropertyName("exclude")]
     public FileItems Exclude { get; set; }
 
     /// <summary>
     /// `src` defines the root folder for the source files, it has the same meaning as `cwd`
     /// </summary>
     [JsonProperty("src")]
+    [JsonPropertyName("src")]
     public string Src { get; set; }
 
     /// <summary>
     /// The destination folder for the files if copy/transform is used
     /// </summary>
     [JsonProperty("dest")]
+    [JsonPropertyName("dest")]
     public string Dest { get; set; }
 
     /// <summary>
@@ -47,6 +53,7 @@ public class FileMappingItem
     /// Cross reference doesn't support cross different groups.
     /// </summary>
     [JsonProperty("group")]
+    [JsonPropertyName("group")]
     public string Group { get; set; }
 
     /// <summary>
@@ -54,6 +61,7 @@ public class FileMappingItem
     /// If not set, will use the toc in output root in current group if exists.
     /// </summary>
     [JsonProperty("rootTocPath")]
+    [JsonPropertyName("rootTocPath")]
     public string RootTocPath { get; set; }
 
     /// <summary>
@@ -61,6 +69,7 @@ public class FileMappingItem
     /// By default the pattern is case insensitive
     /// </summary>
     [JsonProperty("case")]
+    [JsonPropertyName("case")]
     public bool? Case { get; set; }
 
     /// <summary>
@@ -68,6 +77,7 @@ public class FileMappingItem
     /// By default the usage is enabled.
     /// </summary>
     [JsonProperty("noNegate")]
+    [JsonPropertyName("noNegate")]
     public bool? DisableNegate { get; set; }
 
     /// <summary>
@@ -75,6 +85,7 @@ public class FileMappingItem
     /// By default the usage is enabled.
     /// </summary>
     [JsonProperty("noExpand")]
+    [JsonPropertyName("noExpand")]
     public bool? NoExpand { get; set; }
 
     /// <summary>
@@ -82,6 +93,7 @@ public class FileMappingItem
     /// By default the usage is enabled.
     /// </summary>
     [JsonProperty("noEscape")]
+    [JsonPropertyName("noEscape")]
     public bool? NoEscape { get; set; }
 
     /// <summary>
@@ -89,6 +101,7 @@ public class FileMappingItem
     /// By default the usage is enable.
     /// </summary>
     [JsonProperty("noGlobStar")]
+    [JsonPropertyName("noGlobStar")]
     public bool? NoGlobStar { get; set; }
 
     /// <summary>
@@ -96,6 +109,7 @@ public class FileMappingItem
     /// By default files start with `.` will not be matched by `*` unless the pattern starts with `.`.
     /// </summary>
     [JsonProperty("dot")]
+    [JsonPropertyName("dot")]
     public bool? Dot { get; set; }
 
     public FileMappingItem() { }

--- a/src/Docfx.Common/Git/GitDetail.cs
+++ b/src/Docfx.Common/Git/GitDetail.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 using YamlDotNet.Serialization;
 
@@ -13,13 +14,16 @@ public record GitDetail
     /// </summary>
     [YamlMember(Alias = "path")]
     [JsonProperty("path")]
+    [JsonPropertyName("path")]
     public string Path { get; set; }
 
     [YamlMember(Alias = "branch")]
     [JsonProperty("branch")]
+    [JsonPropertyName("branch")]
     public string Branch { get; set; }
 
     [YamlMember(Alias = "repo")]
     [JsonProperty("repo")]
+    [JsonPropertyName("repo")]
     public string Repo { get; set; }
 }

--- a/src/Docfx.Common/Loggers/ReportLogListener.cs
+++ b/src/Docfx.Common/Loggers/ReportLogListener.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Docfx.Common;
@@ -101,18 +102,31 @@ public sealed class ReportLogListener : ILoggerListener
     public class ReportItem
     {
         [JsonProperty("message")]
+        [JsonPropertyName("message")]
         public string Message { get; set; }
+
         [JsonProperty("source")]
+        [JsonPropertyName("source")]
         public string Source { get; set; }
+
         [JsonProperty("file")]
+        [JsonPropertyName("file")]
         public string File { get; set; }
+
         [JsonProperty("line")]
+        [JsonPropertyName("line")]
         public string Line { get; set; }
+
         [JsonProperty("date_time")]
+        [JsonPropertyName("date_time")]
         public DateTime DateTime { get; set; }
+
         [JsonProperty("message_severity")]
+        [JsonPropertyName("message_severity")]
         public MessageSeverity Severity { get; set; }
+
         [JsonProperty("code")]
+        [JsonPropertyName("code")]
         public string Code { get; set; }
     }
 

--- a/src/Docfx.DataContracts.Common/ReferenceViewModel.cs
+++ b/src/Docfx.DataContracts.Common/ReferenceViewModel.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
+using System.Text.Json.Serialization;
 using Docfx.Common;
 using Docfx.YamlSerialization;
 using Newtonsoft.Json;
@@ -13,30 +14,37 @@ public class ReferenceViewModel
 {
     [YamlMember(Alias = Constants.PropertyName.Uid)]
     [JsonProperty(Constants.PropertyName.Uid)]
+    [JsonPropertyName(Constants.PropertyName.Uid)]
     public string Uid { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.CommentId)]
     [JsonProperty(Constants.PropertyName.CommentId)]
+    [JsonPropertyName(Constants.PropertyName.CommentId)]
     public string CommentId { get; set; }
 
     [YamlMember(Alias = "parent")]
     [JsonProperty("parent")]
+    [JsonPropertyName("parent")]
     public string Parent { get; set; }
 
     [YamlMember(Alias = "definition")]
     [JsonProperty("definition")]
+    [JsonPropertyName("definition")]
     public string Definition { get; set; }
 
     [JsonProperty("isExternal")]
     [YamlMember(Alias = "isExternal")]
+    [JsonPropertyName("isExternal")]
     public bool? IsExternal { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Href)]
     [JsonProperty(Constants.PropertyName.Href)]
+    [JsonPropertyName(Constants.PropertyName.Href)]
     public string Href { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Name)]
     [JsonProperty(Constants.PropertyName.Name)]
+    [JsonPropertyName(Constants.PropertyName.Name)]
     public string Name { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Name)]
@@ -46,6 +54,7 @@ public class ReferenceViewModel
 
     [YamlMember(Alias = Constants.PropertyName.NameWithType)]
     [JsonProperty(Constants.PropertyName.NameWithType)]
+    [JsonPropertyName(Constants.PropertyName.NameWithType)]
     public string NameWithType { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.NameWithType)]
@@ -55,6 +64,7 @@ public class ReferenceViewModel
 
     [YamlMember(Alias = Constants.PropertyName.FullName)]
     [JsonProperty(Constants.PropertyName.FullName)]
+    [JsonPropertyName(Constants.PropertyName.FullName)]
     public string FullName { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.FullName)]

--- a/src/Docfx.DataContracts.Common/ReferenceViewModel.cs
+++ b/src/Docfx.DataContracts.Common/ReferenceViewModel.cs
@@ -69,7 +69,8 @@ public class ReferenceViewModel
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     [YamlIgnore]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     [UniqueIdentityReferenceIgnore]
     [MarkdownContentIgnore]
     public CompositeDictionary AdditionalJson =>

--- a/src/Docfx.DataContracts.Common/ReferenceViewModel.cs
+++ b/src/Docfx.DataContracts.Common/ReferenceViewModel.cs
@@ -40,7 +40,8 @@ public class ReferenceViewModel
     public string Name { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Name)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, string> NameInDevLangs { get; private set; } = new SortedList<string, string>();
 
     [YamlMember(Alias = Constants.PropertyName.NameWithType)]
@@ -48,7 +49,8 @@ public class ReferenceViewModel
     public string NameWithType { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.NameWithType)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, string> NameWithTypeInDevLangs { get; private set; } = new SortedList<string, string>();
 
     [YamlMember(Alias = Constants.PropertyName.FullName)]
@@ -56,15 +58,18 @@ public class ReferenceViewModel
     public string FullName { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.FullName)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, string> FullNameInDevLangs { get; private set; } = new SortedList<string, string>();
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Spec)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, List<SpecViewModel>> Specs { get; private set; } = new SortedList<string, List<SpecViewModel>>();
 
     [ExtensibleMember]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public Dictionary<string, object> Additional { get; private set; } = new Dictionary<string, object>();
 
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Docfx.DataContracts.Common/SourceDetail.cs
+++ b/src/Docfx.DataContracts.Common/SourceDetail.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.Common.Git;
 using Newtonsoft.Json;
 using YamlDotNet.Serialization;
@@ -11,10 +12,12 @@ public class SourceDetail
 {
     [YamlMember(Alias = "remote")]
     [JsonProperty("remote")]
+    [JsonPropertyName("remote")]
     public GitDetail Remote { get; set; }
 
     [YamlMember(Alias = "id")]
     [JsonProperty("id")]
+    [JsonPropertyName("id")]
     public string Name { get; set; }
 
     /// <summary>
@@ -22,6 +25,7 @@ public class SourceDetail
     /// </summary>
     [YamlMember(Alias = Constants.PropertyName.Href)]
     [JsonProperty(Constants.PropertyName.Href)]
+    [JsonPropertyName(Constants.PropertyName.Href)]
     public string Href { get; set; }
 
     /// <summary>
@@ -29,13 +33,16 @@ public class SourceDetail
     /// </summary>
     [YamlMember(Alias = "path")]
     [JsonProperty("path")]
+    [JsonPropertyName("path")]
     public string Path { get; set; }
 
     [YamlMember(Alias = "startLine")]
     [JsonProperty("startLine")]
+    [JsonPropertyName("startLine")]
     public int StartLine { get; set; }
 
     [YamlMember(Alias = "endLine")]
     [JsonProperty("endLine")]
+    [JsonPropertyName("endLine")]
     public int EndLine { get; set; }
 }

--- a/src/Docfx.DataContracts.Common/SpecViewModel.cs
+++ b/src/Docfx.DataContracts.Common/SpecViewModel.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 using YamlDotNet.Serialization;
 
@@ -10,17 +11,21 @@ public class SpecViewModel
 {
     [YamlMember(Alias = Constants.PropertyName.Uid)]
     [JsonProperty(Constants.PropertyName.Uid)]
+    [JsonPropertyName(Constants.PropertyName.Uid)]
     public string Uid { get; set; }
 
     [YamlMember(Alias = "name")]
     [JsonProperty("name")]
+    [JsonPropertyName("name")]
     public string Name { get; set; }
 
     [YamlMember(Alias = "isExternal")]
     [JsonProperty("isExternal")]
+    [JsonPropertyName("isExternal")]
     public bool IsExternal { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Href)]
     [JsonProperty(Constants.PropertyName.Href)]
+    [JsonPropertyName(Constants.PropertyName.Href)]
     public string Href { get; set; }
 }

--- a/src/Docfx.DataContracts.Common/TocItemViewModel.cs
+++ b/src/Docfx.DataContracts.Common/TocItemViewModel.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
+using System.Text.Json.Serialization;
 using Docfx.Common;
 using Docfx.YamlSerialization;
 using Newtonsoft.Json;
@@ -13,14 +14,17 @@ public class TocItemViewModel
 {
     [YamlMember(Alias = Constants.PropertyName.Uid)]
     [JsonProperty(Constants.PropertyName.Uid)]
+    [JsonPropertyName(Constants.PropertyName.Uid)]
     public string Uid { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Name)]
     [JsonProperty(Constants.PropertyName.Name)]
+    [JsonPropertyName(Constants.PropertyName.Name)]
     public string Name { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.DisplayName)]
     [JsonProperty(Constants.PropertyName.DisplayName)]
+    [JsonPropertyName(Constants.PropertyName.DisplayName)]
     public string DisplayName { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Name)]
@@ -56,26 +60,32 @@ public class TocItemViewModel
 
     [YamlMember(Alias = Constants.PropertyName.Href)]
     [JsonProperty(Constants.PropertyName.Href)]
+    [JsonPropertyName(Constants.PropertyName.Href)]
     public string Href { get; set; }
 
     [YamlMember(Alias = "originalHref")]
     [JsonProperty("originalHref")]
+    [JsonPropertyName("originalHref")]
     public string OriginalHref { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.TocHref)]
     [JsonProperty(Constants.PropertyName.TocHref)]
+    [JsonPropertyName(Constants.PropertyName.TocHref)]
     public string TocHref { get; set; }
 
     [YamlMember(Alias = "originalTocHref")]
     [JsonProperty("originalTocHref")]
+    [JsonPropertyName("originalTocHref")]
     public string OriginalTocHref { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.TopicHref)]
     [JsonProperty(Constants.PropertyName.TopicHref)]
+    [JsonPropertyName(Constants.PropertyName.TopicHref)]
     public string TopicHref { get; set; }
 
     [YamlMember(Alias = "originalTopicHref")]
     [JsonProperty("originalTopicHref")]
+    [JsonPropertyName("originalTopicHref")]
     public string OriginalTopicHref { get; set; }
 
     [YamlIgnore]
@@ -85,22 +95,27 @@ public class TocItemViewModel
 
     [YamlMember(Alias = "includedFrom")]
     [JsonProperty("includedFrom")]
+    [JsonPropertyName("includedFrom")]
     public string IncludedFrom { get; set; }
 
     [YamlMember(Alias = "homepage")]
     [JsonProperty("homepage")]
+    [JsonPropertyName("homepage")]
     public string Homepage { get; set; }
 
     [YamlMember(Alias = "originalHomepage")]
     [JsonProperty("originalHomepage")]
+    [JsonPropertyName("originalHomepage")]
     public string OriginalHomepage { get; set; }
 
     [YamlMember(Alias = "homepageUid")]
     [JsonProperty("homepageUid")]
+    [JsonPropertyName("homepageUid")]
     public string HomepageUid { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.TopicUid)]
     [JsonProperty(Constants.PropertyName.TopicUid)]
+    [JsonPropertyName(Constants.PropertyName.TopicUid)]
     public string TopicUid { get; set; }
 
     [YamlIgnore]
@@ -110,6 +125,7 @@ public class TocItemViewModel
 
     [YamlMember(Alias = "items")]
     [JsonProperty("items")]
+    [JsonPropertyName("items")]
     public TocViewModel Items { get; set; }
 
     [YamlIgnore]

--- a/src/Docfx.DataContracts.Common/TocItemViewModel.cs
+++ b/src/Docfx.DataContracts.Common/TocItemViewModel.cs
@@ -117,7 +117,8 @@ public class TocItemViewModel
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     [YamlIgnore]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public CompositeDictionary MetadataJson =>
         CompositeDictionary
             .CreateBuilder()

--- a/src/Docfx.DataContracts.Common/TocItemViewModel.cs
+++ b/src/Docfx.DataContracts.Common/TocItemViewModel.cs
@@ -24,11 +24,13 @@ public class TocItemViewModel
     public string DisplayName { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Name)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, string> NameInDevLangs { get; } = new SortedList<string, string>();
 
     [YamlIgnore]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public string NameForCSharp
     {
         get
@@ -40,7 +42,8 @@ public class TocItemViewModel
     }
 
     [YamlIgnore]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public string NameForVB
     {
         get
@@ -76,7 +79,8 @@ public class TocItemViewModel
     public string OriginalTopicHref { get; set; }
 
     [YamlIgnore]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public string AggregatedHref { get; set; }
 
     [YamlMember(Alias = "includedFrom")]
@@ -100,7 +104,8 @@ public class TocItemViewModel
     public string TopicUid { get; set; }
 
     [YamlIgnore]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public string AggregatedUid { get; set; }
 
     [YamlMember(Alias = "items")]
@@ -108,11 +113,13 @@ public class TocItemViewModel
     public TocViewModel Items { get; set; }
 
     [YamlIgnore]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public bool IsHrefUpdated { get; set; }
 
     [ExtensibleMember]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Docfx.DataContracts.Common/TocRootViewModel.cs
+++ b/src/Docfx.DataContracts.Common/TocRootViewModel.cs
@@ -14,6 +14,7 @@ public class TocRootViewModel
     public TocViewModel Items { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.DataContracts.Common/TocRootViewModel.cs
+++ b/src/Docfx.DataContracts.Common/TocRootViewModel.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.YamlSerialization;
 using Newtonsoft.Json;
 using YamlDotNet.Serialization;
@@ -11,6 +12,7 @@ public class TocRootViewModel
 {
     [YamlMember(Alias = "items")]
     [JsonProperty("items")]
+    [JsonPropertyName("items")]
     public TocViewModel Items { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.DataContracts.RestApi/RestApiChildItemViewModel.cs
+++ b/src/Docfx.DataContracts.RestApi/RestApiChildItemViewModel.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.DataContracts.Common;
 using Newtonsoft.Json;
 using YamlDotNet.Serialization;
@@ -11,6 +12,7 @@ public class RestApiChildItemViewModel : RestApiItemViewModelBase
 {
     [YamlMember(Alias = Constants.PropertyName.Path)]
     [JsonProperty(Constants.PropertyName.Path)]
+    [JsonPropertyName(Constants.PropertyName.Path)]
     public string Path { get; set; }
 
     /// <summary>
@@ -18,21 +20,26 @@ public class RestApiChildItemViewModel : RestApiItemViewModelBase
     /// </summary>
     [YamlMember(Alias = "operation")]
     [JsonProperty("operation")]
+    [JsonPropertyName("operation")]
     public string OperationName { get; set; }
 
     [YamlMember(Alias = "operationId")]
     [JsonProperty("operationId")]
+    [JsonPropertyName("operationId")]
     public string OperationId { get; set; }
 
     [YamlMember(Alias = "tags")]
     [JsonProperty("tags")]
+    [JsonPropertyName("tags")]
     public List<string> Tags { get; set; }
 
     [YamlMember(Alias = "parameters")]
     [JsonProperty("parameters")]
+    [JsonPropertyName("parameters")]
     public List<RestApiParameterViewModel> Parameters { get; set; }
 
     [YamlMember(Alias = "responses")]
     [JsonProperty("responses")]
+    [JsonPropertyName("responses")]
     public List<RestApiResponseViewModel> Responses { get; set; }
 }

--- a/src/Docfx.DataContracts.RestApi/RestApiItemViewModelBase.cs
+++ b/src/Docfx.DataContracts.RestApi/RestApiItemViewModelBase.cs
@@ -47,6 +47,7 @@ public class RestApiItemViewModelBase : IOverwriteDocumentViewModel
     public SourceDetail Documentation { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.DataContracts.RestApi/RestApiItemViewModelBase.cs
+++ b/src/Docfx.DataContracts.RestApi/RestApiItemViewModelBase.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.Common.EntityMergers;
 using Docfx.DataContracts.Common;
 using Docfx.YamlSerialization;
@@ -13,36 +14,44 @@ public class RestApiItemViewModelBase : IOverwriteDocumentViewModel
 {
     [YamlMember(Alias = Constants.PropertyName.Uid)]
     [JsonProperty(Constants.PropertyName.Uid)]
+    [JsonPropertyName(Constants.PropertyName.Uid)]
     [MergeOption(MergeOption.MergeKey)]
     public string Uid { get; set; }
 
     [YamlMember(Alias = "htmlId")]
     [JsonProperty("htmlId")]
+    [JsonPropertyName("htmlId")]
     [MergeOption(MergeOption.Ignore)]
     public string HtmlId { get; set; }
 
     [YamlMember(Alias = "name")]
     [JsonProperty("name")]
+    [JsonPropertyName("name")]
     public string Name { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Conceptual)]
     [JsonProperty(Constants.PropertyName.Conceptual)]
+    [JsonPropertyName(Constants.PropertyName.Conceptual)]
     public string Conceptual { get; set; }
 
     [YamlMember(Alias = "description")]
     [JsonProperty("description")]
+    [JsonPropertyName("description")]
     public string Description { get; set; }
 
     [YamlMember(Alias = "remarks")]
     [JsonProperty("remarks")]
+    [JsonPropertyName("remarks")]
     public string Remarks { get; set; }
 
     [YamlMember(Alias = "summary")]
     [JsonProperty("summary")]
+    [JsonPropertyName("summary")]
     public string Summary { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Documentation)]
     [JsonProperty(Constants.PropertyName.Documentation)]
+    [JsonPropertyName(Constants.PropertyName.Documentation)]
     [MergeOption(MergeOption.Ignore)]
     public SourceDetail Documentation { get; set; }
 

--- a/src/Docfx.DataContracts.RestApi/RestApiParameterViewModel.cs
+++ b/src/Docfx.DataContracts.RestApi/RestApiParameterViewModel.cs
@@ -20,6 +20,7 @@ public class RestApiParameterViewModel
     public string Name { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.DataContracts.RestApi/RestApiParameterViewModel.cs
+++ b/src/Docfx.DataContracts.RestApi/RestApiParameterViewModel.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.Common.EntityMergers;
 using Docfx.YamlSerialization;
 using Newtonsoft.Json;
@@ -12,10 +13,12 @@ public class RestApiParameterViewModel
 {
     [YamlMember(Alias = "description")]
     [JsonProperty("description")]
+    [JsonPropertyName("description")]
     public string Description { get; set; }
 
     [YamlMember(Alias = "name")]
     [JsonProperty("name")]
+    [JsonPropertyName("name")]
     [MergeOption(MergeOption.MergeKey)]
     public string Name { get; set; }
 

--- a/src/Docfx.DataContracts.RestApi/RestApiResponseExampleViewModel.cs
+++ b/src/Docfx.DataContracts.RestApi/RestApiResponseExampleViewModel.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 using YamlDotNet.Serialization;
 
@@ -10,9 +11,11 @@ public class RestApiResponseExampleViewModel
 {
     [YamlMember(Alias = "mimeType")]
     [JsonProperty("mimeType")]
+    [JsonPropertyName("mimeType")]
     public string MimeType { get; set; }
 
     [YamlMember(Alias = "content")]
     [JsonProperty("content")]
+    [JsonPropertyName("content")]
     public string Content { get; set; }
 }

--- a/src/Docfx.DataContracts.RestApi/RestApiResponseViewModel.cs
+++ b/src/Docfx.DataContracts.RestApi/RestApiResponseViewModel.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.Common.EntityMergers;
 using Docfx.YamlSerialization;
 using Newtonsoft.Json;
@@ -12,19 +13,23 @@ public class RestApiResponseViewModel
 {
     [YamlMember(Alias = "statusCode")]
     [JsonProperty("statusCode")]
+    [JsonPropertyName("statusCode")]
     [MergeOption(MergeOption.MergeKey)]
     public string HttpStatusCode { get; set; }
 
     [YamlMember(Alias = "description")]
     [JsonProperty("description")]
+    [JsonPropertyName("description")]
     public string Description { get; set; }
 
     [YamlMember(Alias = "summary")]
     [JsonProperty("summary")]
+    [JsonPropertyName("summary")]
     public string Summary { get; set; }
 
     [YamlMember(Alias = "examples")]
     [JsonProperty("examples")]
+    [JsonPropertyName("examples")]
     public List<RestApiResponseExampleViewModel> Examples { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.DataContracts.RestApi/RestApiResponseViewModel.cs
+++ b/src/Docfx.DataContracts.RestApi/RestApiResponseViewModel.cs
@@ -28,6 +28,7 @@ public class RestApiResponseViewModel
     public List<RestApiResponseExampleViewModel> Examples { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.DataContracts.RestApi/RestApiRootItemViewModel.cs
+++ b/src/Docfx.DataContracts.RestApi/RestApiRootItemViewModel.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.Common.EntityMergers;
 using Newtonsoft.Json;
 using YamlDotNet.Serialization;
@@ -15,14 +16,17 @@ public class RestApiRootItemViewModel : RestApiItemViewModelBase
     /// </summary>
     [YamlMember(Alias = "_raw")]
     [JsonProperty("_raw")]
+    [JsonPropertyName("_raw")]
     [MergeOption(MergeOption.Ignore)]
     public string Raw { get; set; }
 
     [YamlMember(Alias = "tags")]
     [JsonProperty("tags")]
+    [JsonPropertyName("tags")]
     public List<RestApiTagViewModel> Tags { get; set; }
 
     [YamlMember(Alias = "children")]
     [JsonProperty("children")]
+    [JsonPropertyName("children")]
     public List<RestApiChildItemViewModel> Children { get; set; }
 }

--- a/src/Docfx.DataContracts.RestApi/RestApiTagViewModel.cs
+++ b/src/Docfx.DataContracts.RestApi/RestApiTagViewModel.cs
@@ -39,6 +39,7 @@ public class RestApiTagViewModel : IOverwriteDocumentViewModel
     public string HtmlId { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.DataContracts.RestApi/RestApiTagViewModel.cs
+++ b/src/Docfx.DataContracts.RestApi/RestApiTagViewModel.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.Common.EntityMergers;
 using Docfx.DataContracts.Common;
 using Docfx.YamlSerialization;
@@ -13,28 +14,34 @@ public class RestApiTagViewModel : IOverwriteDocumentViewModel
 {
     [YamlMember(Alias = Constants.PropertyName.Uid)]
     [JsonProperty(Constants.PropertyName.Uid)]
+    [JsonPropertyName(Constants.PropertyName.Uid)]
     [MergeOption(MergeOption.MergeKey)]
     public string Uid { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Conceptual)]
     [JsonProperty(Constants.PropertyName.Conceptual)]
+    [JsonPropertyName(Constants.PropertyName.Conceptual)]
     public string Conceptual { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Documentation)]
     [JsonProperty(Constants.PropertyName.Documentation)]
+    [JsonPropertyName(Constants.PropertyName.Documentation)]
     [MergeOption(MergeOption.Ignore)]
     public SourceDetail Documentation { get; set; }
 
     [YamlMember(Alias = "name")]
     [JsonProperty("name")]
+    [JsonPropertyName("name")]
     public string Name { get; set; }
 
     [YamlMember(Alias = "description")]
     [JsonProperty("description")]
+    [JsonPropertyName("description")]
     public string Description { get; set; }
 
     [YamlMember(Alias = "htmlId")]
     [JsonProperty("htmlId")]
+    [JsonPropertyName("htmlId")]
     [MergeOption(MergeOption.Ignore)]
     public string HtmlId { get; set; }
 

--- a/src/Docfx.DataContracts.UniversalReference/ApiParameter.cs
+++ b/src/Docfx.DataContracts.UniversalReference/ApiParameter.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.Common.EntityMergers;
 using Docfx.DataContracts.Common;
 using Docfx.YamlSerialization;
@@ -14,6 +15,7 @@ public class ApiParameter
 {
     [YamlMember(Alias = "id")]
     [JsonProperty("id")]
+    [JsonPropertyName("id")]
     [MergeOption(MergeOption.MergeKey)]
     public string Name { get; set; }
 
@@ -23,20 +25,24 @@ public class ApiParameter
     /// </summary>
     [YamlMember(Alias = "type")]
     [JsonProperty("type")]
+    [JsonPropertyName("type")]
     [UniqueIdentityReference]
     public List<string> Type { get; set; }
 
     [YamlMember(Alias = "description")]
     [JsonProperty("description")]
+    [JsonPropertyName("description")]
     [MarkdownContent]
     public string Description { get; set; }
 
     [YamlMember(Alias = "optional")]
     [JsonProperty("optional")]
+    [JsonPropertyName("optional")]
     public bool Optional { get; set; }
 
     [YamlMember(Alias = "defaultValue")]
     [JsonProperty("defaultValue")]
+    [JsonPropertyName("defaultValue")]
     public string DefaultValue { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.DataContracts.UniversalReference/ApiParameter.cs
+++ b/src/Docfx.DataContracts.UniversalReference/ApiParameter.cs
@@ -40,6 +40,7 @@ public class ApiParameter
     public string DefaultValue { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.DataContracts.UniversalReference/ArgumentInfo.cs
+++ b/src/Docfx.DataContracts.UniversalReference/ArgumentInfo.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.DataContracts.Common;
 using Docfx.YamlSerialization;
 
@@ -13,11 +14,13 @@ public class ArgumentInfo
 {
     [YamlMember(Alias = "type")]
     [JsonProperty("type")]
+    [JsonPropertyName("type")]
     [UniqueIdentityReference]
     public string Type { get; set; }
 
     [YamlMember(Alias = "value")]
     [JsonProperty("value")]
+    [JsonPropertyName("value")]
     public object Value { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.DataContracts.UniversalReference/ArgumentInfo.cs
+++ b/src/Docfx.DataContracts.UniversalReference/ArgumentInfo.cs
@@ -21,6 +21,7 @@ public class ArgumentInfo
     public object Value { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.DataContracts.UniversalReference/AttributeInfo.cs
+++ b/src/Docfx.DataContracts.UniversalReference/AttributeInfo.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.DataContracts.Common;
 using Docfx.YamlSerialization;
 
@@ -13,19 +14,23 @@ public class AttributeInfo
 {
     [YamlMember(Alias = "type")]
     [JsonProperty("type")]
+    [JsonPropertyName("type")]
     [UniqueIdentityReference]
     public string Type { get; set; }
 
     [YamlMember(Alias = "ctor")]
     [JsonProperty("ctor")]
+    [JsonPropertyName("ctor")]
     public string Constructor { get; set; }
 
     [YamlMember(Alias = "arguments")]
     [JsonProperty("arguments")]
+    [JsonPropertyName("arguments")]
     public List<ArgumentInfo> Arguments { get; set; }
 
     [YamlMember(Alias = "namedArguments")]
     [JsonProperty("namedArguments")]
+    [JsonPropertyName("namedArguments")]
     public List<NamedArgumentInfo> NamedArguments { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.DataContracts.UniversalReference/AttributeInfo.cs
+++ b/src/Docfx.DataContracts.UniversalReference/AttributeInfo.cs
@@ -29,6 +29,7 @@ public class AttributeInfo
     public List<NamedArgumentInfo> NamedArguments { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.DataContracts.UniversalReference/ExceptionInfo.cs
+++ b/src/Docfx.DataContracts.UniversalReference/ExceptionInfo.cs
@@ -24,6 +24,7 @@ public class ExceptionInfo
     public string Description { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.DataContracts.UniversalReference/ExceptionInfo.cs
+++ b/src/Docfx.DataContracts.UniversalReference/ExceptionInfo.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.Common.EntityMergers;
 using Docfx.DataContracts.Common;
 using Docfx.YamlSerialization;
@@ -15,11 +16,13 @@ public class ExceptionInfo
     [YamlMember(Alias = "type")]
     [MergeOption(MergeOption.MergeKey)]
     [JsonProperty("type")]
+    [JsonPropertyName("type")]
     [UniqueIdentityReference]
     public string Type { get; set; }
 
     [YamlMember(Alias = "description")]
     [JsonProperty("description")]
+    [JsonPropertyName("description")]
     [MarkdownContent]
     public string Description { get; set; }
 

--- a/src/Docfx.DataContracts.UniversalReference/InheritanceTree.cs
+++ b/src/Docfx.DataContracts.UniversalReference/InheritanceTree.cs
@@ -27,6 +27,7 @@ public class InheritanceTree
     public List<InheritanceTree> Inheritance { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.DataContracts.UniversalReference/InheritanceTree.cs
+++ b/src/Docfx.DataContracts.UniversalReference/InheritanceTree.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.Common.EntityMergers;
 using Docfx.DataContracts.Common;
 using Docfx.YamlSerialization;
@@ -14,6 +15,7 @@ public class InheritanceTree
 {
     [YamlMember(Alias = Constants.PropertyName.Type)]
     [JsonProperty(Constants.PropertyName.Type)]
+    [JsonPropertyName(Constants.PropertyName.Type)]
     [UniqueIdentityReference]
     public string Type { get; set; }
 
@@ -24,6 +26,7 @@ public class InheritanceTree
     [YamlMember(Alias = Constants.PropertyName.Inheritance)]
     [MergeOption(MergeOption.Ignore)]
     [JsonProperty(Constants.PropertyName.Inheritance)]
+    [JsonPropertyName(Constants.PropertyName.Inheritance)]
     public List<InheritanceTree> Inheritance { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.DataContracts.UniversalReference/ItemViewModel.cs
+++ b/src/Docfx.DataContracts.UniversalReference/ItemViewModel.cs
@@ -306,7 +306,8 @@ public class ItemViewModel : IOverwriteDocumentViewModel
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     [YamlIgnore]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     [UniqueIdentityReferenceIgnore]
     [MarkdownContentIgnore]
     public CompositeDictionary ExtensionData =>

--- a/src/Docfx.DataContracts.UniversalReference/ItemViewModel.cs
+++ b/src/Docfx.DataContracts.UniversalReference/ItemViewModel.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
-
+using System.Text.Json.Serialization;
 using Docfx.Common;
 using Docfx.Common.EntityMergers;
 using Docfx.DataContracts.Common;
@@ -20,11 +20,13 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     /// </summary>
     [YamlMember(Alias = Constants.PropertyName.Uid)]
     [JsonProperty(Constants.PropertyName.Uid)]
+    [JsonPropertyName(Constants.PropertyName.Uid)]
     [MergeOption(MergeOption.MergeKey)]
     public string Uid { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.CommentId)]
     [JsonProperty(Constants.PropertyName.CommentId)]
+    [JsonPropertyName(Constants.PropertyName.CommentId)]
     public string CommentId { get; set; }
 
     /// <summary>
@@ -32,10 +34,12 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     /// </summary>
     [YamlMember(Alias = Constants.PropertyName.Id)]
     [JsonProperty(Constants.PropertyName.Id)]
+    [JsonPropertyName(Constants.PropertyName.Id)]
     public string Id { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Parent)]
     [JsonProperty(Constants.PropertyName.Parent)]
+    [JsonPropertyName(Constants.PropertyName.Parent)]
     [UniqueIdentityReference]
     public string Parent { get; set; }
 
@@ -46,6 +50,7 @@ public class ItemViewModel : IOverwriteDocumentViewModel
 
     [YamlMember(Alias = "package")]
     [JsonProperty("package")]
+    [JsonPropertyName("package")]
     [UniqueIdentityReference]
     public string Package { get; set; }
 
@@ -57,6 +62,7 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     [YamlMember(Alias = Constants.PropertyName.Children)]
     [MergeOption(MergeOption.Ignore)] // todo : merge more children
     [JsonProperty(Constants.PropertyName.Children)]
+    [JsonPropertyName(Constants.PropertyName.Children)]
     [UniqueIdentityReference]
     public List<string> Children { get; set; }
 
@@ -71,14 +77,17 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     /// </summary>
     [YamlMember(Alias = Constants.PropertyName.Href)]
     [JsonProperty(Constants.PropertyName.Href)]
+    [JsonPropertyName(Constants.PropertyName.Href)]
     public string Href { get; set; }
 
     [YamlMember(Alias = "langs")]
     [JsonProperty("langs")]
+    [JsonPropertyName("langs")]
     public string[] SupportedLanguages { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Name)]
     [JsonProperty(Constants.PropertyName.Name)]
+    [JsonPropertyName(Constants.PropertyName.Name)]
     public string Name { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Name)]
@@ -88,6 +97,7 @@ public class ItemViewModel : IOverwriteDocumentViewModel
 
     [YamlMember(Alias = Constants.PropertyName.NameWithType)]
     [JsonProperty(Constants.PropertyName.NameWithType)]
+    [JsonPropertyName(Constants.PropertyName.NameWithType)]
     public string NameWithType { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.NameWithType)]
@@ -97,6 +107,7 @@ public class ItemViewModel : IOverwriteDocumentViewModel
 
     [YamlMember(Alias = Constants.PropertyName.FullName)]
     [JsonProperty(Constants.PropertyName.FullName)]
+    [JsonPropertyName(Constants.PropertyName.FullName)]
     public string FullName { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.FullName)]
@@ -106,10 +117,12 @@ public class ItemViewModel : IOverwriteDocumentViewModel
 
     [YamlMember(Alias = Constants.PropertyName.Type)]
     [JsonProperty(Constants.PropertyName.Type)]
+    [JsonPropertyName(Constants.PropertyName.Type)]
     public string Type { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Source)]
     [JsonProperty(Constants.PropertyName.Source)]
+    [JsonPropertyName(Constants.PropertyName.Source)]
     public SourceDetail Source { get; set; }
 
     /// <summary>
@@ -126,11 +139,13 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     /// </summary>
     [YamlMember(Alias = Constants.PropertyName.Documentation)]
     [JsonProperty(Constants.PropertyName.Documentation)]
+    [JsonPropertyName(Constants.PropertyName.Documentation)]
     public SourceDetail Documentation { get; set; }
 
     [YamlMember(Alias = Constants.ExtensionMemberPrefix.Assemblies)]
     [MergeOption(MergeOption.Ignore)] // todo : merge more children
     [JsonProperty(Constants.ExtensionMemberPrefix.Assemblies)]
+    [JsonPropertyName(Constants.ExtensionMemberPrefix.Assemblies)]
     public List<string> AssemblyNameList { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Assemblies)]
@@ -140,6 +155,7 @@ public class ItemViewModel : IOverwriteDocumentViewModel
 
     [YamlMember(Alias = Constants.PropertyName.Namespace)]
     [JsonProperty(Constants.PropertyName.Namespace)]
+    [JsonPropertyName(Constants.PropertyName.Namespace)]
     [UniqueIdentityReference]
     public string NamespaceName { get; set; }
 
@@ -154,6 +170,7 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     /// </summary>
     [YamlMember(Alias = "summary")]
     [JsonProperty("summary")]
+    [JsonPropertyName("summary")]
     [MarkdownContent]
     public string Summary { get; set; }
 
@@ -163,6 +180,7 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     /// </summary>
     [YamlMember(Alias = "remarks")]
     [JsonProperty("remarks")]
+    [JsonPropertyName("remarks")]
     [MarkdownContent]
     public string Remarks { get; set; }
 
@@ -172,6 +190,7 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     /// </summary>
     [YamlMember(Alias = "example")]
     [JsonProperty("example")]
+    [JsonPropertyName("example")]
     [MergeOption(MergeOption.Replace)]
     [MarkdownContent]
     public List<string> Examples { get; set; }
@@ -182,10 +201,12 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     /// </summary>
     [YamlMember(Alias = "syntax")]
     [JsonProperty("syntax")]
+    [JsonPropertyName("syntax")]
     public SyntaxDetailViewModel Syntax { get; set; }
 
     [YamlMember(Alias = "overridden")]
     [JsonProperty("overridden")]
+    [JsonPropertyName("overridden")]
     [UniqueIdentityReference]
     public string Overridden { get; set; }
 
@@ -196,6 +217,7 @@ public class ItemViewModel : IOverwriteDocumentViewModel
 
     [YamlMember(Alias = Constants.PropertyName.Overload)]
     [JsonProperty(Constants.PropertyName.Overload)]
+    [JsonPropertyName(Constants.PropertyName.Overload)]
     [UniqueIdentityReference]
     public string Overload { get; set; }
 
@@ -206,6 +228,7 @@ public class ItemViewModel : IOverwriteDocumentViewModel
 
     [YamlMember(Alias = "exceptions")]
     [JsonProperty("exceptions")]
+    [JsonPropertyName("exceptions")]
     public List<ExceptionInfo> Exceptions { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Exceptions)]
@@ -215,15 +238,18 @@ public class ItemViewModel : IOverwriteDocumentViewModel
 
     [YamlMember(Alias = "seealso")]
     [JsonProperty("seealso")]
+    [JsonPropertyName("seealso")]
     public List<LinkInfo> SeeAlsos { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.SeeAlsoContent)]
     [JsonProperty(Constants.PropertyName.SeeAlsoContent)]
+    [JsonPropertyName(Constants.PropertyName.SeeAlsoContent)]
     [MarkdownContent]
     public string SeeAlsoContent { get; set; }
 
     [YamlMember(Alias = "see")]
     [JsonProperty("see")]
+    [JsonPropertyName("see")]
     public List<LinkInfo> Sees { get; set; }
 
     [YamlIgnore]
@@ -245,6 +271,7 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     [YamlMember(Alias = Constants.PropertyName.Inheritance)]
     [MergeOption(MergeOption.Ignore)]
     [JsonProperty(Constants.PropertyName.Inheritance)]
+    [JsonPropertyName(Constants.PropertyName.Inheritance)]
     public List<InheritanceTree> Inheritance { get; set; }
 
     [YamlIgnore]
@@ -261,6 +288,7 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     [YamlMember(Alias = Constants.PropertyName.DerivedClasses)]
     [MergeOption(MergeOption.Ignore)]
     [JsonProperty(Constants.PropertyName.DerivedClasses)]
+    [JsonPropertyName(Constants.PropertyName.DerivedClasses)]
     [UniqueIdentityReference]
     public List<string> DerivedClasses { get; set; }
 
@@ -272,6 +300,7 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     [YamlMember(Alias = Constants.PropertyName.Implements)]
     [MergeOption(MergeOption.Ignore)] // todo : merge more children
     [JsonProperty(Constants.PropertyName.Implements)]
+    [JsonPropertyName(Constants.PropertyName.Implements)]
     [UniqueIdentityReference]
     public List<string> Implements { get; set; }
 
@@ -283,6 +312,7 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     [YamlMember(Alias = Constants.PropertyName.InheritedMembers)]
     [MergeOption(MergeOption.Ignore)] // todo : merge more children
     [JsonProperty(Constants.PropertyName.InheritedMembers)]
+    [JsonPropertyName(Constants.PropertyName.InheritedMembers)]
     [UniqueIdentityReference]
     public List<string> InheritedMembers { get; set; }
 
@@ -294,6 +324,7 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     [YamlMember(Alias = Constants.PropertyName.ExtensionMethods)]
     [MergeOption(MergeOption.Ignore)] // todo : merge more children
     [JsonProperty(Constants.PropertyName.ExtensionMethods)]
+    [JsonPropertyName(Constants.PropertyName.ExtensionMethods)]
     [UniqueIdentityReference]
     public List<string> ExtensionMethods { get; set; }
 
@@ -308,11 +339,13 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     /// </summary>
     [YamlMember(Alias = Constants.PropertyName.Conceptual)]
     [JsonProperty(Constants.PropertyName.Conceptual)]
+    [JsonPropertyName(Constants.PropertyName.Conceptual)]
     [MarkdownContent]
     public string Conceptual { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Platform)]
     [JsonProperty(Constants.PropertyName.Platform)]
+    [JsonPropertyName(Constants.PropertyName.Platform)]
     [MergeOption(MergeOption.Replace)]
     public List<string> Platform { get; set; }
 

--- a/src/Docfx.DataContracts.UniversalReference/ItemViewModel.cs
+++ b/src/Docfx.DataContracts.UniversalReference/ItemViewModel.cs
@@ -40,7 +40,8 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     public string Parent { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Parent)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, string> ParentInDevLangs { get; set; } = new SortedList<string, string>();
 
     [YamlMember(Alias = "package")]
@@ -49,7 +50,8 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     public string Package { get; set; }
 
     [ExtensibleMember("package" + Constants.PrefixSeparator)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, string> PackageInDevLangs { get; set; } = new SortedList<string, string>();
 
     [YamlMember(Alias = Constants.PropertyName.Children)]
@@ -59,7 +61,8 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     public List<string> Children { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Children)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, List<string>> ChildrenInDevLangs { get; set; } = new SortedList<string, List<string>>();
 
     /// <summary>
@@ -79,7 +82,8 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     public string Name { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Name)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, string> Names { get; set; } = new SortedList<string, string>();
 
     [YamlMember(Alias = Constants.PropertyName.NameWithType)]
@@ -87,7 +91,8 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     public string NameWithType { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.NameWithType)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, string> NamesWithType { get; set; } = new SortedList<string, string>();
 
     [YamlMember(Alias = Constants.PropertyName.FullName)]
@@ -95,7 +100,8 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     public string FullName { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.FullName)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, string> FullNames { get; set; } = new SortedList<string, string>();
 
     [YamlMember(Alias = Constants.PropertyName.Type)]
@@ -110,7 +116,8 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     /// item's source code's source detail in different dev langs
     /// </summary>
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Source)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, SourceDetail> SourceInDevLangs { get; set; } = new SortedList<string, SourceDetail>();
 
     /// <summary>
@@ -127,7 +134,8 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     public List<string> AssemblyNameList { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Assemblies)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, List<string>> AssemblyNameListInDevLangs { get; set; } = new SortedList<string, List<string>>();
 
     [YamlMember(Alias = Constants.PropertyName.Namespace)]
@@ -136,7 +144,8 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     public string NamespaceName { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Namespace)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, string> NamespaceNameInDevLangs { get; set; } = new SortedList<string, string>();
 
     /// <summary>
@@ -181,7 +190,8 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     public string Overridden { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Overridden)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, string> OverriddenInDevLangs { get; set; } = new SortedList<string, string>();
 
     [YamlMember(Alias = Constants.PropertyName.Overload)]
@@ -190,7 +200,8 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     public string Overload { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Overload)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, string> OverloadInDevLangs { get; set; } = new SortedList<string, string>();
 
     [YamlMember(Alias = "exceptions")]
@@ -198,7 +209,8 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     public List<ExceptionInfo> Exceptions { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Exceptions)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, List<ExceptionInfo>> ExceptionsInDevLangs { get; set; } = new SortedList<string, List<ExceptionInfo>>();
 
     [YamlMember(Alias = "seealso")]
@@ -214,13 +226,15 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     [JsonProperty("see")]
     public List<LinkInfo> Sees { get; set; }
 
-    [JsonIgnore]
     [YamlIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     [UniqueIdentityReference]
     public List<string> SeeAlsosUidReference => SeeAlsos?.Where(s => s.LinkType == LinkType.CRef).Select(s => s.LinkId).ToList();
 
-    [JsonIgnore]
     [YamlIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     [UniqueIdentityReference]
     public List<string> SeesUidReference => Sees?.Where(s => s.LinkType == LinkType.CRef).Select(s => s.LinkId).ToList();
 
@@ -233,13 +247,15 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     [JsonProperty(Constants.PropertyName.Inheritance)]
     public List<InheritanceTree> Inheritance { get; set; }
 
-    [JsonIgnore]
     [YamlIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     [UniqueIdentityReference]
     public List<string> InheritanceUidReference => GetInheritanceUidReference(Inheritance)?.ToList() ?? new List<string>();
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Inheritance)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, List<InheritanceTree>> InheritanceInDevLangs { get; set; } = new SortedList<string, List<InheritanceTree>>();
 
     [YamlMember(Alias = Constants.PropertyName.DerivedClasses)]
@@ -249,7 +265,8 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     public List<string> DerivedClasses { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.DerivedClasses)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, List<string>> DerivedClassesInDevLangs { get; set; } = new SortedList<string, List<string>>();
 
     [YamlMember(Alias = Constants.PropertyName.Implements)]
@@ -259,7 +276,8 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     public List<string> Implements { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Implements)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, List<string>> ImplementsInDevLangs { get; set; } = new SortedList<string, List<string>>();
 
     [YamlMember(Alias = Constants.PropertyName.InheritedMembers)]
@@ -269,7 +287,8 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     public List<string> InheritedMembers { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.InheritedMembers)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, List<string>> InheritedMembersInDevLangs { get; set; } = new SortedList<string, List<string>>();
 
     [YamlMember(Alias = Constants.PropertyName.ExtensionMethods)]
@@ -279,7 +298,8 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     public List<string> ExtensionMethods { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.ExtensionMethods)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, List<string>> ExtensionMethodsInDevLangs { get; set; } = new SortedList<string, List<string>>();
 
     /// <summary>
@@ -297,11 +317,13 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     public List<string> Platform { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Platform)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, List<string>> PlatformInDevLangs { get; set; } = new SortedList<string, List<string>>();
 
     [ExtensibleMember]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Docfx.DataContracts.UniversalReference/LinkInfo.cs
+++ b/src/Docfx.DataContracts.UniversalReference/LinkInfo.cs
@@ -32,7 +32,8 @@ public class LinkInfo
     public string AltText { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }
 

--- a/src/Docfx.DataContracts.UniversalReference/LinkInfo.cs
+++ b/src/Docfx.DataContracts.UniversalReference/LinkInfo.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.Common.EntityMergers;
 using Docfx.DataContracts.Common;
 using Docfx.YamlSerialization;
@@ -14,21 +15,25 @@ public class LinkInfo
 {
     [YamlMember(Alias = "linkType")]
     [JsonProperty("linkType")]
+    [JsonPropertyName("linkType")]
     [MergeOption(MergeOption.Ignore)]
     public LinkType LinkType { get; set; }
 
     [YamlMember(Alias = "linkId")]
     [MergeOption(MergeOption.MergeKey)]
     [JsonProperty("linkId")]
+    [JsonPropertyName("linkId")]
     public string LinkId { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.CommentId)]
     [JsonProperty(Constants.PropertyName.CommentId)]
+    [JsonPropertyName(Constants.PropertyName.CommentId)]
     [MergeOption(MergeOption.Ignore)]
     public string CommentId { get; set; }
 
     [YamlMember(Alias = "altText")]
     [JsonProperty("altText")]
+    [JsonPropertyName("altText")]
     public string AltText { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.DataContracts.UniversalReference/NamedArgumentInfo.cs
+++ b/src/Docfx.DataContracts.UniversalReference/NamedArgumentInfo.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.DataContracts.Common;
 using Docfx.YamlSerialization;
 
@@ -13,15 +14,18 @@ public class NamedArgumentInfo
 {
     [YamlMember(Alias = "name")]
     [JsonProperty("name")]
+    [JsonPropertyName("name")]
     public string Name { get; set; }
 
     [YamlMember(Alias = "type")]
     [JsonProperty("type")]
+    [JsonPropertyName("type")]
     [UniqueIdentityReference]
     public string Type { get; set; }
 
     [YamlMember(Alias = "value")]
     [JsonProperty("value")]
+    [JsonPropertyName("value")]
     public object Value { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.DataContracts.UniversalReference/NamedArgumentInfo.cs
+++ b/src/Docfx.DataContracts.UniversalReference/NamedArgumentInfo.cs
@@ -25,6 +25,7 @@ public class NamedArgumentInfo
     public object Value { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.DataContracts.UniversalReference/PageViewModel.cs
+++ b/src/Docfx.DataContracts.UniversalReference/PageViewModel.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.DataContracts.Common;
 using Docfx.YamlSerialization;
 
@@ -13,16 +14,19 @@ public class PageViewModel
 {
     [YamlMember(Alias = "items")]
     [JsonProperty("items")]
+    [JsonPropertyName("items")]
     public List<ItemViewModel> Items { get; set; } = new List<ItemViewModel>();
 
     [YamlMember(Alias = "references")]
     [JsonProperty("references")]
+    [JsonPropertyName("references")]
     [UniqueIdentityReferenceIgnore]
     [MarkdownContentIgnore]
     public List<ReferenceViewModel> References { get; set; } = new List<ReferenceViewModel>();
 
     [YamlMember(Alias = "shouldSkipMarkup")]
     [JsonProperty("shouldSkipMarkup")]
+    [JsonPropertyName("shouldSkipMarkup")]
     public bool ShouldSkipMarkup { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.DataContracts.UniversalReference/PageViewModel.cs
+++ b/src/Docfx.DataContracts.UniversalReference/PageViewModel.cs
@@ -26,6 +26,7 @@ public class PageViewModel
     public bool ShouldSkipMarkup { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.DataContracts.UniversalReference/SyntaxDetailViewModel.cs
+++ b/src/Docfx.DataContracts.UniversalReference/SyntaxDetailViewModel.cs
@@ -19,7 +19,8 @@ public class SyntaxDetailViewModel
     public string Content { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Content)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, string> Contents { get; set; } = new SortedList<string, string>();
 
     [YamlMember(Alias = "parameters")]
@@ -40,11 +41,13 @@ public class SyntaxDetailViewModel
     public ApiParameter Return { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Return)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, ApiParameter> ReturnInDevLangs { get; set; } = new SortedList<string, ApiParameter>();
 
     [ExtensibleMember]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Docfx.DataContracts.UniversalReference/SyntaxDetailViewModel.cs
+++ b/src/Docfx.DataContracts.UniversalReference/SyntaxDetailViewModel.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
-
+using System.Text.Json.Serialization;
 using Docfx.Common;
 using Docfx.DataContracts.Common;
 using Docfx.YamlSerialization;
@@ -16,6 +16,7 @@ public class SyntaxDetailViewModel
 {
     [YamlMember(Alias = Constants.PropertyName.Content)]
     [JsonProperty(Constants.PropertyName.Content)]
+    [JsonPropertyName(Constants.PropertyName.Content)]
     public string Content { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Content)]
@@ -25,10 +26,12 @@ public class SyntaxDetailViewModel
 
     [YamlMember(Alias = "parameters")]
     [JsonProperty("parameters")]
+    [JsonPropertyName("parameters")]
     public List<ApiParameter> Parameters { get; set; }
 
     [YamlMember(Alias = "typeParameters")]
     [JsonProperty("typeParameters")]
+    [JsonPropertyName("typeParameters")]
     public List<ApiParameter> TypeParameters { get; set; }
 
     /// <summary>
@@ -38,6 +41,7 @@ public class SyntaxDetailViewModel
     /// </summary>
     [YamlMember(Alias = Constants.PropertyName.Return)]
     [JsonProperty(Constants.PropertyName.Return)]
+    [JsonPropertyName(Constants.PropertyName.Return)]
     public ApiParameter Return { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Return)]

--- a/src/Docfx.DataContracts.UniversalReference/SyntaxDetailViewModel.cs
+++ b/src/Docfx.DataContracts.UniversalReference/SyntaxDetailViewModel.cs
@@ -49,7 +49,8 @@ public class SyntaxDetailViewModel
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     [YamlIgnore]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     [UniqueIdentityReferenceIgnore]
     [MarkdownContentIgnore]
     public CompositeDictionary ExtensionData =>

--- a/src/Docfx.Dotnet/ManagedReference/MetadataItem.cs
+++ b/src/Docfx.Dotnet/ManagedReference/MetadataItem.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.Common.EntityMergers;
 using Docfx.DataContracts.Common;
 using Docfx.DataContracts.ManagedReference;
@@ -16,121 +17,150 @@ internal class MetadataItem : ICloneable
     [System.Text.Json.Serialization.JsonIgnore]
     public bool IsInvalid { get; set; }
 
-    [JsonProperty(Constants.PropertyName.IsEii)]
     [YamlMember(Alias = Constants.PropertyName.IsEii)]
+    [JsonProperty(Constants.PropertyName.IsEii)]
+    [JsonPropertyName(Constants.PropertyName.IsEii)]
     public bool IsExplicitInterfaceImplementation { get; set; }
 
     [YamlMember(Alias = "isExtensionMethod")]
     [JsonProperty("isExtensionMethod")]
+    [JsonPropertyName("isExtensionMethod")]
     public bool IsExtensionMethod { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Id)]
     [JsonProperty(Constants.PropertyName.Id)]
+    [JsonPropertyName(Constants.PropertyName.Id)]
     public string Name { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.CommentId)]
     [JsonProperty(Constants.PropertyName.CommentId)]
+    [JsonPropertyName(Constants.PropertyName.CommentId)]
     public string CommentId { get; set; }
 
     [YamlMember(Alias = "name")]
     [JsonProperty("name")]
+    [JsonPropertyName("name")]
     public SortedList<SyntaxLanguage, string> DisplayNames { get; set; }
 
     [YamlMember(Alias = "nameWithType")]
     [JsonProperty("nameWithType")]
+    [JsonPropertyName("nameWithType")]
     public SortedList<SyntaxLanguage, string> DisplayNamesWithType { get; set; }
 
     [YamlMember(Alias = "qualifiedName")]
     [JsonProperty("qualifiedName")]
+    [JsonPropertyName("qualifiedName")]
     public SortedList<SyntaxLanguage, string> DisplayQualifiedNames { get; set; }
 
     [YamlMember(Alias = "parent")]
     [JsonProperty("parent")]
+    [JsonPropertyName("parent")]
     public MetadataItem Parent { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Type)]
     [JsonProperty(Constants.PropertyName.Type)]
+    [JsonPropertyName(Constants.PropertyName.Type)]
     public MemberType Type { get; set; }
 
     [YamlMember(Alias = "assemblies")]
     [JsonProperty("assemblies")]
+    [JsonPropertyName("assemblies")]
     public List<string> AssemblyNameList { get; set; }
 
     [YamlMember(Alias = "namespace")]
     [JsonProperty("namespace")]
+    [JsonPropertyName("namespace")]
     public string NamespaceName { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Source)]
     [JsonProperty(Constants.PropertyName.Source)]
+    [JsonPropertyName(Constants.PropertyName.Source)]
     public SourceDetail Source { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Documentation)]
     [JsonProperty(Constants.PropertyName.Documentation)]
+    [JsonPropertyName(Constants.PropertyName.Documentation)]
     public SourceDetail Documentation { get; set; }
 
     [YamlMember(Alias = "summary")]
     [JsonProperty("summary")]
+    [JsonPropertyName("summary")]
     public string Summary { get; set; }
 
     [YamlMember(Alias = "remarks")]
     [JsonProperty("remarks")]
+    [JsonPropertyName("remarks")]
     public string Remarks { get; set; }
 
     [YamlMember(Alias = "example")]
     [JsonProperty("example")]
+    [JsonPropertyName("example")]
     public List<string> Examples { get; set; }
 
     [YamlMember(Alias = "syntax")]
     [JsonProperty("syntax")]
+    [JsonPropertyName("syntax")]
     public SyntaxDetail Syntax { get; set; }
 
     [YamlMember(Alias = "overload")]
     [JsonProperty("overload")]
+    [JsonPropertyName("overload")]
     public string Overload { get; set; }
 
     [YamlMember(Alias = "overridden")]
     [JsonProperty("overridden")]
+    [JsonPropertyName("overridden")]
     public string Overridden { get; set; }
 
     [YamlMember(Alias = "exceptions")]
     [JsonProperty("exceptions")]
+    [JsonPropertyName("exceptions")]
     public List<ExceptionInfo> Exceptions { get; set; }
 
     [YamlMember(Alias = "seealso")]
     [JsonProperty("seealso")]
+    [JsonPropertyName("seealso")]
     public List<LinkInfo> SeeAlsos { get; set; }
 
     [YamlMember(Alias = "inheritance")]
     [JsonProperty("inheritance")]
+    [JsonPropertyName("inheritance")]
     public List<string> Inheritance { get; set; }
 
     [YamlMember(Alias = "derivedClasses")]
     [JsonProperty("derivedClasses")]
+    [JsonPropertyName("derivedClasses")]
     public List<string> DerivedClasses { get; set; }
 
     [YamlMember(Alias = "implements")]
     [JsonProperty("implements")]
+    [JsonPropertyName("implements")]
     public List<string> Implements { get; set; }
 
     [YamlMember(Alias = "inheritedMembers")]
     [JsonProperty("inheritedMembers")]
+    [JsonPropertyName("inheritedMembers")]
     public List<string> InheritedMembers { get; set; }
 
     [YamlMember(Alias = "extensionMethods")]
     [JsonProperty("extensionMethods")]
+    [JsonPropertyName("extensionMethods")]
     public List<string> ExtensionMethods { get; set; }
 
     [YamlMember(Alias = "attributes")]
     [JsonProperty("attributes")]
+    [JsonPropertyName("attributes")]
     [MergeOption(MergeOption.Ignore)]
     public List<AttributeInfo> Attributes { get; set; }
 
     [YamlMember(Alias = "items")]
     [JsonProperty("items")]
+    [JsonPropertyName("items")]
     public List<MetadataItem> Items { get; set; }
 
     [YamlMember(Alias = "references")]
     [JsonProperty("references")]
+    [JsonPropertyName("references")]
     public Dictionary<string, ReferenceItem> References { get; set; }
 
     [YamlIgnore]

--- a/src/Docfx.Dotnet/ManagedReference/MetadataItem.cs
+++ b/src/Docfx.Dotnet/ManagedReference/MetadataItem.cs
@@ -12,7 +12,8 @@ namespace Docfx.Dotnet;
 internal class MetadataItem : ICloneable
 {
     [YamlIgnore]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public bool IsInvalid { get; set; }
 
     [JsonProperty(Constants.PropertyName.IsEii)]
@@ -133,7 +134,8 @@ internal class MetadataItem : ICloneable
     public Dictionary<string, ReferenceItem> References { get; set; }
 
     [YamlIgnore]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public XmlComment CommentModel { get; set; }
 
     public override string ToString()

--- a/src/Docfx.Dotnet/ManagedReference/Models/AdditionalNotes.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Models/AdditionalNotes.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.DataContracts.Common;
 
 using Newtonsoft.Json;
@@ -9,19 +10,22 @@ using YamlDotNet.Serialization;
 namespace Docfx.DataContracts.ManagedReference;
 
 public class AdditionalNotes
-{
-    [JsonProperty("caller")]
+{   
     [YamlMember(Alias = "caller")]
+    [JsonProperty("caller")]
+    [JsonPropertyName("caller")]
     [MarkdownContent]
     public string Caller { get; set; }
-
-    [JsonProperty("implementer")]
+        
     [YamlMember(Alias = "implementer")]
+    [JsonProperty("implementer")]
+    [JsonPropertyName("implementer")]
     [MarkdownContent]
     public string Implementer { get; set; }
 
-    [JsonProperty("inheritor")]
     [YamlMember(Alias = "inheritor")]
+    [JsonProperty("inheritor")]
+    [JsonPropertyName("inheritor")]
     [MarkdownContent]
     public string Inheritor { get; set; }
 }

--- a/src/Docfx.Dotnet/ManagedReference/Models/ApiParameter.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Models/ApiParameter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.Common.EntityMergers;
 using Docfx.DataContracts.Common;
 using Newtonsoft.Json;
@@ -12,21 +13,25 @@ public class ApiParameter
 {
     [YamlMember(Alias = "id")]
     [JsonProperty("id")]
+    [JsonPropertyName("id")]
     [MergeOption(MergeOption.MergeKey)]
     public string Name { get; set; }
 
     [YamlMember(Alias = "type")]
     [JsonProperty("type")]
+    [JsonPropertyName("type")]
     [UniqueIdentityReference]
     public string Type { get; set; }
 
     [YamlMember(Alias = "description")]
     [JsonProperty("description")]
+    [JsonPropertyName("description")]
     [MarkdownContent]
     public string Description { get; set; }
 
     [YamlMember(Alias = "attributes")]
     [JsonProperty("attributes")]
+    [JsonPropertyName("attributes")]
     [MergeOption(MergeOption.Ignore)]
     public List<AttributeInfo> Attributes { get; set; }
 }

--- a/src/Docfx.Dotnet/ManagedReference/Models/ArgumentInfo.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Models/ArgumentInfo.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.DataContracts.Common;
 
 using Newtonsoft.Json;
@@ -12,10 +13,12 @@ public class ArgumentInfo
 {
     [YamlMember(Alias = "type")]
     [JsonProperty("type")]
+    [JsonPropertyName("type")]
     [UniqueIdentityReference]
     public string Type { get; set; }
 
     [YamlMember(Alias = "value")]
     [JsonProperty("value")]
+    [JsonPropertyName("value")]
     public object Value { get; set; }
 }

--- a/src/Docfx.Dotnet/ManagedReference/Models/AttributeInfo.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Models/AttributeInfo.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.DataContracts.Common;
 
 using Newtonsoft.Json;
@@ -12,18 +13,22 @@ public class AttributeInfo
 {
     [YamlMember(Alias = "type")]
     [JsonProperty("type")]
+    [JsonPropertyName("type")]
     [UniqueIdentityReference]
     public string Type { get; set; }
 
     [YamlMember(Alias = "ctor")]
     [JsonProperty("ctor")]
+    [JsonPropertyName("ctor")]
     public string Constructor { get; set; }
 
     [YamlMember(Alias = "arguments")]
     [JsonProperty("arguments")]
+    [JsonPropertyName("arguments")]
     public List<ArgumentInfo> Arguments { get; set; }
 
     [YamlMember(Alias = "namedArguments")]
     [JsonProperty("namedArguments")]
+    [JsonPropertyName("namedArguments")]
     public List<NamedArgumentInfo> NamedArguments { get; set; }
 }

--- a/src/Docfx.Dotnet/ManagedReference/Models/ExceptionInfo.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Models/ExceptionInfo.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.Common.EntityMergers;
 using Docfx.DataContracts.Common;
 
@@ -14,16 +15,19 @@ public class ExceptionInfo
     [YamlMember(Alias = "type")]
     [MergeOption(MergeOption.MergeKey)]
     [JsonProperty("type")]
+    [JsonPropertyName("type")]
     [UniqueIdentityReference]
     public string Type { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.CommentId)]
     [JsonProperty(Constants.PropertyName.CommentId)]
+    [JsonPropertyName(Constants.PropertyName.CommentId)]
     [MergeOption(MergeOption.Ignore)]
     public string CommentId { get; set; }
 
     [YamlMember(Alias = "description")]
     [JsonProperty("description")]
+    [JsonPropertyName("description")]
     [MarkdownContent]
     public string Description { get; set; }
 

--- a/src/Docfx.Dotnet/ManagedReference/Models/ItemViewModel.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Models/ItemViewModel.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
-
+using System.Text.Json.Serialization;
 using Docfx.Common;
 using Docfx.Common.EntityMergers;
 using Docfx.DataContracts.Common;
@@ -17,46 +17,56 @@ public class ItemViewModel : IOverwriteDocumentViewModel
 {
     [YamlMember(Alias = Constants.PropertyName.Uid)]
     [JsonProperty(Constants.PropertyName.Uid)]
+    [JsonPropertyName(Constants.PropertyName.Uid)]
     [MergeOption(MergeOption.MergeKey)]
     public string Uid { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.CommentId)]
     [JsonProperty(Constants.PropertyName.CommentId)]
+    [JsonPropertyName(Constants.PropertyName.CommentId)]
     public string CommentId { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Id)]
     [JsonProperty(Constants.PropertyName.Id)]
+    [JsonPropertyName(Constants.PropertyName.Id)]
     public string Id { get; set; }
 
     [YamlMember(Alias = "isEii")]
     [JsonProperty("isEii")]
+    [JsonPropertyName("isEii")]
     public bool IsExplicitInterfaceImplementation { get; set; }
 
     [YamlMember(Alias = "isExtensionMethod")]
     [JsonProperty("isExtensionMethod")]
+    [JsonPropertyName("isExtensionMethod")]
     public bool IsExtensionMethod { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Parent)]
     [JsonProperty(Constants.PropertyName.Parent)]
+    [JsonPropertyName(Constants.PropertyName.Parent)]
     [UniqueIdentityReference]
     public string Parent { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Children)]
     [MergeOption(MergeOption.Ignore)] // todo : merge more children
     [JsonProperty(Constants.PropertyName.Children)]
+    [JsonPropertyName(Constants.PropertyName.Children)]
     [UniqueIdentityReference]
     public List<string> Children { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Href)]
     [JsonProperty(Constants.PropertyName.Href)]
+    [JsonPropertyName(Constants.PropertyName.Href)]
     public string Href { get; set; }
 
     [YamlMember(Alias = "langs")]
     [JsonProperty("langs")]
+    [JsonPropertyName("langs")]
     public string[] SupportedLanguages { get; set; } = new string[] { "csharp", "vb" };
 
     [YamlMember(Alias = Constants.PropertyName.Name)]
     [JsonProperty(Constants.PropertyName.Name)]
+    [JsonPropertyName(Constants.PropertyName.Name)]
     public string Name { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Name)]
@@ -112,6 +122,7 @@ public class ItemViewModel : IOverwriteDocumentViewModel
 
     [YamlMember(Alias = Constants.PropertyName.NameWithType)]
     [JsonProperty(Constants.PropertyName.NameWithType)]
+    [JsonPropertyName(Constants.PropertyName.NameWithType)]
     public string NameWithType { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.NameWithType)]
@@ -167,6 +178,7 @@ public class ItemViewModel : IOverwriteDocumentViewModel
 
     [YamlMember(Alias = Constants.PropertyName.FullName)]
     [JsonProperty(Constants.PropertyName.FullName)]
+    [JsonPropertyName(Constants.PropertyName.FullName)]
     public string FullName { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.FullName)]
@@ -222,66 +234,80 @@ public class ItemViewModel : IOverwriteDocumentViewModel
 
     [YamlMember(Alias = Constants.PropertyName.Type)]
     [JsonProperty(Constants.PropertyName.Type)]
+    [JsonPropertyName(Constants.PropertyName.Type)]
     public MemberType? Type { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Source)]
     [JsonProperty(Constants.PropertyName.Source)]
+    [JsonPropertyName(Constants.PropertyName.Source)]
     public SourceDetail Source { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Documentation)]
     [JsonProperty(Constants.PropertyName.Documentation)]
+    [JsonPropertyName(Constants.PropertyName.Documentation)]
     public SourceDetail Documentation { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Assemblies)]
     [MergeOption(MergeOption.Ignore)] // todo : merge more children
     [JsonProperty(Constants.PropertyName.Assemblies)]
+    [JsonPropertyName(Constants.PropertyName.Assemblies)]
     public List<string> AssemblyNameList { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Namespace)]
     [JsonProperty(Constants.PropertyName.Namespace)]
+    [JsonPropertyName(Constants.PropertyName.Namespace)]
     [UniqueIdentityReference]
     public string NamespaceName { get; set; }
 
     [YamlMember(Alias = "summary")]
     [JsonProperty("summary")]
+    [JsonPropertyName("summary")]
     [MarkdownContent]
     public string Summary { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.AdditionalNotes)]
     [JsonProperty(Constants.PropertyName.AdditionalNotes)]
+    [JsonPropertyName(Constants.PropertyName.AdditionalNotes)]
     public AdditionalNotes AdditionalNotes { get; set; }
 
     [YamlMember(Alias = "remarks")]
     [JsonProperty("remarks")]
+    [JsonPropertyName("remarks")]
     [MarkdownContent]
     public string Remarks { get; set; }
 
     [YamlMember(Alias = "example")]
     [JsonProperty("example")]
+    [JsonPropertyName("example")]
     [MergeOption(MergeOption.Replace)]
     [MarkdownContent]
     public List<string> Examples { get; set; }
 
     [YamlMember(Alias = "syntax")]
     [JsonProperty("syntax")]
+    [JsonPropertyName("syntax")]
     public SyntaxDetailViewModel Syntax { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Overridden)]
     [JsonProperty(Constants.PropertyName.Overridden)]
+    [JsonPropertyName(Constants.PropertyName.Overridden)]
     [UniqueIdentityReference]
     public string Overridden { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Overload)]
     [JsonProperty(Constants.PropertyName.Overload)]
+    [JsonPropertyName(Constants.PropertyName.Overload)]
     [UniqueIdentityReference]
     public string Overload { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Exceptions)]
     [JsonProperty(Constants.PropertyName.Exceptions)]
+    [JsonPropertyName(Constants.PropertyName.Exceptions)]
     public List<ExceptionInfo> Exceptions { get; set; }
 
     [YamlMember(Alias = "seealso")]
     [JsonProperty("seealso")]
+    [JsonPropertyName("seealso")]
     public List<LinkInfo> SeeAlsos { get; set; }
 
     [YamlIgnore]
@@ -293,45 +319,53 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     [YamlMember(Alias = Constants.PropertyName.Inheritance)]
     [MergeOption(MergeOption.Ignore)]
     [JsonProperty(Constants.PropertyName.Inheritance)]
+    [JsonPropertyName(Constants.PropertyName.Inheritance)]
     [UniqueIdentityReference]
     public List<string> Inheritance { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.DerivedClasses)]
     [MergeOption(MergeOption.Ignore)]
     [JsonProperty(Constants.PropertyName.DerivedClasses)]
+    [JsonPropertyName(Constants.PropertyName.DerivedClasses)]
     [UniqueIdentityReference]
     public List<string> DerivedClasses { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Implements)]
     [MergeOption(MergeOption.Ignore)] // todo : merge more children
     [JsonProperty(Constants.PropertyName.Implements)]
+    [JsonPropertyName(Constants.PropertyName.Implements)]
     [UniqueIdentityReference]
     public List<string> Implements { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.InheritedMembers)]
     [MergeOption(MergeOption.Ignore)] // todo : merge more children
     [JsonProperty(Constants.PropertyName.InheritedMembers)]
+    [JsonPropertyName(Constants.PropertyName.InheritedMembers)]
     [UniqueIdentityReference]
     public List<string> InheritedMembers { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.ExtensionMethods)]
     [MergeOption(MergeOption.Ignore)] // todo : merge more children
     [JsonProperty(Constants.PropertyName.ExtensionMethods)]
+    [JsonPropertyName(Constants.PropertyName.ExtensionMethods)]
     [UniqueIdentityReference]
     public List<string> ExtensionMethods { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Conceptual)]
     [JsonProperty(Constants.PropertyName.Conceptual)]
+    [JsonPropertyName(Constants.PropertyName.Conceptual)]
     [MarkdownContent]
     public string Conceptual { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.Platform)]
     [JsonProperty(Constants.PropertyName.Platform)]
+    [JsonPropertyName(Constants.PropertyName.Platform)]
     [MergeOption(MergeOption.Replace)]
     public List<string> Platform { get; set; }
 
     [YamlMember(Alias = "attributes")]
     [JsonProperty("attributes")]
+    [JsonPropertyName("attributes")]
     [MergeOption(MergeOption.Ignore)]
     public List<AttributeInfo> Attributes { get; set; }
 

--- a/src/Docfx.Dotnet/ManagedReference/Models/ItemViewModel.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Models/ItemViewModel.cs
@@ -60,11 +60,13 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     public string Name { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Name)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, string> Names { get; set; } = new SortedList<string, string>();
 
     [YamlIgnore]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public string NameForCSharp
     {
         get
@@ -86,7 +88,8 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     }
 
     [YamlIgnore]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public string NameForVB
     {
         get
@@ -112,11 +115,13 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     public string NameWithType { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.NameWithType)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, string> NamesWithType { get; set; } = new SortedList<string, string>();
 
     [YamlIgnore]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public string NameWithTypeForCSharp
     {
         get
@@ -138,7 +143,8 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     }
 
     [YamlIgnore]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public string NameWithTypeForVB
     {
         get
@@ -164,11 +170,13 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     public string FullName { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.FullName)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, string> FullNames { get; set; } = new SortedList<string, string>();
 
     [YamlIgnore]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public string FullNameForCSharp
     {
         get
@@ -190,7 +198,8 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     }
 
     [YamlIgnore]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public string FullNameForVB
     {
         get
@@ -275,8 +284,9 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     [JsonProperty("seealso")]
     public List<LinkInfo> SeeAlsos { get; set; }
 
-    [JsonIgnore]
     [YamlIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     [UniqueIdentityReference]
     public List<string> SeeAlsosUidReference => SeeAlsos?.Where(s => s.LinkType == LinkType.CRef)?.Select(s => s.LinkId).ToList();
 
@@ -326,7 +336,8 @@ public class ItemViewModel : IOverwriteDocumentViewModel
     public List<AttributeInfo> Attributes { get; set; }
 
     [ExtensibleMember]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Docfx.Dotnet/ManagedReference/Models/ItemViewModel.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Models/ItemViewModel.cs
@@ -331,7 +331,8 @@ public class ItemViewModel : IOverwriteDocumentViewModel
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     [YamlIgnore]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     [UniqueIdentityReferenceIgnore]
     [MarkdownContentIgnore]
     public IDictionary<string, object> ExtensionData =>

--- a/src/Docfx.Dotnet/ManagedReference/Models/LinkInfo.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Models/LinkInfo.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.Common.EntityMergers;
 using Docfx.DataContracts.Common;
 using Newtonsoft.Json;
@@ -12,21 +13,25 @@ public class LinkInfo
 {
     [YamlMember(Alias = "linkType")]
     [JsonProperty("linkType")]
+    [JsonPropertyName("linkType")]
     [MergeOption(MergeOption.Ignore)]
     public LinkType LinkType { get; set; }
 
     [YamlMember(Alias = "linkId")]
     [MergeOption(MergeOption.MergeKey)]
     [JsonProperty("linkId")]
+    [JsonPropertyName("linkId")]
     public string LinkId { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.CommentId)]
     [JsonProperty(Constants.PropertyName.CommentId)]
+    [JsonPropertyName(Constants.PropertyName.CommentId)]
     [MergeOption(MergeOption.Ignore)]
     public string CommentId { get; set; }
 
     [YamlMember(Alias = "altText")]
     [JsonProperty("altText")]
+    [JsonPropertyName("altText")]
     public string AltText { get; set; }
 
     internal LinkInfo Clone()

--- a/src/Docfx.Dotnet/ManagedReference/Models/NamedArgumentInfo.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Models/NamedArgumentInfo.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.DataContracts.Common;
 
 using Newtonsoft.Json;
@@ -12,14 +13,17 @@ public class NamedArgumentInfo
 {
     [YamlMember(Alias = "name")]
     [JsonProperty("name")]
+    [JsonPropertyName("name")]
     public string Name { get; set; }
 
     [YamlMember(Alias = "type")]
     [JsonProperty("type")]
+    [JsonPropertyName("type")]
     [UniqueIdentityReference]
     public string Type { get; set; }
 
     [YamlMember(Alias = "value")]
     [JsonProperty("value")]
+    [JsonPropertyName("value")]
     public object Value { get; set; }
 }

--- a/src/Docfx.Dotnet/ManagedReference/Models/PageViewModel.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Models/PageViewModel.cs
@@ -29,6 +29,7 @@ public class PageViewModel
     public MemberLayout MemberLayout { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.Dotnet/ManagedReference/Models/PageViewModel.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Models/PageViewModel.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.DataContracts.Common;
 using Docfx.YamlSerialization;
 using Newtonsoft.Json;
@@ -12,20 +13,24 @@ public class PageViewModel
 {
     [YamlMember(Alias = "items")]
     [JsonProperty("items")]
+    [JsonPropertyName("items")]
     public List<ItemViewModel> Items { get; set; } = new List<ItemViewModel>();
 
     [YamlMember(Alias = "references")]
     [JsonProperty("references")]
+    [JsonPropertyName("references")]
     [UniqueIdentityReferenceIgnore]
     [MarkdownContentIgnore]
     public List<ReferenceViewModel> References { get; set; } = new List<ReferenceViewModel>();
 
     [YamlMember(Alias = "shouldSkipMarkup")]
     [JsonProperty("shouldSkipMarkup")]
+    [JsonPropertyName("shouldSkipMarkup")]
     public bool ShouldSkipMarkup { get; set; }
 
     [YamlMember(Alias = "memberLayout")]
     [JsonProperty("memberLayout")]
+    [JsonPropertyName("memberLayout")]
     public MemberLayout MemberLayout { get; set; }
 
     [ExtensibleMember]

--- a/src/Docfx.Dotnet/ManagedReference/Models/SyntaxDetailViewModel.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Models/SyntaxDetailViewModel.cs
@@ -80,7 +80,8 @@ public class SyntaxDetailViewModel
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     [YamlIgnore]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     [UniqueIdentityReferenceIgnore]
     [MarkdownContentIgnore]
     public IDictionary<string, object> ExtensionData =>

--- a/src/Docfx.Dotnet/ManagedReference/Models/SyntaxDetailViewModel.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Models/SyntaxDetailViewModel.cs
@@ -19,11 +19,13 @@ public class SyntaxDetailViewModel
     public string Content { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Content)]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SortedList<string, string> Contents { get; set; } = new SortedList<string, string>();
 
     [YamlIgnore]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public string ContentForCSharp
     {
         get
@@ -45,7 +47,8 @@ public class SyntaxDetailViewModel
     }
 
     [YamlIgnore]
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public string ContentForVB
     {
         get

--- a/src/Docfx.Dotnet/ManagedReference/Models/SyntaxDetailViewModel.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Models/SyntaxDetailViewModel.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
-
+using System.Text.Json.Serialization;
 using Docfx.Common;
 using Docfx.DataContracts.Common;
 using Docfx.YamlSerialization;
@@ -16,6 +16,7 @@ public class SyntaxDetailViewModel
 {
     [YamlMember(Alias = Constants.PropertyName.Content)]
     [JsonProperty(Constants.PropertyName.Content)]
+    [JsonPropertyName(Constants.PropertyName.Content)]
     public string Content { get; set; }
 
     [ExtensibleMember(Constants.ExtensionMemberPrefix.Content)]
@@ -71,14 +72,17 @@ public class SyntaxDetailViewModel
 
     [YamlMember(Alias = "parameters")]
     [JsonProperty("parameters")]
+    [JsonPropertyName("parameters")]
     public List<ApiParameter> Parameters { get; set; }
 
     [YamlMember(Alias = "typeParameters")]
     [JsonProperty("typeParameters")]
+    [JsonPropertyName("typeParameters")]
     public List<ApiParameter> TypeParameters { get; set; }
 
     [YamlMember(Alias = "return")]
     [JsonProperty("return")]
+    [JsonPropertyName("return")]
     public ApiParameter Return { get; set; }
 
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Docfx.Dotnet/ManagedReference/ReferenceItem.cs
+++ b/src/Docfx.Dotnet/ManagedReference/ReferenceItem.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Text.Json.Serialization;
 using Docfx.DataContracts.Common;
 using Docfx.DataContracts.ManagedReference;
 using Newtonsoft.Json;
@@ -13,30 +14,37 @@ internal class ReferenceItem
 {
     [YamlMember(Alias = "name")]
     [JsonProperty("name")]
+    [JsonPropertyName("name")]
     public SortedList<SyntaxLanguage, List<LinkItem>> NameParts { get; set; }
 
     [YamlMember(Alias = "nameWithType")]
     [JsonProperty("nameWithType")]
+    [JsonPropertyName("nameWithType")]
     public SortedList<SyntaxLanguage, List<LinkItem>> NameWithTypeParts { get; set; }
 
     [YamlMember(Alias = "qualifiedName")]
     [JsonProperty("qualifiedName")]
+    [JsonPropertyName("qualifiedName")]
     public SortedList<SyntaxLanguage, List<LinkItem>> QualifiedNameParts { get; set; }
 
     [YamlMember(Alias = "isDefinition")]
     [JsonProperty("isDefinition")]
+    [JsonPropertyName("isDefinition")]
     public bool? IsDefinition { get; set; }
 
     [YamlMember(Alias = "definition")]
     [JsonProperty("definition")]
+    [JsonPropertyName("definition")]
     public string Definition { get; set; }
 
     [YamlMember(Alias = "parent")]
     [JsonProperty("parent")]
+    [JsonPropertyName("parent")]
     public string Parent { get; set; }
 
     [YamlMember(Alias = Constants.PropertyName.CommentId)]
     [JsonProperty(Constants.PropertyName.CommentId)]
+    [JsonPropertyName(Constants.PropertyName.CommentId)]
     public string CommentId { get; set; }
 
     internal ReferenceItem Clone()
@@ -158,10 +166,12 @@ internal class LinkItem
 {
     [YamlMember(Alias = "id")]
     [JsonProperty("id")]
+    [JsonPropertyName("id")]
     public string Name { get; set; }
 
     [YamlMember(Alias = "name")]
     [JsonProperty("name")]
+    [JsonPropertyName("name")]
     public string DisplayName { get; set; }
 
     /// <summary>
@@ -169,6 +179,7 @@ internal class LinkItem
     /// </summary>
     [YamlMember(Alias = "isExternal")]
     [JsonProperty("isExternal")]
+    [JsonPropertyName("isExternal")]
     public bool IsExternalPath { get; set; }
 
     /// <summary>
@@ -176,6 +187,7 @@ internal class LinkItem
     /// </summary>
     [YamlMember(Alias = Constants.PropertyName.Href)]
     [JsonProperty(Constants.PropertyName.Href)]
+    [JsonPropertyName(Constants.PropertyName.Href)]
     public string Href { get; set; }
 
     public LinkItem Clone() => (LinkItem)MemberwiseClone();

--- a/src/Docfx.Dotnet/ManagedReference/SyntaxDetail.cs
+++ b/src/Docfx.Dotnet/ManagedReference/SyntaxDetail.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.DataContracts.ManagedReference;
 using Newtonsoft.Json;
 using YamlDotNet.Serialization;
@@ -11,17 +12,21 @@ internal class SyntaxDetail
 {
     [YamlMember(Alias = "content")]
     [JsonProperty("content")]
+    [JsonPropertyName("content")]
     public SortedList<SyntaxLanguage, string> Content { get; set; }
 
     [YamlMember(Alias = "parameters")]
     [JsonProperty("parameters")]
+    [JsonPropertyName("parameters")]
     public List<ApiParameter> Parameters { get; set; }
 
     [YamlMember(Alias = "typeParameters")]
     [JsonProperty("typeParameters")]
+    [JsonPropertyName("typeParameters")]
     public List<ApiParameter> TypeParameters { get; set; }
 
     [YamlMember(Alias = "return")]
     [JsonProperty("return")]
+    [JsonPropertyName("return")]
     public ApiParameter Return { get; set; }
 }

--- a/src/Docfx.Dotnet/MetadataJsonConfig.cs
+++ b/src/Docfx.Dotnet/MetadataJsonConfig.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Docfx;
@@ -84,6 +85,7 @@ internal class MetadataJsonItemConfig
     /// Defines the source projects to have metadata generated.
     /// </summary>
     [JsonProperty("src")]
+    [JsonPropertyName("src")]
     public FileMapping Src { get; set; }
 
     /// <summary>
@@ -91,6 +93,7 @@ internal class MetadataJsonItemConfig
     /// Command line --output argument prepends this value.
     /// </summary>
     [JsonProperty("dest")]
+    [JsonPropertyName("dest")]
     public string Dest { get; set; }
 
     /// <summary>
@@ -98,30 +101,36 @@ internal class MetadataJsonItemConfig
     /// Command line --output argument override this value.
     /// </summary>
     [JsonProperty("output")]
+    [JsonPropertyName("output")]
     public string Output { get; set; }
 
     /// <summary>
     /// Defines the output file format.
     /// </summary>
     [JsonProperty("outputFormat")]
+    [JsonPropertyName("outputFormat")]
     public MetadataOutputFormat OutputFormat { get; set; }
 
     /// <summary>
     /// If set to true, DocFX would not render triple-slash-comments in source code as markdown.
     /// </summary>
     [JsonProperty("shouldSkipMarkup")]
+    [JsonPropertyName("shouldSkipMarkup")]
     public bool? ShouldSkipMarkup { get; set; }
 
     [JsonProperty("raw")]
+    [JsonPropertyName("raw")]
     public bool? Raw { get; set; }
 
     [JsonProperty("references")]
+    [JsonPropertyName("references")]
     public FileMapping References { get; set; }
 
     /// <summary>
     /// Defines the filter configuration file.
     /// </summary>
     [JsonProperty("filter")]
+    [JsonPropertyName("filter")]
     public string Filter { get; set; }
 
     /// <summary>
@@ -129,12 +138,14 @@ internal class MetadataJsonItemConfig
     /// The default is false.
     /// </summary>
     [JsonProperty("includePrivateMembers")]
+    [JsonPropertyName("includePrivateMembers")]
     public bool IncludePrivateMembers { get; set; }
 
     /// <summary>
     /// Specify the name to use for the global namespace.
     /// </summary>
     [JsonProperty("globalNamespaceId")]
+    [JsonPropertyName("globalNamespaceId")]
     public string GlobalNamespaceId { get; set; }
 
     /// <summary>
@@ -143,30 +154,35 @@ internal class MetadataJsonItemConfig
     ///  command line argument.
     /// </summary>
     [JsonProperty("properties")]
+    [JsonPropertyName("properties")]
     public Dictionary<string, string> Properties { get; set; }
 
     /// <summary>
     /// Disables generation of view source links.
     /// </summary>
     [JsonProperty("disableGitFeatures")]
+    [JsonPropertyName("disableGitFeatures")]
     public bool DisableGitFeatures { get; set; }
 
     /// <summary>
     /// Specify the base directory that is used to resolve code source (e.g. `&lt;code source="Example.cs"&gt;`).
     /// </summary>
     [JsonProperty("codeSourceBasePath")]
+    [JsonPropertyName("codeSourceBasePath")]
     public string CodeSourceBasePath { get; set; }
 
     /// <summary>
     /// Disables the default filter configuration file.
     /// </summary>
     [JsonProperty("disableDefaultFilter")]
+    [JsonPropertyName("disableDefaultFilter")]
     public bool DisableDefaultFilter { get; set; }
 
     /// <summary>
     /// Do not run dotnet restore before building the projects.
     /// </summary>
     [JsonProperty("noRestore")]
+    [JsonPropertyName("noRestore")]
     public bool NoRestore { get; set; }
 
     /// <summary>
@@ -175,6 +191,7 @@ internal class MetadataJsonItemConfig
     /// - `nested`: Renders namespaces in a nested tree form.
     /// </summary>
     [JsonProperty("namespaceLayout")]
+    [JsonPropertyName("namespaceLayout")]
     public NamespaceLayout NamespaceLayout { get; set; }
 
     /// <summary>
@@ -183,6 +200,7 @@ internal class MetadataJsonItemConfig
     /// - `separatePages`: Places members in separate pages.
     /// </summary>
     [JsonProperty("memberLayout")]
+    [JsonPropertyName("memberLayout")]
     public MemberLayout MemberLayout { get; set; }
 
     /// <summary>
@@ -191,12 +209,14 @@ internal class MetadataJsonItemConfig
     /// - `separatePages`: Places members in separate pages.
     /// </summary>
     [JsonProperty("enumSortOrder")]
+    [JsonPropertyName("enumSortOrder")]
     public EnumSortOrder EnumSortOrder { get; init; }
 
     /// <summary>
     /// When enabled, continues documentation generation in case of compilation errors.
     /// </summary>
     [JsonProperty("allowCompilationErrors")]
+    [JsonPropertyName("allowCompilationErrors")]
     public bool AllowCompilationErrors { get; set; }
 }
 

--- a/src/Docfx.HtmlToPdf/FileOutput.cs
+++ b/src/Docfx.HtmlToPdf/FileOutput.cs
@@ -20,7 +20,8 @@ public class FileOutput
     [JsonProperty(ManifestConstants.BuildManifestItem.SkipPublish, DefaultValueHandling = DefaultValueHandling.Ignore)]
     public bool SkipPublish { get; set; }
 
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; }
 
     public override string ToString()

--- a/src/Docfx.HtmlToPdf/FileOutput.cs
+++ b/src/Docfx.HtmlToPdf/FileOutput.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.Common;
 using Newtonsoft.Json;
 
@@ -9,15 +10,19 @@ namespace Docfx.HtmlToPdf;
 public class FileOutput
 {
     [JsonProperty(ManifestConstants.BuildManifestItem.OutputRelativePath)]
+    [JsonPropertyName(ManifestConstants.BuildManifestItem.OutputRelativePath)]
     public string RelativePath { get; set; }
 
     [JsonProperty(ManifestConstants.BuildManifestItem.OutputLinkToPath)]
+    [JsonPropertyName(ManifestConstants.BuildManifestItem.OutputLinkToPath)]
     public string LinkToPath { get; set; }
 
     [JsonProperty(ManifestConstants.BuildManifestItem.IsRawPage)]
+    [JsonPropertyName(ManifestConstants.BuildManifestItem.IsRawPage)]
     public bool IsRawPage { get; set; }
 
     [JsonProperty(ManifestConstants.BuildManifestItem.SkipPublish, DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [JsonPropertyName(ManifestConstants.BuildManifestItem.SkipPublish)]
     public bool SkipPublish { get; set; }
 
     [Newtonsoft.Json.JsonExtensionData]

--- a/src/Docfx.HtmlToPdf/FileOutputs.cs
+++ b/src/Docfx.HtmlToPdf/FileOutputs.cs
@@ -22,6 +22,7 @@ public class FileOutputs
     [JsonProperty(ManifestConstants.BuildManifestItem.OutputJson)]
     public FileOutput TocJson { get; set; }
 
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> OtherOutputs { get; set; }
 }

--- a/src/Docfx.HtmlToPdf/FileOutputs.cs
+++ b/src/Docfx.HtmlToPdf/FileOutputs.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Docfx.HtmlToPdf;
@@ -8,18 +9,23 @@ namespace Docfx.HtmlToPdf;
 public class FileOutputs
 {
     [JsonProperty(ManifestConstants.BuildManifestItem.OutputHtml)]
+    [JsonPropertyName(ManifestConstants.BuildManifestItem.OutputHtml)]
     public FileOutput Html { get; set; }
 
     [JsonProperty(ManifestConstants.BuildManifestItem.OutputRawPageJson)]
+    [JsonPropertyName(ManifestConstants.BuildManifestItem.OutputRawPageJson)]
     public FileOutput RawPageJson { get; set; }
 
     [JsonProperty(ManifestConstants.BuildManifestItem.OutputMtaJson)]
+    [JsonPropertyName(ManifestConstants.BuildManifestItem.OutputMtaJson)]
     public FileOutput MtaJson { get; set; }
 
     [JsonProperty(ManifestConstants.BuildManifestItem.OutputResource)]
+    [JsonPropertyName(ManifestConstants.BuildManifestItem.OutputResource)]
     public FileOutput Resource { get; set; }
 
     [JsonProperty(ManifestConstants.BuildManifestItem.OutputJson)]
+    [JsonPropertyName(ManifestConstants.BuildManifestItem.OutputJson)]
     public FileOutput TocJson { get; set; }
 
     [Newtonsoft.Json.JsonExtensionData]

--- a/src/Docfx.HtmlToPdf/PdfInformation.cs
+++ b/src/Docfx.HtmlToPdf/PdfInformation.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Docfx.HtmlToPdf;
@@ -8,14 +9,18 @@ namespace Docfx.HtmlToPdf;
 public class PdfInformation
 {
     [JsonProperty("docset_name")]
+    [JsonPropertyName("docset_name")]
     public string DocsetName { get; set; }
 
     [JsonProperty("asset_id")]
+    [JsonPropertyName("asset_id")]
     public string AssetId { get; set; }
 
     [JsonProperty("version")]
+    [JsonPropertyName("version")]
     public string Version { get; set; }
 
     [JsonProperty("toc_files")]
+    [JsonPropertyName("toc_files")]
     public ICollection<string> TocFiles { get; set; }
 }

--- a/src/Docfx.HtmlToPdf/TocModel.cs
+++ b/src/Docfx.HtmlToPdf/TocModel.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Docfx.HtmlToPdf;
@@ -8,14 +9,18 @@ namespace Docfx.HtmlToPdf;
 public class TocModel
 {
     [JsonProperty("toc_title")]
+    [JsonPropertyName("toc_title")]
     public string Title { get; set; }
 
     [JsonProperty("relative_path_in_depot")]
+    [JsonPropertyName("relative_path_in_depot")]
     public string HtmlFilePath { get; set; }
 
     [JsonProperty("external_link")]
+    [JsonPropertyName("external_link")]
     public string ExternalLink { get; set; }
 
     [JsonProperty("children")]
+    [JsonPropertyName("children")]
     public IList<TocModel> Children { get; set; }
 }

--- a/src/Docfx.Plugins/FileAndType.cs
+++ b/src/Docfx.Plugins/FileAndType.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Docfx.Plugins;
@@ -50,9 +51,11 @@ public sealed class FileAndType
     public StringComparer StringComparer { get; }
 
     [JsonProperty("baseDir")]
+    [JsonPropertyName("baseDir")]
     public string BaseDir { get; }
 
     [JsonProperty("file")]
+    [JsonPropertyName("file")]
     public string File { get; }
 
     [Newtonsoft.Json.JsonIgnore]
@@ -60,12 +63,15 @@ public sealed class FileAndType
     public string FullPath { get; }
 
     [JsonProperty("type")]
+    [JsonPropertyName("type")]
     public DocumentType Type { get; }
 
     [JsonProperty("sourceDir")]
+    [JsonPropertyName("sourceDir")]
     public string SourceDir { get; set; }
 
     [JsonProperty("destinationDir")]
+    [JsonPropertyName("destinationDir")]
     public string DestinationDir { get; set; }
 
     public FileAndType ChangeBaseDir(string baseDir)

--- a/src/Docfx.Plugins/FileAndType.cs
+++ b/src/Docfx.Plugins/FileAndType.cs
@@ -8,7 +8,8 @@ namespace Docfx.Plugins;
 public sealed class FileAndType
     : IEquatable<FileAndType>
 {
-    [JsonConstructor]
+    [Newtonsoft.Json.JsonConstructor]
+    [System.Text.Json.Serialization.JsonConstructor]
     public FileAndType(string baseDir, string file, DocumentType type, string sourceDir = null, string destinationDir = null)
     {
         ArgumentNullException.ThrowIfNull(baseDir);

--- a/src/Docfx.Plugins/FileAndType.cs
+++ b/src/Docfx.Plugins/FileAndType.cs
@@ -44,7 +44,8 @@ public sealed class FileAndType
         StringComparer = GetStringComparer();
     }
 
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public StringComparer StringComparer { get; }
 
     [JsonProperty("baseDir")]
@@ -53,7 +54,8 @@ public sealed class FileAndType
     [JsonProperty("file")]
     public string File { get; }
 
-    [JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
     public string FullPath { get; }
 
     [JsonProperty("type")]

--- a/src/Docfx.Plugins/Manifest.cs
+++ b/src/Docfx.Plugins/Manifest.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Specialized;
 using System.ComponentModel;
-
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Docfx.Plugins;
@@ -26,19 +26,24 @@ public class Manifest
     }
 
     [JsonProperty("sitemap")]
+    [JsonPropertyName("sitemap")]
     public SitemapOptions Sitemap { get; set; }
 
     [JsonProperty("source_base_path")]
+    [JsonPropertyName("source_base_path")]
     public string SourceBasePath { get; set; }
 
     [Obsolete]
     [JsonProperty("xrefmap")]
+    [JsonPropertyName("xrefmap")]
     public object Xrefmap { get; set; }
 
     [JsonProperty("files")]
+    [JsonPropertyName("files")]
     public ManifestItemCollection Files { get; }
 
     [JsonProperty("groups")]
+    [JsonPropertyName("groups")]
     public List<ManifestGroupInfo> Groups { get; set; }
 
     #region Public Methods

--- a/src/Docfx.Plugins/ManifestGroupInfo.cs
+++ b/src/Docfx.Plugins/ManifestGroupInfo.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Docfx.Plugins;
@@ -8,12 +9,15 @@ namespace Docfx.Plugins;
 public class ManifestGroupInfo
 {
     [JsonProperty("name")]
+    [JsonPropertyName("name")]
     public string Name { get; set; }
 
     [JsonProperty("dest")]
+    [JsonPropertyName("dest")]
     public string Destination { get; set; }
 
     [JsonProperty("xrefmap")]
+    [JsonPropertyName("xrefmap")]
     public string XRefmap { get; set; }
 
     [Newtonsoft.Json.JsonExtensionData]

--- a/src/Docfx.Plugins/ManifestGroupInfo.cs
+++ b/src/Docfx.Plugins/ManifestGroupInfo.cs
@@ -16,7 +16,8 @@ public class ManifestGroupInfo
     [JsonProperty("xrefmap")]
     public string XRefmap { get; set; }
 
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 
     public ManifestGroupInfo(GroupInfo groupInfo)

--- a/src/Docfx.Plugins/ManifestItem.cs
+++ b/src/Docfx.Plugins/ManifestItem.cs
@@ -25,7 +25,8 @@ public class ManifestItem
     [JsonProperty("log_codes")]
     public ICollection<string> LogCodes;
 
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 
     public ManifestItem Clone()

--- a/src/Docfx.Plugins/ManifestItem.cs
+++ b/src/Docfx.Plugins/ManifestItem.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Docfx.Plugins;
@@ -8,21 +9,27 @@ namespace Docfx.Plugins;
 public class ManifestItem
 {
     [JsonProperty("type")]
+    [JsonPropertyName("type")]
     public string Type { get; set; }
 
     [JsonProperty("source_relative_path")]
+    [JsonPropertyName("source_relative_path")]
     public string SourceRelativePath { get; set; }
 
     [JsonProperty("output")]
+    [JsonPropertyName("output")]
     public OutputFileCollection Output { get; } = new OutputFileCollection();
 
     [JsonProperty("version")]
+    [JsonPropertyName("version")]
     public string Version { get; set; }
 
     [JsonProperty("group")]
+    [JsonPropertyName("group")]
     public string Group { get; set; }
 
     [JsonProperty("log_codes")]
+    [JsonPropertyName("log_codes")]
     public ICollection<string> LogCodes;
 
     [Newtonsoft.Json.JsonExtensionData]

--- a/src/Docfx.Plugins/ManifestItemCollection.cs
+++ b/src/Docfx.Plugins/ManifestItemCollection.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 
 namespace Docfx.Plugins;
 
-[JsonConverter(typeof(ManifestItemCollectionConverter))]
+[Newtonsoft.Json.JsonConverter(typeof(ManifestItemCollectionConverter))]
 public class ManifestItemCollection : ObservableCollection<ManifestItem>
 {
     public ManifestItemCollection() { }

--- a/src/Docfx.Plugins/MarkdownServiceParameters.cs
+++ b/src/Docfx.Plugins/MarkdownServiceParameters.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Docfx.Plugins;
@@ -12,6 +13,7 @@ public class MarkdownServiceProperties
     /// Enables line numbers.
     /// </summary>
     [JsonProperty("enableSourceInfo")]
+    [JsonPropertyName("enableSourceInfo")]
     public bool EnableSourceInfo { get; set; } = true;
 
     /// <summary>
@@ -19,9 +21,11 @@ public class MarkdownServiceProperties
     /// enabled by default by DocFX.
     /// </summary>
     [JsonProperty("markdigExtensions")]
+    [JsonPropertyName("markdigExtensions")]
     public string[] MarkdigExtensions { get; set; }
 
     [JsonProperty("fallbackFolders")]
+    [JsonPropertyName("fallbackFolders")]
     public string[] FallbackFolders { get; set; }
 
     /// <summary>
@@ -29,6 +33,7 @@ public class MarkdownServiceProperties
     /// E.g., TIP -> alert alert-info
     /// </summary>
     [JsonProperty("alerts")]
+    [JsonPropertyName("alerts")]
     public Dictionary<string, string> Alerts { get; set; }
 }
 

--- a/src/Docfx.Plugins/OutputFileInfo.cs
+++ b/src/Docfx.Plugins/OutputFileInfo.cs
@@ -36,7 +36,8 @@ public class OutputFileInfo : INotifyPropertyChanged
         }
     }
 
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 
     public event PropertyChangedEventHandler PropertyChanged;

--- a/src/Docfx.Plugins/OutputFileInfo.cs
+++ b/src/Docfx.Plugins/OutputFileInfo.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
-
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Docfx.Plugins;
@@ -13,6 +13,7 @@ public class OutputFileInfo : INotifyPropertyChanged
     private string _linkToPath;
 
     [JsonProperty("relative_path")]
+    [JsonPropertyName("relative_path")]
     public string RelativePath
     {
         get { return _relativePath; }
@@ -25,6 +26,7 @@ public class OutputFileInfo : INotifyPropertyChanged
     }
 
     [JsonProperty("link_to_path")]
+    [JsonPropertyName("link_to_path")]
     public string LinkToPath
     {
         get { return _linkToPath; }

--- a/src/Docfx.Plugins/SitemapElementOptions.cs
+++ b/src/Docfx.Plugins/SitemapElementOptions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Docfx.Plugins;
@@ -8,14 +9,18 @@ namespace Docfx.Plugins;
 public class SitemapElementOptions
 {
     [JsonProperty("baseUrl")]
+    [JsonPropertyName("baseUrl")]
     public string BaseUrl { get; set; }
 
     [JsonProperty("changefreq")]
+    [JsonPropertyName("changefreq")]
     public PageChangeFrequency? ChangeFrequency { get; set; }
 
     [JsonProperty("priority")]
+    [JsonPropertyName("priority")]
     public double? Priority { get; set; }
 
     [JsonProperty("lastmod")]
+    [JsonPropertyName("lastmod")]
     public DateTime? LastModified { get; set; }
 }

--- a/src/Docfx.Plugins/SitemapOptions.cs
+++ b/src/Docfx.Plugins/SitemapOptions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Docfx.Plugins;
@@ -8,5 +9,6 @@ namespace Docfx.Plugins;
 public class SitemapOptions : SitemapElementOptions
 {
     [JsonProperty("fileOptions")]
+    [JsonPropertyName("fileOptions")]
     public Dictionary<string, SitemapElementOptions> FileOptions { get; set; }
 }

--- a/src/Docfx.Plugins/TreeItem.cs
+++ b/src/Docfx.Plugins/TreeItem.cs
@@ -10,6 +10,7 @@ public class TreeItem
     [JsonProperty("items")]
     public List<TreeItem> Items { get; set; }
 
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/src/Docfx.Plugins/TreeItem.cs
+++ b/src/Docfx.Plugins/TreeItem.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Docfx.Plugins;
@@ -8,6 +9,7 @@ namespace Docfx.Plugins;
 public class TreeItem
 {
     [JsonProperty("items")]
+    [JsonPropertyName("items")]
     public List<TreeItem> Items { get; set; }
 
     [Newtonsoft.Json.JsonExtensionData]

--- a/src/Docfx.Plugins/UidDefinition.cs
+++ b/src/Docfx.Plugins/UidDefinition.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace Docfx.Plugins;
@@ -8,14 +9,23 @@ namespace Docfx.Plugins;
 public class UidDefinition
 {
     [JsonProperty("name")]
+    [JsonPropertyName("name")]
     public string Name { get; }
+
     [JsonProperty("file")]
+    [JsonPropertyName("file")]
     public string File { get; }
+
     [JsonProperty("line")]
+    [JsonPropertyName("line")]
     public int? Line { get; }
+
     [JsonProperty("column")]
+    [JsonPropertyName("column")]
     public int? Column { get; }
+
     [JsonProperty("path")]
+    [JsonPropertyName("path")]
     public string Path { get; }
 
     [Newtonsoft.Json.JsonConstructor]

--- a/src/Docfx.Plugins/UidDefinition.cs
+++ b/src/Docfx.Plugins/UidDefinition.cs
@@ -18,7 +18,8 @@ public class UidDefinition
     [JsonProperty("path")]
     public string Path { get; }
 
-    [JsonConstructor]
+    [Newtonsoft.Json.JsonConstructor]
+    [System.Text.Json.Serialization.JsonConstructor]
     public UidDefinition(string name, string file, int? line = null, int? column = null, string path = null)
     {
         if (string.IsNullOrEmpty(name))

--- a/src/docfx/Models/BuildCommand.cs
+++ b/src/docfx/Models/BuildCommand.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.Common;
 using Docfx.Plugins;
 using Newtonsoft.Json;
@@ -122,6 +123,7 @@ internal class BuildCommand : Command<BuildCommandOptions>
     private sealed class BuildConfig
     {
         [JsonProperty("build")]
+        [JsonPropertyName("build")]
         public BuildJsonConfig Item { get; set; }
     }
 }

--- a/src/docfx/Models/DefaultCommand.cs
+++ b/src/docfx/Models/DefaultCommand.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel;
 using System.Reflection;
+using System.Text.Json.Serialization;
 using Docfx.Dotnet;
 using Newtonsoft.Json;
 using Spectre.Console.Cli;
@@ -60,12 +61,15 @@ class DefaultCommand : Command<DefaultCommand.Options>
     class Config
     {
         [JsonProperty("build")]
+        [JsonPropertyName("build")]
         public BuildJsonConfig Build { get; set; }
 
         [JsonProperty("metadata")]
+        [JsonPropertyName("metadata")]
         public MetadataJsonConfig Metadata { get; set; }
 
         [JsonProperty("pdf")]
+        [JsonPropertyName("pdf")]
         public PdfJsonConfig Pdf { get; set; }
     }
 }

--- a/src/docfx/Models/InitCommand.cs
+++ b/src/docfx/Models/InitCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 using Docfx.Common;
 using Newtonsoft.Json;
 using Spectre.Console.Cli;
@@ -559,9 +560,11 @@ TODO: Add .NET projects to the *src* folder and run `docfx` to generate **REAL**
     private class DefaultConfigModel
     {
         [JsonProperty("metadata")]
+        [JsonPropertyName("metadata")]
         public MetadataJsonConfig Metadata { get; set; }
 
         [JsonProperty("build")]
+        [JsonPropertyName("build")]
         public BuildJsonConfig Build { get; set; }
     }
 }

--- a/src/docfx/Models/MergeCommand.cs
+++ b/src/docfx/Models/MergeCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 using Spectre.Console.Cli;
 
@@ -45,6 +46,7 @@ internal class MergeCommand : Command<MergeCommandOptions>
     private sealed class MergeConfig
     {
         [JsonProperty("merge")]
+        [JsonPropertyName("merge")]
         public MergeJsonConfig Item { get; set; }
     }
 }

--- a/src/docfx/Models/MetadataCommand.cs
+++ b/src/docfx/Models/MetadataCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 using Docfx.Dotnet;
 using Newtonsoft.Json;
 using Spectre.Console.Cli;
@@ -79,6 +80,7 @@ internal class MetadataCommand : Command<MetadataCommandOptions>
     private sealed class MetadataConfig
     {
         [JsonProperty("metadata")]
+        [JsonPropertyName("metadata")]
         public MetadataJsonConfig Item { get; set; }
     }
 }

--- a/src/docfx/Models/PdfCommand.cs
+++ b/src/docfx/Models/PdfCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 using Spectre.Console.Cli;
 
@@ -97,6 +98,7 @@ internal class PdfCommand : Command<PdfCommandOptions>
     private sealed class PdfConfig
     {
         [JsonProperty("pdf")]
+        [JsonPropertyName("pdf")]
         public PdfJsonConfig Item { get; set; }
     }
 }

--- a/test/Docfx.Build.Tests/DocumentProcessors/YamlDocumentModel.cs
+++ b/test/Docfx.Build.Tests/DocumentProcessors/YamlDocumentModel.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Docfx.YamlSerialization;
 
 using Newtonsoft.Json;
@@ -13,6 +14,7 @@ public class YamlDocumentModel
 {
     [YamlMember(Alias = "documentType")]
     [JsonProperty("documentType")]
+    [JsonPropertyName("documentType")]
     public string DocumentType { get; set; }
 
     [ExtensibleMember]
@@ -22,5 +24,6 @@ public class YamlDocumentModel
 
     [YamlMember(Alias = "metadata")]
     [JsonProperty("metadata")]
+    [JsonPropertyName("metadata")]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 }

--- a/test/Docfx.Build.Tests/DocumentProcessors/YamlDocumentModel.cs
+++ b/test/Docfx.Build.Tests/DocumentProcessors/YamlDocumentModel.cs
@@ -16,7 +16,8 @@ public class YamlDocumentModel
     public string DocumentType { get; set; }
 
     [ExtensibleMember]
-    [JsonExtensionData]
+    [Newtonsoft.Json.JsonExtensionData]
+    [System.Text.Json.Serialization.JsonExtensionData]
     public Dictionary<string, object> Data { get; set; } = new Dictionary<string, object>();
 
     [YamlMember(Alias = "metadata")]

--- a/test/Docfx.Common.Tests/ConvertToObjectHelperTest.cs
+++ b/test/Docfx.Common.Tests/ConvertToObjectHelperTest.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using FluentAssertions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -96,10 +97,15 @@ public class ConvertToObjectHelperTest
     private sealed class ComplexTypeWithJson
     {
         [JsonProperty("str")]
+        [JsonPropertyName("str")]
         public string String { get; set; }
+
         [JsonProperty("list")]
+        [JsonPropertyName("list")]
         public List<string> List { get; set; }
+
         [JsonProperty("dict")]
+        [JsonPropertyName("dict")]
         public Dictionary<int, string> IntDictionary { get; set; }
     }
 }


### PR DESCRIPTION
**What included in this PR**
This PR add following System.Text.Json's attributes to existing Newtonsoft.Json based models.
  - `JsonPropertyName`
  - `JsonIgnore`
  - `JsonExtensionData`
  - `JsonConstructor`
 
**What's tested on my local environment**
In this PR. attributes are manually added.
So I've verified attributes are aligned with existing `Newtonsoft.Json` value with reflection API.

**Background**
This PR is intended to be used for #8968. (Because `JsonSchema.Net` support only `System.Text.Json` attributes)
So JsonConverter for `System.Text.Json` is not added in this PR.

To fully migrate to  `System.Text.Json`. #8137 to be resolved. 
