### PR TITLE
chore: Change actionbar button style attribute to css

### DIFF
--- a/templates/modern/layout/_master.tmpl
+++ b/templates/modern/layout/_master.tmpl
@@ -103,7 +103,7 @@
       <div class="content">
         <div class="actionbar">
           {{^_disableToc}}
-          <button class="btn btn-lg border-0 d-md-none" style="margin-top: -.65em; margin-left: -.8em"
+          <button class="btn btn-lg border-0 d-md-none"
               type="button" data-bs-toggle="offcanvas" data-bs-target="#tocOffcanvas"
               aria-controls="tocOffcanvas" aria-expanded="false" aria-label="Show table of contents">
             <i class="bi bi-list"></i>

--- a/templates/modern/src/layout.scss
+++ b/templates/modern/src/layout.scss
@@ -161,6 +161,11 @@ body[data-layout="landing"] {
             display: flex;
             align-items: flex-start;
             margin-top: .5rem;
+            
+            >button {
+              margin-top: -.65em;
+              margin-left: -.8em
+            }
           }
 
           article {


### PR DESCRIPTION
This PR move ActionBar button's style attribute to `layout.scss`.
(ActionBar button is displayed on mobile view)

This change is required to suppress errors that occurs on CSP(Content-Security Policy) enabled environment. (e.g. #10018)

Almost of CSP errors can be suppressed by explicitly specifying `hash-source`.
But **`style` attributes** can not suppressed by this setting.
And following following message is displayed.

> Either the 'unsafe-inline' keyword, a hash ('sha256-hrMAdouS/Nq0Km7HyvR/ocksu2luFnpaxSswePO7FOY='), or a nonce ('nonce-...') is required to enable inline execution.
> Note that hashes do not apply to event handlers, style attributes and javascript: navigations unless the 'unsafe-hashes' keyword is present.
