### PR TITLE
fix: missing delegate group name

### DIFF
--- a/templates/default/toc.html.primary.js
+++ b/templates/default/toc.html.primary.js
@@ -56,6 +56,7 @@ function transformMemberPage(model) {
       "enum":        { key: "enumsInSubtitle" },
       "interface":   { key: "interfacesInSubtitle" },
       "namespace":   { key: "namespacesInSubtitle" },
+      "delegate":    { key: "delegatesInSubtitle" },
   };
 
   groupChildren(model);

--- a/templates/default/toc.json.js
+++ b/templates/default/toc.json.js
@@ -41,6 +41,7 @@ exports.transform = function (model) {
         "enum":        { key: "enumsInSubtitle" },
         "interface":   { key: "interfacesInSubtitle" },
         "namespace":   { key: "namespacesInSubtitle" },
+        "delegate":    { key: "delegatesInSubtitle" },
     };
   
     groupChildren(model);


### PR DESCRIPTION
As part of #10090 `type` was introduced to the TOC.
However I've missed the `delegate` group name.

There's other names that are not present, but I think they are never exposed to the TOC?

* Variable
* Function
* Type Alias
* Member