### PR TITLE
chore: Fix `filterconfig.yml` and `enumSortOrder` documentation

### DIFF
--- a/docs/docs/dotnet-api-docs.md
+++ b/docs/docs/dotnet-api-docs.md
@@ -229,12 +229,12 @@ API filter are hierarchical, if a namespace is excluded, all types/members defin
 ```yaml
 apiRules:
 - exclude:
-  hasAttribute:
-    uid: System.AttributeUsageAttribute
-    ctorArguments:
-    - System.AttributeTargets.Class
-    ctorNamedArguments:
-      Inherited: "true"
+    hasAttribute:
+      uid: System.AttributeUsageAttribute
+      ctorArguments:
+      - System.AttributeTargets.Class
+      ctorNamedArguments:
+        Inherited: "True"
 ```
 
 Where the `ctorArguments` property specifies a list of match conditions based on constructor parameters and the `ctorNamedArguments` property specifies match conditions using named constructor arguments.

--- a/src/Docfx.Dotnet/MetadataJsonConfig.cs
+++ b/src/Docfx.Dotnet/MetadataJsonConfig.cs
@@ -213,9 +213,9 @@ internal class MetadataJsonItemConfig
     public MemberLayout MemberLayout { get; set; }
 
     /// <summary>
-    /// Defines how member pages are organized:
-    /// - `samePage` (default): Places members in the same page as their containing type.
-    /// - `separatePages`: Places members in separate pages.
+    /// Specifies how enum members are sorted:
+    /// - `alphabetic`(default): Sort enum members in alphabetic order.
+    /// - `declaringOrder`: Sort enum members in the order as they are declared in the source code.
     /// </summary>
     [JsonProperty("enumSortOrder")]
     [JsonPropertyName("enumSortOrder")]


### PR DESCRIPTION
This PR contains following documentation changes.

- Fix `hasAttribute` indentation level.
- Fix `Inherited` condition string from `true` to  `True` (It's case sensitive because it's compared by  `KeyValuePair<string,string>`)
- Fix `enumSortOrder` document comment.
