### PR TITLE
chore: add `Newtonsoft.Json` compatible number converters

### DIFF
--- a/src/Docfx.Common/Json/System.Text.Json/NewtonsoftJsonCompatibleConverters.DoubleConverter.cs
+++ b/src/Docfx.Common/Json/System.Text.Json/NewtonsoftJsonCompatibleConverters.DoubleConverter.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers;
+using System.Buffers.Text;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Numerics;
+using System.Reflection.PortableExecutable;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Newtonsoft.Json.Linq;
+using YamlDotNet.Core.Tokens;
+
+#nullable enable
+
+namespace Docfx.Common;
+
+internal partial class NewtonsoftJsonCompatibleConverters
+{
+    internal class DoubleConverter : JsonConverter<double>
+    {
+        private const int MaximumFormatDoubleLength = 128; // System.Text.Json using this setting.
+
+        public override double Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.String)
+                return reader.GetDouble();
+
+            return ReadStringAsNumber<double>(ref reader, options);
+        }
+
+        public override void Write(Utf8JsonWriter writer, double value, JsonSerializerOptions options)
+        {
+            if (TryHandleNamedFloatingPointLiterals(writer, value, options))
+                return;
+
+            if (options.NumberHandling.HasFlag(JsonNumberHandling.WriteAsString))
+                throw new NotSupportedException("JsonNumberHandling.WriteAsString option is not supported.");
+
+            // Allocate temp buffer
+            Span<byte> buffer = stackalloc byte[MaximumFormatDoubleLength + 2];
+            Utf8Formatter.TryFormat(value, buffer, out var bytesWritten, StandardFormatGeneral);
+
+            // If number contains period or exponential. Use default WriteNumberValue implementation
+            if (buffer.IndexOfAny("E."u8) != -1)
+            {
+                writer.WriteNumberValue(value);
+                return;
+            }
+
+            // Append `.0` suffix
+            buffer[bytesWritten++] = (byte)'.';
+            buffer[bytesWritten++] = (byte)'0';
+
+            // Write value with WriteRawValue API.
+            bool needIndent = writer.Options.Indented && GetTokenType(writer) != JsonTokenType.PropertyName;
+            if (needIndent)
+                WriteRawValueIndent(writer, buffer[..bytesWritten]);
+            else
+                writer.WriteRawValue(buffer[..bytesWritten], skipInputValidation: true);
+        }
+    }
+}

--- a/src/Docfx.Common/Json/System.Text.Json/NewtonsoftJsonCompatibleConverters.FloatConverter.cs
+++ b/src/Docfx.Common/Json/System.Text.Json/NewtonsoftJsonCompatibleConverters.FloatConverter.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+#nullable enable
+
+namespace Docfx.Common;
+
+internal partial class NewtonsoftJsonCompatibleConverters
+{
+    internal class FloatConverter : JsonConverter<float>
+    {
+        private const int MaximumFormatSingleLength = 128; // System.Text.Json using this setting.
+
+        public override float Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.String)
+                return reader.GetSingle();
+
+            return ReadStringAsNumber<float>(ref reader, options);
+        }
+
+        public override void Write(Utf8JsonWriter writer, float value, JsonSerializerOptions options)
+        {
+            if (TryHandleNamedFloatingPointLiterals(writer, value, options))
+                return;
+
+            if (options.NumberHandling.HasFlag(JsonNumberHandling.WriteAsString))
+                throw new NotSupportedException("JsonNumberHandling.WriteAsString option is not supported.");
+
+            // Allocate temp buffer
+            Span<byte> buffer = stackalloc byte[MaximumFormatSingleLength + 2];
+            Utf8Formatter.TryFormat(value, buffer, out var bytesWritten, StandardFormatGeneral);
+
+            // If number contains period or exponential. Use default WriteNumberValue implementation
+            if (buffer.IndexOfAny("E."u8) != -1)
+            {
+                writer.WriteNumberValue(value);
+                return;
+            }
+
+            // Append `.0` suffix
+            buffer[bytesWritten++] = (byte)'.';
+            buffer[bytesWritten++] = (byte)'0';
+
+            // Write value with WriteRawValue API.
+            bool needIndent = writer.Options.Indented && GetTokenType(writer) != JsonTokenType.PropertyName;
+            if (needIndent)
+                WriteRawValueIndent(writer, buffer[..bytesWritten]);
+            else
+                writer.WriteRawValue(buffer[..bytesWritten], skipInputValidation: true);
+        }
+    }
+}

