### PR TITLE
chore: drop phase from logger output

### DIFF
--- a/src/Docfx.Common/Loggers/ILogItem.cs
+++ b/src/Docfx.Common/Loggers/ILogItem.cs
@@ -7,7 +7,6 @@ public interface ILogItem
 {
     LogLevel LogLevel { get; }
     string Message { get; }
-    string Phase { get; }
     string File { get; }
     string Line { get; }
     string Code { get; }

--- a/src/Docfx.Common/Loggers/Logger.cs
+++ b/src/Docfx.Common/Loggers/Logger.cs
@@ -94,7 +94,6 @@ public static class Logger
             LogLevel = level,
             Message = message,
             Code = code,
-            Phase = phase ?? LoggerPhaseScope.GetPhaseName(),
         });
     }
 
@@ -107,7 +106,6 @@ public static class Logger
             LogLevel = level,
             Message = message,
             Code = code,
-            Phase = phase ?? LoggerPhaseScope.GetPhaseName(),
         };
     }
 
@@ -172,7 +170,7 @@ public static class Logger
         ConsoleUtility.WriteLine($"    {_errorCount} error(s)\n", _errorCount > 0 ? ConsoleColor.Red : ConsoleColor.White);
     }
 
-        private class LogItem : ILogItem
+    private class LogItem : ILogItem
     {
         public string File { get; set; }
 
@@ -181,8 +179,6 @@ public static class Logger
         public LogLevel LogLevel { get; set; }
 
         public string Message { get; set; }
-
-        public string Phase { get; set; }
 
         public string Code { get; set; }
     }

--- a/src/Docfx.Common/Loggers/ReportLogListener.cs
+++ b/src/Docfx.Common/Loggers/ReportLogListener.cs
@@ -32,7 +32,6 @@ public sealed class ReportLogListener : ILoggerListener
 
         var level = item.LogLevel;
         var message = item.Message;
-        var phase = item.Phase;
         var file = item.File;
         var line = item.Line;
         if (level < LogLevelThreshold) return;
@@ -41,7 +40,6 @@ public sealed class ReportLogListener : ILoggerListener
         {
             Severity = GetSeverity(level),
             Message = message,
-            Source = phase,
             File = TransformFile(file),
             Line = line,
             DateTime = DateTime.UtcNow,
@@ -104,10 +102,6 @@ public sealed class ReportLogListener : ILoggerListener
         [JsonProperty("message")]
         [JsonPropertyName("message")]
         public string Message { get; set; }
-
-        [JsonProperty("source")]
-        [JsonPropertyName("source")]
-        public string Source { get; set; }
 
         [JsonProperty("file")]
         [JsonPropertyName("file")]

--- a/test/Docfx.Build.ManagedReference.Tests/ManagedReferenceDocumentProcessorTest.cs
+++ b/test/Docfx.Build.ManagedReference.Tests/ManagedReferenceDocumentProcessorTest.cs
@@ -218,32 +218,24 @@ public class ManagedReferenceDocumentProcessorTest : TestBase
         files.Add(DocumentType.Article, new[] { "TestData/mref/System.String.yml" }, "TestData/");
         files.Add(DocumentType.Overwrite, new[] { "TestData/overwrite/mref.overwrite.invalid.ref.md" });
 
-        var listener = TestLoggerListener.CreateLoggerListenerWithPhaseStartFilter(nameof(ProcessMrefWithInvalidCrossReferenceShouldWarn), LogLevel.Info);
-        try
+        using var listener = new TestListenerScope();
+
+        using (new LoggerPhaseScope(nameof(ProcessMrefWithInvalidCrossReferenceShouldWarn)))
         {
-            Logger.RegisterListener(listener);
-
-            using (new LoggerPhaseScope(nameof(ProcessMrefWithInvalidCrossReferenceShouldWarn)))
-            {
-                BuildDocument(files);
-            }
-
-            var warnings = listener.GetItemsByLogLevel(LogLevel.Warning);
-            Assert.Single(warnings);
-            var warning = warnings.Single();
-            Assert.Equal("2 invalid cross reference(s) \"<xref:invalidXref1>\", \"<xref:invalidXref2>\".", warning.Message);
-            Assert.Equal("TestData/mref/System.String.yml", warning.File);
-
-            var infos = listener.GetItemsByLogLevel(LogLevel.Info).Where(i => i.Message.Contains("Details for invalid cross reference(s)")).ToList();
-            Assert.Single(infos);
-            Assert.Equal("Details for invalid cross reference(s): \"<xref:invalidXref1>\" in line 6, \"<xref:invalidXref2>\" in line 8", infos[0].Message);
-            Assert.Equal("TestData/overwrite/mref.overwrite.invalid.ref.md", infos[0].File);
-            Assert.Null(infos[0].Line);
+            BuildDocument(files);
         }
-        finally
-        {
-            Logger.UnregisterListener(listener);
-        }
+
+        var warnings = listener.GetItemsByLogLevel(LogLevel.Warning);
+        Assert.Single(warnings);
+        var warning = warnings.Single();
+        Assert.Equal("2 invalid cross reference(s) \"<xref:invalidXref1>\", \"<xref:invalidXref2>\".", warning.Message);
+        Assert.Equal("TestData/mref/System.String.yml", warning.File);
+
+        var infos = listener.GetItemsByLogLevel(LogLevel.Info).Where(i => i.Message.Contains("Details for invalid cross reference(s)")).ToList();
+        Assert.Single(infos);
+        Assert.Equal("Details for invalid cross reference(s): \"<xref:invalidXref1>\" in line 6, \"<xref:invalidXref2>\" in line 8", infos[0].Message);
+        Assert.Equal("TestData/overwrite/mref.overwrite.invalid.ref.md", infos[0].File);
+        Assert.Null(infos[0].Line);
     }
 
     [Fact]
