### PR TITLE
fix: Modify `isCoverPage` check conditions

### DIFF
--- a/samples/seed/docfx.json
+++ b/samples/seed/docfx.json
@@ -70,7 +70,7 @@
       { "files": [ "**" ], "src": "obj/md", "dest": "md" },
       { "files": [ "**" ], "src": "obj/apipage", "dest": "apipage" },
       { "files": [ "articles/**/*.{md,yml}", "*.md", "toc.yml", "restapi/**" ] },
-      { "files": [ "pdf/**" ] }
+      { "files": [ "pdf/*.{md,yml}" ] }
     ],
     "resource": [
       {


### PR DESCRIPTION
This PR intended to fix issue reported at https://github.com/dotnet/docfx/issues/10414

I've added #10416 before to fix coverPage rendering issue.
But  `isCoverPage` check logics is not sufficient for relative path.

**What's changed in this PR**
- Normalize page URL before comparing to coverPage URL.
- Add settings for seed projects to exclude `pdf/*.html` files from contents.
