### PR TITLE
chore: Change project scoped utility class visibility to internal

### DIFF
--- a/src/Docfx.HtmlToPdf/Guard.cs
+++ b/src/Docfx.HtmlToPdf/Guard.cs
@@ -6,7 +6,7 @@ namespace Docfx.HtmlToPdf;
 /// <summary>
 /// Represents a simple class for validating parameters and throwing exceptions.
 /// </summary>
-public static class Guard
+internal static class Guard
 {
     /// <summary>
     /// Validates argumentValue is not null and throws ArgumentNullException if it is null.

--- a/src/Docfx.MarkdigEngine.Extensions/Constants.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/Constants.cs
@@ -3,7 +3,7 @@
 
 namespace Docfx.MarkdigEngine.Extensions;
 
-public static class Constants
+internal static class Constants
 {
     public static readonly string FencedCodePrefix = "lang-";
 


### PR DESCRIPTION
**What's changed in this PR**
Change visibility of project-scoped helper class from public to internal.

**Background**
This PR intended to avoid some classes that have generic name displayed as code completion targets
when using `Docfx.App` package.
