### PR TITLE
feat: publish nightly pre-release packages

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,30 @@
+name: nightly
+on:
+  schedule:
+  - cron: '0 0 * * *'
+
+jobs:
+  publish-github-packages:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+ 
+    - id: version
+      uses: paulhatch/semantic-version@v5.3.0
+      with:
+        version_format: ${major}.${minor}.${patch}-preview.${increment}
+
+    - uses: ./.github/actions/build
+    
+    - name: dotnet pack
+      run: dotnet pack -c Release /p:Version=${{ steps.version.outputs.version }} -o drop/nuget
+
+    - name: dotnet nuget push
+      run: |
+        dotnet nuget push drop/nuget/*.nupkg --api-key "${{ secrets.GITHUB_TOKEN }}" --skip-duplicate --source https://nuget.pkg.github.com/dotnet/index.json
+

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Docfx is planned to continue as a community-driven project. We hope to produce f
 
 For more information, refer to [Getting Started](http://dotnet.github.io/docfx/tutorial/docfx_getting_started.html).
 
+> [!TIP]
+> Docfx publishes nightly builds to [GitHub Packages](https://github.com/orgs/dotnet/packages), this allows you to stay up-to-date with the latest developments in Docfx.
+
 ## Contributing
 
 Use [Discussions](https://github.com/dotnet/docfx/discussions) for questions and general discussions. 


### PR DESCRIPTION
Publish nightly pre-release packages to https://github.com/dotnet/docfx/pkgs/nuget/docfx

Fixes #9609