### PR TITLE
chore: Add additional globalization settings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,8 +5,12 @@
     <TargetFrameworks Condition=" '$(ContinuousIntegrationBuild)' == 'true' ">$(TargetFrameworks);net8.0</TargetFrameworks>
     <LangVersion>Preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
-    <InvariantGlobalization>true</InvariantGlobalization>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <PredefinedCulturesOnly>false</PredefinedCulturesOnly>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />


### PR DESCRIPTION
**What's included in this PR**

- Add solution-wide `<PredefinedCulturesOnly>false</PredefinedCulturesOnly>` settings.
  - This settings allow to create `new CultureInfo("custom-lang");` when running under `InvariantGlobalization` mode.  
  - This settings is required to use `resx-based localization` on custom plugins DLL
- Add `<SatelliteResourceLanguages>en</SatelliteResourceLanguages>` settings for test projects. to reduce disk space consumption.  
  - This property is set already for `docfx` project (#8813). 