### PR TITLE
fix: Bootstrap variable override problem

### DIFF
--- a/templates/modern/src/docfx.scss
+++ b/templates/modern/src/docfx.scss
@@ -3,13 +3,12 @@
  * The .NET Foundation licenses this file to you under the MIT license.
  */
 
-$enable-important-utilities: false;
-$container-max-widths: (
-  xxl: 1768px
-) !default;
-
 @use "mixins";
-@use "bootstrap/scss/bootstrap";
+@use "bootstrap/scss/bootstrap" with (
+  $container-max-widths: (
+    xxl: 1768px
+  )
+);
 @use "highlight";
 @use "layout";
 @use "nav";


### PR DESCRIPTION
This PR intend to fix issue #10411 

**What's changed**
1. Remove `SCSS variable override`. Instead, directly pass `SCSS variable override` by [with Configuration](https://sass-lang.com/documentation/at-rules/use/#configuration) syntax.
2. Remove `$enable-important-utilities: false;` setting.

**Background**

PR #10301 changes `@import` statement to `@use` statement to suppress following warnings.
  > [WARNING] Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

These changes are automatically refactored by using [sass-migrator](https://github.com/dotnet/docfx/pull/10301#issuecomment-2423720683) command.
But after these changes. It seems `SCSS variable override` is not works as expected.
And regression seems not detected by percy visual regression tests. 
Because percy tests with following display resolution widths (375px/1280px)