### PR TITLE
chore: Refactor test related project references 

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -24,6 +24,16 @@
     <VSTestLogger>$(VSTestLogger);html%3BLogFileName=TestResults-$(MSBuildProjectName)-$(TargetFramework)-$(RUNNER_OS).html</VSTestLogger>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
+    <ProjectReference Include="$(MSBuildThisFileDirectory)Docfx.Tests.Common/Docfx.Tests.Common.csproj" />
+  </ItemGroup>
+
+  <!-- Set additional PackagesReferences to suppress warning MSB3277 (Assembly version conflict) -->
+  <ItemGroup>
+    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Text.Json" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/test/Docfx.Build.ManagedReference.Tests/Docfx.Build.ManagedReference.Tests.csproj
+++ b/test/Docfx.Build.ManagedReference.Tests/Docfx.Build.ManagedReference.Tests.csproj
@@ -2,6 +2,5 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.Build\Docfx.Build.csproj" />
     <ProjectReference Include="..\..\src\Docfx.Build.ManagedReference\Docfx.Build.ManagedReference.csproj" />
-    <ProjectReference Include="..\Docfx.Tests.Common\Docfx.Tests.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/test/Docfx.Build.OverwriteDocuments.Tests/Docfx.Build.OverwriteDocuments.Tests.csproj
+++ b/test/Docfx.Build.OverwriteDocuments.Tests/Docfx.Build.OverwriteDocuments.Tests.csproj
@@ -4,6 +4,5 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.Build.OverwriteDocuments\Docfx.Build.OverwriteDocuments.csproj" />
-    <ProjectReference Include="..\Docfx.Tests.Common\Docfx.Tests.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/test/Docfx.Build.RestApi.Tests/Docfx.Build.RestApi.Tests.csproj
+++ b/test/Docfx.Build.RestApi.Tests/Docfx.Build.RestApi.Tests.csproj
@@ -11,6 +11,5 @@
     <ProjectReference Include="..\..\src\Docfx.Build\Docfx.Build.csproj" />
     <ProjectReference Include="..\..\src\Docfx.Build.ManagedReference\Docfx.Build.ManagedReference.csproj" />
     <ProjectReference Include="..\..\src\Docfx.Common\Docfx.Common.csproj" />
-    <ProjectReference Include="..\Docfx.Tests.Common\Docfx.Tests.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/test/Docfx.Build.RestApi.WithPlugins.Tests/Docfx.Build.RestApi.WithPlugins.Tests.csproj
+++ b/test/Docfx.Build.RestApi.WithPlugins.Tests/Docfx.Build.RestApi.WithPlugins.Tests.csproj
@@ -7,6 +7,5 @@
     <ProjectReference Include="..\..\src\Docfx.Build.RestApi\Docfx.Build.RestApi.csproj" />
     <ProjectReference Include="..\..\src\Docfx.DataContracts.Common\Docfx.DataContracts.Common.csproj" />
     <ProjectReference Include="..\..\src\Docfx.DataContracts.RestApi\Docfx.DataContracts.RestApi.csproj" />
-    <ProjectReference Include="..\Docfx.Tests.Common\Docfx.Tests.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/test/Docfx.Build.SchemaDriven.Tests/Docfx.Build.SchemaDriven.Tests.csproj
+++ b/test/Docfx.Build.SchemaDriven.Tests/Docfx.Build.SchemaDriven.Tests.csproj
@@ -6,6 +6,5 @@
     <ProjectReference Include="..\..\src\Docfx.DataContracts.Common\Docfx.DataContracts.Common.csproj" />
     <ProjectReference Include="..\..\src\Docfx.Plugins\Docfx.Plugins.csproj" />
     <ProjectReference Include="..\..\src\Docfx.YamlSerialization\Docfx.YamlSerialization.csproj" />
-    <ProjectReference Include="..\Docfx.Tests.Common\Docfx.Tests.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/test/Docfx.Build.Tests/Docfx.Build.Tests.csproj
+++ b/test/Docfx.Build.Tests/Docfx.Build.Tests.csproj
@@ -10,13 +10,11 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.Build.Common\Docfx.Build.Common.csproj" />
     <ProjectReference Include="..\..\src\Docfx.Build.ManagedReference\Docfx.Build.ManagedReference.csproj" />
