### PR TITLE
feat: add `AllowUnsafeBlocks` supports for source code based metadata generation

### DIFF
--- a/docs/reference/docfx-json-reference.md
+++ b/docs/reference/docfx-json-reference.md
@@ -397,6 +397,13 @@ Specifies an optional set of MSBuild properties used when interpreting project f
 > [!Note]
 > Make sure to specify `"TargetFramework": <one of the frameworks>` in your docfx.json when the project is targeting for multiple platforms.
 
+> [!Note]
+> When generating metadata from source code files.
+> Supported properties are limited to the following.
+>   - `DefineConstants`
+>   - `AllowUnsafeBlocks`
+> If other properties are specified. These properties are ignored silently.
+
 ### `noRestore`
 
 Do not run `dotnet restore` before building the projects.

--- a/src/Docfx.Dotnet/CompilationHelper.cs
+++ b/src/Docfx.Dotnet/CompilationHelper.cs
@@ -62,7 +62,7 @@ internal static class CompilationHelper
 
         return CS.CSharpCompilation.Create(
             assemblyName: null,
-            options: new CS.CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, xmlReferenceResolver: XmlFileResolver.Default),
+            options: GetCSharpCompilationOptions(msbuildProperties),
             syntaxTrees: syntaxTrees,
             references: GetDefaultMetadataReferences("C#").Concat(references));
     }
@@ -74,7 +74,7 @@ internal static class CompilationHelper
 
         return CS.CSharpCompilation.Create(
             name,
-            options: new CS.CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, xmlReferenceResolver: XmlFileResolver.Default),
+            options: GetCSharpCompilationOptions(msbuildProperties),
             syntaxTrees: [syntaxTree],
             references: GetDefaultMetadataReferences("C#").Concat(references ?? []));
     }
@@ -86,7 +86,7 @@ internal static class CompilationHelper
 
         return VB.VisualBasicCompilation.Create(
             assemblyName: null,
-            options: new VB.VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, globalImports: GetVBGlobalImports(), xmlReferenceResolver: XmlFileResolver.Default),
+            options: GetVisualBasicCompilationOptions(msbuildProperties),
             syntaxTrees: syntaxTrees,
             references: GetDefaultMetadataReferences("VB").Concat(references));
     }
@@ -98,7 +98,7 @@ internal static class CompilationHelper
 
         return VB.VisualBasicCompilation.Create(
             name,
-            options: new VB.VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, globalImports: GetVBGlobalImports(), xmlReferenceResolver: XmlFileResolver.Default),
+            options: GetVisualBasicCompilationOptions(msbuildProperties),
             syntaxTrees: [syntaxTree],
             references: GetDefaultMetadataReferences("VB").Concat(references ?? []));
     }
@@ -230,5 +230,27 @@ internal static class CompilationHelper
         }
 
         return new VB.VisualBasicParseOptions(preprocessorSymbols: preprocessorSymbols);
+    }
+
+    private static CS.CSharpCompilationOptions GetCSharpCompilationOptions(IDictionary<string, string> msbuildProperties)
+    {
+        var options = new CS.CSharpCompilationOptions(
+            OutputKind.DynamicallyLinkedLibrary,
+            xmlReferenceResolver: XmlFileResolver.Default);
+
+        if (msbuildProperties.TryGetValue("AllowUnsafeBlocks", out var valueText) && bool.TryParse(valueText, out var allowUnsafe))
+        {
+            options = options.WithAllowUnsafe(allowUnsafe);
+        }
+
+        return options;
+    }
+
+    private static VB.VisualBasicCompilationOptions GetVisualBasicCompilationOptions(IDictionary<string, string> msbuildProperties)
+    {
+        return new VB.VisualBasicCompilationOptions(
+            OutputKind.DynamicallyLinkedLibrary,
+            globalImports: GetVBGlobalImports(),
+            xmlReferenceResolver: XmlFileResolver.Default);
     }
 }


### PR DESCRIPTION
This PR intended to fix #10174.

When generating metadata from **source files**.
MSBuild properties  need to be mapped to  related property. 

Currently `DefineConstants` is supported.
This PR add `AllowUnsafeBlocks` property support for C# source build (VB don't support `unsafe`)
