### PR TITLE
fix incorrect as usages

### DIFF
--- a/src/Docfx.Build.ManagedReference/SplitClassPageToMemberLevel.cs
+++ b/src/Docfx.Build.ManagedReference/SplitClassPageToMemberLevel.cs
@@ -90,7 +90,7 @@ public class SplitClassPageToMemberLevel : BaseDocumentBuildStep
 
     private static void RenewDupeFileModels(FileModel dupeModel, Dictionary<string, int> newFilePaths, Dictionary<string, FileModel> modelsDict)
     {
-        var page = dupeModel.Content as PageViewModel;
+        var page = (PageViewModel)dupeModel.Content;
         var memberType = page.Items[0]?.Type;
         var newFileName = Path.GetFileNameWithoutExtension(dupeModel.File);
 

--- a/src/Docfx.Common/FileModelParser.cs
+++ b/src/Docfx.Common/FileModelParser.cs
@@ -16,7 +16,7 @@ internal static class FileModelParser
         }
         else if (item.Type == JTokenType.Property)
         {
-            JProperty jProperty = item as JProperty;
+            JProperty jProperty = (JProperty)item;
             FileMappingItem model = new() { Name = jProperty.Name };
             var value = jProperty.Value;
             if (value.Type == JTokenType.Array)


### PR DESCRIPTION
better to have an informative cast exception on the correct line, instead of a null ref on the incorrect line