### PR TITLE
chore: Change generated HTML encoding to UTF-8N (without BOM)

### DIFF
--- a/src/Docfx.Build/PostProcessors/HtmlPostProcessor.cs
+++ b/src/Docfx.Build/PostProcessors/HtmlPostProcessor.cs
@@ -13,6 +13,8 @@ namespace Docfx.Build.Engine;
 
 sealed class HtmlPostProcessor : IPostProcessor
 {
+    private static readonly UTF8Encoding Utf8EncodingWithoutBom = new(false);
+
     public List<IHtmlDocumentHandler> Handlers { get; } = new List<IHtmlDocumentHandler>();
 
     private bool _handlerInitialized;
@@ -79,7 +81,7 @@ sealed class HtmlPostProcessor : IPostProcessor
             }
             using (var stream = EnvironmentContext.FileAbstractLayer.Create(tuple.OutputFile))
             {
-                document.Save(stream, Encoding.UTF8);
+                document.Save(stream, Utf8EncodingWithoutBom);
             }
         }
         foreach (var handler in Handlers)


### PR DESCRIPTION
This PR intended to fix #9545.

Currently docfx generates UTF-8 encoded HTML files with BOM.
This PR change output file encoding to UTF-8N (without BOM)

This change introduce **BREAKING CHANGES** for some users who depends on BOM.
But it' required for consistency. (Because docfx template files are already using UTF-8N).
