### PR TITLE
fix: Add `remarks` content to enum members

### DIFF
--- a/templates/modern/partials/class.header.tmpl.partial
+++ b/templates/modern/partials/class.header.tmpl.partial
@@ -139,7 +139,8 @@
 <dl class="parameters">
 {{#children}}
   <dt id="{{id}}"><code>{{syntax.content.0.value}}</code></dt>
-  <dd>{{{summary}}}</dd>
+  {{#remarks}}<dd>{{{summary}}}{{{remarks}}}</dd>{{/remarks}}
+  {{^remarks}}<dd>{{{summary}}}</dd>{{/remarks}}
 {{/children}}
 </dl>
 {{/children}}


### PR DESCRIPTION
This PR intended to fix #10430
By adding `remarks` content to enum members to `modern` template's `class.header.tmpl.partial`.

**Rendered Result**
If `remarks` comment exists.
`summary` and `remarks` content are rendered as following. (It's same as `ApiPage` output results.)

```html
<dd>
  <p>{summary}</p>
  <p>{remarks}</p>
<\dd>"
```