### PR TITLE
chore: Add detailed error message for specific exceptions

### DIFF
--- a/src/Docfx.Build/HostServiceCreator.cs
+++ b/src/Docfx.Build/HostServiceCreator.cs
@@ -63,8 +63,12 @@ class HostServiceCreator
             {
                 if (e is not DocumentException)
                 {
+                    var message = e is ArgumentException or NullReferenceException
+                        ? e.ToString()
+                        : e.Message;
+
                     Logger.LogError(
-                        $"Unable to load file '{file.File}' via processor '{processor.Name}': {e.Message}",
+                        $"Unable to load file '{file.File}' via processor '{processor.Name}': {message}",
                         code: ErrorCodes.Build.InvalidInputFile);
                 }
                 return (null, false);


### PR DESCRIPTION
This PR is intended to help diagnose the CI error which occurred in #9744.

**Error Message**
> /home/runner/work/docfx/docfx/docs/extensions/tools.yml: error InvalidInputFile: Unable to load file 'extensions/tools.yml' via processor 'Dashboard': Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')

It seems to be throwing an `ArgumentOutOfRangeException`. but there is no StackTrace information contained in log.
So I've added full exception message to following exception types.

- `ArgumentException` derived class
- `NullReferenceException`  
   (It occurred at #9146)




