### PR TITLE
docs: Fix Docfx.App nuget package usage document

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -98,7 +98,9 @@ jobs:
 You can also use docfx as a NuGet library:
 
 ```xml
-<PackageReference Include="Docfx.App" Version="2.73.2" />
+<PackageReference Include="Docfx.App" Version="2.76.0" />
+<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.9.2" />
+<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
 ```
 
 Then build a docset using:


### PR DESCRIPTION
This PR intended to fix issue that reported at #9988.

When using `Docfx.App` 2.76.0 or later.
It need to explicitly add references to Roslyn packages.

**Background**
Roslyn 4.9.2 or later packages contains `BuildHost` related `contentFiles`.
And these files needs to be copied to output directory.

It works as expected when using `ProjectReference`.
But when using `PackageReference` and these files are not copied to output directory when packages are referenced as `transitive`.

To resolve this issue. It need to add direct package references manually.
https://github.com/NuGet/Home/issues/6826
 