### PR TITLE
chore: Modify nightly build workflow and add status badges

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,6 +41,7 @@ jobs:
       run: dotnet pack -c Release /p:Version=${{ steps.version.outputs.version }} /p:ApiCompatGenerateSuppressionFile=true -o drop/nuget
 
     - name: dotnet nuget push
+      if: github.repository == 'dotnet/docfx'
       run: |
         dotnet nuget push drop/nuget/*.nupkg --api-key "${{ secrets.GITHUB_TOKEN }}" --skip-duplicate --source https://nuget.pkg.github.com/dotnet/index.json
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Build your docs with docfx
 
 [![NuGet](https://img.shields.io/nuget/v/docfx)](https://www.nuget.org/packages/docfx)
+[![ci](https://github.com/dotnet/docfx/actions/workflows/ci.yml/badge.svg)](https://github.com/dotnet/docfx/actions/workflows/ci.yml)
+[![nightly](https://github.com/dotnet/docfx/actions/workflows/nightly.yml/badge.svg)](https://github.com/dotnet/docfx/actions/workflows/nightly.yml)
 [![Help Wanted](https://img.shields.io/github/issues/dotnet/docfx/help-wanted?label=help-wanted)](https://github.com/dotnet/docfx/labels/help-wanted)
 
 * [Getting Started](#getting-started)


### PR DESCRIPTION
This PR include following changes.
- Skip `dotnet nuget push` steps when it's executed on forked repository.
- Add status badges for CI/Nightly Build.