### PR TITLE
fix: change link as plaintext if API is excluded

### DIFF
--- a/src/Docfx.Dotnet/DotnetApiCatalog.ApiPage.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.ApiPage.cs
@@ -707,14 +707,16 @@ partial class DotnetApiCatalog
         Inline ShortLink(ISymbol symbol, Compilation compilation)
         {
             var title = SymbolFormatter.GetNameWithType(symbol, SyntaxLanguage.CSharp);
-            var url = SymbolUrlResolver.GetSymbolUrl(symbol, compilation, config.MemberLayout, symbolUrlKind, allAssemblies);
+            var url = filter.IncludeApi(symbol)
+                        ? SymbolUrlResolver.GetSymbolUrl(symbol, compilation, config.MemberLayout, symbolUrlKind, allAssemblies)
+                        : null;
             return Link(title, url);
         }
 
         Inline FullLink(ISymbol symbol, Compilation compilation)
         {
             var parts = SymbolFormatter.GetNameWithTypeParts(symbol, SyntaxLanguage.CSharp);
-            var linkItems = SymbolFormatter.ToLinkItems(parts, compilation, config.MemberLayout, allAssemblies, overload: false, symbolUrlKind);
+            var linkItems = SymbolFormatter.ToLinkItems(parts, compilation, config.MemberLayout, allAssemblies, overload: false, filter, symbolUrlKind);
 
             return linkItems.Select(i => Link(i.DisplayName, i.Href)).ToArray();
         }
@@ -722,7 +724,9 @@ partial class DotnetApiCatalog
         Inline NameOnlyLink(ISymbol symbol, Compilation compilation)
         {
             var title = SymbolFormatter.GetName(symbol, SyntaxLanguage.CSharp);
-            var url = SymbolUrlResolver.GetSymbolUrl(symbol, compilation, config.MemberLayout, symbolUrlKind, allAssemblies);
+            var url = filter.IncludeApi(symbol)
+                        ? SymbolUrlResolver.GetSymbolUrl(symbol, compilation, config.MemberLayout, symbolUrlKind, allAssemblies)
+                        : null;
             return Link(title, url);
         }
 

--- a/src/Docfx.Dotnet/DotnetApiCatalog.ApiPage.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.ApiPage.cs
@@ -707,9 +707,7 @@ partial class DotnetApiCatalog
         Inline ShortLink(ISymbol symbol, Compilation compilation)
         {
             var title = SymbolFormatter.GetNameWithType(symbol, SyntaxLanguage.CSharp);
-            var url = filter.IncludeApi(symbol)
-                        ? SymbolUrlResolver.GetSymbolUrl(symbol, compilation, config.MemberLayout, symbolUrlKind, allAssemblies)
-                        : null;
+            var url = SymbolUrlResolver.GetSymbolUrl(symbol, compilation, config.MemberLayout, symbolUrlKind, allAssemblies, filter);
             return Link(title, url);
         }
 
@@ -724,9 +722,7 @@ partial class DotnetApiCatalog
         Inline NameOnlyLink(ISymbol symbol, Compilation compilation)
         {
             var title = SymbolFormatter.GetName(symbol, SyntaxLanguage.CSharp);
-            var url = filter.IncludeApi(symbol)
-                        ? SymbolUrlResolver.GetSymbolUrl(symbol, compilation, config.MemberLayout, symbolUrlKind, allAssemblies)
-                        : null;
+            var url = SymbolUrlResolver.GetSymbolUrl(symbol, compilation, config.MemberLayout, symbolUrlKind, allAssemblies, filter);
             return Link(title, url);
         }
 

--- a/src/Docfx.Dotnet/ManagedReference/Visitors/SymbolVisitorAdapter.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Visitors/SymbolVisitorAdapter.cs
@@ -374,7 +374,7 @@ internal class SymbolVisitorAdapter : SymbolVisitor<MetadataItem>
             Debug.Fail("Unexpected member type.");
             throw new InvalidOperationException("Unexpected member type.");
         }
-        return _generator.AddReference(symbol, _references);
+        return _generator.AddReference(symbol, _references, _filter);
     }
 
     public string AddReference(string id, string commentId)
@@ -390,7 +390,7 @@ internal class SymbolVisitorAdapter : SymbolVisitor<MetadataItem>
             reference.QualifiedNameParts = new();
             reference.IsDefinition = symbol.IsDefinition;
 
-            _generator.GenerateReference(symbol, reference, asOverload: false);
+            _generator.GenerateReference(symbol, reference, asOverload: false, _filter);
         }
 
         _references[id] = reference;
@@ -406,7 +406,7 @@ internal class SymbolVisitorAdapter : SymbolVisitor<MetadataItem>
             case MemberType.Constructor:
             case MemberType.Method:
             case MemberType.Operator:
