### PR TITLE
feat: Reformat YouTube videos to the embeded URL

### DIFF
--- a/test/Docfx.MarkdigEngine.Extensions.Tests/QuoteSectionNoteTest.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/QuoteSectionNoteTest.cs
@@ -423,6 +423,19 @@ We should support that.</p>
 
     [Fact]
     [Trait("Related", "DfmMarkdown")]
+    public void TestVideoBlock_Http()
+    {
+        var source = @"# Article 2
+> [!VIDEO http://microsoft.com:8080?query=http+A#bookmark]
+";
+        var expected = @"<h1 id=""article-2"">Article 2</h1>
+<div class=""embeddedvideo""><iframe src=""https://microsoft.com:8080/?query=http+A#bookmark"" frameborder=""0"" allowfullscreen=""true""></iframe></div>
+";
+        TestUtility.VerifyMarkup(source, expected);
+    }
+
+    [Fact]
+    [Trait("Related", "DfmMarkdown")]
     public void TestVideoBlock_Channel9()
     {
         var source = @"# Article 2

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/VideoTest.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/VideoTest.cs
@@ -13,14 +13,18 @@ public class VideoTest
 </div></p>
 ")]
     [InlineData(@":::video source=""https://www.youtube.com/embed/wV11_nbT2XE"" title=""Video: Build-Your-First-Android-App-with-Visual-Studio-2019-and-Xamarin"" thumbnail=""media/3-eclipse-install-button.png"" upload-date=""07/27/2020"":::", @"<p><div class=""embeddedvideo"">
-<iframe src=""https://www.youtube-nocookie.com/embed/wV11_nbT2XE"" allowFullScreen=""true"" frameBorder=""0"" title=""Video: Build-Your-First-Android-App-with-Visual-Studio-2019-and-Xamarin"" thumbnail=""media/3-eclipse-install-button.png"" upload-date=""07/27/2020""></iframe>
+<iframe src=""https://www.youtube-nocookie.com/embed/wV11_nbT2XE?rel=0"" allowFullScreen=""true"" frameBorder=""0"" title=""Video: Build-Your-First-Android-App-with-Visual-Studio-2019-and-Xamarin"" thumbnail=""media/3-eclipse-install-button.png"" upload-date=""07/27/2020""></iframe>
+</div></p>
+")]
+    [InlineData(@":::video source=""https://www.youtube.com/embed/wV11_nbT2XE?rel=1"" title=""Video: Build-Your-First-Android-App-with-Visual-Studio-2019-and-Xamarin"" thumbnail=""media/3-eclipse-install-button.png"" upload-date=""07/27/2020"":::", @"<p><div class=""embeddedvideo"">
+<iframe src=""https://www.youtube-nocookie.com/embed/wV11_nbT2XE?rel=1"" allowFullScreen=""true"" frameBorder=""0"" title=""Video: Build-Your-First-Android-App-with-Visual-Studio-2019-and-Xamarin"" thumbnail=""media/3-eclipse-install-button.png"" upload-date=""07/27/2020""></iframe>
 </div></p>
 ")]
     [InlineData(
         @":::video source=""https://www.youtube.com/embed/wV11_nbT2XE"" title=""Video: Build-Your-First-Android-App-with-Visual-Studio-2019-and-Xamarin"" thumbnail=""media/3-eclipse-install-button.png"" upload-date=""07/27/2020"":::
 :::video source=""https://channel9.msdn.com/Shows/XamarinShow/Build-Your-First-Android-App-with-Visual-Studio-2019-and-Xamarin/player?nocookie=true"" title=""Video: Build-Your-First-Android-App-with-Visual-Studio-2019-and-Xamarin"" max-width=""400"" thumbnail=""media/3-eclipse-install-button.png"" upload-date=""07/27/2020"":::
 ", @"<p><div class=""embeddedvideo"">
-<iframe src=""https://www.youtube-nocookie.com/embed/wV11_nbT2XE"" allowFullScreen=""true"" frameBorder=""0"" title=""Video: Build-Your-First-Android-App-with-Visual-Studio-2019-and-Xamarin"" thumbnail=""media/3-eclipse-install-button.png"" upload-date=""07/27/2020"">
+<iframe src=""https://www.youtube-nocookie.com/embed/wV11_nbT2XE?rel=0"" allowFullScreen=""true"" frameBorder=""0"" title=""Video: Build-Your-First-Android-App-with-Visual-Studio-2019-and-Xamarin"" thumbnail=""media/3-eclipse-install-button.png"" upload-date=""07/27/2020"">
 </iframe></div>
 <div class=""embeddedvideo"">
 <iframe src=""https://channel9.msdn.com/Shows/XamarinShow/Build-Your-First-Android-App-with-Visual-Studio-2019-and-Xamarin/player?nocookie=true&amp;nocookie=true"" allowFullScreen=""true"" frameBorder=""0"" title=""Video: Build-Your-First-Android-App-with-Visual-Studio-2019-and-Xamarin"" style=""max-width:400px;"" thumbnail=""media/3-eclipse-install-button.png"" upload-date=""07/27/2020"">


### PR DESCRIPTION
Extract the YouTube video or list ID and generates the embed URL.
Simplifies embedding YouTube videos by allowing one to copy paste the direct YouTube URL rather than extracting the embed URL from the <iframe> source.
Supports short youtu.be links.

Add "rel=0" (unless explicitly specified) to only show related videos from the same channel.