### PR TITLE
fix: Xrefmap baseUrl problem reported at #9866

### DIFF
--- a/src/Docfx.Build/XRefMaps/XRefArchiveBuilder.cs
+++ b/src/Docfx.Build/XRefMaps/XRefArchiveBuilder.cs
@@ -47,16 +47,6 @@ public class XRefArchiveBuilder
             return null;
         }
 
-        // If BaseUrl is not set. Use xrefmap file download url as basePath.
-        if (string.IsNullOrEmpty(map.BaseUrl))
-        {
-            var baseUrl = uri.GetLeftPart(UriPartial.Path);
-            baseUrl = baseUrl.Substring(0, baseUrl.LastIndexOf('/') + 1);
-            map.BaseUrl = baseUrl;
-            map.UpdateHref(new Uri(baseUrl)); // Update hrefs from relative to absolute url.
-            map.HrefUpdated = null; // Don't save this flag for downloaded XRefMap.
-        }
-
         // Enforce XRefMap's references are sorted by uid.
         // Note:
         //   Sort is not needed if `map.Sorted == true`.

--- a/test/Docfx.Build.Tests/XRefMapDownloaderTest.cs
+++ b/test/Docfx.Build.Tests/XRefMapDownloaderTest.cs
@@ -50,4 +50,58 @@ public class XRefMapDownloadTest
         xrefMap.Should().NotBeNull();
         xrefMap.References.Should().HaveCount(1);
     }
+
+    /// <summary>
+    /// XrefmapDownloader test for xrefmap that has no baseUrl and href is defined by relative path.
+    /// </summary>
+    [Fact(Skip = "Has dependency to external site content.")]
+    public async Task ReadRemoteXRefMapYamlFileTest1()
+    {
+        // Arrange
+        var path = "https://horizongir.github.io/ZedGraph/xrefmap.yml";
+
+        XRefMapDownloader downloader = new XRefMapDownloader();
+        var xrefMap = await downloader.DownloadAsync(new Uri(path)) as XRefMap;
+
+        // Assert
+        xrefMap.Sorted.Should().BeTrue();
+        xrefMap.HrefUpdated.Should().BeNull();
+
+        // If baseUrl is not exists. Set download URL is set automatically.
+        xrefMap.BaseUrl.Should().Be("https://horizongir.github.io/ZedGraph/");
+
+        // Test relative URL is preserved.
+        xrefMap.References[0].Href.Should().Be("api/ZedGraph.html");
+        xrefMap.References[0].Href = "https://horizongir.github.io/ZedGraph/api/ZedGraph.html";
+        xrefMap.BaseUrl = "http://localhost";
+
+        // Test url is resolved as absolute URL.
+        var reader = xrefMap.GetReader();
+        reader.Find("ZedGraph").Href.Should().Be("https://horizongir.github.io/ZedGraph/api/ZedGraph.html");
+    }
+
+    /// <summary>
+    /// XrefmapDownloader test for xrefmap that has no baseUrl, and href is defined by absolute path.
+    /// </summary>
+    [Fact(Skip = "Has dependency to external site content.")]
+    public async Task ReadRemoteXRefMapJsonFileTest2()
+    {
+        // Arrange
+        var path = "https://normanderwan.github.io/UnityXrefMaps/xrefmap.yml";
+
+        XRefMapDownloader downloader = new XRefMapDownloader();
+        var xrefMap = await downloader.DownloadAsync(new Uri(path)) as XRefMap;
+
+        // Assert
+        xrefMap.Sorted.Should().BeTrue();
+        xrefMap.HrefUpdated.Should().BeNull();
+
+        // If baseUrl is not exists. XrefMap download URL is set automatically.
+        xrefMap.BaseUrl.Should().Be("https://normanderwan.github.io/UnityXrefMaps/");
+
+        // If href is absolute URL. baseURL is ignored.
+        var xrefSpec = xrefMap.References[0];
+        xrefSpec.Href.Should().Be("https://docs.unity3d.com/ScriptReference/index.html");
+        xrefMap.GetReader().Find(xrefSpec.Uid).Href.Should().Be("https://docs.unity3d.com/ScriptReference/index.html");
+    }
 }

--- a/test/docfx.Tests/Api.verified.cs
+++ b/test/docfx.Tests/Api.verified.cs
@@ -476,7 +476,6 @@ namespace Docfx.Build.Engine
         protected virtual System.Threading.Tasks.Task<Docfx.Build.Engine.IXRefContainer> DownloadBySchemeAsync(System.Uri uri) { }
         protected static Docfx.Build.Engine.IXRefContainer DownloadFromLocal(System.Uri uri) { }
         protected static System.Threading.Tasks.Task<Docfx.Build.Engine.XRefMap> DownloadFromWebAsync(System.Uri uri) { }
-        public static void UpdateHref(Docfx.Build.Engine.XRefMap map, System.Uri uri) { }
     }
     public sealed class XRefMapReader : Docfx.Build.Engine.XRefRedirectionReader
     {


### PR DESCRIPTION
This PR intended to fix bug reported at #9866.

It's a regression that introduced by PR #9721

**Current behaviors**
If following conditions are met. 
`<xref:>` link is resolved based on current site. It should be resolved to xrefmap download file based path.
- xrefmap is specified with URL.
- Xrefmap don't define baseUrl. And using `relative URL` for href.

**What's changed in this PR**

1. `XRefArchiveBuilder`
  1.1. Remove `baseUrl` set logics. Because it's set at downloader by this PR changes.
  1.2.  `map.UpdateHref` call is also removed.  Because it's expected to be called by [BasicXRefMapReader]( https://github.com/dotnet/docfx/blob/main/src/Docfx.Build/XRefMaps/BasicXRefMapReader.cs#L17-L24)
  1.3. By this change. downloaded `xrefmap.zip` content are changed. (href's relative url are preserved as is)
2. `XrefArchiveDownloader`
  2.1. Add logics to set `baseUrl`  if baseUrl is not defined.
  2.2. Remove `UpdateHref` method. (It's not used by docfx)
3. Add additional XrefmapDownloader tests with following patterns
  3.1 `baseUrl` is not defined, and href is relative URL (In this case. `baseUrl` is used to resolve relative url)
  3.2. `baseUrl` is not defined, and href is absolute URL (In this case. absolute URL is used.)


Note: `docfx download` related command tests are executed manually.