-                return _generator.AddOverloadReference(symbol, _references);
+                return _generator.AddOverloadReference(symbol, _references, _filter);
             default:
                 Debug.Fail("Unexpected member type.");
                 throw new InvalidOperationException("Unexpected member type.");
@@ -418,7 +418,7 @@ internal class SymbolVisitorAdapter : SymbolVisitor<MetadataItem>
         IReadOnlyList<string> typeGenericParameters = null,
         IReadOnlyList<string> methodGenericParameters = null)
     {
-        return _generator.AddSpecReference(symbol, typeGenericParameters, methodGenericParameters, _references, this);
+        return _generator.AddSpecReference(symbol, typeGenericParameters, methodGenericParameters, _references, _filter);
     }
 
     private static MemberType GetMemberTypeFromSymbol(ISymbol symbol)

--- a/src/Docfx.Dotnet/ManagedReference/Visitors/YamlModelGenerator.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Visitors/YamlModelGenerator.cs
@@ -30,7 +30,7 @@ internal class YamlModelGenerator
         item.DisplayQualifiedNames[SyntaxLanguage.VB] = SymbolFormatter.GetQualifiedName(symbol, SyntaxLanguage.VB);
     }
 
-    public void GenerateReference(ISymbol symbol, ReferenceItem reference, bool asOverload)
+    public void GenerateReference(ISymbol symbol, ReferenceItem reference, bool asOverload, SymbolFilter filter)
     {
         if (!reference.NameParts.ContainsKey(SyntaxLanguage.CSharp))
             reference.NameParts.Add(SyntaxLanguage.CSharp, new());
@@ -39,9 +39,9 @@ internal class YamlModelGenerator
         if (!reference.QualifiedNameParts.ContainsKey(SyntaxLanguage.CSharp))
             reference.QualifiedNameParts.Add(SyntaxLanguage.CSharp, new());
 
-        reference.NameParts[SyntaxLanguage.CSharp] = SymbolFormatter.GetNameParts(symbol, SyntaxLanguage.CSharp, nullableReferenceType: false, asOverload).ToLinkItems(_compilation, _memberLayout, _allAssemblies, asOverload);
-        reference.NameWithTypeParts[SyntaxLanguage.CSharp] = SymbolFormatter.GetNameWithTypeParts(symbol, SyntaxLanguage.CSharp, nullableReferenceType: false, asOverload).ToLinkItems(_compilation, _memberLayout, _allAssemblies, asOverload);
-        reference.QualifiedNameParts[SyntaxLanguage.CSharp] = SymbolFormatter.GetQualifiedNameParts(symbol, SyntaxLanguage.CSharp, nullableReferenceType: false, asOverload).ToLinkItems(_compilation, _memberLayout, _allAssemblies, asOverload);
+        reference.NameParts[SyntaxLanguage.CSharp] = SymbolFormatter.GetNameParts(symbol, SyntaxLanguage.CSharp, nullableReferenceType: false, asOverload).ToLinkItems(_compilation, _memberLayout, _allAssemblies, asOverload, filter);
+        reference.NameWithTypeParts[SyntaxLanguage.CSharp] = SymbolFormatter.GetNameWithTypeParts(symbol, SyntaxLanguage.CSharp, nullableReferenceType: false, asOverload).ToLinkItems(_compilation, _memberLayout, _allAssemblies, asOverload, filter);
+        reference.QualifiedNameParts[SyntaxLanguage.CSharp] = SymbolFormatter.GetQualifiedNameParts(symbol, SyntaxLanguage.CSharp, nullableReferenceType: false, asOverload).ToLinkItems(_compilation, _memberLayout, _allAssemblies, asOverload, filter);
 
         if (!reference.NameParts.ContainsKey(SyntaxLanguage.VB))
             reference.NameParts.Add(SyntaxLanguage.VB, new());
@@ -50,9 +50,9 @@ internal class YamlModelGenerator
         if (!reference.QualifiedNameParts.ContainsKey(SyntaxLanguage.VB))
             reference.QualifiedNameParts.Add(SyntaxLanguage.VB, new());
 
-        reference.NameParts[SyntaxLanguage.VB] = SymbolFormatter.GetNameParts(symbol, SyntaxLanguage.VB, nullableReferenceType: false, asOverload).ToLinkItems(_compilation, _memberLayout, _allAssemblies, asOverload);
-        reference.NameWithTypeParts[SyntaxLanguage.VB] = SymbolFormatter.GetNameWithTypeParts(symbol, SyntaxLanguage.VB, nullableReferenceType: false, asOverload).ToLinkItems(_compilation, _memberLayout, _allAssemblies, asOverload);
-        reference.QualifiedNameParts[SyntaxLanguage.VB] = SymbolFormatter.GetQualifiedNameParts(symbol, SyntaxLanguage.VB, nullableReferenceType: false, asOverload).ToLinkItems(_compilation, _memberLayout, _allAssemblies, asOverload);
+        reference.NameParts[SyntaxLanguage.VB] = SymbolFormatter.GetNameParts(symbol, SyntaxLanguage.VB, nullableReferenceType: false, asOverload).ToLinkItems(_compilation, _memberLayout, _allAssemblies, asOverload, filter);
+        reference.NameWithTypeParts[SyntaxLanguage.VB] = SymbolFormatter.GetNameWithTypeParts(symbol, SyntaxLanguage.VB, nullableReferenceType: false, asOverload).ToLinkItems(_compilation, _memberLayout, _allAssemblies, asOverload, filter);
+        reference.QualifiedNameParts[SyntaxLanguage.VB] = SymbolFormatter.GetQualifiedNameParts(symbol, SyntaxLanguage.VB, nullableReferenceType: false, asOverload).ToLinkItems(_compilation, _memberLayout, _allAssemblies, asOverload, filter);
     }
 
     public void GenerateSyntax(ISymbol symbol, SyntaxDetail syntax, SymbolFilter filter)
