### PR TITLE
chore: Remove template file copy verbose logs

### DIFF
--- a/src/Docfx.Build/TemplateProcessors/TemplateProcessor.cs
+++ b/src/Docfx.Build/TemplateProcessors/TemplateProcessor.cs
@@ -174,13 +174,11 @@ public class TemplateProcessor
                          && inputFileInfo.LastWriteTimeUtc == outputFileInfo.LastWriteTimeUtc; // File's LastWriteTimeUtc are identical.
         if (skipFileCopy)
         {
-            Logger.Log(LogLevel.Verbose, $"Skipped resource {filePath} that template dependants on to {outputFileInfo.FullName}");
             return;
         }
         else
         {
             File.Copy(inputFileInfo.FullName, outputFileInfo.FullName, isOverwrite); // Use `File.Copy` API to preserve LastWriteTime.
-            Logger.Log(LogLevel.Verbose, $"Saved resource {filePath} that template dependants on to {outputFileInfo.FullName}");
         }
     }
 


### PR DESCRIPTION
**What's included in this PR**
- Remove template file copy logs (skipped or saved)

**Background**
When running `docfx build` command with `--logLevel Verbose`.
Too much logs are written relating to template files copy.

Example:
> Skipped resource public/docfx.min.css that template dependants on to C:\Projects\GitHub\filzrev\docfx\samples\seed\_site\public\docfx.min.css
> Skipped resource public/docfx.min.css.map that template dependants on to C:\Projects\GitHub\filzrev\docfx\samples\seed\_site\public\docfx.min.css.map
> Skipped resource public/docfx.min.js that template dependants on to C:\Projects\GitHub\filzrev\docfx\samples\seed\_site\public\docfx.min.js

These logs are less important to build document process logging.
And not consistent compared to other file output processing. (e.g. Output HTML files is not logged)
So I've remove these logs in this PR.

I thought these logs should be logged as `Debug` level. (Currently not supported)
And it can be filtered by category with customizable configurations (By using `Microsoft.Extensions.Logging`)