### PR TITLE
fix: ApiPage is not generated when multiple namespaces defined across projects

### DIFF
--- a/src/Docfx.Dotnet/DotnetApiCatalog.Toc.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.Toc.cs
@@ -88,11 +88,9 @@ partial class DotnetApiCatalog
 
             IEnumerable<TocNode> CreateNamespaceToc(INamespaceSymbol ns)
             {
-                var idExists = true;
                 var id = VisitorHelper.PathFriendlyId(VisitorHelper.GetId(symbol));
                 if (!tocNodes.TryGetValue(id, out var node))
                 {
-                    idExists = false;
                     tocNodes.Add(id, node = new()
                     {
                         id = id,
@@ -120,7 +118,7 @@ partial class DotnetApiCatalog
                 }
 
                 node.containsLeafNodes = node.items.Any(i => i.containsLeafNodes);
-                if (!idExists && node.containsLeafNodes)
+                if (node.containsLeafNodes)
                 {
                     yield return node;
                 }


### PR DESCRIPTION
This PR is intended to fix #9618.

On current implementation. 
`CreateNamespaceToc` returns only first namespace that is processed.

This PR removing `idExists` check for `CreateNamespaceToc`.
It's because `Namespace` with same `id` can be defined by multiple projects.
