### PR TITLE
chore: Update xUnit related package version to v3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,6 @@ templates/** eol=lf
 
 # VerifyTests
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
+*.verified.json text eol=lf working-tree-encoding=UTF-8
+*.verified.yml text eol=lf working-tree-encoding=UTF-8
+*.verified.md text eol=lf working-tree-encoding=UTF-8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches: [ main, feature/*, hotfix/* ]
   workflow_dispatch:
 
+env:
+  NO_COLOR: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -31,30 +34,47 @@ jobs:
       shell: bash
       working-directory: templates
 
-    - run: dotnet test -c Release -f net10.0 --no-build --collect:"XPlat Code Coverage" --consoleLoggerParameters:"Summary;Verbosity=Minimal"
+    - name: Install Chromium headless shell
+      shell: pwsh
+      working-directory: src/docfx/bin/Release/net8.0
+      run: |
+        $env:PLAYWRIGHT_NODEJS_PATH = (Get-Command node).Path
+        ./playwright.ps1 install chromium --only-shell
+
+    - name: Install `dotnet-coverage` as .NET Global Tool
+      run: dotnet tool install -g dotnet-coverage
+
+    - name: Start dotnet-coverage with background server mode
+      run: dotnet coverage collect --session-id docfx_coverage --settings test/CodeCoverage.config --server-mode --background
+
+    - run: dotnet coverage connect docfx_coverage "dotnet test -c Release -f net10.0 --no-build"
       id: test-net100
 
-    - run: dotnet test -c Release -f net9.0 --no-build --collect:"XPlat Code Coverage" --consoleLoggerParameters:"Summary;Verbosity=Minimal"
+    - run: dotnet coverage connect docfx_coverage "dotnet test -c Release -f net9.0 --no-build"
       if: matrix.os == 'ubuntu-latest'
       id: test-net90
 
-    - run: dotnet test -c Release -f net8.0 --no-build --collect:"XPlat Code Coverage" --consoleLoggerParameters:"Summary;Verbosity=Minimal"
+    - run: dotnet coverage connect docfx_coverage "dotnet test -c Release -f net8.0 --no-build"
       if: matrix.os == 'ubuntu-latest'
       id: test-net80
 
     - run: npm i -g @percy/cli
       if: matrix.os == 'ubuntu-latest'
 
-    - run: percy exec -- dotnet test -c Release -f net10.0 --filter Stage=Percy --no-build --collect:"XPlat Code Coverage"
+    - run: dotnet coverage connect docfx_coverage "percy exec -- dotnet test -c Release -f net10.0 --no-build -- --filter-trait "Stage=Percy""
       if: matrix.os == 'ubuntu-latest'
       env:
         PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+
+    - name: Shutdown dotnet-coverage server.
+      run: dotnet coverage shutdown docfx_coverage  --timeout 60000
 
     - uses: codecov/codecov-action@v7
       if: matrix.os == 'ubuntu-latest'
       with:
         fail_ci_if_error: false
         token: ${{ secrets.CODECOV_TOKEN }}
+        directory: test/TestResults/code-coverages
 
     - run: echo "DOTNET_DbgEnableMiniDump=1" >> $GITHUB_ENV
       if: matrix.os == 'ubuntu-latest'
@@ -74,8 +94,10 @@ jobs:
         name: logs-${{ matrix.os }}
         path: |
           msbuild.binlog
+          test/**/TestResults/*.log
           test/**/TestResults/*.trx
           test/**/TestResults/*.html
+          test/**/TestResults/*.ctrf
 
     - uses: actions/upload-artifact@v7
       if: ${{ failure() && matrix.os == 'ubuntu-latest' }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,10 +40,6 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
-  <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
-
   <!-- Remove Node.js runtime dependencies that used by playwright -->
   <Target Name="RemoveNodeJsRuntimes" AfterTargets="CopyPlaywrightFilesToOutput">
     <ItemGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,7 @@
+<Project>
+  
+  <ItemGroup Condition="'$(IsPackable)' == 'true'">
+    <None Include="$(MSBuildThisFileDirectory)\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+</Project>

--- a/docfx.slnx
+++ b/docfx.slnx
@@ -2,6 +2,7 @@
   <Folder Name="/Solution Items/">
     <File Path=".editorconfig" />
     <File Path="Directory.Build.props" />
+    <File Path="Directory.Build.targets" />
     <File Path="Directory.Packages.props" />
   </Folder>
   <Folder Name="/src/">
@@ -38,6 +39,7 @@
   </Folder>
   <Folder Name="/test/">
     <File Path="test/Directory.Build.props" />
+    <File Path="test/Directory.Build.targets" />
     <File Path="test/Directory.Packages.props" />
     <Project Path="test/Docfx.Build.Common.Tests/Docfx.Build.Common.Tests.csproj" />
     <Project Path="test/Docfx.Build.Tests/Docfx.Build.Tests.csproj" />

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -1,0 +1,2 @@
+<Project>
+</Project>

--- a/test/CodeCoverage.config
+++ b/test/CodeCoverage.config
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration>
+  <!-- Available Options: https://github.com/microsoft/codecoverage/blob/main/docs/configuration.md -->
+  <CoverageFileName>coverage.cobertura.xml</CoverageFileName>
+  <Format>cobertura</Format>
+  <IncludeTestAssembly>false</IncludeTestAssembly>
+  <DeterministicReport>true</DeterministicReport>
+  <CollectFromChildProcesses>true</CollectFromChildProcesses>
+  <CodeCoverage>
+    <ModulePaths>
+      <Include>
+        <ModulePath>.*Docfx.*\.dll$</ModulePath>
+      </Include>
+      <Exclude>
+        <!-- Exclude test DLLs -->
+        <ModulePath>.*Docfx\.Tests\.Common\.dll$</ModulePath>
+        <ModulePath>.*\.Tests\.dll$</ModulePath>
+
+        <!-- Exclude third party DLLs -->
+        <ModulePath>.*ICSharpCode\.Decompiler\.dll$</ModulePath>
+        <ModulePath>.*Spectre\.Console\.Cli\.dll$</ModulePath>
+        <ModulePath>.*Spectre\.Console\.dll$</ModulePath>
+        <ModulePath>.*DiffEngine\.dll$</ModulePath>
+
+        <!-- Following DLLs are included when using `dotnet coverage` commands -->
+        <ModulePath>.*Argon\.dll$</ModulePath>
+        <ModulePath>.*EmptyFiles\.dll$</ModulePath>
+        <ModulePath>.*Verify\.dll$</ModulePath>
+        <ModulePath>.*Verify\.DiffPlex\.dll$</ModulePath>
+        <ModulePath>.*Verify\.XunitV3\.dll$</ModulePath>
+      </Exclude>
+    </ModulePaths>
+    <Attributes>
+      <Exclude>
+        <Attribute>^System\.CodeDom\.Compiler\.GeneratedCodeAttribute$</Attribute>
+      </Exclude>
+    </Attributes>
+    <Sources>
+      <Exclude>
+        <Source>.*\\[^\\]*\.g\.cs</Source>
+      </Exclude>
+    </Sources>
+    <!-- Disable following settings. Because C++ code is not contained (See: https://github.com/microsoft/codecoverage/blob/main/README.md#get-started)-->
+    <EnableStaticNativeInstrumentation>False</EnableStaticNativeInstrumentation>
+    <EnableDynamicNativeInstrumentation>False</EnableDynamicNativeInstrumentation>
+  </CodeCoverage>
+</Configuration>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,37 +1,72 @@
 <Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('$(MSBuildThisFile)', '$(MSBuildThisFileDirectory)../'))" />
+
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
+    <IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
+  <!-- .NET 9 or later run tests per TargetFramework in parallel by default.
+        It is necessary to disable this feature because there are tests that need to be executed sequentially that are marked with `[Collection("docfx STA")]`. -->
   <PropertyGroup>
-    <!--
-    .NET 9 preview 2 or later run tests in parallel by default.
-    It is necessary to disable this feature because there are tests that need to be executed sequentially that are marked with `[Collection("docfx STA")]`.
-    -->
     <TestTfmsInParallel>false</TestTfmsInParallel>
   </PropertyGroup>
 
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('$(MSBuildThisFile)', '$(MSBuildThisFileDirectory)../'))" />
+  <!-- Configure `Microsoft.Testing.Platform` mode behaviors (https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-platform-integration-dotnet-test)-->
 
-  <ItemGroup>
-    <None Include="TestData\**" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
-
-  <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true' AND '$(PERCY_TOKEN)' == ''">
-    <VSTestResultsDirectory>$(MSBuildThisFileDirectory)TestResults</VSTestResultsDirectory>
-    <VSTestLogger>$(VSTestLogger);trx%3BLogFileName=TestResults-$(MSBuildProjectName)-$(TargetFramework)-$(RUNNER_OS).trx</VSTestLogger>
-    <VSTestLogger>$(VSTestLogger);html%3BLogFileName=TestResults-$(MSBuildProjectName)-$(TargetFramework)-$(RUNNER_OS).html</VSTestLogger>
+  <!-- Following settings are required for .NET 9 SDK and earlier -->
+  <PropertyGroup Condition="'$(TargetFramework)'=='net9.0' OR '$(TargetFramework)'=='net8.0'">
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <TestingPlatformCaptureOutput>false</TestingPlatformCaptureOutput>
+    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
+  <PropertyGroup>
+    <!-- Use `Microsoft.Testing.Platform` entrypoint -->
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Show xUnit.net headers and information -->
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --xunit-info</TestingPlatformCommandLineArguments>
+
+    <!-- Change TestResults output directory. And enable detailed log outputs -->
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --results-directory "$(MSBuildThisFileDirectory)TestResults"</TestingPlatformCommandLineArguments>
+
+    <!-- Ignore exit code 8 (the test session run zero tests) -->
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --ignore-exit-code 8</TestingPlatformCommandLineArguments>
+
+    <!-- Enable output for passed tests -->
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --output Detailed</TestingPlatformCommandLineArguments>
+  </PropertyGroup>
+
+  <!-- Settings for CI environment -->
+  <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true' AND '$(PERCY_TOKEN)' == ''">
+    <!-- Disable progress reports -->
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --no-progress</TestingPlatformCommandLineArguments>
+
+    <!-- Enable reporters (trx/html/ctrf ) -->
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-xunit-trx  --report-xunit-trx-filename  TestResults-$(MSBuildProjectName)-$(TargetFramework)-$(RUNNER_OS).trx</TestingPlatformCommandLineArguments>
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-xunit-html --report-xunit-html-filename TestResults-$(MSBuildProjectName)-$(TargetFramework)-$(RUNNER_OS).html</TestingPlatformCommandLineArguments>
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-ctrf       --report-ctrf-filename       TestResults-$(MSBuildProjectName)-$(TargetFramework)-$(RUNNER_OS).ctrf</TestingPlatformCommandLineArguments>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
+    <!-- Set [assembly:CaptureConsole] attribute to assembly -->
+    <AssemblyAttribute Include="Xunit.CaptureConsole" />
+
+    <!-- Add project items -->
+    <None Include="TestData\**" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(MSBuildThisFileDirectory)xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+
+    <!-- Add Docfx.Tests.Common` project reference to test projects -->
     <ProjectReference Include="$(MSBuildThisFileDirectory)Docfx.Tests.Common/Docfx.Tests.Common.csproj" />
+
+    <!-- Add common test package references -->
+    <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="xunit.v3" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="xunit" />
-  </ItemGroup>
 </Project>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('$(MSBuildThisFile)', '$(MSBuildThisFileDirectory)../'))" />
+</Project>

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -4,14 +4,11 @@
 
   <ItemGroup>
     <PackageVersion Include="AwesomeAssertions" Version="9.6.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-    <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
-    <PackageVersion Include="Verify.Xunit" Version="31.12.5" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="Verify.DiffPlex" Version="3.3.1" />
+    <PackageVersion Include="Verify.XunitV3" Version="31.28.0" />
+    <PackageVersion Include="xunit.v3.assert" Version="4.0.0" />
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="4.0.0" />
+    <PackageVersion Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
-  
-  <ItemGroup>
-    <GlobalPackageReference Include="coverlet.collector" Version="10.0.1" />
-  </ItemGroup>
+
 </Project>

--- a/test/Docfx.Build.Common.Tests/Docfx.Build.Common.Tests.csproj
+++ b/test/Docfx.Build.Common.Tests/Docfx.Build.Common.Tests.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.Build.Common\Docfx.Build.Common.csproj" />
     <ProjectReference Include="..\..\src\Docfx.Build\Docfx.Build.csproj" />

--- a/test/Docfx.Build.ManagedReference.Tests/Docfx.Build.ManagedReference.Tests.csproj
+++ b/test/Docfx.Build.ManagedReference.Tests/Docfx.Build.ManagedReference.Tests.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.Build\Docfx.Build.csproj" />
     <ProjectReference Include="..\..\src\Docfx.Build.ManagedReference\Docfx.Build.ManagedReference.csproj" />

--- a/test/Docfx.Build.OverwriteDocuments.Tests/Docfx.Build.OverwriteDocuments.Tests.csproj
+++ b/test/Docfx.Build.OverwriteDocuments.Tests/Docfx.Build.OverwriteDocuments.Tests.csproj
@@ -1,7 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Markdig" />
   </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.Build.OverwriteDocuments\Docfx.Build.OverwriteDocuments.csproj" />
   </ItemGroup>

--- a/test/Docfx.Build.RestApi.Tests/Docfx.Build.RestApi.Tests.csproj
+++ b/test/Docfx.Build.RestApi.Tests/Docfx.Build.RestApi.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <None Include="TestData\**" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.YamlSerialization\Docfx.YamlSerialization.csproj" />

--- a/test/Docfx.Build.RestApi.WithPlugins.Tests/Docfx.Build.RestApi.WithPlugins.Tests.csproj
+++ b/test/Docfx.Build.RestApi.WithPlugins.Tests/Docfx.Build.RestApi.WithPlugins.Tests.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.Build.OperationLevelRestApi\Docfx.Build.OperationLevelRestApi.csproj" />
     <ProjectReference Include="..\..\src\Docfx.Build.TagLevelRestApi\Docfx.Build.TagLevelRestApi.csproj" />

--- a/test/Docfx.Build.SchemaDriven.Tests/Docfx.Build.SchemaDriven.Tests.csproj
+++ b/test/Docfx.Build.SchemaDriven.Tests/Docfx.Build.SchemaDriven.Tests.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.Build.Common\Docfx.Build.Common.csproj" />
     <ProjectReference Include="..\..\src\Docfx.Build\Docfx.Build.csproj" />

--- a/test/Docfx.Build.Tests/Docfx.Build.Tests.csproj
+++ b/test/Docfx.Build.Tests/Docfx.Build.Tests.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Remove="TestData\snippets\dataflowdegreeofparallelism.cs" />
   </ItemGroup>

--- a/test/Docfx.Build.Tests/ExtractSearchIndexFromHtmlTest.cs
+++ b/test/Docfx.Build.Tests/ExtractSearchIndexFromHtmlTest.cs
@@ -284,7 +284,7 @@ public class ExtractSearchIndexFromHtmlTest
         manifest.Files.Add(manifestItem);
 
         // process the fake manifest, using tempTestFolder as the output folder
-        _extractor.Process(manifest, tempTestFolder);
+        _extractor.Process(manifest, tempTestFolder, TestContext.Current.CancellationToken);
 
         var expectedIndexJSON = @"{
   ""index.html"": {

--- a/test/Docfx.Build.Tests/PostProcessors/SitemapGeneratorTests.cs
+++ b/test/Docfx.Build.Tests/PostProcessors/SitemapGeneratorTests.cs
@@ -50,7 +50,7 @@ public class SitemapGeneratorTests : TestBase
         var sitemapPath = Path.Combine(outputFolder, "sitemap.xml");
 
         // Act
-        manifest = sitemapGenerator.Process(manifest, outputFolder);
+        manifest = sitemapGenerator.Process(manifest, outputFolder, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal("https://example.com/", manifest.Sitemap.BaseUrl);

--- a/test/Docfx.Build.Tests/RemoveDebugInfoTest.cs
+++ b/test/Docfx.Build.Tests/RemoveDebugInfoTest.cs
@@ -43,7 +43,7 @@ public class RemoveDebugInfoTest : TestBase
         new HtmlPostProcessor
         {
             Handlers = { new RemoveDebugInfo() }
-        }.Process(manifest, _outputFolder);
+        }.Process(manifest, _outputFolder, TestContext.Current.CancellationToken);
 
         var actual = File.ReadAllText(Path.Combine(_outputFolder, "a.html"));
         Assert.Equal("<p id='b1'>section<a href='http://bing.com#top'>Microsoft Bing</a></p>", actual);

--- a/test/Docfx.Build.Tests/ValidateBookmarkTest.cs
+++ b/test/Docfx.Build.Tests/ValidateBookmarkTest.cs
@@ -63,7 +63,7 @@ public class ValidateBookmarkTest : TestBase
             new HtmlPostProcessor
             {
                 Handlers = { new ValidateBookmark() }
-            }.Process(manifest, _outputFolder);
+            }.Process(manifest, _outputFolder, TestContext.Current.CancellationToken);
         }
         finally
         {
@@ -107,7 +107,7 @@ public class ValidateBookmarkTest : TestBase
             new HtmlPostProcessor
             {
                 Handlers = { new ValidateBookmark() }
-            }.Process(manifest, _outputFolder);
+            }.Process(manifest, _outputFolder, TestContext.Current.CancellationToken);
         }
         finally
         {
@@ -150,7 +150,7 @@ public class ValidateBookmarkTest : TestBase
             new HtmlPostProcessor
             {
                 Handlers = { new ValidateBookmark() }
-            }.Process(manifest, _outputFolder);
+            }.Process(manifest, _outputFolder, TestContext.Current.CancellationToken);
         }
         finally
         {

--- a/test/Docfx.Build.Tests/XRefArchiveBuilderTest.cs
+++ b/test/Docfx.Build.Tests/XRefArchiveBuilderTest.cs
@@ -24,10 +24,10 @@ public class XRefArchiveBuilderTest
                 ### YamlMime:XRefMap
                 sorted: true
                 references: []
-                """);
+                """, TestContext.Current.CancellationToken);
 
             var builder = new XRefArchiveBuilder();
-            Assert.True(await builder.DownloadAsync(new Uri(xrefMapFile), archiveFile));
+            Assert.True(await builder.DownloadAsync(new Uri(xrefMapFile), archiveFile, TestContext.Current.CancellationToken));
 
             using var xar = XRefArchive.Open(archiveFile, XRefArchiveMode.Read);
             var map = xar.GetMajor();

--- a/test/Docfx.Build.Tests/XRefMapDownloaderTest.cs
+++ b/test/Docfx.Build.Tests/XRefMapDownloaderTest.cs
@@ -12,7 +12,7 @@ public class XRefMapDownloadTest
     public async Task BaseUrlIsSet()
     {
         var downloader = new XRefMapDownloader();
-        var xrefs = await downloader.DownloadAsync(new Uri("https://dotnet.github.io/docfx/xrefmap.yml")) as XRefMap;
+        var xrefs = await downloader.DownloadAsync(new Uri("https://dotnet.github.io/docfx/xrefmap.yml"), TestContext.Current.CancellationToken) as XRefMap;
         Assert.NotNull(xrefs);
         Assert.Equal("https://dotnet.github.io/docfx/", xrefs.BaseUrl);
     }
@@ -26,7 +26,7 @@ public class XRefMapDownloadTest
 
         // Get fallback TestData/xrefmap.yml which contains uid: 'str'
         var reader = await new XRefCollection(from u in xrefmaps
-                                              select new Uri(u, UriKind.RelativeOrAbsolute)).GetReaderAsync(basePath, fallbackFolders);
+                                              select new Uri(u, UriKind.RelativeOrAbsolute)).GetReaderAsync(basePath, fallbackFolders, TestContext.Current.CancellationToken);
 
         var xrefSpec = reader.Find("str");
         Assert.NotNull(xrefSpec);
@@ -40,7 +40,7 @@ public class XRefMapDownloadTest
         var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "xrefmap.json");
 
         var downloader = new XRefMapDownloader();
-        var xrefMap = await downloader.DownloadAsync(new Uri(path)) as XRefMap;
+        var xrefMap = await downloader.DownloadAsync(new Uri(path), TestContext.Current.CancellationToken) as XRefMap;
 
         // Assert
         xrefMap.Should().NotBeNull();
@@ -54,7 +54,7 @@ public class XRefMapDownloadTest
         var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "xrefmap.json.gz");
 
         var downloader = new XRefMapDownloader();
-        var xrefMap = await downloader.DownloadAsync(new Uri(path)) as XRefMap;
+        var xrefMap = await downloader.DownloadAsync(new Uri(path), TestContext.Current.CancellationToken) as XRefMap;
 
         // Assert
         xrefMap.Should().NotBeNull();
@@ -68,7 +68,7 @@ public class XRefMapDownloadTest
         var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "xrefmap.yml.gz");
 
         var downloader = new XRefMapDownloader();
-        var xrefMap = await downloader.DownloadAsync(new Uri(path)) as XRefMap;
+        var xrefMap = await downloader.DownloadAsync(new Uri(path), TestContext.Current.CancellationToken) as XRefMap;
 
         // Assert
         xrefMap.Should().NotBeNull();
@@ -85,7 +85,7 @@ public class XRefMapDownloadTest
         var path = "https://horizongir.github.io/ZedGraph/xrefmap.yml";
 
         var downloader = new XRefMapDownloader();
-        var xrefMap = await downloader.DownloadAsync(new Uri(path)) as XRefMap;
+        var xrefMap = await downloader.DownloadAsync(new Uri(path), TestContext.Current.CancellationToken) as XRefMap;
 
         // Assert
         xrefMap.Sorted.Should().BeTrue();
@@ -114,7 +114,7 @@ public class XRefMapDownloadTest
         var path = "https://normanderwan.github.io/UnityXrefMaps/xrefmap.yml";
 
         var downloader = new XRefMapDownloader();
-        var xrefMap = await downloader.DownloadAsync(new Uri(path)) as XRefMap;
+        var xrefMap = await downloader.DownloadAsync(new Uri(path), TestContext.Current.CancellationToken) as XRefMap;
 
         // Assert
         xrefMap.Sorted.Should().BeTrue();

--- a/test/Docfx.Build.UniversalReference.Tests/Docfx.Build.UniversalReference.Tests.csproj
+++ b/test/Docfx.Build.UniversalReference.Tests/Docfx.Build.UniversalReference.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <None Include="TestData\**" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.Build\Docfx.Build.csproj" />

--- a/test/Docfx.Common.Tests/Docfx.Common.Tests.csproj
+++ b/test/Docfx.Common.Tests/Docfx.Common.Tests.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.YamlSerialization\Docfx.YamlSerialization.csproj" />
     <ProjectReference Include="..\..\src\Docfx.Plugins\Docfx.Plugins.csproj" />

--- a/test/Docfx.Dotnet.Tests/Docfx.Dotnet.Tests.csproj
+++ b/test/Docfx.Dotnet.Tests/Docfx.Dotnet.Tests.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="TestDataReferences\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/test/Docfx.Dotnet.Tests/GenerateMetadataFromAssemblyTest.cs
+++ b/test/Docfx.Dotnet.Tests/GenerateMetadataFromAssemblyTest.cs
@@ -14,7 +14,7 @@ public class GenerateMetadataFromAssemblyTest
     {
         {
             var (compilation, assembly) = CompilationHelper.CreateCompilationFromAssembly("TestData/CatLibrary.dll");
-            Assert.Empty(compilation.GetDeclarationDiagnostics());
+            Assert.Empty(compilation.GetDeclarationDiagnostics(TestContext.Current.CancellationToken));
 
             var output = assembly.GenerateMetadataItem(compilation);
             var @class = output.Items[0].Items[2];
@@ -26,7 +26,7 @@ public class GenerateMetadataFromAssemblyTest
 
         {
             var (compilation, assembly) = CompilationHelper.CreateCompilationFromAssembly("TestData/CatLibrary2.dll");
-            Assert.Empty(compilation.GetDeclarationDiagnostics());
+            Assert.Empty(compilation.GetDeclarationDiagnostics(TestContext.Current.CancellationToken));
 
             var output = assembly.GenerateMetadataItem(compilation);
             var @class = output.Items[0].Items[0];
@@ -40,7 +40,7 @@ public class GenerateMetadataFromAssemblyTest
     public void TestGenerateMetadataFromAssemblyWithReferences()
     {
         var (compilation, assembly) = CompilationHelper.CreateCompilationFromAssembly("TestData/TupleLibrary.dll");
-        Assert.Empty(compilation.GetDeclarationDiagnostics());
+        Assert.Empty(compilation.GetDeclarationDiagnostics(TestContext.Current.CancellationToken));
 
         var output = assembly.GenerateMetadataItem(compilation);
         var @class = output.Items[0].Items[0];

--- a/test/Docfx.Dotnet.Tests/XmlCommentTests/XmlCommentSummaryTest.cs
+++ b/test/Docfx.Dotnet.Tests/XmlCommentTests/XmlCommentSummaryTest.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using AwesomeAssertions;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Docfx.Dotnet.Tests;
 

--- a/test/Docfx.Glob.Tests/Docfx.Glob.Tests.csproj
+++ b/test/Docfx.Glob.Tests/Docfx.Glob.Tests.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.Glob\Docfx.Glob.csproj" />
   </ItemGroup>

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/Docfx.MarkdigEngine.Extensions.Tests.csproj
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/Docfx.MarkdigEngine.Extensions.Tests.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.MarkdigEngine.Extensions\Docfx.MarkdigEngine.Extensions.csproj" />
   </ItemGroup>

--- a/test/Docfx.MarkdigEngine.Tests/Docfx.MarkdigEngine.Tests.csproj
+++ b/test/Docfx.MarkdigEngine.Tests/Docfx.MarkdigEngine.Tests.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.MarkdigEngine\Docfx.MarkdigEngine.csproj" />
   </ItemGroup>

--- a/test/Docfx.Tests.Common/Docfx.Tests.Common.csproj
+++ b/test/Docfx.Tests.Common/Docfx.Tests.Common.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <OutputType>Library</OutputType>
     <IsTestProject>false</IsTestProject>
+    <IsTestingPlatformApplication>false</IsTestingPlatformApplication>
   </PropertyGroup>
 
   <!-- Add assembly level ExcludeFromCodeCoverage attribute -->
@@ -10,5 +12,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.Common\Docfx.Common.csproj" />
+  </ItemGroup>
+  
+  <!-- Test library project need to reference separated package instead of `xunit.v3`-->
+  <ItemGroup>
+    <PackageReference Include="xunit.v3.assert" />
+    <PackageReference Include="xunit.v3.extensibility.core" />
   </ItemGroup>
 </Project>

--- a/test/docfx.Snapshot.Tests/Attributes/UseCustomBranchNameAttribute.cs
+++ b/test/docfx.Snapshot.Tests/Attributes/UseCustomBranchNameAttribute.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Xunit.v3;
+
+namespace Docfx.Tests;
+
+internal class UseCustomBranchNameAttribute(string branchName) : BeforeAfterTestAttribute
+{
+    public override void Before(MethodInfo methodUnderTest, IXunitTest test)
+    {
+        if (test.TestCase.TestCollection.TestCollectionDisplayName != "docfx STA")
+            throw new InvalidOperationException(@"UseCustomBranchNameAttribute change global context. Use `[Collection(""docfx STA"")]` to avoid parallel test executions.");
+
+        Environment.SetEnvironmentVariable("DOCFX_SOURCE_BRANCH_NAME", branchName);
+    }
+
+    public override void After(MethodInfo methodUnderTest, IXunitTest test)
+    {
+        Environment.SetEnvironmentVariable("DOCFX_SOURCE_BRANCH_NAME", null);
+    }
+}

--- a/test/docfx.Snapshot.Tests/SamplesTest.cs
+++ b/test/docfx.Snapshot.Tests/SamplesTest.cs
@@ -40,7 +40,10 @@ public class SamplesTest : IDisposable
 
     private class SamplesFactAttribute : FactAttribute
     {
-        public SamplesFactAttribute()
+        public SamplesFactAttribute(
+            [CallerFilePath] string sourceFilePath = null,
+            [CallerLineNumber] int sourceLineNumber = -1
+        ) : base(sourceFilePath, sourceLineNumber)
         {
             // When target framework is changed.
             // It need to modify TargetFrameworks property of `docfx.Snapshot.Tests.csproj`
@@ -51,6 +54,7 @@ public class SamplesTest : IDisposable
     }
 
     [SamplesFact]
+    [UseCustomBranchName("main")]
     public async Task Seed()
     {
         var samplePath = $"{s_samplesDir}/seed";
@@ -62,7 +66,6 @@ public class SamplesTest : IDisposable
 
         if (Debugger.IsAttached || IsWslRemoteTest())
         {
-            Environment.SetEnvironmentVariable("DOCFX_SOURCE_BRANCH_NAME", "main");
             Assert.Equal(0, Program.Main([$"{samplePath}/docfx.json"]));
         }
         else
@@ -118,6 +121,7 @@ public class SamplesTest : IDisposable
     }
 
     [SamplesFact]
+    [UseCustomBranchName("main")]
     public async Task SeedMarkdown()
     {
         var samplePath = $"{s_samplesDir}/seed";
@@ -131,32 +135,28 @@ public class SamplesTest : IDisposable
     }
 
     [SamplesFact]
+    [UseCustomBranchName("main")]
     public async Task CSharp()
     {
         var samplePath = $"{s_samplesDir}/csharp";
         Clean(samplePath);
 
-        Environment.SetEnvironmentVariable("DOCFX_SOURCE_BRANCH_NAME", "main");
-
-        try
-        {
-            await DotnetApiCatalog.GenerateManagedReferenceYamlFiles($"{samplePath}/docfx.json");
-            await Docset.Build($"{samplePath}/docfx.json");
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("DOCFX_SOURCE_BRANCH_NAME", null);
-        }
+        await DotnetApiCatalog.GenerateManagedReferenceYamlFiles($"{samplePath}/docfx.json");
+        await Docset.Build($"{samplePath}/docfx.json");
 
         await VerifyDirectory($"{samplePath}/_site", IncludeFile).AutoVerify(includeBuildServer: false);
     }
 
     [SamplesFact]
+    [UseCustomBranchName("main")]
     public Task Extensions()
     {
         var samplePath = $"{s_samplesDir}/extensions";
         Clean(samplePath);
 
+        // On some specific environment. `dotnet build` command takes about 15 minutes.
+        // So adding `-nodeReuse:false` parameter to resolve issue (https://github.com/dotnet/sdk/issues/9452)
+        // Additionaly use `--no-dependencies` parameter to suppress dependent projects build.
 #if DEBUG
         using var process = Process.Start("dotnet", $"build \"{samplePath}/build\"");
         process.WaitForExit();
@@ -174,13 +174,14 @@ public class SamplesTest : IDisposable
 
     private static int Exec(string filename, string args, string workingDirectory = null)
     {
-        var psi = new ProcessStartInfo(filename, args);
-        psi.EnvironmentVariables.Add("DOCFX_SOURCE_BRANCH_NAME", "main");
-        if (workingDirectory != null)
-            psi.WorkingDirectory = Path.GetFullPath(workingDirectory);
-        using var process = Process.Start(psi);
-        process.WaitForExit();
-        return process.ExitCode;
+        var execTask = ProcessHelper.ExecAsync(
+            filename,
+            args,
+            workingDirectory,
+            environmentVariables: [],
+            TestContext.Current.CancellationToken);
+
+        return execTask.GetAwaiter().GetResult();
     }
 
     private static void Clean(string samplePath)

--- a/test/docfx.Snapshot.Tests/Utilities/ProcessHelper.cs
+++ b/test/docfx.Snapshot.Tests/Utilities/ProcessHelper.cs
@@ -1,0 +1,115 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Docfx.Tests;
+
+internal static class ProcessHelper
+{
+    public static async ValueTask<int> ExecAsync(
+        string filename,
+        string args,
+        string workingDirectory = null,
+        KeyValuePair<string, string>[] environmentVariables = null,
+        CancellationToken cancellationToken = default)
+    {
+        var psi = new ProcessStartInfo(filename, args)
+        {
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            ErrorDialog = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = false,
+        };
+
+        if (workingDirectory != null)
+            psi.WorkingDirectory = Path.GetFullPath(workingDirectory);
+
+        if (environmentVariables != null)
+        {
+            foreach (var v in environmentVariables)
+                psi.EnvironmentVariables.Add(v.Key, v.Value);
+        }
+
+        using var process = new Process
+        {
+            StartInfo = psi,
+            EnableRaisingEvents = true,
+        };
+        process.OutputDataReceived += OnOutputDataReceived;
+        process.ErrorDataReceived += OnErrorDataReceived;
+
+        try
+        {
+            process.Start();
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            // On .NET 6 or later. Process.WaitForExitAsync wait for redirected output reads
+            await process.WaitForExitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            TerminateProcess(process);
+            throw;
+        }
+        catch
+        {
+            TerminateProcess(process);
+            return -1;
+        }
+
+        CleanupProcess(process);
+        return process.ExitCode;
+    }
+
+    private static void CleanupProcess(Process process)
+    {
+        // Stop async event processing. (To avoid callback invoked after disposed)
+        process.CancelOutputRead();
+        process.CancelErrorRead();
+
+        // Remove event handler
+        process.OutputDataReceived -= OnOutputDataReceived;
+        process.ErrorDataReceived -= OnErrorDataReceived;
+    }
+
+    private static void TerminateProcess(Process process)
+    {
+        CleanupProcess(process);
+
+        if (process.HasExited)
+            return;
+
+        try
+        {
+            process.Kill(entireProcessTree: true);
+        }
+        catch
+        {
+            // Ignore exception
+        }
+    }
+
+    private static void OnOutputDataReceived(object sender, DataReceivedEventArgs e)
+    {
+        var message = e.Data;
+        if (string.IsNullOrEmpty(message))
+            return;
+
+        // Ignore output message. When need to output logs. uncomment following line.
+        // TestContext.Current.TestOutputHelper.WriteLine(message);
+    }
+
+    private static void OnErrorDataReceived(object sender, DataReceivedEventArgs e)
+    {
+        var message = e.Data;
+        if (string.IsNullOrEmpty(message))
+            return;
+
+        // Ignore output message. When need to output logs. uncomment following line.
+        // TestContext.Current.TestOutputHelper.WriteLine($"Error: {message}");
+    }
+}

--- a/test/docfx.Snapshot.Tests/docfx.Snapshot.Tests.csproj
+++ b/test/docfx.Snapshot.Tests/docfx.Snapshot.Tests.csproj
@@ -1,12 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net10.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
-  
+
+  <!-- Settings to enable `dotnet test` with .NET 10 tfm only -->
+  <PropertyGroup Condition="'$(TargetFramework)' != 'net10.0'">
+    <IsTestingPlatformApplication>false</IsTestingPlatformApplication>
+    <IsTestProject>false</IsTestProject>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Playwright" />
     <PackageReference Include="Verify.DiffPlex" />
-    <PackageReference Include="Verify.Xunit" />
+    <PackageReference Include="Verify.XunitV3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/docfx.Tests/Attributes/WindowsOnlyFactAttribute.cs
+++ b/test/docfx.Tests/Attributes/WindowsOnlyFactAttribute.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace docfx.Tests.Attributes;
@@ -13,7 +14,10 @@ namespace docfx.Tests.Attributes;
 /// </remarks>
 public class WindowsOnlyFactAttribute : FactAttribute
 {
-    public WindowsOnlyFactAttribute()
+    public WindowsOnlyFactAttribute(
+        [CallerFilePath] string sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1
+    ) : base(sourceFilePath, sourceLineNumber)
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {

--- a/test/docfx.Tests/MetadataCommandTest.cs
+++ b/test/docfx.Tests/MetadataCommandTest.cs
@@ -22,6 +22,10 @@ public class MetadataCommandTest : TestBase
     {
         _outputFolder = GetRandomFolder();
         _projectFolder = GetRandomFolder();
+
+        // Create empty `Directory.Build.props`.
+        var propsFilePath = Path.Combine(_projectFolder, "Directory.Build.props");
+        File.WriteAllText(propsFilePath, "<Project></Project>");
     }
 
     [Fact]
@@ -35,7 +39,7 @@ public class MetadataCommandTest : TestBase
 
         await DotnetApiCatalog.Exec(
             new(new MetadataJsonItemConfig { Dest = _outputFolder, Src = new(new FileMappingItem(projectFile)) { Expanded = true } }),
-            new(), Directory.GetCurrentDirectory());
+            new(), Directory.GetCurrentDirectory(), cancellationToken: TestContext.Current.CancellationToken);
 
         CheckResult();
     }
@@ -49,7 +53,7 @@ public class MetadataCommandTest : TestBase
 
         await DotnetApiCatalog.Exec(
             new(new MetadataJsonItemConfig { Dest = _outputFolder, Src = new(new FileMappingItem(dllFile)) { Expanded = true } }),
-            new(), Directory.GetCurrentDirectory());
+            new(), Directory.GetCurrentDirectory(), cancellationToken: TestContext.Current.CancellationToken);
 
         CheckResult();
     }
@@ -71,7 +75,7 @@ public class MetadataCommandTest : TestBase
                 Src = new(new FileMappingItem(projectFile)) { Expanded = true },
                 Properties = new() { ["TargetFramework"] = "net8.0" },
             }),
-            new(), Directory.GetCurrentDirectory());
+            new(), Directory.GetCurrentDirectory(), cancellationToken: TestContext.Current.CancellationToken);
 
         CheckResult();
     }
@@ -91,7 +95,7 @@ public class MetadataCommandTest : TestBase
 
         await DotnetApiCatalog.Exec(
             new(new MetadataJsonItemConfig { Dest = _outputFolder, Src = new(new FileMappingItem(projectFile)) { Expanded = true } }),
-            new(), Directory.GetCurrentDirectory());
+            new(), Directory.GetCurrentDirectory(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.True(File.Exists(Path.Combine(_outputFolder, ".manifest")));
 
@@ -158,7 +162,7 @@ public class MetadataCommandTest : TestBase
                 Src = new(new FileMappingItem(projectFile)) { Expanded = true },
                 Filter = filterFile,
             }),
-            new(), Directory.GetCurrentDirectory());
+            new(), Directory.GetCurrentDirectory(), cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.True(File.Exists(Path.Combine(_outputFolder, ".manifest")));
 
@@ -203,7 +207,7 @@ public class MetadataCommandTest : TestBase
 
         await DotnetApiCatalog.Exec(
             new(new MetadataJsonItemConfig { Dest = _outputFolder, Src = new(new FileMappingItem(projectFile)) { Expanded = true } }),
-            new(), Directory.GetCurrentDirectory());
+            new(), Directory.GetCurrentDirectory(), cancellationToken: TestContext.Current.CancellationToken);
 
         CheckResult();
     }
@@ -224,7 +228,7 @@ public class MetadataCommandTest : TestBase
                 Src = new(new FileMappingItem(projectFile)) { Expanded = true },
                 NamespaceLayout = NamespaceLayout.Nested,
             }),
-            new(), Directory.GetCurrentDirectory());
+            new(), Directory.GetCurrentDirectory(), cancellationToken: TestContext.Current.CancellationToken);
 
         var file = Path.Combine(_outputFolder, "toc.yml");
         Assert.True(File.Exists(file));
@@ -263,7 +267,7 @@ public class MetadataCommandTest : TestBase
                 Src = new(new FileMappingItem(projectFile)) { Expanded = true },
                 NamespaceLayout = NamespaceLayout.Flattened,
             }),
-            new(), Directory.GetCurrentDirectory());
+            new(), Directory.GetCurrentDirectory(), cancellationToken: TestContext.Current.CancellationToken);
 
         var file = Path.Combine(_outputFolder, "toc.yml");
         Assert.True(File.Exists(file));
@@ -302,7 +306,7 @@ public class MetadataCommandTest : TestBase
                 Src = new(new FileMappingItem(projectFile)) { Expanded = true },
                 NamespaceLayout = NamespaceLayout.Nested,
             }),
-            new(), Directory.GetCurrentDirectory());
+            new(), Directory.GetCurrentDirectory(), cancellationToken: TestContext.Current.CancellationToken);
 
         var file = Path.Combine(_outputFolder, "toc.yml");
         Assert.True(File.Exists(file));

--- a/test/docfx.Tests/SerializationTests/TestData/TestDataAttribute.cs
+++ b/test/docfx.Tests/SerializationTests/TestData/TestDataAttribute.cs
@@ -3,12 +3,15 @@
 
 using System.Reflection;
 using Xunit.Sdk;
+using Xunit.v3;
 
 namespace docfx.Tests;
 
 public class TestDataAttribute<T> : DataAttribute
 {
-    public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+    public override bool SupportsDiscoveryEnumeration() => true;
+
+    public override ValueTask<IReadOnlyCollection<ITheoryDataRow>> GetData(MethodInfo testMethod, DisposalTracker disposalTracker)
     {
         var key = GetTestDataKey();
         var paths = TestData.GetTestDataFilePaths(key);
@@ -28,7 +31,9 @@ public class TestDataAttribute<T> : DataAttribute
                 throw new NotSupportedException($"{className} is not supported.");
         }
 
-        return new TheoryData<string>(paths);
+        var results = paths.Select(x => new TheoryDataRow<string>(x)).ToArray();
+
+        return ValueTask.FromResult<IReadOnlyCollection<ITheoryDataRow>>(results);
     }
 
     private static string GetTestDataKey()

--- a/test/docfx.Tests/docfx.Tests.csproj
+++ b/test/docfx.Tests/docfx.Tests.csproj
@@ -1,11 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup />
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="Assets\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Verify.Xunit" />
+    <PackageReference Include="Verify.XunitV3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/xunit.runner.json
+++ b/test/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "diagnosticMessages": true,
+  "showLiveOutput": true
+}


### PR DESCRIPTION
This is **Draft** PR to migrate unit test projects to `xUnit v3`. (Prev draft PR is #10375)
Currently test execution on VS is unstable

### What's changed to this PR

**1. Switch xUnit.NET related NuGet packages to v3.**
  - `Verify.Xunit` -> `Verify.XunitV3`
  - `xunit` -> `xunit.v3.mtp-v2`

**2. Add additional output log types (`*.log`/`*.ctrf`)**

**3. Change unittest's projects `OutputType` from `Library` to `Exe` and Explicitly set `IsTestProject` property**

**4. Add `Microsoft.Testing.Platform` related settings**
[Microsoft.Testing.Platform](https://learn.microsoft.com/en-us/dotnet/core/testing) is alternative unit test execution layers.

**6. Add `xunit.runner.json` config file for test project.**

**7. Pass `TestContext.Current.CancellationToken` that require Cancellation token.**

**8. Modify `MetadataCommandTest.cs` And add steps to create dummy `Directory.Build.props` file.**
It's required to ignore project directories `Directory.Build.props` settings

**9. Add empty  `Directory.Build.props` file to samples directory**

**10. ~~Modify CI workflow to use custom `seed` value to reproduce issue on CI~~**
~~By default. xUnit determine `seed` on **build time** and seed value is different between assemblies. ~~
~~So to fix seed value. Use `github.run_number` as a seed value. (It's incremented from 1)~~
seed parameter is seems not used for deterministic test orders.
On current xUnit implementation `ModuleVersionId` is used instead.

**11. Add `UseCustomBranchNameAttribute` that derived from `BeforeAfterTestAttribute`**
When running `SeedMarkdown` tests before other snapshot tests.
It cause snapshot diffs because `GitUtility.cs` caching **actual branch name**.
To simplify environment variable set/restore.
Add custom `BeforeAfterTestAttribute` for this purpose.

**12. Add `[assembly:CaptureConsole]` attribute to test assemblies.**

**13. Add **ProcessHelper** class to invoke external command (e.g. dotnet, docfx).**
When using `Process.Start` to launch external command that stdout.
Running tests is not completed when running tests on Test Explorer.
So I've added utility code to ignoring stdout/stdout.

**15. Modify `dotnet test --filter Stage=Percy` command. to use `-- --filter-trait "Stage=Percy"`**
When `TestingPlatformDotnetTestSupport` is enabled. `dotnet test` command's  `--filter` argument is silently ignored. (Same behavior as that reported at `https://github.com/microsoft/testfx/issues/4401`)
It need modify command to pass additional argument(`-- --filter-trait "Stage=Percy"`)

**16. Separate `Chromium Headless Shell` installation from test steps**
Chromium is installed on when running `docfx pdf` command first time.
It take times and it affects test execution times.
So creating separate chromium install step that is executed before running `dotnet test`.

https://github.com/dotnet/docfx/pull/10474/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR43-R48

**17. Add `-nodereuse:false` and `--no-dependencies` parameter to `dotnet build` command inside tests**
After migrated to xUnit v3.
`SamplesTest::Extensions` `dotnet build` command takes extra 15 minutes on Windows CI.
It seems relating to `https://github.com/dotnet/sdk/issues/9452` so I've added  `-nodereuse:false`  parameter to resolve issue.
And adding `--no-dependencies` parameter to suppress `Docfx.App` project build during test.

**18. Add `dotnet-coverage` command related settings.**
Currently Microsoft.Testing.Platform don't support coveret-based codecoverage with `dotnet test` command.

**19. Modify custom Fact  constructors to suppress xUnit3003 warnings.**

**20. Add `Directory.Build.targets` and `tests/Directory.Build.targets`**
These files are used for settings that need to be set after loading project file. 

**21. Add `global.json` and enable MTP mode.**
This setting is required to use `Microsoft.Testing.Platform` with `dotnet test`.
https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-with-dotnet-test#microsofttestingplatform-mtp-mode-of-dotnet-test

**22. Modify .gitattributes file to use LF for verified files**
Latest version of `Verify.XunitV3` enforcing to use LF for verified files by default,
So I've added related settings to `.gitattributes`.