### PR TITLE
chore: add .NET 6 SDK installation steps for environment that don't have SDK

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -10,6 +10,7 @@ runs:
   - uses: actions/setup-dotnet@v4
     with:
       dotnet-version: |
+        6.x
         8.x
 
   - run: npm install

--- a/samples/extensions/build/build.csproj
+++ b/samples/extensions/build/build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
This PR intended to fix CI errors that occurred on `ubuntu-24.04` OS image.

`ubuntu-latest` image is [expected to be switched to `ubuntu-24.04` in this month.](https://github.com/actions/runner-images/issues/10636)

But `ubuntu-24.04` image preinstall `.NET 8 SDK` only.
So it need to manually install `.NET 6 SDK`.

**List of Preinstalled Software**
- `ubuntu-22.04`: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#net-tools
- `ubuntu-24.04`: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#net-tools
