### PR TITLE
feat: Add `CancellationToken` support for `RunBuild.Exec`

### DIFF
--- a/src/Docfx.App/Helpers/DocumentBuilderWrapper.cs
+++ b/src/Docfx.App/Helpers/DocumentBuilderWrapper.cs
@@ -15,7 +15,7 @@ internal static class DocumentBuilderWrapper
 {
     private static readonly Assembly[] s_pluginAssemblies = LoadPluginAssemblies(AppContext.BaseDirectory).ToArray();
 
-    public static void BuildDocument(BuildJsonConfig config, BuildOptions options, TemplateManager templateManager, string baseDirectory, string outputDirectory, string templateDirectory)
+    public static void BuildDocument(BuildJsonConfig config, BuildOptions options, TemplateManager templateManager, string baseDirectory, string outputDirectory, string templateDirectory, CancellationToken cancellationToken)
     {
         var postProcessorNames = config.PostProcessors.ToImmutableArray();
         var metadata = config.GlobalMetadata?.ToImmutableDictionary();
@@ -39,7 +39,7 @@ internal static class DocumentBuilderWrapper
         using var builder = new DocumentBuilder(s_pluginAssemblies.Concat(pluginAssemblies), postProcessorNames);
 
         var parameters = ConfigToParameter(config, options, templateManager, baseDirectory, outputDirectory, templateDirectory);
-        builder.Build(parameters, outputDirectory);
+        builder.Build(parameters, outputDirectory, cancellationToken);
     }
 
     private static IEnumerable<Assembly> LoadPluginAssemblies(string pluginDirectory)

--- a/src/Docfx.App/RunBuild.cs
+++ b/src/Docfx.App/RunBuild.cs
@@ -16,7 +16,7 @@ internal static class RunBuild
     /// <summary>
     /// Build document with specified settings.
     /// </summary>
-    public static string Exec(BuildJsonConfig config, BuildOptions options, string configDirectory, string outputDirectory = null)
+    public static string Exec(BuildJsonConfig config, BuildOptions options, string configDirectory, string outputDirectory = null, CancellationToken cancellationToken = default)
     {
         var stopwatch = Stopwatch.StartNew();
         if (config.Template == null || config.Template.Count == 0)
@@ -36,7 +36,7 @@ internal static class RunBuild
         {
             var templateManager = new TemplateManager(config.Template, config.Theme, configDirectory);
 
-            DocumentBuilderWrapper.BuildDocument(config, options, templateManager, baseDirectory, outputFolder, null);
+            DocumentBuilderWrapper.BuildDocument(config, options, templateManager, baseDirectory, outputFolder, null, cancellationToken);
 
             templateManager.ProcessTheme(outputFolder, true);
         }

--- a/src/Docfx.Build/DocumentBuilder.cs
+++ b/src/Docfx.Build/DocumentBuilder.cs
@@ -39,9 +39,11 @@ public class DocumentBuilder : IDisposable
         Build(new DocumentBuildParameters[] { parameter }, parameter.OutputBaseDir);
     }
 
-    public void Build(IList<DocumentBuildParameters> parameters, string outputDirectory)
+    public void Build(IList<DocumentBuildParameters> parameters, string outputDirectory, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(parameters);
+
+        cancellationToken.ThrowIfCancellationRequested();
 
         if (parameters.Count == 0)
         {
@@ -119,7 +121,7 @@ public class DocumentBuilder : IDisposable
                     MetadataValidators = MetadataValidators.ToList(),
                     Processors = Processors,
                 };
-                manifests.Add(builder.Build(parameter, markdownService));
+                manifests.Add(builder.Build(parameter, markdownService, cancellationToken));
             }
         }
         if (noContentFound)

--- a/src/Docfx.Build/HostServiceCreator.cs
+++ b/src/Docfx.Build/HostServiceCreator.cs
@@ -97,7 +97,9 @@ class HostServiceCreator
             {
                 invalidFiles.Add(file.File);
             }
-        }, _context.MaxParallelism);
+        },
+        _context.MaxParallelism,
+        _context.CancellationToken);
 
         return (models.OrderBy(m => m.File, StringComparer.Ordinal).ToArray(), invalidFiles);
     }

--- a/src/Docfx.Build/LinkPhaseHandler.cs
+++ b/src/Docfx.Build/LinkPhaseHandler.cs
@@ -77,7 +77,7 @@ internal class LinkPhaseHandler
                     }
                 }
             }
