### PR TITLE
fix: Xref links are not resolved on docs site

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -45,6 +45,9 @@
       "priority": 0.5,
       "changefreq": "daily"
     },
+    "xref": [
+      "../.xrefmap.json"
+    ], 
     "output": "_site",
     "template": [
       "default",


### PR DESCRIPTION
This PR intended to fix issue that reported at https://github.com/dotnet/docfx/issues/9879#issuecomment-2066936822.

Currently `docs` config don't have `xref` entry.
And then docfx **silently** ignore unresolved `xref` entry (When `alt`/`altProperty` specified. it render plaintext alternatively).

This PR add `xref` config to resolve xref resolver issue.

