### PR TITLE
perf: Change serializer for XrefMap from NewtonsoftJson to System.Text.Json

### DIFF
--- a/src/Docfx.Build/XRefMaps/XRefMapRedirection.cs
+++ b/src/Docfx.Build/XRefMaps/XRefMapRedirection.cs
@@ -15,7 +15,7 @@ public class XRefMapRedirection
     public string UidPrefix { get; set; }
 
     [YamlMember(Alias = "href")]
-    [JsonProperty("Href")]
+    [JsonProperty("href")]
     [JsonPropertyName("href")]
     public string Href { get; set; }
 }

--- a/src/Docfx.Common/Docfx.Common.csproj
+++ b/src/Docfx.Common/Docfx.Common.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="Spectre.Console" />
   </ItemGroup>
@@ -6,5 +6,11 @@
   <ItemGroup>
     <ProjectReference Include="..\Docfx.Plugins\Docfx.Plugins.csproj" />
     <ProjectReference Include="..\Docfx.YamlSerialization\Docfx.YamlSerialization.csproj" />
+  </ItemGroup>
+
+  <!-- TODO: Following settings will be removed after NewtonsoftJson dependencies are removed. -->
+  <ItemGroup>
+    <InternalsVisibleTo Include="docfx.Build" />
+    <InternalsVisibleTo Include="Docfx.Build.Tests" />
   </ItemGroup>
 </Project>

--- a/src/Docfx.Common/Json/System.Text.Json/ObjectToInferredTypesConverter.cs
+++ b/src/Docfx.Common/Json/System.Text.Json/ObjectToInferredTypesConverter.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+#nullable enable
+
+namespace Docfx.Common;
+
+/// <summary>
+/// Custom JsonConverters for <see cref="object"/>.
+/// </summary>
+/// <seealso href="https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/converters-how-to?pivots=dotnet-8-0#deserialize-inferred-types-to-object-properties" />
+/// <seealso href="https://github.com/dotnet/runtime/issues/98038" />
+internal class ObjectToInferredTypesConverter : JsonConverter<object>
+{
+    /// <inheritdoc/>
+    public override object? Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.True:
+                return true;
+            case JsonTokenType.False:
+                return false;
+            case JsonTokenType.Number when reader.TryGetInt32(out int intValue):
+                return intValue;
+            case JsonTokenType.Number when reader.TryGetInt64(out long longValue):
+                return longValue;
+            case JsonTokenType.Number:
+                return reader.GetDouble();
+            case JsonTokenType.String when reader.TryGetDateTime(out DateTime datetime):
+                return datetime;
+            case JsonTokenType.String:
+                return reader.GetString();
+            case JsonTokenType.Null:
+                return null;
+            case JsonTokenType.StartArray:
+                {
+                    var list = new List<object?>();
+                    while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+                    {
+                        object? element = Read(ref reader, typeof(object), options);
+                        list.Add(element);
+                    }
+                    return list;
+                }
+            case JsonTokenType.StartObject:
+                {
+                    try
+                    {
+                        using var doc = JsonDocument.ParseValue(ref reader);
+                        return JsonSerializer.Deserialize<Dictionary<string, dynamic>>(doc, options);
+                    }
+                    catch (Exception)
+                    {
+                        goto default;
+                    }
+                }
+            default:
+                {
+                    using var doc = JsonDocument.ParseValue(ref reader);
+                    return doc.RootElement.Clone();
+                }
+        }
+    }
+
+    /// <inheritdoc/>
+    public override void Write(Utf8JsonWriter writer, object objectToWrite, JsonSerializerOptions options)
+    {
+        JsonSerializer.Serialize(writer, objectToWrite, objectToWrite.GetType(), options);
+    }
+}

--- a/src/Docfx.Common/Json/System.Text.Json/SystemTextJsonUtility.cs
+++ b/src/Docfx.Common/Json/System.Text.Json/SystemTextJsonUtility.cs
@@ -11,7 +11,7 @@ namespace Docfx.Common;
 /// <summary>
 /// Utility class for JSON serialization/deserialization.
 /// </summary>
