### PR TITLE
docs: Add node.js as prerequisite

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ In this section we will build a simple documentation site on your local machine.
 > Prerequisites
 > - Familiarity with the command line
 > - Install [.NET SDK](https://dotnet.microsoft.com/en-us/download) 6.0 or higher
+> - Install [Node.js](https://nodejs.org/) v20 or higher
 
 Make sure you have [.NET SDK](https://dotnet.microsoft.com/en-us/download) installed, then open a terminal and enter the following command to install the latest docfx:
 

--- a/docs/reference/docfx-environment-variables-reference.md
+++ b/docs/reference/docfx-environment-variables-reference.md
@@ -30,5 +30,5 @@ Maximum time in milliseconds to override the default [Playwright timeout](https:
 
 ## `PLAYWRIGHT_NODEJS_PATH`
 
-Custom Node.js executable path that will be used by the `docfx pdf' command.
+Custom Node.js executable path that will be used by the `docfx pdf` command.
 By default, docfx automatically detect installed Node.js from `PATH`.


### PR DESCRIPTION
This PR add document prerequisite for `Node.js` installation and related type fix.

Node.js runtime bundles are removed by #10066.
So docfx user who using `pdf generation` need to install Node.js runtime.



