### PR TITLE
chore: Add error handling logics

### DIFF
--- a/src/Docfx.Dotnet/DotnetApiCatalog.Compile.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.Compile.cs
@@ -41,7 +41,19 @@ partial class DotnetApiCatalog
         });
 
         using var workspace = MSBuildWorkspace.Create(msbuildProperties);
-        workspace.WorkspaceFailed += (sender, e) => Logger.LogWarning($"{e.Diagnostic}");
+        workspace.WorkspaceFailed += (sender, e) =>
+        {
+            var message = e.Diagnostic.ToString();
+            switch (e.Diagnostic.Kind)
+            {
+                case WorkspaceDiagnosticKind.Failure when !config.AllowCompilationErrors:
+                    Logger.LogError(message);
+                    break;
+                default:
+                    Logger.LogWarning(message);
+                    break;
+            }
+        };
 
         if (files.TryGetValue(FileType.NotSupported, out var unsupportedFiles))
         {

--- a/src/docfx/Models/DefaultCommand.cs
+++ b/src/docfx/Models/DefaultCommand.cs
@@ -45,7 +45,7 @@ class DefaultCommand : Command<DefaultCommand.Options>
                 DotnetApiCatalog.Exec(config.metadata, new(), configDirectory).GetAwaiter().GetResult();
             }
 
-            if (config.build is not null)
+            if (config.build is not null && !Logger.HasError)
             {
                 BuildCommand.MergeOptionsToConfig(options, config.build, configDirectory);
                 serveDirectory = RunBuild.Exec(config.build, new(), configDirectory, outputFolder);
@@ -53,7 +53,7 @@ class DefaultCommand : Command<DefaultCommand.Options>
                 PdfBuilder.CreatePdf(serveDirectory).GetAwaiter().GetResult();
             }
 
-            if (options.Serve && serveDirectory is not null)
+            if (options.Serve && serveDirectory is not null && !Logger.HasError)
             {
                 RunServe.Exec(serveDirectory, options.Host, options.Port, options.OpenBrowser, options.OpenFile);
             }


### PR DESCRIPTION
This PR intended to fix issue reported by #9941.

In the current implementation.
When `WorkspaceDiagnosticKind.Failure` error occurred when calling [MSbuildWorkSpace::OpenProjectAsync](https://github.com/dotnet/docfx/blob/12ddaf6e53a193238eb8172b3dbec2ddecaf17a5/src/Docfx.Dotnet/DotnetApiCatalog.Compile.cs#L150)
Code analysis is interrupted and it's recorded as **warning** at following callback method.
https://github.com/dotnet/docfx/blob/12ddaf6e53a193238eb8172b3dbec2ddecaf17a5/src/Docfx.Dotnet/DotnetApiCatalog.Compile.cs#L44

It’s confusing that root cause of issue is reported as **warning**.
So this PR changes this behavior to record `WorkspaceDiagnosticKind.Failure` as an error. (Only when AllowCompilationErrors is not specified)

---

Additionally. This PR add `fail-fast` logics to `DefaultCommand`.
(Currently build/serve command is executed even if an error has occurred in the previous process.