### PR TITLE
chore: Add PolySharp libarary to use latest C# syntax

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,6 +46,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,7 @@
     <PackageVersion Include="OneOf.SourceGenerator" Version="3.0.271" />
     <PackageVersion Include="PdfPig" Version="0.1.9-alpha-20240510-d86c2" />
     <PackageVersion Include="PlantUml.Net" Version="1.4.80" />
+    <PackageVersion Include="PolySharp" Version="1.14.1" />
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />
     <PackageVersion Include="Stubble.Core" Version="1.10.8" />

--- a/src/Docfx.Build/ApiPage/ApiPage.cs
+++ b/src/Docfx.Build/ApiPage/ApiPage.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if NET7_0_OR_GREATER
-
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using OneOf;
@@ -160,5 +158,3 @@ record ApiPage
     public string? languageId { get; init; }
     public Dictionary<string, OneOf<string, string[]>>? metadata { get; init; }
 }
-
-#endif

--- a/src/Docfx.Build/ApiPage/ApiPageHtmlTemplate.cs
+++ b/src/Docfx.Build/ApiPage/ApiPageHtmlTemplate.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if NET7_0_OR_GREATER
-
 using System.Net;
 using OneOf;
 using static Docfx.Build.HtmlTemplate;
@@ -158,5 +156,3 @@ static class ApiPageHtmlTemplate
         };
     }
 }
-
-#endif

--- a/src/Docfx.Build/ApiPage/ApiPageMarkdownTemplate.cs
+++ b/src/Docfx.Build/ApiPage/ApiPageMarkdownTemplate.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if NET7_0_OR_GREATER
-
 using System.Text;
 
 #nullable enable
@@ -124,5 +122,3 @@ static class ApiPageMarkdownTemplate
         return sb.ToString();
     }
 }
-
-#endif

--- a/src/Docfx.Build/ApiPage/ApiPageProcessor.cs
+++ b/src/Docfx.Build/ApiPage/ApiPageProcessor.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if NET7_0_OR_GREATER
-
 using System.Collections.Immutable;
 using System.Text.Json;
 using Docfx.Common;
@@ -74,5 +72,3 @@ class ApiPageDocumentProcessor(IMarkdownService markdownService) : IDocumentProc
         };
     }
 }
-
-#endif

--- a/src/Docfx.Build/DocumentBuilder.cs
+++ b/src/Docfx.Build/DocumentBuilder.cs
@@ -50,9 +50,7 @@ public class DocumentBuilder : IDisposable
 
         var markdownService = CreateMarkdigMarkdownService(parameters[0]);
 
-#if NET7_0_OR_GREATER
         Processors = Processors.Append(new ApiPage.ApiPageDocumentProcessor(markdownService));
-#endif
 
         Logger.LogInfo($"{Processors.Count()} plug-in(s) loaded.");
         foreach (var processor in Processors)

--- a/src/Docfx.Dotnet/DotnetApiCatalog.ApiPage.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.ApiPage.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if NET7_0_OR_GREATER
-
 using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
 using Docfx.Build.ApiPage;
@@ -774,5 +772,3 @@ partial class DotnetApiCatalog
         return doc.DocumentNode.InnerText;
     }
 }
-
-#endif

--- a/src/Docfx.Dotnet/DotnetApiCatalog.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.cs
@@ -89,20 +89,15 @@ public static partial class DotnetApiCatalog
             switch (config.OutputFormat)
             {
                 case MetadataOutputFormat.Markdown:
-#if NET7_0_OR_GREATER
                     CreatePages(WriteMarkdown, assemblies, config, options);
 
                     void WriteMarkdown(string outputFolder, string id, Build.ApiPage.ApiPage apiPage)
                     {
                         File.WriteAllText(Path.Combine(outputFolder, $"{id}.md"), Docfx.Build.ApiPage.ApiPageMarkdownTemplate.Render(apiPage));
                     }
-#else
-                    Logger.LogError($"Markdown output format is only supported for docfx built against .NET 7 or greater.");
-#endif
                     break;
 
                 case MetadataOutputFormat.ApiPage:
-#if NET7_0_OR_GREATER
                     var serializer = new DeserializerBuilder().WithAttemptingUnquotedStringTypeDeserialization().Build();
                     CreatePages(WriteYaml, assemblies, config, options);
 
@@ -112,9 +107,6 @@ public static partial class DotnetApiCatalog
                         var obj = serializer.Deserialize(json);
                         YamlUtility.Serialize(Path.Combine(outputFolder, $"{id}.yml"), obj, "YamlMime:ApiPage");
                     }
-#else
-                    Logger.LogError($"ApiPage output format is only supported for docfx built against .NET 7 or greater.");
-#endif
                     break;
 
                 case MetadataOutputFormat.Mref:


### PR DESCRIPTION
This PR add [PolySharp](https://github.com/Sergio0694/PolySharp) package reference to projects.

**Background**

Currently docfx use multi target frameworks `net6` and `net8`.
So some latest C# feature usage is limited. (e.g. [required modifier](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/required))

By this changes. 
It can use latest C# 12 features when targeting `.NET 6` runtime.  
And it can remove `#ifdef` from metadata generation when using `markdown`/`apiPage` output format.

---

PolySharp generate source-only polyfills. So runtime library dependency is not needed.
The only concern is the increase of build time due to running source generator.
But it's acceptable increase rate.

**CI build time**

| OS | Original | [This PR CI](https://github.com/dotnet/docfx/actions/runs/9263366790)
|----|----|-----|
| Windows| 10m18s | 9m2s
| Ubuntu    |11m10s | 12m12s
| macOS     | 6m 33s | 6m41s