### PR TITLE
feat: Remove Node.js runtime dependencies from docfx tools

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,9 @@ jobs:
 
     - name: dotnet publish
       run: |
-        dotnet publish src/docfx -f net8.0 -c Release /p:Version=${GITHUB_REF_NAME#v} --self-contained -r win-x64 -o drop/publish/win-x64 /p:PlaywrightPlatform=win
-        dotnet publish src/docfx -f net8.0 -c Release /p:Version=${GITHUB_REF_NAME#v} --self-contained -r linux-x64 -o drop/publish/linux-x64 /p:PlaywrightPlatform=linux
-        dotnet publish src/docfx -f net8.0 -c Release /p:Version=${GITHUB_REF_NAME#v} --self-contained -r osx-x64 -o drop/publish/osx-x64 /p:PlaywrightPlatform=osx
+        dotnet publish src/docfx -f net8.0 -c Release /p:Version=${GITHUB_REF_NAME#v} --self-contained -r win-x64 -o drop/publish/win-x64
+        dotnet publish src/docfx -f net8.0 -c Release /p:Version=${GITHUB_REF_NAME#v} --self-contained -r linux-x64 -o drop/publish/linux-x64
+        dotnet publish src/docfx -f net8.0 -c Release /p:Version=${GITHUB_REF_NAME#v} --self-contained -r osx-x64 -o drop/publish/osx-x64
         mkdir -p drop/bin
 
     - run: zip -r ../../bin/docfx-win-x64-${GITHUB_REF_NAME}.zip .

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -59,4 +59,12 @@
     </PackageReference>
   </ItemGroup>
 
+
+  <!-- Remove Node.js runtime dependencies that used by playwright -->
+  <Target Name="RemoveNodeJsRuntimes" AfterTargets="CopyPlaywrightFilesToOutput">
+    <ItemGroup>
+      <Content Remove="@(Content)" Condition="$([System.String]::Copy('%(Content.PlaywrightFolder)').Contains('node\'))" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/docs/reference/docfx-environment-variables-reference.md
+++ b/docs/reference/docfx-environment-variables-reference.md
@@ -27,3 +27,8 @@ This setting is intended to be used on offline environment.
 ## `DOCFX_PDF_TIMEOUT`
 
 Maximum time in milliseconds to override the default [Playwright timeout](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout) for PDF generation.
+
+## `PLAYWRIGHT_NODEJS_PATH`
+
+Custom Node.js executable path that will be used by the `docfx pdf' command.
+By default, docfx automatically detect installed Node.js from `PATH`.

--- a/src/Docfx.App/Docfx.App.csproj
+++ b/src/Docfx.App/Docfx.App.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="docfx" />
     <InternalsVisibleTo Include="docfx.Tests" />
+    <InternalsVisibleTo Include="docfx.Snapshot.Tests" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Docfx.App/Helpers/PlaywrightHelper.cs
+++ b/src/Docfx.App/Helpers/PlaywrightHelper.cs
@@ -25,7 +25,7 @@ internal static class PlaywrightHelper
             throw new DocfxException("Node.js executable is not found. Try to install Node.js or set the `PLAYWRIGHT_NODEJS_PATH` environment variable.");
         }
 
-        Logger.LogInfo($"Using custom Node.js {nodeVersion} executable.");
+        Logger.LogInfo($"Using Node.js {nodeVersion} executable.");
         Logger.LogVerbose($"Path: {exePath}");
 
         Environment.SetEnvironmentVariable("PLAYWRIGHT_NODEJS_PATH", exePath, EnvironmentVariableTarget.Process);

--- a/src/Docfx.App/Helpers/PlaywrightHelper.cs
+++ b/src/Docfx.App/Helpers/PlaywrightHelper.cs
@@ -1,0 +1,80 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using Docfx.Common;
+using Docfx.Exceptions;
+
+#nullable enable
+
+namespace Docfx;
+
+internal static class PlaywrightHelper
+{
+    public static void EnsurePlaywrightNodeJsPath()
+    {
+        // Skip if playwright environment variable exists.
+        if (Environment.GetEnvironmentVariable("PLAYWRIGHT_DRIVER_SEARCH_PATH") != null)
+            return;
+
+        if (Environment.GetEnvironmentVariable("PLAYWRIGHT_NODEJS_PATH") != null)
+            return;
+
+        if (!TryFindNodeExecutable(out var exePath, out var nodeVersion))
+        {
+            throw new DocfxException("Node.js executable is not found. Try to install Node.js or set the `PLAYWRIGHT_NODEJS_PATH` environment variable.");
+        }
+
+        Logger.LogInfo($"Using custom Node.js {nodeVersion} executable.");
+        Logger.LogVerbose($"Path: {exePath}");
+
+        Environment.SetEnvironmentVariable("PLAYWRIGHT_NODEJS_PATH", exePath, EnvironmentVariableTarget.Process);
+    }
+
+    private static bool TryFindNodeExecutable(out string exePath, out string nodeVersion)
+    {
+        // Find Node.js executable installation path from PATHs.
+        string exeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "node.exe" : "node";
+
+        var pathEnv = Environment.GetEnvironmentVariable("PATH");
+        if (pathEnv == null)
+            throw new DocfxException("Failed to get `PATH` environment variable.");
+
+        var paths = pathEnv.Split(Path.PathSeparator);
+        foreach (var path in paths)
+        {
+            string fullPath = Path.GetFullPath(Path.Combine(path, exeName));
+
+            if (File.Exists(fullPath))
+            {
+                exePath = fullPath;
+                nodeVersion = GetNodeVersion(exePath);
+                return true;
+            }
+        }
+
+        exePath = "";
+        nodeVersion = "";
+        return false;
+    }
+
+    /// <summary>
+    /// Returns `node --version` command result
+    /// </summary>
+    private static string GetNodeVersion(string exePath)
+    {
+        using var memoryStream = new MemoryStream();
+        using var stdoutWriter = new StreamWriter(memoryStream);
+
+        var exitCode = CommandUtility.RunCommand(new CommandInfo { Name = exePath, Arguments = "--version" }, stdoutWriter);
+
+        if (exitCode != 0)
+            return "";
+
+        stdoutWriter.Flush();
+        memoryStream.Position = 0;
+
+        using var streamReader = new StreamReader(memoryStream);
+        return streamReader.ReadLine() ?? "";
+    }
+}

--- a/src/Docfx.App/PdfBuilder.cs
+++ b/src/Docfx.App/PdfBuilder.cs
@@ -47,6 +47,11 @@ static class PdfBuilder
         public string? pdfFooterTemplate { get; init; }
     }
 
+    static PdfBuilder()
+    {
+        PlaywrightHelper.EnsurePlaywrightNodeJsPath();
+    }
+
     public static Task Run(BuildJsonConfig config, string configDirectory, string? outputDirectory = null)
     {
         var outputFolder = Path.GetFullPath(Path.Combine(

--- a/test/docfx.Snapshot.Tests/PercyTest.cs
+++ b/test/docfx.Snapshot.Tests/PercyTest.cs
@@ -38,6 +38,7 @@ public class PercyTest
 
     static PercyTest()
     {
+        PlaywrightHelper.EnsurePlaywrightNodeJsPath();
         Microsoft.Playwright.Program.Main(["install", "chromium"]);
     }
 


### PR DESCRIPTION
This PR intended to resolve #9396.

**Background**

Playwright `1.41` or later supports following environment variables. (It's not documented though)

- `PLAYWRIGHT_NODEJS_PATH`
- `PLAYWRIGHT_DRIVER_SEARCH_PATH`

So it can remove Node.js runtime from `docfx` package.
Instead.  it can use locally installed Node.js runtime instead. 

By this changes. `docfx` packages size can be reduced from `208MB` -> `56 MB`

**BREAKING CHANGES**
This PR remove `Node.js` runtime bundles.
So it may introduce **breaking changes** for some users who using docfx without Node.js installation.
(e.g. docker image users)

I'll try to fix official docker image later.
https://github.com/dotnet/docfx/blob/main/Dockerfile
