### PR TITLE
feat: Enable PreferCSSPageSize option for PDF generation

### DIFF
--- a/src/Docfx.App/PdfBuilder.cs
+++ b/src/Docfx.App/PdfBuilder.cs
@@ -166,7 +166,11 @@ static class PdfBuilder
                     Logger.LogWarning($"Timeout waiting for page to load, generated PDF page may be incomplete: {url}");
                 }
 
-                return await page.PdfAsync(new PagePdfOptions { PrintBackground = outline.pdfPrintBackground });
+                return await page.PdfAsync(new PagePdfOptions
+                {
+                    PreferCSSPageSize = true,
+                    PrintBackground = outline.pdfPrintBackground,
+                });
             }
             finally
             {


### PR DESCRIPTION
This PR intended to fix #9842.

By default, docfx generating PDF files with following settings. 
- `PageSize`:  Letter (215.9 x 279.4) 
- `PageOrientation`: Portrait

This PR enable PagePdfOptions's `PreferCSSPageSize` settings.
So It can customize PDF option by custom CSS. 

**Example CSS settings**
```
@media print {
  @page {
    size: A4 landscape
  }
}
```
