### PR TITLE
chore: Add a warning about relative path resolution.

### DIFF
--- a/docs/reference/docfx-json-reference.md
+++ b/docs/reference/docfx-json-reference.md
@@ -2,6 +2,9 @@
 
 The `docfx.json` file indicates that the directory is the root of a docfx project.
 
+> [!IMPORTANT]
+> All relative paths specified in config file are relative to the location of `docfx.json`
+
 ```json
 {
   "build": { },


### PR DESCRIPTION
It's not obvious whether paths are resolved based on current working directory where docfx is called or based on location of `docfx.json` file.

It's worth to be explicit about it in the documentation.