-        });
+        }, Context.CancellationToken);
         return manifestItems;
     }
 
@@ -136,7 +136,7 @@ internal class LinkPhaseHandler
                     Logger.LogWarning($"Invalid file link:({fileLink}).", code: WarningCodes.Build.InvalidFileLink);
                 }
             }
-        });
+        }, Context.CancellationToken);
     }
 
     private void HandleUids(SaveResult result)

--- a/src/Docfx.Build/ManifestProcessor.cs
+++ b/src/Docfx.Build/ManifestProcessor.cs
@@ -87,7 +87,8 @@ internal class ManifestProcessor
                 }
             }
         },
-        _context.MaxParallelism);
+        _context.MaxParallelism,
+        _context.CancellationToken);
     }
 
     private void FeedOptions()
@@ -113,7 +114,8 @@ internal class ManifestProcessor
                 }
             }
         },
-        _context.MaxParallelism);
+        _context.MaxParallelism,
+        _context.CancellationToken);
     }
 
     private void UpdateHref()
@@ -130,7 +132,8 @@ internal class ManifestProcessor
                 m.Item.Content = m.FileModel.Content;
             }
         },
-        _context.MaxParallelism);
+        _context.MaxParallelism,
+        _context.CancellationToken);
     }
 
     private void ApplySystemMetadata()
@@ -171,7 +174,8 @@ internal class ManifestProcessor
                 }
             }
         },
-        _context.MaxParallelism);
+        _context.MaxParallelism,
+        _context.CancellationToken);
 
         _globalMetadata["_shared"] = sharedObjects;
     }

--- a/src/Docfx.Build/PostProcessors/ExtractSearchIndex.cs
+++ b/src/Docfx.Build/PostProcessors/ExtractSearchIndex.cs
@@ -37,7 +37,7 @@ class ExtractSearchIndex : IPostProcessor
         return metadata;
     }
 
-    public Manifest Process(Manifest manifest, string outputFolder)
+    public Manifest Process(Manifest manifest, string outputFolder, CancellationToken cancellationToken = default)
     {
         if (outputFolder == null)
         {
@@ -57,6 +57,8 @@ class ExtractSearchIndex : IPostProcessor
         Logger.LogInfo($"Extracting index data from {htmlFiles.Count} html files");
         foreach (var relativePath in htmlFiles)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var filePath = Path.Combine(outputFolder, relativePath);
             var html = new HtmlDocument();
             Logger.LogDiagnostic($"Extracting index data from {filePath}");

--- a/src/Docfx.Build/PostProcessors/HtmlPostProcessor.cs
+++ b/src/Docfx.Build/PostProcessors/HtmlPostProcessor.cs
@@ -39,7 +39,7 @@ sealed class HtmlPostProcessor : IPostProcessor
         return metadata;
     }
 
-    public Manifest Process(Manifest manifest, string outputFolder)
+    public Manifest Process(Manifest manifest, string outputFolder, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(manifest);
         ArgumentNullException.ThrowIfNull(outputFolder);
@@ -58,6 +58,8 @@ sealed class HtmlPostProcessor : IPostProcessor
                                   OutputFile = output.Value.RelativePath,
                               })
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (!EnvironmentContext.FileAbstractLayer.Exists(tuple.OutputFile))
             {
                 continue;

--- a/src/Docfx.Build/PostProcessors/PostProcessorsManager.cs
+++ b/src/Docfx.Build/PostProcessors/PostProcessorsManager.cs
@@ -34,11 +34,11 @@ class PostProcessorsManager : IDisposable
         return updatedMetadata;
     }
 
