### PR TITLE
feat: Add `toc.json` transform logics using `toc.extension.js`

### DIFF
--- a/templates/default/toc.extension.js
+++ b/templates/default/toc.extension.js
@@ -2,14 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 /**
- * This method will be called at the start of exports.transform in toc.html.js
+ * This method will be called at the start of exports.transform in toc.html.js and toc.json.js
  */
 exports.preTransform = function (model) {
   return model;
 }
 
 /**
- * This method will be called at the end of exports.transform in toc.html.js
+ * This method will be called at the end of exports.transform in toc.html.js and toc.json.js
  */
 exports.postTransform = function (model) {
   return model;

--- a/templates/default/toc.json.js
+++ b/templates/default/toc.json.js
@@ -1,10 +1,19 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+var extension = require('./toc.extension.js')
 
 exports.transform = function (model) {
 
+    if (extension && extension.preTransform) {
+      model = extension.preTransform(model);
+    }
+
     if (model.memberLayout === 'SeparatePages') {
       model = transformMemberPage(model);
+    }
+
+    if (extension && extension.postTransform) {
+      model = extension.postTransform(model);
     }
   
     for (var key in model) {


### PR DESCRIPTION
This PR intended to fix #9944.

Currently `toc.extension.js` is applied to HTML files only . (By [toc.html.primary.js](https://github.com/dotnet/docfx/blob/main/templates/default/toc.html.primary.js))

This PR add same logics to [toc.json.js](https://github.com/dotnet/docfx/blob/main/templates/default/toc.json.js).
