### PR TITLE
chore: Reduce `dotnet test` log messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
       shell: bash
       working-directory: templates
 
-    - run: dotnet test -c Release -f net8.0 --no-build --collect:"XPlat Code Coverage"
+    - run: dotnet test -c Release -f net8.0 --no-build --collect:"XPlat Code Coverage" --consoleLoggerParameters:Summary;Verbosity=Minimal
 
-    - run: dotnet test -c Release -f net6.0 --no-build --collect:"XPlat Code Coverage"
+    - run: dotnet test -c Release -f net6.0 --no-build --collect:"XPlat Code Coverage" --consoleLoggerParameters:Summary;Verbosity=Minimal
       if: matrix.os == 'ubuntu-latest'
 
     - run: npm i -g @percy/cli


### PR DESCRIPTION
This PR change output log level of `dotnet test` commands.

Currently a lot of messages are outputted on `dotnet test` command.
And it's hard to find failed tests. (Need to grep `[FAIL]` from logs)

So this PR change MSBuild log level from `Normal` to `Minimal` (Output warnings/errors only)
And additionally output test results summary when test finished.

One problem of this PR is that **normal logs** are not output to the GitHub Actions logs.
If detailed test logs are needed in future.
It can be resolved by adding additional loggers (e.g. file logger or `trx` logger)