### PR TITLE
chore: Remove code that create unused docfx temp directory

### DIFF
--- a/src/Docfx.App/PdfBuilder.cs
+++ b/src/Docfx.App/PdfBuilder.cs
@@ -258,9 +258,6 @@ static class PdfBuilder
         Func<Outline, Uri, Task<byte[]?>> printPdf, Func<Outline, int, int, Page, Task<byte[]>> printHeaderFooter, ProgressTask task,
         Uri outlineUrl, Outline outline, string outputFolder, string outputPath, Action<Dictionary<Outline, int>> updatePageNumbers)
     {
-        var tempDirectory = Path.Combine(Path.GetTempPath(), ".docfx", "pdf", "pages");
-        Directory.CreateDirectory(tempDirectory);
-
         var pages = GetPages(outline).ToArray();
         if (pages.Length == 0)
             return;


### PR DESCRIPTION
This PR intended to remove extra file I/O.

**Background**
Currently  `docfx pdf` command create temp directory ( `%Temp%\.docfx\pdf\pages`)
But this temp directory seems not be used. (On current implementation/ **All PDF page bytes**  are processed on memory)

Related code is removed at [this commit](https://github.com/dotnet/docfx/commit/ab267481509bc82257abb7733dad4b39606c4990#diff-3f70f352ed586c231937daece7b2ba735496e330f83386aac433fd19b7e07bbdL189-L195)





