### PR TITLE
chore: Fix nightly build errors

### DIFF
--- a/src/Docfx.Build/PostProcessors/PostProcessorsManager.cs
+++ b/src/Docfx.Build/PostProcessors/PostProcessorsManager.cs
@@ -16,7 +16,6 @@ class PostProcessorsManager : IDisposable
     public PostProcessorsManager(CompositionHost container, ImmutableArray<string> postProcessorNames)
     {
         ArgumentNullException.ThrowIfNull(container);
-        ArgumentNullException.ThrowIfNull(postProcessorNames);
 
         _postProcessors = GetPostProcessor(container, postProcessorNames);
     }

--- a/test/Docfx.Common.Tests/ConvertToObjectHelperTest.cs
+++ b/test/Docfx.Common.Tests/ConvertToObjectHelperTest.cs
@@ -67,7 +67,7 @@ public class ConvertToObjectHelperTest
         Assert.Same(converted.key1, converted);
         Assert.Equal("value", converted.key1.key);
 
-        Dictionary<string, object> obj = ConvertToObjectHelper.ConvertExpandoObjectToObject(converted);
+        Dictionary<string, object> obj = (Dictionary<string, object>)ConvertToObjectHelper.ConvertExpandoObjectToObject(converted);
         Assert.True(ReferenceEquals(obj["key1"], obj));
         Assert.Equal("value", ((Dictionary<string, object>)obj["key1"])["key"]);
     }


### PR DESCRIPTION
This PR intended to fix following build errors that occurred on [nightly build CI](https://github.com/dotnet/docfx/actions/runs/9047253506).

> Error: /home/runner/work/docfx/docfx/test/Docfx.Common.Tests/ConvertToObjectHelperTest.cs(70,42): error CS0266: Cannot implicitly convert type 'object' to 'System.Collections.Generic.Dictionary<string, object>'. An explicit conversion exists (are you missing a cast?)

It is unclear why this error occurs when running build with .NET SDK 9.
In any way it's test code.  Fix build errors by adding cast.

---

> Error: /home/runner/work/docfx/docfx/src/Docfx.Build/PostProcessors/PostProcessorsManager.cs(19,9): error CA2264: Calling 'ArgumentNullException.ThrowIfNull' and passing a non-nullable value is a no-op (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2264)

It seems `CA2264` code analysis rule is enabled when targeting `net9.0`.
So remove unused 'ArgumentNullException.ThrowIfNull' from code.
