### PR TITLE
chore: remove detailed error messages for diagnostics

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="ICSharpCode.Decompiler" Version="8.2.0.7535" />
     <PackageVersion Include="IgnoresAccessChecksToGenerator" Version="0.7.0" />
     <PackageVersion Include="Jint" Version="3.1.0" />
-    <PackageVersion Include="JsonSchema.Net" Version="7.0.1" />
+    <PackageVersion Include="JsonSchema.Net" Version="7.0.2" />
     <PackageVersion Include="Markdig" Version="0.37.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.9.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.9.2" />

--- a/src/Docfx.Build/HostServiceCreator.cs
+++ b/src/Docfx.Build/HostServiceCreator.cs
@@ -63,12 +63,8 @@ class HostServiceCreator
             {
                 if (e is not DocumentException)
                 {
-                    var message = e is ArgumentException or NullReferenceException
-                        ? e.ToString()
-                        : e.Message;
-
                     Logger.LogError(
-                        $"Unable to load file '{file.File}' via processor '{processor.Name}': {message}",
+                        $"Unable to load file '{file.File}' via processor '{processor.Name}': {e.Message}",
                         code: ErrorCodes.Build.InvalidInputFile);
                 }
                 return (null, false);


### PR DESCRIPTION
This PR contains following changes.

- ~~Update JsonSchema.NET package version to `7.0.2`~~
- Remove temporary detailed logging code for diagnostic . (Introduced at https://github.com/dotnet/docfx/pull/9746#issuecomment-2007566046)