### PR TITLE
feat: Add DefineConstants supports for source file based build

### DIFF
--- a/src/Docfx.Dotnet/DotnetApiCatalog.Compile.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.Compile.cs
@@ -85,14 +85,14 @@ partial class DotnetApiCatalog
 
         if (files.TryGetValue(FileType.CSSourceCode, out var csFiles))
         {
-            var compilation = CompilationHelper.CreateCompilationFromCSharpFiles(csFiles.Select(f => f.NormalizedPath));
+            var compilation = CompilationHelper.CreateCompilationFromCSharpFiles(csFiles.Select(f => f.NormalizedPath), msbuildProperties);
             hasCompilationError |= compilation.CheckDiagnostics(config.AllowCompilationErrors);
             assemblies.Add((compilation.Assembly, compilation));
         }
 
         if (files.TryGetValue(FileType.VBSourceCode, out var vbFiles))
         {
-            var compilation = CompilationHelper.CreateCompilationFromVBFiles(vbFiles.Select(f => f.NormalizedPath));
+            var compilation = CompilationHelper.CreateCompilationFromVBFiles(vbFiles.Select(f => f.NormalizedPath), msbuildProperties);
             hasCompilationError |= compilation.CheckDiagnostics(config.AllowCompilationErrors);
             assemblies.Add((compilation.Assembly, compilation));
         }

--- a/test/Docfx.Dotnet.Tests/ApiFilterUnitTest.cs
+++ b/test/Docfx.Dotnet.Tests/ApiFilterUnitTest.cs
@@ -10,6 +10,8 @@ namespace Docfx.Dotnet.Tests;
 [Collection("docfx STA")]
 public class ApiFilterUnitTest
 {
+    private static readonly Dictionary<string, string> EmptyMSBuildProperties = new();
+
     [Fact]
     public void TestApiFilter()
     {
@@ -365,9 +367,9 @@ namespace Microsoft.DevDiv.SpecialCase
         Assert.True((ExtendedSymbolKind.Type | ExtendedSymbolKind.Member).Contains(new SymbolFilterData { Kind = ExtendedSymbolKind.Interface }));
     }
 
-    private static MetadataItem Verify(string code, ExtractMetadataConfig config = null, DotnetApiOptions options = null)
+    private static MetadataItem Verify(string code, ExtractMetadataConfig config = null, DotnetApiOptions options = null, IDictionary<string, string> msbuildProperties = null)
     {
-        var compilation = CompilationHelper.CreateCompilationFromCSharpCode(code, "test.dll");
+        var compilation = CompilationHelper.CreateCompilationFromCSharpCode(code, msbuildProperties ?? EmptyMSBuildProperties, "test.dll");
         Assert.Empty(compilation.GetDeclarationDiagnostics());
         return compilation.Assembly.GenerateMetadataItem(compilation, config, options);
     }

--- a/test/Docfx.Dotnet.Tests/DefinitionMergeUnitTest.cs
+++ b/test/Docfx.Dotnet.Tests/DefinitionMergeUnitTest.cs
@@ -31,7 +31,7 @@ namespace A {
 
 ";
         // act
-        var compilation = CompilationHelper.CreateCompilationFromCSharpCode(code, "test.dll");
+        var compilation = CompilationHelper.CreateCompilationFromCSharpCode(code, msbuildProperties: new Dictionary<string, string>(), "test.dll");
         var output = compilation.Assembly.GenerateMetadataItem(compilation);
 
         // assert


### PR DESCRIPTION
This PR intended to fix https://github.com/dotnet/docfx/issues/8028.

When building API metadata from C#/VB source files.
The `DefineConstants` properties defined in `docfx.json` are not currently used.

This PR add logics to read `DefineConstants` MSBuild properties and set values to `CSharpParseOptions`/ `VisualBasicParseOptions`.
