### PR TITLE
chore: Add cancellation support for PdfBuilder operation

### DIFF
--- a/src/docfx/Models/CancellableCommandBase.cs
+++ b/src/docfx/Models/CancellableCommandBase.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Runtime.InteropServices;
+using Spectre.Console.Cli;
+
+namespace Docfx;
+
+public abstract class CancellableCommandBase<TSettings> : Command<TSettings>
+     where TSettings : CommandSettings
+{
+    public abstract int Execute(CommandContext context, TSettings settings, CancellationToken cancellation);
+
+    public sealed override int Execute(CommandContext context, TSettings settings)
+    {
+        using var cancellationSource = new CancellationTokenSource();
+
+        using var sigInt = PosixSignalRegistration.Create(PosixSignal.SIGINT, onSignal);
+        using var sigQuit = PosixSignalRegistration.Create(PosixSignal.SIGQUIT, onSignal);
+        using var sigTerm = PosixSignalRegistration.Create(PosixSignal.SIGTERM, onSignal);
+
+        var exitCode = Execute(context, settings, cancellationSource.Token);
+        return exitCode;
+
+        void onSignal(PosixSignalContext context)
+        {
+            context.Cancel = true;
+            cancellationSource.Cancel();
+        }
+    }
+}

--- a/src/docfx/Models/DefaultCommand.cs
+++ b/src/docfx/Models/DefaultCommand.cs
@@ -10,7 +10,7 @@ using Spectre.Console.Cli;
 
 namespace Docfx;
 
-class DefaultCommand : Command<DefaultCommand.Options>
+class DefaultCommand : CancellableCommandBase<DefaultCommand.Options>
 {
     [Description("Runs metadata, build and pdf commands")]
     internal class Options : BuildCommandOptions
@@ -20,7 +20,7 @@ class DefaultCommand : Command<DefaultCommand.Options>
         public bool Version { get; set; }
     }
 
-    public override int Execute(CommandContext context, Options options)
+    public override int Execute(CommandContext context, Options options, CancellationToken cancellationToken)
     {
         if (options.Version)
         {
@@ -48,9 +48,9 @@ class DefaultCommand : Command<DefaultCommand.Options>
             if (config.build is not null)
             {
                 BuildCommand.MergeOptionsToConfig(options, config.build, configDirectory);
-                serveDirectory = RunBuild.Exec(config.build, new(), configDirectory, outputFolder);
+                serveDirectory = RunBuild.Exec(config.build, new(), configDirectory, outputFolder, cancellationToken);
 
-                PdfBuilder.CreatePdf(serveDirectory).GetAwaiter().GetResult();
+                PdfBuilder.CreatePdf(serveDirectory, cancellationToken).GetAwaiter().GetResult();
             }
 
             if (options.Serve && serveDirectory is not null)

--- a/src/docfx/Models/PdfCommand.cs
+++ b/src/docfx/Models/PdfCommand.cs
@@ -1,22 +1,23 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
 using Docfx.Pdf;
 using Spectre.Console.Cli;
 
+#nullable enable
+
 namespace Docfx;
 
-internal class PdfCommand : Command<PdfCommandOptions>
+internal class PdfCommand : CancellableCommandBase<PdfCommandOptions>
 {
-    public override int Execute([NotNull] CommandContext context, [NotNull] PdfCommandOptions options)
+    public override int Execute(CommandContext context, PdfCommandOptions options, CancellationToken cancellationToken)
     {
         return CommandHelper.Run(options, () =>
         {
             var (config, configDirectory) = Docset.GetConfig(options.ConfigFile);
 
             if (config.build is not null)
-                PdfBuilder.Run(config.build, configDirectory, options.OutputFolder).GetAwaiter().GetResult();
+                PdfBuilder.Run(config.build, configDirectory, options.OutputFolder, cancellationToken).GetAwaiter().GetResult();
         });
     }
 }

--- a/test/Docfx.Build.Tests/XRefMapSerializationTest.cs
+++ b/test/Docfx.Build.Tests/XRefMapSerializationTest.cs
@@ -3,7 +3,6 @@
 
 using System.Text;
 using Docfx.Common;
-using Docfx.Plugins;
 using FluentAssertions;
 using Xunit;
 


### PR DESCRIPTION
This PR intended to fix issue #9870.

Currently when running `docfx pdf` command.
`Ctrl+C` command interruption is not accepted.
So I've added codes to  manually cancel running operations.

> [!NOTE]
> Playwright don't supports cancellationToken parameters.
> So it need manually cancel operation by dispose playwright context.
>
> `Specre.Console` don't support native cancellation support .
> So PdfCommand/DefaultCommand is not modified. (It need to migrate to `AsyncCommand` in future)
> `https://github.com/spectreconsole/spectre.console/issues/701`

**What's changed in this PR**
1. Add cancellationToken parameter to PdfBuilder's public APIs
2. Add `Console.CancelKeyPress` event handlers to cancel running operations
3. Add `cancellationToken` parameter to following methods
  3.1. WebApplication.Start
  3.2. `ParallelOptions` parameter of `Parallel.Foreach`
4. Call `cancellationToken.ThrowIfCancellationRequested()` inside loop.
5. Rename `outputPath` parameter to `pdfOutputPath`.



