### PR TITLE
fix: PDF `Producer` document information

### DIFF
--- a/src/Docfx.App/PdfBuilder.cs
+++ b/src/Docfx.App/PdfBuilder.cs
@@ -270,7 +270,7 @@ static class PdfBuilder
         if (numberOfPages is 0)
             return;
 
-        var producer = $"docfx ({typeof(PdfBuilder).Assembly.GetCustomAttribute<AssemblyVersionAttribute>()?.Version})";
+        var producer = $"docfx ({typeof(PdfBuilder).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version})";
 
         using var output = File.Create(outputPath);
         using var builder = new PdfDocumentBuilder(output);


### PR DESCRIPTION
This PR intended to fix #9843.

Currently PDF files that generated by docfx has wrong `Producer` document information.
(It's resolved to `docfx ()` text always).

This PR add following changes to set `Producer` document information.
- ~~Get application name from EntryAssembly's name. (for custom application that use `Docfx.App` package)~~
- Get assembly version from `AssemblyFileVersionAttribute`  information.

By this PR changes.
PDF `Producer` document information information is displayed as `docfx (2.76.0.0)` 
