### PR TITLE
fix: ApiPage is not generated when multiple namespaces defined across projects

### DIFF
--- a/src/Docfx.Dotnet/DotnetApiCatalog.Toc.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.Toc.cs
@@ -102,6 +102,8 @@ partial class DotnetApiCatalog
                     });
                 }
 
+                var existingNodeHasNoLeafNode = idExists && !node.containsLeafNodes;
+
                 node.items ??= new();
                 node.symbols.Add((symbol, compilation));
 
@@ -120,9 +122,12 @@ partial class DotnetApiCatalog
                 }
 
                 node.containsLeafNodes = node.items.Any(i => i.containsLeafNodes);
-                if (!idExists && node.containsLeafNodes)
+                if (node.containsLeafNodes)
                 {
-                    yield return node;
+                    if (!idExists || existingNodeHasNoLeafNode)
+                    {
+                        yield return node;
+                    }
                 }
             }
 


### PR DESCRIPTION
This PR is intended to fix https://github.com/dotnet/docfx/issues/9618.

On current implementation.
`CreateNamespaceToc` method don't call `yield return node` if `node.containsLeafNodes` is `false`.
So if empty namespace is processed first. other items that share same namespaces are not included as docfx output.

This PR change logics to call `yield return node` with following 2 condition. 
1. `TocNode` is created & items are added.
2. `TocNode` is exists but has no items & items are added.