### PR TITLE
deps: Update fluentassertions version to 7.1.0 (and suppress updating to `8.x`)

### DIFF
--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('$(MSBuildThisFile)', '$(MSBuildThisFileDirectory)../'))" />
 
   <ItemGroup>
-    <PackageVersion Include="FluentAssertions" Version="7.0.0" />
+    <PackageVersion Include="FluentAssertions" Version="[7.1.0]" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
     <PackageVersion Include="Verify.Xunit" Version="28.4.0" />

--- a/test/Docfx.Build.Tests/XRefMapSerializationTest.cs
+++ b/test/Docfx.Build.Tests/XRefMapSerializationTest.cs
@@ -3,7 +3,6 @@
 
 using System.Text;
 using Docfx.Common;
-using Docfx.Plugins;
 using FluentAssertions;
 using Xunit;
 


### PR DESCRIPTION
This PR update `FluentAssertions` version from `7.0.0` to `7.1.0`.
And lock package version to `7.1.0`.  (Latest version that is published with `Apache-2.0 license`)

**Background**
FluentAssertions library has changed license from version `8.x` or later. (It's free for OSS usage though)
So it need to fix version `7.x` (Latest version that is published with `Apache-2.0 license`)
