### PR TITLE
feat: Enforce `GlobMatcherOptions.AllowDotMatch` option for file's `excludePatterns`

### DIFF
--- a/src/Docfx.Glob/FileGlob.cs
+++ b/src/Docfx.Glob/FileGlob.cs
@@ -19,7 +19,7 @@ public class FileGlob
         var globArray = patterns.Select(s => new GlobMatcher(s, options)).ToArray();
         var excludeGlobArray = excludePatterns == null ?
             Array.Empty<GlobMatcher>() :
-            excludePatterns.Select(s => new GlobMatcher(s, options)).ToArray();
+            excludePatterns.Select(s => new GlobMatcher(s, options | GlobMatcherOptions.AllowDotMatch)).ToArray();
         return GetFilesCore(cwd, globArray, excludeGlobArray);
     }
 

--- a/test/Docfx.Glob.Tests/GlobFileTest.cs
+++ b/test/Docfx.Glob.Tests/GlobFileTest.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Docfx.Tests.Common;
+using FluentAssertions;
+using FluentAssertions.Execution;
 using Xunit;
 
 namespace Docfx.Glob.Tests;
@@ -79,6 +81,80 @@ public class GlobFileTest : TestBase
              new string[] { "[EJ]/*.{md,cs,csproj}" },
              new string[] { "**.cs" }).ToArray();
         Assert.Equal(2, result.Length);
+    }
+
+    [Fact]
+    public void TestGlobGetFilesWithDotStartedDirectoryFiles()
+    {
+        // - .Hidden/
+        //   |- A.cs
+        //   |- B.cs
+        //   |- .Nested/
+        //   |    |- C.cs
+        //   |- D/
+        //   |  |- E.cs
+        // - .NotHidden/
+        //   |- F.cs
+        //   |- G.cs
+        //   |- .HiddenFile.cs
+        var files = new string[]
+        {
+            ".Hidden/A.cs",
+            ".Hidden/B.cs",
+            ".Hidden/.Nested/C.cs",
+            ".Hidden/D/E.cs",
+            "NotHidden/F.cs",
+            "NotHidden/G.cs",
+            "NotHidden/.HiddenFile.cs",
+        };
+        CreateFilesOrFolders(_workingDirectory, files);
+
+        var totalFileCount = files.Length;
+
+        using (var scope = new AssertionScope())
+        {
+            // Test wildcard pattern with AllowDotMatch option.
+            var result = FileGlob.GetFiles(
+                _workingDirectory,
+                patterns: new[] { "**.cs" },
+                excludePatterns: null,
+                options: GlobMatcher.DefaultOptions | GlobMatcherOptions.AllowDotMatch
+            ).ToArray();
+            result.Should().HaveCount(totalFileCount); // All files are included when using AllowDotMatch option.
+
+            // Test wildcard pattern with default options.
+            result = FileGlob.GetFiles(
+                _workingDirectory,
+                patterns: new[] { "**.cs" },
+                excludePatterns: null
+                ).ToArray();
+            result.Should().HaveCount(2); // Dot started directories/files are excluded when using DefaultOptions.
+
+            // Test explicitly specified wildcard pattern with default options.
+            result = FileGlob.GetFiles(
+                _workingDirectory,
+                patterns: new[] { "**.cs", ".Hidden/**.cs" },
+                excludePatterns: null
+            ).ToArray();
+            result.Should().HaveCount(5); // Explicitly specified `.Hidden/**.cs` files are included. But `.Hidden/.Nested/**` files are excluded.
+
+            // Test `excludePatterns` with default option.
+            result = FileGlob.GetFiles(
+                _workingDirectory,
+                patterns: new[] { "**.cs", ".Hidden/**.cs" },
+                excludePatterns: new[] { ".Hidden/D/E.cs" }
+            ).ToArray();
+            result.Should().HaveCount(4); // `.Hidden/D/E.cs` file is excluded.
+
+            // Test `excludePatterns` with AllowDotMatch option.
+            result = FileGlob.GetFiles(
+                _workingDirectory,
+                patterns: new string[] { "**.cs", },
+                excludePatterns: new string[] { "**/.Nested/C.cs" },
+                options: GlobMatcher.DefaultOptions | GlobMatcherOptions.AllowDotMatch
+            ).ToArray();
+            result.Should().HaveCount(totalFileCount - 1); // `.Hidden/.Nested/C.cs` file is excluded.
+        }
     }
 
     private static void CreateFilesOrFolders(string cwd, params string[] items)


### PR DESCRIPTION
This PR intended to fix #8913 issue.

By default. docfx exclude directories/files that name starts with `dot` char .
And there are two options available to include these files.

- **Option 1:** Explicitly specify path that contains `dot` char.
- **Option 2:** Set [FileMappings `dot` property](https://github.com/dotnet/docfx/blob/ad6db161e426413aeea52f3cd42c65a7e60e99e7/src/Docfx.Common/FileMappingItem.cs#L107-L113) to `true`

But when using **Option1**.
There is problem that can't exclude some paths by using `exclude` settings.
Because  default `AllowDotMatch:false` settings is also applied to `exclude` filter rules.

This PR enforce `AllowDotMatch` options for `exclude` filter rules.
