### PR TITLE
chore: Fix code formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -141,7 +141,8 @@ csharp_prefer_simple_using_statement = false:none                       # IDE006
 csharp_using_directive_placement = outside_namespace:suggestion         # IDE0065: using directive placement
 
 # File header preferences
-file_header_template = unset                                            # IDE0073: Require file header
+dotnet_diagnostic.IDE0073.severity = warning                            # IDE0073: Require file header
+file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.
 
 # Namespace naming preferences
 dotnet_style_namespace_match_folder = true:suggestion                   # IDE0130: Namespace does not match folder structure

--- a/src/Docfx.App/Docfx.App.csproj
+++ b/src/Docfx.App/Docfx.App.csproj
@@ -15,7 +15,7 @@
     <InternalsVisibleTo Include="docfx.Tests" />
     <InternalsVisibleTo Include="docfx.Snapshot.Tests" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <InternalsAssemblyName Include="UglyToad.PdfPig" />
   </ItemGroup>

--- a/src/Docfx.App/Helpers/MetadataMerger.cs
+++ b/src/Docfx.App/Helpers/MetadataMerger.cs
@@ -31,11 +31,11 @@ internal class MetadataMerger
         }
         parameters.Metadata ??= ImmutableDictionary<string, object>.Empty;
 
-            Directory.CreateDirectory(parameters.OutputBaseDir);
-            Logger.LogInfo("Start merge metadata...");
-            MergePageViewModel(parameters);
-            MergeToc(parameters);
-            Logger.LogInfo("Merge metadata completed.");
+        Directory.CreateDirectory(parameters.OutputBaseDir);
+        Logger.LogInfo("Start merge metadata...");
+        MergePageViewModel(parameters);
+        MergeToc(parameters);
+        Logger.LogInfo("Merge metadata completed.");
     }
 
     private void MergePageViewModel(MetadataMergeParameters parameters)

--- a/src/Docfx.Build.Common/Docfx.Build.Common.csproj
+++ b/src/Docfx.Build.Common/Docfx.Build.Common.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\Docfx.Common\Docfx.Common.csproj" />
     <ProjectReference Include="..\Docfx.DataContracts.Common\Docfx.DataContracts.Common.csproj" />

--- a/src/Docfx.Build.ManagedReference/Docfx.Build.ManagedReference.csproj
+++ b/src/Docfx.Build.ManagedReference/Docfx.Build.ManagedReference.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\Docfx.Build.Common\Docfx.Build.Common.csproj" />
     <ProjectReference Include="..\Docfx.Common\Docfx.Common.csproj" />

--- a/src/Docfx.Build.OverwriteDocuments/Docfx.Build.OverwriteDocuments.csproj
+++ b/src/Docfx.Build.OverwriteDocuments/Docfx.Build.OverwriteDocuments.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="Markdig" />
   </ItemGroup>

--- a/src/Docfx.Build.RestApi/Docfx.Build.RestApi.csproj
+++ b/src/Docfx.Build.RestApi/Docfx.Build.RestApi.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\Docfx.Build.Common\Docfx.Build.Common.csproj" />
     <ProjectReference Include="..\Docfx.Common\Docfx.Common.csproj" />

--- a/src/Docfx.Build.TagLevelRestApi/Docfx.Build.TagLevelRestApi.csproj
+++ b/src/Docfx.Build.TagLevelRestApi/Docfx.Build.TagLevelRestApi.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.Build.Common\Docfx.Build.Common.csproj" />
     <ProjectReference Include="..\..\src\Docfx.Common\Docfx.Common.csproj" />

--- a/src/Docfx.Build.UniversalReference/Docfx.Build.UniversalReference.csproj
+++ b/src/Docfx.Build.UniversalReference/Docfx.Build.UniversalReference.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\Docfx.Build.Common\Docfx.Build.Common.csproj" />
     <ProjectReference Include="..\Docfx.Common\Docfx.Common.csproj" />

--- a/src/Docfx.Build/ApiPage/ApiPageProcessor.cs
+++ b/src/Docfx.Build/ApiPage/ApiPageProcessor.cs
@@ -46,7 +46,7 @@ class ApiPageDocumentProcessor(IMarkdownService markdownService) : IDocumentProc
             foreach (var (key, value) in data.metadata.OrderBy(item => item.Key))
                 content[key] = value.Value;
         }
-        
+
         content["title"] = data.title;
         content["content"] = ApiPageHtmlTemplate.Render(data, Markup).ToString();
         content["yamlmime"] = "ApiPage";

--- a/src/Docfx.Build/ManifestUtility.cs
+++ b/src/Docfx.Build/ManifestUtility.cs
@@ -40,8 +40,8 @@ static class ManifestUtility
         ArgumentNullException.ThrowIfNull(manifests);
 
         var xrefMaps = (from manifest in manifests
-                                where manifest.Xrefmap != null
-                                select manifest.Xrefmap).ToList();
+                        where manifest.Xrefmap != null
+                        select manifest.Xrefmap).ToList();
         var manifestGroupInfos = (from manifest in manifests
                                   from g in manifest.Groups ?? Enumerable.Empty<ManifestGroupInfo>()
                                   select g).ToList();

--- a/src/Docfx.Build/OneOfJsonConverterFactory.cs
+++ b/src/Docfx.Build/OneOfJsonConverterFactory.cs
@@ -3,8 +3,8 @@
 
 using System.Diagnostics;
 using System.Reflection;
-using System.Text.Json.Serialization;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using OneOf;
 
 #nullable enable

