### PR TITLE
feat: add start event.

### DIFF
--- a/samples/seed/template/public/main.js
+++ b/samples/seed/template/public/main.js
@@ -14,7 +14,10 @@ export default {
     }
   ],
   lunrLanguages: ['en', 'ru'],
-  configureHljs: function (hljs) {
+  start() {
+    console.log('started');
+  },
+  configureHljs (hljs) {
     hljs.registerLanguage('bicep', bicep);
   },
 }

--- a/templates/modern/src/docfx.ts
+++ b/templates/modern/src/docfx.ts
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import 'bootstrap'
+import { options } from './helper'
 import { highlight } from './highlight'
 import { renderMarkdown } from './markdown'
 import { enableSearch } from './search'
@@ -24,6 +25,9 @@ declare global {
 
 async function init() {
   window.docfx = window.docfx || {}
+
+  const { start } = await options()
+  start?.()
 
   const pdfmode = navigator.userAgent.indexOf('docfx/pdf') >= 0
   if (pdfmode) {

--- a/templates/modern/src/options.d.ts
+++ b/templates/modern/src/options.d.ts
@@ -38,6 +38,9 @@ export type DocfxOptions = {
   /** A list of [lunr languages](https://github.com/MihaiValentin/lunr-languages#readme) such as fr, es for full text search */
   lunrLanguages?: string[],
 
+  /** Hooks to app start event */
+  start?: () => void,
+
   /** Configures [hightlight.js](https://highlightjs.org/) */
   configureHljs?: (hljs: HLJSApi) => void,
 }


### PR DESCRIPTION
Add `start` event to `main.js` to make it easier to discover application start entry point. Though any scripts in `main.js` will execute on `DOMContentLoaded`, this event helps with discovery.

https://github.com/dotnet/docfx/discussions/9414