### PR TITLE
build: upgrade to Jint 3.0.0-beta-2059

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="HtmlAgilityPack" Version="1.11.57" />
     <PackageVersion Include="ICSharpCode.Decompiler" Version="8.2.0.7535" />
     <PackageVersion Include="IgnoresAccessChecksToGenerator" Version="0.7.0" />
-    <PackageVersion Include="Jint" Version="3.0.0-beta-2058" />
+    <PackageVersion Include="Jint" Version="3.0.0-beta-2059" />
     <PackageVersion Include="JsonSchema.Net" Version="5.4.3" />
     <PackageVersion Include="Markdig" Version="0.34.0" />
     <!-- "17.3.2" is the latest compatible version for .NET 6 -->

--- a/src/Docfx.Build/TemplateProcessors/Preprocessors/TemplateJintPreprocessor.cs
+++ b/src/Docfx.Build/TemplateProcessors/Preprocessors/TemplateJintPreprocessor.cs
@@ -204,7 +204,7 @@ public class TemplateJintPreprocessor : ITemplatePreprocessor
         {
             return null;
         }
-        if (func is FunctionInstance)
+        if (func is Function)
         {
             return s =>
             {


### PR DESCRIPTION
With [latest release](https://github.com/sebastienros/jint/releases/tag/v3.0.0-beta-2059) we made some API changes for consistency and clearer type names. This requires some code changes in consuming code and here I'm offering them to you, free of charge.