### PR TITLE
chore: Fix build error on .NET 9 SDK preview6

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,6 +23,8 @@
     <PackageVersion Include="Stubble.Core" Version="1.10.8" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="System.Composition" Version="8.0.0" />
+    <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
     <PackageVersion Include="YamlDotNet" Version="15.3.0" />
   </ItemGroup>
 

--- a/src/Docfx.Common/Docfx.Common.csproj
+++ b/src/Docfx.Common/Docfx.Common.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="Spectre.Console" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Docfx.Dotnet/Docfx.Dotnet.csproj
+++ b/src/Docfx.Dotnet/Docfx.Dotnet.csproj
@@ -34,6 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Formats.Asn1" />
     <PackageReference Include="HtmlAgilityPack" />
     <PackageReference Include="ICSharpCode.Decompiler" />
     <PackageReference Include="IgnoresAccessChecksToGenerator" PrivateAssets="All" />

--- a/test/Docfx.Build.Tests/XRefMapDownloaderTest.cs
+++ b/test/Docfx.Build.Tests/XRefMapDownloaderTest.cs
@@ -12,9 +12,6 @@ public class XRefMapDownloadTest
     [Fact(Skip = "Flaky SSL connection problems on GH windows CI")]
     public async Task BaseUrlIsSet()
     {
-        // GitHub doesn't support TLS 1.1 since Feb 23, 2018. See: https://github.com/blog/2507-weak-cryptographic-standards-removed
-        ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-
         var downloader = new XRefMapDownloader();
         var xrefs = await downloader.DownloadAsync(new Uri("https://dotnet.github.io/docfx/xrefmap.yml")) as XRefMap;
         Assert.NotNull(xrefs);


### PR DESCRIPTION
On recent nightly CI build.
Build failed with following errors.

1.  error NU1903: Package 'System.Text.Json' 8.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-hh2w-p6rv-4g7w
2. error NU1903: Package 'System.Formats.Asn1' 7.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-447r-wph3-92pm
3. error SYSLIB0014: 'ServicePointManager' is obsolete: 'WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead. Settings on ServicePointManager no longer affect SslStream or HttpClient.' (https://aka.ms/dotnet-warnings/SYSLIB0014) 

For NU1903 warnings. Packages are transitively referenced by other NuGet packages.
So adding explicit NuGet reference to projects.
