### PR TITLE
chore: Add fail-fast logics  when `--serve` option enabled & port is already used

### DIFF
--- a/src/docfx/Models/BuildCommand.cs
+++ b/src/docfx/Models/BuildCommand.cs
@@ -14,6 +14,12 @@ internal class BuildCommand : Command<BuildCommandOptions>
     {
         return CommandHelper.Run(settings, () =>
         {
+            if (settings.Serve && CommandHelper.IsTcpPortAlreadyUsed(settings.Host, settings.Port))
+            {
+                Logger.LogError($"Serve option specified. But TCP port {settings.Port ?? 8080} is already being in use.");
+                return;
+            }
+
             var (config, baseDirectory) = Docset.GetConfig(settings.ConfigFile);
             MergeOptionsToConfig(settings, config.build, baseDirectory);
             var serveDirectory = RunBuild.Exec(config.build, new(), baseDirectory, settings.OutputFolder);

--- a/src/docfx/Models/DefaultCommand.cs
+++ b/src/docfx/Models/DefaultCommand.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel;
 using System.Reflection;
+using Docfx.Common;
 using Docfx.Dotnet;
 using Docfx.Pdf;
 using Spectre.Console.Cli;
@@ -29,6 +30,12 @@ class DefaultCommand : Command<DefaultCommand.Options>
 
         return CommandHelper.Run(options, () =>
         {
+            if (options.Serve && CommandHelper.IsTcpPortAlreadyUsed(options.Host, options.Port))
+            {
+                Logger.LogError($"Serve option specified. But TCP port {options.Port ?? 8080} is already being in use.");
+                return;
+            }
+
             var (config, configDirectory) = Docset.GetConfig(options.ConfigFile);
             var outputFolder = options.OutputFolder;
             string serveDirectory = null;


### PR DESCRIPTION
**What included in this PR**
Add fail-fast logics when  `--serve` option enabled and specified TCP port is already used.

**Background**
`docfx build` commands takes some times to complete.
When combined with `--serve` options.
Command fails on `RunServe::Exec` phase.
And need to run the `docfx serve' command separately.

This PR add TCP port availability check before start `metadata`/`build` commands.
And fail-fast if port is already used.

**Test**
I've manually confirmed behaviors with following `--hostname` patterns

- `null`/ `localhost` 
  - It's bound to loopback addressed (both `127.0.0.1` and `::1`)
- `*`
  -  It's bound to all available IPv4/IPv6 addressed
- IPAddress: (e.g. `127.0.0.1` / `127.0.0.2`)
  - I’ve confirmed that docfx can successfully host both sites simultaneously.
