### PR TITLE
chore: Hide the Docfx templates folder from VS project tree

### DIFF
--- a/src/Docfx.App/Build/docfx.app.props
+++ b/src/Docfx.App/Build/docfx.app.props
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <!-- Hide the Docfx templates folder from VS project tree.
+         Can be removed once https://github.com/NuGet/Home/issues/4856 is resolved -->
+    <ItemGroup>
+        <Content Update="@(Content)">
+            <Visible Condition="'%(NuGetItemType)' == 'Content' and '%(NuGetPackageId)' == 'docfx.app'">False</Visible>
+        </Content>
+    </ItemGroup>
+</Project>

--- a/src/Docfx.App/Docfx.App.csproj
+++ b/src/Docfx.App/Docfx.App.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <Content Include="templates/**" CopyToOutputDirectory="PreserveNewest" PackageCopyToOutput="true" PackagePath="contentFiles/any/any/templates" />
+    <None Include="Build\docfx.app.props" Pack="true" PackagePath="build\" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hide the Docfx templates folder from VS project tree, via docfx.app.props file as workaround until the issue is resolved from NuGet side.

Credits for workaround: https://github.com/NuGet/Home/issues/4856#issuecomment-1363934310

Fixes #9549