### PR TITLE
feat: Support for all emphasis supported by MarkDig

### DIFF
--- a/src/Docfx.MarkdigEngine.Extensions/MarkdownExtensions.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/MarkdownExtensions.cs
@@ -17,7 +17,7 @@ public static class MarkdownExtensions
     {
         return pipeline
             .UseMathematics()
-            .UseEmphasisExtras(EmphasisExtraOptions.Strikethrough)
+            .UseEmphasisExtras()
             .UseAutoIdentifiers(AutoIdentifierOptions.GitHub)
             .UseMediaLinks()
             .UsePipeTables()


### PR DESCRIPTION
Currently docfx only supports emphasis Strikethrough.
This PR add support for all emphasis supported by Markdig