### PR TITLE
feat: Add support for .NET8

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -10,9 +10,7 @@ runs:
   - uses: actions/setup-dotnet@v3
     with:
       dotnet-version: |
-        6.x
-        7.x
-        8.0.100-rc.2.23502.2
+        8.x
 
   - run: npm install
     shell: bash

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,9 +18,7 @@ jobs:
     - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
-          6.x
-          7.x
-          8.0.100-rc.2.23502.2
+          8.x
 
     - uses: github/codeql-action/init@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,7 @@ jobs:
     - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
-          6.x
-          7.x
-          8.0.100-rc.2.23502.2
+          8.x
 
     - run: npm install
       working-directory: templates
@@ -60,14 +58,14 @@ jobs:
     steps:
     - uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.x
+        dotnet-version: 8.x
 
     - uses: actions/download-artifact@v3
       with:
         name: nuget
         path: drop/nuget
 
-    - run: dotnet tool install --tool-path . sign --version 0.9.1-beta.23356.1
+    - run: dotnet tool install --tool-path . sign --version 0.9.1-beta.23530.1
 
     - run: >
         ./sign code azure-key-vault
@@ -94,7 +92,7 @@ jobs:
     steps:
     - uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.x
+        dotnet-version: 8.x
 
     - uses: actions/download-artifact@v3
       with:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(ContinuousIntegrationBuild)' == 'true' ">$(TargetFrameworks);net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <!--<TargetFrameworks Condition=" '$(ContinuousIntegrationBuild)' == 'true' ">$(TargetFrameworks);net9.0</TargetFrameworks>-->
     <LangVersion>Preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <!-- "17.3.2" is the latest compatible version for .NET 6 -->
     <PackageVersion Include="Microsoft.Build" Version="[17.3.2]" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageVersion Include="Microsoft.Build" Version="[17.7.2]" Condition="'$(TargetFramework)' == 'net7.0'" />
-    <PackageVersion Include="Microsoft.Build" Version="17.7.2" Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net7.0'" />
+    <PackageVersion Include="Microsoft.Build" Version="17.8.3" Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net7.0'" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.6.10" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.8.0-3.final" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.8.0-3.final" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,16 +12,17 @@
     <PackageVersion Include="Markdig" Version="0.33.0" />
     <!-- "17.3.2" is the latest compatible version for .NET 6 -->
     <PackageVersion Include="Microsoft.Build" Version="[17.3.2]" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageVersion Include="Microsoft.Build" Version="17.7.2" Condition="'$(TargetFramework)' != 'net6.0'" />
+    <PackageVersion Include="Microsoft.Build" Version="[17.7.2]" Condition="'$(TargetFramework)' == 'net7.0'" />
+    <PackageVersion Include="Microsoft.Build" Version="17.7.2" Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net7.0'" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.6.10" />
-    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.7.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.8.0-3.final" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.8.0-3.final" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0-3.final" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0-3.final" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.8.0-3.final" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.8.0-3.final" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.8.0-3.final" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.8.0-3.final" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.37.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
@@ -31,8 +32,8 @@
     <PackageVersion Include="Spectre.Console" Version="0.47.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.47.0" />
     <PackageVersion Include="Stubble.Core" Version="1.10.8" />
-    <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
-    <PackageVersion Include="System.Composition" Version="7.0.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Include="System.Composition" Version="8.0.0" />
     <PackageVersion Include="YamlDotNet" Version="13.7.1" />
     <!-- Test only -->
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />

--- a/test/docfx.Tests/Assets/ref.csproj.sample.1
+++ b/test/docfx.Tests/Assets/ref.csproj.sample.1
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/test/docfx.Tests/Assets/test.csproj.sample.1
+++ b/test/docfx.Tests/Assets/test.csproj.sample.1
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/test/docfx.Tests/Assets/test.vbproj.sample.1
+++ b/test/docfx.Tests/Assets/test.vbproj.sample.1
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <RootNamespace>testVBproj1</RootNamespace>
     <AssemblyName>test.sample.1</AssemblyName>
     <OptionExplicit>On</OptionExplicit>


### PR DESCRIPTION
**What's included in this PR**

- Update CI build to use .NET 8 SDK.
- Update `dotnet-sign` tool version.
- Update `Microsoft.CodeAnalysis*` packages to latest preview version (.NET 8 RTM version is not released yet)
- Update following NuGet packages to .NET 8 version
  - `Microsoft.Build` 
  - `System.Collections.Immutable`
  - `System.Composition`
- Change `TargetFrameworks` to `net6.0;net7.0;net8.0`  
  (it might be possible to drop .NET7 support. Because .NET 7 support lifecycle ends at `May 14, 2024`)

**Backlog**

- It failed to run `MetadataCommandTest` at `Docfx.Tests` project when running on **.NET 7 runtime. (with .NET 8 SDK)**
- Following packages needs to be updated to .NET 8 RTM version.
  - `Microsoft.CodeAnalysis*` 
  - `NuGet.Frameworks`
- Add C# 12 specific tests (e,g, https://github.com/dotnet/docfx/discussions/9339)