### PR TITLE
Optimize CountWordInText

### DIFF
--- a/src/Docfx.Build/Conceptual/WordCounter.cs
+++ b/src/Docfx.Build/Conceptual/WordCounter.cs
@@ -9,6 +9,14 @@ internal static class WordCounter
 {
     private static readonly string[] ExcludeNodeXPaths = ["//title"];
 
+#if NET8_0_OR_GREATER
+    private static readonly System.Buffers.SearchValues<char> SpecialChars = System.Buffers.SearchValues.Create(".?!;:,()[]");
+#else
+    private static readonly string SpecialChars = ".?!;:,()[]";
+#endif
+
+    private static readonly char[] DelimiterChars = [' ', '\t', '\n'];
+
     public static long CountWord(string html)
     {
         ArgumentNullException.ThrowIfNull(html);
@@ -50,10 +58,7 @@ internal static class WordCounter
             return 0;
         }
 
-        string specialChars = ".?!;:,()[]";
-        char[] delimiterChars = [' ', '\t', '\n'];
-
-        string[] wordList = text.Split(delimiterChars, StringSplitOptions.RemoveEmptyEntries);
-        return wordList.Count(s => !s.Trim().All(specialChars.Contains));
+        string[] wordList = text.Split(DelimiterChars, StringSplitOptions.RemoveEmptyEntries);
+        return wordList.Count(static s => !s.Trim().All(static c => SpecialChars.Contains(c)));
     }
 }


### PR DESCRIPTION
* use `SearchValues` for special chars lookup on NET 8
* only allocate delimiter chars once
* ensure no closure allocations with static lambdas

![image](https://github.com/dotnet/docfx/assets/171892/ea7f52dc-c8f7-4435-b671-4b6ca1346edd)