-    public void Process(Manifest manifest, string outputFolder)
+    public void Process(Manifest manifest, string outputFolder, CancellationToken cancellationToken = default)
     {
         foreach (var postProcessor in _postProcessors)
         {
-            manifest = postProcessor.Processor.Process(manifest, outputFolder) ??
+            manifest = postProcessor.Processor.Process(manifest, outputFolder, cancellationToken) ??
                 throw new DocfxException($"Post processor {postProcessor.ContractName} should not return null manifest");
 
             // To make sure post processor won't generate duplicate output files

--- a/src/Docfx.Build/PostProcessors/SitemapGenerator.cs
+++ b/src/Docfx.Build/PostProcessors/SitemapGenerator.cs
@@ -26,7 +26,7 @@ class SitemapGenerator : IPostProcessor
         return metadata;
     }
 
-    public Manifest Process(Manifest manifest, string outputFolder)
+    public Manifest Process(Manifest manifest, string outputFolder, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(manifest.Sitemap?.BaseUrl))
         {

--- a/src/Docfx.Build/TemplateProcessors/TemplateProcessor.cs
+++ b/src/Docfx.Build/TemplateProcessors/TemplateProcessor.cs
@@ -104,6 +104,8 @@ public class TemplateProcessor
     {
         foreach (var resourceInfo in templateBundles.SelectMany(s => s.Resources).Distinct())
         {
+            _context.CancellationToken.ThrowIfCancellationRequested();
+
             var resourceKey = resourceInfo.ResourceKey;
 
             try
@@ -194,7 +196,8 @@ public class TemplateProcessor
                     manifest.Add(transformer.Transform(item));
                 }
             },
-            _maxParallelism);
+            _maxParallelism,
+            _context.CancellationToken);
         return manifest.ToList();
 
     }

--- a/src/Docfx.Build/XRefMaps/XRefArchiveBuilder.cs
+++ b/src/Docfx.Build/XRefMaps/XRefArchiveBuilder.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Threading;
 using Docfx.Common;
 
 namespace Docfx.Build.Engine;
@@ -10,7 +11,7 @@ public class XRefArchiveBuilder
     private readonly object _syncRoot = new();
     private readonly XRefMapDownloader _downloader = new();
 
