### PR TITLE
pref: Optimize xrefmap download performance

### DIFF
--- a/src/Docfx.Build/XRefMaps/XRefMapDownloader.cs
+++ b/src/Docfx.Build/XRefMaps/XRefMapDownloader.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net;
 using Docfx.Common;
 
 using EnvironmentVariables = Docfx.DataContracts.Common.Constants.EnvironmentVariables;
@@ -127,11 +128,15 @@ public class XRefMapDownloader
 
         using var httpClient = new HttpClient(new HttpClientHandler()
         {
+            AutomaticDecompression = DecompressionMethods.All,
             CheckCertificateRevocationList = !EnvironmentVariables.NoCheckCertificateRevocationList,
-        });
+        })
+        {
+            Timeout = TimeSpan.FromMinutes(30), // Default: 100 seconds
+        };
 
         using var stream = await httpClient.GetStreamAsync(uri);
-        using var sr = new StreamReader(stream);
+        using var sr = new StreamReader(stream, bufferSize: 81920); // Default :1024 byte
         var map = YamlUtility.Deserialize<XRefMap>(sr);
         map.BaseUrl = baseUrl;
         UpdateHref(map, null);


### PR DESCRIPTION
This PR is intended to resolve #9558

**What's included in this PR**

- Add settings to use HTTP Compression (if available)
- Change HttpClient's timeout to 30 minutes (Default: 100 seconds)
- Change StreamReader's buffer size to 80KB (Default: 1024 byte)
  -  `80KB` is default buffer size that used by `Stream::CopyTo`. 

**What's tested**

I've manually tested xrefmap download with following configuration.
```
  "build": {
    "xref": [
      "https://learn.microsoft.com/en-us/dotnet/.xrefmap.json"
    ]
  }
```

And confirmed server returns following  HTTP Response headers. And download size is reduced. (`316MB` -> `16MB`)

```
HTTP/1.1 200 OK
Content-Type: application/json
Content-Length: 15978441
Content-Encoding: gzip
```

**TODO Tasks**
I'll create another PR later relating #9558.

- Add special deserialization code path for JSON file.
   (Because YamlDotNet based JsonDeserializer is 5x slower than `System.Text.Json` based deserialization)
- Add support  for loading `xrefmap compressed by gzip` (`xrefmap.json.gz`) from local disk.  
