### PR TITLE
chore: Update node.js version

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -3,11 +3,11 @@ description: build the project
 runs:
   using: "composite"
   steps:
-  - uses: actions/setup-node@v3
+  - uses: actions/setup-node@v4
     with:
-      node-version: 18
+      node-version: 20
 
-  - uses: actions/setup-dotnet@v3
+  - uses: actions/setup-dotnet@v4
     with:
       dotnet-version: |
         8.x

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 20
     - uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ We welcome code contributions through pull requests, issues tagged as **[`help-w
 
 - Install [Visual Studio 2022 (Community or higher)](https://www.visualstudio.com/) and make sure you have the latest updates.
 - Install [.NET SDK](https://dotnet.microsoft.com/download/dotnet) 6.x, 7.x and 8.x.
-- Install NodeJS (18.x.x).
+- Install NodeJS (20.x.x).
 
 ### Build and Test
 


### PR DESCRIPTION
**What's included in this PR**
- Update `Node.js` to use latest LTS version.
- Update dependent github actions that  use older versions of Node.js (16) to suppress warnings at GitHub actions.
  - See: https://github.com/actions/setup-dotnet/releases/tag/v4.0.0
