### PR TITLE
chore: Change npm package install command to `npm ci`

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -13,7 +13,7 @@ runs:
         9.x
         8.x
 
-  - run: npm install
+  - run: npm ci
     shell: bash
     working-directory: templates
 


### PR DESCRIPTION
This PR change CI build steps to use `npm ci` command to install packages.

- Run faster than `npm install`
- Strict version package is installed that defined by `package-lock.json`