### PR TITLE
chore: Fix error on `npm run build -- --watch` command

### DIFF
--- a/templates/build.js
+++ b/templates/build.js
@@ -113,8 +113,8 @@ function copyToDist() {
 }
 
 function buildContent() {
-  exec(`dotnet run -f net7.0 --project ../src/docfx/docfx.csproj -- metadata ${project}/docfx.json`)
-  exec(`dotnet run -f net7.0 --project ../src/docfx/docfx.csproj --no-build -- build ${project}/docfx.json`)
+  exec(`dotnet run -f net8.0 --project ../src/docfx/docfx.csproj -- metadata ${project}/docfx.json`)
+  exec(`dotnet run -f net8.0 --project ../src/docfx/docfx.csproj --no-build -- build ${project}/docfx.json`)
 
   function exec(cmd) {
     if (spawnSync(cmd, { stdio: 'inherit', shell: true }).status !== 0) {


### PR DESCRIPTION
This PR intended to fix error when running `npm run build -- --watch` command.