### PR TITLE
Feat/private symbols

### DIFF
--- a/src/Docfx.Dotnet/CompilationHelper.cs
+++ b/src/Docfx.Dotnet/CompilationHelper.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
-using System.Reflection;
 using Docfx.Common;
 using Docfx.Exceptions;
 using ICSharpCode.Decompiler.Metadata;
@@ -104,22 +103,17 @@ internal static class CompilationHelper
             references: GetDefaultMetadataReferences("VB").Concat(references ?? []));
     }
 
-    public static (Compilation, IAssemblySymbol) CreateCompilationFromAssembly(string assemblyPath, ExtractMetadataConfig? config = null, params MetadataReference[] references)
+    public static (Compilation, IAssemblySymbol) CreateCompilationFromAssembly(string assemblyPath, bool includePrivateMembers = false, params MetadataReference[] references)
     {
-        var options = new CS.CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
-
-        if (config?.IncludePrivateMembers ?? false)
-        {
-            var propertyInfo = typeof (CS.CSharpCompilationOptions).GetProperty ("MetadataImportOptions", BindingFlags.Public | BindingFlags.Instance);
-
-            propertyInfo?.SetValue(options, (byte)2);
-
-        }
-
         var metadataReference = CreateMetadataReference(assemblyPath);
         var compilation = CS.CSharpCompilation.Create(
             assemblyName: null,
-            options: options,
+            options: new CS.CSharpCompilationOptions(
+                outputKind            : OutputKind.DynamicallyLinkedLibrary,
+                metadataImportOptions : includePrivateMembers
+                    ? MetadataImportOptions.All
+                    : MetadataImportOptions.Public
+            ),
             syntaxTrees: s_assemblyBootstrap,
             references: GetReferenceAssemblies(assemblyPath)
                 .Select(CreateMetadataReference)

--- a/src/Docfx.Dotnet/DotnetApiCatalog.Compile.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.Compile.cs
@@ -117,7 +117,7 @@ partial class DotnetApiCatalog
             foreach (var assemblyFile in assemblyFiles)
             {
                 Logger.LogInfo($"Loading assembly {assemblyFile.NormalizedPath}");
-                var (compilation, assembly) = CompilationHelper.CreateCompilationFromAssembly(assemblyFile.NormalizedPath, config, metadataReferences);
+                var (compilation, assembly) = CompilationHelper.CreateCompilationFromAssembly(assemblyFile.NormalizedPath, config.IncludePrivateMembers, metadataReferences);
                 hasCompilationError |= compilation.CheckDiagnostics(config.AllowCompilationErrors);
                 assemblies.Add((assembly, compilation));
             }

--- a/src/Docfx.Dotnet/DotnetApiCatalog.Compile.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.Compile.cs
@@ -117,7 +117,7 @@ partial class DotnetApiCatalog
             foreach (var assemblyFile in assemblyFiles)
             {
                 Logger.LogInfo($"Loading assembly {assemblyFile.NormalizedPath}");
-                var (compilation, assembly) = CompilationHelper.CreateCompilationFromAssembly(assemblyFile.NormalizedPath, metadataReferences);
+                var (compilation, assembly) = CompilationHelper.CreateCompilationFromAssembly(assemblyFile.NormalizedPath, config, metadataReferences);
                 hasCompilationError |= compilation.CheckDiagnostics(config.AllowCompilationErrors);
                 assemblies.Add((assembly, compilation));
             }

--- a/src/Docfx.Dotnet/ManagedReference/Visitors/SymbolVisitorAdapter.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Visitors/SymbolVisitorAdapter.cs
@@ -181,7 +181,13 @@ internal class SymbolVisitorAdapter : SymbolVisitor<MetadataItem>
         }
 
         item.Items = new List<MetadataItem>();
-        foreach (var member in symbol.GetMembers().Where(s => s is not INamedTypeSymbol))
+        foreach (
+            var member in symbol.GetMembers()
+            .Where(static s =>
+                s is not INamedTypeSymbol
+                && ! s.Name.StartsWith('<')
+                && (s is not IMethodSymbol ms || ms.MethodKind != MethodKind.StaticConstructor)
+            ))
         {
             var memberItem = member.Accept(this);
             if (memberItem != null)


### PR DESCRIPTION
When specifying `"includePrivateMembers" : "true"` in `docfx.js`, the private classes of an assembly are documented, but not the private members of a class.

This fix, modified how the members are enumerated, in order to include the private members of a class, if needed.
Unfortunately, the method used to enumerate the members, using Roslyn, doesn't provide a way to enumerate also the private, so I have to set a flag using reflection to do this.

To be correct, code has also been added to not document the class constructor, if any, or compiler-generated members.