### PR TITLE
BREAKING CHANGE: drop configureLunr

### DIFF
--- a/templates/modern/src/docfx.ts
+++ b/templates/modern/src/docfx.ts
@@ -26,9 +26,9 @@ async function init() {
   window.docfx = window.docfx || {}
 
   initTheme()
-  enableSearch()
 
   await Promise.all([
+    enableSearch(),
     renderInThisArticle(),
     renderMarkdown(),
     renderNav(),

--- a/templates/modern/src/options.d.ts
+++ b/templates/modern/src/options.d.ts
@@ -5,7 +5,6 @@ import BootstrapIcons from 'bootstrap-icons/font/bootstrap-icons.json'
 import { HLJSApi } from 'highlight.js'
 import { AnchorJSOptions } from 'anchor-js'
 import { MermaidConfig } from 'mermaid'
-import lunr from 'lunr'
 
 export type Theme = 'light' | 'dark' | 'auto'
 
@@ -41,7 +40,4 @@ export type DocfxOptions = {
 
   /** Configures [hightlight.js](https://highlightjs.org/) */
   configureHljs?: (hljs: HLJSApi) => void,
-
-  /** Configures [lunr](https://lunrjs.com/docs/index.html) */
-  configureLunr?: (lunr: lunr.Builder) => void,
 }

--- a/templates/modern/src/search.ts
+++ b/templates/modern/src/search.ts
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-import { loc, meta } from './helper'
+import { loc, meta, options } from './helper'
 import { html, render, TemplateResult } from 'lit-html'
 import { classMap } from 'lit-html/directives/class-map.js'
 
@@ -16,7 +16,7 @@ let query
 /**
  * Support full-text-search
  */
-export function enableSearch() {
+export async function enableSearch() {
   const searchQuery = document.getElementById('search-query') as HTMLInputElement
   if (!searchQuery || !window.Worker) {
     return
@@ -46,6 +46,9 @@ export function enableSearch() {
         break
     }
   }
+
+  const { lunrLanguages } = await options()
+  worker.postMessage({ init: { lunrLanguages } })
 
   function onSearchQueryInput() {
     query = searchQuery.value
@@ -100,7 +103,7 @@ export function enableSearch() {
       const curHits = hits.slice(start, start + numPerPage)
 
       const items = html`
-        <div class="search-list">${loc('searchResultsCount', { count: hits.length, query })}</div>
+        <div class="search-list">${loc('searchResultsCount', { count: hits.length.toString(), query })}</div>
         <div class="sr-items">${curHits.map(hit => {
           const currentUrl = window.location.href
           const itemRawHref = relativeUrlToAbsoluteUrl(currentUrl, relHref + hit.href)


### PR DESCRIPTION
Makes `main.js` loads only from the browser not web wokers. Since we cannot reliably pass functions from main script to web workers, drop support of `configureLunr`.

This is a *BREAKING CHANGE* but since the `configureLunr` options was just recently released with little adoptions, it feels better to drop support now than later. Lunr customization options would only be added as serializable options.

Fixes https://github.com/dotnet/docfx/discussions/9332