### PR TITLE
fix: TOC filter value is not shared between pages

### DIFF
--- a/templates/modern/src/toc.ts
+++ b/templates/modern/src/toc.ts
@@ -29,11 +29,12 @@ export async function renderToc(): Promise<TocNode[]> {
   const tocFilterUrl = disableTocFilter ? '' : (localStorage?.getItem('tocFilterUrl') || '')
   let tocFilter = disableTocFilter ? '' : (localStorage?.getItem('tocFilter') || '')
 
-  if (tocFilterUrl !== tocUrl.toString()) {
+  if (tocFilterUrl === '' || tocFilterUrl !== tocUrl.toString()) {
     tocFilter = ''
-    localStorage?.setItem('tocFilterUrl', '')
-  } else {
-    localStorage?.setItem('tocFilterUrl', tocUrl.toString())
+    if (!disableTocFilter) {
+      localStorage?.setItem('tocFilter', '')
+      localStorage?.setItem('tocFilterUrl', tocUrl.toString())
+    }
   }
 
   const activeNodes = []


### PR DESCRIPTION
This PR intended to fix issue reported by #9791.

On current implementation.
TOC filtering text value is not propagated between pages as expected.
And It seems to work  as following behaviors.
- `tocFilterUrl` is always set as empty string. 
- `tocFilter` value is set on textbox update. But it's reset on every page loading.

This PR change behaviors.
1. `tocFilterUrl` value is updated if existing value is empty or another TOC URL is referenced. 
2. `tocFilter` value is reset to `empty string` when following conditions.
 2.1. When navigating to docfx site  (`tocFilterUrl === ''`)
 2.2. When navigated page referencing another TOC. (`tocFilterUrl !== tocUrl.toString()`)  (#9117)
