### PR TITLE
chore: Add CI logs artifacts and failed test reports

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -20,5 +20,5 @@ runs:
     shell: bash
     working-directory: templates
 
-  - run: dotnet build -c Release --warnAsError --maxcpucount
+  - run: dotnet build -c Release --warnAsError --maxcpucount --binaryLogger
     shell: bash

--- a/.github/actions/report-failed-tests/action.yml
+++ b/.github/actions/report-failed-tests/action.yml
@@ -1,0 +1,27 @@
+name: Report failed tests
+description: Report failed tests
+runs:
+  using: "composite"
+  steps:
+  - name: Report failed tests
+    shell: pwsh
+    run: |
+      $trxFiles = Get-ChildItem test -Filter *.trx -Recurse
+      $failedTests = @()
+      foreach($trxFile in $trxFiles)
+      {
+        [xml]$trx = Get-Content $trxFile -Raw
+        if($trx.TestRun.ResultSummary.outcome -eq 'Failed')
+        {
+          $failedTests += $trx.TestRun.Results.UnitTestResult | where { $_.outcome -eq 'Failed' }
+        }
+      }
+
+      if($failedTests.Length -gt 0)
+      {
+        Write-Output "## Failed Tests" >> $env:GITHUB_STEP_SUMMARY
+        foreach($failedTest in $failedTests)
+        {
+          Write-Output "<details><summary>$($failedTest.testName)</summary><pre>$($failedTest.Output.ErrorInfo.Message)`nStackTrace:`n"$($failedTest.Output.ErrorInfo.StackTrace)"</pre></details>" >> $env:GITHUB_STEP_SUMMARY
+        }
+      }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,11 @@ jobs:
       working-directory: templates
 
     - run: dotnet test -c Release -f net8.0 --no-build --collect:"XPlat Code Coverage" --consoleLoggerParameters:"Summary;Verbosity=Minimal"
+      id: test-net80
 
     - run: dotnet test -c Release -f net6.0 --no-build --collect:"XPlat Code Coverage" --consoleLoggerParameters:"Summary;Verbosity=Minimal"
       if: matrix.os == 'ubuntu-latest'
+      id: test-net60
 
     - run: npm i -g @percy/cli
       if: matrix.os == 'ubuntu-latest'
@@ -54,12 +56,26 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       with:
         path: docs/_site
-  
+
+    - name: Upload Logs
+      uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: logs-${{ matrix.os }}
+        path: |
+          msbuild.binlog
+          test/**/TestResults/*.trx
+          test/**/TestResults/*.html
+
     - uses: actions/upload-artifact@v4
       if: ${{ failure() && matrix.os == 'ubuntu-latest' }}
       with:
         name: dump
         path: /tmp/coredump*
+
+    - name: Report failed tests
+      if: ${{ failure() && (steps.test-net80.outcome == 'failure' || steps.test-net60.outcome == 'failure') }}
+      uses: ./.github/actions/report-failed-tests
 
   publish-docs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,12 @@ jobs:
     - uses: ./.github/actions/build
 
     - name: dotnet test
+      id: test-net90
       run: dotnet test -c Release -f net9.0 --no-build
+
+    - name: Report failed tests
+      if: ${{ failure() && steps.test-net90.outcome == 'failure' }}
+      uses: ./.github/actions/report-failed-tests
     
     - name: dotnet pack
       run: dotnet pack -c Release /p:Version=${{ steps.version.outputs.version }} /p:ApiCompatGenerateSuppressionFile=true -o drop/nuget

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ _site_pdf
 docs/api
 samples/**/api
 src/Docfx.App/templates
+test/**/TestResults
 
 *.user
 *.log

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -18,6 +18,12 @@
     <None Include="TestData\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">
+    <VSTestResultsDirectory>$(MSBuildThisFileDirectory)TestResults</VSTestResultsDirectory>
+    <VSTestLogger>$(VSTestLogger);trx%3BLogFileName=TestResults-$(MSBuildProjectName)-$(TargetFramework).trx</VSTestLogger>
+    <VSTestLogger>$(VSTestLogger);html%3BLogFileName=TestResults-$(MSBuildProjectName)-$(TargetFramework).html</VSTestLogger>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This PR add following features for CI.

- Add `Logs` artifacts that contains following files.
  - Binary log of  `dotnet build` command (`msbuild.binlog`)
  - `dotnet test` command test results (`trx` and `html`)
- Report `Failed Tests` to GitHub job summary.

**Example logs artifacts & failed test reports**
https://github.com/filzrev/docfx/actions/runs/9898236420