### PR TITLE
chore: Refactor `MarkdigExtensionSetting` deserialization logics

### DIFF
--- a/src/Docfx.MarkdigEngine.Extensions/MarkdigExtensionSetting.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/MarkdigExtensionSetting.cs
@@ -51,7 +51,7 @@ public class MarkdigExtensionSetting
     public T GetOptions<T>(T fallbackValue)
     {
         return Options is null ? fallbackValue
-            : JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(Options), MarkdigExtensionSettingConverter.DefaultSerializerOptions) ?? fallbackValue;
+            : Options.Value.Deserialize<T>(MarkdigExtensionSettingConverter.DefaultSerializerOptions) ?? fallbackValue;
     }
 
     /// <summary>

--- a/src/Docfx.MarkdigEngine.Extensions/MarkdigExtensionSettingConverter.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/MarkdigExtensionSettingConverter.cs
@@ -11,8 +11,8 @@ internal partial class MarkdigExtensionSettingConverter
     // Shared JsonSerializerOptions instance.
     internal static readonly System.Text.Json.JsonSerializerOptions DefaultSerializerOptions = new()
     {
-        IncludeFields = true,
         AllowTrailingCommas = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
         DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         PropertyNameCaseInsensitive = true,

--- a/test/docfx.Tests/SerializationTests/JsonSerializationTest.MarkdownServiceProperties.cs
+++ b/test/docfx.Tests/SerializationTests/JsonSerializationTest.MarkdownServiceProperties.cs
@@ -7,6 +7,7 @@ using Docfx.Common;
 using Docfx.MarkdigEngine.Extensions;
 using Docfx.Plugins;
 using FluentAssertions;
+using Markdig.Extensions.MediaLinks;
 
 namespace docfx.Tests;
 
@@ -21,5 +22,14 @@ public partial class JsonSerializationTest
 
         // Act/Assert
         ValidateJsonRoundTrip(model);
+
+        // Additional test to validate deserialized result.
+        var medialinksSettings = model.MarkdigExtensions.First(x => x.Name == "MediaLinks");
+        var options = medialinksSettings.GetOptions(fallbackValue: new MediaOptions());
+        options.Should().BeEquivalentTo(new MediaOptions
+        {
+            Width = "800",
+            Height = "400",
+        });
     }
 }

--- a/test/docfx.Tests/SerializationTests/TestData/MarkdownServiceProperties/markdownServiceProperties_01.json
+++ b/test/docfx.Tests/SerializationTests/TestData/MarkdownServiceProperties/markdownServiceProperties_01.json
@@ -6,8 +6,8 @@
     { "AutoIdentifiers": "default" },
     {
       "MediaLinks": {
-        "width": 800,
-        "height": 400
+        "width": "800",
+        "height": "400"
       }
     }
   ],

--- a/test/docfx.Tests/SerializationTests/TestData/MarkdownServiceProperties/markdownServiceProperties_02.json
+++ b/test/docfx.Tests/SerializationTests/TestData/MarkdownServiceProperties/markdownServiceProperties_02.json
@@ -1,0 +1,15 @@
+{
+  "markdigExtensions": [
+    "FootNotes",
+    // Comment1
+    { "Emojis": "default" },
+    { "AutoIdentifiers": "default" },
+    {
+      // Comment2
+      "MediaLinks": {
+        "width": "800", // Comment3
+        "height": "400"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR contains following changes

- Simplify deserialization logics.
- Remove `IncludeFields` option. (It seems not used by [any available markdig options](https://github.com/dotnet/docfx/blob/fd3d09e27d6340da29e2426457b248a0c42277a3/src/Docfx.MarkdigEngine.Extensions/MarkdownExtensions.cs#L98-L164))
- Add `JsonCommentHandling.Skip` (Previously it works because comment is dropped with text serialization)
- Add simple test to verify behaviors of above changes.
  - Add `markdownServiceProperties` test case that contains comment.
  - Modify invalid test data (width/height should be string)
 