### PR TITLE
chore: Add `Codecov` step for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,11 @@ jobs:
       env:
         PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 
+    - uses: codecov/codecov-action@v5
+      if: matrix.os == 'ubuntu-latest'
+      with:
+        fail_ci_if_error: true
+
     - run: echo "DOTNET_DbgEnableMiniDump=1" >> $GITHUB_ENV
       if: matrix.os == 'ubuntu-latest'
 

--- a/test/Docfx.Tests.Common/Docfx.Tests.Common.csproj
+++ b/test/Docfx.Tests.Common/Docfx.Tests.Common.csproj
@@ -3,6 +3,11 @@
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
+  <!-- Add assembly level ExcludeFromCodeCoverage attribute -->
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.Common\Docfx.Common.csproj" />
   </ItemGroup>


### PR DESCRIPTION
This PR intended to fix #9853.

Previously I've removed Codecov step from CI workflow.
Because it's behavior is unstable.

Codecov `v5` support new `Tokenless Uploads for Public Repositories` feature.
So it's expected to be works as expected without explicitly specify `CODECOV_TOKEN` token.

Note: It might requires additional settings on Codecov site with admin privileges to use tokenless upload.

- https://app.codecov.io/gh/dotnet/docfx
- https://docs.codecov.com/docs/codecov-tokens#uploading-without-a-token
