### PR TITLE
feat: Add  DLL references support for file-based API metadata generation

### DIFF
--- a/src/Docfx.Dotnet/CompilationHelper.cs
+++ b/src/Docfx.Dotnet/CompilationHelper.cs
@@ -54,7 +54,7 @@ internal static class CompilationHelper
         return errorCount > 0;
     }
 
-    public static Compilation CreateCompilationFromCSharpFiles(IEnumerable<string> files, IDictionary<string, string> msbuildProperties)
+    public static Compilation CreateCompilationFromCSharpFiles(IEnumerable<string> files, IDictionary<string, string> msbuildProperties, MetadataReference[] references)
     {
         var parserOption = GetCSharpParseOptions(msbuildProperties);
         var syntaxTrees = files.Select(path => CS.CSharpSyntaxTree.ParseText(File.ReadAllText(path), parserOption, path: path));
@@ -63,7 +63,7 @@ internal static class CompilationHelper
             assemblyName: null,
             options: new CS.CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, xmlReferenceResolver: XmlFileResolver.Default),
             syntaxTrees: syntaxTrees,
-            references: GetDefaultMetadataReferences("C#"));
+            references: GetDefaultMetadataReferences("C#").Concat(references));
     }
 
     public static Compilation CreateCompilationFromCSharpCode(string code, IDictionary<string, string> msbuildProperties, string? name = null, params MetadataReference[] references)
@@ -75,10 +75,10 @@ internal static class CompilationHelper
             name,
             options: new CS.CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, xmlReferenceResolver: XmlFileResolver.Default),
             syntaxTrees: [syntaxTree],
-            references: GetDefaultMetadataReferences("C#").Concat(references));
+            references: GetDefaultMetadataReferences("C#").Concat(references ?? []));
     }
 
-    public static Compilation CreateCompilationFromVBFiles(IEnumerable<string> files, IDictionary<string, string> msbuildProperties)
+    public static Compilation CreateCompilationFromVBFiles(IEnumerable<string> files, IDictionary<string, string> msbuildProperties, MetadataReference[] references)
     {
         var parserOption = GetVisualBasicParseOptions(msbuildProperties);
         var syntaxTrees = files.Select(path => VB.VisualBasicSyntaxTree.ParseText(File.ReadAllText(path), parserOption, path: path));
@@ -87,7 +87,7 @@ internal static class CompilationHelper
             assemblyName: null,
             options: new VB.VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, globalImports: GetVBGlobalImports(), xmlReferenceResolver: XmlFileResolver.Default),
             syntaxTrees: syntaxTrees,
-            references: GetDefaultMetadataReferences("VB"));
+            references: GetDefaultMetadataReferences("VB").Concat(references));
     }
 
     public static Compilation CreateCompilationFromVBCode(string code, IDictionary<string, string> msbuildProperties, string? name = null, params MetadataReference[] references)
@@ -99,10 +99,10 @@ internal static class CompilationHelper
             name,
             options: new VB.VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, globalImports: GetVBGlobalImports(), xmlReferenceResolver: XmlFileResolver.Default),
             syntaxTrees: [syntaxTree],
-            references: GetDefaultMetadataReferences("VB").Concat(references));
+            references: GetDefaultMetadataReferences("VB").Concat(references ?? []));
     }
 
-    public static (Compilation, IAssemblySymbol) CreateCompilationFromAssembly(string assemblyPath, IEnumerable<string>? references = null)
+    public static (Compilation, IAssemblySymbol) CreateCompilationFromAssembly(string assemblyPath, params MetadataReference[] references)
     {
         var metadataReference = CreateMetadataReference(assemblyPath);
         var compilation = CS.CSharpCompilation.Create(
@@ -110,8 +110,8 @@ internal static class CompilationHelper
             options: new CS.CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
             syntaxTrees: s_assemblyBootstrap,
             references: GetReferenceAssemblies(assemblyPath)
-                .Concat(references ?? Enumerable.Empty<string>())
                 .Select(CreateMetadataReference)
+                .Concat(references ?? [])
                 .Append(metadataReference));
 
         var assembly = (IAssemblySymbol)compilation.GetAssemblyOrModuleSymbol(metadataReference)!;


### PR DESCRIPTION
**What's changed in this PR**
Currently metadata's [references](https://dotnet.github.io/docfx/reference/docfx-json-reference.html?q=references#references)  config is used only when generating API metadata from DLL files.

This PR intended to add same functionality to C#/VB source-file based build. (#9706)

**Other Changes**
Add `using`  keyword for `MSBuildWorkspace`. Because it's disposable. 
