### PR TITLE
chore: Disable parallel tests for target frameworks that introduced at .NET 9 preview2

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -4,6 +4,14 @@
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!--
+    .NET 9 preview 2 or later run tests in parallel by default.
+    It is necessary to disable this feature because there are tests that need to be executed sequentially that are marked with `[Collection("docfx STA")]`.
+    -->
+    <TestTfmsInParallel>false</TestTfmsInParallel>
+  </PropertyGroup>
+
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <ItemGroup>


### PR DESCRIPTION
If .NET 9 Preview 2 is installed.
The `dotnet test` command runs tests in parallel for available target frameworks .
https://github.com/dotnet/core/blob/main/release-notes/9.0/preview/preview2/sdk.md#parallel-testing-and-terminal-logger-test-display

This PR suppress this behavior by setting `TestTfmsInParallel` to `false`.
