### PR TITLE
chore: Update Roslyn package versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,14 +41,14 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
-    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.10.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.10.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.10.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.10.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.10.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Docfx.Dotnet/SymbolFormatter.Symbols.cs
+++ b/src/Docfx.Dotnet/SymbolFormatter.Symbols.cs
@@ -19,6 +19,10 @@ partial class SymbolFormatter
 
         public bool IsParams => false;
 
+        public bool IsParamsArray => false;
+
+        public bool IsParamsCollection => false;
+
         public bool IsOptional => false;
 
         public bool IsThis => false;


### PR DESCRIPTION
This PR update Roslyn packages version from `4.9.2` to `4.10.0`.
And add stub properties `IsParamsArray`/`IsParamsCollection` that are added to `IParameterSymbol` interface.
