### PR TITLE
feat: Allow extensionless URL HTML file access

### DIFF
--- a/test/Docfx.Build.Tests/XRefMapSerializationTest.cs
+++ b/test/Docfx.Build.Tests/XRefMapSerializationTest.cs
@@ -3,7 +3,6 @@
 
 using System.Text;
 using Docfx.Common;
-using Docfx.Plugins;
 using FluentAssertions;
 using Xunit;
 


### PR DESCRIPTION
This PR is intended to add support for extensionless HTML URLs for `docfx serve` command.

**Background**
`GitHub Pages` support extensionless URLs. (e.g. https://dotnet.github.io/docfx/docs/basic-concepts)
And other static HTML hosting site also have similar features.

So I thought it's reasonable to support extensionless URLs with the `docfx serve` command.

Extensionless URL support is partially related to #2865.
It might be better to add options to output extensionless URLs for docfx internal links. 