-    public async Task<bool> DownloadAsync(Uri uri, string outputFile)
+    public async Task<bool> DownloadAsync(Uri uri, string outputFile, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(uri);
 
@@ -24,7 +25,7 @@ public class XRefArchiveBuilder
             try
             {
                 using var xa = XRefArchive.Open(outputFile, XRefArchiveMode.Create);
-                await DownloadCoreAsync(uri, xa);
+                await DownloadCoreAsync(uri, xa, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -36,10 +37,10 @@ public class XRefArchiveBuilder
         }
     }
 
-    private async Task<string> DownloadCoreAsync(Uri uri, XRefArchive xa)
+    private async Task<string> DownloadCoreAsync(Uri uri, XRefArchive xa, CancellationToken cancellationToken)
     {
         IXRefContainer container;
-        container = await _downloader.DownloadAsync(uri);
+        container = await _downloader.DownloadAsync(uri, cancellationToken);
         if (container is not XRefMap map)
         {
             // XRefArchive is not supported by `docfx download`.

--- a/src/Docfx.DataContracts.Common/ExternalReferences/ExternalReferencePackageCollection.cs
+++ b/src/Docfx.DataContracts.Common/ExternalReferences/ExternalReferencePackageCollection.cs
@@ -8,11 +8,14 @@ public class ExternalReferencePackageCollection : IDisposable
 {
     private readonly LruList<ReferenceViewModelCacheItem> _cache = LruList<ReferenceViewModelCacheItem>.Create(0x100);
 
-    public ExternalReferencePackageCollection(IEnumerable<string> packageFiles, int maxParallelism)
+    public ExternalReferencePackageCollection(IEnumerable<string> packageFiles, int maxParallelism, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(packageFiles);
 
-        Readers = (from file in packageFiles.AsParallel().WithDegreeOfParallelism(maxParallelism).AsOrdered()
+        Readers = (from file in packageFiles.AsParallel()
+                                            .WithDegreeOfParallelism(maxParallelism)
+                                            .WithCancellation(cancellationToken)
+                                            .AsOrdered()
                    let reader = ExternalReferencePackageReader.CreateNoThrow(file)
                    where reader != null
                    select reader).ToImmutableList();

--- a/src/Docfx.Plugins/IDocumentBuildContext.cs
+++ b/src/Docfx.Plugins/IDocumentBuildContext.cs
@@ -94,4 +94,9 @@ public interface IDocumentBuildContext
     /// Custom href generator
     /// </summary>
     ICustomHrefGenerator HrefGenerator { get; }
+
+    /// <summary>
+    /// The token to cancel build operation.
+    /// </summary>
+    CancellationToken CancellationToken { get; }
 }

--- a/src/Docfx.Plugins/IPostProcessor.cs
+++ b/src/Docfx.Plugins/IPostProcessor.cs
@@ -19,6 +19,7 @@ public interface IPostProcessor
     /// </summary>
     /// <param name="manifest"></param>
     /// <param name="outputFolder">The output folder where our static website will be placed</param>
+    /// <param name="cancellationToken">The token to cancel operation.</param>
     /// <returns></returns>
-    Manifest Process(Manifest manifest, string outputFolder);
+    Manifest Process(Manifest manifest, string outputFolder, CancellationToken cancellationToken);
 }

--- a/test/docfx.Tests/Api.verified.cs
+++ b/test/docfx.Tests/Api.verified.cs
@@ -58,13 +58,11 @@ namespace Docfx.Build.Engine
     }
     public sealed class DocumentBuildContext : Docfx.Plugins.IDocumentBuildContext
     {
-        public DocumentBuildContext(Docfx.Build.Engine.DocumentBuildParameters parameters) { }
-        public DocumentBuildContext(string buildOutputFolder) { }
-        public DocumentBuildContext(string buildOutputFolder, System.Collections.Generic.IEnumerable<Docfx.Plugins.FileAndType> allSourceFiles, System.Collections.Immutable.ImmutableArray<string> externalReferencePackages, System.Collections.Immutable.ImmutableArray<string> xrefMaps, int maxParallelism, string baseFolder, string versionName, Docfx.Build.Engine.ApplyTemplateSettings applyTemplateSetting, string rootTocPath) { }
-        public DocumentBuildContext(string buildOutputFolder, System.Collections.Generic.IEnumerable<Docfx.Plugins.FileAndType> allSourceFiles, System.Collections.Immutable.ImmutableArray<string> externalReferencePackages, System.Collections.Immutable.ImmutableArray<string> xrefMaps, int maxParallelism, string baseFolder, string versionName, Docfx.Build.Engine.ApplyTemplateSettings applyTemplateSetting, string rootTocPath, string versionFolder, Docfx.Plugins.GroupInfo groupInfo) { }
+        public DocumentBuildContext(Docfx.Build.Engine.DocumentBuildParameters parameters, System.Threading.CancellationToken cancellationToken) { }
         public System.Collections.Immutable.ImmutableDictionary<string, Docfx.Plugins.FileAndType> AllSourceFiles { get; }
         public Docfx.Build.Engine.ApplyTemplateSettings ApplyTemplateSettings { get; set; }
         public string BuildOutputFolder { get; }
+        public System.Threading.CancellationToken CancellationToken { get; }
         public System.Collections.Immutable.ImmutableArray<string> ExternalReferencePackages { get; }
         public System.Collections.Concurrent.ConcurrentDictionary<string, string> FileMap { get; }
         public Docfx.Plugins.GroupInfo GroupInfo { get; }
@@ -120,7 +118,7 @@ namespace Docfx.Build.Engine
     {
         public DocumentBuilder(System.Collections.Generic.IEnumerable<System.Reflection.Assembly> assemblies, System.Collections.Immutable.ImmutableArray<string> postProcessorNames) { }
         public void Build(Docfx.Build.Engine.DocumentBuildParameters parameter) { }
-        public void Build(System.Collections.Generic.IList<Docfx.Build.Engine.DocumentBuildParameters> parameters, string outputDirectory) { }
+        public void Build(System.Collections.Generic.IList<Docfx.Build.Engine.DocumentBuildParameters> parameters, string outputDirectory, System.Threading.CancellationToken cancellationToken = default) { }
         public void Dispose() { }
     }
     public sealed class EmptyResourceReader : Docfx.Build.Engine.ResourceFileReader
@@ -391,7 +389,7 @@ namespace Docfx.Build.Engine
     public class XRefArchiveBuilder
     {
         public XRefArchiveBuilder() { }
-        public System.Threading.Tasks.Task<bool> DownloadAsync(System.Uri uri, string outputFile) { }
+        public System.Threading.Tasks.Task<bool> DownloadAsync(System.Uri uri, string outputFile, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public enum XRefArchiveMode
     {
@@ -2452,7 +2450,7 @@ namespace Docfx.DataContracts.Common
     }
     public class ExternalReferencePackageCollection : System.IDisposable
     {
-        public ExternalReferencePackageCollection(System.Collections.Generic.IEnumerable<string> packageFiles, int maxParallelism) { }
+        public ExternalReferencePackageCollection(System.Collections.Generic.IEnumerable<string> packageFiles, int maxParallelism, System.Threading.CancellationToken cancellationToken) { }
         public System.Collections.Immutable.ImmutableList<Docfx.DataContracts.Common.ExternalReferencePackageReader> Readers { get; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
@@ -3954,11 +3952,11 @@ namespace Docfx.Plugins
     }
     public static class DocumentExceptionExtensions
     {
-        public static void RunAll<TElement>(this System.Collections.Generic.IEnumerable<TElement> elements, System.Action<TElement> action) { }
-        public static void RunAll<TElement>(this System.Collections.Generic.IReadOnlyList<TElement> elements, System.Action<TElement> action) { }
-        public static void RunAll<TElement>(this System.Collections.Generic.IEnumerable<TElement> elements, System.Action<TElement> action, int parallelism) { }
-        public static void RunAll<TElement>(this System.Collections.Generic.IReadOnlyList<TElement> elements, System.Action<TElement> action, int parallelism) { }
-        public static TResult[] RunAll<TElement, TResult>(this System.Collections.Generic.IReadOnlyList<TElement> elements, System.Func<TElement, TResult> func) { }
+        public static void RunAll<TElement>(this System.Collections.Generic.IEnumerable<TElement> elements, System.Action<TElement> action, System.Threading.CancellationToken cancellationToken = default) { }
+        public static void RunAll<TElement>(this System.Collections.Generic.IReadOnlyList<TElement> elements, System.Action<TElement> action, System.Threading.CancellationToken cancellationToken = default) { }
+        public static void RunAll<TElement>(this System.Collections.Generic.IEnumerable<TElement> elements, System.Action<TElement> action, int parallelism, System.Threading.CancellationToken cancellationToken = default) { }
+        public static void RunAll<TElement>(this System.Collections.Generic.IReadOnlyList<TElement> elements, System.Action<TElement> action, int parallelism, System.Threading.CancellationToken cancellationToken = default) { }
+        public static TResult[] RunAll<TElement, TResult>(this System.Collections.Generic.IReadOnlyList<TElement> elements, System.Func<TElement, TResult> func, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public enum DocumentType
     {
@@ -4064,6 +4062,7 @@ namespace Docfx.Plugins
     }
     public interface IDocumentBuildContext
     {
+        System.Threading.CancellationToken CancellationToken { get; }
         Docfx.Plugins.GroupInfo GroupInfo { get; }
         Docfx.Plugins.ICustomHrefGenerator HrefGenerator { get; }
         string RootTocPath { get; }
@@ -4154,7 +4153,7 @@ namespace Docfx.Plugins
     public interface IPostProcessor
     {
         System.Collections.Immutable.ImmutableDictionary<string, object> PrepareMetadata(System.Collections.Immutable.ImmutableDictionary<string, object> metadata);
-        Docfx.Plugins.Manifest Process(Docfx.Plugins.Manifest manifest, string outputFolder);
+        Docfx.Plugins.Manifest Process(Docfx.Plugins.Manifest manifest, string outputFolder, System.Threading.CancellationToken cancellationToken);
     }
     public readonly struct LinkSourceInfo
     {

--- a/test/docfx.Tests/Assets/template/plugins/CustomPostProcessor.cs
+++ b/test/docfx.Tests/Assets/template/plugins/CustomPostProcessor.cs
@@ -9,7 +9,7 @@ public class CustomPostProcessor : IPostProcessor
 {
     public ImmutableDictionary<string, object> PrepareMetadata(ImmutableDictionary<string, object> metadata) => metadata;
 
-    public Manifest Process(Manifest manifest, string outputFolder)
+    public Manifest Process(Manifest manifest, string outputFolder, CancellationToken cancellationToken = default)
     {
         File.WriteAllText(Path.Combine(outputFolder, "customPostProcessor.txt"), "customPostProcessor");
         return manifest;


### PR DESCRIPTION
This PR add `CancellationToken` support to`RunBuild.Exec` method.
It's expected to be used by `docfx watch` command.

**What's Changed in this PR**

- Add `CancellationToken` parameter to methods and use token on operations that take times.
  - `for`/`foreach` operations
  - `Parallel.ForEach` operations
  - `AsParallel()` operations

- `DocumentBuildContext.cs`
  - Add `CancellationToken` property.
  - Change some constructor's access modifiers from `public` to `internal/private` that used by tests.

- `DocumentExceptionExtensions.cs`
  - Add logics to handle `AggregateException` on cancellation.

**Breaking Changes**

This PR change some public method signatures.
The user who using `Docfx.Plugins` package  need to update versions.

**Test**
Manually run cancellation tests with various delay patterns.
And confirmed operation is canceled with `OperationCanceledException` based exception (including `TaskCanceledException`)
