### PR TITLE
chore: Add logger methods

### DIFF
--- a/src/Docfx.Common/Loggers/CompositeLogListener.cs
+++ b/src/Docfx.Common/Loggers/CompositeLogListener.cs
@@ -39,6 +39,14 @@ public class CompositeLogListener : ILoggerListener
         }
     }
 
+    public IEnumerable<ILoggerListener> GetAllListeners()
+    {
+        lock (_sync)
+        {
+            return _listeners.ToArray();
+        }
+    }
+
     public ILoggerListener FindListener(Predicate<ILoggerListener> predicate)
     {
         ArgumentNullException.ThrowIfNull(predicate);

--- a/src/Docfx.Common/Loggers/Logger.cs
+++ b/src/Docfx.Common/Loggers/Logger.cs
@@ -27,6 +27,18 @@ public static class Logger
         _syncListener.AddListener(listener);
     }
 
+    public static void RegisterListeners(IEnumerable<ILoggerListener> listeners)
+    {
+        ArgumentNullException.ThrowIfNull(listeners);
+
+        _syncListener.AddListeners(listeners);
+    }
+
+    public static IEnumerable<ILoggerListener> GetAllListeners()
+    {
+        return _syncListener.GetAllListeners();
+    }
+
     public static ILoggerListener FindListener(Predicate<ILoggerListener> predicate)
     {
         ArgumentNullException.ThrowIfNull(predicate);
@@ -171,6 +183,13 @@ public static class Logger
         AnsiConsole.WriteLine($"    {_warningCount} warning(s)");
         AnsiConsole.Foreground = _errorCount > 0 ? ConsoleColor.Red : ConsoleColor.White;
         AnsiConsole.WriteLine($"    {_errorCount} error(s)\n");
+    }
+
+    public static void ResetCount()
+    {
+        _warningCount = 0;
+        _errorCount = 0;
+        HasError = false;
     }
 
     class LogItem : ILogItem

--- a/test/docfx.Tests/Api.verified.cs
+++ b/test/docfx.Tests/Api.verified.cs
@@ -1696,6 +1696,7 @@ namespace Docfx.Common
         public void Dispose() { }
         public Docfx.Common.ILoggerListener FindListener(System.Predicate<Docfx.Common.ILoggerListener> predicate) { }
         public void Flush() { }
+        public System.Collections.Generic.IEnumerable<Docfx.Common.ILoggerListener> GetAllListeners() { }
         public void RemoveAllListeners() { }
         public void RemoveListener(Docfx.Common.ILoggerListener listener) { }
         public void WriteLine(Docfx.Common.ILogItem item) { }
@@ -1887,6 +1888,7 @@ namespace Docfx.Common
         public static int WarningCount { get; }
         public static Docfx.Common.ILoggerListener FindListener(System.Predicate<Docfx.Common.ILoggerListener> predicate) { }
         public static void Flush() { }
+        public static System.Collections.Generic.IEnumerable<Docfx.Common.ILoggerListener> GetAllListeners() { }
         public static Docfx.Common.ILogItem GetLogItem(Docfx.Common.LogLevel level, string message, string phase = null, string file = null, string line = null, string code = null) { }
         public static void Log(object result) { }
         public static void Log(Docfx.Common.LogLevel level, string message, string phase = null, string file = null, string line = null, string code = null) { }
@@ -1898,6 +1900,8 @@ namespace Docfx.Common
         public static void LogWarning(string message, string phase = null, string file = null, string line = null, string code = null) { }
         public static void PrintSummary() { }
         public static void RegisterListener(Docfx.Common.ILoggerListener listener) { }
+        public static void RegisterListeners(System.Collections.Generic.IEnumerable<Docfx.Common.ILoggerListener> listeners) { }
+        public static void ResetCount() { }
         public static void UnregisterAllListeners() { }
         public static void UnregisterListener(Docfx.Common.ILoggerListener listener) { }
     }


### PR DESCRIPTION
This PR contains following changes.

## 1. Add  `ResetCount` method to `Logger` class.

When running build with **multiple** times (e.g. `docfx watch` command). warning/error counts are accumulated.
Currently  it seems no way to reset these counters.

## 2.  Add `GetAllListeners`/`RegisterListeners` to `Logger`/`CompositeLogListener` class

These methods are required to **temporary** replace LogListeners.

