### PR TITLE
fix: NullReferenceException occurred when both include and exclude are null

### DIFF
--- a/src/Docfx.Dotnet/Filters/ConfigFilterRuleItemUnion.cs
+++ b/src/Docfx.Dotnet/Filters/ConfigFilterRuleItemUnion.cs
@@ -54,7 +54,10 @@ internal class ConfigFilterRuleItemUnion
             }
 
             // If kind is not specified for exclude. Set `ExtendedSymbolKind.Type` as default kind.
-            Exclude.Kind ??= ExtendedSymbolKind.Type | ExtendedSymbolKind.Member;
+            if (Exclude != null)
+            {
+                Exclude.Kind ??= ExtendedSymbolKind.Type | ExtendedSymbolKind.Member;
+            }
 
             return Exclude;
         }


### PR DESCRIPTION
This PR intended to fix #9782.

Add null check when accessing `Exclude` property to avoid `NullReferenceException` occurred when both `Include` and `Exclude` rules are null.


