### PR TITLE
feat: Enable view transitions feature

### DIFF
--- a/templates/.stylelintrc.json
+++ b/templates/.stylelintrc.json
@@ -11,6 +11,12 @@
       "ignoreFontFamilies": [
         "bootstrap-icons"
       ]
+    }],
+    "property-no-unknown": [ true, {
+      "ignoreProperties": [ "navigation" ]
+    }],
+    "scss/at-rule-no-unknown": [ true, {
+      "ignoreAtRules": [ "view-transition" ]
     }]
   }
 }

--- a/templates/modern/src/docfx.scss
+++ b/templates/modern/src/docfx.scss
@@ -97,3 +97,13 @@ article {
     }
   }
 }
+
+@view-transition {
+   navigation: auto;
+}
+
+@media (prefers-reduced-motion) {
+  @view-transition {
+    navigation: none;
+  }
+}


### PR DESCRIPTION
This PR intended to support ViewTransition for modern template.

**Background**
Chrome 126 (It'll be released next month) supports Multi-Page-Application(MPA) ViewTransition by default.
- https://chromestatus.com/roadmap
- [View Transitions Same-Origin Navigation](https://chromestatus.com/feature/5118874666663936)

This PR enable view transition by adding related CSS styles
that based on https://github.com/WICG/view-transitions/blob/main/cross-doc-explainer.md#declarative-opt-in

By enabling MPA view transition.
TOC/breadcrumb regions are more smoothly transitioned when navigating between pages.

**How to test ViewTransition features**
- Manually enable `chrome://flags/#view-transition-on-navigation` feature flags or.
- Use [Chrome Canary](https://www.google.com/intl/en/chrome/canary/) build.
