### PR TITLE
perf: Optimize xrefmap.json file deserialization performance

### DIFF
--- a/src/Docfx.Build/XRefMaps/XRefMapRedirection.cs
+++ b/src/Docfx.Build/XRefMaps/XRefMapRedirection.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 using YamlDotNet.Serialization;
 
 namespace Docfx.Build.Engine;
@@ -8,8 +10,12 @@ namespace Docfx.Build.Engine;
 public class XRefMapRedirection
 {
     [YamlMember(Alias = "uidPrefix")]
+    [JsonProperty("uidPrefix")]
+    [JsonPropertyName("uidPrefix")]
     public string UidPrefix { get; set; }
 
     [YamlMember(Alias = "href")]
+    [JsonProperty("Href")]
+    [JsonPropertyName("href")]
     public string Href { get; set; }
 }

--- a/test/Docfx.Build.Tests/TestData/xrefmap.json
+++ b/test/Docfx.Build.Tests/TestData/xrefmap.json
@@ -1,0 +1,10 @@
+﻿{
+  "references": [
+    {
+      "fullName": "str",
+      "href": "https://docs.python.org/3.5/library/stdtypes.html#str",
+      "name": "str",
+      "uid": "str"
+    }
+  ]
+}

--- a/test/Docfx.Build.Tests/XRefMapDownloaderTest.cs
+++ b/test/Docfx.Build.Tests/XRefMapDownloaderTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
+using FluentAssertions;
 using Xunit;
 
 namespace Docfx.Build.Engine.Tests;
@@ -34,5 +35,19 @@ public class XRefMapDownloadTest
         var xrefSpec = reader.Find("str");
         Assert.NotNull(xrefSpec);
         Assert.Equal("https://docs.python.org/3.5/library/stdtypes.html#str", xrefSpec.Href);
+    }
+
+    [Fact]
+    public async Task ReadLocalXRefMapJsonFileTest()
+    {
+        // Arrange
+        var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "xrefmap.json");
+
+        XRefMapDownloader downloader = new XRefMapDownloader();
+        var xrefMap = await downloader.DownloadAsync(new Uri(path)) as XRefMap;
+
+        // Assert
+        xrefMap.Should().NotBeNull();
+        xrefMap.References.Should().HaveCount(1);
     }
 }

--- a/test/Docfx.Build.Tests/XRefMapSerializationTest.cs
+++ b/test/Docfx.Build.Tests/XRefMapSerializationTest.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using Docfx.Common;
+using Docfx.Plugins;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Docfx.Build.Engine.Tests;
+
+public class XRefMapSerializationTest
+{  
+    [Fact]
+    public void XRefMapSerializationRoundTripTest()
+    {
+        var model = new XRefMap
+        {
+            BaseUrl = "http://localhost",
+            Sorted = true,
+            HrefUpdated = null,
+            Redirections = new List<XRefMapRedirection>
+            {
+                new XRefMapRedirection
+                {
+                    Href = "Dummy",
+                    UidPrefix = "Dummy"
+                },
+            },
+            References = new List<XRefSpec>
+            {
+                new XRefSpec(new Dictionary<string,object>
+                {
+                    ["Additional1"] = "Dummy",
+                })
+                {
+                    Uid =  "Dummy",
+                    Name = "Dummy",
+                    Href = "Dummy",
+                    CommentId ="Dummy",
+                    IsSpec = true,
+                },
+            },
+            Others = new Dictionary<string, object>
+            {
+                ["Other1"] = "Dummy",
+            }
+        };
+
+        // Arrange
+        var jsonResult = RoundtripByNewtonsoftJson(model);
+        var yamlResult = RoundtripWithYamlDotNet(model);
+
+        // Assert
+        jsonResult.Should().BeEquivalentTo(model);
+        yamlResult.Should().BeEquivalentTo(model);
+    }
+
+    private static T RoundtripByNewtonsoftJson<T>(T model)
+    {
+        var json = JsonUtility.Serialize(model);
+        return JsonUtility.Deserialize<T>(new StringReader(json));
+    }
+
+    private static T RoundtripWithYamlDotNet<T>(T model)
+    {
+        var sb = new StringBuilder();
+        using var sw = new StringWriter(sb);
+        YamlUtility.Serialize(sw, model);
+        var json = sb.ToString();
+        return YamlUtility.Deserialize<T>(new StringReader(json));
+    }
+}

--- a/test/docfx.Tests/Api.verified.cs
+++ b/test/docfx.Tests/Api.verified.cs
@@ -486,8 +486,12 @@ namespace Docfx.Build.Engine
     public class XRefMapRedirection
     {
         public XRefMapRedirection() { }
+        [Newtonsoft.Json.JsonProperty("Href")]
+        [System.Text.Json.Serialization.JsonPropertyName("href")]
         [YamlDotNet.Serialization.YamlMember(Alias="href")]
         public string Href { get; set; }
+        [Newtonsoft.Json.JsonProperty("uidPrefix")]
+        [System.Text.Json.Serialization.JsonPropertyName("uidPrefix")]
         [YamlDotNet.Serialization.YamlMember(Alias="uidPrefix")]
         public string UidPrefix { get; set; }
     }


### PR DESCRIPTION
**What's changed in this PR**

When XrefMap is loaded from local file or network.
The current implementation using `YamlDotNet`'s deserialize method.

For JSON file deserialization.
It seems to be faster to use `Newtonsoft.json` for JSON deserialization.

**Benchmark**

|             |                |               |
|---------|-----------|-----------|
| YamlDotnet         | 8781[ms] |
| Newtonsoft.Json | 2304[ms] |
| System.Text.Json | 1687[ms] |  Note: It's not included in this PR. I'll create separated PR later.
