### PR TITLE
fix: InvalidInputFile error occurs if file contains URI escaped charactors

### DIFF
--- a/src/Docfx.Common/Path/PathUtility.cs
+++ b/src/Docfx.Common/Path/PathUtility.cs
@@ -69,13 +69,13 @@ public static class PathUtility
             return absolutePath;
         }
 
+        if (toUri.IsFile && !toUri.OriginalString.StartsWith("file://", StringComparison.InvariantCultureIgnoreCase))
+        {
+           return Path.GetRelativePath(basePath, absolutePath).BackSlashToForwardSlash();
+        }
+
         Uri relativeUri = fromUri.MakeRelativeUri(toUri);
         string relativePath = Uri.UnescapeDataString(relativeUri.ToString());
-
-        if (string.Equals(toUri.Scheme, "FILE", StringComparison.InvariantCultureIgnoreCase))
-        {
-            relativePath = relativePath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
-        }
 
         return relativePath.BackSlashToForwardSlash();
     }

--- a/test/Docfx.Common.Tests/PathUtilityTest.cs
+++ b/test/Docfx.Common.Tests/PathUtilityTest.cs
@@ -9,7 +9,7 @@ namespace Docfx.Common.Tests;
 public class PathUtilityTest
 {
     [Theory]
-    [MemberData(nameof(TestData.AdditionalTests), MemberType = typeof(TestData), DisableDiscoveryEnumeration = false)]
+    [MemberData(nameof(TestData.AdditionalTests), MemberType = typeof(TestData))]
     public void TestMakeRelativePath(string basePath, string targetPath, string expected)
     {
         // Act
@@ -20,7 +20,7 @@ public class PathUtilityTest
     }
 
     [Theory]
-    [MemberData(nameof(TestData.EscapedPaths), MemberType = typeof(TestData), DisableDiscoveryEnumeration = true)]
+    [MemberData(nameof(TestData.EscapedPaths), MemberType = typeof(TestData))]
     public void TestMakeRelativePathWithEncodedPath(string inputPath)
     {
         // Arrange

--- a/test/Docfx.Common.Tests/PathUtilityTest.cs
+++ b/test/Docfx.Common.Tests/PathUtilityTest.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Xunit;
+
+namespace Docfx.Common.Tests;
+
+public class PathUtilityTest
+{
+    [Theory]
+    [MemberData(nameof(TestData.AdditionalTests), MemberType = typeof(TestData), DisableDiscoveryEnumeration = false)]
+    public void TestMakeRelativePath(string basePath, string targetPath, string expected)
+    {
+        // Act
+        var result = PathUtility.MakeRelativePath(basePath, targetPath);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(TestData.EscapedPaths), MemberType = typeof(TestData), DisableDiscoveryEnumeration = true)]
+    public void TestMakeRelativePathWithEncodedPath(string inputPath)
+    {
+        // Arrange
+        string basePath = "./";
+        var expected = inputPath;
+
+        // Act
+        var result = PathUtility.MakeRelativePath(basePath, inputPath);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    private static class TestData
+    {
+        public static TheoryData<string, string, string> AdditionalTests = new()
+        {
+            { @"/a/b/d",          @"/a/b/file.md",            @"../file.md"},            // root relative path
+            { @"~/a/b/d",         @"~/a/b/file.md",           @"../file.md"},            // user home directory relative path
+            { @"./",              @"\\UNCPath\file.md",       @"//UNCPath/file.md"},     // UNC path
+            { @"./",              @"file:///C:/temp/test.md", @"file:/C:/temp/test.md"}, // `file:` Uri path
+            { @"file:///C:/temp", @"file:///C:/temp/test.md", @"test.md"},               // `file:` Uri relative path
+            { @"/temp/dir",       @"/temp/dir/subdir/",       @"subdir/"},               // If target path endsWith directory separator char. resolved path should contain directory separator.
+        };
+
+        public static TheoryData<string> EscapedPaths = new()
+        {
+            "EscapedHypen(%2D).md",                      // Contains escaped hypen char
+            "EscapedSpace(%20)_with_NonAsciiChar(α).md", // Contains escaped space char and non-unicode char
+        };
+    }
+}


### PR DESCRIPTION
This PR intended to fix #5132.

**What's included in this PR**
- Fix `PathUtility.MakeRelativePath` methods to use `Path.GetRelativePath` method if specified path is file protocol. 
  -  It seems `file://` protocol can't be handled by this `PathUtility.MakeRelativePath`.   
     So add fallback to use existing implementation (`Uri::MakeRelativeUri`)
- Add additional tests for `PathUtility.MakeRelativePath` method.
