### PR TITLE
build(deps): update nuget dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,11 +40,11 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="Magick.NET-Q16-AnyCPU" Version="13.5.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0-preview-23531-01" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0-preview-23577-04" />
     <PackageVersion Include="PublicApiGenerator" Version="11.1.0" />
     <PackageVersion Include="Verify.DiffPlex" Version="2.3.0" />
     <PackageVersion Include="Verify.Xunit" Version="22.8.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.4" />
-    <PackageVersion Include="xunit" Version="2.6.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6" />
+    <PackageVersion Include="xunit" Version="2.6.5" />
   </ItemGroup>
 </Project>

--- a/test/Docfx.Build.Common.Tests/ModelAttributeHandlerTest.cs
+++ b/test/Docfx.Build.Common.Tests/ModelAttributeHandlerTest.cs
@@ -106,8 +106,8 @@ public class ModelAttributeHandlerTest
 
         Assert.Equal(12, context.LinkToUids.Count);
         Assert.Equal(new List<string> {
-            "0", "1", "2", "3", "2.2", "0.0", "1.1", "1.2", "1.3", "0.0.0", "1.1.1", "1.1.2"
-        }, context.LinkToUids);
+            "0", "0.0", "0.0.0", "1", "1.1", "1.1.1","1.1.2", "1.2", "1.3","2",  "2.2", "3",
+        }, context.LinkToUids.OrderBy(x => x));
     }
 
     #endregion


### PR DESCRIPTION
This PR manually update following package dependencies.

- `Microsoft.NET.Test.Sdk`
- `xunit`
- `xunit.runner.visualstudio`

Note: I don't know why dependabot don't create PR automatically for xunit packages.
(It seems worked before [November 20](https://github.com/dotnet/docfx/pull/9442))

---
To resolve following warning.
I've modified `ModelAttributeHandlerTest.cs`.

> Warning	xUnit2027	Comparing an instance of List<string> with an instance of HashSet<string> has undefined results, because the order of items in the set is not predictable. Create a stable order for the set (i.e., by using OrderBy from Linq).
