### PR TITLE
fix: Broken examples problems when using inheritdoc tag

### DIFF
--- a/src/Docfx.Dotnet/Parsers/XmlComment.cs
+++ b/src/Docfx.Dotnet/Parsers/XmlComment.cs
@@ -112,6 +112,10 @@ internal class XmlComment
         }
         try
         {
+            // Format xml with indentation.
+            // It's needed to fix issue (https://github.com/dotnet/docfx/issues/9736)
+            xml = XElement.Parse(xml).ToString(SaveOptions.None);
+
             return new XmlComment(xml, context ?? new());
         }
         catch (XmlException)

--- a/test/Docfx.Dotnet.Tests/XmlCommentUnitTest.cs
+++ b/test/Docfx.Dotnet.Tests/XmlCommentUnitTest.cs
@@ -28,8 +28,7 @@ public class XmlCommentUnitTest
         Assert.Equal(
             """
             a
-            <p>b</p>
-            <p>c</p>
+            <p>b</p><p>c</p>
             """,
             XmlComment.Parse("""
                 <summary>
@@ -53,8 +52,10 @@ public class XmlCommentUnitTest
     {
         var comment = XmlComment.Parse(
             """
-            <param name="args">arg1</param>
-            <param name="args">arg2</param>
+            <doc>
+              <param name="args">arg1</param>
+              <param name="args">arg2</param>
+            </doc>
             """);
         Assert.Equal("arg1", comment.Parameters["args"]);
     }
@@ -205,6 +206,7 @@ public class XmlCommentUnitTest
     {
         var comment = XmlComment.Parse(
             """
+            <doc>
             <summary>
                 public int Main(string[] args)
                 {
@@ -226,6 +228,7 @@ public class XmlCommentUnitTest
             }
             ```
             </remarks>
+            </doc>
             """);
 
         Assert.Equal("""
@@ -289,7 +292,7 @@ public class XmlCommentUnitTest
                 <remarks>
                 <see href="https://example.org"/>
                 <see href="https://example.org">example</see>
-                <para>This is <paramref name='ref'/> <paramref />a sample of exception node</para>
+                <para>This is <paramref name='ref'/><paramref /> a sample of exception node</para>
                 <list type='bullet'>
                     <item>
                         <description>
@@ -387,13 +390,13 @@ public class XmlCommentUnitTest
             <a href="https://example.org">example</a>
             <p>This is <code class="paramref">ref</code> a sample of exception node</p>
             <ul><li>
-                        <pre><code class="lang-c#">public class XmlElement
-                            : XmlLinkedNode</code></pre>
-                        <ol><li>
+                  <pre><code class="lang-c#">public class XmlElement
+                      : XmlLinkedNode</code></pre>
+                  <ol><li>
                                     word inside list-&gt;listItem-&gt;list-&gt;listItem-&gt;para.&gt;
                                     the second line.
                                 </li><li>item2 in numbered list</li></ol>
-                    </li><li>item2 in bullet list</li><li>
+                </li><li>item2 in bullet list</li><li>
                     loose text <i>not</i> wrapped in description
                 </li></ul>
             """, remarks, ignoreLineEndingDifferences: true);


### PR DESCRIPTION
This PR intended to fix problems that are reported by #9736, #9495.

When using `example` tag with `<inheritdoc />`.
`symbol.GetDocumentationComment` API returns slightly different format xml.
And it cause wrong metadata generation.

**Problems of parsed results**
**1. Parsed example comments contains heading spaces.**

It cause rendered as markdown as `Fenced code blocks`.

**2. HTML `<pre>` element without preceding line break cause wrong HTML output. ** 

This may be due to CommonMark specifications.  
Because CommonMark/Markdig/GFM have same rendered result.
By this problem. it must be formatted as indented XML.

**Example markdown code that reproduce problems**
```
DUMMY<pre>{
  indended text
}</pre>
```

```
DUMMY
<pre>{
  indended text
}</pre>
```






