### PR TITLE
chore: Fix picture image click event handling

### DIFF
--- a/templates/modern/src/markdown.ts
+++ b/templates/modern/src/markdown.ts
@@ -114,9 +114,18 @@ async function renderClickableImage() {
       const a = document.createElement('a')
       a.target = '_blank'
       a.rel = 'noopener noreferrer nofollow'
-      a.href = img.src
-      img.replaceWith(a)
-      a.appendChild(img)
+
+      if (img.parentElement.tagName === 'PICTURE') {
+        const picture = img.parentElement
+        picture.addEventListener('click', () => {
+          a.href = img.currentSrc
+          a.click()
+        })
+      } else {
+        a.href = img.src
+        img.replaceWith(a)
+        a.appendChild(img)
+      }
     }
 
     function shouldMakeClickable(): boolean {


### PR DESCRIPTION
Fix #9571

**What's changed this PR**
Add `<picture>` tag special handling to `makeClickable()` function.

`<picture>` tag's `img.currentSrc` is changed dynamically based on context.
So it need to add `onClick` event handler to picture tag itself.

## Test Code

```html
<div>
<picture>
    <source srcset="images/example_dark.png" media="(max-width: 600px)" alt=""/>
    <img src="images/example.png" alt=""/>
</picture>
</div>
```
## What's tested manually
1. When window size is over 600px. `images/example.png` is displayed. and this image opened when clicking.
2. When window size is <= 600 px. `images/example_dark.png"` is displayed. and this image opened when clicking.
3. Other `<img>` tags  behavior is not changed (wrapped by anchor tag)