### PR TITLE
chore: Fix json schemas

### DIFF
--- a/schemas/docfx.schema.json
+++ b/schemas/docfx.schema.json
@@ -399,6 +399,7 @@
     "sitemap": {
       "type": "object",
       "description": "Specifies the options for the sitemap.xml file.",
+      "additionalProperties": false,
       "properties": {
         "baseUrl": {
           "type": "string",
@@ -465,6 +466,7 @@
     "markdownEngineProperties": {
       "description": "Set the parameters for markdown engine, value should be a JSON string.",
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "enableSourceInfo": {
           "type": "boolean",
@@ -520,6 +522,7 @@
     "plantUmlOptions": {
       "type": "object",
       "description": "PlantUml extension configuration parameters",
+      "additionalProperties": false,
       "properties": {
         "javaPath": {
           "type": "string",
@@ -572,6 +575,7 @@
       "type": "array",
       "items": {
         "type": "object",
+        "additionalProperties": false,
         "properties": {
           "src": {
             "$ref": "#/$defs/srcFileMapping"
@@ -742,6 +746,7 @@
       "type": "array",
       "items": {
         "type": "object",
+        "additionalProperties": false,
         "properties": {
           "content": {
             "$ref": "#/$defs/contentFileMapping"

--- a/schemas/filterconfig.schema.json
+++ b/schemas/filterconfig.schema.json
@@ -27,28 +27,30 @@
       "properties": {
         "include": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "uidRegex": {
               "type": "string"
             },
-            "kind": {
+            "type": {
               "$ref": "#/$defs/extendedSymbolKind"
             },
-            "attribute": {
+            "hasAttribute": {
               "$ref": "#/$defs/attributeFilterInfo"
             }
           }
         },
         "exclude": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "uidRegex": {
               "type": "string"
             },
-            "kind": {
+            "type": {
               "$ref": "#/$defs/extendedSymbolKind"
             },
-            "attribute": {
+            "hasAttribute": {
               "$ref": "#/$defs/attributeFilterInfo"
             }
           }
@@ -57,19 +59,19 @@
     },
     "extendedSymbolKind": {
       "enum": [
-        "assembly",
-        "namespace",
-        "class",
-        "struct",
-        "enum",
-        "interface",
-        "delegate",
-        "type",
-        "event",
-        "field",
-        "method",
-        "property",
-        "member"
+        "Assembly",
+        "Namespace",
+        "Class",
+        "Struct",
+        "Enum",
+        "Interface",
+        "Delegate",
+        "Type",
+        "Event",
+        "Field",
+        "Method",
+        "Property",
+        "Member"
       ]
     },
     "attributeFilterInfo": {


### PR DESCRIPTION
This PR contains following changes

1. Add `additionalProperties: false` settings for types that don't have `JsonExtensionData` properties.
2. Fix filterconfig` JSON Schema problems that found by adding  `additionalProperties: false`.
3. Change type related enum names to Capital Cases.