@@ -61,7 +61,7 @@ internal class YamlModelGenerator
         syntax.Content[SyntaxLanguage.VB] = SymbolFormatter.GetSyntax(symbol, SyntaxLanguage.VB, filter);
     }
 
-    public string AddReference(ISymbol symbol, Dictionary<string, ReferenceItem> references)
+    public string AddReference(ISymbol symbol, Dictionary<string, ReferenceItem> references, SymbolFilter filter)
     {
         var id = VisitorHelper.GetId(symbol);
         var reference = new ReferenceItem
@@ -72,7 +72,7 @@ internal class YamlModelGenerator
             IsDefinition = symbol.IsDefinition,
             CommentId = VisitorHelper.GetCommentId(symbol)
         };
-        GenerateReference(symbol, reference, false);
+        GenerateReference(symbol, reference, false, filter);
 
         if (!references.TryAdd(id, reference))
         {
@@ -82,7 +82,7 @@ internal class YamlModelGenerator
         return id;
     }
 
-    public string AddOverloadReference(ISymbol symbol, Dictionary<string, ReferenceItem> references)
+    public string AddOverloadReference(ISymbol symbol, Dictionary<string, ReferenceItem> references, SymbolFilter filter)
     {
         var uidBody = VisitorHelper.GetOverloadIdBody(symbol);
         var reference = new ReferenceItem
@@ -94,7 +94,7 @@ internal class YamlModelGenerator
             CommentId = "Overload:" + uidBody
         };
 
-        GenerateReference(symbol, reference, true);
+        GenerateReference(symbol, reference, true, filter);
 
         var uid = uidBody + "*";
         if (!references.TryAdd(uid, reference))
@@ -110,7 +110,7 @@ internal class YamlModelGenerator
         IReadOnlyList<string> typeGenericParameters,
         IReadOnlyList<string> methodGenericParameters,
         Dictionary<string, ReferenceItem> references,
-        SymbolVisitorAdapter adapter)
+        SymbolFilter filter)
     {
         var rawId = VisitorHelper.GetId(symbol);
         var id = SpecIdHelper.GetSpecId(symbol, typeGenericParameters, methodGenericParameters);
@@ -124,7 +124,7 @@ internal class YamlModelGenerator
             NameWithTypeParts = new(),
             QualifiedNameParts = new(),
         };
-        GenerateReference(symbol, reference, false);
+        GenerateReference(symbol, reference, false, filter);
         var originalSymbol = symbol;
         var reducedFrom = (symbol as IMethodSymbol)?.ReducedFrom;
         if (reducedFrom != null)
@@ -135,10 +135,10 @@ internal class YamlModelGenerator
 
         if (!reference.IsDefinition.Value && rawId != null)
         {
-            reference.Definition = AddReference(originalSymbol.OriginalDefinition, references);
+            reference.Definition = AddReference(originalSymbol.OriginalDefinition, references, filter);
         }
 
-        reference.Parent = GetReferenceParent(originalSymbol, typeGenericParameters, methodGenericParameters, references, adapter);
+        reference.Parent = GetReferenceParent(originalSymbol, typeGenericParameters, methodGenericParameters, references, filter);
         reference.CommentId = VisitorHelper.GetCommentId(originalSymbol);
 
         if (!references.TryAdd(id, reference))
@@ -153,7 +153,7 @@ internal class YamlModelGenerator
         IReadOnlyList<string> typeGenericParameters,
         IReadOnlyList<string> methodGenericParameters,
         Dictionary<string, ReferenceItem> references,