--- a/src/Docfx.Common/Json/System.Text.Json/NewtonsoftJsonCompatibleConverters.cs
+++ b/src/Docfx.Common/Json/System.Text.Json/NewtonsoftJsonCompatibleConverters.cs
@@ -1,0 +1,131 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Globalization;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+#nullable enable
+
+namespace Docfx.Common;
+
+internal partial class NewtonsoftJsonCompatibleConverters
+{
+    // System.Text.Json write float/double with "G" format. (Newtonsoft.Json using "R" format)
+    private static readonly StandardFormat StandardFormatGeneral = StandardFormat.Parse("G");
+
+    private static readonly JsonEncodedText EncodedNaN = JsonEncodedText.Encode("NaN");
+    private static readonly JsonEncodedText EncodedPositiveInfinity = JsonEncodedText.Encode("Infinity");
+    private static readonly JsonEncodedText EncodedNegativeInfinity = JsonEncodedText.Encode("-Infinity");
+
+    // Try to hande NaN/PositiveInfinity/NegativeInfinity
+    private static bool TryHandleNamedFloatingPointLiterals<T>(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+        where T : IFloatingPointIeee754<T>
+    {
+        if (!options.NumberHandling.HasFlag(JsonNumberHandling.AllowNamedFloatingPointLiterals))
+            return false;
+
+        // Try to handle Nan/PositiveInfinity/NegativeInfinity
+        if (T.IsNaN(value))
+        {
+            writer.WriteStringValue(EncodedNaN);
+            return true;
+        }
+
+        if (T.IsPositiveInfinity(value))
+        {
+            writer.WriteStringValue(EncodedPositiveInfinity);
+            return true;
+        }
+
+        if (T.IsNegativeInfinity(value))
+        {
+            writer.WriteStringValue(EncodedNegativeInfinity);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static T ReadStringAsNumber<T>(ref Utf8JsonReader reader, JsonSerializerOptions options)
+        where T : IFloatingPointIeee754<T>
+    {
+        // Try to parse NaN/PositiveInfinity/NegativeInfinity
+        if (options.NumberHandling.HasFlag(JsonNumberHandling.AllowNamedFloatingPointLiterals))
+        {
+            if (reader.ValueTextEquals("NaN"))
+                return T.NaN;
+            if (reader.ValueTextEquals("Infinity"))
+                return T.PositiveInfinity;
+            if (reader.ValueTextEquals("-Infinity"))
+                return T.NegativeInfinity;
+        }
+
+        // Try to parse text as number
+        if (options.NumberHandling.HasFlag(JsonNumberHandling.AllowReadingFromString))
+        {
+            ReadOnlySpan<byte> valueSpan = reader.HasValueSequence
+                ? reader.ValueSequence.ToArray()
+                : reader.ValueSpan;
+
+            if (!T.TryParse(valueSpan, NumberStyles.Float, CultureInfo.InvariantCulture, out var result))
+            {
+                var numberText = reader.GetString();
+                throw new JsonException($"Unable to parse text({numberText}) as {typeof(T).FullName}.");
+            }
+
+            return result;
+        }
+
+        // Failed to parse string as number. throw InvalidOperationException by expected value.
+        var type = typeof(T);
+        if (type == typeof(float)) reader.GetSingle();
+        if (type == typeof(double)) reader.GetDouble();
+
+        throw new UnreachableException($"Unexpected generic type parameter({type.FullName})");
+    }
+
+    // Write number with emmulating `Utf8JsonWriter.WriteNumberValueIndented` behavior.
+    private static void WriteRawValueIndent(Utf8JsonWriter writer, ReadOnlySpan<byte> numberData)
+    {
+        Debug.Assert(writer.Options.Indented);
+
+#if NET9_0_OR_GREATER
+        var options = writer.Options;
+        var newLineLength = options.NewLine.Length;
+        var indentLength = options.IndentSize * writer.CurrentDepth;
+#else
+        var newLineLength = Environment.NewLine.Length;
+        var indentLength = 2 * writer.CurrentDepth;
+#endif
+
+        // Allocate buffer
+        Span<byte> buffer = stackalloc byte[newLineLength + (writer.CurrentDepth * 2) + numberData.Length];
+        int bytesWritten = 0;
+
+        // Add newline chars
+        if (newLineLength == 2)
+            buffer[bytesWritten++] = (byte)'\r';
+        buffer[bytesWritten++] = (byte)'\n';
+
+        // Add spaces for indent
+        for (int i = 0; i < writer.CurrentDepth; ++i)
+        {
+            buffer[bytesWritten++] = (byte)' ';
+            buffer[bytesWritten++] = (byte)' ';
+        }
+
+        // Copy number bytes to buffer
+        numberData.CopyTo(buffer[bytesWritten..]);
+
+        writer.WriteRawValue(buffer, skipInputValidation: true);
+    }
+
+    // Helper method to access `Utf8JsonWriter.TokenType` property.
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "get_TokenType")]
+    public static extern JsonTokenType GetTokenType(Utf8JsonWriter writer);
+}

--- a/src/Docfx.Common/Json/System.Text.Json/SystemTextJsonUtility.cs
+++ b/src/Docfx.Common/Json/System.Text.Json/SystemTextJsonUtility.cs
@@ -38,9 +38,11 @@ internal static class SystemTextJsonUtility
             PropertyNameCaseInsensitive = true,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             // DictionaryKeyPolicy = JsonNamingPolicy.CamelCase, // This setting is not compatible to `Newtonsoft.Json` serialize result.
-            NumberHandling = JsonNumberHandling.AllowReadingFromString,
+            NumberHandling = JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.AllowNamedFloatingPointLiterals,
             Converters =
             {
+                new NewtonsoftJsonCompatibleConverters.FloatConverter(),
+                new NewtonsoftJsonCompatibleConverters.DoubleConverter(),
                 new JsonStringEnumConverter(JsonNamingPolicy.CamelCase),
                 new ObjectToInferredTypesConverter(), // Required for `Dictionary<string, object>` type deserialization.
             },

--- a/test/Docfx.Common.Tests/NewtonsoftJsonCompatibleJsonConverterTest.cs
+++ b/test/Docfx.Common.Tests/NewtonsoftJsonCompatibleJsonConverterTest.cs
@@ -1,0 +1,145 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using System.Text.Json;
+using System.Text;
+using Xunit;
+using System.Text.Json.Serialization;
+
+namespace Docfx.Common.Tests;
+
+public class NewtonsoftJsonCompatibleJsonConverterTest
+{
+    [Theory]
+    [InlineData(0f, "0.0")]
+    [InlineData(1.0f, "1.0")]
+    [InlineData(1.2345678f, "1.2345678")]
+    [InlineData(-1.2345678f, "-1.2345678")]
+    [InlineData(1234e5f, "123400000.0")]
+    [InlineData(1234E-5f, "0.01234")]
+    [InlineData(float.E, "2.7182817")]
+    [InlineData(float.Epsilon, "1E-45")]
+    [InlineData(float.MinValue, "-3.4028235E+38")]
+    [InlineData(float.MaxValue, "3.4028235E+38")]
+    // Following values are rounded by "G" format.
+    // https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#general-format-specifier-g
+    [InlineData(float.Pi, "3.1415927")]  // Defined as `3.14159265`
+    [InlineData(float.Tau, "6.2831855")] // Defined as `6.283185307`
+    // Following values are serialized to string
+    [InlineData(float.NaN, "\"NaN\"")]
+    [InlineData(float.PositiveInfinity, "\"Infinity\"")]
+    [InlineData(float.NegativeInfinity, "\"-Infinity\"")]
+    public void FloatConverterTest(float value, string expected)
+    {
+        // Arrange
+        var converter = new NewtonsoftJsonCompatibleConverters.FloatConverter();
+        var options = SystemTextJsonUtility.DefaultSerializerOptions;
+
+        // Act
+        var json = Serialize(value, converter, options);
+        var result = Deserialize<float>(json, converter, options);
+        var roundtripJson = Serialize(result, converter, options);
+
+        // Assert
+        json.Should().Be(expected);
+        json.Should().Be(roundtripJson);
+        result.Should().Be(value);
+    }
+
+    [Theory]
+    [InlineData(0d, "0.0")]
+    [InlineData(1.0d, "1.0")]
+    [InlineData(1.2345678901234567d, "1.2345678901234567")]
+    [InlineData(-1.2345678901234567d, "-1.2345678901234567")]
+    [InlineData(1234e5d, "123400000.0")]
+    [InlineData(1234E-5d, "0.01234")]
+    [InlineData(double.MinValue, "-1.7976931348623157E+308")]
+    [InlineData(double.MaxValue, "1.7976931348623157E+308")]
+    // Following values are rounded by "G" format.
+    // https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#general-format-specifier-g
+    [InlineData(double.Epsilon, "5E-324")]        // Defined as `4.9406564584124654E-324`
+    [InlineData(double.E, "2.718281828459045")]   // Defined as `2.7182818284590452354`
+    [InlineData(double.Pi, "3.141592653589793")]  // Defined as `3.14159265358979323846`
+    [InlineData(double.Tau, "6.283185307179586")] // Defined as `6.283185307179586476925`
+    // Following values are serialized to string
+    [InlineData(double.NaN, "\"NaN\"")]
+    [InlineData(double.PositiveInfinity, "\"Infinity\"")]
+    [InlineData(double.NegativeInfinity, "\"-Infinity\"")]
+    public void DoubleConverterTest(double value, string expected)
+    {
+        // Arrange
+        var converter = new NewtonsoftJsonCompatibleConverters.DoubleConverter();
+        var options = SystemTextJsonUtility.DefaultSerializerOptions;
+
+        // Act
+        var json = Serialize(value, converter, options);
+        var result = Deserialize<double>(json, converter, options);
+        var roundtripJson = Serialize(result, converter, options);
+
+        // Assert
+        json.Should().Be(expected);
+        json.Should().Be(roundtripJson);
+        result.Should().Be(value);
+    }
+
+    [Fact]
+    public void NumberConverterIndentsTest()
+    {
+        // Arrange
+        var model = new TestData
+        {
+            FloatValue = 1f,
+            DoubleValue = 2d,
+            FloatValues = [1f, 2f, 3f],
+            DoubleValues = [1d, 2d, 3d],
+        };
+
+        // Act
+        var json = JsonUtility.Serialize(model, indented: true);
+        var result = JsonUtility.Deserialize<TestData>(new StringReader(json));
+        var roundtripJson = JsonUtility.Serialize(result, indented: true);
+
+        var newtonSoftJson = NewtonsoftJsonUtility.Serialize(model, Newtonsoft.Json.Formatting.Indented);
+
+        // Assert
+        json.Should().Be(roundtripJson);
+        result.Should().BeEquivalentTo(model);
+
+        json.Should().Be(newtonSoftJson);
+    }
+
+    private class TestData
+    {
+        [Newtonsoft.Json.JsonProperty(PropertyName = "floatValue")]
+        public float FloatValue { get; set; }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "doubleValue")]
+        public double DoubleValue { get; set; }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "floatValues")]
+        public float[] FloatValues { get; set; }
+
+        [Newtonsoft.Json.JsonProperty(PropertyName = "doubleValues")]
+        public double[] DoubleValues { get; set; }
+    }
+
+    private static string Serialize<T>(T value, JsonConverter<T> converter, JsonSerializerOptions options)
+    {
+        using var memoryStream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(memoryStream);
+        converter.Write(writer, value, options);
+        writer.Flush();
+        var bytes = memoryStream.ToArray();
+        return Encoding.UTF8.GetString(bytes);
+    }
+
+    private static T Deserialize<T>(string json, JsonConverter<T> converter, JsonSerializerOptions options)
+    {
+        ReadOnlySpan<byte> span = Encoding.UTF8.GetBytes(json);
+        var reader = new Utf8JsonReader(span);
+        reader.Read();
+
+        return converter.Read(ref reader, typeof(T), options);
+    }
+}


### PR DESCRIPTION
This PR intended to fix `floating-point number` serialization compatibility issue.
See: https://github.com/dotnet/docfx/pull/10318#issuecomment-2434076871 for details.

**What's changed to this PR**

1. Add following custom converters for float/double types
  1.1. `NewtonsoftJsonCompatibleConverters.SingleConverter`
  1.2. `NewtonsoftJsonCompatibleConverters.DoubleConverter`
2. Custom converter append `.0` suffix when needed (Not contains period or exponential char)
3. Add `JsonNumberHandling.AllowNamedFloatingPointLiterals` options to support Nan/Infinity/-Infinity serialization/deserialization.
