### PR TITLE
fix: When `disableDefaultFilter` is enabled. `filterConfig.yml' is not loaded.

### DIFF
--- a/src/Docfx.Dotnet/SymbolFilter.cs
+++ b/src/Docfx.Dotnet/SymbolFilter.cs
@@ -21,7 +21,9 @@ internal class SymbolFilter
     {
         _options = options;
         _config = config;
-        _filterRule = config.DisableDefaultFilter ? null : ConfigFilterRule.LoadWithDefaults(config.FilterConfigFile);
+        _filterRule = config.DisableDefaultFilter
+                            ? ConfigFilterRule.Load(config.FilterConfigFile)
+                            : ConfigFilterRule.LoadWithDefaults(config.FilterConfigFile);
     }
 
     public bool IncludeApi(ISymbol symbol)


### PR DESCRIPTION
This PR fixes the issue that it can't use `"disableDefaultFilter": true' settings with custom `filterConfig.yml'.

I've tested this PR manually with following configurations.

```
  "metadata": [
    {
      "filter": "filterConfig.yml",
      "disableDefaultFilter": true
    }
  ],
```