### PR TITLE
chore: Update xunit package versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -60,8 +60,8 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="PublicApiGenerator" Version="11.1.0" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.1.0" />
-    <PackageVersion Include="Verify.Xunit" Version="26.5.0" />
+    <PackageVersion Include="Verify.Xunit" Version="26.6.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="xunit" Version="2.9.0" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
   </ItemGroup>
 </Project>

--- a/test/Docfx.Build.OverwriteDocuments.Tests/OverwriteDocumentModelCreatorTest.cs
+++ b/test/Docfx.Build.OverwriteDocuments.Tests/OverwriteDocumentModelCreatorTest.cs
@@ -106,7 +106,7 @@ definitions:
         }
 
         var logs = _listener.Items;
-        Assert.Single(logs.Where(l => l.Code == WarningCodes.Overwrite.InvalidMarkdownFragments));
+        Assert.Single(logs, l => l.Code == WarningCodes.Overwrite.InvalidMarkdownFragments);
         Assert.Single(contentsMetadata);
         Assert.Equal("test2",
             ((ParagraphBlock)((MarkdownDocument)((Dictionary<object, object>)contentsMetadata["function"])["parameters"])[0]).Inline.FirstChild.ToString());


### PR DESCRIPTION
This PR update xunit related packages.
And change lines to suppress following warnings that occurred when update xunit version to `2.9.1`.

> OverwriteDocumentModelCreatorTest.cs(109,9):
> warning xUnit2031:
> Do not use a Where clause to filter before calling Assert.Single. Use the overload of Assert.Single that accepts a filtering function. (https://xunit.net/xunit.analyzers/rules/xUnit2031)