### PR TITLE
feat: Use PlantUML Online Server as default configs

### DIFF
--- a/src/Docfx.MarkdigEngine.Extensions/PlantUml/PlantUmlExtension.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/PlantUml/PlantUmlExtension.cs
@@ -18,7 +18,7 @@ public class PlantUmlOptions
 
     [JsonProperty("remoteUrl")]
     [JsonPropertyName("remoteUrl")]
-    public string RemoteUrl { get; set; }
+    public string RemoteUrl { get; set; } = "http://www.plantuml.com/plantuml/";
 
     [JsonProperty("localPlantUmlPath")]
     [JsonPropertyName("localPlantUmlPath")]
@@ -30,7 +30,7 @@ public class PlantUmlOptions
 
     [JsonProperty("renderingMode")]
     [JsonPropertyName("renderingMode")]
-    public RenderingMode RenderingMode { get; set; }
+    public RenderingMode RenderingMode { get; set; } = RenderingMode.Remote;
 
     [JsonProperty("delimitor")]
     [JsonPropertyName("delimitor")]


### PR DESCRIPTION
This PR change `PlantUmlOptions` default settings.

**Background**
When using `PlantUML` diagrams.
It need to explicitly set  `build/markdownEngineProperties/plantuml` configs.
https://dotnet.github.io/docfx/docs/markdown.html#settings

Currently when above config is not defined. following exception is thrown.

> error PlantUmlExtension: Value cannot be null. (Parameter 'uriString')

This PR change default settings to use PlantUML Online server as default options.




