### PR TITLE
feat: Support `search.min.js` script customize functionality

### DIFF
--- a/templates/build.js
+++ b/templates/build.js
@@ -51,12 +51,24 @@ async function buildModernTemplate() {
     entryPoints: [
       'modern/src/docfx.ts',
       'modern/src/search-worker.ts',
+      'modern/src/search.ts',
     ],
     external: [
       './main.js'
     ],
     plugins: [
-      sassPlugin()
+      sassPlugin(),
+      {
+        name: 'Exclude `./search` script from bundle',
+        setup(build) {
+          build.onResolve({ filter: /^\.\/search$/ }, args => {
+            return {
+              path: './search.min.js',
+              external: true
+            };
+          });
+        }
+      }
     ],
     loader,
   }
@@ -113,8 +125,8 @@ function copyToDist() {
 }
 
 function buildContent() {
-  exec(`dotnet run -f net7.0 --project ../src/docfx/docfx.csproj -- metadata ${project}/docfx.json`)
-  exec(`dotnet run -f net7.0 --project ../src/docfx/docfx.csproj --no-build -- build ${project}/docfx.json`)
+  exec(`dotnet run -f net8.0 --project ../src/docfx/docfx.csproj -- metadata ${project}/docfx.json`)
+  exec(`dotnet run -f net8.0 --project ../src/docfx/docfx.csproj --no-build -- build ${project}/docfx.json`)
 
   function exec(cmd) {
     if (spawnSync(cmd, { stdio: 'inherit', shell: true }).status !== 0) {


### PR DESCRIPTION
This PR intended to support `search.min.js` script customization.

Currently docfx `modern` template bundle scripts to `docfx.min.js`.
So it can't customize search scripts with custom template.

This PR exclude `search.ts` file from bundling by adding following settings

- Set 'modern/src/search.ts' as `entryPoints` to separately create `search.min.js`.
- Rewrite `./search`  import statement settings by custom esbuild plugin.
  - Set `external` property to `true` to exclude from `esbuild bundle`
  - Rewrite `path` from `./search` to `./search.min.js`

Additionally this PR fix .NET runtime version to .NET 8 (that used by `npm run start`)

