### PR TITLE
chore: update pdfpig nuget package version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="OneOf" Version="3.0.263" />
     <PackageVersion Include="OneOf.SourceGenerator" Version="3.0.263" />
-    <PackageVersion Include="PdfPig" Version="0.1.9-alpha-20240312-845e3" />
+    <PackageVersion Include="PdfPig" Version="0.1.9-alpha-20240318-69e2b" />
     <PackageVersion Include="PlantUml.Net" Version="1.4.80" />
     <PackageVersion Include="Spectre.Console" Version="0.48.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.48.0" />

--- a/src/Docfx.App/PdfBuilder.cs
+++ b/src/Docfx.App/PdfBuilder.cs
@@ -291,7 +291,7 @@ static class PdfBuilder
             if (outline.pdfTocPage)
             {
                 var href = $"/_pdftoc{outlineUrl.AbsolutePath}";
-                yield return (new(outlineUrl, href), new() { href = href, pdfPrintBackground = outline.pdfPrintBackground  });
+                yield return (new(outlineUrl, href), new() { href = href, pdfPrintBackground = outline.pdfPrintBackground });
             }
 
             if (!string.IsNullOrEmpty(outline.href))
@@ -325,6 +325,9 @@ static class PdfBuilder
                     // Refresh TOC page numbers
                     updatePageNumbers(pageNumbers);
                     bytes = await printPdf(outline, url);
+
+                    if (bytes == null)
+                        continue;
                 }
 
                 using var document = PdfDocument.Open(bytes);


### PR DESCRIPTION
This PR manually update `pdfpig` nuget package version.

PR #9800 failed with following errors.
Because latest version of `pdfpig`  enables nullable annotations.

> Possible null reference argument for parameter 'fileBytes' in 'PdfDocument PdfDocument.Open(byte[] fileBytes, ParsingOptions? options = null)'.

This PR intended to fix above issue by adding null check.