### PR TITLE
Fix `resource` configuration property

### DIFF
--- a/docs/reference/docfx-json-reference.md
+++ b/docs/reference/docfx-json-reference.md
@@ -45,7 +45,7 @@ Specifies an array of resource files to include in the project. Supports [File M
 ```json
 {
   "build": {
-    "resources": ["**/*.png"]
+    "resource": ["**/*.png"]
   }
 }
 ```

--- a/src/docfx/Models/InitCommand.cs
+++ b/src/docfx/Models/InitCommand.cs
@@ -50,7 +50,7 @@ class InitCommand : Command<InitCommandOptions>
                 {
                     new { files = new[] { "**/*.{md,yml}" }, exclude = new[] { "_site/**" } }
                 },
-                resources = new[]
+                resource = new[]
                 {
                     new { files = new[] { "images/**" } }
                 },


### PR DESCRIPTION
Docfx `init` command produces `docfx.json` with `resources` property name. However correct property name for resource files to include in the project output directory is `resource` (singular noun).

This PR fixes `docfx.json` produced by `init` command and corrects the property name in [Config Reference](https://dotnet.github.io/docfx/reference/docfx-json-reference.html#resource) page