### PR TITLE
chore: Add `type` property to TOC schema

### DIFF
--- a/schemas/toc.schema.json
+++ b/schemas/toc.schema.json
@@ -82,6 +82,10 @@
           "default": 0,
           "description": "Specify the order of toc item, TOCs with a smaller order value are picked first."
         },
+        "type": {
+          "type": "string",
+          "description": "Specify the type of toc item."
+        },
         "items": {
           "type": "array",
           "description": "List of TOC items.",


### PR DESCRIPTION
This PR adding `type` property to TOC schema. (that introduced by #10090)

