### PR TITLE
feat: Add additional layout options to modern template

### DIFF
--- a/docs/docs/template.md
+++ b/docs/docs/template.md
@@ -40,6 +40,10 @@ Name         | Type    | Description
 `_gitContribute`        | object  | Defines the `repo` and `branch` property of git links.
 `_gitUrlPattern`        | string  | URL pattern of git links.
 `_disableNewTab`        | bool    | Whether to render external link indicator icons and open external links in a new tab.
+`_disableNavbar`        | bool    | Whether to show the navigation bar.
+`_disableBreadcrumb`    | bool    | Whether to show the breadcrumb.
+`_disableToc`           | bool    | Whether to show the TOC.
+`_disableAffix`         | bool    | Whether to show the right rail.
 `_disableNextArticle`   | bool    | Whether to show the previous and next article link.
 `_disableTocFilter`     | bool    | Whether to show the table of content filter box.
 `_googleAnalyticsTagId` | string  | Enables Google Analytics web traffic analysis.

--- a/templates/modern/layout/_master.tmpl
+++ b/templates/modern/layout/_master.tmpl
@@ -60,6 +60,7 @@
 
   <body class="tex2jax_ignore" data-layout="{{_layout}}{{layout}}" data-yaml-mime="{{yamlmime}}">
     <header class="bg-body border-bottom">
+      {{^_disableNavbar}}
       <nav id="autocollapse" class="navbar navbar-expand-md" role="navigation">
         <div class="container-xxl flex-nowrap">
           <a class="navbar-brand" href="{{_appLogoUrl}}{{^_appLogoUrl}}{{_rel}}index.html{{/_appLogoUrl}}">
@@ -81,9 +82,11 @@
           </div>
         </div>
       </nav>
+      {{/_disableNavbar}}
     </header>
 
     <main class="container-xxl">
+      {{^_disableToc}}
       <div class="toc-offcanvas">
         <div class="offcanvas-md offcanvas-start" tabindex="-1" id="tocOffcanvas" aria-labelledby="tocOffcanvasLabel">
           <div class="offcanvas-header">
@@ -95,16 +98,21 @@
           </div>
         </div>
       </div>
+      {{/_disableToc}}
 
       <div class="content">
         <div class="actionbar">
+          {{^_disableToc}}
           <button class="btn btn-lg border-0 d-md-none" style="margin-top: -.65em; margin-left: -.8em"
               type="button" data-bs-toggle="offcanvas" data-bs-target="#tocOffcanvas"
               aria-controls="tocOffcanvas" aria-expanded="false" aria-label="Show table of contents">
             <i class="bi bi-list"></i>
           </button>
+          {{/_disableToc}}
 
+          {{^_disableBreadcrumb}}
           <nav id="breadcrumb"></nav>
+          {{/_disableBreadcrumb}}
         </div>
 
         <article data-uid="{{uid}}">
@@ -128,9 +136,11 @@
 
       </div>
 
+      {{^_disableAffix}}
       <div class="affix">
         <nav id="affix"></nav>
       </div>
+      {{/_disableAffix}}
     </main>
 
     {{#_enableSearch}}

--- a/templates/modern/src/layout.scss
+++ b/templates/modern/src/layout.scss
@@ -161,7 +161,6 @@ body[data-layout="landing"] {
             display: flex;
             align-items: flex-start;
             margin-top: .5rem;
-            min-height: 40px;
           }
 
           article {

--- a/templates/modern/src/nav.ts
+++ b/templates/modern/src/nav.ts
@@ -23,7 +23,7 @@ export type NavItemContainer = {
 export async function renderNavbar(): Promise<NavItem[]> {
   const navbar = document.getElementById('navbar')
   if (!navbar) {
-    return
+    return []
   }
 
   const { iconLinks } = await options()


### PR DESCRIPTION
This PR intended to fix #8686.
By adding following additional layout options to `modern` template.
- `_disableNavbar`
- `_disableBreadcrumb`
- `_disableToc`
- `_disableAffix`

**Test**
It's manually tested on my local environment.
And confirms that the following checks have been passed. 
- When setting `_disable*` option. The corresponding elements is not be rendered in HTML.
- No JavaScript Error occurred when features are disabled.

**Background**
It seems some users are requesting above options. (#8686, #9116, #9296)
It can partially resolved by using `_layout: landing` option. (This option disable both toc and affix)
But there are feature requests that hide individual elements separately.






