### PR TITLE
chore: Add StackTrace logs for Javascript error

### DIFF
--- a/src/Docfx.Build/TemplateProcessors/Preprocessors/PreprocessorWithResourcePool.cs
+++ b/src/Docfx.Build/TemplateProcessors/Preprocessors/PreprocessorWithResourcePool.cs
@@ -3,6 +3,7 @@
 
 using Docfx.Common;
 using Esprima;
+using Jint.Runtime;
 
 namespace Docfx.Build.Engine;
 
@@ -71,9 +72,13 @@ internal class PreprocessorWithResourcePool : ITemplatePreprocessor
         {
             return lease.Resource.TransformModel(model);
         }
-        catch (Exception e)
+        catch (Exception ex)
         {
-            throw new InvalidPreprocessorException($"Error running Transform function inside template preprocessor: {e.Message}");
+            string message = ex is JavaScriptException jsException
+                ? jsException.GetJavaScriptErrorString()
+                : ex.Message;
+
+            throw new InvalidPreprocessorException($"Error running Transform function inside template preprocessor: {message}");
         }
     }
 }


### PR DESCRIPTION
This PR intended to fix #4057.

**What included in this PR**
Add JavaScript stack trace information to error logs.
When `JavaScriptException` is thrown by Jint.

**Test**
It's manually tested with following steps.

1. Add custom docfx template settings
2. Create `ManagedReference.extension.js`. and add `throw new Error("DummyException");` statement.
3. Run `docfx build` command and confirm error message.

**Error message**
I've confirmed that the following stacktrace text is appended to the end of the error message.
`   at ManagedReference.extension.js:2:7`

**Full error log**
```
C:\projects\docfx.issue4057\docs\api\Examples.Class1.yml: error ApplyTemplatePreprocessorError: Error transforming model generated from "api/Examples.Class1.yml" using "ManagedReference.html.primary.js". To get the detailed raw model, please run docfx with debug mode --debug. Error running Transform function inside template preprocessor: Error: DummyException
   at ManagedReference.extension.js:2:7
```


