### PR TITLE
feat: UseClrTypeNames: new option to indicate that the output must use the CLR  type names instead of the language specific aliases

### DIFF
--- a/docs/reference/docfx-cli-reference/docfx-metadata.md
+++ b/docs/reference/docfx-cli-reference/docfx-metadata.md
@@ -95,6 +95,15 @@ Run `docfx metadata --help` or `docfx -h` to get a list of all available options
   - `SeparatePages`
     - Place members in separate pages.
 
+- **--useClrTypeNames**
+
+  Indicates whether the CLR type names or the language aliases must be used.
+
+    - not specified or `false`
+        - The language aliases are used: `int`.
+    - `true`
+        - The CLR type names are used: `Int32`.
+
 ## Examples
 
 - Generate YAML files with default config.
@@ -102,4 +111,3 @@ Run `docfx metadata --help` or `docfx -h` to get a list of all available options
 ```pwsh
 docfx metadata
 ```
-

--- a/schemas/docfx.schema.json
+++ b/schemas/docfx.schema.json
@@ -688,6 +688,11 @@
             "type": "boolean",
             "default": false,
             "description": "When enabled, continues documentation generation in case of compilation errors."
+          },
+          "useClrTypeNames": {
+            "type": "boolean",
+            "default": false,
+            "description": "When enabled, use CLR type names instead of language aliases."
           }
         }
       }

--- a/src/Docfx.Dotnet/DotnetApiCatalog.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.cs
@@ -148,6 +148,8 @@ public static partial class DotnetApiCatalog
         var expandedFiles = GlobUtility.ExpandFileMapping(EnvironmentContext.BaseDirectory, projects);
         var expandedReferences = GlobUtility.ExpandFileMapping(EnvironmentContext.BaseDirectory, references);
 
+        ExtractMetadataConfig.UseClrTypeNames = configModel?.UseClrTypeNames ?? false;
+
         return new ExtractMetadataConfig
         {
             ShouldSkipMarkup = configModel?.ShouldSkipMarkup ?? false,

--- a/src/Docfx.Dotnet/ManagedReference/ExtractMetadataConfig.cs
+++ b/src/Docfx.Dotnet/ManagedReference/ExtractMetadataConfig.cs
@@ -42,4 +42,7 @@ internal class ExtractMetadataConfig
     public Dictionary<string, string> MSBuildProperties { get; init; }
 
     public bool AllowCompilationErrors { get; init; }
+
+    public static bool UseClrTypeNames { get; set; }
+
 }

--- a/src/Docfx.Dotnet/MetadataJsonConfig.cs
+++ b/src/Docfx.Dotnet/MetadataJsonConfig.cs
@@ -258,6 +258,13 @@ internal class MetadataJsonItemConfig
     [JsonProperty("allowCompilationErrors")]
     [JsonPropertyName("allowCompilationErrors")]
     public bool AllowCompilationErrors { get; set; }
+
+    /// <summary>
+    ///   When enabled, the types uses the CLR type names instead of the C# aliases.
+    /// </summary>
+    [JsonProperty("useClrTypeNames")]
+    [JsonPropertyName("useClrTypeNames")]
+    public bool UseClrTypeNames { get; init; }
 }
 
 /// <summary>

--- a/src/Docfx.Dotnet/SymbolFormatter.Syntax.cs
+++ b/src/Docfx.Dotnet/SymbolFormatter.Syntax.cs
@@ -38,8 +38,10 @@ partial class SymbolFormatter
                 SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier |
                 SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers |
                 SymbolDisplayMiscellaneousOptions.AllowDefaultLiteral |
-                SymbolDisplayMiscellaneousOptions.UseSpecialTypes |
-                SymbolDisplayMiscellaneousOptions.RemoveAttributeSuffix,
+                SymbolDisplayMiscellaneousOptions.RemoveAttributeSuffix |
+                (ExtractMetadataConfig.UseClrTypeNames
+                    ? SymbolDisplayMiscellaneousOptions.None
+                    : SymbolDisplayMiscellaneousOptions.UseSpecialTypes),
             localOptions: SymbolDisplayLocalOptions.IncludeType,
             propertyStyle: SymbolDisplayPropertyStyle.ShowReadWriteDescriptor,
             delegateStyle: SymbolDisplayDelegateStyle.NameAndSignature,
@@ -47,8 +49,13 @@ partial class SymbolFormatter
             typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypes);
 
         private static readonly SymbolDisplayFormat s_syntaxTypeNameFormat = new(
-            genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
-            miscellaneousOptions: SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier | SymbolDisplayMiscellaneousOptions.UseSpecialTypes,
+            genericsOptions:
+                SymbolDisplayGenericsOptions.IncludeTypeParameters,
+            miscellaneousOptions:
+                SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier |
+                (ExtractMetadataConfig.UseClrTypeNames
+                    ? SymbolDisplayMiscellaneousOptions.None
+                    : SymbolDisplayMiscellaneousOptions.UseSpecialTypes),
             typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypes);
 
         private static readonly SymbolDisplayFormat s_syntaxEnumConstantFormat = s_syntaxFormat

--- a/src/Docfx.Dotnet/SymbolFormatter.cs
+++ b/src/Docfx.Dotnet/SymbolFormatter.cs
@@ -9,10 +9,19 @@ namespace Docfx.Dotnet;
 internal static partial class SymbolFormatter
 {
     private static readonly SymbolDisplayFormat s_nameFormat = new(
-        memberOptions: SymbolDisplayMemberOptions.IncludeParameters | SymbolDisplayMemberOptions.IncludeExplicitInterface,
-        genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
-        parameterOptions: SymbolDisplayParameterOptions.IncludeType,
-        miscellaneousOptions: SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier | SymbolDisplayMiscellaneousOptions.AllowDefaultLiteral | SymbolDisplayMiscellaneousOptions.UseSpecialTypes,
+        memberOptions:
+            SymbolDisplayMemberOptions.IncludeParameters |
+            SymbolDisplayMemberOptions.IncludeExplicitInterface,
+        genericsOptions:
+            SymbolDisplayGenericsOptions.IncludeTypeParameters,
+        parameterOptions:
+            SymbolDisplayParameterOptions.IncludeType,
+        miscellaneousOptions:
+            SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier |
+            SymbolDisplayMiscellaneousOptions.AllowDefaultLiteral |
+            (ExtractMetadataConfig.UseClrTypeNames
+                ? SymbolDisplayMiscellaneousOptions.None
+                : SymbolDisplayMiscellaneousOptions.UseSpecialTypes),
         extensionMethodStyle: SymbolDisplayExtensionMethodStyle.StaticMethod);
 
     private static readonly SymbolDisplayFormat s_nameWithTypeFormat = s_nameFormat


### PR DESCRIPTION
The option can be set in `docfx.json`configuration file, under the `metadata` object.

If the option is not set or its value is `false`, docfx works as usual: the output uses the language aliases.
For example, in C#, it displays `int`.

If the option value is `true`, docfx output will use the CLR type names.
For example, in C#, it displays `Int32`.