### PR TITLE
chore: Remove options from MarkdigExtensionSetting

### DIFF
--- a/src/Docfx.MarkdigEngine.Extensions/MarkdigExtensionSetting.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/MarkdigExtensionSetting.cs
@@ -29,7 +29,7 @@ public class MarkdigExtensionSetting
     /// <summary>
     /// Initializes a new instance of the <see cref="MarkdigExtensionSetting"/> class.
     /// </summary>
-    public MarkdigExtensionSetting(string name, JsonObject? options = null)
+    public MarkdigExtensionSetting(string name, JsonNode? options = null)
     {
         Name = name;
         if (options != null)
@@ -58,49 +58,8 @@ public class MarkdigExtensionSetting
     /// </summary>
     public T GetOptions<T>(T fallbackValue)
     {
-        if (Options == null)
-        {
-            return fallbackValue;
-        }
-
-        var jsonObject = JsonSerializer.SerializeToNode(Options)?.AsObject();
-
-        if (jsonObject != null
-         && jsonObject.TryGetPropertyValue("options", out var optionsNode)
-         && optionsNode != null)
-        {
-            return optionsNode.Deserialize<T>(DefaultSerializerOptions)!;
-        }
-        else
-        {
-            return fallbackValue;
-        }
-    }
-
-    /// <summary>
-    /// Gets markdig extension options as specified class object.
-    /// </summary>
-    public T GetOptionsValue<T>(string key, T fallbackValue)
-    {
-        if (Options == null)
-        {
-            return fallbackValue;
-        }
-
-        var jsonNode = JsonSerializer.SerializeToNode(Options)?.AsObject();
-
-        // Try to read options property that have specified key.
-        if (jsonNode != null
-         && jsonNode.TryGetPropertyValue("options", out var optionsNode)
-         && optionsNode != null
-         && optionsNode.AsObject().TryGetPropertyValue(key, out var valueNode))
-        {
-            return valueNode!.GetValue<T>()!;
-        }
-        else
-        {
-            return fallbackValue;
-        }
+        return Options is null ? fallbackValue
+            : JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(Options), DefaultSerializerOptions) ?? fallbackValue;
     }
 
     /// <summary>

--- a/src/Docfx.MarkdigEngine.Extensions/MarkdownExtensions.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/MarkdownExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Text.Json;
 using Markdig;
 using Markdig.Extensions.AutoIdentifiers;
 using Markdig.Extensions.AutoLinks;
@@ -18,6 +17,8 @@ namespace Docfx.MarkdigEngine.Extensions;
 
 public static class MarkdownExtensions
 {
+    enum EmojiMappingOption { Default, DefaultAndSmileys }
+
     public static MarkdownPipelineBuilder UseDocfxExtensions(
         this MarkdownPipelineBuilder pipeline, MarkdownContext context,
         Dictionary<string, string> notes = null, PlantUmlOptions plantUml = null)
@@ -121,10 +122,11 @@ public static class MarkdownExtensions
             // EmojiExtension (Docfx default: enableSmileys: false)
             case "emojis":
                 {
-                    var enableSmileys = extension.GetOptions(fallbackValue: true);
-                    EmojiMapping emojiMapping = enableSmileys
-                        ? EmojiMapping.DefaultEmojisAndSmileysMapping
-                        : EmojiMapping.DefaultEmojisOnlyMapping;
+                    var emojiMapping = extension.GetOptions(fallbackValue: EmojiMappingOption.DefaultAndSmileys) switch
+                    {
+                        EmojiMappingOption.DefaultAndSmileys => EmojiMapping.DefaultEmojisAndSmileysMapping,
+                        _ => EmojiMapping.DefaultEmojisOnlyMapping,
+                    };
                     pipeline.Extensions.ReplaceOrAdd<EmojiExtension>(new EmojiExtension(emojiMapping));
                     return true;
                 }

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/MarkdigBuiltinExtensionTests/AutoIdentifierTest.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/MarkdigBuiltinExtensionTests/AutoIdentifierTest.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.Json.Nodes;
 using Markdig.Extensions.AutoIdentifiers;
 using Xunit;
 
@@ -23,10 +22,7 @@ public class AutoIdentifierTest
 
         TestUtility.VerifyMarkup(content, expected);
         TestUtility.VerifyMarkup(content, expected, optionalExtensions: [
-           new("AutoIdentifiers", new JsonObject
-           {
-               ["options"] = "GitHub",
-           })
+           new("AutoIdentifiers", "GitHub")
         ]);
     }
 
