### PR TITLE
fix: Resolved .NET SDK version problem on source-based API metadata generation

### DIFF
--- a/src/Docfx.Dotnet/CompilationHelper.cs
+++ b/src/Docfx.Dotnet/CompilationHelper.cs
@@ -136,10 +136,14 @@ internal static class CompilationHelper
     {
         try
         {
+            // Get current .NET runtime version with `{major}.{minor}` format.
+            var dotnetMajorMinorVersion = Environment.Version.ToString(2);
+
+            // Resolve .NET SDK packs directory path. (e.g. `C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.2\ref\net8.0`)
             var dotnetExeDirectory = DotNetCorePathFinder.FindDotNetExeDirectory();
             var refDirectory = Path.Combine(dotnetExeDirectory, "packs/Microsoft.NETCore.App.Ref");
-            var version = new DirectoryInfo(refDirectory).GetDirectories().Select(d => d.Name).Max()!;
-            var moniker = new DirectoryInfo(Path.Combine(refDirectory, version, "ref")).GetDirectories().Select(d => d.Name).Max()!;
+            var version = new DirectoryInfo(refDirectory).GetDirectories().Select(d => d.Name).Where(x => x.StartsWith(dotnetMajorMinorVersion)).Max()!;
+            var moniker = new DirectoryInfo(Path.Combine(refDirectory, version, "ref")).GetDirectories().Select(d => d.Name).Where(x => x.EndsWith(dotnetMajorMinorVersion)).Max()!;
             var path = Path.Combine(refDirectory, version, "ref", moniker);
 
             Logger.LogInfo($"Compiling {language} files using .NET SDK {version} for {moniker}");

--- a/test/Docfx.Dotnet.Tests/GenerateMetadataFromCSUnitTest.cs
+++ b/test/Docfx.Dotnet.Tests/GenerateMetadataFromCSUnitTest.cs
@@ -2580,7 +2580,12 @@ namespace Test1
 
         var undefined = output.Items[0].Items[0].Items[1];
         Assert.NotNull(undefined);
+
+#if NET8_0_OR_GREATER
         Assert.Equal(@"public void Undefined(ConsoleKey key = ConsoleKey.None)", undefined.Syntax.Content[SyntaxLanguage.CSharp]);
+#else
+        Assert.Equal(@"public void Undefined(ConsoleKey key = default)", undefined.Syntax.Content[SyntaxLanguage.CSharp]);
+#endif
     }
 
     [Fact]
@@ -2648,8 +2653,12 @@ namespace Test1
 
         var enumUndefinedDefault = output.Items[0].Items[0].Items[3];
         Assert.NotNull(enumUndefinedDefault);
-        Assert.Equal(@"public void EnumUndefinedDefault(ConsoleKey? key = ConsoleKey.None)", enumUndefinedDefault.Syntax.Content[SyntaxLanguage.CSharp]);
 
+#if NET8_0_OR_GREATER
+        Assert.Equal(@"public void EnumUndefinedDefault(ConsoleKey? key = ConsoleKey.None)", enumUndefinedDefault.Syntax.Content[SyntaxLanguage.CSharp]);
+#else
+        Assert.Equal(@"public void EnumUndefinedDefault(ConsoleKey? key = null)", enumUndefinedDefault.Syntax.Content[SyntaxLanguage.CSharp]);
+#endif
         var enumUndefinedValue = output.Items[0].Items[0].Items[4];
         Assert.NotNull(enumUndefinedValue);
         Assert.Equal(@"public void EnumUndefinedValue(ConsoleKey? key = (ConsoleKey)999)", enumUndefinedValue.Syntax.Content[SyntaxLanguage.CSharp]);


### PR DESCRIPTION
This PR intended to fix #9705.

Changes the logic to find the .NET SDK `packs` directory based on the `{major}.{minor}` version of the current .NET runtime. 

