### PR TITLE
chore: Add `InternalsVisibleTo` attribute for benchmark

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,4 +4,9 @@
   <ItemGroup>
     <InternalsVisibleTo Include="$(AssemblyName).Tests" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <InternalsVisibleTo Include="Docfx.Benchmarks" />
+    <InternalsVisibleTo Include="LINQPadQuery" /> 
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
**What's included in this PR**

Add `InternalsVisibleTo` attribute for following assembly names.
  - `Docfx.Benchmarks`
  - `LINQPadQuery`

**Background**
I want to write benchmark & test code that use docfx internal types.

Currently I'm using `IgnoresAccessChecksToGenerator` to ignore .NET access checks.
But there are some limitations. (e.g. it can't using from [LINQPad](https://www.linqpad.net))

So I want to add `InternalsVisibleTo` attributes for specific assembly names to docfx DLLs.

---
[.NET Accessibility Levels](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/accessibility-levels) is not security features. And it can be ignorable by several ways. (e.g. By using .NET 8 [UnsafeAccessorAttribute](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.unsafeaccessorattribute))
I don't think there is a problem with the addition of the InternalsVisibleTo attribute to external assembly names.