@@ -308,29 +300,21 @@ public class ManagedReferenceDocumentProcessorTest : TestBase
         var file = new FileAndType(Directory.GetCurrentDirectory(), fileWithNoContent, DocumentType.Article);
         var processor = new ManagedReferenceDocumentProcessor();
 
-        var listener = TestLoggerListener.CreateLoggerListenerWithPhaseStartFilter(nameof(LoadArticleWithEmptyFileShouldWarnAndReturnNull), LogLevel.Info);
-        try
+        using var listener = new TestListenerScope();
+
+        FileModel actualFileModel;
+        using (new LoggerPhaseScope(nameof(LoadArticleWithEmptyFileShouldWarnAndReturnNull)))
         {
-            Logger.RegisterListener(listener);
-
-            FileModel actualFileModel;
-            using (new LoggerPhaseScope(nameof(LoadArticleWithEmptyFileShouldWarnAndReturnNull)))
-            {
-                actualFileModel = processor.Load(file, null);
-            }
-
-            var warnings = listener.GetItemsByLogLevel(LogLevel.Warning);
-            Assert.Single(warnings);
-            var warning = warnings.Single();
-            Assert.Equal("Please add `YamlMime` as the first line of file, e.g.: `### YamlMime:ManagedReference`, otherwise the file will be not treated as ManagedReference source file in near future.", warning.Message);
-            Assert.Equal(fileWithNoContent, warning.File);
-
-            Assert.Null(actualFileModel);
+            actualFileModel = processor.Load(file, null);
         }
-        finally
-        {
-            Logger.UnregisterListener(listener);
-        }
+
+        var warnings = listener.GetItemsByLogLevel(LogLevel.Warning);
+        Assert.Single(warnings);
+        var warning = warnings.Single();
+        Assert.Equal("Please add `YamlMime` as the first line of file, e.g.: `### YamlMime:ManagedReference`, otherwise the file will be not treated as ManagedReference source file in near future.", warning.Message);
+        Assert.Equal(fileWithNoContent, warning.File);
+
+        Assert.Null(actualFileModel);
     }
 
     private void BuildDocument(FileCollection files)

--- a/test/Docfx.Build.ManagedReference.Tests/ManagedReferenceDocumentProcessorTest.cs
+++ b/test/Docfx.Build.ManagedReference.Tests/ManagedReferenceDocumentProcessorTest.cs
@@ -218,7 +218,7 @@ public class ManagedReferenceDocumentProcessorTest : TestBase
         files.Add(DocumentType.Article, new[] { "TestData/mref/System.String.yml" }, "TestData/");
         files.Add(DocumentType.Overwrite, new[] { "TestData/overwrite/mref.overwrite.invalid.ref.md" });
 
