### PR TITLE
chore: Add verify code styles workflow.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,46 @@
+name: lint
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Lint
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false   
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.x
+
+      - name: Run `dotnet format` command
+        run: |
+          dotnet restore
+          dotnet format --no-restore --verify-no-changes
+
+      - name: Add sticky comment to PR
+        if: ${{ failure() && github.event_name == 'pull_request' }}
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
+        with:
+          header: lint
+          skip_unchanged: true
+          recreate: true
+          message: |
+            ## Failed to run the `lint.yml` workflow
+            To fix workflow errors. Please follow the steps below.
+             1. Run `dotnet format` command.
+             2. Commit changes as separated commit.
+             3. Push changes to source branch of PR.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,8 +14,6 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false   
-    permissions:
-      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,16 +29,15 @@ jobs:
           dotnet restore
           dotnet format --no-restore --verify-no-changes
 
-      - name: Add sticky comment to PR
-        if: ${{ failure() && github.event_name == 'pull_request' }}
-        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
-        with:
-          header: lint
-          skip_unchanged: true
-          recreate: true
-          message: |
-            ## Failed to run the `lint.yml` workflow
-            To fix workflow errors. Please follow the steps below.
-             1. Run `dotnet format` command.
-             2. Commit changes as separated commit.
-             3. Push changes to source branch of PR.
+      - name: Report failures as Job Summary
+        if: ${{ failure() }}
+        shell: pwsh
+        run: |
+          $content = '
+          ## Failed to run the `lint.yml` workflow
+          To fix workflow errors. Please follow the steps below.
+           1. Run `dotnet format` command.
+           2. Commit changes as separated commit.
+           3. Push changes to source branch of PR.
+          '
+          Write-Output $content >> $env:GITHUB_STEP_SUMMARY

--- a/src/Docfx.Build.RestApi/ValidateRestApiDocumentMetadata.cs
+++ b/src/Docfx.Build.RestApi/ValidateRestApiDocumentMetadata.cs
@@ -29,10 +29,9 @@ public class ValidateRestApiDocumentMetadata : BaseDocumentBuildStep
             case DocumentType.Overwrite:
                 foreach (var item in (List<OverwriteDocumentModel>)model.Content)
                 {
-                    host.ValidateInputMetadata(
-                        model.OriginalFileAndType.File,
-                        // use RestApiChildItemViewModel because it contains all properties for REST.
-                        item.ConvertTo<RestApiChildItemViewModel>().Metadata.ToImmutableDictionary());
+                    // use RestApiChildItemViewModel because it contains all properties for REST
+                    var metadata = item.ConvertTo<RestApiChildItemViewModel>().Metadata.ToImmutableDictionary();
+                    host.ValidateInputMetadata(model.OriginalFileAndType.File, metadata);
                 }
                 break;
             default:


### PR DESCRIPTION
This PR add lint workflow to verify code styles.
By executing `dotnet format --verify-no-changes` command.

If diffs are found. 
`lint.yml`workflow add following sticky comment to PR. 

```
## Failed to run the `lint.yml` workflow
To fix workflow errors. Please follow the steps below.
 1. Run `dotnet format` command.
 2. Commit changes as separated commit.
 3. Push changes to source branch of PR.
```