-    <ProjectReference Include="..\..\src\Docfx.Build.RestApi\Docfx.Build.RestApi.csproj" />
     <ProjectReference Include="..\..\src\Docfx.Build.SchemaDriven\Docfx.Build.SchemaDriven.csproj" />
     <ProjectReference Include="..\..\src\Docfx.Build\Docfx.Build.csproj" />
     <ProjectReference Include="..\..\src\Docfx.Common\Docfx.Common.csproj" />
     <ProjectReference Include="..\..\src\Docfx.DataContracts.Common\Docfx.DataContracts.Common.csproj" />
     <ProjectReference Include="..\..\src\Docfx.Plugins\Docfx.Plugins.csproj" />
     <ProjectReference Include="..\..\src\Docfx.YamlSerialization\Docfx.YamlSerialization.csproj" />
-    <ProjectReference Include="..\Docfx.Tests.Common\Docfx.Tests.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/test/Docfx.Build.Tests/XRefMapSerializationTest.cs
+++ b/test/Docfx.Build.Tests/XRefMapSerializationTest.cs
@@ -3,7 +3,6 @@
 
 using System.Text;
 using Docfx.Common;
-using Docfx.Plugins;
 using FluentAssertions;
 using Xunit;
 

--- a/test/Docfx.Build.UniversalReference.Tests/Docfx.Build.UniversalReference.Tests.csproj
+++ b/test/Docfx.Build.UniversalReference.Tests/Docfx.Build.UniversalReference.Tests.csproj
@@ -6,6 +6,5 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.Build\Docfx.Build.csproj" />
     <ProjectReference Include="..\..\src\Docfx.Build.UniversalReference\Docfx.Build.UniversalReference.csproj" />
-    <ProjectReference Include="..\Docfx.Tests.Common\Docfx.Tests.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/test/Docfx.Common.Tests/Docfx.Common.Tests.csproj
+++ b/test/Docfx.Common.Tests/Docfx.Common.Tests.csproj
@@ -3,6 +3,5 @@
     <ProjectReference Include="..\..\src\Docfx.YamlSerialization\Docfx.YamlSerialization.csproj" />
     <ProjectReference Include="..\..\src\Docfx.Plugins\Docfx.Plugins.csproj" />
     <ProjectReference Include="..\..\src\Docfx.Common\Docfx.Common.csproj" />
-    <ProjectReference Include="..\Docfx.Tests.Common\Docfx.Tests.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/test/Docfx.Glob.Tests/Docfx.Glob.Tests.csproj
+++ b/test/Docfx.Glob.Tests/Docfx.Glob.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docfx.Glob\Docfx.Glob.csproj" />
-    <ProjectReference Include="..\Docfx.Tests.Common\Docfx.Tests.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/test/Docfx.MarkdigEngine.Tests/Docfx.MarkdigEngine.Tests.csproj
+++ b/test/Docfx.MarkdigEngine.Tests/Docfx.MarkdigEngine.Tests.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Docfx.Build\Docfx.Build.csproj" />
-    <ProjectReference Include="..\..\src\Docfx.MarkdigEngine.Extensions\Docfx.MarkdigEngine.Extensions.csproj" />
     <ProjectReference Include="..\..\src\Docfx.MarkdigEngine\Docfx.MarkdigEngine.csproj" />
-    <ProjectReference Include="..\..\src\Docfx.Plugins\Docfx.Plugins.csproj" />
   </ItemGroup>
 </Project>

--- a/test/docfx.Tests/docfx.Tests.csproj
+++ b/test/docfx.Tests/docfx.Tests.csproj
@@ -10,6 +10,5 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\docfx\docfx.csproj" />
-    <ProjectReference Include="..\Docfx.Tests.Common\Docfx.Tests.Common.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR contains following changes.

1. Move `Docfx.Tests.Common` project reference to `Directory.Build.props` level.  
   (To suppress diffs when adding shared test code on other PR)
2. Add `System.Collections.Immutable`/`System.Text.Json` package references to avoid `MSB3277` warnings.  
3. Remove unused project references.
4. cherry pick `dotnet format` commit (4a7ef1a434b2b2a563172eebad701e8ea8e199b7)
