### PR TITLE
chore: Add intellisense code completion supports for docfx config

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -1,4 +1,5 @@
 ﻿{
+  "$schema": "https://raw.githubusercontent.com/dotnet/docfx/main/schemas/docfx.schema.json",
   "metadata": [
     {
       "src": [

--- a/samples/seed/docfx.json
+++ b/samples/seed/docfx.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/dotnet/docfx/main/schemas/docfx.schema.json",
   "metadata": [
     {
       "src": [

--- a/schemas/docfx.schema.json
+++ b/schemas/docfx.schema.json
@@ -5,6 +5,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "$schema": {
+      "type": "string",
+      "default": "https://raw.githubusercontent.com/dotnet/docfx/main/schemas/docfx.schema.json"
+    },
     "build": {
       "$ref": "#/$defs/buildConfig"
     },

--- a/schemas/filterconfig.schema.json
+++ b/schemas/filterconfig.schema.json
@@ -5,6 +5,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "$schema": {
+      "type": "string",
+      "default": "https://raw.githubusercontent.com/dotnet/docfx/main/schemas/filterconfig.schema.json"
+    },
     "apiRules": {
       "type": "array",
       "description": "Include/exclude rules using uid.",

--- a/schemas/toc.schema.json
+++ b/schemas/toc.schema.json
@@ -4,7 +4,7 @@
   "title": "JSON Schema for docfx TOC file.",
   "anyOf": [
     {
-      "$ref": "#/$defs/tocItem"
+      "$ref": "#/$defs/rootTocItem"
     },
     {
       "type": "array",
@@ -14,6 +14,101 @@
     }
   ],
   "$defs": {
+    "rootTocItem": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "$schema": {
+          "type": "string",
+          "default": "https://raw.githubusercontent.com/dotnet/docfx/main/schemas/toc.schema.json"
+        },
+        "uid": {
+          "type": "string",
+          "description": "The uid of the article. Can be used instead of href."
+        },
+        "name": {
+          "type": "string",
+          "description": ""
+        },
+        "displayName": {
+          "type": "string",
+          "description": "An optional display name for the TOC node. When not specified, uses the title metadata or the first Heading 1 element from the referenced article as the display name."
+        },
+        "href": {
+          "type": "string",
+          "description": "The path the TOC node leads to. Optional because a node can exist just to parent other nodes."
+        },
+        "originalHref": {
+          "type": "string",
+          "description": ""
+        },
+        "tocHref": {
+          "type": "string",
+          "description": ""
+        },
+        "originalTocHref": {
+          "type": "string",
+          "description": ""
+        },
+        "topicHref": {
+          "type": "string",
+          "description": "Specify the topic href of the TOC Item. It is useful when href is linking to a folder or TOC file or tocHref is used."
+        },
+        "originalTopicHref": {
+          "type": "string",
+          "description": ""
+        },
+        "includedFrom": {
+          "type": "string",
+          "description": ""
+        },
+        "homepage": {
+          "type": "string",
+          "description": "(Deprecated)",
+          "deprecated": true
+        },
+        "originalHomepage": {
+          "type": "string",
+          "description": "(Deprecated).",
+          "deprecated": true
+        },
+        "homepageUid": {
+          "type": "string",
+          "description": "(Deprecated).",
+          "deprecated": true
+        },
+        "topicUid": {
+          "type": "string",
+          "description": "Specify the uid of the referenced file. If the value is set, it overwrites the value of topicHref."
+        },
+        "order": {
+          "type": "integer",
+          "default": 0,
+          "description": "Specify the order of toc item, TOCs with a smaller order value are picked first."
+        },
+        "type": {
+          "type": "string",
+          "description": "Specify the type of toc item."
+        },
+        "items": {
+          "type": "array",
+          "description": "List of TOC items.",
+          "items": {
+            "$ref": "#/$defs/tocItem"
+          }
+        },
+        "expanded": {
+          "type": "boolean",
+          "default": false,
+          "description": "If set to true, Child items are displayed as expanded."
+        },
+        "dropdown": {
+          "type": "boolean",
+          "default": false,
+          "description": "If set to true, Child items are displayed as dropdown on top navigation bar."
+        }
+      }
+    },
     "tocItem": {
       "type": "object",
       "additionalProperties": true,

--- a/schemas/xrefmap.schema.json
+++ b/schemas/xrefmap.schema.json
@@ -5,6 +5,10 @@
   "type": "object",
   "additionalProperties": true,
   "properties": {
+    "$schema": {
+      "type": "string",
+      "default": "https://raw.githubusercontent.com/dotnet/docfx/main/schemas/xrefmap.schema.json"
+    },
     "sorted": {
       "type": "boolean",
       "default": false,

--- a/src/docfx/Models/InitCommand.cs
+++ b/src/docfx/Models/InitCommand.cs
@@ -33,6 +33,7 @@ class InitCommand : Command<InitCommandOptions>
 
         var docfx = new
         {
+            schema = "https://raw.githubusercontent.com/dotnet/docfx/main/schemas/docfx.schema.json",
             metadata = dotnetApi ? new[]
             {
                 new
@@ -72,7 +73,7 @@ class InitCommand : Command<InitCommandOptions>
             {
                 WriteIndented = true,
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-            }),
+            }).Replace("\"schema\"", "\"$schema\""),
 
             ["toc.yml"] = dotnetApi ?
                 $"""


### PR DESCRIPTION
1. Add `$schema` property to following `docfx.json` files to support intellisense code completion.
    - `docfx.json` file for `docs` site.
    - `docfx.json` file for `samples/seed` site.
    - `docfx.json` file for site that created by `docfx init` command.
2. Add `$schema` definition to related schemas. It's required to suppress intellisense error. 
3. Reorganize `toc.schema.json` schema to support `$schema` property. (There is no functionality changes)

**Test**
I've confirmed intellisense behaviors with following editors.
- Visual Studio 2022
- VSCode

