### PR TITLE
chore: Fix `navrel`/`tocrel` URL resolve behaviors when using `Site Relative URL`

### DIFF
--- a/templates/modern/src/nav.ts
+++ b/templates/modern/src/nav.ts
@@ -73,7 +73,9 @@ export async function renderNavbar(): Promise<NavItem[]> {
       return []
     }
 
-    const navUrl = new URL(navrel.replace(/.html$/gi, '.json'), window.location.href)
+    const navUrl = navrel.startsWith('/')
+      ? new URL(navrel.replace(/.html$/gi, '.json'), document.baseURI)
+      : new URL(navrel.replace(/.html$/gi, '.json'), window.location.href)
     const { items } = await fetch(navUrl).then(res => res.json())
     return items.map((a: NavItem | NavItemContainer) => {
       if ('items' in a) {

--- a/templates/modern/src/toc.ts
+++ b/templates/modern/src/toc.ts
@@ -23,7 +23,9 @@ export async function renderToc(): Promise<TocNode[]> {
 
   const disableTocFilter = meta('docfx:disabletocfilter') === 'true'
 
-  const tocUrl = new URL(tocrel.replace(/.html$/gi, '.json'), window.location.href)
+  const tocUrl = tocrel.startsWith('/')
+    ? new URL(tocrel.replace(/.html$/gi, '.json'), document.baseURI)
+    : new URL(tocrel.replace(/.html$/gi, '.json'), window.location.href)
   const { items, pdf, pdfFileName } = await (await fetch(tocUrl)).json()
 
   const tocFilterUrl = disableTocFilter ? '' : (localStorage?.getItem('tocFilterUrl') || '')


### PR DESCRIPTION
This PR intended to fix some problem that discussed at #10028

On current docfx modern template implementation.
`navrel` / `tocrel` absolute URL is resolve by using following code.

>  `new URL('toc.json', window.location.href)

So when I've modified docfx generated pages URLs to `Site Relative URL` (That starts with '/') based URL.
JavaScript errors are occurred on non-site-root pages.

This PR fix this issue by adding dedicated code path for `Site Relative URL`.

**Test**
I've manually confirmed following patterns and it works as expected.
1. Default page (That use relative URLs)
2. Rewriting HTML page URLs to `Site Relative URL` .
3. Rewriting HTML page URLs to `Absolute URL`.

And it also tested on `default` template environment.
It ssems `default` template processing `navrel` / `tocrel` URL as plain string. so no modification needed.

 