### PR TITLE
fix: Outputted PDF displays garbled characters when name contains non-ASCII chars

### DIFF
--- a/src/Docfx.App/PdfBuilder.cs
+++ b/src/Docfx.App/PdfBuilder.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
+using System.Text;
 using System.Text.Json;
 using Docfx.Build;
 using Docfx.Common;
@@ -137,7 +138,7 @@ static class PdfBuilder
         IResult TocPage(string url)
         {
             var pageNumbers = pdfPageNumbers.TryGetValue(url, out var x) ? x : default;
-            return Results.Content(TocHtmlTemplate(new Uri(baseUrl!, url), pdfTocs[url], pageNumbers).ToString(), "text/html");
+            return Results.Content(TocHtmlTemplate(new Uri(baseUrl!, url), pdfTocs[url], pageNumbers).ToString(), "text/html", Encoding.UTF8);
         }
 
         async Task<byte[]?> PrintPdf(Outline outline, Uri url)

--- a/src/docfx/Properties/launchSettings.json
+++ b/src/docfx/Properties/launchSettings.json
@@ -40,6 +40,7 @@
       "commandLineArgs": "pdf ../../samples/seed/docfx.json",
       "workingDirectory": ".",
       "environmentVariables": {
+        "DOCFX_PDF_TIMEOUT": "0"
       }
     },
     // Run `docfx download` command.
@@ -56,6 +57,7 @@
       "commandLineArgs": "../../samples/seed/docfx.json",
       "workingDirectory": ".",
       "environmentVariables": {
+        "DOCFX_PDF_TIMEOUT": "0"
       }
     }
   }


### PR DESCRIPTION
This PR intended to fix #9761.

When `toc.yml` contains non-ASCII chars at toc name.
Outputted PDF contains garbled characters.

Additionally this PR add settings `DOCFX_PDF_TIMEOUT` to `0` for debug purpose.