### PR TITLE
chore: Add snapshot update workflow

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,63 @@
+# This workflow update snapshot.
+name: snapshot
+on:
+  workflow_dispatch:
+    inputs:
+      dryrun:
+        type: boolean
+        description: Set `true` to skip commit diffs.
+        default: true
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    environment: ci
+    strategy:
+      fail-fast: false
+    permissions:
+      actions: write    # Required to invoke another workflow with `createWorkflowDispatch`.
+      contents: write   # Required to commit snapshot diffs.
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.ref_name }}
+        lfs: true
+
+    # Build projects
+    - uses: ./.github/actions/build
+
+    # Update snapshots & accept changes
+    - run: dotnet test -c Release -f net8.0 --no-build --filter Stage=Snapshot
+      working-directory: test/docfx.Snapshot.Tests
+      env:
+        BUILD_SERVER: false # Need to accept file changes automatically.
+
+    # Show diff file names (It's required when using dryrun option)
+    - name: Show diff file names
+      run: |
+        git diff --name-only
+
+    # Commit updated snapshot contents
+    - uses: stefanzweifel/git-auto-commit-action@v5
+      id: auto-commit-action
+      if: ${{ github.event.inputs.dryrun == 'false'}} 
+      with:
+        commit_message: 'test(snapshot): update snapshots ${{ github.sha }}'
+
+    # Invoke CI workflow if changes are committed.
+    - uses: actions/github-script@v7
+      if: ${{ steps.auto-commit-action.outputs.changes_detected == 'true' }} 
+      with:
+        script: |
+          try {
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ci.yml',
+              ref: '${{ github.ref_name }}',
+            })
+           }
+           catch(error) {
+             console.error(error)
+             core.setFailed(error)
+           }


### PR DESCRIPTION
This PR intended to resolve #9831 issue.

Currently snapshots are not synced to latest snapshot tests results.
This PR add `snapshot,yml` workflow to update snapshots.
And run `ci.yml` if snapshots are updated.

## How to run snapshot update workflow
First of all. This PR must be merged to `main` branch to run workflow.

After PR is merged.
It can run workflow via GitHub Action Web UI.
![image](https://github.com/dotnet/docfx/assets/103790468/ebadb2a4-4a88-47a3-9db5-c08af6383ef0)

It can also run workflow by using `gh` command.

> gh workflow run snapshot.yml --repo dotnet/docfx --ref test-branch -f dryrun=true

## How to test snapshot workflow

1. Ensure this PR is merged to `main` branch.
2. Create test branch (e.g. `test-branch`) and push to GitHub.
3. Run snapshot workflow with `dryrun=false` setting
4. Confirm snapshot is updated by workflow. And `cy.yml` is executed.

If it's confirmed to works as expected.
Please try to update `main` branch snapshot.










 

  



