### PR TITLE
chore: Add remote testing settings for WSL environment

### DIFF
--- a/test/Docfx.Build.Tests/XRefMapSerializationTest.cs
+++ b/test/Docfx.Build.Tests/XRefMapSerializationTest.cs
@@ -3,7 +3,6 @@
 
 using System.Text;
 using Docfx.Common;
-using Docfx.Plugins;
 using FluentAssertions;
 using Xunit;
 

--- a/test/docfx.Snapshot.Tests/SamplesTest.cs
+++ b/test/docfx.Snapshot.Tests/SamplesTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
@@ -56,7 +57,7 @@ public class SamplesTest : IDisposable
         using var process = Process.Start("dotnet", $"build \"{s_samplesDir}/seed/dotnet/assembly/BuildFromAssembly.csproj\"");
         await process.WaitForExitAsync();
 
-        if (Debugger.IsAttached)
+        if (Debugger.IsAttached || IsWslRemoteTest())
         {
             Environment.SetEnvironmentVariable("DOCFX_SOURCE_BRANCH_NAME", "main");
             Assert.Equal(0, Program.Main([$"{samplePath}/docfx.json"]));
@@ -228,5 +229,14 @@ public class SamplesTest : IDisposable
         sb.Replace("\r\n", "\n");
 
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Returns true if running on WSL and executed on Visual Studio Remote Testing.
+    /// </summary>
+    private static bool IsWslRemoteTest([CallerFilePath] string callerFilePath = "")
+    {
+        return Environment.GetEnvironmentVariable("WSLENV") != null
+            && callerFilePath.Contains('\\', StringComparison.Ordinal); // Contains `\` when build on windows environment.
     }
 }

--- a/testEnvironments.json
+++ b/testEnvironments.json
@@ -1,0 +1,10 @@
+{
+    "version": "1",
+    "environments": [
+      {
+        "name": "WSL-Ubuntu",
+        "type": "wsl",
+        "wslDistribution": "Ubuntu"
+      }
+    ]
+}


### PR DESCRIPTION
This PR add  [Visual Studio Remote Testing (Preview)](https://learn.microsoft.com/en-us/visualstudio/test/remote-testing) supports to run snapshot tests on WSL Ubuntu environment.

**What's changed in this PR**

1. Add `testEnvironments.json` setting file for WSL with Visual Studio Remote Testing.
2. Add `CallerFilePath` related path rewrite logics for WSL environment that use  `Visual Studio Remote Testing`.
    (When using `Visual Studio Remote Testing`. docfx assemblies are build on Windows. And tested on WSL environment.) 

**How to setup WSL environment(Ubuntu)**

1. Install Visual Studio Remote Debugger on WSL environment.
On my environment it failed to install debugger dependencies by Visual Studio Test Explorer.
It need to execute following command on WSL environment to install remote debugger.

> curl -sSL https://aka.ms/getvsdbgsh | sudo /bin/sh /dev/stdin -v latest -l /usr/local/.vsdbg/

2. Install node.js 
Install Node.js 18 with following command.
> sudo apt install nodejs

3. Install additional fonts
It need to additional fonts that used for PDF embedded fonts to suppress PDF JSON diffs.

```
sudo apt-get install "fonts-liberation"
sudo apt install "fonts-noto-color-emoji"
```