### PR TITLE
fix: `docfx download` command behaviors

### DIFF
--- a/src/Docfx.Build/XRefMaps/XRefArchiveBuilder.cs
+++ b/src/Docfx.Build/XRefMaps/XRefArchiveBuilder.cs
@@ -47,6 +47,16 @@ public class XRefArchiveBuilder
             return null;
         }
 
+        // If BaseUrl is not set. Use xrefmap file download url as basePath.
+        if (string.IsNullOrEmpty(map.BaseUrl))
+        {
+            var baseUrl = uri.GetLeftPart(UriPartial.Path);
+            baseUrl = baseUrl.Substring(0, baseUrl.LastIndexOf('/') + 1);
+            map.BaseUrl = baseUrl;
+            map.UpdateHref(new Uri(baseUrl)); // Update hrefs from relative to absolute url.
+            map.HrefUpdated = null; // Don't save this flag for downloaded XRefMap.
+        }
+
         // Enforce XRefMap's references are sorted by uid.
         // Note:
         //   Sort is not needed if `map.Sorted == true`.

--- a/src/Docfx.Build/XRefMaps/XRefMap.cs
+++ b/src/Docfx.Build/XRefMaps/XRefMap.cs
@@ -10,28 +10,49 @@ using YamlDotNet.Serialization;
 
 namespace Docfx.Build.Engine;
 