-public static class SystemTextJsonUtility
+internal static class SystemTextJsonUtility
 {
     /// <summary>
     /// Default JsonSerializerOptions options.

--- a/src/Docfx.Common/Json/System.Text.Json/SystemTextJsonUtility.cs
+++ b/src/Docfx.Common/Json/System.Text.Json/SystemTextJsonUtility.cs
@@ -1,0 +1,101 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+#nullable enable
+
+namespace Docfx.Common;
+
+/// <summary>
+/// Utility class for JSON serialization/deserialization.
+/// </summary>
+public static class SystemTextJsonUtility
+{
+    /// <summary>
+    /// Default JsonSerializerOptions options.
+    /// </summary>
+    public static readonly JsonSerializerOptions DefaultSerializerOptions;
+
+    /// <summary>
+    ///  Default JsonSerializerOptions options with indent setting.
+    /// </summary>
+    public static readonly JsonSerializerOptions IndentedSerializerOptions;
+
+    static SystemTextJsonUtility()
+    {
+        DefaultSerializerOptions = new JsonSerializerOptions()
+        {
+            // DefaultBufferSize = 1024 * 16, // TODO: Set appropriate buffer size based on benchmark.(Default: 16KB)
+            AllowTrailingCommas = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull | JsonIgnoreCondition.WhenWritingDefault,
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            // DictionaryKeyPolicy = JsonNamingPolicy.CamelCase, // This setting is not compatible to `Newtonsoft.Json` serialize result.
+            NumberHandling = JsonNumberHandling.AllowReadingFromString,
+            Converters =
+            {
+                new JsonStringEnumConverter(),
+                new ObjectToInferredTypesConverter(), // Required for `Dictionary<string, object>` type deserialization.
+            },
+            WriteIndented = false,
+        };
+
+        IndentedSerializerOptions = new JsonSerializerOptions(DefaultSerializerOptions)
+        {
+            WriteIndented = true,
+        };
+    }
+
+    /// <summary>
+    /// Converts the value of a type specified by a generic type parameter into a JSON string.
+    /// </summary>
+    public static string Serialize<T>(T model, bool indented = false)
+    {
+        var options = indented
+            ? IndentedSerializerOptions
+            : DefaultSerializerOptions;
+
+        return JsonSerializer.Serialize(model, options);
+    }
+
+    /// <summary>
+    /// Converts the value of a type specified by a generic type parameter into a JSON string.
+    /// </summary>
+    public static string Serialize<T>(Stream stream, bool indented = false)
+    {
+        var options = indented
+            ? IndentedSerializerOptions
+            : DefaultSerializerOptions;
+
+        return JsonSerializer.Serialize(stream, options);
+    }
+
+    /// <summary>
+    /// Reads the UTF-8 encoded text representing a single JSON value into a TValue.
+    /// The Stream will be read to completion.
+    /// </summary>
+    public static T? Deserialize<T>(string json)
+    {
+        return JsonSerializer.Deserialize<T>(json, DefaultSerializerOptions);
+    }
+
+    /// <summary>
+    /// Reads the UTF-8 encoded text representing a single JSON value into a TValue.
+    /// The Stream will be read to completion.
+    /// </summary>
+    public static T? Deserialize<T>(Stream stream)
+    {
+        return JsonSerializer.Deserialize<T>(stream, DefaultSerializerOptions);
+    }
+
+    /// <summary>
+    /// Asynchronously reads the UTF-8 encoded text representing a single JSON value
+    //  into an instance of a type specified by a generic type parameter. The stream
+    //  will be read to completion.
+    public static async ValueTask<T?> DeserializeAsync<T>(Stream stream, CancellationToken token = default)
+    {
+        return await JsonSerializer.DeserializeAsync<T>(stream, DefaultSerializerOptions, cancellationToken: token);
+    }
+}

--- a/src/Docfx.Common/Json/System.Text.Json/SystemTextJsonUtility.cs
+++ b/src/Docfx.Common/Json/System.Text.Json/SystemTextJsonUtility.cs
@@ -29,7 +29,7 @@ internal static class SystemTextJsonUtility
         {
             // DefaultBufferSize = 1024 * 16, // TODO: Set appropriate buffer size based on benchmark.(Default: 16KB)
             AllowTrailingCommas = true,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull | JsonIgnoreCondition.WhenWritingDefault,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             PropertyNameCaseInsensitive = true,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             // DictionaryKeyPolicy = JsonNamingPolicy.CamelCase, // This setting is not compatible to `Newtonsoft.Json` serialize result.

--- a/test/docfx.Tests/Api.verified.cs
+++ b/test/docfx.Tests/Api.verified.cs
@@ -469,13 +469,10 @@ namespace Docfx.Build.Engine
         public void Sort() { }
         public void UpdateHref(System.Uri baseUri) { }
     }
-    public class XRefMapDownloader
+    public sealed class XRefMapDownloader
     {
         public XRefMapDownloader(string baseFolder = null, System.Collections.Generic.IReadOnlyList<string> fallbackFolders = null, int maxParallelism = 16) { }
-        public System.Threading.Tasks.Task<Docfx.Build.Engine.IXRefContainer> DownloadAsync(System.Uri uri) { }
-        protected virtual System.Threading.Tasks.Task<Docfx.Build.Engine.IXRefContainer> DownloadBySchemeAsync(System.Uri uri) { }
-        protected static Docfx.Build.Engine.IXRefContainer DownloadFromLocal(System.Uri uri) { }
-        protected static System.Threading.Tasks.Task<Docfx.Build.Engine.XRefMap> DownloadFromWebAsync(System.Uri uri) { }
+        public System.Threading.Tasks.Task<Docfx.Build.Engine.IXRefContainer> DownloadAsync(System.Uri uri, System.Threading.CancellationToken token = default) { }
     }
     public sealed class XRefMapReader : Docfx.Build.Engine.XRefRedirectionReader
     {
@@ -485,7 +482,7 @@ namespace Docfx.Build.Engine
     public class XRefMapRedirection
     {
         public XRefMapRedirection() { }
-        [Newtonsoft.Json.JsonProperty("Href")]
+        [Newtonsoft.Json.JsonProperty("href")]
         [System.Text.Json.Serialization.JsonPropertyName("href")]
         [YamlDotNet.Serialization.YamlMember(Alias="href")]
         public string Href { get; set; }
@@ -2055,6 +2052,16 @@ namespace Docfx.Common
             public const string EmptyInputContents = "EmptyInputContents";
             public const string EmptyInputFiles = "EmptyInputFiles";
         }
+    }
+    public static class SystemTextJsonUtility
+    {
+        public static readonly System.Text.Json.JsonSerializerOptions DefaultSerializerOptions;
+        public static readonly System.Text.Json.JsonSerializerOptions IndentedSerializerOptions;
+        public static T? Deserialize<T>(System.IO.Stream stream) { }
+        public static T? Deserialize<T>(string json) { }
+        public static System.Threading.Tasks.ValueTask<T?> DeserializeAsync<T>(System.IO.Stream stream, System.Threading.CancellationToken token = default) { }
+        public static string Serialize<T>(System.IO.Stream stream, bool indented = false) { }
+        public static string Serialize<T>(T model, bool indented = false) { }
     }
     public static class TreeIterator
     {

--- a/test/docfx.Tests/Api.verified.cs
+++ b/test/docfx.Tests/Api.verified.cs
@@ -2053,16 +2053,6 @@ namespace Docfx.Common
             public const string EmptyInputFiles = "EmptyInputFiles";
         }
     }
