### PR TITLE
chore: Cleanup code that relating dropping .NET 6 support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,20 +45,12 @@
     <None Include="$(MSBuildThisFileDirectory)\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(ProjectName)' != 'Docfx.Common'">
-    <PackageReference Include="PolySharp">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
 
   <!-- Remove Node.js runtime dependencies that used by playwright -->
   <Target Name="RemoveNodeJsRuntimes" AfterTargets="CopyPlaywrightFilesToOutput">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,6 @@
     <PackageVersion Include="OneOf.SourceGenerator" Version="3.0.271" />
     <PackageVersion Include="PdfPig" Version="0.1.9" />
     <PackageVersion Include="PlantUml.Net" Version="1.4.80" />
-    <PackageVersion Include="PolySharp" Version="1.14.1" />
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />
     <PackageVersion Include="Stubble.Core" Version="1.10.8" />

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ We welcome code contributions through pull requests, issues tagged as **[`help-w
 ### Prerequisites
 
 - Install [Visual Studio 2022 (Community or higher)](https://www.visualstudio.com/) and make sure you have the latest updates.
-- Install [.NET SDK](https://dotnet.microsoft.com/download/dotnet) 6.x and 8.x.
+- Install [.NET SDK](https://dotnet.microsoft.com/download/dotnet) 8.x and 9.x.
 - Install NodeJS (20.x.x).
 
 ### Build and Test

--- a/src/Docfx.Common/Docfx.Common.csproj
+++ b/src/Docfx.Common/Docfx.Common.csproj
@@ -10,13 +10,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="Docfx.Build.ManagedReference" />
+    <InternalsVisibleTo Include="docfx.Build" />
     <InternalsVisibleTo Include="Docfx.Dotnet" />
   </ItemGroup>
 
   <!-- TODO: Following settings will be removed after NewtonsoftJson dependencies are removed. -->
   <ItemGroup>
-    <InternalsVisibleTo Include="docfx.Build" />
     <InternalsVisibleTo Include="Docfx.Build.Tests" />
     <InternalsVisibleTo Include="docfx.Tests" />
   </ItemGroup>


### PR DESCRIPTION
This PR contains following changes.

1. Remove `PolySharp` package dependency.
2. Update `README.md`   
   (Note: Until .NET 9 RTM released. it requires Visual Studio **Preview** to build .NET 9 project)
3. Remove unused `InternalsVisibleTo` attribute from `Docfx.Common` project.
4. ~~Remove `System.Formats.Asn1` dependency (That is added by #10107)~~  
    `Microsoft.CodeAnalysis.Workspaces.MSBuild` package still have transitive dependency to `System.Formats.Asn1`.
