### PR TITLE
feat: support description metadata

### DIFF
--- a/src/Docfx.Build/SystemMetadata.cs
+++ b/src/Docfx.Build/SystemMetadata.cs
@@ -8,21 +8,6 @@ namespace Docfx.Build.Engine;
 
 class SystemMetadata
 {
-    [JsonProperty("_title")]
-    [JsonPropertyName("_title")]
-    public string Title { get; set; }
-
-    [JsonProperty("_tocTitle")]
-    [JsonPropertyName("_tocTitle")]
-    public string TocTitle { get; set; }
-
-    [JsonProperty("_name")]
-    [JsonPropertyName("_name")]
-    public string Name { get; set; }
-
-    [JsonProperty("_description")]
-    [JsonPropertyName("_description")]
-    public string Description { get; set; }
 
     /// <summary>
     /// TOC PATH from ~ ROOT

--- a/templates/default/partials/head.tmpl.partial
+++ b/templates/default/partials/head.tmpl.partial
@@ -20,6 +20,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="{{#title}}{{title}}{{/title}}{{^title}}{{>partials/title}}{{/title}} {{#_appTitle}}| {{_appTitle}} {{/_appTitle}}">
     {{#_description}}<meta name="description" content="{{_description}}">{{/_description}}
+    {{#description}}<meta name="description" content="{{description}}">{{/description}}
     <link rel="shortcut icon" href="{{_rel}}{{{_appFaviconPath}}}{{^_appFaviconPath}}favicon.ico{{/_appFaviconPath}}">
     <link rel="stylesheet" href="{{_rel}}styles/docfx.vendor.min.css">
     <link rel="stylesheet" href="{{_rel}}styles/docfx.css">

--- a/templates/modern/layout/_master.tmpl
+++ b/templates/modern/layout/_master.tmpl
@@ -14,6 +14,7 @@
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <meta name="title" content="{{#title}}{{title}}{{/title}}{{^title}}{{>partials/title}}{{/title}} {{#_appTitle}}| {{_appTitle}} {{/_appTitle}}">
       {{#_description}}<meta name="description" content="{{_description}}">{{/_description}}
+      {{#description}}<meta name="description" content="{{description}}">{{/description}}
       <link rel="icon" href="{{_rel}}{{{_appFaviconPath}}}{{^_appFaviconPath}}favicon.ico{{/_appFaviconPath}}">
       <link rel="stylesheet" href="{{_rel}}public/docfx.min.css">
       <link rel="stylesheet" href="{{_rel}}public/main.css">

--- a/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/api-BuildFromProject.Class1.html.verified.html
+++ b/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/api-BuildFromProject.Class1.html.verified.html
@@ -6,6 +6,7 @@
       <meta name="title" content="Class Class1
  | docfx seed website ">
       
+      
       <link rel="icon" href="../favicon.ico">
       <style class="anchorjs"></style><link rel="stylesheet" href="../public/docfx.min.css">
       <link rel="stylesheet" href="../public/main.css">

--- a/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/api-CatLibrary.Cat-2.html-q-cat.verified.html
+++ b/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/api-CatLibrary.Cat-2.html-q-cat.verified.html
@@ -6,6 +6,7 @@
       <meta name="title" content="Class Cat<T, K>
  | docfx seed website ">
       
+      
       <link rel="icon" href="../favicon.ico">
       <style class="anchorjs"></style><link rel="stylesheet" href="../public/docfx.min.css">
       <link rel="stylesheet" href="../public/main.css">

--- a/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/api-CatLibrary.html-term-cat.verified.html
+++ b/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/api-CatLibrary.html-term-cat.verified.html
@@ -6,6 +6,7 @@
       <meta name="title" content="Namespace CatLibrary
  | docfx seed website ">
       
+      
       <link rel="icon" href="../favicon.ico">
       <style class="anchorjs"></style><link rel="stylesheet" href="../public/docfx.min.css">
       <link rel="stylesheet" href="../public/main.css">

--- a/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/api-CatLibrary.html.verified.html
+++ b/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/api-CatLibrary.html.verified.html
@@ -6,6 +6,7 @@
       <meta name="title" content="Namespace CatLibrary
  | docfx seed website ">
       
+      
       <link rel="icon" href="../favicon.ico">
       <style class="anchorjs"></style><link rel="stylesheet" href="../public/docfx.min.css">
       <link rel="stylesheet" href="../public/main.css">

--- a/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/articles-csharp_coding_standards.html.verified.html
+++ b/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/articles-csharp_coding_standards.html.verified.html
@@ -4,6 +4,7 @@
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <meta name="title" content="C# Coding Standards | docfx seed website ">
       
+      
       <link rel="icon" href="../favicon.ico">
       <style class="anchorjs"></style><link rel="stylesheet" href="../public/docfx.min.css">
       <link rel="stylesheet" href="../public/main.css">

--- a/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/articles-markdown.html-tabs-windows-2Ctypescript-markdown-extensions.verified.html
+++ b/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/articles-markdown.html-tabs-windows-2Ctypescript-markdown-extensions.verified.html
@@ -4,6 +4,7 @@
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <meta name="title" content="Markdown | docfx seed website ">
       
+      
       <link rel="icon" href="../favicon.ico">
       <style class="anchorjs"></style><link rel="stylesheet" href="../public/docfx.min.css">
       <link rel="stylesheet" href="../public/main.css">

--- a/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/index.html.verified.html
+++ b/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/index.html.verified.html
@@ -4,6 +4,7 @@
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <meta name="title" content="docfx-seed | docfx seed website ">
       
+      
       <link rel="icon" href="favicon.ico">
       <style class="anchorjs"></style><link rel="stylesheet" href="public/docfx.min.css">
       <link rel="stylesheet" href="public/main.css">

--- a/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/restapi-petstore.html.verified.html
+++ b/test/docfx.Snapshot.Tests/SamplesTest.SeedHtml/html/restapi-petstore.html.verified.html
@@ -4,6 +4,7 @@
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <meta name="title" content="Pet Store APIs | docfx seed website ">
       
+      
       <link rel="icon" href="../favicon.ico">
       <style class="anchorjs"></style><link rel="stylesheet" href="../public/docfx.min.css">
       <link rel="stylesheet" href="../public/main.css">


### PR DESCRIPTION
Supports both `description` and `_description` metadata.

Fixes #9584