### PR TITLE
chore: Update Node.js version to latest LTS (v22)

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
   - uses: actions/setup-node@v4
     with:
-      node-version: 20
+      node-version: 22
 
   - uses: actions/setup-dotnet@v4
     with:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ We welcome code contributions through pull requests, issues tagged as **[`help-w
 
 - Install [Visual Studio 2022 (Community or higher)](https://www.visualstudio.com/) and make sure you have the latest updates.
 - Install [.NET SDK](https://dotnet.microsoft.com/download/dotnet) 8.x and 9.x.
-- Install NodeJS (20.x.x).
+- Install NodeJS (22.x.x).
 
 ### Build and Test
 

--- a/templates/package.json
+++ b/templates/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "node build.js",
     "lint": "eslint modern/src && stylelint modern/src",
-    "test": "node --import tsx --test modern/src/helper.test.ts",
+    "test": "node --import tsx --test modern/src/*.test.ts",
     "start": "node build.js --watch"
   },
   "dependencies": {


### PR DESCRIPTION
**What's included in this PR**
1. Update `Node.js` to use latest LTS version 22.
2. Update `README.md`  Node.js version (for developer)
  2.1.  Node.js version of `docs/index,md` is remained as is (Node.js 20 or later). 
3. Revert commit(ce914a1ab517ace743fd0f9d0610249fab615c11) 
