### PR TITLE
chore: Add warnings for UnresolvedAnalyzerReference

### DIFF
--- a/src/Docfx.Dotnet/DotnetApiCatalog.Compile.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.Compile.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.Construction;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.MSBuild;
 
 #nullable enable
@@ -132,6 +133,11 @@ partial class DotnetApiCatalog
                     await Process.Start("dotnet", $"restore \"{path}\"").WaitForExitAsync();
                 }
                 project = await workspace.OpenProjectAsync(path, msbuildLogger);
+
+                foreach (var unresolvedAnalyzer in project.AnalyzerReferences.OfType<UnresolvedAnalyzerReference>())
+                {
+                    Logger.LogWarning("There is .NET Analyzer that can't be resolved. Path: " + unresolvedAnalyzer.FullPath);
+                }
             }
 
             if (!project.SupportsCompilation)

--- a/src/Docfx.Dotnet/DotnetApiCatalog.Compile.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.Compile.cs
@@ -136,7 +136,9 @@ partial class DotnetApiCatalog
 
                 foreach (var unresolvedAnalyzer in project.AnalyzerReferences.OfType<UnresolvedAnalyzerReference>())
                 {
-                    Logger.LogWarning("There is .NET Analyzer that can't be resolved. Path: " + unresolvedAnalyzer.FullPath);
+                    Logger.LogWarning($"There is .NET Analyzer that can't be resolved. "
+                                    + $"If this analyzer is .NET Source Generator project. "
+                                    + $"Try build with `dotnet build -c Release` command before running docfx. Path: {unresolvedAnalyzer.FullPath}");
                 }
             }
 


### PR DESCRIPTION
**What's included in this PR**
Add warning logs for `UnresolvedAnalyzerReference`.
(That occurs when analyzer DLL can't resolved when running `dotnet metadata` command.
See: https://github.com/dotnet/docfx/issues/9619

**Test**
I've tested PR manually with solution that contains SourceGenerator project.

**Warning message examples**
> warning: There is .NET Analyzer that can't be resolved. Path: C:\Projects\SampleApp\src\SampleSourceGenerator\bin\Release\netstandard2.0\SampleSourceGenerator.dll