### PR TITLE
fix: suppress assembly load warning for wpf 8.0 project

### DIFF
--- a/src/Docfx.Dotnet/CompilationHelper.cs
+++ b/src/Docfx.Dotnet/CompilationHelper.cs
@@ -179,7 +179,12 @@ internal static class CompilationHelper
                 var file = assemblyResolver.FindAssemblyFile(reference);
                 if (file is null)
                 {
-                    Logger.LogWarning($"Unable to resolve assembly reference {reference}", code: "InvalidAssemblyReference");
+                    // Skip warning for some weired assembly references: https://github.com/dotnet/docfx/issues/9459
+                    if (reference.Version?.ToString() != "0.0.0.0")
+                    {
+                        Logger.LogWarning($"Unable to resolve assembly reference {reference}", code: "InvalidAssemblyReference");
+                    }
+
                     continue;
                 }
 


### PR DESCRIPTION
Fixes #9459 