-        SymbolVisitorAdapter adapter)
+        SymbolFilter filter)
     {
         switch (symbol.Kind)
         {
@@ -172,7 +172,7 @@ internal class YamlModelGenerator
                     {
                         return null;
                     }
-                    return AddSpecReference(parentSymbol, typeGenericParameters, methodGenericParameters, references, adapter); ;
+                    return AddSpecReference(parentSymbol, typeGenericParameters, methodGenericParameters, references, filter);
                 }
             default:
                 return null;

--- a/src/Docfx.Dotnet/SymbolFormatter.cs
+++ b/src/Docfx.Dotnet/SymbolFormatter.cs
@@ -138,9 +138,7 @@ internal static partial class SymbolFormatter
             {
                 Name = overload ? VisitorHelper.GetOverloadId(symbol) : VisitorHelper.GetId(symbol),
                 DisplayName = part.ToString(),
-                Href = filter.IncludeApi(symbol)
-                        ? SymbolUrlResolver.GetSymbolUrl(symbol, compilation, memberLayout, urlKind, allAssemblies)
-                        : null,
+                Href = SymbolUrlResolver.GetSymbolUrl(symbol, compilation, memberLayout, urlKind, allAssemblies, filter),
                 IsExternalPath = symbol.IsExtern || symbol.DeclaringSyntaxReferences.Length == 0,
             };
         }

--- a/src/Docfx.Dotnet/SymbolFormatter.cs
+++ b/src/Docfx.Dotnet/SymbolFormatter.cs
@@ -113,7 +113,7 @@ internal static partial class SymbolFormatter
     }
 
     public static List<LinkItem> ToLinkItems(this ImmutableArray<SymbolDisplayPart> parts,
-        Compilation compilation, MemberLayout memberLayout, HashSet<IAssemblySymbol> allAssemblies, bool overload, SymbolUrlKind urlKind = SymbolUrlKind.Html)
+        Compilation compilation, MemberLayout memberLayout, HashSet<IAssemblySymbol> allAssemblies, bool overload, SymbolFilter filter, SymbolUrlKind urlKind = SymbolUrlKind.Html)
     {
         var result = new List<LinkItem>();
         foreach (var part in parts)
@@ -138,7 +138,9 @@ internal static partial class SymbolFormatter
             {
                 Name = overload ? VisitorHelper.GetOverloadId(symbol) : VisitorHelper.GetId(symbol),
                 DisplayName = part.ToString(),
-                Href = SymbolUrlResolver.GetSymbolUrl(symbol, compilation, memberLayout, urlKind, allAssemblies),
+                Href = filter.IncludeApi(symbol)
+                        ? SymbolUrlResolver.GetSymbolUrl(symbol, compilation, memberLayout, urlKind, allAssemblies)
+                        : null,
                 IsExternalPath = symbol.IsExtern || symbol.DeclaringSyntaxReferences.Length == 0,
             };
         }

--- a/src/Docfx.Dotnet/SymbolUrlResolver.cs
+++ b/src/Docfx.Dotnet/SymbolUrlResolver.cs
@@ -16,11 +16,14 @@ enum SymbolUrlKind
 
 internal static partial class SymbolUrlResolver
 {
-    public static string? GetSymbolUrl(ISymbol symbol, Compilation compilation, MemberLayout memberLayout, SymbolUrlKind urlKind, HashSet<IAssemblySymbol> allAssemblies)
+    public static string? GetSymbolUrl(ISymbol symbol, Compilation compilation, MemberLayout memberLayout, SymbolUrlKind urlKind, HashSet<IAssemblySymbol> allAssemblies, SymbolFilter filter)
     {
         // Reduce symbol into generic definitions
         symbol = symbol is IMethodSymbol method ? method.ReducedFrom ?? symbol : symbol;
         symbol = symbol.OriginalDefinition ?? symbol;
+
+        if (!filter.IncludeApi(symbol))
+            return null;
 
         return GetDocfxUrl(symbol, memberLayout, urlKind, allAssemblies)
             ?? GetMicrosoftLearnUrl(symbol)


### PR DESCRIPTION
This PR intended to fix problem reported at #10287.

When class is excluded. link target document is not exists. 
So link to excluded symbol should be rendered as **plain text**. 

**What's changed in this PR**
It needs `SymbolFilter::IncludeApi` instance to check specific symbol is excluded or not.
So it need to pass `SymbolFilter` instance to API that generate URL.

- Add  `SymbolFilter filter` parameter to several APIs. 
- Change `url` generation logics to check `filter.IncludeApi(symbol)` and set null when symbol is excluded.
- Remove `SymbolVisitorAdapter adapter` parameter (that seems not be used).

**Test**
Tested on local environment with following output formats.
- `mref`
- `markdown`
- `apiPage`

