### PR TITLE
chore: Add explicit timeout settings to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,7 @@ jobs:
   build:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: github.event.pull_request.draft == false   
     steps:
       - name: Checkout

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,6 +11,7 @@ jobs:
   publish-github-packages:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       packages: write
     steps:

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   report:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' }}
     steps:
     - name: Create Test Report

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   snapshot:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     environment: ci
     strategy:
       fail-fast: false


### PR DESCRIPTION
This PR change GitHub Action's timeout settings to 30 minutes (Default: 360 minutes)

Currently when CI tests has deadlock related issues.
It need to wait 6 hours until workflow is stopped.

Currently CI build takes about 10-15minutes to complete.
So this PR change timeout setting to 30 minutes.
