### PR TITLE
chore: Drop .NET 7 SDK supports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
 
     - run: dotnet test -c Release -f net8.0 --no-build --collect:"XPlat Code Coverage"
 
-    - run: dotnet test -c Release -f net7.0 --no-build --collect:"XPlat Code Coverage"
-      if: matrix.os == 'ubuntu-latest'
-
     - run: dotnet test -c Release -f net6.0 --no-build --collect:"XPlat Code Coverage"
       if: matrix.os == 'ubuntu-latest'
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,6 +3,9 @@ on:
   schedule:
   - cron: '0 0 * * *'
 
+env:
+  DOCFX_PREVIEW_BUILD: true
+
 jobs:
   publish-github-packages:
     if: github.ref == 'refs/heads/main'
@@ -10,6 +13,11 @@ jobs:
     permissions:
       packages: write
     steps:
+    - uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          9.x
+
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
@@ -20,6 +28,9 @@ jobs:
         version_format: ${major}.${minor}.${patch}-preview.${increment}
 
     - uses: ./.github/actions/build
+
+    - name: dotnet test
+      run: dotnet test -c Release -f net9.0 --no-build
     
     - name: dotnet pack
       run: dotnet pack -c Release /p:Version=${{ steps.version.outputs.version }} -o drop/nuget

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         name: nuget
         path: drop/nuget
 
-    - run: dotnet tool install --tool-path . sign --version 0.9.1-beta.23530.1
+    - run: dotnet tool install --tool-path . sign --version 0.9.1-beta.24170.3
 
     - run: >
         ./sign code azure-key-vault

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
-    <!--<TargetFrameworks Condition=" '$(ContinuousIntegrationBuild)' == 'true' ">$(TargetFrameworks);net9.0</TargetFrameworks>-->
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DOCFX_PREVIEW_BUILD)' == 'true'">net8.0;net9.0</TargetFrameworks> 
     <LangVersion>Preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ We welcome code contributions through pull requests, issues tagged as **[`help-w
 ### Prerequisites
 
 - Install [Visual Studio 2022 (Community or higher)](https://www.visualstudio.com/) and make sure you have the latest updates.
-- Install [.NET SDK](https://dotnet.microsoft.com/download/dotnet) 6.x, 7.x and 8.x.
+- Install [.NET SDK](https://dotnet.microsoft.com/download/dotnet) 6.x and 8.x.
 - Install NodeJS (20.x.x).
 
 ### Build and Test


### PR DESCRIPTION
This PR contains following changes.

- Drop `.NET 7 SDK` supports. (Supports ends at May 14, 2024)
- Add `.NET 9 SDK preview` supports to nightly build.  
   (It's relating to #9745)
- Update `dotnet-sign` tool version
- Update related docs

