### PR TITLE
chore: Update Microsoft.Build package version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <!-- "17.3.2" is the latest compatible version for .NET 6 -->
     <PackageVersion Include="Microsoft.Build" Version="[17.3.2]" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageVersion Include="Microsoft.Build" Version="[17.7.2]" Condition="'$(TargetFramework)' == 'net7.0'" />
-    <PackageVersion Include="Microsoft.Build" Version="17.8.3" Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net7.0'" />
+    <PackageVersion Include="Microsoft.Build" Version="17.9.5" Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net7.0'" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.8.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />


### PR DESCRIPTION
This PR update `Microsoft.Build` package version to `17.9.5`.

It needs to be updated manually because dependabot doesn't support conditional package version references.