### PR TITLE
chore: Fix nightly build errors

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,7 +33,7 @@ jobs:
       run: dotnet test -c Release -f net9.0 --no-build
     
     - name: dotnet pack
-      run: dotnet pack -c Release /p:Version=${{ steps.version.outputs.version }} -o drop/nuget
+      run: dotnet pack -c Release /p:Version=${{ steps.version.outputs.version }} /p:ApiCompatGenerateSuppressionFile=true -o drop/nuget
 
     - name: dotnet nuget push
       run: |

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,9 +17,11 @@
     <!--
       Suppress warnings similar to the following:
           warning NU1507: There are 2 package sources defined in your configuration.
+          warning NU5104: A stable release of a package should not have a prerelease dependency. Either modify the version spec of dependency "PdfPig [0.1.9-alpha-20240510-d86c2, )" or update the version field in the nuspec.
+          warning NU5111: The script file 'tools\.playwright\package\bin\install_media_pack.ps1' is not recognized by NuGet and hence will not be executed during installation of this package.
           warning CS0436: IgnoresAccessChecksTo redefinition due to InternalsVisibleTo
      -->
-    <NoWarn>$(NoWarn);NU1507;CS0436</NoWarn>
+    <NoWarn>$(NoWarn);NU1507;NU5104;NU5111;CS0436</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This PR is successor of #9913.

On latest nightly CI build.
Following errors are occurred additionally .

> Error: /usr/share/dotnet/sdk/9.0.100-preview.3.24204.13/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets(39,5): error PKV006: Target framework net6.0 is no longer supported in the latest version. [/home/runner/work/docfx/docfx/src/Docfx.App/Docfx.App.csproj]
>
> Error: /usr/share/dotnet/sdk/9.0.100-preview.3.24204.13/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets(39,5): error PKV006: Target framework net7.0 is no longer supported in the latest version. [/home/runner/work/docfx/docfx/src/Docfx.App/Docfx.App.csproj]

And following message is displayed.

> /usr/share/dotnet/sdk/9.0.100-preview.3.24204.13/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.ApiCompat.ValidatePackage.targets(39,5): error : API breaking changes found. If those are intentional, the APICompat suppression file can be updated by rebuilding with '/p:ApiCompatGenerateSuppressionFile=true' [/home/runner/work/docfx/docfx/src/Docfx.App/Docfx.App.csproj]

Above 2-errors are raised because it compare `.nupkg` compatibility between versions.
And it's detected that .NET 6/7 supports are dropped for nightly CI build.
So suppress errors by adding `/p:ApiCompatGenerateSuppressionFile=true` parameter to `dotnet pack` command.

---
Additionaly. I've modified  `<NoWarn>` property to suppress following warnings displayed on `dotnet pack`.
- warning NU5104: A stable release of a package should not have a prerelease dependency. Either modify the version spec of dependency "PdfPig [0.1.9-alpha-20240510-d86c2, )" or update the version field in the nuspec.
- warning NU5111: The script file 'tools\.playwright\package\bin\install_media_pack.ps1' is not recognized by NuGet and hence will not be executed during installation of this package.
