### PR TITLE
chore: Modify chromium install options

### DIFF
--- a/src/Docfx.App/PdfBuilder.cs
+++ b/src/Docfx.App/PdfBuilder.cs
@@ -67,7 +67,7 @@ static class PdfBuilder
 
         PlaywrightHelper.EnsurePlaywrightNodeJsPath();
 
-        Program.Main(["install", "chromium"]);
+        Program.Main(["install", "chromium", "--only-shell"]);
 
         var builder = WebApplication.CreateBuilder();
         builder.Logging.ClearProviders();

--- a/test/docfx.Snapshot.Tests/PercyTest.cs
+++ b/test/docfx.Snapshot.Tests/PercyTest.cs
@@ -39,7 +39,7 @@ public class PercyTest
     static PercyTest()
     {
         PlaywrightHelper.EnsurePlaywrightNodeJsPath();
-        Microsoft.Playwright.Program.Main(["install", "chromium"]);
+        Microsoft.Playwright.Program.Main(["install", "chromium", "--only-shell"]);
     }
 
     [PercyFact]


### PR DESCRIPTION
Playwright 1.49 or later install two versions of chromium by default. (full browser and `Chromium Headless Shell`)

To reduce download size and disk spaces.
Change installation option to install  only  by adding `--only-shell` option.

> [!NOTE]
> When using `--only-shell` option. Playwright install `old Headless` binaries (`chromium_headless_shell`)
> It's recommended to use `old Headless mode` for docfx use cases. 
>
> For more information, See following URLs
> - https://developer.chrome.com/blog/chrome-headless-shell
> - `https://github.com/microsoft/playwright/issues/33566`