-        using var listener = new TestListenerScope();
+        using var listener = new TestListenerScope(LogLevel.Info);
 
         using (new LoggerPhaseScope(nameof(ProcessMrefWithInvalidCrossReferenceShouldWarn)))
         {

--- a/test/Docfx.Build.OverwriteDocuments.Tests/OverwriteDocumentModelCreatorTest.cs
+++ b/test/Docfx.Build.OverwriteDocuments.Tests/OverwriteDocumentModelCreatorTest.cs
@@ -12,7 +12,7 @@ namespace Docfx.Build.OverwriteDocuments.Tests;
 
 public class OverwriteDocumentModelCreatorTest
 {
-    private readonly TestLoggerListener _listener = TestLoggerListener.CreateLoggerListenerWithPhaseEqualFilter("overwrite_document_model_creator");
+    private readonly TestLoggerListener _listener = new();
 
     [Fact]
     public void YamlCodeBlockTest()

--- a/test/Docfx.Build.SchemaDriven.Tests/MarkdownFragmentsValidationTest.cs
+++ b/test/Docfx.Build.SchemaDriven.Tests/MarkdownFragmentsValidationTest.cs
@@ -22,7 +22,7 @@ public class MarkdownFragmentsValidationTest : TestBase
     private TemplateManager _templateManager;
     private FileCollection _files;
 
-    private TestLoggerListener _listener;
+    private TestLoggerListener _listener = new();
     private string _rawModelFilePath;
 
     private const string RawModelFileExtension = ".raw.json";
@@ -38,7 +38,6 @@ public class MarkdownFragmentsValidationTest : TestBase
 
         _templateManager = new TemplateManager(new List<string> { "template" }, null, _templateFolder);
 
-        _listener = TestLoggerListener.CreateLoggerListenerWithPhaseEqualFilter(null);
         _rawModelFilePath = GetRawModelFilePath("FragmentsValidation.yml");
 
         var schemaFile = CreateFile("template/schemas/fragments.validation.schema.json", File.ReadAllText("TestData/schemas/fragments.validation.schema.json"), _templateFolder);

--- a/test/Docfx.Build.SchemaDriven.Tests/MergeMarkdownFragmentsTest.cs
+++ b/test/Docfx.Build.SchemaDriven.Tests/MergeMarkdownFragmentsTest.cs
@@ -20,7 +20,7 @@ public class MergeMarkdownFragmentsTest : TestBase
     private readonly TemplateManager _templateManager;
     private readonly FileCollection _files;
 
-    private readonly TestLoggerListener _listener;
+    private readonly TestLoggerListener _listener = new();
     private readonly string _rawModelFilePath;
 
     private const string RawModelFileExtension = ".raw.json";
@@ -35,7 +35,6 @@ public class MergeMarkdownFragmentsTest : TestBase
 
         _templateManager = new TemplateManager(new List<string> { "template" }, null, _templateFolder);
 
-        _listener = TestLoggerListener.CreateLoggerListenerWithPhaseEqualFilter(null);
         _rawModelFilePath = GetRawModelFilePath("Suppressions.yml");
 
         var schemaFile = CreateFile("template/schemas/rest.mixed.schema.json", File.ReadAllText("TestData/schemas/rest.mixed.schema.json"), _templateFolder);
@@ -319,7 +318,7 @@ overwrite in contents block
     [Fact]
     public void TestFragmentsWithIncremental()
     {
-        using var listener = new TestListenerScope(nameof(TestFragmentsWithIncremental));
+        using var listener = new TestListenerScope();
         // first build
         using (new LoggerPhaseScope("FirstBuild"))
         {

--- a/test/Docfx.Build.SchemaDriven.Tests/SchemaDrivenProcessorTest.cs
+++ b/test/Docfx.Build.SchemaDriven.Tests/SchemaDrivenProcessorTest.cs
@@ -50,7 +50,7 @@ public class SchemaDrivenProcessorTest : TestBase
     [Fact]
     public void TestRef()
     {
-        using var listener = new TestListenerScope("TestRef");
+        using var listener = new TestListenerScope();
         var schemaFile = CreateFile("template/schemas/general.test.schema.json", File.ReadAllText("TestData/schemas/general.test.schema.json"), _templateFolder);
         var templateFile = CreateFile("template/General.html.tmpl", @"{{#items}}
 {{#aggregatedExceptions}}
@@ -122,7 +122,7 @@ items:
     [Fact]
     public void TestXrefResolver()
     {
-        using var listener = new TestListenerScope("TestXrefResolver");
+        using var listener = new TestListenerScope();
         // arrange
         var schemaFile = CreateFile("template/schemas/mref.test.schema.json", File.ReadAllText("TestData/schemas/mref.test.schema.json"), _templateFolder);
         var templateXref = CreateFile(
@@ -172,7 +172,7 @@ This method is within <a class=""xref"" href=""CatLibrary.ICat.html"">ICat</a></
     [Fact]
     public void TestXrefResolverShouldWarnWithEmptyUidReference()
     {
-        using var listener = new TestListenerScope(nameof(TestXrefResolverShouldWarnWithEmptyUidReference));
+        using var listener = new TestListenerScope();
         // arrange
         var schemaFile = CreateFile("template/schemas/mref.test.schema.json", File.ReadAllText("TestData/schemas/mref.test.schema.json"), _templateFolder);
         var inputFileName = "inputs/CatLibrary.ICat.yml";
@@ -191,7 +191,7 @@ This method is within <a class=""xref"" href=""CatLibrary.ICat.html"">ICat</a></
     [Fact]
     public void TestValidMetadataReferenceWithIncremental()
     {
-        using var listener = new TestListenerScope("TestGeneralFeaturesInSDP");
+        using var listener = new TestListenerScope();
         var schemaFile = CreateFile("template/schemas/mta.reference.test.schema.json", @"
 {
   ""$schema"": ""http://dotnet.github.io/docfx/schemas/v1.0/schema.json#"",
@@ -288,7 +288,7 @@ title: Web Apps Documentation
     public void TestInvalidSchemaDefinition()
     {
         // Json.NET schema has limitation of 1000 calls per hour
-        using var listener = new TestListenerScope("TestInvalidMetadataReference");
+        using var listener = new TestListenerScope();
         var schemaFile = CreateFile("template/schemas/mta.reference.test.schema.json", @"
 {
   ""$schema"": ""http://dotnet.github.io/docfx/schemas/v1.0/schema.json#"",
@@ -319,7 +319,7 @@ metadata: Web Apps Documentation
     [Fact]
     public void TestInvalidObjectAgainstSchema()
     {
-        using var listener = new TestListenerScope("TestInvalidMetadataReference");
+        using var listener = new TestListenerScope();
         var schemaFile = CreateFile("template/schemas/mta.reference.test.schema.json", @"
 {
   ""$schema"": ""http://dotnet.github.io/docfx/schemas/v1.0/schema.json#"",
@@ -351,7 +351,7 @@ metadata: Web Apps Documentation
     [Fact]
     public void TestInvalidMetadataReference()
     {
-        using var listener = new TestListenerScope("TestGeneralFeaturesInSDP");
+        using var listener = new TestListenerScope();
         var schemaFile = CreateFile("template/schemas/mta.reference.test.schema.json", @"
 {
   ""$schema"": ""http://dotnet.github.io/docfx/schemas/v1.0/schema.json#"",

--- a/test/Docfx.Build.SchemaDriven.Tests/SchemaMergerTest.cs
+++ b/test/Docfx.Build.SchemaDriven.Tests/SchemaMergerTest.cs
@@ -43,7 +43,7 @@ public class SchemaMergerTest : TestBase
     [Fact]
     public void TestSchemaOverwriteWithGeneralMergeTypes()
     {
-        using var listener = new TestListenerScope("TestSchemaOverwriteWithGeneralMergeTypes");
+        using var listener = new TestListenerScope();
         var schema = new Dictionary<string, object>
         {
             ["type"] = "object",
@@ -290,7 +290,7 @@ Overwrite with content
     [Fact]
     public void TestSchemaOverwriteWithGeneralSchemaOptions()
     {
-        using var listener = new TestListenerScope("TestSchemaOverwriteWithGeneralSchemaOptions");
+        using var listener = new TestListenerScope();
         var templateFile = CreateFile("template/testmerger2.html.tmpl", @"<xref uid=""{{xref}}""/>", _templateFolder);
         var schema = new Dictionary<string, object>
         {

--- a/test/Docfx.Build.Tests/DocumentBuilderTest.cs
+++ b/test/Docfx.Build.Tests/DocumentBuilderTest.cs
@@ -777,7 +777,7 @@ exports.getOptions = function (){
 
     private void Init(string phaseName)
     {
-        Listener = TestLoggerListener.CreateLoggerListenerWithPhaseEndFilter("BuildConceptualDocument");
+        Listener = new();
         Logger.RegisterListener(Listener);
     }
 

--- a/test/Docfx.Build.Tests/TemplateManagerUnitTest.DotnetToolMode.cs
+++ b/test/Docfx.Build.Tests/TemplateManagerUnitTest.DotnetToolMode.cs
@@ -83,7 +83,7 @@ public partial class TemplateManagerUnitTest
         // Arrange
         var templates = new List<string> { "default" };
         var manager = new TemplateManager(templates, null, null);
-        var listener = CreateTestLoggerListener();
+        var listener = new TestLoggerListener();
         Logger.RegisterListener(listener);
 
         try
@@ -106,8 +106,6 @@ public partial class TemplateManagerUnitTest
             DisableDotNetToolMode();
         }
     }
-
-    private static TestLoggerListener CreateTestLoggerListener() => TestLoggerListener.CreateLoggerListenerWithPhaseStartFilter(PhaseNameForFilter, LogLevel.Warning);
 
     private static void EnableDotNetToolMode() => AppContext.SetSwitch(Switches.DotnetToolMode, true);
     private static void DisableDotNetToolMode() => AppContext.SetSwitch(Switches.DotnetToolMode, false); // There is no API to clear switch.

--- a/test/Docfx.Build.Tests/TemplatePageLoaderUnitTest.cs
+++ b/test/Docfx.Build.Tests/TemplatePageLoaderUnitTest.cs
@@ -20,7 +20,7 @@ public class TemplatePageLoaderUnitTest : TestBase
     [Fact]
     public void TestLoaderWhenNoFileExists()
     {
-        using var listener = new TestListenerScope("NoTemplate");
+        using var listener = new TestListenerScope();
         var templates = LoadAllTemplates();
         Assert.Empty(listener.Items);
         Assert.Empty(templates);
@@ -47,7 +47,7 @@ public class TemplatePageLoaderUnitTest : TestBase
     {
         var file1 = CreateFile("a.tmpl", string.Empty, _inputFolder);
 
-        using var listener = new TestListenerScope("TestLoaderWhenRendererExists");
+        using var listener = new TestListenerScope();
         var templates = LoadAllTemplates();
 
         Assert.Empty(listener.Items);
@@ -70,7 +70,7 @@ public class TemplatePageLoaderUnitTest : TestBase
         var file1 = CreateFile("a.primary.tmpl", string.Empty, _inputFolder);
         var file2 = CreateFile("a.primary.js", "exports.transform = function(){}", _inputFolder);
 
-        using var listener = new TestListenerScope("TestLoaderWhenPreprocessorExists");
+        using var listener = new TestListenerScope();
         var templates = LoadAllTemplates();
 
         Assert.Empty(listener.Items);
@@ -95,7 +95,7 @@ public class TemplatePageLoaderUnitTest : TestBase
     {
         var file1 = CreateFile("a.ext.TMPL.js", "exports.transform = function(){}", _inputFolder);
 
-        using var listener = new TestListenerScope("TestLoaderWhenStandalonePreprocessorExists");
+        using var listener = new TestListenerScope();
         var templates = LoadAllTemplates();
 
         Assert.Empty(listener.Items);

--- a/test/Docfx.Build.Tests/TemplatePreprocessorLoaderUnitTest.cs
+++ b/test/Docfx.Build.Tests/TemplatePreprocessorLoaderUnitTest.cs
@@ -20,7 +20,7 @@ public class TemplatePreprocessorLoaderUnitTest : TestBase
     [Fact]
     public void TestLoaderWithValidInput()
     {
-        using var listener = new TestListenerScope("TestLoaderWhenStandalonePreprocessorExists");
+        using var listener = new TestListenerScope();
         var preprocessor = Load("a.ext.TMPL.js", "exports.transform = function(model) { return model; }");
 
         Assert.Empty(listener.Items);

--- a/test/Docfx.Build.Tests/TemplateRendererLoaderUnitTest.cs
+++ b/test/Docfx.Build.Tests/TemplateRendererLoaderUnitTest.cs
@@ -20,7 +20,7 @@ public class TemplateRendererLoaderUnitTest : TestBase
     [Fact]
     public void TestLoaderWhenNoFileExists()
     {
-        using var listener = new TestListenerScope("NoTemplate");
+        using var listener = new TestListenerScope();
         var renderers = LoadAllRenderers();
         Assert.Empty(listener.Items);
         Assert.Empty(renderers);
@@ -47,7 +47,7 @@ public class TemplateRendererLoaderUnitTest : TestBase
     {
         var file1 = CreateFile("a.tmpl", "{{name}}", _inputFolder);
 
-        using var listener = new TestListenerScope("TestLoaderWithValidInput");
+        using var listener = new TestListenerScope();
         var renderers = LoadAllRenderers();
 
         Assert.Empty(listener.Items);
@@ -68,7 +68,7 @@ public class TemplateRendererLoaderUnitTest : TestBase
         var path = "a.tmpl";
         var file1 = CreateFile(path, "{{name}}", _inputFolder);
 
-        using var listener = new TestListenerScope("TestLoaderWithValidInput");
+        using var listener = new TestListenerScope();
         var renderer = Load(path);
 
         Assert.Empty(listener.Items);

--- a/test/Docfx.Build.Tests/ValidateBookmarkTest.cs
+++ b/test/Docfx.Build.Tests/ValidateBookmarkTest.cs
@@ -13,7 +13,7 @@ namespace Docfx.Build.Engine.Tests;
 public class ValidateBookmarkTest : TestBase
 {
     private readonly string _outputFolder;
-    private readonly TestLoggerListener _listener = TestLoggerListener.CreateLoggerListenerWithPhaseEqualFilter("validate_bookmark.ValidateBookmark");
+    private readonly TestLoggerListener _listener = new();
 
     public ValidateBookmarkTest()
     {

--- a/test/Docfx.Build.UniversalReference.Tests/UniversalReferenceDocumentProcessorTest.cs
+++ b/test/Docfx.Build.UniversalReference.Tests/UniversalReferenceDocumentProcessorTest.cs
@@ -173,7 +173,7 @@ public class UniversalReferenceDocumentProcessorTest : TestBase
         var files = new FileCollection(Directory.GetCurrentDirectory());
         files.Add(DocumentType.Article, fileNames.Select(f => $"{YmlDataDirectory}/{f}"), TestDataDirectory);
 
-        using var listener = new TestListenerScope(nameof(UniversalReferenceDocumentProcessorTest));
+        using var listener = new TestListenerScope();
         BuildDocument(files);
         Assert.NotNull(listener.Items);
         Assert.Equal(2, listener.Items.Count);

--- a/test/Docfx.MarkdigEngine.Tests/InclusionTest.cs
+++ b/test/Docfx.MarkdigEngine.Tests/InclusionTest.cs
@@ -166,7 +166,7 @@ This is a file A included by another file.
         TestUtility.WriteToFile("r/a.md", refa);
         TestUtility.WriteToFile("r/b.md", refb);
 
-        var listener = TestLoggerListener.CreateLoggerListenerWithPhaseEqualFilter("CircularReferenceTest");
+        var listener = new TestLoggerListener();
         Logger.RegisterListener(listener);
         using (new LoggerPhaseScope("CircularReferenceTest"))
         {

--- a/test/Docfx.MarkdigEngine.Tests/TestUtility/TestLoggerListener.cs
+++ b/test/Docfx.MarkdigEngine.Tests/TestUtility/TestLoggerListener.cs
@@ -7,15 +7,7 @@ namespace Docfx.MarkdigEngine.Tests;
 
 internal class TestLoggerListener : ILoggerListener
 {
-    private readonly Func<ILogItem, bool> _filter;
     public List<ILogItem> Items { get; } = new List<ILogItem>();
-
-    public TestLoggerListener(Func<ILogItem, bool> filter)
-    {
-        ArgumentNullException.ThrowIfNull(filter);
-
-        _filter = filter;
-    }
 
     public void Dispose()
     {
@@ -27,29 +19,6 @@ internal class TestLoggerListener : ILoggerListener
 
     public void WriteLine(ILogItem item)
     {
-        ArgumentNullException.ThrowIfNull(item);
-
-        if (_filter(item))
-        {
-            Items.Add(item);
-        }
-    }
-
-    public static TestLoggerListener CreateLoggerListenerWithPhaseEqualFilter(string phase, LogLevel logLevel = LogLevel.Warning)
-    {
-        return new TestLoggerListener(iLogItem =>
-        {
-            if (iLogItem.LogLevel < logLevel)
-            {
-                return false;
-            }
-
-            if (phase == null || (iLogItem?.Phase != null && iLogItem.Phase == phase))
-            {
-                return true;
-            }
-
-            return false;
-        });
+        Items.Add(item);
     }
 }

--- a/test/Docfx.Tests.Common/TestListenerScope.cs
+++ b/test/Docfx.Tests.Common/TestListenerScope.cs
@@ -8,11 +8,13 @@ namespace Docfx.Tests.Common;
 public class TestListenerScope : ILoggerListener, IDisposable
 {
     private static AsyncLocal<List<ILogItem>> s_items = new();
+    private readonly LogLevel _logLevel;
 
     public List<ILogItem> Items => s_items.Value;
 
-    public TestListenerScope()
+    public TestListenerScope(LogLevel logLevel = LogLevel.Warning)
     {
+        _logLevel = logLevel;
         s_items.Value = new();
         Logger.RegisterListener(this);
     }
@@ -21,7 +23,7 @@ public class TestListenerScope : ILoggerListener, IDisposable
 
     public void WriteLine(ILogItem item)
     {
-        if (item.LogLevel >= LogLevel.Warning)
+        if (item.LogLevel >= _logLevel)
             s_items.Value.Add(item);
     }
 

--- a/test/Docfx.Tests.Common/TestLoggerListener.cs
+++ b/test/Docfx.Tests.Common/TestLoggerListener.cs
@@ -11,20 +11,16 @@ public class TestLoggerListener : ILoggerListener
 
     private readonly Func<ILogItem, bool> _filter;
 
-    public TestLoggerListener(Func<ILogItem, bool> filter)
+    public TestLoggerListener(Func<ILogItem, bool> filter = null)
     {
-        ArgumentNullException.ThrowIfNull(filter);
-
         _filter = filter;
     }
-
-    #region ILoggerListener
 
     public void WriteLine(ILogItem item)
     {
         ArgumentNullException.ThrowIfNull(item);
 
-        if (_filter(item))
+        if (_filter is null || _filter(item))
         {
             Items.Add(item);
         }
@@ -38,75 +34,14 @@ public class TestLoggerListener : ILoggerListener
     {
     }
 
-    #endregion
-
-    #region Creators
-
     public static TestLoggerListener CreateLoggerListenerWithCodeFilter(string code, LogLevel logLevel = LogLevel.Warning)
         => new(i => i.LogLevel >= logLevel && i?.Code == code);
 
     public static TestLoggerListener CreateLoggerListenerWithCodesFilter(List<string> codes, LogLevel logLevel = LogLevel.Warning)
         => new(i => i.LogLevel >= logLevel && codes.Contains(i.Code));
 
-    public static TestLoggerListener CreateLoggerListenerWithPhaseStartFilter(string phase, LogLevel logLevel = LogLevel.Warning)
-    {
-        return new TestLoggerListener(iLogItem =>
-        {
-            if (iLogItem.LogLevel < logLevel)
-            {
-                return false;
-            }
-            if (phase == null ||
-               (iLogItem?.Phase != null && iLogItem.Phase.StartsWith(phase)))
-            {
-                return true;
-            }
-            return false;
-        });
-    }
-
-    public static TestLoggerListener CreateLoggerListenerWithPhaseEndFilter(string phase, LogLevel logLevel = LogLevel.Warning)
-    {
-        return new TestLoggerListener(iLogItem =>
-        {
-            if (iLogItem.LogLevel < logLevel)
-            {
-                return false;
-            }
-            if (phase == null ||
-               (iLogItem?.Phase != null && iLogItem.Phase.EndsWith(phase)))
-            {
-                return true;
-            }
-            return false;
-        });
-    }
-
-    public static TestLoggerListener CreateLoggerListenerWithPhaseEqualFilter(string phase, LogLevel logLevel = LogLevel.Warning)
-    {
-        return new TestLoggerListener(iLogItem =>
-        {
-            if (iLogItem.LogLevel < logLevel)
-            {
-                return false;
-            }
-            if (phase == null ||
-               (iLogItem?.Phase != null && iLogItem.Phase == phase))
-            {
-                return true;
-            }
-            return false;
-        });
-    }
-
-    #endregion
-
-    #region Helper methods
-
     public IEnumerable<ILogItem> GetItemsByLogLevel(LogLevel logLevel)
     {
         return Items.Where(i => i.LogLevel == logLevel);
     }
-
-    #endregion
 }


### PR DESCRIPTION
`phase` isn't a stable contract to depend on for logger output, as we update the internals of the build engine, log messages may change the phase in which it occurs.