### PR TITLE
Fix: Build problems when running .NET 6 version of docfx on some environment

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,14 +10,6 @@
     <PackageVersion Include="Jint" Version="3.1.0" />
     <PackageVersion Include="JsonSchema.Net" Version="7.0.1" />
     <PackageVersion Include="Markdig" Version="0.37.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.9.2" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.43.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
@@ -31,6 +23,34 @@
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="System.Composition" Version="8.0.0" />
     <PackageVersion Include="YamlDotNet" Version="15.1.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <!-- "17.3.2" is the latest compatible version for .NET 6 -->
+    <PackageVersion Include="Microsoft.Build" Version="[17.3.2]" />
+    <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.8" />
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="[4.8.0]" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="[4.8.0]" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="[4.8.0]" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="[4.8.0]" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="[4.8.0]" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="[4.8.0]" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="[4.8.0]" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="[4.8.0]" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.9.2" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Test only -->
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />

--- a/src/Docfx.Dotnet/Docfx.Dotnet.csproj
+++ b/src/Docfx.Dotnet/Docfx.Dotnet.csproj
@@ -28,6 +28,11 @@
     <ProjectReference Include="..\Docfx.Plugins\Docfx.Plugins.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Locator" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" />
     <PackageReference Include="ICSharpCode.Decompiler" />

--- a/src/Docfx.Dotnet/DotnetApiCatalog.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.cs
@@ -57,6 +57,8 @@ public static partial class DotnetApiCatalog
     {
         var stopwatch = Stopwatch.StartNew();
 
+        EnsureMSBuildLocator();
+
         try
         {
             string originalGlobalNamespaceId = VisitorHelper.GlobalNamespaceId;
@@ -120,6 +122,26 @@ public static partial class DotnetApiCatalog
                     break;
             }
         }
+    }
+
+    private static void EnsureMSBuildLocator()
+    {
+#if NET6_0
+        try
+        {
+            if (!Microsoft.Build.Locator.MSBuildLocator.IsRegistered)
+            {
+                var vs = Microsoft.Build.Locator.MSBuildLocator.RegisterDefaults() ?? throw new Docfx.Exceptions.ExtractMetadataException(
+                    $"Cannot find a supported .NET Core SDK. Install .NET Core SDK {Environment.Version.Major}.{Environment.Version.Minor}.x to build .NET API docs.");
+
+                Logger.LogInfo($"Using {vs.Name} {vs.Version}");
+            }
+        }
+        catch (Exception e)
+        {
+            throw new Docfx.Exceptions.ExtractMetadataException(e.Message, e);
+        }
+#endif
     }
 
     private static ExtractMetadataConfig ConvertConfig(MetadataJsonItemConfig configModel, string configDirectory, string outputDirectory)


### PR DESCRIPTION
This PR intended to fix some part of issues that are reported at #9753.

By reverting changes that introduced by #9753 for .NET 6 target.

**Background**

It seems RPC to `BuildHost` (Separated build process) is failed on some specific environment.

I've confirmed it can be reproduced that on .NET 6 docker image.

And it's not expected to be fixed.
(Because next [Microsoft.CodeAnalysis.Workspaces.MSBuild](https://www.nuget.org/packages/Microsoft.CodeAnalysis.Workspaces.MSBuild/4.10.0-3.final#dependencies-body-tab) 4.10.0 dropping .NET 6 supports)

So as a temporary workaround. I've reverted some code for the .NET 6 target build.
