### PR TITLE
chore: Update `Verify.Xunit` dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,11 @@ updates:
       patterns:
       - "Spectre.Console"
       - "Spectre.Console.*"
+    xunit:
+      patterns:
+      - "xunit"
+      - "xunit.*"
+      - "Verify.Xunit"
 
 - package-ecosystem: npm
   target-branch: main

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,8 +43,8 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0-preview-23577-04" />
     <PackageVersion Include="PublicApiGenerator" Version="11.1.0" />
     <PackageVersion Include="Verify.DiffPlex" Version="2.3.0" />
-    <PackageVersion Include="Verify.Xunit" Version="22.11.5" />
+    <PackageVersion Include="Verify.Xunit" Version="23.0.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6" />
-    <PackageVersion Include="xunit" Version="2.6.5" />
+    <PackageVersion Include="xunit" Version="2.6.6" />
   </ItemGroup>
 </Project>

--- a/test/docfx.Snapshot.Tests/SamplesTest.cs
+++ b/test/docfx.Snapshot.Tests/SamplesTest.cs
@@ -21,7 +21,6 @@ using UglyToad.PdfPig.Outline;
 
 namespace Docfx.Tests;
 
-[UsesVerify]
 [Trait("Stage", "Snapshot")]
 public class SamplesTest
 {

--- a/test/docfx.Tests/PublicApiContractTest.cs
+++ b/test/docfx.Tests/PublicApiContractTest.cs
@@ -6,7 +6,6 @@ using PublicApiGenerator;
 
 namespace Docfx.Tests;
 
-[UsesVerify]
 public class PublicApiContractTest
 {
     [Fact]


### PR DESCRIPTION
**What's included in this PR**

- Update `Verify.Xunit` NuGet package version 
- Update `xunit` Nuget package version
- Add dependabot grouping configuration for xUnit.

**Background**
This PR intended to supersede #9620.
`Verify.Xunit` package seems requireing latest version of `xunit` packages as minimum requirement.
So I've added dependabot grouping configuration for xunit related packages also.
 