### PR TITLE
fix: Change same URL check logic to case invariant

### DIFF
--- a/templates/modern/src/helper.test.ts
+++ b/templates/modern/src/helper.test.ts
@@ -19,6 +19,7 @@ test('is same URL', () => {
   expect(isSameURL({ pathname: '/a/foo.html' }, { pathname: '/a/foo' })).toBeTruthy()
   expect(isSameURL({ pathname: '/a/foo/' }, { pathname: '/a/foo' })).toBeTruthy()
   expect(isSameURL({ pathname: '/a/foo/index.html' }, { pathname: '/a/foo' })).toBeTruthy()
+  expect(isSameURL({ pathname: '/a/index.html' }, { pathname: '/A/Index.html' })).toBeTruthy()
 
   expect(isSameURL({ pathname: '/a/foo/index.html' }, { pathname: '/a/bar' })).toBeFalsy()
 })

--- a/templates/modern/src/helper.ts
+++ b/templates/modern/src/helper.ts
@@ -89,5 +89,6 @@ export function isSameURL(a: { pathname: string }, b: { pathname: string }): boo
       .replace(/\/index\.html$/gi, '/')
       .replace(/\.html$/gi, '')
       .replace(/\/$/gi, '')
+      .toLowerCase()
   }
 }


### PR DESCRIPTION
This PR intended to fix issue reported at #9882

By changing `isSameURL` logic to compare string with case invariant.