### PR TITLE
chore: Enable multi process build

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -20,5 +20,5 @@ runs:
     shell: bash
     working-directory: templates
 
-  - run: dotnet build -c Release --warnAsError
+  - run: dotnet build -c Release --warnAsError --maxcpucount
     shell: bash


### PR DESCRIPTION
This PR enable build with **multiple MSBuild worker processes**.
by adding `maxcpucount` switch to `dotnet build` command.

**`-maxcpucount` switch**
https://learn.microsoft.com/en-us/visualstudio/msbuild/building-multiple-projects-in-parallel-with-msbuild?view=vs-2022#-maxcpucount-switch

---

GitHub Action have [multiple CPU cores](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
So by this changes. it's expected to reduce total build time on CI.

**Current CI Build Times**
Below are the current build times for reference.
I'll try to compare build times after this PR is merged to `main`.

| OS     | Total CI Time | `dotnet build` time  |
|--------|---------------|--------------------- |
|Windows | 9m31s         | 2.14m                |
|macos   | 6m20s         | 56.6s                |
|Ubuntu  | 11m32s        | 1m3s                 |

