### PR TITLE
fix: NullReferenceException thrown when running tests in parallel

### DIFF
--- a/test/Docfx.Tests.Common/TestListenerScope.cs
+++ b/test/Docfx.Tests.Common/TestListenerScope.cs
@@ -24,7 +24,7 @@ public class TestListenerScope : ILoggerListener, IDisposable
     public void WriteLine(ILogItem item)
     {
         if (item.LogLevel >= _logLevel)
-            s_items.Value.Add(item);
+            s_items.Value?.Add(item);
     }
 
     public IEnumerable<ILogItem> GetItemsByLogLevel(LogLevel logLevel)


### PR DESCRIPTION
When running unit tests on Visual Studio TestExplorer.
`NullReferenceException` is thrown on some cases.


It's seems to be occurred when running following tests in parallel.
1. UnitTest that use `new TestListenerScope();` 
2. UnitTest that try to write logs.

**How to reproduce problems**

1. Select following tests on Visual Studio TestExplorer.
  1.1. `TestLoaderWhenStandalonePreprocessorExists`
  1.2. `TestBadMdToc` 
2. Run unit tests.
