### PR TITLE
chore: Explicitly set ‘IsTestProject‘ property to `false` for non-test project

### DIFF
--- a/test/Docfx.Tests.Common/Docfx.Tests.Common.csproj
+++ b/test/Docfx.Tests.Common/Docfx.Tests.Common.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsTestProject>false</IsTestProject>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.Common\Docfx.Common.csproj" />
   </ItemGroup>

--- a/test/docfx.Snapshot.Tests/SamplesTest.cs
+++ b/test/docfx.Snapshot.Tests/SamplesTest.cs
@@ -37,6 +37,8 @@ public class SamplesTest : IDisposable
     {
         public SamplesFactAttribute()
         {
+            // When target framework is changed.
+            // It need to modify TargetFrameworks property of `docfx.Snapshot.Tests.csproj`
 #if !NET8_0
             Skip = "Skip by target framework";
 #endif

--- a/test/docfx.Snapshot.Tests/docfx.Snapshot.Tests.csproj
+++ b/test/docfx.Snapshot.Tests/docfx.Snapshot.Tests.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.Playwright" />
     <PackageReference Include="Verify.DiffPlex" />


### PR DESCRIPTION
This PR change  `Docfx.Tests.Common` project's `IsTestProject` property to `false`.
Because it's shared library project and not contais tests.

It's required to exclude projects from test execution.
e.g. https://github.com/dotnet/docfx/runs/31762712785#r60

> No tests found

Additionally  `docfx.Snapshot.Tests` project for `.NET 6` have no runnable tests.
So I've override `TargetFrameworks` property with following reasons.

- Reduce build time and disk spaces (It takes about `150MB`)
- When updated to xUnit v3 and running with [Microsoft.Testing.Platform](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-platform-intro) test project that have no tests returns error code. 




