### PR TITLE
build(deps): bump YamlDotNet from 15.1.0 to 15.1.1  dependencies .NET

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,7 +35,7 @@
     <PackageVersion Include="Stubble.Core" Version="1.10.8" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="System.Composition" Version="8.0.0" />
-    <PackageVersion Include="YamlDotNet" Version="15.1.0" />
+    <PackageVersion Include="YamlDotNet" Version="15.1.1" />
     <!-- Test only -->
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />

--- a/src/Docfx.YamlSerialization/YamlSerializer.cs
+++ b/src/Docfx.YamlSerialization/YamlSerializer.cs
@@ -125,7 +125,6 @@ public class YamlSerializer
         {
             return new TypeAssigningEventEmitter(
                 writer,
-                IsOptionSet(SerializationOptions.Roundtrip),
                 new Dictionary<Type, TagName>(),
                 quoteNecessaryStrings: false,
                 quoteYaml1_1Strings: false,


### PR DESCRIPTION
This PR was intended to replace #9681.

**What's changed in this PR**

- Update YamlDotNet version from 15.1.0 to 15.1.1
- Remove `requireTagWhenStaticAndActualTypesAreDifferent` parameter from `new TypeAssigningEventEmitter`. 

As far as I've confirmed YamlDotNet  changes. (https://github.com/aaubry/YamlDotNet/releases)
There are no compatibility issues by removing the `requireTagWhenStaticAndActualTypesAreDifferent` parameter.