### PR TITLE
chore: Improve unresolved xref messages

### DIFF
--- a/src/Docfx.Build/TemplateProcessors/TemplateModelTransformer.cs
+++ b/src/Docfx.Build/TemplateProcessors/TemplateModelTransformer.cs
@@ -177,7 +177,7 @@ public class TemplateModelTransformer
         foreach (var group in unresolvedXRefs.GroupBy(i => i.SourceFile))
         {
             // For each source file, print the first 10 invalid cross reference
-            var details = group.Take(MaxInvalidXrefMessagePerFile).Select(i => $"\"{HttpUtility.HtmlDecode(i.RawSource)}\" in line {i.SourceStartLineNumber}").Distinct().ToList();
+            var details = group.Take(MaxInvalidXrefMessagePerFile).Select(i => $"\"{HttpUtility.HtmlDecode(i.RawSource ?? i.Uid)}\" in line {i.SourceStartLineNumber}").Distinct().ToList();
             var prefix = details.Count > MaxInvalidXrefMessagePerFile ? $"top {MaxInvalidXrefMessagePerFile} " : string.Empty;
             var message = $"Details for {prefix}invalid cross reference(s): {details.ToDelimitedString(", ")}";
 


### PR DESCRIPTION
This PR intended to improve output message that shown when unresolved xref id found.

**Markdown content for test**
```
<xref:AAA>
<xref href="BBB" data-throw-if-not-resolved="true"/> <!--This type of xref reference needs attribute to report unresolved xref -->
<a href="xref:CCC"/> 
```

**Current output message**
```
C:\temp\docfx_project\index.md: warning UidNotFound: 3 invalid cross reference(s) "<xref:AAA>", "BBB", "CCC".
C:\temp\docfx_project\index.md: Details for invalid cross reference(s): "<xref:AAA>" in line 7
C:\temp\docfx_project\index.md: Details for invalid cross reference(s): "" in line 0
```

First line show invalid cross references as expected.
But last line output `""`.

**Improved output message**
```
C:\temp\docfx_project\index.md: warning UidNotFound: 3 invalid cross reference(s) "<xref:AAA>", "BBB", "CCC".
C:\temp\docfx_project\index.md: Details for invalid cross reference(s): "<xref:AAA>" in line 7
C:\temp\docfx_project\index.md: Details for invalid cross reference(s): "BBB" in line 0, "CCC" in line 0
```