--- a/src/Docfx.Build/ResourceFiles/IResourceFileConfig.cs
+++ b/src/Docfx.Build/ResourceFiles/IResourceFileConfig.cs
@@ -1,4 +1,7 @@
-﻿namespace Docfx.Build.ResourceFiles;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Docfx.Build.ResourceFiles;
 
 public interface IResourceFileConfig
 {

--- a/src/Docfx.Build/TableOfContents/MarkdownTocReader.cs
+++ b/src/Docfx.Build/TableOfContents/MarkdownTocReader.cs
@@ -1,4 +1,7 @@
-﻿using System.Text.RegularExpressions;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.RegularExpressions;
 using Docfx.Common;
 using Docfx.DataContracts.Common;
 using Docfx.Plugins;

--- a/src/Docfx.Build/TableOfContents/TocResolver.cs
+++ b/src/Docfx.Build/TableOfContents/TocResolver.cs
@@ -125,9 +125,9 @@ class TocResolver
                 if (item.Items != null && item.Items.Count > 0)
                 {
                     item.Items = new List<TocItemViewModel>(from i in item.Items
-                                                  select ResolveItem(new TocItemInfo(file, i), stack) into r
-                                                  where r != null
-                                                  select r.Content);
+                                                            select ResolveItem(new TocItemInfo(file, i), stack) into r
+                                                            where r != null
+                                                            select r.Content);
                     if (string.IsNullOrEmpty(item.TopicHref) && string.IsNullOrEmpty(item.TopicUid))
                     {
                         var defaultItem = GetDefaultHomepageItem(item);

--- a/src/Docfx.Build/TemplateProcessors/Preprocessors/JintProcessorHelper.cs
+++ b/src/Docfx.Build/TemplateProcessors/Preprocessors/JintProcessorHelper.cs
@@ -23,7 +23,7 @@ public static class JintProcessorHelper
         {
             // allow Jint to take ownership of the array
             var elements = new JsValue[list.Count];
-            for (int i = 0; i < (uint) elements.Length; i++)
+            for (int i = 0; i < (uint)elements.Length; i++)
             {
                 elements[i] = ConvertObjectToJsValue(engine, list[i]);
             }

--- a/src/Docfx.Common/ConvertToObjectHelper.cs
+++ b/src/Docfx.Common/ConvertToObjectHelper.cs
@@ -3,9 +3,8 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
-
-using Newtonsoft.Json.Linq;
 using System.Runtime.CompilerServices;
+using Newtonsoft.Json.Linq;
 
 namespace Docfx.Common;
 

--- a/src/Docfx.Common/EntityMergers/IMergeContext.cs
+++ b/src/Docfx.Common/EntityMergers/IMergeContext.cs
@@ -1,4 +1,7 @@
-﻿namespace Docfx.Common.EntityMergers;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Docfx.Common.EntityMergers;
 
 public interface IMergeContext
 {

--- a/src/Docfx.Common/EntityMergers/IMergeHandler.cs
+++ b/src/Docfx.Common/EntityMergers/IMergeHandler.cs
@@ -1,4 +1,7 @@
-﻿namespace Docfx.Common.EntityMergers;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Docfx.Common.EntityMergers;
 
 public interface IMergeHandler
 {

--- a/src/Docfx.Common/EntityMergers/MergeContext.cs
+++ b/src/Docfx.Common/EntityMergers/MergeContext.cs
@@ -1,4 +1,7 @@
-﻿namespace Docfx.Common.EntityMergers;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Docfx.Common.EntityMergers;
 
 internal sealed class MergeContext : IMergeContext
 {

--- a/src/Docfx.Common/EntityMergers/MergePlacement.cs
+++ b/src/Docfx.Common/EntityMergers/MergePlacement.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.\r
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 

--- a/src/Docfx.Common/EntityMergers/ReflectionEntityMerger.cs
+++ b/src/Docfx.Common/EntityMergers/ReflectionEntityMerger.cs
@@ -92,10 +92,10 @@ public class ReflectionEntityMerger : IMerger
                     placement =
                         placementValue switch
                         {
-                            "after"   => MergePlacement.After,
-                            "before"  => MergePlacement.Before,
+                            "after" => MergePlacement.After,
+                            "before" => MergePlacement.Before,
                             "replace" => MergePlacement.Replace,
-                            _         => MergePlacement.None
+                            _ => MergePlacement.None
                         };
                 }
             }
@@ -117,8 +117,8 @@ public class ReflectionEntityMerger : IMerger
 
                     s = placement switch
                     {
-                        MergePlacement.After   => $"{s}{o}",
-                        MergePlacement.Before  => $"{o}{s}",
+                        MergePlacement.After => $"{s}{o}",
+                        MergePlacement.Before => $"{o}{s}",
                         MergePlacement.Replace => o.ToString()
                     };
 

--- a/src/Docfx.Common/IItemWithMetadata.cs
+++ b/src/Docfx.Common/IItemWithMetadata.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.\r
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 

--- a/src/Docfx.Common/LruList.cs
+++ b/src/Docfx.Common/LruList.cs
@@ -1,4 +1,7 @@
-﻿namespace Docfx.Common;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Docfx.Common;
 
 public class LruList<T>
 {

--- a/src/Docfx.Common/Path/PathUtility.cs
+++ b/src/Docfx.Common/Path/PathUtility.cs
@@ -71,7 +71,7 @@ public static class PathUtility
 
         if (toUri.IsFile && !toUri.OriginalString.StartsWith("file://", StringComparison.InvariantCultureIgnoreCase))
         {
-           return Path.GetRelativePath(basePath, absolutePath).BackSlashToForwardSlash();
+            return Path.GetRelativePath(basePath, absolutePath).BackSlashToForwardSlash();
         }
 
         Uri relativeUri = fromUri.MakeRelativeUri(toUri);

--- a/src/Docfx.DataContracts.Common/Docfx.DataContracts.Common.csproj
+++ b/src/Docfx.DataContracts.Common/Docfx.DataContracts.Common.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\Docfx.Common\Docfx.Common.csproj" />
   </ItemGroup>

--- a/src/Docfx.DataContracts.Common/ExternalReferences/ExternalReferencePackageCollection.cs
+++ b/src/Docfx.DataContracts.Common/ExternalReferences/ExternalReferencePackageCollection.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Immutable;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
 
 using Docfx.Common;
 

--- a/src/Docfx.DataContracts.RestApi/Docfx.DataContracts.RestApi.csproj
+++ b/src/Docfx.DataContracts.RestApi/Docfx.DataContracts.RestApi.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\Docfx.DataContracts.Common\Docfx.DataContracts.Common.csproj" />
     <ProjectReference Include="..\Docfx.Common\Docfx.Common.csproj" />

--- a/src/Docfx.DataContracts.UniversalReference/Docfx.DataContracts.UniversalReference.csproj
+++ b/src/Docfx.DataContracts.UniversalReference/Docfx.DataContracts.UniversalReference.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\Docfx.Common\Docfx.Common.csproj" />
     <ProjectReference Include="..\Docfx.YamlSerialization\Docfx.YamlSerialization.csproj" />

--- a/src/Docfx.Dotnet/CompilationHelper.cs
+++ b/src/Docfx.Dotnet/CompilationHelper.cs
@@ -109,8 +109,8 @@ internal static class CompilationHelper
         var compilation = CS.CSharpCompilation.Create(
             assemblyName: null,
             options: new CS.CSharpCompilationOptions(
-                outputKind            : OutputKind.DynamicallyLinkedLibrary,
-                metadataImportOptions : includePrivateMembers
+                outputKind: OutputKind.DynamicallyLinkedLibrary,
+                metadataImportOptions: includePrivateMembers
                     ? MetadataImportOptions.All
                     : MetadataImportOptions.Public
             ),

--- a/src/Docfx.Dotnet/DotnetApiCatalog.Toc.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.Toc.cs
@@ -263,7 +263,7 @@ partial class DotnetApiCatalog
 
                     // Insert category as text label.
                     case CategoryLayout.Flattened:
-                    default:                    
+                    default:
                         {
                             if (items.FirstOrDefault(i => i.type == type) is { } node)
                                 items.Insert(items.IndexOf(node), new() { name = name });

--- a/src/Docfx.Dotnet/ManagedReference/Models/AdditionalNotes.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Models/AdditionalNotes.cs
@@ -10,13 +10,13 @@ using YamlDotNet.Serialization;
 namespace Docfx.DataContracts.ManagedReference;
 
 public class AdditionalNotes
-{   
+{
     [YamlMember(Alias = "caller")]
     [JsonProperty("caller")]
     [JsonPropertyName("caller")]
     [MarkdownContent]
     public string Caller { get; set; }
-        
+
     [YamlMember(Alias = "implementer")]
     [JsonProperty("implementer")]
     [JsonPropertyName("implementer")]

--- a/src/Docfx.Dotnet/ManagedReference/Visitors/SymbolVisitorAdapter.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Visitors/SymbolVisitorAdapter.cs
@@ -96,7 +96,7 @@ internal class SymbolVisitorAdapter : SymbolVisitor<MetadataItem>
             {
                 { SyntaxLanguage.Default, symbol.MetadataName },
             },
-                DisplayQualifiedNames = new SortedList<SyntaxLanguage, string>
+            DisplayQualifiedNames = new SortedList<SyntaxLanguage, string>
             {
                 { SyntaxLanguage.Default, symbol.MetadataName },
             },
@@ -185,7 +185,7 @@ internal class SymbolVisitorAdapter : SymbolVisitor<MetadataItem>
             var member in symbol.GetMembers()
             .Where(static s =>
                 s is not INamedTypeSymbol
-                && ! s.Name.StartsWith('<')
+                && !s.Name.StartsWith('<')
                 && (s is not IMethodSymbol ms || ms.MethodKind != MethodKind.StaticConstructor)
             ))
         {

--- a/src/Docfx.Dotnet/Parsers/XHtmlWriter.cs
+++ b/src/Docfx.Dotnet/Parsers/XHtmlWriter.cs
@@ -1,4 +1,7 @@
-﻿using System.Xml;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Xml;
 
 /// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.

--- a/src/Docfx.Dotnet/Parsers/XmlComment.cs
+++ b/src/Docfx.Dotnet/Parsers/XmlComment.cs
@@ -374,9 +374,9 @@ internal class XmlComment
 
                 if (detailedInfo.Length == 0 && node is XDocument doc)
                 {
-                    var memberName = (string) doc.Element("member")?.Attribute("name");
+                    var memberName = (string)doc.Element("member")?.Attribute("name");
 
-                    if (! string.IsNullOrEmpty(memberName))
+                    if (!string.IsNullOrEmpty(memberName))
                     {
                         detailedInfo.Append(", member name is ");
                         detailedInfo.Append(memberName);

--- a/src/Docfx.Dotnet/SourceLink/PortableCustomDebugInfoKinds.cs
+++ b/src/Docfx.Dotnet/SourceLink/PortableCustomDebugInfoKinds.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.CodeAnalysis.Debugging;
 

--- a/src/Docfx.Dotnet/SourceLink/SourceLinkMap.cs
+++ b/src/Docfx.Dotnet/SourceLink/SourceLinkMap.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.ObjectModel;
 using System.Diagnostics;

--- a/src/Docfx.Dotnet/SourceLink/SymbolSourceDocumentFinder.cs
+++ b/src/Docfx.Dotnet/SourceLink/SymbolSourceDocumentFinder.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;

--- a/src/Docfx.Dotnet/SymbolFormatter.Symbols.cs
+++ b/src/Docfx.Dotnet/SymbolFormatter.Symbols.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Immutable;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;

--- a/src/Docfx.Dotnet/SymbolFormatter.Syntax.cs
+++ b/src/Docfx.Dotnet/SymbolFormatter.Syntax.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Immutable;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
 using Docfx.DataContracts.ManagedReference;
 using Microsoft.CodeAnalysis;
 using CS = Microsoft.CodeAnalysis.CSharp;

--- a/src/Docfx.Dotnet/SymbolFormatter.cs
+++ b/src/Docfx.Dotnet/SymbolFormatter.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Immutable;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
 using Docfx.DataContracts.ManagedReference;
 using Microsoft.CodeAnalysis;
 using CS = Microsoft.CodeAnalysis.CSharp;

--- a/src/Docfx.Dotnet/SymbolHelper.cs
+++ b/src/Docfx.Dotnet/SymbolHelper.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 
 #nullable enable

--- a/src/Docfx.Dotnet/SymbolUrlResolver.Langword.cs
+++ b/src/Docfx.Dotnet/SymbolUrlResolver.Langword.cs
@@ -1,4 +1,7 @@
-﻿#nullable enable
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
 
 using System.Text.Json;
 

--- a/src/Docfx.Dotnet/SymbolUrlResolver.MSLearn.cs
+++ b/src/Docfx.Dotnet/SymbolUrlResolver.MSLearn.cs
@@ -1,4 +1,7 @@
-﻿using System.Text;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
 using Microsoft.CodeAnalysis;
 
 #nullable enable

--- a/src/Docfx.Dotnet/SymbolUrlResolver.MSLearnAssemblies.cs
+++ b/src/Docfx.Dotnet/SymbolUrlResolver.MSLearnAssemblies.cs
@@ -1,4 +1,7 @@
-﻿using System.Text.Json;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
 
 namespace Docfx.Dotnet;
 

--- a/src/Docfx.Dotnet/SymbolUrlResolver.SourceLink.cs
+++ b/src/Docfx.Dotnet/SymbolUrlResolver.SourceLink.cs
@@ -1,4 +1,7 @@
-﻿using System.Reflection.Metadata;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;

--- a/src/Docfx.Dotnet/SymbolUrlResolver.cs
+++ b/src/Docfx.Dotnet/SymbolUrlResolver.cs
@@ -1,4 +1,7 @@
-﻿using System.Text.RegularExpressions;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 
 #nullable enable

--- a/src/Docfx.Glob/Docfx.Glob.csproj
+++ b/src/Docfx.Glob/Docfx.Glob.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\Docfx.Common\Docfx.Common.csproj" />
   </ItemGroup>

--- a/src/Docfx.Glob/GlobMatcher.cs
+++ b/src/Docfx.Glob/GlobMatcher.cs
@@ -728,7 +728,7 @@ public class GlobMatcher : IEquatable<GlobMatcher>
         }
     }
 
-        private sealed class GlobRegexItem
+    private sealed class GlobRegexItem
     {
         public static readonly GlobRegexItem GlobStar = new(GlobRegexItemType.GlobStar);
         public static readonly GlobRegexItem GlobStarForFileOnly = new(GlobRegexItemType.GlobStarForFileOnly);

--- a/src/Docfx.MarkdigEngine.Extensions/Docfx.MarkdigEngine.Extensions.csproj
+++ b/src/Docfx.MarkdigEngine.Extensions/Docfx.MarkdigEngine.Extensions.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="Markdig" />
     <PackageReference Include="Newtonsoft.Json" />

--- a/src/Docfx.MarkdigEngine.Extensions/MarkdigExtensionSettingConverter.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/MarkdigExtensionSettingConverter.cs
@@ -1,8 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Newtonsoft.Json.Linq;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Docfx.MarkdigEngine.Extensions;
 

--- a/src/Docfx.MarkdigEngine.Extensions/Noloc/NolocInline.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/Noloc/NolocInline.cs
@@ -1,4 +1,6 @@
-﻿
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using Markdig.Syntax.Inlines;
 
 namespace Docfx.MarkdigEngine.Extensions;

--- a/src/Docfx.MarkdigEngine.Extensions/Noloc/NolocParser.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/Noloc/NolocParser.cs
@@ -1,4 +1,6 @@
-﻿
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using Markdig.Helpers;
 using Markdig.Parsers;
 

--- a/src/Docfx.MarkdigEngine.Extensions/Noloc/NolocRender.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/Noloc/NolocRender.cs
@@ -1,4 +1,6 @@
-﻿
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
 

--- a/src/Docfx.MarkdigEngine.Extensions/PlantUml/PlantUmlCodeBlockRenderer.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/PlantUml/PlantUmlCodeBlockRenderer.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
 using Markdig.Syntax;

--- a/src/Docfx.MarkdigEngine.Extensions/PlantUml/PlantUmlCodeBlockRenderer.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/PlantUml/PlantUmlCodeBlockRenderer.cs
@@ -1,9 +1,8 @@
-using static System.Text.Encoding;
-
 using Markdig.Renderers;
-using Markdig.Syntax;
 using Markdig.Renderers.Html;
+using Markdig.Syntax;
 using PlantUml.Net;
+using static System.Text.Encoding;
 
 namespace Docfx.MarkdigEngine.Extensions;
 

--- a/src/Docfx.MarkdigEngine.Extensions/PlantUml/PlantUmlExtension.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/PlantUml/PlantUmlExtension.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Text.Json.Serialization;
 using Markdig;
 using Markdig.Renderers;

--- a/src/Docfx.MarkdigEngine/Docfx.MarkdigEngine.csproj
+++ b/src/Docfx.MarkdigEngine/Docfx.MarkdigEngine.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="Markdig" />
     <PackageReference Include="Newtonsoft.Json" />

--- a/src/Docfx.MarkdigEngine/MarkdigMarkdownService.cs
+++ b/src/Docfx.MarkdigEngine/MarkdigMarkdownService.cs
@@ -49,7 +49,7 @@ public class MarkdigMarkdownService : IMarkdownService
 #if NET7_0_OR_GREATER
         ArgumentException.ThrowIfNullOrEmpty(filePath);
 #else
-        if(string.IsNullOrEmpty(filePath))
+        if (string.IsNullOrEmpty(filePath))
             throw new ArgumentNullException(nameof(filePath));
 #endif
 

--- a/src/Docfx.Plugins/Docfx.Plugins.csproj
+++ b/src/Docfx.Plugins/Docfx.Plugins.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="Newtonsoft.Json" />

--- a/src/Docfx.Plugins/DocumentException.cs
+++ b/src/Docfx.Plugins/DocumentException.cs
@@ -1,4 +1,7 @@
-﻿namespace Docfx.Plugins;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Docfx.Plugins;
 
 public class DocumentException : Exception
 {

--- a/src/Docfx.Plugins/DocumentExceptionExtensions.cs
+++ b/src/Docfx.Plugins/DocumentExceptionExtensions.cs
@@ -1,4 +1,7 @@
-﻿namespace Docfx.Plugins;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Docfx.Plugins;
 
 public static class DocumentExceptionExtensions
 {

--- a/src/Docfx.Plugins/DocumentExceptionExtensions.cs
+++ b/src/Docfx.Plugins/DocumentExceptionExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.ExceptionServices;
+
 namespace Docfx.Plugins;
 
 public static class DocumentExceptionExtensions

--- a/src/Docfx.Plugins/XRefSpec.cs
+++ b/src/Docfx.Plugins/XRefSpec.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
 
 namespace Docfx.Plugins;
 

--- a/src/Docfx.YamlSerialization/Docfx.YamlSerialization.csproj
+++ b/src/Docfx.YamlSerialization/Docfx.YamlSerialization.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="YamlDotNet" />
   </ItemGroup>

--- a/src/Docfx.YamlSerialization/TypeInspectors/EmitTypeInspector.cs
+++ b/src/Docfx.YamlSerialization/TypeInspectors/EmitTypeInspector.cs
@@ -184,8 +184,8 @@ public class EmitTypeInspector : ExtensibleTypeInspectorSkeleton
                 valueType = GetGenericValueTypeCore(propertyType);
             }
             valueType ??= (from t in propertyType.GetInterfaces()
-                 where t.IsVisible
-                 select GetGenericValueTypeCore(t)).FirstOrDefault(x => x != null);
+                           where t.IsVisible
+                           select GetGenericValueTypeCore(t)).FirstOrDefault(x => x != null);
             return valueType;
         }
 

--- a/src/Docfx.YamlSerialization/TypeInspectors/ExtensibleYamlAttributesTypeInspector.cs
+++ b/src/Docfx.YamlSerialization/TypeInspectors/ExtensibleYamlAttributesTypeInspector.cs
@@ -1,4 +1,7 @@
-﻿using YamlDotNet.Serialization;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using YamlDotNet.Serialization;
 
 namespace Docfx.YamlSerialization.TypeInspectors;
 

--- a/src/docfx/Models/InitCommand.cs
+++ b/src/docfx/Models/InitCommand.cs
@@ -69,10 +69,10 @@ class InitCommand : Command<InitCommandOptions>
         var files = new Dictionary<string, string>
         {
             ["docfx.json"] = JsonSerializer.Serialize(docfx, new JsonSerializerOptions()
-                {
-                    WriteIndented = true,
-                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-                }),
+            {
+                WriteIndented = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            }),
 
             ["toc.yml"] = dotnetApi ?
                 $"""

--- a/test/Docfx.Build.Common.Tests/Docfx.Build.Common.Tests.csproj
+++ b/test/Docfx.Build.Common.Tests/Docfx.Build.Common.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.Build.Common\Docfx.Build.Common.csproj" />
     <ProjectReference Include="..\..\src\Docfx.Build\Docfx.Build.csproj" />

--- a/test/Docfx.Build.ManagedReference.Tests/Docfx.Build.ManagedReference.Tests.csproj
+++ b/test/Docfx.Build.ManagedReference.Tests/Docfx.Build.ManagedReference.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.Build\Docfx.Build.csproj" />
     <ProjectReference Include="..\..\src\Docfx.Build.ManagedReference\Docfx.Build.ManagedReference.csproj" />

--- a/test/Docfx.Build.RestApi.Tests/Docfx.Build.RestApi.Tests.csproj
+++ b/test/Docfx.Build.RestApi.Tests/Docfx.Build.RestApi.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <None Include="TestData\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/test/Docfx.Build.SchemaDriven.Tests/Docfx.Build.SchemaDriven.Tests.csproj
+++ b/test/Docfx.Build.SchemaDriven.Tests/Docfx.Build.SchemaDriven.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.Build.Common\Docfx.Build.Common.csproj" />
     <ProjectReference Include="..\..\src\Docfx.Build\Docfx.Build.csproj" />

--- a/test/Docfx.Build.SchemaDriven.Tests/MergeMarkdownFragmentsTest.cs
+++ b/test/Docfx.Build.SchemaDriven.Tests/MergeMarkdownFragmentsTest.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Immutable;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
 using Docfx.Build.Engine;
 using Docfx.Common;
 using Docfx.Plugins;

--- a/test/Docfx.Build.Tests/Docfx.Build.Tests.csproj
+++ b/test/Docfx.Build.Tests/Docfx.Build.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <Compile Remove="TestData\snippets\dataflowdegreeofparallelism.cs" />
   </ItemGroup>

--- a/test/Docfx.Build.Tests/JintProcessorHelperTest.cs
+++ b/test/Docfx.Build.Tests/JintProcessorHelperTest.cs
@@ -1,4 +1,6 @@
-﻿
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using Docfx.Common;
 using Jint;
 using Xunit;

--- a/test/Docfx.Build.UniversalReference.Tests/Docfx.Build.UniversalReference.Tests.csproj
+++ b/test/Docfx.Build.UniversalReference.Tests/Docfx.Build.UniversalReference.Tests.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <None Include="TestData\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.Build\Docfx.Build.csproj" />
     <ProjectReference Include="..\..\src\Docfx.Build.UniversalReference\Docfx.Build.UniversalReference.csproj" />

--- a/test/Docfx.Common.Tests/Docfx.Common.Tests.csproj
+++ b/test/Docfx.Common.Tests/Docfx.Common.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.YamlSerialization\Docfx.YamlSerialization.csproj" />
     <ProjectReference Include="..\..\src\Docfx.Plugins\Docfx.Plugins.csproj" />

--- a/test/Docfx.Dotnet.Tests/Docfx.Dotnet.Tests.csproj
+++ b/test/Docfx.Dotnet.Tests/Docfx.Dotnet.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <None Include="TestDataReferences\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/test/Docfx.Glob.Tests/Docfx.Glob.Tests.csproj
+++ b/test/Docfx.Glob.Tests/Docfx.Glob.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.Glob\Docfx.Glob.csproj" />
     <ProjectReference Include="..\Docfx.Tests.Common\Docfx.Tests.Common.csproj" />

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/NolocTest.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/NolocTest.cs
@@ -1,4 +1,6 @@
-﻿
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using Xunit;
 
 namespace Docfx.MarkdigEngine.Tests;

--- a/test/Docfx.MarkdigEngine.Tests/Docfx.MarkdigEngine.Tests.csproj
+++ b/test/Docfx.MarkdigEngine.Tests/Docfx.MarkdigEngine.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.Build\Docfx.Build.csproj" />
     <ProjectReference Include="..\..\src\Docfx.MarkdigEngine.Extensions\Docfx.MarkdigEngine.Extensions.csproj" />

--- a/test/Docfx.MarkdigEngine.Tests/InclusionTest.cs
+++ b/test/Docfx.MarkdigEngine.Tests/InclusionTest.cs
@@ -13,11 +13,11 @@ namespace Docfx.MarkdigEngine.Tests;
 [Collection("docfx STA")]
 public class InclusionTest
 {
-        [Fact]
-        [Trait("Related", "Inclusion")]
-        public void TestBlockLevelInclusion_General()
-        {
-                var root = @"
+    [Fact]
+    [Trait("Related", "Inclusion")]
+    public void TestBlockLevelInclusion_General()
+    {
+        var root = @"
 # Hello World
 
 Test Include File
@@ -28,7 +28,7 @@ Test Include File
 
 ";
 
-                var refa = @"---
+        var refa = @"---
 title: include file
 description: include file
 ---
@@ -39,37 +39,37 @@ This is a file A included by another file. [!include[refb](b.md)] [!include[refb
 
 ";
 
-                var refb = @"---
+        var refb = @"---
 title: include file
 description: include file
 ---
 
 # Hello Include File B
 ";
-                TestUtility.WriteToFile("r/root.md", root);
-                TestUtility.WriteToFile("r/a.md", refa);
-                TestUtility.WriteToFile("r/b.md", refb);
+        TestUtility.WriteToFile("r/root.md", root);
+        TestUtility.WriteToFile("r/a.md", refa);
+        TestUtility.WriteToFile("r/b.md", refb);
 
-                var result = TestUtility.MarkupWithoutSourceInfo(root, "r/root.md");
-                var expected = @"<h1 id=""hello-world"">Hello World</h1>
+        var result = TestUtility.MarkupWithoutSourceInfo(root, "r/root.md");
+        var expected = @"<h1 id=""hello-world"">Hello World</h1>
 <p>Test Include File</p>
 <h1 id=""hello-include-file-a"">Hello Include File A</h1>
 <p>This is a file A included by another file. # Hello Include File B [!include<a href=""%7E/r/b.md"">refb</a> ]</p>
 
 <p>[!include<a href=""a.md"">refa</a> ]</p>
 ";
-                Assert.Equal(expected.Replace("\r\n", "\n"), result.Html);
+        Assert.Equal(expected.Replace("\r\n", "\n"), result.Html);
 
-                var dependency = result.Dependency;
-                var expectedDependency = new List<string> { "a.md", "b.md" };
-                Assert.Equal(expectedDependency.ToImmutableList(), dependency);
-        }
+        var dependency = result.Dependency;
+        var expectedDependency = new List<string> { "a.md", "b.md" };
+        Assert.Equal(expectedDependency.ToImmutableList(), dependency);
+    }
 
-        [Fact]
-        [Trait("Related", "IncludeFile")]
-        public void TestBlockLevelInclusion_Escape()
-        {
-                var root = @"
+    [Fact]
+    [Trait("Related", "IncludeFile")]
+    public void TestBlockLevelInclusion_Escape()
+    {
+        var root = @"
 # Hello World
 
 Test Include File
@@ -78,33 +78,33 @@ Test Include File
 
 ";
 
-                var refa = @"
+        var refa = @"
 # Hello Include File A
 
 This is a file A included by another file.
 ";
 
-                TestUtility.WriteToFile("r/root.md", root);
-                TestUtility.WriteToFile("r/a(x).md", refa);
+        TestUtility.WriteToFile("r/root.md", root);
+        TestUtility.WriteToFile("r/a(x).md", refa);
 
-                var result = TestUtility.MarkupWithoutSourceInfo(root, "r/root.md");
-                var expected = @"<h1 id=""hello-world"">Hello World</h1>
+        var result = TestUtility.MarkupWithoutSourceInfo(root, "r/root.md");
+        var expected = @"<h1 id=""hello-world"">Hello World</h1>
 <p>Test Include File</p>
 <h1 id=""hello-include-file-a"">Hello Include File A</h1>
 <p>This is a file A included by another file.</p>
 ";
-                Assert.Equal(expected.Replace("\r\n", "\n"), result.Html);
+        Assert.Equal(expected.Replace("\r\n", "\n"), result.Html);
 
-                var dependency = result.Dependency;
-                var expectedDependency = new List<string> { "a(x).md" };
-                Assert.Equal(expectedDependency.ToImmutableList(), dependency);
-        }
+        var dependency = result.Dependency;
+        var expectedDependency = new List<string> { "a(x).md" };
+        Assert.Equal(expectedDependency.ToImmutableList(), dependency);
+    }
 
-        [Fact]
-        [Trait("Related", "Inclusion")]
-        public void TestBlockLevelInclusion_RelativePath()
-        {
-                var root = @"
+    [Fact]
+    [Trait("Related", "Inclusion")]
+    public void TestBlockLevelInclusion_RelativePath()
+    {
+        var root = @"
 # Hello World
 
 Test Include File
@@ -113,33 +113,33 @@ Test Include File
 
 ";
 
-                var refa = @"
+        var refa = @"
 # Hello Include File A
 
 This is a file A included by another file.
 ";
 
-                TestUtility.WriteToFile("r/root.md", root);
-                TestUtility.WriteToFile("r/a.md", refa);
+        TestUtility.WriteToFile("r/root.md", root);
+        TestUtility.WriteToFile("r/a.md", refa);
 
-                var result = TestUtility.MarkupWithoutSourceInfo(root, "r/root.md");
-                var expected = @"<h1 id=""hello-world"">Hello World</h1>
+        var result = TestUtility.MarkupWithoutSourceInfo(root, "r/root.md");
+        var expected = @"<h1 id=""hello-world"">Hello World</h1>
 <p>Test Include File</p>
 <h1 id=""hello-include-file-a"">Hello Include File A</h1>
 <p>This is a file A included by another file.</p>
 ";
-                Assert.Equal(expected.Replace("\r\n", "\n"), result.Html);
+        Assert.Equal(expected.Replace("\r\n", "\n"), result.Html);
 
-                var dependency = result.Dependency;
-                var expectedDependency = new List<string> { "a.md" };
-                Assert.Equal(expectedDependency.ToImmutableList(), dependency);
-        }
+        var dependency = result.Dependency;
+        var expectedDependency = new List<string> { "a.md" };
+        Assert.Equal(expectedDependency.ToImmutableList(), dependency);
+    }
 
-        [Fact]
-        [Trait("Related", "Inclusion")]
-        public void TestBlockLevelInclusion_CycleInclude()
-        {
-                var root = @"
+    [Fact]
+    [Trait("Related", "Inclusion")]
+    public void TestBlockLevelInclusion_CycleInclude()
+    {
+        var root = @"
 # Hello World
 
 Test Include File
@@ -148,7 +148,7 @@ Test Include File
 
 ";
 
-                var refa = @"
+        var refa = @"
 # Hello Include File A
 
 This is a file A included by another file.
@@ -157,37 +157,37 @@ This is a file A included by another file.
 
 ";
 
-                var refb = @"
+        var refb = @"
 # Hello Include File B
 
 [!include[refa](a.md)]
 ";
-                TestUtility.WriteToFile("r/root.md", root);
-                TestUtility.WriteToFile("r/a.md", refa);
-                TestUtility.WriteToFile("r/b.md", refb);
+        TestUtility.WriteToFile("r/root.md", root);
+        TestUtility.WriteToFile("r/a.md", refa);
+        TestUtility.WriteToFile("r/b.md", refb);
 
-                var listener = new TestLoggerListener();
-                Logger.RegisterListener(listener);
-                var result = TestUtility.MarkupWithoutSourceInfo(root, "r/root.md");
-                var expected = @"<h1 id=""hello-world"">Hello World</h1>
+        var listener = new TestLoggerListener();
+        Logger.RegisterListener(listener);
+        var result = TestUtility.MarkupWithoutSourceInfo(root, "r/root.md");
+        var expected = @"<h1 id=""hello-world"">Hello World</h1>
 <p>Test Include File</p>
 <h1 id=""hello-include-file-a"">Hello Include File A</h1>
 <p>This is a file A included by another file.</p>
 <h1 id=""hello-include-file-b"">Hello Include File B</h1>
 [!include[refa](a.md)]";
 
-                Assert.Equal(expected.Replace("\r\n", "\n"), result.Html);
-                Logger.UnregisterListener(listener);
-                Assert.Collection(listener.Items, log => Assert.Equal(
-                    "Build has identified file(s) referencing each other: 'r/root.md' --> '~/r/a.md' --> '~/r/b.md' --> '~/r/a.md'",
-                    log.Message));
-        }
+        Assert.Equal(expected.Replace("\r\n", "\n"), result.Html);
+        Logger.UnregisterListener(listener);
+        Assert.Collection(listener.Items, log => Assert.Equal(
+            "Build has identified file(s) referencing each other: 'r/root.md' --> '~/r/a.md' --> '~/r/b.md' --> '~/r/a.md'",
+            log.Message));
+    }
 
-        [Fact]
-        [Trait("Related", "Inclusion")]
-        public void TestInlineLevelInclusion_General()
-        {
-                var root = @"
+    [Fact]
+    [Trait("Related", "Inclusion")]
+    public void TestInlineLevelInclusion_General()
+    {
+        var root = @"
 # Hello World
 
 Test Inline Included File: \\[!include[refa](~/r/a.md)].
@@ -195,122 +195,122 @@ Test Inline Included File: \\[!include[refa](~/r/a.md)].
 Test Escaped Inline Included File: \[!include[refa](~/r/a.md)].
 ";
 
-                var refa = "This is a **included** token";
+        var refa = "This is a **included** token";
 
-                TestUtility.WriteToFile("r/root.md", root);
-                TestUtility.WriteToFile("r/a.md", refa);
+        TestUtility.WriteToFile("r/root.md", root);
+        TestUtility.WriteToFile("r/a.md", refa);
 
-                var result = TestUtility.MarkupWithoutSourceInfo(root, "r/root.md"); ;
-                var expected = @"<h1 id=""hello-world"">Hello World</h1>
+        var result = TestUtility.MarkupWithoutSourceInfo(root, "r/root.md"); ;
+        var expected = @"<h1 id=""hello-world"">Hello World</h1>
 <p>Test Inline Included File: \This is a <strong>included</strong> token.</p>
 <p>Test Escaped Inline Included File: [!include<a href=""%7E/r/a.md"">refa</a>].</p>
 ";
-                Assert.Equal(expected.Replace("\r\n", "\n"), result.Html);
+        Assert.Equal(expected.Replace("\r\n", "\n"), result.Html);
 
-                var dependency = result.Dependency;
-                var expectedDependency = new List<string> { "a.md" };
-                Assert.Equal(expectedDependency.ToImmutableList(), dependency);
-        }
+        var dependency = result.Dependency;
+        var expectedDependency = new List<string> { "a.md" };
+        Assert.Equal(expectedDependency.ToImmutableList(), dependency);
+    }
 
-        [Fact]
-        [Trait("Related", "Inclusion")]
-        public void TestInlineLevelInclusion_CycleInclude()
-        {
-                var root = @"
+    [Fact]
+    [Trait("Related", "Inclusion")]
+    public void TestInlineLevelInclusion_CycleInclude()
+    {
+        var root = @"
 # Hello World
 
 Test Inline Included File: [!include[refa](~/r/a.md)].
 
 ";
 
-                var refa = "This is a **included** token with [!include[root](~/r/root.md)]";
+        var refa = "This is a **included** token with [!include[root](~/r/root.md)]";
 
-                TestUtility.WriteToFile("r/root.md", root);
-                TestUtility.WriteToFile("r/a.md", refa);
+        TestUtility.WriteToFile("r/root.md", root);
+        TestUtility.WriteToFile("r/a.md", refa);
 
-                var result = TestUtility.MarkupWithoutSourceInfo(root, "r/root.md");
-                var expected = @"<h1 id=""hello-world"">Hello World</h1>
+        var result = TestUtility.MarkupWithoutSourceInfo(root, "r/root.md");
+        var expected = @"<h1 id=""hello-world"">Hello World</h1>
 <p>Test Inline Included File: This is a <strong>included</strong> token with [!include[root](~/r/root.md)].</p>
 ";
 
-                Assert.Equal(expected.Replace("\r\n", "\n"), result.Html);
-        }
+        Assert.Equal(expected.Replace("\r\n", "\n"), result.Html);
+    }
 
-        [Fact]
-        [Trait("Related", "Inclusion")]
-        public void TestInlineLevelInclusion_Block()
-        {
-                var root = @"
+    [Fact]
+    [Trait("Related", "Inclusion")]
+    public void TestInlineLevelInclusion_Block()
+    {
+        var root = @"
 # Hello World
 
 Test Inline Included File: [!include[refa](~/r/a.md)].
 
 ";
 
-                var refa = @"## This is a included token
+        var refa = @"## This is a included token
 
 block content in Inline Inclusion.";
 
-                TestUtility.WriteToFile("r/root.md", root);
-                TestUtility.WriteToFile("r/a.md", refa);
+        TestUtility.WriteToFile("r/root.md", root);
+        TestUtility.WriteToFile("r/a.md", refa);
 
-                var result = TestUtility.MarkupWithoutSourceInfo(root, "r/root.md");
-                var expected = @"<h1 id=""hello-world"">Hello World</h1>
+        var result = TestUtility.MarkupWithoutSourceInfo(root, "r/root.md");
+        var expected = @"<h1 id=""hello-world"">Hello World</h1>
 <p>Test Inline Included File: ## This is a included tokenblock content in Inline Inclusion..</p>
 ";
-                Assert.Equal(expected.Replace("\r\n", "\n"), result.Html);
+        Assert.Equal(expected.Replace("\r\n", "\n"), result.Html);
 
-                var dependency = result.Dependency;
-                var expectedDependency = new List<string> { "a.md" };
-                Assert.Equal(expectedDependency.ToImmutableList(), dependency);
-        }
+        var dependency = result.Dependency;
+        var expectedDependency = new List<string> { "a.md" };
+        Assert.Equal(expectedDependency.ToImmutableList(), dependency);
+    }
 
-        [Fact]
-        [Trait("Related", "DfmMarkdown")]
-        public void TestBlockLevelInclusion()
-        {
-                // -r
-                //  |- root.md
-                //  |- empty.md
-                //  |- a
-                //  |  |- refc.md
-                //  |- b
-                //  |  |- linkAndRefRoot.md
-                //  |  |- a.md
-                //  |  |- img
-                //  |  |   |- img.jpg
-                //  |- c
-                //  |  |- c.md
-                //  |- link
-                //     |- link2.md
-                //     |- md
-                //         |- c.md
-                var root = @"
+    [Fact]
+    [Trait("Related", "DfmMarkdown")]
+    public void TestBlockLevelInclusion()
+    {
+        // -r
+        //  |- root.md
+        //  |- empty.md
+        //  |- a
+        //  |  |- refc.md
+        //  |- b
+        //  |  |- linkAndRefRoot.md
+        //  |  |- a.md
+        //  |  |- img
+        //  |  |   |- img.jpg
+        //  |- c
+        //  |  |- c.md
+        //  |- link
+        //     |- link2.md
+        //     |- md
+        //         |- c.md
+        var root = @"
 [!include[linkAndRefRoot](b/linkAndRefRoot.md)]
 [!include[refc](a/refc.md ""This is root"")]
 [!include[refc_using_cache](a/refc.md)]
 [!include[empty](empty.md)]
 [!include[external](http://microsoft.com/a.md)]";
 
-                var linkAndRefRoot = @"
+        var linkAndRefRoot = @"
 Paragraph1
 [link](a.md)
 [!include-[link2](../link/link2.md)]
 ![Image](img/img.jpg)
 [!include-[root](../root.md)]";
-                var link2 = "[link](md/c.md)";
-                var refc = @"[!include[c](../c/c.md ""This is root"")]";
-                var c = "**Hello**";
-                TestUtility.WriteToFile("r/root.md", root);
+        var link2 = "[link](md/c.md)";
+        var refc = @"[!include[c](../c/c.md ""This is root"")]";
+        var c = "**Hello**";
+        TestUtility.WriteToFile("r/root.md", root);
 
-                TestUtility.WriteToFile("r/a/refc.md", refc);
-                TestUtility.WriteToFile("r/b/linkAndRefRoot.md", linkAndRefRoot);
-                TestUtility.WriteToFile("r/link/link2.md", link2);
-                TestUtility.WriteToFile("r/c/c.md", c);
-                TestUtility.WriteToFile("r/empty.md", string.Empty);
-                var marked = TestUtility.MarkupWithoutSourceInfo(root, "r/root.md");
-                var dependency = marked.Dependency;
-                var expected = @"<p>Paragraph1
+        TestUtility.WriteToFile("r/a/refc.md", refc);
+        TestUtility.WriteToFile("r/b/linkAndRefRoot.md", linkAndRefRoot);
+        TestUtility.WriteToFile("r/link/link2.md", link2);
+        TestUtility.WriteToFile("r/c/c.md", c);
+        TestUtility.WriteToFile("r/empty.md", string.Empty);
+        var marked = TestUtility.MarkupWithoutSourceInfo(root, "r/root.md");
+        var dependency = marked.Dependency;
+        var expected = @"<p>Paragraph1
 <a href=""%7E/r/b/a.md"">link</a>
 <a href=""%7E/r/link/md/c.md"">link</a>
 <img src=""%7E/r/b/img/img.jpg"" alt=""Image"" />
@@ -319,154 +319,154 @@ Paragraph1
 <p><strong>Hello</strong></p>
 [!include[external](http://microsoft.com/a.md)]".Replace("\r\n", "\n");
 
-                Assert.Equal(expected, marked.Html);
-                Assert.Equal(
-                    new[]
-                    {
+        Assert.Equal(expected, marked.Html);
+        Assert.Equal(
+            new[]
+            {
                 "a/refc.md",
                 "b/linkAndRefRoot.md",
                 "c/c.md",
                 "empty.md",
                 "link/link2.md",
                 "root.md",
-                    },
-                    dependency.OrderBy(x => x).ToArray());
-        }
+            },
+            dependency.OrderBy(x => x).ToArray());
+    }
 
-        [Fact]
-        [Trait("Related", "DfmMarkdown")]
-        public void TestBlockLevelInclusionWithSameFile()
-        {
-                // -r
-                //  |- r.md
-                //  |- a
-                //  |  |- a.md
-                //  |- b
-                //  |  |- token.md
-                //  |- c
-                //     |- d
-                //        |- d.md
-                //  |- img
-                //  |  |- img.jpg
-                var r = @"
+    [Fact]
+    [Trait("Related", "DfmMarkdown")]
+    public void TestBlockLevelInclusionWithSameFile()
+    {
+        // -r
+        //  |- r.md
+        //  |- a
+        //  |  |- a.md
+        //  |- b
+        //  |  |- token.md
+        //  |- c
+        //     |- d
+        //        |- d.md
+        //  |- img
+        //  |  |- img.jpg
+        var r = @"
 [!include[](a/a.md)]
 [!include[](c/d/d.md)]
 ";
-                var a = @"
+        var a = @"
 [!include[](../b/token.md)]";
-                var token = @"
+        var token = @"
 ![](../img/img.jpg)
 [](#anchor)
 [a](../a/a.md)
 [](invalid.md)
 [d](../c/d/d.md#anchor)
 ";
-                var d = @"
+        var d = @"
 [!include[](../../b/token.md)]";
-                TestUtility.WriteToFile("r/r.md", r);
-                TestUtility.WriteToFile("r/a/a.md", a);
-                TestUtility.WriteToFile("r/b/token.md", token);
-                TestUtility.WriteToFile("r/c/d/d.md", d);
-                var marked = TestUtility.MarkupWithoutSourceInfo(a, "r/a/a.md");
-                var expected = @"<p><img src=""%7E/r/img/img.jpg"" alt="""" />
+        TestUtility.WriteToFile("r/r.md", r);
+        TestUtility.WriteToFile("r/a/a.md", a);
+        TestUtility.WriteToFile("r/b/token.md", token);
+        TestUtility.WriteToFile("r/c/d/d.md", d);
+        var marked = TestUtility.MarkupWithoutSourceInfo(a, "r/a/a.md");
+        var expected = @"<p><img src=""%7E/r/img/img.jpg"" alt="""" />
 <a href=""#anchor""></a>
 <a href=""%7E/r/a/a.md"">a</a>
 <a href=""%7E/r/b/invalid.md""></a>
 <a href=""%7E/r/c/d/d.md#anchor"">d</a></p>".Replace("\r\n", "\n") + "\n";
-                var dependency = marked.Dependency;
-                Assert.Equal(expected, marked.Html);
-                Assert.Equal(
-                    new[] { "../b/token.md" },
-                    dependency.OrderBy(x => x).ToArray());
+        var dependency = marked.Dependency;
+        Assert.Equal(expected, marked.Html);
+        Assert.Equal(
+            new[] { "../b/token.md" },
+            dependency.OrderBy(x => x).ToArray());
 
-                marked = TestUtility.MarkupWithoutSourceInfo(d, "r/c/d/d.md");
-                dependency = marked.Dependency;
-                Assert.Equal(expected, marked.Html);
-                Assert.Equal(
-                    new[] { "../../b/token.md" },
-                    dependency.OrderBy(x => x).ToArray());
+        marked = TestUtility.MarkupWithoutSourceInfo(d, "r/c/d/d.md");
+        dependency = marked.Dependency;
+        Assert.Equal(expected, marked.Html);
+        Assert.Equal(
+            new[] { "../../b/token.md" },
+            dependency.OrderBy(x => x).ToArray());
 
-                dependency.Clear();
-                marked = TestUtility.MarkupWithoutSourceInfo(r, "r/r.md");
-                dependency = marked.Dependency;
-                Assert.Equal($"{expected}{expected}", marked.Html);
-                Assert.Equal(
-                    new[] { "a/a.md", "b/token.md", "c/d/d.md" },
-                    dependency.OrderBy(x => x).ToArray());
-        }
+        dependency.Clear();
+        marked = TestUtility.MarkupWithoutSourceInfo(r, "r/r.md");
+        dependency = marked.Dependency;
+        Assert.Equal($"{expected}{expected}", marked.Html);
+        Assert.Equal(
+            new[] { "a/a.md", "b/token.md", "c/d/d.md" },
+            dependency.OrderBy(x => x).ToArray());
+    }
 
-        [Fact]
-        [Trait("Related", "DfmMarkdown")]
-        public void TestBlockLevelInclusionWithWorkingFolder()
-        {
-                // -r
-                //  |- root.md
-                //  |- b
-                //  |  |- linkAndRefRoot.md
-                var root = "[!include[linkAndRefRoot](~/r/b/linkAndRefRoot.md)]";
-                var linkAndRefRoot = "Paragraph1";
-                TestUtility.WriteToFile("r/root.md", root);
-                TestUtility.WriteToFile("r/b/linkAndRefRoot.md", linkAndRefRoot);
-                var marked = TestUtility.MarkupWithoutSourceInfo(root, "r/root.md");
-                var expected = "<p>Paragraph1</p>" + "\n";
-                Assert.Equal(expected, marked.Html);
-        }
+    [Fact]
+    [Trait("Related", "DfmMarkdown")]
+    public void TestBlockLevelInclusionWithWorkingFolder()
+    {
+        // -r
+        //  |- root.md
+        //  |- b
+        //  |  |- linkAndRefRoot.md
+        var root = "[!include[linkAndRefRoot](~/r/b/linkAndRefRoot.md)]";
+        var linkAndRefRoot = "Paragraph1";
+        TestUtility.WriteToFile("r/root.md", root);
+        TestUtility.WriteToFile("r/b/linkAndRefRoot.md", linkAndRefRoot);
+        var marked = TestUtility.MarkupWithoutSourceInfo(root, "r/root.md");
+        var expected = "<p>Paragraph1</p>" + "\n";
+        Assert.Equal(expected, marked.Html);
+    }
 
-        #region Fallback folders testing
+    #region Fallback folders testing
 
-        [Fact(Skip = "won't support")]
-        [Trait("Related", "DfmMarkdown")]
-        public void TestFallback_Inclusion_random_name()
-        {
-                // -root_folder (this is also docset folder)
-                //  |- root.md
-                //  |- a_folder
-                //  |  |- a.md
-                //  |- token_folder
-                //  |  |- token1.md
-                // -fallback_folder
-                //  |- token_folder
-                //     |- token2.md
+    [Fact(Skip = "won't support")]
+    [Trait("Related", "DfmMarkdown")]
+    public void TestFallback_Inclusion_random_name()
+    {
+        // -root_folder (this is also docset folder)
+        //  |- root.md
+        //  |- a_folder
+        //  |  |- a.md
+        //  |- token_folder
+        //  |  |- token1.md
+        // -fallback_folder
+        //  |- token_folder
+        //     |- token2.md
 
-                // 1. Prepare data
-                var uniqueFolderName = Path.GetRandomFileName();
-                var root = $@"1markdown root.md main content start.
+        // 1. Prepare data
+        var uniqueFolderName = Path.GetRandomFileName();
+        var root = $@"1markdown root.md main content start.
 
 [!include[a](a_folder_{uniqueFolderName}/a_{uniqueFolderName}.md ""This is a.md"")]
 
 markdown root.md main content end.";
 
-                var a = $@"1markdown a.md main content start.
+        var a = $@"1markdown a.md main content start.
 
 [!include[token1](../token_folder_{uniqueFolderName}/token1_{uniqueFolderName}.md ""This is token1.md"")]
 [!include[token1](../token_folder_{uniqueFolderName}/token2_{uniqueFolderName}.md ""This is token2.md"")]
 
 markdown a.md main content end.";
 
-                var token1 = $@"1markdown token1.md content start.
+        var token1 = $@"1markdown token1.md content start.
 
 [!include[token2](token2_{uniqueFolderName}.md ""This is token2.md"")]
 
 markdown token1.md content end.";
 
-                var token2 = "**1markdown token2.md main content**";
+        var token2 = "**1markdown token2.md main content**";
 
-                TestUtility.WriteToFile($"{uniqueFolderName}/root_folder_{uniqueFolderName}/root_{uniqueFolderName}.md", root);
-                TestUtility.WriteToFile($"{uniqueFolderName}/root_folder_{uniqueFolderName}/a_folder_{uniqueFolderName}/a_{uniqueFolderName}.md", a);
-                TestUtility.WriteToFile($"{uniqueFolderName}/root_folder_{uniqueFolderName}/token_folder_{uniqueFolderName}/token1_{uniqueFolderName}.md", token1);
-                TestUtility.WriteToFile($"{uniqueFolderName}/fallback_folder_{uniqueFolderName}/token_folder_{uniqueFolderName}/token2_{uniqueFolderName}.md", token2);
+        TestUtility.WriteToFile($"{uniqueFolderName}/root_folder_{uniqueFolderName}/root_{uniqueFolderName}.md", root);
+        TestUtility.WriteToFile($"{uniqueFolderName}/root_folder_{uniqueFolderName}/a_folder_{uniqueFolderName}/a_{uniqueFolderName}.md", a);
+        TestUtility.WriteToFile($"{uniqueFolderName}/root_folder_{uniqueFolderName}/token_folder_{uniqueFolderName}/token1_{uniqueFolderName}.md", token1);
+        TestUtility.WriteToFile($"{uniqueFolderName}/fallback_folder_{uniqueFolderName}/token_folder_{uniqueFolderName}/token2_{uniqueFolderName}.md", token2);
 
-                var fallbackFolders = new List<string> { { Path.Combine(Directory.GetCurrentDirectory(), $"{uniqueFolderName}/fallback_folder_{uniqueFolderName}") } };
-                var parameter = new MarkdownServiceParameters
-                {
-                        BasePath = "."
-                };
-                var service = new MarkdigMarkdownService(parameter);
-                //var marked = service.Markup(Path.Combine(Directory.GetCurrentDirectory(), $"{uniqueFolderName}/root_folder_{uniqueFolderName}"), root, fallbackFolders, $"root_{uniqueFolderName}.md");
-                var marked = service.Markup("place", "holder");
-                var dependency = marked.Dependency;
+        var fallbackFolders = new List<string> { { Path.Combine(Directory.GetCurrentDirectory(), $"{uniqueFolderName}/fallback_folder_{uniqueFolderName}") } };
+        var parameter = new MarkdownServiceParameters
+        {
+            BasePath = "."
+        };
+        var service = new MarkdigMarkdownService(parameter);
+        //var marked = service.Markup(Path.Combine(Directory.GetCurrentDirectory(), $"{uniqueFolderName}/root_folder_{uniqueFolderName}"), root, fallbackFolders, $"root_{uniqueFolderName}.md");
+        var marked = service.Markup("place", "holder");
+        var dependency = marked.Dependency;
 
-                Assert.Equal(@"<p>1markdown root.md main content start.</p>
+        Assert.Equal(@"<p>1markdown root.md main content start.</p>
 <p>1markdown a.md main content start.</p>
 <p>1markdown token1.md content start.</p>
 <p><strong>1markdown token2.md main content</strong></p>
@@ -475,29 +475,29 @@ markdown token1.md content end.";
 <p>markdown a.md main content end.</p>
 <p>markdown root.md main content end.</p>
 ".Replace("\r\n", "\n"), marked.Html);
-                Assert.Equal(
-                    new[] { $"../fallback_folder_{uniqueFolderName}/token_folder_{uniqueFolderName}/token2_{uniqueFolderName}.md", $"a_folder_{uniqueFolderName}/a_{uniqueFolderName}.md", $"token_folder_{uniqueFolderName}/token1_{uniqueFolderName}.md", $"token_folder_{uniqueFolderName}/token2_{uniqueFolderName}.md" },
-                    dependency.OrderBy(x => x).ToArray());
-        }
+        Assert.Equal(
+            new[] { $"../fallback_folder_{uniqueFolderName}/token_folder_{uniqueFolderName}/token2_{uniqueFolderName}.md", $"a_folder_{uniqueFolderName}/a_{uniqueFolderName}.md", $"token_folder_{uniqueFolderName}/token1_{uniqueFolderName}.md", $"token_folder_{uniqueFolderName}/token2_{uniqueFolderName}.md" },
+            dependency.OrderBy(x => x).ToArray());
+    }
 
-        [Fact(Skip = "won't support")]
-        [Trait("Related", "DfmMarkdown")]
-        public void TestFallback_InclusionWithCodeFences()
-        {
-                // -root_folder (this is also docset folder)
-                //  |- root.md
-                //  |- a_folder
-                //     |- a.md
-                //  |- code_folder
-                //     |- sample1.cs
-                // -fallback_folder
-                //  |- a_folder
-                //     |- code_in_a.cs
-                //  |- code_folder
-                //     |- sample2.cs
+    [Fact(Skip = "won't support")]
+    [Trait("Related", "DfmMarkdown")]
+    public void TestFallback_InclusionWithCodeFences()
+    {
+        // -root_folder (this is also docset folder)
+        //  |- root.md
+        //  |- a_folder
+        //     |- a.md
+        //  |- code_folder
+        //     |- sample1.cs
+        // -fallback_folder
+        //  |- a_folder
+        //     |- code_in_a.cs
+        //  |- code_folder
+        //     |- sample2.cs
 
-                // 1. Prepare data
-                var root = @"markdown root.md main content start.
+        // 1. Prepare data
+        var root = @"markdown root.md main content start.
 
 markdown a content in root.md content start
 
@@ -519,7 +519,7 @@ sample 2 code in root.md content end
 
 markdown root.md main content end.";
 
-                var a = @"markdown a.md main content start.
+        var a = @"markdown a.md main content start.
 
 code_in_a code in a.md content start
 
@@ -529,31 +529,31 @@ code_in_a in a.md content end
 
 markdown a.md a.md content end.";
 
-                var code_in_a = "namespace code_in_a{}";
+        var code_in_a = "namespace code_in_a{}";
 
-                var sample1 = "namespace sample1{}";
+        var sample1 = "namespace sample1{}";
 
-                var sample2 = "namespace sample2{}";
+        var sample2 = "namespace sample2{}";
 
-                var uniqueFolderName = Path.GetRandomFileName();
-                TestUtility.WriteToFile($"{uniqueFolderName}/root_folder/root.md", root);
-                TestUtility.WriteToFile($"{uniqueFolderName}/root_folder/a_folder/a.md", a);
-                TestUtility.WriteToFile($"{uniqueFolderName}/root_folder/code_folder/sample1.cs", sample1);
-                TestUtility.WriteToFile($"{uniqueFolderName}/fallback_folder/a_folder/code_in_a.cs", code_in_a);
-                TestUtility.WriteToFile($"{uniqueFolderName}/fallback_folder/code_folder/sample2.cs", sample2);
+        var uniqueFolderName = Path.GetRandomFileName();
+        TestUtility.WriteToFile($"{uniqueFolderName}/root_folder/root.md", root);
+        TestUtility.WriteToFile($"{uniqueFolderName}/root_folder/a_folder/a.md", a);
+        TestUtility.WriteToFile($"{uniqueFolderName}/root_folder/code_folder/sample1.cs", sample1);
+        TestUtility.WriteToFile($"{uniqueFolderName}/fallback_folder/a_folder/code_in_a.cs", code_in_a);
+        TestUtility.WriteToFile($"{uniqueFolderName}/fallback_folder/code_folder/sample2.cs", sample2);
 
-                var fallbackFolders = new List<string> { { Path.Combine(Directory.GetCurrentDirectory(), $"{uniqueFolderName}/fallback_folder") } };
+        var fallbackFolders = new List<string> { { Path.Combine(Directory.GetCurrentDirectory(), $"{uniqueFolderName}/fallback_folder") } };
 
-                // Verify root.md markup result
-                var parameter = new MarkdownServiceParameters
-                {
-                        BasePath = "."
-                };
-                var service = new MarkdigMarkdownService(parameter);
-                //var rootMarked = service.Markup(Path.Combine(Directory.GetCurrentDirectory(), $"{uniqueFolderName}/root_folder"), root, fallbackFolders, "root.md");
-                var rootMarked = service.Markup("place", "holder");
-                var rootDependency = rootMarked.Dependency;
-                Assert.Equal(@"<p>markdown root.md main content start.</p>
+        // Verify root.md markup result
+        var parameter = new MarkdownServiceParameters
+        {
+            BasePath = "."
+        };
+        var service = new MarkdigMarkdownService(parameter);
+        //var rootMarked = service.Markup(Path.Combine(Directory.GetCurrentDirectory(), $"{uniqueFolderName}/root_folder"), root, fallbackFolders, "root.md");
+        var rootMarked = service.Markup("place", "holder");
+        var rootDependency = rootMarked.Dependency;
+        Assert.Equal(@"<p>markdown root.md main content start.</p>
 <p>markdown a content in root.md content start</p>
 <p>markdown a.md main content start.</p>
 <p>code_in_a code in a.md content start</p>
@@ -569,93 +569,93 @@ markdown a.md a.md content end.";
 </code></pre><p>sample 2 code in root.md content end</p>
 <p>markdown root.md main content end.</p>
 ".Replace("\r\n", "\n"), rootMarked.Html);
-                Assert.Equal(
-                    new[] { "../fallback_folder/a_folder/code_in_a.cs", "../fallback_folder/code_folder/sample2.cs", "a_folder/a.md", "a_folder/code_in_a.cs", "code_folder/sample1.cs", "code_folder/sample2.cs" },
-                    rootDependency.OrderBy(x => x).ToArray());
+        Assert.Equal(
+            new[] { "../fallback_folder/a_folder/code_in_a.cs", "../fallback_folder/code_folder/sample2.cs", "a_folder/a.md", "a_folder/code_in_a.cs", "code_folder/sample1.cs", "code_folder/sample2.cs" },
+            rootDependency.OrderBy(x => x).ToArray());
 
-                // Verify a.md markup result
-                //var aMarked = service.Markup(Path.Combine(Directory.GetCurrentDirectory(), $"{uniqueFolderName}/root_folder"), a, fallbackFolders, "a_folder/a.md");
-                var aMarked = service.Markup("place", "holder");
-                var aDependency = aMarked.Dependency;
-                Assert.Equal(@"<p>markdown a.md main content start.</p>
+        // Verify a.md markup result
+        //var aMarked = service.Markup(Path.Combine(Directory.GetCurrentDirectory(), $"{uniqueFolderName}/root_folder"), a, fallbackFolders, "a_folder/a.md");
+        var aMarked = service.Markup("place", "holder");
+        var aDependency = aMarked.Dependency;
+        Assert.Equal(@"<p>markdown a.md main content start.</p>
 <p>code_in_a code in a.md content start</p>
 <pre><code class=""lang-cs"" name=""this is code_in_a code"">namespace code_in_a{}
 </code></pre><p>code_in_a in a.md content end</p>
 <p>markdown a.md a.md content end.</p>
 ".Replace("\r\n", "\n"), aMarked.Html);
-                Assert.Equal(
-                    new[] { "../../fallback_folder/a_folder/code_in_a.cs", "code_in_a.cs" },
-                    aDependency.OrderBy(x => x).ToArray());
-        }
+        Assert.Equal(
+            new[] { "../../fallback_folder/a_folder/code_in_a.cs", "code_in_a.cs" },
+            aDependency.OrderBy(x => x).ToArray());
+    }
 
-        #endregion
+    #endregion
 
-        [Fact]
-        [Trait("Related", "DfmMarkdown")]
-        public void TestInclusion_InlineLevel()
-        {
-                // 1. Prepare data
-                var root = @"
+    [Fact]
+    [Trait("Related", "DfmMarkdown")]
+    public void TestInclusion_InlineLevel()
+    {
+        // 1. Prepare data
+        var root = @"
 Inline [!include[ref1](ref1.md ""This is root"")]
 Inline [!include[ref3](ref3.md ""This is root"")]
 ";
 
-                var ref1 = @"[!include[ref2](ref2.md ""This is root"")]";
-                var ref2 = @"## Inline inclusion do not parse header [!include[root](root.md ""This is root"")]";
-                var ref3 = "**Hello**  ";
-                File.WriteAllText("root.md", root);
-                File.WriteAllText("ref1.md", ref1);
-                File.WriteAllText("ref2.md", ref2);
-                File.WriteAllText("ref3.md", ref3);
+        var ref1 = @"[!include[ref2](ref2.md ""This is root"")]";
+        var ref2 = @"## Inline inclusion do not parse header [!include[root](root.md ""This is root"")]";
+        var ref3 = "**Hello**  ";
+        File.WriteAllText("root.md", root);
+        File.WriteAllText("ref1.md", ref1);
+        File.WriteAllText("ref2.md", ref2);
+        File.WriteAllText("ref3.md", ref3);
 
-                var marked = TestUtility.MarkupWithoutSourceInfo(root, "root.md");
-                var dependency = marked.Dependency;
-                var expected = "<p>Inline ## Inline inclusion do not parse header [!include[root](root.md)]\nInline <strong>Hello</strong></p>\n";
+        var marked = TestUtility.MarkupWithoutSourceInfo(root, "root.md");
+        var dependency = marked.Dependency;
+        var expected = "<p>Inline ## Inline inclusion do not parse header [!include[root](root.md)]\nInline <strong>Hello</strong></p>\n";
 
-                Assert.Equal(expected, marked.Html);
-                Assert.Equal(
-                    new[] { "ref1.md", "ref2.md", "ref3.md", "root.md" },
-                    dependency.OrderBy(x => x).ToArray());
-        }
+        Assert.Equal(expected, marked.Html);
+        Assert.Equal(
+            new[] { "ref1.md", "ref2.md", "ref3.md", "root.md" },
+            dependency.OrderBy(x => x).ToArray());
+    }
 
-        [Fact]
-        [Trait("Related", "DfmMarkdown")]
-        public void TestBlockInclude_ShouldExcludeBracketInRegex()
-        {
-                // 1. Prepare data
-                var root = @"[!INCLUDE [azure-probe-intro-include](inc1.md)].
+    [Fact]
+    [Trait("Related", "DfmMarkdown")]
+    public void TestBlockInclude_ShouldExcludeBracketInRegex()
+    {
+        // 1. Prepare data
+        var root = @"[!INCLUDE [azure-probe-intro-include](inc1.md)].
 
 [!INCLUDE [azure-arm-classic-important-include](inc2.md)] [Resource Manager model](inc1.md).
 
 
 [!INCLUDE [azure-ps-prerequisites-include.md](inc3.md)]";
 
-                var expected = @"<p>inc1.</p>
+        var expected = @"<p>inc1.</p>
 <p>inc2 <a href=""inc1.md"">Resource Manager model</a>.</p>
 <p>inc3</p>
 ";
 
-                var inc1 = "inc1";
-                var inc2 = "inc2";
-                var inc3 = "inc3";
-                File.WriteAllText("root.md", root);
-                File.WriteAllText("inc1.md", inc1);
-                File.WriteAllText("inc2.md", inc2);
-                File.WriteAllText("inc3.md", inc3);
+        var inc1 = "inc1";
+        var inc2 = "inc2";
+        var inc3 = "inc3";
+        File.WriteAllText("root.md", root);
+        File.WriteAllText("inc1.md", inc1);
+        File.WriteAllText("inc2.md", inc2);
+        File.WriteAllText("inc3.md", inc3);
 
-                var marked = TestUtility.MarkupWithoutSourceInfo(root, "root.md");
-                var dependency = marked.Dependency;
-                Assert.Equal(expected.Replace("\r\n", "\n"), marked.Html);
-                Assert.Equal(
-                  new[] { "inc1.md", "inc2.md", "inc3.md" },
-                  dependency.OrderBy(x => x).ToArray());
-        }
+        var marked = TestUtility.MarkupWithoutSourceInfo(root, "root.md");
+        var dependency = marked.Dependency;
+        Assert.Equal(expected.Replace("\r\n", "\n"), marked.Html);
+        Assert.Equal(
+          new[] { "inc1.md", "inc2.md", "inc3.md" },
+          dependency.OrderBy(x => x).ToArray());
+    }
 
-        [Fact]
-        [Trait("Related", "Inclusion")]
-        public void TestBlockInclude_ImageRelativePath()
-        {
-                var root = @"
+    [Fact]
+    [Trait("Related", "Inclusion")]
+    public void TestBlockInclude_ImageRelativePath()
+    {
+        var root = @"
 # Hello World
 
 Test Include File
@@ -664,34 +664,34 @@ Test Include File
 
 ";
 
-                var refa = @"
+        var refa = @"
 # Hello Include File A
 
 ![img](./media/refb.png)
 ";
 
-                var rootPath = "r/parent_folder/child_folder/root.md";
-                TestUtility.WriteToFile(rootPath, root);
-                TestUtility.WriteToFile("r/include/a.md", refa);
+        var rootPath = "r/parent_folder/child_folder/root.md";
+        TestUtility.WriteToFile(rootPath, root);
+        TestUtility.WriteToFile("r/include/a.md", refa);
 
-                var result = TestUtility.MarkupWithoutSourceInfo(root, rootPath);
-                var expected = @"<h1 id=""hello-world"">Hello World</h1>
+        var result = TestUtility.MarkupWithoutSourceInfo(root, rootPath);
+        var expected = @"<h1 id=""hello-world"">Hello World</h1>
 <p>Test Include File</p>
 <h1 id=""hello-include-file-a"">Hello Include File A</h1>
 <p><img src=""%7E/r/include/media/refb.png"" alt=""img"" /></p>
 ";
-                Assert.Equal(expected.Replace("\r\n", "\n"), result.Html);
+        Assert.Equal(expected.Replace("\r\n", "\n"), result.Html);
 
-                var dependency = result.Dependency;
-                var expectedDependency = new List<string> { "../../include/a.md" };
-                Assert.Equal(expectedDependency.ToImmutableList(), dependency);
-        }
+        var dependency = result.Dependency;
+        var expectedDependency = new List<string> { "../../include/a.md" };
+        Assert.Equal(expectedDependency.ToImmutableList(), dependency);
+    }
 
-        [Fact]
-        [Trait("Related", "Inclusion")]
-        public void TestBlockInclude_WithYamlHeader()
-        {
-                var root = @"
+    [Fact]
+    [Trait("Related", "Inclusion")]
+    public void TestBlockInclude_WithYamlHeader()
+    {
+        var root = @"
 # Hello World
 
 Test Include File
@@ -700,99 +700,99 @@ Test Include File
 
 ";
 
-                var refa = @"---
+        var refa = @"---
 a: b
 ---
 body";
 
-                var rootPath = "r/parent_folder/child_folder/root.md";
-                TestUtility.WriteToFile(rootPath, root);
-                TestUtility.WriteToFile("r/include/a.md", refa);
+        var rootPath = "r/parent_folder/child_folder/root.md";
+        TestUtility.WriteToFile(rootPath, root);
+        TestUtility.WriteToFile("r/include/a.md", refa);
 
-                var result = TestUtility.MarkupWithoutSourceInfo(root, rootPath);
-                var expected = @"<h1 id=""hello-world"">Hello World</h1>
+        var result = TestUtility.MarkupWithoutSourceInfo(root, rootPath);
+        var expected = @"<h1 id=""hello-world"">Hello World</h1>
 <p>Test Include File</p>
 <p>body</p>
 ";
-                Assert.Equal(expected.Replace("\r\n", "\n"), result.Html);
+        Assert.Equal(expected.Replace("\r\n", "\n"), result.Html);
 
-                var dependency = result.Dependency;
-                var expectedDependency = new List<string> { "../../include/a.md" };
-                Assert.Equal(expectedDependency.ToImmutableList(), dependency);
-        }
+        var dependency = result.Dependency;
+        var expectedDependency = new List<string> { "../../include/a.md" };
+        Assert.Equal(expectedDependency.ToImmutableList(), dependency);
+    }
 
-        [Fact(Skip = "failed frequently")]
-        [Trait("Related", "Inclusion")]
-        public void TestInclusionContext_CurrentFile_RootFile()
+    [Fact(Skip = "failed frequently")]
+    [Trait("Related", "Inclusion")]
+    public void TestInclusionContext_CurrentFile_RootFile()
+    {
+        var root = "[!include[](embed)]";
+
+        var context = new MarkdownContext(
+            readFile: (path, _) =>
+            {
+                Assert.Equal("embed", path);
+
+                Assert.Equal("root", InclusionContext.RootFile);
+                Assert.Equal("root", InclusionContext.File);
+
+                return ("embed [content](c.md)", "embed");
+            });
+
+        var pipeline = new MarkdownPipelineBuilder().UseDocfxExtensions(context).Build();
+
+        Assert.Null(InclusionContext.RootFile);
+        Assert.Null(InclusionContext.File);
+
+        using (InclusionContext.PushFile("root"))
         {
-                var root = "[!include[](embed)]";
+            Assert.Equal("root", InclusionContext.RootFile);
+            Assert.Equal("root", InclusionContext.File);
 
-                var context = new MarkdownContext(
-                    readFile: (path, _) =>
-                    {
-                            Assert.Equal("embed", path);
+            var result = Markdown.ToHtml(root, pipeline);
 
-                            Assert.Equal("root", InclusionContext.RootFile);
-                            Assert.Equal("root", InclusionContext.File);
-
-                            return ("embed [content](c.md)", "embed");
-                    });
-
-                var pipeline = new MarkdownPipelineBuilder().UseDocfxExtensions(context).Build();
-
-                Assert.Null(InclusionContext.RootFile);
-                Assert.Null(InclusionContext.File);
-
-                using (InclusionContext.PushFile("root"))
-                {
-                        Assert.Equal("root", InclusionContext.RootFile);
-                        Assert.Equal("root", InclusionContext.File);
-
-                        var result = Markdown.ToHtml(root, pipeline);
-
-                        Assert.Equal("<p>embed <a href=\"c.md\">content</a></p>", result.Trim());
-                        Assert.Equal("root", InclusionContext.RootFile);
-                        Assert.Equal("root", InclusionContext.File);
-                }
-                Assert.Null(InclusionContext.RootFile);
-                Assert.Null(InclusionContext.File);
+            Assert.Equal("<p>embed <a href=\"c.md\">content</a></p>", result.Trim());
+            Assert.Equal("root", InclusionContext.RootFile);
+            Assert.Equal("root", InclusionContext.File);
         }
+        Assert.Null(InclusionContext.RootFile);
+        Assert.Null(InclusionContext.File);
+    }
 
-        [Fact]
-        [Trait("Related", "DfmMarkdown")]
-        public void TestComplexImageBlockSrcResolveInToken()
-        {
-                // -r
-                //  |- r.md
-                //  |- b
-                //  |  |- token.md
-                //  |  |- img.jpg
-                var r = @"
+    [Fact]
+    [Trait("Related", "DfmMarkdown")]
+    public void TestComplexImageBlockSrcResolveInToken()
+    {
+        // -r
+        //  |- r.md
+        //  |- b
+        //  |  |- token.md
+        //  |  |- img.jpg
+        var r = @"
 [!include[](b/token.md)]
 ";
-                var token = @"
+        var token = @"
 :::image source=""example.jpg"" type=""complex"" alt-text=""example"":::
 Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
 :::image-end:::
 ";
-                TestUtility.WriteToFile("r/r.md", r);
-                TestUtility.WriteToFile("r/b/token.md", token);
-                var marked = TestUtility.MarkupWithoutSourceInfo(r, "r/r.md");
+        TestUtility.WriteToFile("r/r.md", r);
+        TestUtility.WriteToFile("r/b/token.md", token);
+        var marked = TestUtility.MarkupWithoutSourceInfo(r, "r/r.md");
 
-                var expected = @"<p class=""mx-imgBorder"">
+        var expected = @"<p class=""mx-imgBorder"">
 <img src=""~/r/b/example.jpg"" alt=""example"" aria-describedby=""1-0"">
 <div id=""1-0"" class=""visually-hidden""><p>
 Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p></div>
 </p>
 ";
-                Assert.Equal(expected.Replace("\r\n", "\n"), marked.Html);
-        }
+        Assert.Equal(expected.Replace("\r\n", "\n"), marked.Html);
+    }
 
-        [Fact]
-        public void ImageTestBlockGeneralWithInclude()
-        {
-                var source = "[!include[](includes/source.md)]";
-                var includeContent = @":::image type=""content"" source=""../media/example.jpg"" alt-text=""example"" lightbox=""../media/example.jpg"":::
+    [Fact]
+    public void ImageTestBlockGeneralWithInclude()
+    {
+        var source = "[!include[](includes/source.md)]";
+        var includeContent = @":::image type=""content"" source=""../media/example.jpg"" alt-text=""example"" lightbox=""../media/example.jpg"":::
 
 :::image type=""content"" source=""~/media/example.jpg"" alt-text=""example"" lightbox=""~/media/example.jpg"":::
 
@@ -800,11 +800,11 @@ Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
 
 :::image type=""content"" source=""../media/example.jpg"" alt-text=""example"" lightbox=""~/media/example.jpg"":::";
 
-                TestUtility.WriteToFile("a.md", source);
-                TestUtility.WriteToFile("includes/source.md", includeContent);
-                var marked = TestUtility.MarkupWithoutSourceInfo(source, "a.md");
+        TestUtility.WriteToFile("a.md", source);
+        TestUtility.WriteToFile("includes/source.md", includeContent);
+        var marked = TestUtility.MarkupWithoutSourceInfo(source, "a.md");
 
-                var expected = @"<p><span class=""mx-imgBorder"">
+        var expected = @"<p><span class=""mx-imgBorder"">
 <a href=""~/media/example.jpg#lightbox"" data-linktype=""relative-path"">
 <img src=""~/media/example.jpg"" alt=""example"">
 </a>
@@ -830,30 +830,30 @@ Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
 </p>
 ";
 
-                Assert.Equal(expected.Replace("\r\n", "\n").Replace("\n", ""), marked.Html.Replace("\r\n", "\n").Replace("\n", ""));
-        }
+        Assert.Equal(expected.Replace("\r\n", "\n").Replace("\n", ""), marked.Html.Replace("\r\n", "\n").Replace("\n", ""));
+    }
 
-        [Fact]
-        [Trait("Related", "DfmMarkdown")]
-        public void TestImageWithIconTypeBlockSrcResolveInToken()
-        {
-                // -r
-                //  |- r.md
-                //  |- b
-                //  |  |- token.md
-                //  |  |- img.jpg
-                var r = @"
+    [Fact]
+    [Trait("Related", "DfmMarkdown")]
+    public void TestImageWithIconTypeBlockSrcResolveInToken()
+    {
+        // -r
+        //  |- r.md
+        //  |- b
+        //  |  |- token.md
+        //  |  |- img.jpg
+        var r = @"
 [!include[](b/token.md)]
 ";
-                var token = @"
+        var token = @"
 :::image source=""example.svg"" type=""icon"" alt-text=""example"":::
 ";
-                TestUtility.WriteToFile("r/r.md", r);
-                TestUtility.WriteToFile("r/b/token.md", token);
-                var marked = TestUtility.MarkupWithoutSourceInfo(r, "r/r.md");
-                var expected = @"<p><img src=""~/r/b/example.svg"" role=""presentation"">
+        TestUtility.WriteToFile("r/r.md", r);
+        TestUtility.WriteToFile("r/b/token.md", token);
+        var marked = TestUtility.MarkupWithoutSourceInfo(r, "r/r.md");
+        var expected = @"<p><img src=""~/r/b/example.svg"" role=""presentation"">
 </p>
 ";
-                Assert.Equal(expected.Replace("\r\n", "\n"), marked.Html);
-        }
+        Assert.Equal(expected.Replace("\r\n", "\n"), marked.Html);
+    }
 }

--- a/test/Docfx.Tests.Common/Docfx.Tests.Common.csproj
+++ b/test/Docfx.Tests.Common/Docfx.Tests.Common.csproj
@@ -1,5 +1,5 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.Common\Docfx.Common.csproj" />
   </ItemGroup>
- </Project>
+</Project>

--- a/test/docfx.Tests/Assets/template/plugins/CustomPostProcessor.cs
+++ b/test/docfx.Tests/Assets/template/plugins/CustomPostProcessor.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Immutable;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
 using System.Composition;
 using Docfx.Plugins;
 

--- a/test/docfx.Tests/Attributes/WindowsOnlyFactAttribute.cs
+++ b/test/docfx.Tests/Attributes/WindowsOnlyFactAttribute.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.InteropServices;
 

--- a/test/docfx.Tests/DocsetBuildTest.cs
+++ b/test/docfx.Tests/DocsetBuildTest.cs
@@ -224,7 +224,7 @@ public class DocsetBuildTest : TestBase
                 <meta http-equiv="refresh" content="0;URL='redirected.html'">
               </head>
             </html>
-            """.Replace("\r\n","\n"), result.Trim());
+            """.Replace("\r\n", "\n"), result.Trim());
 
         // Test redirect page.is excluded from sitemap.
         var sitemapXml = outputs["sitemap.xml"]();

--- a/test/docfx.Tests/Utilities/JsonSchemaUtility.cs
+++ b/test/docfx.Tests/Utilities/JsonSchemaUtility.cs
@@ -1,9 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Json.Schema;
 using System.Text;
 using System.Text.Json;
+using Json.Schema;
 
 namespace Docfx.Tests;
 

--- a/test/docfx.Tests/docfx.Tests.csproj
+++ b/test/docfx.Tests/docfx.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <None Include="Assets\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>


### PR DESCRIPTION
This PR contains following change commits.

1. Remove BOM from project files and remove extra whitespaces
2. Apply `dotnet format whitespace` command.
3. Apply `dotnet format style` command.
4. Edit `.editorconfig` file to enforce file header rule. And apply `dotnet format style` command.
