### PR TITLE
chore: Remove `OneOf.SourceGenerator` runtime dependency

### DIFF
--- a/src/Docfx.Build/Docfx.Build.csproj
+++ b/src/Docfx.Build/Docfx.Build.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Jint" />
     <PackageReference Include="Stubble.Core" />
     <PackageReference Include="OneOf" />
-    <PackageReference Include="OneOf.SourceGenerator" />
+    <PackageReference Include="OneOf.SourceGenerator" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Docfx.Dotnet/Docfx.Dotnet.csproj
+++ b/src/Docfx.Dotnet/Docfx.Dotnet.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="ICSharpCode.Decompiler" />
     <PackageReference Include="IgnoresAccessChecksToGenerator" PrivateAssets="All" />
     <PackageReference Include="OneOf" />
-    <PackageReference Include="OneOf.SourceGenerator" />
+    <PackageReference Include="OneOf.SourceGenerator" PrivateAssets="All" />
     <PackageReference Include="Markdig" />
     <PackageReference Include="Microsoft.CodeAnalysis" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" />


### PR DESCRIPTION
This PR remove runtime dependency to `OneOf.SourceGenerator` of following packages.

- https://www.nuget.org/packages/Docfx.Build#dependencies-body-tab
- https://www.nuget.org/packages/Docfx.DotNet#dependencies-body-tab
