### PR TITLE
fix: Corrected class name in inheritedMembers block

### DIFF
--- a/templates/modern/partials/class.header.tmpl.partial
+++ b/templates/modern/partials/class.header.tmpl.partial
@@ -96,7 +96,7 @@
 {{/inClass}}
 
 {{#inheritedMembers.0}}
-<dl class="typelist derived">
+<dl class="typelist inheritedMembers">
   <dt>{{__global.inheritedMembers}}</dt>
   <dd>
 {{/inheritedMembers.0}}


### PR DESCRIPTION
## Description
This pull request addresses a bug found in the `inheritedMembers` block of the code. The class name was previously set as `derived`, which was incorrect. This PR updates the class name to `inheritedMembers`.

## Changes
- Updated the class name from `derived` to `inheritedMembers` in the `inheritedMembers` block.

