### PR TITLE
chore: Remove `IgnoresAccessChecksToGenerator` dependencies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,9 +19,8 @@
           warning NU1507: There are 2 package sources defined in your configuration.
           warning NU5104: A stable release of a package should not have a prerelease dependency. Either modify the version spec of dependency "PdfPig [0.1.9-alpha-20240510-d86c2, )" or update the version field in the nuspec.
           warning NU5111: The script file 'tools\.playwright\package\bin\install_media_pack.ps1' is not recognized by NuGet and hence will not be executed during installation of this package.
-          warning CS0436: IgnoresAccessChecksTo redefinition due to InternalsVisibleTo
      -->
-    <NoWarn>$(NoWarn);NU1507;NU5104;NU5111;CS0436</NoWarn>
+    <NoWarn>$(NoWarn);NU1507;NU5104;NU5111</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,6 @@
   <ItemGroup>
     <PackageVersion Include="HtmlAgilityPack" Version="1.11.70" />
     <PackageVersion Include="ICSharpCode.Decompiler" Version="8.2.0.7535" />
-    <PackageVersion Include="IgnoresAccessChecksToGenerator" Version="0.7.0" />
     <PackageVersion Include="Jint" Version="4.1.0" />
     <PackageVersion Include="JsonSchema.Net" Version="7.2.3" />
     <PackageVersion Include="Markdig" Version="0.38.0" />

--- a/src/Docfx.App/Docfx.App.csproj
+++ b/src/Docfx.App/Docfx.App.csproj
@@ -18,11 +18,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsAssemblyName Include="UglyToad.PdfPig" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="IgnoresAccessChecksToGenerator" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Playwright" />
     <PackageReference Include="PdfPig" />
   </ItemGroup>

--- a/src/Docfx.App/Helpers/PdfPigTypeExtensions.cs
+++ b/src/Docfx.App/Helpers/PdfPigTypeExtensions.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using UglyToad.PdfPig.Content;
+using UglyToad.PdfPig.Outline.Destinations;
+
+#nullable enable
+
+namespace Docfx;
+
+internal static class PdfPigTypeExtensions
+{
+    public static NamedDestinations GetNamedDestinations(this Catalog catalog)
+        => GetNamedDestinationsProperty(catalog);
+
+    public static bool TryGet(this NamedDestinations namedDestinations, string name, out ExplicitDestination dest)
+        => TryGetNamedDestinations(namedDestinations, name, out dest);
+
+    // Gets property value of catalog.NamedDestination.
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "get_NamedDestinations")]
+    private static extern NamedDestinations GetNamedDestinationsProperty(Catalog value);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "TryGet")]
+    private static extern bool TryGetNamedDestinations(NamedDestinations namedDestinations, string name, out ExplicitDestination dest);
+}
+

--- a/src/Docfx.App/PdfBuilder.cs
+++ b/src/Docfx.App/PdfBuilder.cs
@@ -301,7 +301,7 @@ static class PdfBuilder
             var key = CleanUrl(url);
             if (!pagesByUrl.TryGetValue(key, out var dests))
                 pagesByUrl[key] = dests = new();
-            dests.Add((node, document.Structure.Catalog.NamedDestinations));
+            dests.Add((node, document.Structure.Catalog.GetNamedDestinations()));
 
             pageBytes[node] = bytes;
             pageNumbers[node] = numberOfPages + 1;

--- a/src/Docfx.Dotnet/Docfx.Dotnet.csproj
+++ b/src/Docfx.Dotnet/Docfx.Dotnet.csproj
@@ -17,10 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsAssemblyName Include="Microsoft.CodeAnalysis.Workspaces" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Docfx.Common\Docfx.Common.csproj" />
     <ProjectReference Include="..\Docfx.DataContracts.Common\Docfx.DataContracts.Common.csproj" />
     <ProjectReference Include="..\Docfx.Glob\Docfx.Glob.csproj" />
@@ -32,7 +28,6 @@
     <PackageReference Include="System.Formats.Asn1" />
     <PackageReference Include="HtmlAgilityPack" />
     <PackageReference Include="ICSharpCode.Decompiler" />
-    <PackageReference Include="IgnoresAccessChecksToGenerator" PrivateAssets="All" />
     <PackageReference Include="OneOf" />
     <PackageReference Include="OneOf.SourceGenerator" PrivateAssets="All" />
     <PackageReference Include="Markdig" />