@@ -40,17 +36,11 @@ public class AutoIdentifierTest
         TestUtility.VerifyMarkup(content, expected, optionalExtensions: ["AutoIdentifiers"]);
 
         TestUtility.VerifyMarkup(content, expected, optionalExtensions: [
-           new("AutoIdentifiers", new JsonObject
-           {
-               ["options"] = "Default",
-           })
+           new("AutoIdentifiers", "Default")
         ]);
 
         TestUtility.VerifyMarkup(content, expected, optionalExtensions: [
-           new("AutoIdentifiers", new JsonObject
-           {
-               ["options"] = "AutoLink, AllowOnlyAscii", // Same as Default option.
-           })
+           new("AutoIdentifiers", "AutoLink, AllowOnlyAscii")
         ]);
     }
 
@@ -61,10 +51,7 @@ public class AutoIdentifierTest
         var expected = @"<h1 id=""this-is-a-heading_with.and"">This - is a &amp;@! heading _ with . and ! -</h1>";
 
         TestUtility.VerifyMarkup(content, expected, optionalExtensions: [
-           new("AutoIdentifiers", new JsonObject
-           {
-               ["options"] = "None",
-           })
+           new("AutoIdentifiers", "None")
         ]);
     }
 }

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/MarkdigBuiltinExtensionTests/AutoLinkTest.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/MarkdigBuiltinExtensionTests/AutoLinkTest.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using Docfx.MarkdigEngine.Extensions;
 using Markdig.Extensions.AutoLinks;
 using Xunit;
@@ -41,10 +40,7 @@ public class AutoLinkTest
         var expected = @"<p>Sample URL (<a href=""http://www.google.com"" target=""_blank"">http://www.google.com</a>)</p>";
 
         TestUtility.VerifyMarkup(content, expected, optionalExtensions: [
-           new("AutoLinks", new JsonObject
-           {
-               ["options"] = JsonSerializer.SerializeToNode(options, MarkdigExtensionSettingConverter.DefaultSerializerOptions),
-           })
+           new("AutoLinks", JsonSerializer.SerializeToNode(options, MarkdigExtensionSettingConverter.DefaultSerializerOptions))
         ]);
     }
 }

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/MarkdigBuiltinExtensionTests/EmojiTest.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/MarkdigBuiltinExtensionTests/EmojiTest.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.Json.Nodes;
 using Markdig.Extensions.Emoji;
 using Xunit;
 
@@ -41,10 +40,7 @@ public class EmojiTest
         var expected = @"<p>😃</p>";
 
         TestUtility.VerifyMarkup(content, expected, optionalExtensions: [
-            new("Emojis", new JsonObject
-            {
-                ["options"] = true
-            }),
+            new("Emojis", "DefaultAndSmileys"),
         ]);
     }
 
@@ -55,10 +51,7 @@ public class EmojiTest
         var expected = @"<p>:)</p>";
 
         TestUtility.VerifyMarkup(content, expected, optionalExtensions: [
-            new("Emojis", new JsonObject
-            {
-                ["options"] = false,
-            }),
+            new("Emojis", "Default"),
         ]);
     }
 }

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/MarkdigBuiltinExtensionTests/EmphasisExtraTest.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/MarkdigBuiltinExtensionTests/EmphasisExtraTest.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.Json.Nodes;
 using Markdig.Extensions.EmphasisExtras;
 using Xunit;
 
@@ -63,10 +62,7 @@ public class EmphasisExtraTest
         {
             var expected = @"<p>H<sub>2</sub>O is a liquid. 2<sup>10</sup> is 1024</p>";
             TestUtility.VerifyMarkup(content, expected, optionalExtensions: [
-              new("EmphasisExtras", new JsonObject
-              {
-                  ["options"] = "Superscript, Subscript",
-              })]);
+              new("EmphasisExtras", "Superscript, Subscript")]);
         }
     }
 
@@ -84,10 +80,7 @@ public class EmphasisExtraTest
         {
             var expected = @"<p><ins>Inserted text</ins></p>";
             TestUtility.VerifyMarkup(content, expected, optionalExtensions: [
-              new("EmphasisExtras", new JsonObject
-              {
-                  ["options"] = "Inserted",
-              })]);
+              new("EmphasisExtras", "Inserted")]);
         }
     }
 
