### PR TITLE
fix: `docfx metadata` command throw `ArgumentException` when referencing empty namespace by doc comment

### DIFF
--- a/src/Docfx.Dotnet/ManagedReference/Resolvers/YamlMetadataResolver.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Resolvers/YamlMetadataResolver.cs
@@ -102,7 +102,7 @@ internal static class YamlMetadataResolver
                         };
                         missingNamespace.DisplayNames.Add(SyntaxLanguage.Default, partialParentNamespace);
                         namespacedItems[partialParentNamespace] = missingNamespace;
-                        allReferences.Add(partialParentNamespace, new());
+                        allReferences.TryAdd(partialParentNamespace, new());
 
                         if (!partialParentNamespace.Contains('.'))
                         {
@@ -137,10 +137,18 @@ internal static class YamlMetadataResolver
         }
 
         foreach (var member in namespacedItems.Values)
+        {
             member.Items = member.Items
                 .OrderBy(x => x.Type == MemberType.Namespace ? 0 : 1)
                 .ThenBy(x => x.Name)
                 .ToList();
+
+            if (member.Type == MemberType.Namespace
+             && member.Items.All(x => x.Type == MemberType.Namespace))
+            {
+                allReferences[member.Name] = new();
+            }
+        }
 
         return root;
     }


### PR DESCRIPTION
This PR intended to fix issue reported at https://github.com/dotnet/docfx/issues/2532#issuecomment-2181542930

**Details of problem**

`docfx metadata` command failed with `ArgumentException` at [this line](https://github.com/dotnet/docfx/blob/cc5754aa8c4d7fb083ed1de8514265804b58ce76/src/Docfx.Dotnet/ManagedReference/Resolvers/YamlMetadataResolver.cs#L105)

```
ArgumentException: An item with the same key has already been added. Key: Root.Datastore
  at bool TryInsert(TKey key, TValue value, InsertionBehavior behavior)
  at void Add(TKey key, TValue value)
  at MetadataItem GenerateNestedTocStructure(IEnumerable<KeyValuePair<string, MetadataItem>> namespaces,
     Dictionary<string, ReferenceItem> allReferences) in YamlMetadataResolver.cs:105
```

This problem is occurred when following conditions are met

1. Referencing empty namespace with `<see cref="">` tag.
2. Using "namespaceLayout": "nested"
3. Using "outputFormat": "mref"

**What's changed in this PR**

This PR changes `allReferences.Add` logic to `allReferences.TryAdd` method to skip when key already exists.

For example.  When `/// <see cref="Root.Datastore"/>` comment exists.
`allReferences` contains this information as `ReferenceItem` (`N:Root.Datastore`).

Additionally I've added post-process logics to overwrite **empty namespace** reference.
It's required because **Empty namespace** don't generate HTML page.
So `<see cref=""/>` link is not works for empty namespace.

**Test**
I've manually tested following tests by using [DocFxUndefinedReferenceBugDemo](https://github.com/scott-ainsworth/DocFxUndefinedReferenceBugDemo) content.

1. `docfx metadata` command successfully completed.
2. `<see cref=""` link to **empty namespace** is rendered as plain text.
3. `<see cref=""` link to **other namespace** is rendered as normal link.