--- a/src/Docfx.Dotnet/ExtensionMethods/ISymbolExtensions.cs
+++ b/src/Docfx.Dotnet/ExtensionMethods/ISymbolExtensions.cs
@@ -1,0 +1,114 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Reflection;
+using System.Reflection.Emit;
+
+#nullable enable
+
+namespace Docfx.Dotnet;
+
+internal static class ISymbolExtensions
+{
+    public static ImmutableArray<IParameterSymbol> GetParameters(this ISymbol? symbol)
+    {
+        return symbol switch
+        {
+            IMethodSymbol m => m.Parameters,
+            IPropertySymbol nt => nt.Parameters,
+            _ => [],
+        };
+    }
+
+    public static ImmutableArray<ITypeParameterSymbol> GetTypeParameters(this ISymbol? symbol)
+    {
+        return symbol switch
+        {
+            IMethodSymbol m => m.TypeParameters,
+            INamedTypeSymbol nt => nt.TypeParameters,
+            _ => [],
+        };
+    }
+
+    public static DocumentationComment GetDocumentationComment(this ISymbol symbol, Compilation compilation, CultureInfo? preferredCulture = null, bool expandIncludes = false, bool expandInheritdoc = false, CancellationToken cancellationToken = default)
+    {
+        // Gets FullXmlFragment by calling `symbol.DocumentationComment(...).FullXmlFragment`
+        string fullXmlFragment = Helpers.GetFullXmlFragment(symbol, compilation, preferredCulture, expandIncludes, expandInheritdoc, cancellationToken);
+
+        return new DocumentationComment
+        {
+            FullXmlFragment = fullXmlFragment,
+        };
+    }
+
+    internal class DocumentationComment
+    {
+        public required string FullXmlFragment { get; init; }
+    }
+
+    private static class Helpers
+    {
+        /// <summary>
+        /// Gets result of `symbol.GetDocumentationComment(args).FullXmlFragment`
+        /// </summary>
+        public static string GetFullXmlFragment(ISymbol symbol, Compilation compilation, CultureInfo? preferredCulture = null, bool expandIncludes = false, bool expandInheritdoc = false, CancellationToken cancellationToken = default)
+          => CachedDelegate(symbol, compilation, preferredCulture, expandIncludes, expandInheritdoc, cancellationToken);
+
+        static Helpers()
+        {
+            CachedDelegate = GetDelegate();
+        }
+
+        private delegate string GetFullXmlFragmentDelegate(ISymbol symbol, Compilation compilation, CultureInfo? preferredCulture, bool expandIncludes, bool expandInheritdoc, CancellationToken cancellationToken);
+        private static readonly GetFullXmlFragmentDelegate CachedDelegate;
+
+        private static GetFullXmlFragmentDelegate GetDelegate()
+        {
+            // Gets Microsoft.CodeAnalysis.Workspaces assembly
+            var workspaceAssembly = typeof(Workspace).Assembly;
+
+            // Gets MethodInfo for GetDocumentationComment
+            var type = workspaceAssembly.GetType("Microsoft.CodeAnalysis.Shared.Extensions.ISymbolExtensions", throwOnError: true)!;
+            var methodInfo = type.GetMethod("GetDocumentationComment", BindingFlags.Public | BindingFlags.Static);
+
+            // Gets PropertyInfo for DocumentationComment.
+            var docCommentType = workspaceAssembly.GetType("Microsoft.CodeAnalysis.Shared.Utilities.DocumentationComment", throwOnError: true)!;
+            var propertyInfo = docCommentType.GetProperty("FullXmlFragment", BindingFlags.Instance | BindingFlags.Public)!;
+
+            // Reflection may fail when updating the Microsoft.CodeAnalysis.Workspaces.Common package..
+            if (methodInfo == null || propertyInfo == null)
+                throw new InvalidOperationException("Failed to get required MethodInfo/PropertyInfo via reflection.");
+
+            var dm = new DynamicMethod(string.Empty, returnType: typeof(string), parameterTypes: [
+                typeof(ISymbol),
+                typeof(Compilation),
+                typeof(CultureInfo), // preferredCulture
+                typeof(bool),        // expandIncludes
+                typeof(bool),        // expandInheritdoc
+                typeof(CancellationToken),
+            ]);
+
+            ILGenerator il = dm.GetILGenerator();
+
+            // call Microsoft.CodeAnalysis.Shared.Extensions.ISymbolExtensions::GetDocumentationComment(args)
+            il.Emit(OpCodes.Ldarg_0);    // symbol
+            il.Emit(OpCodes.Ldarg_1);    // compilation
+            il.Emit(OpCodes.Ldarg_2);    // preferredCulture
+            il.Emit(OpCodes.Ldarg_3);    // expandIncludes
+            il.Emit(OpCodes.Ldarg_S, 4); // expandInheritdoc
+            il.Emit(OpCodes.Ldarg_S, 5); // cancellationToken
+            il.EmitCall(OpCodes.Call, methodInfo, null);
+
+            // callvirt DocumentationComment::get_FullXmlFragment()
+            il.EmitCall(OpCodes.Callvirt, propertyInfo.GetMethod!, null);
+
+            // return FullXmlFragment
+            il.Emit(OpCodes.Ret);
+
+            return dm.CreateDelegate<GetFullXmlFragmentDelegate>();
+        }
+    }
+}


### PR DESCRIPTION
This PR intended to remove depencency to `IgnoresAccessChecksToGenerator` library.

There are two reasons for this changes.
- `IgnoresAccessChecksToGenerator` run MSBuild Task(`PublicizeInternals`) and it introduce extra build complexity.
- All internal types are exposed to Intellisense code completion. 

.NET 8 or later supports `UnsafeAccessor` attribute. 
And it can safely expose internal/private members via `static extern` method.

---

#### What's changed

**1. `Catalog::NamedDestinations` / `NamedDestinations::TryGetNamedDestinations`**
Replace to extension methods.
And access internal implementation via `UnsafeAccessor`.
 
**2. `ISymbol::GetParameters` / `ISymbol::GetTypeParameters`**

Replaced with `custom extension methods` that equivalent to [original methods](https://github.com/dotnet/roslyn/blob/main/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs#L358-L372).

**3. `symbol.GetDocumentationComment(args).FullXmlFragment`**

Replaced with `custom delegate` that is generated by ILGenerator.

These logics will be replaced by `UnsafeAccessor` in future.
It require `private type access` supports (See: `https://github.com/dotnet/runtime/issues/90081`)