@@ -105,10 +98,7 @@ public class EmphasisExtraTest
         {
             var expected = @"<p><mark>Marked text</mark></p>";
             TestUtility.VerifyMarkup(content, expected, optionalExtensions: [
-              new("EmphasisExtras", new JsonObject
-              {
-                  ["options"] = "Marked",
-              })]);
+              new("EmphasisExtras", "Marked")]);
         }
     }
 }

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/MarkdigBuiltinExtensionTests/MediaLinksTest.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/MarkdigBuiltinExtensionTests/MediaLinksTest.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using Docfx.MarkdigEngine.Extensions;
 using Markdig.Extensions.MediaLinks;
 using Xunit;
@@ -44,10 +43,7 @@ public class MediaLinksTest
         var expected = $"""<p><video class="{options.Class}" width="{options.Width}" height="{options.Height}"><source type="video/mp4" src="https://example.com/video.mp4"></source></video></p>""";
 
         TestUtility.VerifyMarkup(content, expected, optionalExtensions: [
-            new("MediaLinks", new JsonObject
-            {
-                ["options"] = JsonSerializer.SerializeToNode(options, MarkdigExtensionSettingConverter.DefaultSerializerOptions),
-            })
+            new("MediaLinks", JsonSerializer.SerializeToNode(options, MarkdigExtensionSettingConverter.DefaultSerializerOptions))
         ]);
     }
 }

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/MarkdigBuiltinExtensionTests/PipeTableTest.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/MarkdigBuiltinExtensionTests/PipeTableTest.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using Docfx.MarkdigEngine.Extensions;
 using Markdig.Extensions.Tables;
 using Xunit;
@@ -86,10 +85,7 @@ public class PipeTableTest
 
         TestUtility.VerifyMarkup(content, expected, optionalExtensions: ["gfm-pipetables"]);
         TestUtility.VerifyMarkup(content, expected, optionalExtensions: [
-            new ("PipeTables", new JsonObject
-            {
-                ["options"] = JsonSerializer.SerializeToNode(options,  MarkdigExtensionSettingConverter.DefaultSerializerOptions),
-            })
+            new ("PipeTables", JsonSerializer.SerializeToNode(options,  MarkdigExtensionSettingConverter.DefaultSerializerOptions))
         ]);
     }
 }

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/MarkdigBuiltinExtensionTests/SmartyPantsTest.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/MarkdigBuiltinExtensionTests/SmartyPantsTest.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
-using System.Text.Json.Nodes;
-using System.Text.Json.Serialization;
 using Docfx.MarkdigEngine.Extensions;
 using Markdig.Extensions.SmartyPants;
 using Xunit;
@@ -52,10 +50,7 @@ public class SmartyPantsTest
         string expected = "<p>This is a <<text with>> a another text'</p>";
 
         TestUtility.VerifyMarkup(content, expected, optionalExtensions: [
-            new("SmartyPants", new JsonObject
-            {
-                ["options"] = JsonSerializer.SerializeToNode(options, MarkdigExtensionSettingConverter.DefaultSerializerOptions),
-            })
+            new("SmartyPants", JsonSerializer.SerializeToNode(options, MarkdigExtensionSettingConverter.DefaultSerializerOptions))
         ]);
     }
 }

--- a/test/docfx.Tests/Api.verified.cs
+++ b/test/docfx.Tests/Api.verified.cs
@@ -3572,11 +3572,10 @@ namespace Docfx.MarkdigEngine.Extensions
     [System.Diagnostics.DebuggerDisplay("Name = {Name}")]
     public class MarkdigExtensionSetting
     {
-        public MarkdigExtensionSetting(string name, System.Text.Json.Nodes.JsonObject? options = null) { }
+        public MarkdigExtensionSetting(string name, System.Text.Json.Nodes.JsonNode? options = null) { }
         public string Name { get; init; }
         public System.Text.Json.JsonElement? Options { get; init; }
         public T GetOptions<T>(T fallbackValue) { }
-        public T GetOptionsValue<T>(string key, T fallbackValue) { }
         public static Docfx.MarkdigEngine.Extensions.MarkdigExtensionSetting op_Implicit(string name) { }
     }
     public class MarkdownContext


### PR DESCRIPTION
Some minor tweak to #9820 

1. Simplify config by removing the `options` property
2. Change emoji config from bool to an enum

```json
{
  "markdigExtensions": [
    "FootNotes",
    {"Emojis": "default"},
    {"AutoIdentifiers": "default"},
    {"MediaLinks": {"width": 800, "height": 400}}
  ]
}
```

cc @filzrev 