### PR TITLE
chore: Suppress test logs output when running `percy exec`

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -18,7 +18,7 @@
     <None Include="TestData\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">
+  <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true' AND '$(PERCY_TOKEN)' == ''">
     <VSTestResultsDirectory>$(MSBuildThisFileDirectory)TestResults</VSTestResultsDirectory>
     <VSTestLogger>$(VSTestLogger);trx%3BLogFileName=TestResults-$(MSBuildProjectName)-$(TargetFramework).trx</VSTestLogger>
     <VSTestLogger>$(VSTestLogger);html%3BLogFileName=TestResults-$(MSBuildProjectName)-$(TargetFramework).html</VSTestLogger>


### PR DESCRIPTION
This PR intended to fix following problems

1. Test logs for `ubuntu(.NET 8)` are overwritten by `percy tests` execution.  
    -> Skip test logs output if `PERCY_TOKEN` environment variable is available.
