### PR TITLE
chore: Fix CI build error on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
       shell: bash
       working-directory: templates
 
-    - run: dotnet test -c Release -f net8.0 --no-build --collect:"XPlat Code Coverage" --consoleLoggerParameters:Summary;Verbosity=Minimal
+    - run: dotnet test -c Release -f net8.0 --no-build --collect:"XPlat Code Coverage" --consoleLoggerParameters:"Summary;Verbosity=Minimal"
 
-    - run: dotnet test -c Release -f net6.0 --no-build --collect:"XPlat Code Coverage" --consoleLoggerParameters:Summary;Verbosity=Minimal
+    - run: dotnet test -c Release -f net6.0 --no-build --collect:"XPlat Code Coverage" --consoleLoggerParameters:"Summary;Verbosity=Minimal"
       if: matrix.os == 'ubuntu-latest'
 
     - run: npm i -g @percy/cli


### PR DESCRIPTION
This PR fix CI build problems that introduced by #10092

On Windows CI environment.
Following error is occurred after PR is merged to `main` branch`.
```
 … at Code Coverage" --consoleLoggerParameters:Summary;Verbosity=Minimal
     |                                                        ~~~~~~~~~~~~~~~~~
     | The term 'Verbosity=Minimal' is not recognized as a name of a cmdlet, function, script file, or executable
     | program. Check the spelling of the name, or if a path was included, verify that the path is correct and try
     | again.
```

This PR add **quote** to parameter to avoid command parse problems on pwsh.