### PR TITLE
chore: Update docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,30 @@ FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim
 # Add dotnet tools to path.
 ENV PATH="${PATH}:/root/.dotnet/tools"
 
-# Install DocFX as a dotnet tool.
-RUN dotnet tool update -g docfx && \
-    docfx --version
+# Set target docfx version.
+ARG DOCFX_VERSION=2.77.0
 
-# Install dependences for chromium PDF.
+# Install DocFX as a dotnet tool.
+RUN dotnet tool install docfx -g --version ${DOCFX_VERSION} && \
+    docfx --version && \
+    rm  -f /root/.dotnet/tools/.store/docfx/${DOCFX_VERSION}/docfx/${DOCFX_VERSION}/docfx.nupkg                         && \
+    rm  -f /root/.dotnet/tools/.store/docfx/${DOCFX_VERSION}/docfx/${DOCFX_VERSION}/docfx.${DOCFX_VERSION}.nupkg        && \
+    rm -rf /root/.dotnet/tools/.store/docfx/${DOCFX_VERSION}/docfx/${DOCFX_VERSION}/tools/net6.0
+
+# Install Node.js and dependences for chromium PDF.
 RUN apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends \
+    nodejs \
     libglib2.0-0 libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
     libdbus-1-3 libxcb1 libxkbcommon0 libatspi2.0-0 libx11-6 libxcomposite1 libxdamage1 \
     libxext6 libxfixes3 libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2 && \
     rm -rf /var/lib/apt/lists/* /tmp/*
+
+# Install Chromium.
+RUN PLAYWRIGHT_NODEJS_PATH="/usr/bin/node" && \
+    ln -s /root/.dotnet/tools/.store/docfx/${DOCFX_VERSION}/docfx/${DOCFX_VERSION}/tools/.playwright /root/.dotnet/tools/.store/docfx/${DOCFX_VERSION}/docfx/${DOCFX_VERSION}/tools/net8.0/any/.playwright && \
+    pwsh -File /root/.dotnet/tools/.store/docfx/${DOCFX_VERSION}/docfx/${DOCFX_VERSION}/tools/net8.0/any/playwright.ps1 install chromium && \
+    unlink /root/.dotnet/tools/.store/docfx/${DOCFX_VERSION}/docfx/${DOCFX_VERSION}/tools/net8.0/any/.playwright
 
 WORKDIR /opt/prj
 VOLUME [ "/opt/prj" ]


### PR DESCRIPTION
This PR include following changes.

1. Specify install docfx version explicitly  
  Without this setting. Docker try to use `cached layer` if exists. In this case it need to manually clear cache.
2. Remove unused files to reduce docker image size
  2.1. `.nupkg` files
  2.2. Executables for .NET 6 
3. Additional Node.js installation (Required for #10066)
4. Pre-Install Chromium browser  

Note:  By `#10066`) changes. directory structures are not matched to `playwright.ps1` expecting structure.
So It need to create **temporary** symlink to run `playwright.ps1`.