### PR TITLE
chore: fix NU5129 warning on `dotnet pack` command

### DIFF
--- a/src/Docfx.App/Docfx.App.csproj
+++ b/src/Docfx.App/Docfx.App.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <Content Include="templates/**" CopyToOutputDirectory="PreserveNewest" PackageCopyToOutput="true" PackagePath="contentFiles/any/any/templates" />
-    <None Include="Build\Docfx.App.props" Pack="true" PackagePath="build\" />
+    <None Include="Build\Docfx.App.props" Pack="true" PackagePath="build/" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR is successor of #9942.

`NU5129`  warning is still occurred on latest nightly build.
It seems can be fixed by changing `PackagePath` directory separator to forward slash.
