### PR TITLE
chore: Update YamlDotNet version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,7 +35,7 @@
     <PackageVersion Include="Stubble.Core" Version="1.10.8" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="System.Composition" Version="8.0.0" />
-    <PackageVersion Include="YamlDotNet" Version="13.7.1" />
+    <PackageVersion Include="YamlDotNet" Version="15.1.0" />
     <!-- Test only -->
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />

--- a/src/Docfx.YamlSerialization/NodeDeserializers/EmitGenericCollectionNodeDeserializer.cs
+++ b/src/Docfx.YamlSerialization/NodeDeserializers/EmitGenericCollectionNodeDeserializer.cs
@@ -7,6 +7,7 @@ using Docfx.YamlSerialization.Helpers;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
 using YamlDotNet.Serialization.Utilities;
 using EditorBrowsable = System.ComponentModel.EditorBrowsableAttribute;
 using EditorBrowsableState = System.ComponentModel.EditorBrowsableState;
@@ -84,13 +85,13 @@ public class EmitGenericCollectionNodeDeserializer : INodeDeserializer
             var value = nestedObjectDeserializer(reader, typeof(TItem));
             if (value is not IValuePromise promise)
             {
-                result.Add(TypeConverter.ChangeType<TItem>(value));
+                result.Add(TypeConverter.ChangeType<TItem>(value, NullNamingConvention.Instance));
             }
             else if (result is IList<TItem> list)
             {
                 var index = list.Count;
                 result.Add(default);
-                promise.ValueAvailable += v => list[index] = TypeConverter.ChangeType<TItem>(v);
+                promise.ValueAvailable += v => list[index] = TypeConverter.ChangeType<TItem>(v, NullNamingConvention.Instance);
             }
             else
             {

--- a/src/Docfx.YamlSerialization/NodeDeserializers/ExtensibleObjectNodeDeserializer.cs
+++ b/src/Docfx.YamlSerialization/NodeDeserializers/ExtensibleObjectNodeDeserializer.cs
@@ -4,6 +4,7 @@
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
 using YamlDotNet.Serialization.Utilities;
 
 namespace Docfx.YamlSerialization.NodeDeserializers;
@@ -43,7 +44,7 @@ public sealed class ExtensibleObjectNodeDeserializer : INodeDeserializer
             var propertyValue = nestedObjectDeserializer(reader, property.Type);
             if (propertyValue is not IValuePromise propertyValuePromise)
             {
-                var convertedValue = TypeConverter.ChangeType(propertyValue, property.Type);
+                var convertedValue = TypeConverter.ChangeType(propertyValue, property.Type, NullNamingConvention.Instance);
                 property.Write(value, convertedValue);
             }
             else
@@ -51,7 +52,7 @@ public sealed class ExtensibleObjectNodeDeserializer : INodeDeserializer
                 var valueRef = value;
                 propertyValuePromise.ValueAvailable += v =>
                 {
-                    var convertedValue = TypeConverter.ChangeType(v, property.Type);
+                    var convertedValue = TypeConverter.ChangeType(v, property.Type, NullNamingConvention.Instance);
                     property.Write(valueRef, convertedValue);
                 };
             }

--- a/src/Docfx.YamlSerialization/YamlDeserializer.cs
+++ b/src/Docfx.YamlSerialization/YamlDeserializer.cs
@@ -89,12 +89,12 @@ public sealed class YamlDeserializer
         {
             new TypeConverterNodeDeserializer(_converters),
             new NullNodeDeserializer(),
-            new ScalarNodeDeserializer(attemptUnknownTypeDeserialization: false, _reflectionTypeConverter, YamlFormatter.Default),
+            new ScalarNodeDeserializer(attemptUnknownTypeDeserialization: false, _reflectionTypeConverter, YamlFormatter.Default, NullNamingConvention.Instance),
             new EmitArrayNodeDeserializer(),
             new EmitGenericDictionaryNodeDeserializer(objectFactory),
             new DictionaryNodeDeserializer(objectFactory, duplicateKeyChecking: true),
             new EmitGenericCollectionNodeDeserializer(objectFactory),
-            new CollectionNodeDeserializer(objectFactory),
+            new CollectionNodeDeserializer(objectFactory, NullNamingConvention.Instance),
             new EnumerableNodeDeserializer(),
             new ExtensibleObjectNodeDeserializer(objectFactory, _typeDescriptor, ignoreUnmatched)
         };
@@ -106,7 +106,7 @@ public sealed class YamlDeserializer
             new ScalarYamlNodeTypeResolver()
         };
 
-        NodeValueDeserializer nodeValueDeserializer = new(NodeDeserializers, TypeResolvers, _reflectionTypeConverter);
+        NodeValueDeserializer nodeValueDeserializer = new(NodeDeserializers, TypeResolvers, _reflectionTypeConverter, NullNamingConvention.Instance);
         if (ignoreNotFoundAnchor)
         {
             _valueDeserializer = new LooseAliasValueDeserializer(nodeValueDeserializer);

--- a/src/Docfx.YamlSerialization/YamlSerializer.cs
+++ b/src/Docfx.YamlSerialization/YamlSerializer.cs
@@ -119,11 +119,19 @@ public class YamlSerializer
 
         if (IsOptionSet(SerializationOptions.JsonCompatible))
         {
-            return new JsonEventEmitter(writer);
+            return new JsonEventEmitter(writer, YamlFormatter.Default, NullNamingConvention.Instance);
         }
         else
         {
-            return new TypeAssigningEventEmitter(writer, IsOptionSet(SerializationOptions.Roundtrip), new Dictionary<Type, TagName>());
+            return new TypeAssigningEventEmitter(
+                writer,
+                IsOptionSet(SerializationOptions.Roundtrip),
+                new Dictionary<Type, TagName>(),
+                quoteNecessaryStrings: false,
+                quoteYaml1_1Strings: false,
+                defaultScalarStyle: ScalarStyle.Any,
+                formatter: YamlFormatter.Default,
+                enumNamingConvention: NullNamingConvention.Instance);
         }
     }
 


### PR DESCRIPTION
This PR update YamlDotNet version to `15.1.0`.

In this release. Following breaking changes are announced.

> Breaking: For those that get impacted pass in NullNamingConvention.Instance to the EnumNamingConvetion arguments on the constructor
> Breaking: Removed many of the redundant constructors for the classes, pass in the old default values to the new constructors
I've modified following parts.

So I've applied following changed in this PR.
1. Add `NullNamingConvention.Instance` args for  `TypeConverter.ChangeType` method
2. Add `NullNamingConvention.Instance` args for following type constructors.
  2.1. `ScalarNodeDeserializer`
  2.2. `CollectionNodeDeserializer`
  2.3. `NodeValueDeserializer`
3. Add missing args for following type constructors
  3.1. `JsonEventEmitter`
  3.2. `TypeAssigningEventEmitter`

The completed parameters are taken from the following code changes.
https://github.com/aaubry/YamlDotNet/commit/88a9189474609f4c8fea2e6fdd9370974ad71120