### PR TITLE
build(deps): bump xunit from 2.5.3 to 2.6.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,6 +45,6 @@
     <PackageVersion Include="Verify.DiffPlex" Version="2.3.0" />
     <PackageVersion Include="Verify.Xunit" Version="22.1.4" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" />
-    <PackageVersion Include="xunit" Version="2.5.3" />
+    <PackageVersion Include="xunit" Version="2.6.1" />
   </ItemGroup>
 </Project>

--- a/test/Docfx.Common.Tests/ConvertToObjectHelperTest.cs
+++ b/test/Docfx.Common.Tests/ConvertToObjectHelperTest.cs
@@ -64,7 +64,7 @@ public class ConvertToObjectHelperTest
         a["key1"] = a;
 
         dynamic converted = ConvertToObjectHelper.ConvertToDynamic(a);
-        Assert.Equal(converted.key1, converted);
+        Assert.Same(converted.key1, converted);
         Assert.Equal("value", converted.key1.key);
 
         Dictionary<string, object> obj = ConvertToObjectHelper.ConvertExpandoObjectToObject(converted);


### PR DESCRIPTION
**What's included in this PR**

- Update `xunit` version from 2.5.3 to 2.6.1
- Fix problems that cause `StackOverflowException` when upgraded xUnit package to `2.6.0` or later.

**Background**
It seems xUnit don't support `Assert.Equal` for object that contains `circular reference`.
For example. When executing following code. Test process crash with Stackoverflow.  (Tested with version 2.5.3 / 2.6.0 / 2.6.1)

```
 var dict = new Dictionary<string, object>
 {
 };
 dict["Ref"] = dict; // Set circular reference to self
 Assert.Equals(dict, dict["Ref"]); // Cause StackOverflowException
```

I don't know what changes of xUnit `2.6.0` cause this problem [Release Note](https://xunit.net/releases/v2/2.6.0)
But it seems some assertion library changes cause above circular reference problem.

So I've changed `Assert.Equals` assertion logics to `Assert.Same` that test `object reference equity`. 
