### PR TITLE
feat: Add `noRestore` option to `docfx metadata` command

### DIFF
--- a/docs/reference/docfx-cli-reference/docfx-metadata.md
+++ b/docs/reference/docfx-cli-reference/docfx-metadata.md
@@ -77,6 +77,10 @@ Run `docfx metadata --help` or `docfx -h` to get a list of all available options
 
   Disable the default API filter (default filter only generate public or protected APIs).
 
+- **--noRestore**
+
+  Do not run `dotnet restore` before building the projects.
+
 - **--namespaceLayout**
 
   Determines the namespace layout in table of contents.

--- a/src/docfx/Models/MetadataCommand.cs
+++ b/src/docfx/Models/MetadataCommand.cs
@@ -27,6 +27,7 @@ internal class MetadataCommand : Command<MetadataCommandOptions>
             item.ShouldSkipMarkup |= options.ShouldSkipMarkup;
             item.DisableGitFeatures |= options.DisableGitFeatures;
             item.DisableDefaultFilter |= options.DisableDefaultFilter;
+            item.NoRestore |= options.NoRestore;
             item.CategoryLayout = options.CategoryLayout ?? item.CategoryLayout;
             item.NamespaceLayout = options.NamespaceLayout ?? item.NamespaceLayout;
             item.MemberLayout = options.MemberLayout ?? item.MemberLayout;

--- a/src/docfx/Models/MetadataCommandOptions.cs
+++ b/src/docfx/Models/MetadataCommandOptions.cs
@@ -45,6 +45,10 @@ internal class MetadataCommandOptions : LogOptions
     [CommandOption("--disableDefaultFilter")]
     public bool DisableDefaultFilter { get; set; }
 
+    [Description("Do not run `dotnet restore` before building the projects")]
+    [CommandOption("--noRestore")]
+    public bool NoRestore { get; set; }
+
     [Description("Determines the category layout in table of contents.")]
     [CommandOption("--categoryLayout")]
     public CategoryLayout? CategoryLayout { get; set; }


### PR DESCRIPTION
This PR intended to fix #10419.
By adding `noRestore` option to `docfx metadata` command. 
