### PR TITLE
Prevent the first navbar element from being set as active unnecessarily in the modern template

### DIFF
--- a/templates/modern/src/nav.ts
+++ b/templates/modern/src/nav.ts
@@ -142,10 +142,9 @@ function findActiveItem(items: (NavItem | NavItemContainer)[]): NavItem {
       continue
     }
     const prefix = commonUrlPrefix(url, item.href)
-    if (prefix == maxPrefix) {
+    if (prefix === maxPrefix) {
       activeItem = undefined
-    }
-    else if (prefix > maxPrefix) {
+    } else if (prefix > maxPrefix) {
       maxPrefix = prefix
       activeItem = item
     }

--- a/templates/modern/src/nav.ts
+++ b/templates/modern/src/nav.ts
@@ -142,7 +142,10 @@ function findActiveItem(items: (NavItem | NavItemContainer)[]): NavItem {
       continue
     }
     const prefix = commonUrlPrefix(url, item.href)
-    if (prefix > maxPrefix) {
+    if (prefix == maxPrefix) {
+      activeItem = undefined
+    }
+    else if (prefix > maxPrefix) {
       maxPrefix = prefix
       activeItem = item
     }


### PR DESCRIPTION
Fixes #9877