### PR TITLE
fix: some API page child namespaces 404

### DIFF
--- a/samples/seed/dotnet/project/Project/Namespace.cs
+++ b/samples/seed/dotnet/project/Project/Namespace.cs
@@ -7,3 +7,13 @@ namespace BuildFromProject.Issue8540.B
 {
     public class B {}
 }
+
+namespace InternalNamespace
+{
+    class A {}
+
+    namespace InternalNamespace2
+    {
+        class B {}
+    }
+}

--- a/src/Docfx.Dotnet/DotnetApiCatalog.ApiPage.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.ApiPage.cs
@@ -31,6 +31,7 @@ partial class DotnetApiCatalog
         var symbolUrlKind = config.OutputFormat is MetadataOutputFormat.Markdown ? SymbolUrlKind.Markdown : SymbolUrlKind.Html;
         var toc = CreateToc(assemblies, config, options);
         var allSymbols = EnumerateToc(toc).SelectMany(node => node.symbols).ToList();
+        var allNamespaceSymbols = allSymbols.Where(i => i.symbol.Kind is SymbolKind.Namespace).ToHashSet();
         allSymbols.Sort((a, b) => a.symbol.Name.CompareTo(b.symbol.Name));
 
         Parallel.ForEach(EnumerateToc(toc), n => SaveTocNode(n.id, n.symbols));
@@ -164,6 +165,7 @@ partial class DotnetApiCatalog
                 {
                     var items = symbols
                         .SelectMany(n => ((INamespaceSymbol)n.symbol).GetNamespaceMembers().Select(symbol => (symbol, n.compilation)))
+                        .Where(n => allNamespaceSymbols.Contains(n))
                         .DistinctBy(n => n.symbol.Name)
                         .OrderBy(n => n.symbol.Name)
                         .ToList();


### PR DESCRIPTION
Some child namespace links are 404 because due to not included in the output.

#9343 