### PR TITLE
fix: Use provided references for search of dependencies in AssemblyCompilations

### DIFF
--- a/src/Docfx.Dotnet/CompilationHelper.cs
+++ b/src/Docfx.Dotnet/CompilationHelper.cs
@@ -189,7 +189,7 @@ internal static class CompilationHelper
                             if (!string.IsNullOrEmpty(name)
                                 && !referenceFiles.TryAdd(name, referenceFile.FilePath!))
                             {
-                                Logger.LogWarning($"Duplicate reference files for '{name}'.");
+                                Logger.LogWarning($"Duplicate reference files for '{name}'.", code: "InvalidAssemblyReference");
                             }
                         }
                     }

--- a/src/Docfx.Dotnet/CompilationHelper.cs
+++ b/src/Docfx.Dotnet/CompilationHelper.cs
@@ -115,7 +115,7 @@ internal static class CompilationHelper
                     : MetadataImportOptions.Public
             ),
             syntaxTrees: s_assemblyBootstrap,
-            references: GetReferenceAssemblies(assemblyPath)
+            references: GetReferenceAssemblies(assemblyPath, references)
                 .Select(CreateMetadataReference)
                 .Concat(references ?? [])
                 .Append(metadataReference));
@@ -164,11 +164,12 @@ internal static class CompilationHelper
         }
     }
 
-    private static IEnumerable<string> GetReferenceAssemblies(string assemblyPath)
+    private static IEnumerable<string> GetReferenceAssemblies(string assemblyPath, MetadataReference[] references)
     {
         using var assembly = new PEFile(assemblyPath);
         var assemblyResolver = new UniversalAssemblyResolver(assemblyPath, false, assembly.DetectTargetFrameworkId());
         var result = new Dictionary<string, string>();
+        Dictionary<string, string>? referenceFiles = default;
 
         GetReferenceAssembliesCore(assembly);
 
@@ -179,20 +180,36 @@ internal static class CompilationHelper
                 var file = assemblyResolver.FindAssemblyFile(reference);
                 if (file is null)
                 {
-                    // Skip warning for some weired assembly references: https://github.com/dotnet/docfx/issues/9459
-                    if (reference.Version?.ToString() != "0.0.0.0")
+                    if(referenceFiles == null)
                     {
-                        Logger.LogWarning($"Unable to resolve assembly reference {reference}", code: "InvalidAssemblyReference");
+                        referenceFiles = new();
+                        foreach (var referenceFile in references.OfType<PortableExecutableReference>())
+                        {
+                            var name = Path.GetFileNameWithoutExtension(referenceFile.FilePath);
+                            if (!string.IsNullOrEmpty(name)
+                                && !referenceFiles.TryAdd(name, referenceFile.FilePath!))
+                            {
+                                Logger.LogWarning($"Duplicate reference files for '{name}'.");
+                            }
+                        }
                     }
+                    if(!referenceFiles.TryGetValue(reference.Name, out file))
+                    {
+                        // Skip warning for some weired assembly references: https://github.com/dotnet/docfx/issues/9459
+                        if (reference.Version?.ToString() != "0.0.0.0")
+                        {
+                            Logger.LogWarning($"Unable to resolve assembly reference {reference}", code: "InvalidAssemblyReference");
+                        }
 
-                    continue;
+                        continue;
+                    }
                 }
 
                 Logger.LogVerbose($"Loaded {reference.Name} from {file}");
 
-                using var referenceAssembly = new PEFile(file);
-                if (result.TryAdd(referenceAssembly.Name, file))
+                if (result.TryAdd(reference.Name, file))
                 {
+                    using var referenceAssembly = new PEFile(file);
                     GetReferenceAssembliesCore(referenceAssembly);
                 }
             }
@@ -201,7 +218,7 @@ internal static class CompilationHelper
         return result.Values;
     }
 
-    private static MetadataReference CreateMetadataReference(string assemblyPath)
+    internal static MetadataReference CreateMetadataReference(string assemblyPath)
     {
         var documentation = XmlDocumentationProvider.CreateFromFile(Path.ChangeExtension(assemblyPath, ".xml"));
         return MetadataReference.CreateFromFile(assemblyPath, documentation: documentation);

--- a/src/Docfx.Dotnet/CompilationHelper.cs
+++ b/src/Docfx.Dotnet/CompilationHelper.cs
@@ -180,7 +180,7 @@ internal static class CompilationHelper
                 var file = assemblyResolver.FindAssemblyFile(reference);
                 if (file is null)
                 {
-                    if(referenceFiles == null)
+                    if (referenceFiles == null)
                     {
                         referenceFiles = new();
                         foreach (var referenceFile in references.OfType<PortableExecutableReference>())
@@ -193,7 +193,7 @@ internal static class CompilationHelper
                             }
                         }
                     }
-                    if(!referenceFiles.TryGetValue(reference.Name, out file))
+                    if (!referenceFiles.TryGetValue(reference.Name, out file))
                     {
                         // Skip warning for some weired assembly references: https://github.com/dotnet/docfx/issues/9459
                         if (reference.Version?.ToString() != "0.0.0.0")

--- a/src/Docfx.Dotnet/DotnetApiCatalog.Compile.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.Compile.cs
@@ -86,11 +86,7 @@ partial class DotnetApiCatalog
         }
 
         var references = config.References ?? [];
-        var metadataReferences = references.Select(assemblyPath =>
-        {
-            var documentation = XmlDocumentationProvider.CreateFromFile(Path.ChangeExtension(assemblyPath, ".xml"));
-            return MetadataReference.CreateFromFile(assemblyPath, documentation: documentation);
-        }).ToArray();
+        var metadataReferences = references.Select(CompilationHelper.CreateMetadataReference).ToArray();
 
         // LoadCompilationFrom C# source files
         if (files.TryGetValue(FileType.CSSourceCode, out var csFiles))


### PR DESCRIPTION
Use provided references for search of dependencies in AssemblyCompilations.

This should resolve my issue in #10423.

Since I did not get any feedback on how best resolve the issue I thought maybe this would get some attention. What this approach does is basicly use the provided Metadatareferences and use their filepaths (if present) to help resolve dependencies via filenames for those that are not found by default.

I also included a small code duplication cleanup, I hope thats also ok.