### PR TITLE
chore: Update roslyn packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,19 +10,14 @@
     <PackageVersion Include="Jint" Version="3.0.1" />
     <PackageVersion Include="JsonSchema.Net" Version="6.0.3" />
     <PackageVersion Include="Markdig" Version="0.35.0" />
-    <!-- "17.3.2" is the latest compatible version for .NET 6 -->
-    <PackageVersion Include="Microsoft.Build" Version="[17.3.2]" Condition="'$(TargetFramework)' == 'net6.0'" />
-    <PackageVersion Include="Microsoft.Build" Version="[17.7.2]" Condition="'$(TargetFramework)' == 'net7.0'" />
-    <PackageVersion Include="Microsoft.Build" Version="17.9.5" Condition="'$(TargetFramework)' != 'net6.0' And '$(TargetFramework)' != 'net7.0'" />
-    <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.8.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.9.2" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.40.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/Docfx.Dotnet/Docfx.Dotnet.csproj
+++ b/src/Docfx.Dotnet/Docfx.Dotnet.csproj
@@ -35,8 +35,6 @@
     <PackageReference Include="OneOf" />
     <PackageReference Include="OneOf.SourceGenerator" />
     <PackageReference Include="Markdig" />
-    <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Locator" />
     <PackageReference Include="Microsoft.CodeAnalysis" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" />

--- a/src/Docfx.Dotnet/DotnetApiCatalog.Compile.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.Compile.cs
@@ -28,6 +28,11 @@ partial class DotnetApiCatalog
             msbuildProperties["Configuration"] = "Release";
         }
 
+        // NOTE:
+        // logger parameter is not works when using Roslyn 4.9.0 or later.
+        // It'll be fixed in later releases.
+        // - https://github.com/dotnet/roslyn/discussions/71950
+        // - https://github.com/dotnet/roslyn/issues/72202
         var msbuildLogger = new ConsoleLogger(Logger.LogLevelThreshold switch
         {
             LogLevel.Verbose => LoggerVerbosity.Normal,

--- a/src/Docfx.Dotnet/DotnetApiCatalog.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.cs
@@ -6,7 +6,6 @@ using System.Text.Json;
 using Docfx.Common;
 using Docfx.Exceptions;
 using Docfx.Plugins;
-using Microsoft.Build.Locator;
 using Newtonsoft.Json.Linq;
 using YamlDotNet.Serialization;
 
@@ -58,8 +57,6 @@ public static partial class DotnetApiCatalog
     internal static async Task Exec(MetadataJsonConfig config, DotnetApiOptions options, string configDirectory, string outputDirectory = null)
     {
         var stopwatch = Stopwatch.StartNew();
-
-        EnsureMSBuildLocator();
 
         try
         {
@@ -123,24 +120,6 @@ public static partial class DotnetApiCatalog
                     CreateManagedReference(assemblies, config, options);
                     break;
             }
-        }
-    }
-
-    private static void EnsureMSBuildLocator()
-    {
-        try
-        {
-            if (!MSBuildLocator.IsRegistered)
-            {
-                var vs = MSBuildLocator.RegisterDefaults() ?? throw new ExtractMetadataException(
-                    $"Cannot find a supported .NET Core SDK. Install .NET Core SDK {Environment.Version.Major}.{Environment.Version.Minor}.x to build .NET API docs.");
-
-                Logger.LogInfo($"Using {vs.Name} {vs.Version}");
-            }
-        }
-        catch (Exception e)
-        {
-            throw new ExtractMetadataException(e.Message, e);
         }
     }
 


### PR DESCRIPTION
**What's included in this PR**

- Update roslyn packages from `4.8.0` to `4.9.2`
- Remove explicit `Microsoft.Build.Locator` package dependencies.
- Remove explicit `Microsoft.Build` package dependencies.

**Background**
Roslyn `4.9,0` or later executing MSBuild in separated process.
By this changes it can resolve some problems that relating MSBuild and NuGet.Frameworks. (#9494/#8048/#9271)

**Known problems**
logger parameter for MSBuildWorkspace is not works when using Roslyn 4.9.0 or later.
It's expected to befixed in later releases.
 - https://github.com/dotnet/roslyn/discussions/71950
- https://github.com/dotnet/roslyn/issues/72202

