### PR TITLE
chore: Fix nightly build errors that occurred on .NET 9 SDK Preview 5

### DIFF
--- a/src/Docfx.Build.SchemaDriven/SchemaDrivenDocumentProcessor.cs
+++ b/src/Docfx.Build.SchemaDriven/SchemaDrivenDocumentProcessor.cs
@@ -183,9 +183,13 @@ public class SchemaDrivenDocumentProcessor : DisposableDocumentProcessor
             ExternalXRefSpecs = ImmutableArray.CreateRange(model.Properties.ExternalXRefSpecs)
         };
 
-        if (((IDictionary<string, object>)model.Properties).ContainsKey("XrefSpec"))
+        if (((IDictionary<string, object>)model.Properties).TryGetValue("XrefSpec", out var value))
         {
-            result.XRefSpecs = ImmutableArray.Create(model.Properties.XrefSpec);
+            var xrefSpec = value as XRefSpec;
+            if (xrefSpec != null)
+            {
+                result.XRefSpecs = [xrefSpec];
+            }
         }
 
         return result;

--- a/src/Docfx.Build/Conceptual/ConceptualDocumentProcessor.cs
+++ b/src/Docfx.Build/Conceptual/ConceptualDocumentProcessor.cs
@@ -104,9 +104,14 @@ class ConceptualDocumentProcessor : DisposableDocumentProcessor
             FileLinkSources = model.FileLinkSources,
             UidLinkSources = model.UidLinkSources,
         };
-        if (model.Properties.XrefSpec != null)
+
+        if (((IDictionary<string, object>)model.Properties).TryGetValue("XrefSpec", out var value))
         {
-            result.XRefSpecs = ImmutableArray.Create(model.Properties.XrefSpec);
+            var xrefSpec = value as XRefSpec;
+            if (xrefSpec != null)
+            {
+                result.XRefSpecs = [xrefSpec];
+            }
         }
 
         return result;


### PR DESCRIPTION
This PR intended to fix nightly build error that occurred after CI build is updated to .NET 9 SDK Preview 5.

**Warning Message**
> CS9220
> One or more overloads of method 'Create' having non-array params collection parameter might be applicable only in expanded form which is not supported during dynamic dispatch.	Docfx.Build.SchemaDriven (net9.0)

Above warning occurred when passing `dynamic` variable to `ImmutableArray.Create`.
So I've added type cast logics.