### PR TITLE
chore: Add setting to suppress FluentAssertions version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,10 @@ updates:
       - "xunit"
       - "xunit.*"
       - "Verify.Xunit"
+  ignore:
+    - dependency-name: "FluentAssertions"
+      update-types: 
+        - version-update:semver-major
 
 - package-ecosystem: npm
   target-branch: main


### PR DESCRIPTION
This PR is intended to prevent the creation of PRs by dependabot that update FluentAssertions to `8.x`.