### PR TITLE
fix: Place `.playwright` directory under bin directory

### DIFF
--- a/src/docfx/docfx.csproj
+++ b/src/docfx/docfx.csproj
@@ -11,11 +11,9 @@
     <None Include="../../THIRD-PARTY-NOTICES.TXT" CopyToOutputDirectory="PreserveNewest" PackageCopyToOutput="true" />
   </ItemGroup>
 
-  <!-- Custom target to merge large docfx dependencies to TargetFramework independent folder.
-       By default, these files are packed to `tools/$(TargetFramework)/any/*`.
-       This target rewrite:
-       - templates to the `/templates` directory.
-       - .playwright to the `/tools/.playwright` directory.
+  <!-- Custom target to merge docfx templates to TargetFramework independent folder.
+       By default, docfx templates is packed to `tools/$(TargetFramework)/any/templates/*`.
+       This target rewrite PackagePath and template files are placed at `templates/*` directory.
   -->
   <Target Name="RewriteDocfxTemplateFiles" AfterTargets="PackTool">
     <PropertyGroup>
@@ -27,16 +25,11 @@
       <TfmSpecificPackageFile Update="@(TfmSpecificPackageFile)"
                               Condition="$([System.String]::new('%(TfmSpecificPackageFile.PackagePath)').StartsWith('tools/$(TargetFramework)/any/templates/'))"
                               PackagePath="$([System.String]::new('%(TfmSpecificPackageFile.PackagePath)').Replace('tools/$(TargetFramework)/any/',''))"/>
-      <TfmSpecificPackageFile Update="@(TfmSpecificPackageFile)"
-                              Condition="$([System.String]::new('%(TfmSpecificPackageFile.PackagePath)').StartsWith('tools/$(TargetFramework)/any/.playwright/'))"
-                              PackagePath="$([System.String]::new('%(TfmSpecificPackageFile.PackagePath)').Replace('$(TargetFramework)/any/',''))"/>
     </ItemGroup>
     <!-- If TargetFramework is not selected version. Remove template files from package. -->
     <ItemGroup Condition="'$(TargetFramework)' != '$(DocfxTemplateSourceTargetFramework)'">
       <TfmSpecificPackageFile Remove="@(TfmSpecificPackageFile)"
                               Condition="$([System.String]::new('%(TfmSpecificPackageFile.PackagePath)').StartsWith('tools/$(TargetFramework)/any/templates/'))"/>
-      <TfmSpecificPackageFile Remove="@(TfmSpecificPackageFile)"
-                              Condition="$([System.String]::new('%(TfmSpecificPackageFile.PackagePath)').StartsWith('tools/$(TargetFramework)/any/.playwright/'))"/>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This PR intended to fix issue #10398.
By temporary revert commit (https://github.com/dotnet/docfx/pull/9363)

**Background**
When using [`PLAYWRIGHT_NODEJS_PATH` environment variable](https://dotnet.github.io/docfx/reference/docfx-environment-variables-reference.html#playwright_nodejs_path).
`../../.playwright` fallback from bin directory is not used.
And failed to find `.playwright\package\cli.js` file.

- https://github.com/microsoft/playwright-dotnet/blob/main/src/Playwright/Helpers/Driver.cs#L89-L90
- https://github.com/microsoft/playwright-dotnet/blob/main/src/Playwright/Helpers/Driver.cs#L145

To fix problems. it need to change `playwright-dotnet` side code  
(or install chromium browser directly by calling `.playwright/package/cli.js`)

So I've temporary reverted #9363 code. And place `.playwright` folder under bin directory.
By this changes. `.nupkg` size increased about `1.8MB`.

