### PR TITLE
fix: Warnings that occurs when bookmark link contains non-ASCII chars

### DIFF
--- a/src/Docfx.Build/PostProcessors/ValidateBookmark.cs
+++ b/src/Docfx.Build/PostProcessors/ValidateBookmark.cs
@@ -43,7 +43,7 @@ sealed class ValidateBookmark : HtmlDocumentHandler
              {
                  Title = node.InnerText,
                  Href = TransformPath(outputFile, decodedLink),
-                 Bookmark = bookmark,
+                 Bookmark = Uri.UnescapeDataString(bookmark),
                  SourceFragment = WebUtility.HtmlDecode(node.GetAttributeValue("data-raw-source", null)),
                  SourceFile = WebUtility.HtmlDecode(node.GetAttributeValue("sourceFile", null)),
                  SourceLineNumber = node.GetAttributeValue("sourceStartLineNumber", 0),


### PR DESCRIPTION
This PR intended to fix issue #5233
By adding `URI normalization logics` to validate bookmark URLs .

---

**Examples markdown that contains non-ASCI chars**
```markdown
# foo

Visit [Québec](#québec).

## Québec

The province or the city.
```

**Generated output HTML**
```html
<h2 id="foo">foo</h2>
<p>Visit <a href="#qu%C3%A9bec">Québec</a>.</p>
<h2 id="québec">Québec</h2>
<p>The province or the city.</p>
```

**Background**
Markdown link `[Québec](#québec)` is converted to url-encoded anchor link (`#qu%C3%A9bec`)
[This behavior is according to the CommonMark spec](https://github.com/xoofx/markdig/issues/380#issuecomment-547699642).

Instead, `## Québec` heading is converted to `<h2 id="québec">`
Because  it's generated by `AutoIdentifier` markdig extension.
And docfx explicitly specify `AutoIdentifierOptions.GitHub` options.

So bookmark URI validation should be executed by `Normalized URI` comparison.
(In this PR. This normalization is executed by `Uri.UnescapeDataString` API).

It might be better to use API that comply with the following standard specifications
- RFC 3987 - Internationalized Resource Identifiers (IRIs)
- [WHATWG URL Standard](https://url.spec.whatwg.org)
