### PR TITLE
Fix japanese search

### DIFF
--- a/templates/modern/src/search-worker.ts
+++ b/templates/modern/src/search-worker.ts
@@ -29,7 +29,7 @@ async function loadIndex({ lunrLanguages }: { lunrLanguages?: string[] }) {
     if (lunrLanguages && lunrLanguages.length > 0) {
       multi(lunr)
       stemmer(lunr)
-      if(lunrLanguages.includes('ja')) {
+      if (lunrLanguages.includes('ja')) {
         tinyseg(lunr)
       }
       await Promise.all(lunrLanguages.map(initLanguage))

--- a/templates/modern/src/search-worker.ts
+++ b/templates/modern/src/search-worker.ts
@@ -3,7 +3,7 @@
 
 import lunr from 'lunr'
 import stemmer from 'lunr-languages/lunr.stemmer.support'
-import tinyseg from 'lunr-languages/tinyseg.js'
+import tinyseg from 'lunr-languages/tinyseg'
 import multi from 'lunr-languages/lunr.multi'
 import { get, set, createStore } from 'idb-keyval'
 

--- a/templates/modern/src/search-worker.ts
+++ b/templates/modern/src/search-worker.ts
@@ -3,6 +3,7 @@
 
 import lunr from 'lunr'
 import stemmer from 'lunr-languages/lunr.stemmer.support'
+import tinyseg from 'lunr-languages/tinyseg.js'
 import multi from 'lunr-languages/lunr.multi'
 import { get, set, createStore } from 'idb-keyval'
 
@@ -28,6 +29,9 @@ async function loadIndex({ lunrLanguages }: { lunrLanguages?: string[] }) {
     if (lunrLanguages && lunrLanguages.length > 0) {
       multi(lunr)
       stemmer(lunr)
+      if(lunrLanguages.includes('ja')) {
+        tinyseg(lunr)
+      }
       await Promise.all(lunrLanguages.map(initLanguage))
     }
 


### PR DESCRIPTION
<details><summary>Original(Japanese)</summary>

## 概要
このPRでは #9601 を修正します。

## 変更概要
+ modern テンプレートにおいて、lunrLanguages に `ja` が存在する場合はtinysegを適応する

## 確認手順
1. `cd templates/ && npm i && npm run build && cd ../`
1. samples/seed/template/public/main.js の `lunrLanguages` に `ja`を追加する
1. samples/seed/articles に後述の内容を含む`japanese.md`ファイルを作成する
1. toc.ymlにjapanese.mdを追加する
1. `dotnet run --framework net8.0 --project ./src/docfx/docfx.csproj -- ./samples/seed/docfx.json --serve`
1. http://localhost:8080 に飛び、`概要`と検索し、検索結果が表示される
    + indexの質が良くないのか、`日本語`や`ドキュメント`等では引っかかりませんが、別の問題であるためこのPRでは無視します。

`japanese.md`
```md
## 概要
これは、日本語のテストドキュメントです。
```
- [x] 検索が実行できる -> ![スクリーンショット 2024-01-10 210932](https://github.com/dotnet/docfx/assets/37934691/00366b25-96d0-470c-9706-cdbcba97e6a4)

</details>

## Overview.
This PR fixes #9601.

## Change summary.
+ In modern templates, adapt tinyseg if `ja` is present in lunrLanguages.

## Check procedure.
1. `cd templates/ && npm i && npm run build && cd . /`
1. Add `ja` to `lunrLanguages` in samples/seed/template/public/main.js
1. Create a `japanese.md` file in samples/seed/articles with the contents described below. 
1. Add `japanese.md` to toc.yml 1.
1. `dotnet run --framework net8.0 --project . /src/docfx/docfx.csproj -- . /samples/seed/docfx.json --serve`.
1. jump to http://localhost:8080, search for `概要` and you will see.
    + The quality of the index may not be good, it does not catch `日本語`, `ドキュメント`, etc., but this is a different problem and will be ignored in this PR.

`japanese.md`
```md
## 概要
これは、日本語のテストドキュメントです。
```
- [x] searches can be performed -> 
![スクリーンショット 2024-01-10 210932](https://github.com/dotnet/docfx/assets/37934691/00366b25-96d0-470c-9706-cdbcba97e6a4)