### PR TITLE
remove redundant finalizers

### DIFF
--- a/src/Docfx.Common/ResourcePools/ResourcePoolManager.cs
+++ b/src/Docfx.Common/ResourcePools/ResourcePoolManager.cs
@@ -52,29 +52,11 @@ public class ResourcePoolManager<TResource>
         }
     }
 
-    #region IDisposable
-
     public void Dispose()
     {
-        Dispose(true);
-        GC.SuppressFinalize(this);
-    }
-
-    ~ResourcePoolManager()
-    {
-        Dispose(false);
-    }
-
-    protected virtual void Dispose(bool disposing)
-    {
-        if (disposing)
+        foreach (var resource in _resources)
         {
-            foreach (var resource in _resources)
-            {
-                (resource as IDisposable)?.Dispose();
-            }
+            (resource as IDisposable)?.Dispose();
         }
     }
-
-    #endregion
 }

--- a/src/Docfx.DataContracts.Common/ExternalReferences/ExternalReferencePackageCollection.cs
+++ b/src/Docfx.DataContracts.Common/ExternalReferences/ExternalReferencePackageCollection.cs
@@ -49,37 +49,13 @@ public class ExternalReferencePackageCollection : IDisposable
         return false;
     }
 
-    #region IDisposable Support
-
-    private bool disposedValue = false;
-
-    protected virtual void Dispose(bool disposing)
-    {
-        if (!disposedValue)
-        {
-            if (disposing)
-            {
-                foreach (var reader in Readers)
-                {
-                    reader.Dispose();
-                }
-            }
-            disposedValue = true;
-        }
-    }
-
-    ~ExternalReferencePackageCollection()
-    {
-        Dispose(false);
-    }
-
     public void Dispose()
     {
-        Dispose(true);
-        GC.SuppressFinalize(this);
+        foreach (var reader in Readers)
+        {
+            reader.Dispose();
+        }
     }
-
-    #endregion
 
     private sealed class ReferenceViewModelCacheItem : IEquatable<ReferenceViewModelCacheItem>
     {

--- a/src/Docfx.DataContracts.Common/ExternalReferences/ExternalReferencePackageReader.cs
+++ b/src/Docfx.DataContracts.Common/ExternalReferences/ExternalReferencePackageReader.cs
@@ -137,36 +137,10 @@ public class ExternalReferencePackageReader : IDisposable
         return GetReferenceViewModels(index);
     }
 
-    #region IDisposable Support
-
-    private bool disposedValue = false;
-
-    protected virtual void Dispose(bool disposing)
-    {
-        if (!disposedValue)
-        {
-            if (disposing)
-            {
-                _zip.Dispose();
-            }
-            disposedValue = true;
-        }
-    }
-
-    ~ExternalReferencePackageReader()
-    {
-        // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-        Dispose(false);
-    }
-
-    // This code added to correctly implement the disposable pattern.
     public void Dispose()
     {
-        Dispose(true);
-        GC.SuppressFinalize(this);
+        _zip.Dispose();
     }
-
-    #endregion
 
     internal sealed class PackageEntry
     {

--- a/src/Docfx.Dotnet/SymbolUrlResolver.SourceLink.cs
+++ b/src/Docfx.Dotnet/SymbolUrlResolver.SourceLink.cs
@@ -115,7 +115,6 @@ partial class SymbolUrlResolver
 
         public void Dispose()
         {
-            GC.SuppressFinalize(this);
             _peReader.Dispose();
             _pdbReaderProvider.Dispose();
         }


### PR DESCRIPTION
finalizers should only be used when cleaning up unmanaged resources