### PR TITLE
chore: Update `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,26 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim
+FROM mcr.microsoft.com/dotnet/sdk:8.0-noble
 
 # Add dotnet tools to path.
 ENV PATH="${PATH}:/root/.dotnet/tools"
 
+# Set Node.js path
+ENV PLAYWRIGHT_NODEJS_PATH="/usr/bin/node"
+
 # Set target docfx version.
-ARG DOCFX_VERSION=2.77.0
+ARG DOCFX_VERSION=2.78.1
 
 # Install DocFX as a dotnet tool.
 RUN dotnet tool install docfx -g --version ${DOCFX_VERSION} && \
     docfx --version && \
     rm  -f /root/.dotnet/tools/.store/docfx/${DOCFX_VERSION}/docfx/${DOCFX_VERSION}/docfx.nupkg                         && \
     rm  -f /root/.dotnet/tools/.store/docfx/${DOCFX_VERSION}/docfx/${DOCFX_VERSION}/docfx.${DOCFX_VERSION}.nupkg        && \
-    rm -rf /root/.dotnet/tools/.store/docfx/${DOCFX_VERSION}/docfx/${DOCFX_VERSION}/tools/net6.0
+    rm -rf /root/.dotnet/tools/.store/docfx/${DOCFX_VERSION}/docfx/${DOCFX_VERSION}/tools/net9.0
 
-# Install Node.js and dependences for chromium PDF.
-RUN apt-get update -qq && \
-    apt-get install -y -qq --no-install-recommends \
-    nodejs \
-    libglib2.0-0 libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
-    libdbus-1-3 libxcb1 libxkbcommon0 libatspi2.0-0 libx11-6 libxcomposite1 libxdamage1 \
-    libxext6 libxfixes3 libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2 && \
-    rm -rf /var/lib/apt/lists/* /tmp/*
-
-# Install Chromium.
-RUN PLAYWRIGHT_NODEJS_PATH="/usr/bin/node" && \
-    ln -s /root/.dotnet/tools/.store/docfx/${DOCFX_VERSION}/docfx/${DOCFX_VERSION}/tools/.playwright /root/.dotnet/tools/.store/docfx/${DOCFX_VERSION}/docfx/${DOCFX_VERSION}/tools/net8.0/any/.playwright && \
-    pwsh -File /root/.dotnet/tools/.store/docfx/${DOCFX_VERSION}/docfx/${DOCFX_VERSION}/tools/net8.0/any/playwright.ps1 install chromium && \
-    unlink /root/.dotnet/tools/.store/docfx/${DOCFX_VERSION}/docfx/${DOCFX_VERSION}/tools/net8.0/any/.playwright
+# Install Node.js and browser(chromium) with dependencies
+RUN apt-get install -y -qq --update --no-install-recommends nodejs && \
+    pwsh -File /root/.dotnet/tools/.store/docfx/${DOCFX_VERSION}/docfx/${DOCFX_VERSION}/tools/net8.0/any/playwright.ps1 install --with-deps chromium && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/*
 
 WORKDIR /opt/prj
 VOLUME [ "/opt/prj" ]


### PR DESCRIPTION
This PR update [Dockerfile](https://github.com/dotnet/docfx/blob/main/Dockerfile)

**What's changed**

1. Update base OS image version.
2. Update docfx version to `2.78.1`
3. Remove `apt-get update` command. And use `apt-get install` with `--update` option instead (that is added on Ubuntu 24)
4. Change library dependencies installation to use `--with-deps` options.
5. Remove temporary `symbolic link` steps. (Currently `.playwright` directory is placed under bin)

**Test**
I've confirmed docker image successfully build.
And `docfx pdf` command is works as expected with following steps.

```
docker build ./ -t docfx

docker run -it --rm --entrypoint /bin/bash docfx
docfx init --yes
docfx build
docfx pdf
```