+/// <summary>
+/// Xrefmap.
+/// </summary>
 public class XRefMap : IXRefContainer
 {
+    /// <summary>
+    /// Indicate <see cref="References"/> are sorted by <see cref="XRefSpec.Uid"/> with or not.
+    /// </summary>
     [YamlMember(Alias = "sorted")]
     [JsonProperty("sorted")]
     [JsonPropertyName("sorted")]
     public bool? Sorted { get; set; }
 
+    /// <summary>
+    /// Indicate href links are updated or not.
+    /// </summary>
     [YamlMember(Alias = "hrefUpdated")]
     [JsonProperty("hrefUpdated")]
     [JsonPropertyName("hrefUpdated")]
     public bool? HrefUpdated { get; set; }
 
+    /// <summary>
+    /// Base url. It's used when href is specified as relative url.
+    /// </summary>
     [YamlMember(Alias = "baseUrl")]
     [JsonProperty("baseUrl")]
     [JsonPropertyName("baseUrl")]
     public string BaseUrl { get; set; }
 
+    /// <summary>
+    /// List of <see href="XRefMapRedirection"/> settings.
+    /// </summary>
     [YamlMember(Alias = "redirections")]
     [JsonProperty("redirections")]
     [JsonPropertyName("redirections")]
     public List<XRefMapRedirection> Redirections { get; set; }
 
+    /// <summary>
+    /// List of <see href="XRefSpec"/>.
+    /// </summary>
+    /// <remarks>
+    /// If <see cref="Sorted"/> is true. XRefSpec items must be sorted by <see cref="XRefSpec.Uid"/> with InvariantCulture.
+    /// </remarks>
     [YamlMember(Alias = "references")]
     [JsonProperty("references")]
     [JsonPropertyName("references")]

--- a/src/Docfx.Build/XRefMaps/XRefMapDownloader.cs
+++ b/src/Docfx.Build/XRefMaps/XRefMapDownloader.cs
@@ -81,7 +81,7 @@ public class XRefMapDownloader
     /// </remarks>
     protected virtual async Task<IXRefContainer> DownloadBySchemeAsync(Uri uri)
     {
-        IXRefContainer result = null;
+        IXRefContainer result;
         if (uri.IsFile)
         {
             result = DownloadFromLocal(uri);
@@ -123,8 +123,6 @@ public class XRefMapDownloader
     protected static async Task<XRefMap> DownloadFromWebAsync(Uri uri)
     {
         Logger.LogVerbose($"Reading from web: {uri.OriginalString}");
-        var baseUrl = uri.GetLeftPart(UriPartial.Path);
-        baseUrl = baseUrl.Substring(0, baseUrl.LastIndexOf('/') + 1);
 
         using var httpClient = new HttpClient(new HttpClientHandler()
         {
@@ -138,8 +136,7 @@ public class XRefMapDownloader
         using var stream = await httpClient.GetStreamAsync(uri);
         using var sr = new StreamReader(stream, bufferSize: 81920); // Default :1024 byte
         var map = YamlUtility.Deserialize<XRefMap>(sr);
-        map.BaseUrl = baseUrl;
-        UpdateHref(map, null);
+
         return map;
     }
 

--- a/src/docfx/Properties/launchSettings.json
+++ b/src/docfx/Properties/launchSettings.json
@@ -42,6 +42,14 @@
       "environmentVariables": {
       }
     },
+    // Run `docfx download` command.
+    "docfx download": {
+      "commandName": "Project",
+      "commandLineArgs": "download xrefmap.zip --xref https://github.com/dotnet/docfx/raw/main/.xrefmap.json",
+      "workingDirectory": ".",
+      "environmentVariables": {
+      }
+    },
     // Run `docfx` command.
     "docfx": {
       "commandName": "Project",

--- a/test/Docfx.Build.Tests/XRefArchiveBuilderTest.cs
+++ b/test/Docfx.Build.Tests/XRefArchiveBuilderTest.cs
@@ -14,12 +14,18 @@ public class XRefArchiveBuilderTest
         const string ZipFile = "test.zip";
         var builder = new XRefArchiveBuilder();
 
+        // Download following xrefmap.yml content.
+        // ```
+        // ### YamlMime:XRefMap
+        // sorted: true
+        // references: []
+        // ```
         Assert.True(await builder.DownloadAsync(new Uri("http://dotnet.github.io/docfx/xrefmap.yml"), ZipFile));
 
         using (var xar = XRefArchive.Open(ZipFile, XRefArchiveMode.Read))
         {
             var map = xar.GetMajor();
-            Assert.True(map.HrefUpdated);
+            Assert.Null(map.HrefUpdated);
             Assert.True(map.Sorted);
             Assert.NotNull(map.References);
             Assert.Null(map.Redirections);


### PR DESCRIPTION
This PR intended to fix problems commented at https://github.com/dotnet/docfx/issues/9659#issuecomment-1957018027

**Background**
When running `docfx download` with following command.
> docfx download xrefmap.zip --xref https://github.com/dotnet/docfx/raw/main/.xrefmap.json

Xrefmap is downloaded as `xrefmap.zip`.
However, the contents of `xrefmap.yml` are modified as follows.
1. `baseUrl` (`https://learn.microsoft.com/dotnet/api/`) is updated to `https://github.com/dotnet/docfx/raw/main/`.
2. `href` with relative URLs are rewritten to absolute URL that based on `https://github.com/dotnet/docfx/raw/main/`.

This PR fix above behaviors by removing relating code.
And this changes. `docfx download` command simply execute following tasks. 
- Download `.json` or `.yml` file from specified URL.
- Load downloaded content as XRefMap model. And serialize data to `xrefmap.yml`.
- Sort `XRefMap`'s references by UID to optimize performance.
- Save zip archive as specified file name. (`xrefmap.zip`)
---

**What's included in this PR**
- Remove `baseUrl`/`href` update related logics that are used when `docfx download` command.
- Remove unused code. (Relating `CreateMinor` method)
- Add documentation comment for `XRefMap` type.
- Add warning messages when specify zip archive to download URL. (Currently it seems silently ignored. See: #2805)
- Sort references by UID to optimize performance (for not sorted xrefmap), 
   and to support not properly sorted xrefmap. (sorted:true but not properly sorted) (See: https://github.com/NormandErwan/UnityXrefMaps/issues/4)

**Test**
I've tested `docfx download` command with following xrefmaps.
And It works as expected.
- `https://github.com/dotnet/docfx/raw/main/.xrefmap.json`
- `https://normanderwan.github.io/UnityXrefMaps/xrefmap.yml`

**Additional notes**
This PR contains some `docfx download` command behavior changes.
It might be better to list changelog as `BREAKIN CHANGES`.