-    public static class SystemTextJsonUtility
-    {
-        public static readonly System.Text.Json.JsonSerializerOptions DefaultSerializerOptions;
-        public static readonly System.Text.Json.JsonSerializerOptions IndentedSerializerOptions;
-        public static T? Deserialize<T>(System.IO.Stream stream) { }
-        public static T? Deserialize<T>(string json) { }
-        public static System.Threading.Tasks.ValueTask<T?> DeserializeAsync<T>(System.IO.Stream stream, System.Threading.CancellationToken token = default) { }
-        public static string Serialize<T>(System.IO.Stream stream, bool indented = false) { }
-        public static string Serialize<T>(T model, bool indented = false) { }
-    }
     public static class TreeIterator
     {
         public static void Preorder<T>(T current, T parent, System.Func<T, System.Collections.Generic.IEnumerable<T>> childrenGetter, System.Func<T, T, bool> action) { }


### PR DESCRIPTION
This PR is recreated instead of #9832.

This PR contains cherry picked commit from above PR.
And resolve conflicts that are occurred at following codes.
-  `DownloadFromWebAsync` method of `XRefMapDownloader.cs`
-  `Api.verified.cs`.

Following review comment is remaining that need to be resolved.
 ('https://github.com/dotnet/docfx/pull/9832#discussion_r1561946897)

>Can we change Dictionary<string, object> Others -> Dictionary<string, JsonElement> Others if that is the only place using this converter?

