### PR TITLE
chore: Add `workflow_dispatch` trigger to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     branches: [ main, feature/*, hotfix/* ]
   push:
     branches: [ main, feature/*, hotfix/* ]
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
This PR add [workflow_dispatch trigger](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) to CI workflow.

It's expected to be used to re-run workflow when failed test on CI.
And to invoke CI workflow from snapshot update workflow (#9831)

**Usage**
This PR need to be merged to `main` branch to invoke workflow.
After PR merged. User who have `write` permission to repository can invoke workflow by following ways. 

1. GitHub Action Web UI
2. `gh` command line interface.

**Example of gh command to invoke CI workflow on specified branch`**
> gh workflow run ci.yml --repo dotnet/docfx --ref test-branch


