### PR TITLE
deps: Update xUnit v2 relating package versions

### DIFF
--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -6,11 +6,11 @@
     <PackageVersion Include="FluentAssertions" Version="[7.1.0]" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
-    <PackageVersion Include="Verify.Xunit" Version="28.4.0" />
+    <PackageVersion Include="Verify.Xunit" Version="28.9.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <GlobalPackageReference Include="coverlet.collector" Version="6.0.2" />
   </ItemGroup>


### PR DESCRIPTION
This PR intended to supersede PR #10505.

Migrating xUnit from v2 to v3 is handle with draft PR (#10474).   
So existing code continue to use xUnit v2. (Until known `Microsoft.TestingPlatform` issues are resolved)
