### PR TITLE
chore: Add `InternalVisibleTo` attribute for benchmark project

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,5 +3,6 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="$(AssemblyName).Tests" />
+    <InternalsVisibleTo Include="Docfx.Benchmarks" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR add `InternalsVisibleTo` attribute for benchmark projects.

I'll planning to add benchmark project to `benchmarks/Docfx.Benchmarks` in separated PR.
after this PR content is published to NuGet. 

**Previous PR discussion about `InternalsVisibleTo` attributes**
https://github.com/dotnet/docfx/pull/9652