### PR TITLE
chore: Update YamlDotNet version to 16.3.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="System.Composition" Version="9.0.2" />
     <PackageVersion Include="System.Formats.Asn1" Version="9.0.2" />
     <PackageVersion Include="System.Text.Json" Version="9.0.2" />
-    <PackageVersion Include="YamlDotNet" Version="15.3.0" />
+    <PackageVersion Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 
   <!-- .slnx solution format is supported Microsoft.Build 17.13.9 or later. -->

--- a/src/Docfx.YamlSerialization/Helpers/ReflectionExtensions.cs
+++ b/src/Docfx.YamlSerialization/Helpers/ReflectionExtensions.cs
@@ -11,12 +11,18 @@ internal static class ReflectionExtensions
     /// Determines whether the specified type has a default constructor.
     /// </summary>
     /// <param name="type">The type.</param>
+    /// <param name="allowPrivateConstructors">Allow private constructor.</param>
     /// <returns>
     ///     <c>true</c> if the type has a default constructor; otherwise, <c>false</c>.
     /// </returns>
-    public static bool HasDefaultConstructor(this Type type)
+    public static bool HasDefaultConstructor(this Type type, bool allowPrivateConstructors)
     {
-        return type.IsValueType || type.GetConstructor(BindingFlags.Public | BindingFlags.Instance, null, Type.EmptyTypes, null) != null;
+        var bindingFlags = BindingFlags.Public | BindingFlags.Instance;
+        if (allowPrivateConstructors)
+        {
+            bindingFlags |= BindingFlags.NonPublic;
+        }
+        return type.IsValueType || type.GetConstructor(bindingFlags, null, Type.EmptyTypes, null) != null;
     }
 
     public static IEnumerable<PropertyInfo> GetPublicProperties(this Type type)

--- a/src/Docfx.YamlSerialization/Helpers/TypeConverterCache.cs
+++ b/src/Docfx.YamlSerialization/Helpers/TypeConverterCache.cs
@@ -1,0 +1,83 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using YamlDotNet.Serialization;
+
+namespace Docfx.YamlSerialization.Helpers;
+
+/// <summary>
+/// A cache / map for <see cref="IYamlTypeConverter"/> instances.
+/// </summary>
+/// <remarks>
+/// This class is copied from following YamlDotNet implementation.
+/// https://github.com/aaubry/YamlDotNet/blob/master/YamlDotNet/Serialization/Utilities/TypeConverterCache.cs
+/// </remarks>
+internal sealed class TypeConverterCache
+{
+    private readonly IYamlTypeConverter[] typeConverters;
+    private readonly ConcurrentDictionary<Type, (bool HasMatch, IYamlTypeConverter? TypeConverter)> cache = new();
+
+    public TypeConverterCache(IEnumerable<IYamlTypeConverter>? typeConverters)
+        : this(typeConverters?.ToArray() ?? [])
+    {
+    }
+
+    public TypeConverterCache(IYamlTypeConverter[] typeConverters)
+    {
+        this.typeConverters = typeConverters;
+    }
+
+    /// <summary>
+    /// Returns the first <see cref="IYamlTypeConverter"/> that accepts the given type.
+    /// </summary>
+    /// <param name="type">The <see cref="Type"/> to lookup.</param>
+    /// <param name="typeConverter">The <see cref="IYamlTypeConverter" /> that accepts this type or <see langword="false" /> if no converter is found.</param>
+    /// <returns><see langword="true"/> if a type converter was found; <see langword="false"/> otherwise.</returns>
+    public bool TryGetConverterForType(Type type, [NotNullWhen(true)] out IYamlTypeConverter? typeConverter)
+    {
+        var result = cache.GetOrAdd(type, static (t, tc) => LookupTypeConverter(t, tc), typeConverters);
+
+        typeConverter = result.TypeConverter;
+        return result.HasMatch;
+    }
+
+    /// <summary>
+    /// Returns the <see cref="IYamlTypeConverter"/> of the given type.
+    /// </summary>
+    /// <param name="converter">The type of the converter.</param>
+    /// <returns>The <see cref="IYamlTypeConverter"/> of the given type.</returns>
+    /// <exception cref="ArgumentException">If no type converter of the given type is found.</exception>
+    /// <remarks>
+    /// Note that this method searches on the type of the <see cref="IYamlTypeConverter"/> itself. If you want to find a type converter
+    /// that accepts a given <see cref="Type"/>, use <see cref="TryGetConverterForType(Type, out IYamlTypeConverter?)"/> instead.
+    /// </remarks>
+    public IYamlTypeConverter GetConverterByType(Type converter)
+    {
+        // Intentially avoids LINQ as this is on a hot path
+        foreach (var typeConverter in typeConverters)
+        {
+            if (typeConverter.GetType() == converter)
+            {
+                return typeConverter;
+            }
+        }
+
+        throw new ArgumentException($"{nameof(IYamlTypeConverter)} of type {converter.FullName} not found", nameof(converter));
+    }
+
+    private static (bool HasMatch, IYamlTypeConverter? TypeConverter) LookupTypeConverter(Type type, IYamlTypeConverter[] typeConverters)
+    {
+        // Intentially avoids LINQ as this is on a hot path
+        foreach (var typeConverter in typeConverters)
+        {
+            if (typeConverter.Accepts(type))
+            {
+                return (true, typeConverter);
+            }
+        }
+
+        return (false, null);
+    }
+}

--- a/src/Docfx.YamlSerialization/NodeDeserializers/EmitGenericCollectionNodeDeserializer.cs
+++ b/src/Docfx.YamlSerialization/NodeDeserializers/EmitGenericCollectionNodeDeserializer.cs
@@ -7,7 +7,6 @@ using Docfx.YamlSerialization.Helpers;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
 using YamlDotNet.Serialization.Utilities;
 using EditorBrowsable = System.ComponentModel.EditorBrowsableAttribute;
 using EditorBrowsableState = System.ComponentModel.EditorBrowsableState;
@@ -19,15 +18,21 @@ public class EmitGenericCollectionNodeDeserializer : INodeDeserializer
     private static readonly MethodInfo DeserializeHelperMethod =
         typeof(EmitGenericCollectionNodeDeserializer).GetMethod(nameof(DeserializeHelper))!;
     private readonly IObjectFactory _objectFactory;
-    private readonly Dictionary<Type, Type?> _gpCache = [];
-    private readonly Dictionary<Type, Action<IParser, Type, Func<IParser, Type, object?>, object?>> _actionCache = [];
+    private readonly INamingConvention _enumNamingConvention;
+    private readonly ITypeInspector _typeDescriptor;
+    private readonly Dictionary<Type, Type?> _gpCache =
+        new();
+    private readonly Dictionary<Type, Action<IParser, Type, Func<IParser, Type, object?>, object?, INamingConvention, ITypeInspector>> _actionCache =
+        new();
 
-    public EmitGenericCollectionNodeDeserializer(IObjectFactory objectFactory)
+    public EmitGenericCollectionNodeDeserializer(IObjectFactory objectFactory, INamingConvention enumNamingConvention, ITypeInspector typeDescriptor)
     {
         _objectFactory = objectFactory;
+        _enumNamingConvention = enumNamingConvention;
+        _typeDescriptor = typeDescriptor;
     }
 
-    bool INodeDeserializer.Deserialize(IParser reader, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, out object? value)
+    bool INodeDeserializer.Deserialize(IParser reader, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, out object? value, ObjectDeserializer rootDeserializer)
     {
         if (!_gpCache.TryGetValue(expectedType, out var gp))
         {
@@ -55,25 +60,44 @@ public class EmitGenericCollectionNodeDeserializer : INodeDeserializer
         value = _objectFactory.Create(expectedType);
         if (!_actionCache.TryGetValue(gp, out var action))
         {
-            var dm = new DynamicMethod(string.Empty, typeof(void), [typeof(IParser), typeof(Type), typeof(Func<IParser, Type, object>), typeof(object)]);
+            var dm = new DynamicMethod(
+                string.Empty,
+                returnType: typeof(void),
+                [
+                    typeof(IParser),
+                    typeof(Type),
+                    typeof(Func<IParser, Type, object?>),
+                    typeof(object),
+                    typeof(INamingConvention),
+                    typeof(ITypeInspector)
+                ]);
+
             var il = dm.GetILGenerator();
-            il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Ldarg_2);
-            il.Emit(OpCodes.Ldarg_3);
+            il.Emit(OpCodes.Ldarg_0); // reader
+            il.Emit(OpCodes.Ldarg_1); // expectedType
+            il.Emit(OpCodes.Ldarg_2); // nestedObjectDeserializer
+            il.Emit(OpCodes.Ldarg_3); // result
             il.Emit(OpCodes.Castclass, typeof(ICollection<>).MakeGenericType(gp));
+            il.Emit(OpCodes.Ldarg_S, (byte)4); // enumNamingConvention
+            il.Emit(OpCodes.Ldarg_S, (byte)5); // typeDescriptor
             il.Emit(OpCodes.Call, DeserializeHelperMethod.MakeGenericMethod(gp));
             il.Emit(OpCodes.Ret);
-            action = (Action<IParser, Type, Func<IParser, Type, object?>, object?>)dm.CreateDelegate(typeof(Action<IParser, Type, Func<IParser, Type, object?>, object?>));
+            action = (Action<IParser, Type, Func<IParser, Type, object?>, object?, INamingConvention, ITypeInspector>)dm.CreateDelegate(typeof(Action<IParser, Type, Func<IParser, Type, object?>, object?, INamingConvention, ITypeInspector>));
             _actionCache[gp] = action;
         }
 
-        action(reader, expectedType, nestedObjectDeserializer, value);
+        action(reader, expectedType, nestedObjectDeserializer, value, _enumNamingConvention, _typeDescriptor);
         return true;
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static void DeserializeHelper<TItem>(IParser reader, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, ICollection<TItem> result)
+    public static void DeserializeHelper<TItem>(
+        IParser reader,
+        Type expectedType,
+        Func<IParser, Type, object?> nestedObjectDeserializer,
+        ICollection<TItem> result,
+        INamingConvention enumNamingConvention,
+        ITypeInspector typeDescriptor)
     {
         reader.Consume<SequenceStart>();
         while (!reader.Accept<SequenceEnd>(out _))
@@ -81,13 +105,13 @@ public class EmitGenericCollectionNodeDeserializer : INodeDeserializer
             var value = nestedObjectDeserializer(reader, typeof(TItem));
             if (value is not IValuePromise promise)
             {
-                result.Add(TypeConverter.ChangeType<TItem>(value, NullNamingConvention.Instance));
+                result.Add(TypeConverter.ChangeType<TItem>(value, enumNamingConvention, typeDescriptor));
             }
             else if (result is IList<TItem> list)
             {
                 var index = list.Count;
                 result.Add(default!);
-                promise.ValueAvailable += v => list[index] = TypeConverter.ChangeType<TItem>(v, NullNamingConvention.Instance);
+                promise.ValueAvailable += v => list[index] = TypeConverter.ChangeType<TItem>(v, enumNamingConvention, typeDescriptor);
             }
             else
             {

--- a/src/Docfx.YamlSerialization/NodeDeserializers/EmitGenericDictionaryNodeDeserializer.cs
+++ b/src/Docfx.YamlSerialization/NodeDeserializers/EmitGenericDictionaryNodeDeserializer.cs
@@ -24,7 +24,7 @@ public class EmitGenericDictionaryNodeDeserializer : INodeDeserializer
         _objectFactory = objectFactory;
     }
 
-    bool INodeDeserializer.Deserialize(IParser reader, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, out object? value)
+    bool INodeDeserializer.Deserialize(IParser reader, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, out object? value, ObjectDeserializer rootDeserializer)
     {
         if (!_gpCache.TryGetValue(expectedType, out var gp))
         {

--- a/src/Docfx.YamlSerialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
+++ b/src/Docfx.YamlSerialization/ObjectGraphTraversalStrategies/FullObjectGraphTraversalStrategy.cs
@@ -3,11 +3,12 @@
 
 using System.Collections;
 using System.ComponentModel;
-using System.Globalization;
+using System.Diagnostics;
 using System.Reflection;
 using System.Reflection.Emit;
-using Docfx.YamlSerialization.Helpers;
+using System.Text;
 using Docfx.YamlSerialization.ObjectDescriptors;
+using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 using IObjectGraphVisitor = System.Object;
@@ -23,154 +24,223 @@ public class FullObjectGraphTraversalStrategy : IObjectGraphTraversalStrategy
 {
     private static MethodInfo TraverseGenericDictionaryHelperMethod { get; } =
         typeof(FullObjectGraphTraversalStrategy).GetMethod(nameof(TraverseGenericDictionaryHelper))!;
-    protected YamlSerializer Serializer { get; }
+
     private readonly int _maxRecursion;
     private readonly ITypeInspector _typeDescriptor;
     private readonly ITypeResolver _typeResolver;
     private readonly INamingConvention _namingConvention;
-    private readonly Dictionary<Tuple<Type, Type>, Action<IObjectDescriptor, IObjectGraphVisitor, int, IObjectGraphVisitorContext>> _behaviorCache = [];
-    private readonly Dictionary<Tuple<Type, Type, Type>, Action<FullObjectGraphTraversalStrategy, object?, IObjectGraphVisitor, int, INamingConvention, IObjectGraphVisitorContext>> _traverseGenericDictionaryCache = [];
+    private readonly IObjectFactory _objectFactory;
 
-    public FullObjectGraphTraversalStrategy(YamlSerializer serializer, ITypeInspector typeDescriptor, ITypeResolver typeResolver, int maxRecursion, INamingConvention? namingConvention)
+    // private readonly Dictionary<Tuple<Type, Type>, Action<IPropertyDescriptor?, IObjectDescriptor, IObjectGraphVisitor, Type, Type, IObjectGraphVisitorContext, Stack<FullObjectGraphTraversalStrategy.ObjectPathSegment>, ObjectSerializer>> _behaviorCache = new();
+    private readonly Dictionary<Tuple<Type, Type, Type>, Action<FullObjectGraphTraversalStrategy, object, IObjectGraphVisitor, INamingConvention, IObjectGraphVisitorContext, Stack<ObjectPathSegment>, ObjectSerializer>> _traverseGenericDictionaryCache = new();
+
+    protected YamlSerializer Serializer { get; }
+
+    public FullObjectGraphTraversalStrategy(YamlSerializer serializer, ITypeInspector typeDescriptor, ITypeResolver typeResolver, int maxRecursion, INamingConvention namingConvention, IObjectFactory objectFactory)
     {
-        if (maxRecursion <= 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(maxRecursion), maxRecursion, "maxRecursion must be greater than 1");
-        }
-
-        ArgumentNullException.ThrowIfNull(typeDescriptor);
-        ArgumentNullException.ThrowIfNull(typeResolver);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxRecursion);
 
         Serializer = serializer;
+
         _typeDescriptor = typeDescriptor;
         _typeResolver = typeResolver;
+
         _maxRecursion = maxRecursion;
-        _namingConvention = namingConvention ?? NullNamingConvention.Instance;
+        _namingConvention = namingConvention;
+        _objectFactory = objectFactory;
     }
 
-    void IObjectGraphTraversalStrategy.Traverse<TContext>(IObjectDescriptor graph, IObjectGraphVisitor<TContext> visitor, TContext context)
+    void IObjectGraphTraversalStrategy.Traverse<TContext>(IObjectDescriptor graph, IObjectGraphVisitor<TContext> visitor, TContext context, ObjectSerializer serializer)
     {
-        Traverse(graph, visitor, 0, context);
+        Traverse(null, "<root>", graph, visitor, context, new Stack<ObjectPathSegment>(_maxRecursion), serializer);
     }
 
-    protected virtual void Traverse<TContext>(IObjectDescriptor value, IObjectGraphVisitor<TContext> visitor, int currentDepth, TContext context)
+    protected virtual void Traverse<TContext>(IPropertyDescriptor? propertyDescriptor, object name, IObjectDescriptor value, IObjectGraphVisitor<TContext> visitor, TContext context, Stack<ObjectPathSegment> path, ObjectSerializer serializer)
     {
-        if (++currentDepth > _maxRecursion)
+        if (path.Count >= _maxRecursion)
         {
-            throw new InvalidOperationException("Too much recursion when traversing the object graph");
+            var message = new StringBuilder();
+            message.AppendLine("Too much recursion when traversing the object graph.");
+            message.AppendLine("The path to reach this recursion was:");
+
+            var lines = new Stack<KeyValuePair<string, string>>(path.Count);
+            var maxNameLength = 0;
+            foreach (var segment in path)
+            {
+                var segmentName = segment.Name?.ToString() ?? string.Empty;
+                maxNameLength = Math.Max(maxNameLength, segmentName.Length);
+                lines.Push(new KeyValuePair<string, string>(segmentName, segment.Value.Type.FullName!));
+            }
+
+            foreach (var line in lines)
+            {
+                message
+                    .Append(" -> ")
+                    .Append(line.Key.PadRight(maxNameLength))
+                    .Append("  [")
+                    .Append(line.Value)
+                    .AppendLine("]");
+            }
+
+            throw new MaximumRecursionLevelReachedException(message.ToString());
         }
 
-        if (!visitor.Enter(value, context))
+        if (!visitor.Enter(propertyDescriptor, value, context, serializer))
         {
             return;
         }
 
-        var typeCode = Type.GetTypeCode(value.Type);
-        switch (typeCode)
+        path.Push(new ObjectPathSegment(name, value));
+
+        try
         {
-            case TypeCode.Boolean:
-            case TypeCode.Byte:
-            case TypeCode.Int16:
-            case TypeCode.Int32:
-            case TypeCode.Int64:
-            case TypeCode.SByte:
-            case TypeCode.UInt16:
-            case TypeCode.UInt32:
-            case TypeCode.UInt64:
-            case TypeCode.Single:
-            case TypeCode.Double:
-            case TypeCode.Decimal:
-            case TypeCode.String:
-            case TypeCode.Char:
-            case TypeCode.DateTime:
-                visitor.VisitScalar(value, context);
-                break;
-            case TypeCode.DBNull:
-                visitor.VisitScalar(new BetterObjectDescriptor(null, typeof(object), typeof(object)), context);
-                break;
-            case TypeCode.Empty:
-                throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, "TypeCode.{0} is not supported.", typeCode));
-            default:
-                if (value.Value == null || value.Type == typeof(TimeSpan))
-                {
-                    visitor.VisitScalar(value, context);
+            var typeCode = Type.GetTypeCode(value.Type);
+            switch (typeCode)
+            {
+                case TypeCode.Boolean:
+                case TypeCode.Byte:
+                case TypeCode.Int16:
+                case TypeCode.Int32:
+                case TypeCode.Int64:
+                case TypeCode.SByte:
+                case TypeCode.UInt16:
+                case TypeCode.UInt32:
+                case TypeCode.UInt64:
+                case TypeCode.Single:
+                case TypeCode.Double:
+                case TypeCode.Decimal:
+                case TypeCode.String:
+                case TypeCode.Char:
+                case TypeCode.DateTime:
+                    visitor.VisitScalar(value, context, serializer);
                     break;
-                }
 
-                var underlyingType = Nullable.GetUnderlyingType(value.Type);
-                if (underlyingType != null)
-                {
-                    // This is a nullable type, recursively handle it with its underlying type.
-                    // Note that if it contains null, the condition above already took care of it
-                    Traverse(new BetterObjectDescriptor(value.Value, underlyingType, value.Type, value.ScalarStyle), visitor, currentDepth, context);
-                }
-                else
-                {
-                    TraverseObject(value, visitor, currentDepth, context);
-                }
-                break;
+                case TypeCode.DBNull:
+                    visitor.VisitScalar(new BetterObjectDescriptor(null, typeof(object), typeof(object)), context, serializer);
+                    break;
+
+                case TypeCode.Empty:
+                    throw new NotSupportedException($"TypeCode.{typeCode} is not supported.");
+
+                case TypeCode.Object:
+                default:
+                    if (value.Value == null || value.Type == typeof(TimeSpan))
+                    {
+                        visitor.VisitScalar(value, context, serializer);
+                        break;
+                    }
+
+                    var underlyingType = Nullable.GetUnderlyingType(value.Type);
+                    if (underlyingType != null)
+                    {
+                        // This is a nullable type, recursively handle it with its underlying type.
+                        // Note that if it contains null, the condition above already took care of it
+                        Traverse(
+                            propertyDescriptor,
+                            "Value",
+                            new BetterObjectDescriptor(value.Value, underlyingType, value.Type, value.ScalarStyle),
+                            visitor,
+                            context,
+                            path,
+                            serializer
+                        );
+                    }
+                    else
+                    {
+                        TraverseObject(propertyDescriptor, value, visitor, context, path, serializer);
+                    }
+                    break;
+            }
+        }
+        finally
+        {
+            path.Pop();
         }
     }
 
-    protected virtual void TraverseObject<TContext>(IObjectDescriptor value, IObjectGraphVisitor<TContext> visitor, int currentDepth, TContext context)
+    protected virtual void TraverseObject<TContext>(
+        IPropertyDescriptor? propertyDescriptor,
+        IObjectDescriptor value,
+        IObjectGraphVisitor<TContext> visitor,
+        TContext context,
+        Stack<ObjectPathSegment> path,
+        ObjectSerializer serializer)
     {
+        Debug.Assert(context != null);
+
         var key = Tuple.Create(value.Type, typeof(TContext));
-        if (!_behaviorCache.TryGetValue(key, out var action))
+
+        if (typeof(IDictionary).IsAssignableFrom(value.Type))
         {
-            if (typeof(IDictionary).IsAssignableFrom(value.Type))
-            {
-                action = TraverseDictionary<TContext>;
-            }
-            else
-            {
-                var dictionaryType = ReflectionUtility.GetImplementedGenericInterface(value.Type, typeof(IDictionary<,>));
-                if (dictionaryType != null)
-                {
-                    action = (v, vi, d, c) => TraverseGenericDictionary<TContext>(v, dictionaryType, vi, d, c);
-                }
-                else if (typeof(IEnumerable).IsAssignableFrom(value.Type))
-                {
-                    action = TraverseList<TContext>;
-                }
-                else
-                {
-                    action = TraverseProperties<TContext>;
-                }
-            }
-            _behaviorCache[key] = action;
-        }
-        action(value, visitor, currentDepth, context!);
-    }
-
-    protected virtual void TraverseDictionary<TContext>(IObjectDescriptor dictionary, object visitor, int currentDepth, object context)
-    {
-        var v = (IObjectGraphVisitor<TContext>)visitor;
-        var c = (TContext)context;
-        v.VisitMappingStart(dictionary, typeof(object), typeof(object), c);
-
-        foreach (DictionaryEntry entry in (IDictionary)dictionary.NonNullValue())
-        {
-            var key = GetObjectDescriptor(entry.Key, typeof(object));
-            var value = GetObjectDescriptor(entry.Value, typeof(object));
-
-            if (v.EnterMapping(key, value, c))
-            {
-                Traverse(key, v, currentDepth, c);
-                Traverse(value, v, currentDepth, c);
-            }
+            TraverseDictionary(propertyDescriptor, value, visitor, typeof(object), typeof(object), context, path, serializer);
+            return;
         }
 
-        v.VisitMappingEnd(dictionary, c);
+        if (_objectFactory.GetDictionary(value, out var adaptedDictionary, out var genericArguments))
+        {
+            Debug.Assert(genericArguments != null);
+
+            var objectDescriptor = new ObjectDescriptor(adaptedDictionary, value.Type, value.StaticType, value.ScalarStyle);
+            var dictionaryKeyType = genericArguments[0];
+            var dictionaryValueType = genericArguments[1];
+
+            TraverseDictionary(propertyDescriptor, objectDescriptor, visitor, dictionaryKeyType, dictionaryValueType, context, path, serializer);
+            return;
+        }
+
+        if (typeof(IEnumerable).IsAssignableFrom(value.Type))
+        {
+            TraverseList(propertyDescriptor, value, visitor, context, path, serializer);
+            return;
+        }
+
+        TraverseProperties(value, visitor, context, path, serializer);
     }
 
-    private void TraverseGenericDictionary<TContext>(IObjectDescriptor dictionary, Type dictionaryType, IObjectGraphVisitor visitor, int currentDepth, IObjectGraphVisitorContext context)
+    protected virtual void TraverseDictionary<TContext>(
+        IPropertyDescriptor? propertyDescriptor,
+        IObjectDescriptor dictionary,
+        IObjectGraphVisitor<TContext> visitor,
+        Type keyType,
+        Type valueType,
+        TContext context,
+        Stack<ObjectPathSegment> path,
+        ObjectSerializer serializer)
     {
-        var v = (IObjectGraphVisitor<TContext>)visitor;
-        var c = (TContext)context;
+        visitor.VisitMappingStart(dictionary, keyType, valueType, context, serializer);
+
+        var isDynamic = dictionary.Type.FullName!.Equals("System.Dynamic.ExpandoObject");
+        foreach (DictionaryEntry? entry in (IDictionary)dictionary.NonNullValue())
+        {
+            var entryValue = entry!.Value;
+            var keyValue = isDynamic ? _namingConvention.Apply(entryValue.Key.ToString()!) : entryValue.Key;
+            var key = GetObjectDescriptor(keyValue, keyType);
+            var value = GetObjectDescriptor(entryValue.Value, valueType);
+
+            if (visitor.EnterMapping(key, value, context, serializer))
+            {
+                Traverse(propertyDescriptor, keyValue, key, visitor, context, path, serializer);
+                Traverse(propertyDescriptor, keyValue, value, visitor, context, path, serializer);
+            }
+        }
+
+        visitor.VisitMappingEnd(dictionary, context, serializer);
+    }
+
+    private void TraverseGenericDictionary<TContext>(
+        IObjectDescriptor dictionary,
+        Type dictionaryType,
+        IObjectGraphVisitor<TContext> visitor,
+        TContext context,
+        Stack<ObjectPathSegment> path,
+        ObjectSerializer serializer)
+    {
+        Debug.Assert(dictionary.Value != null);
+
         var entryTypes = dictionaryType.GetGenericArguments();
 
         // dictionaryType is IDictionary<TKey, TValue>
-        v.VisitMappingStart(dictionary, entryTypes[0], entryTypes[1], c);
+        visitor.VisitMappingStart(dictionary, entryTypes[0], entryTypes[1], context, serializer);
 
         var key = Tuple.Create(entryTypes[0], entryTypes[1], typeof(TContext));
         if (!_traverseGenericDictionaryCache.TryGetValue(key, out var action))
@@ -178,14 +248,26 @@ public class FullObjectGraphTraversalStrategy : IObjectGraphTraversalStrategy
             action = GetTraverseGenericDictionaryHelper(entryTypes[0], entryTypes[1], typeof(TContext));
             _traverseGenericDictionaryCache[key] = action;
         }
-        action(this, dictionary.Value, v, currentDepth, _namingConvention, c);
+        action(this, dictionary.Value, visitor, _namingConvention ?? NullNamingConvention.Instance, context!, path, serializer);
 
-        v.VisitMappingEnd(dictionary, c);
+        visitor.VisitMappingEnd(dictionary, context, serializer);
     }
 
-    private static Action<FullObjectGraphTraversalStrategy, object?, IObjectGraphVisitor, int, INamingConvention, IObjectGraphVisitorContext> GetTraverseGenericDictionaryHelper(Type tkey, Type tvalue, Type tcontext)
+    private static Action<FullObjectGraphTraversalStrategy, object, IObjectGraphVisitor, INamingConvention, IObjectGraphVisitorContext, Stack<ObjectPathSegment>, ObjectSerializer> GetTraverseGenericDictionaryHelper(Type tkey, Type tvalue, Type tcontext)
     {
-        var dm = new DynamicMethod(string.Empty, typeof(void), [typeof(FullObjectGraphTraversalStrategy), typeof(object), typeof(IObjectGraphVisitor), typeof(int), typeof(INamingConvention), typeof(IObjectGraphVisitorContext)]);
+        var dm = new DynamicMethod(
+            string.Empty,
+            returnType: typeof(void),
+            parameterTypes:
+            [
+                typeof(FullObjectGraphTraversalStrategy),
+                typeof(object),
+                typeof(IObjectGraphVisitor),
+                typeof(INamingConvention),
+                typeof(IObjectGraphVisitorContext),
+                typeof(Stack<ObjectPathSegment>),
+                typeof(ObjectSerializer),
+            ]);
         var il = dm.GetILGenerator();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldarg_1);
@@ -196,77 +278,116 @@ public class FullObjectGraphTraversalStrategy : IObjectGraphTraversalStrategy
         il.Emit(OpCodes.Ldarg_S, (byte)5);
         il.Emit(OpCodes.Call, TraverseGenericDictionaryHelperMethod.MakeGenericMethod(tkey, tvalue, tcontext));
         il.Emit(OpCodes.Ret);
-        return (Action<FullObjectGraphTraversalStrategy, object?, IObjectGraphVisitor, int, INamingConvention, IObjectGraphVisitorContext>)dm.CreateDelegate(typeof(Action<FullObjectGraphTraversalStrategy, object?, IObjectGraphVisitor, int, INamingConvention, IObjectGraphVisitorContext>));
+        return (Action<FullObjectGraphTraversalStrategy, object, IObjectGraphVisitor, INamingConvention, IObjectGraphVisitorContext, Stack<ObjectPathSegment>, ObjectSerializer>)dm.CreateDelegate(typeof(Action<FullObjectGraphTraversalStrategy, object, IObjectGraphVisitor, INamingConvention, IObjectGraphVisitorContext, Stack<ObjectPathSegment>, ObjectSerializer>));
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static void TraverseGenericDictionaryHelper<TKey, TValue, TContext>(
+    private static void TraverseGenericDictionaryHelper<TKey, TValue, TContext>(
         FullObjectGraphTraversalStrategy self,
+        IPropertyDescriptor propertyDescriptor,
         IDictionary<TKey, TValue> dictionary,
-        IObjectGraphVisitor visitor,
-        int currentDepth,
+        IObjectGraphVisitor<TContext> visitor,
         INamingConvention namingConvention,
-        IObjectGraphVisitorContext context)
+        TContext context,
+        Stack<ObjectPathSegment> paths,
+        ObjectSerializer serializer)
     {
-        var v = (IObjectGraphVisitor<TContext>)visitor;
-        var c = (TContext)context;
+
         var isDynamic = dictionary.GetType().FullName!.Equals("System.Dynamic.ExpandoObject");
+
         foreach (var entry in dictionary)
         {
-            var keyString = isDynamic ? namingConvention.Apply(entry.Key!.ToString()!) : entry.Key!.ToString();
+            Debug.Assert(entry.Key != null);
+            Debug.Assert(entry.Value != null);
+
+            var keyString = isDynamic
+                              ? namingConvention.Apply(entry.Key!.ToString()!)!
+                              : entry.Key.ToString()!;
             var key = self.GetObjectDescriptor(keyString, typeof(TKey));
             var value = self.GetObjectDescriptor(entry.Value, typeof(TValue));
 
-            if (v.EnterMapping(key, value, c))
+            if (visitor.EnterMapping(key, value, context, serializer))
             {
-                self.Traverse(key, v, currentDepth, c);
-                self.Traverse(value, v, currentDepth, c);
+                self.Traverse(propertyDescriptor, propertyDescriptor.Name, key, visitor, context, paths, serializer);
+                self.Traverse(propertyDescriptor, propertyDescriptor.Name, key, visitor, context, paths, serializer);
             }
         }
     }
 
-    private void TraverseList<TContext>(IObjectDescriptor value, IObjectGraphVisitor visitor, int currentDepth, IObjectGraphVisitorContext context)
+    private void TraverseList<TContext>(
+        IPropertyDescriptor? propertyDescriptor,
+        IObjectDescriptor value,
+        IObjectGraphVisitor<TContext> visitor,
+        TContext context,
+        Stack<ObjectPathSegment> path,
+        ObjectSerializer serializer)
     {
-        var v = (IObjectGraphVisitor<TContext>)visitor;
-        var c = (TContext)context;
-        var enumerableType = ReflectionUtility.GetImplementedGenericInterface(value.Type, typeof(IEnumerable<>));
-        var itemType = enumerableType != null ?
-            enumerableType.GetGenericArguments()[0]
-            : typeof(object);
+        var itemType = _objectFactory.GetValueType(value.Type);
 
-        v.VisitSequenceStart(value, itemType, c);
+        visitor.VisitSequenceStart(value, itemType, context, serializer);
+
+        var index = 0;
 
         foreach (var item in (IEnumerable)value.NonNullValue())
         {
-            Traverse(GetObjectDescriptor(item, itemType), v, currentDepth, c);
+            Traverse(propertyDescriptor, index, GetObjectDescriptor(item, itemType), visitor, context, path, serializer);
+            ++index;
         }
 
-        v.VisitSequenceEnd(value, c);
+        visitor.VisitSequenceEnd(value, context, serializer);
     }
 
-    protected virtual void TraverseProperties<TContext>(IObjectDescriptor value, IObjectGraphVisitor visitor, int currentDepth, IObjectGraphVisitorContext context)
+    protected virtual void TraverseProperties<TContext>(
+        IObjectDescriptor value,
+        IObjectGraphVisitor<TContext> visitor,
+        TContext context,
+        Stack<ObjectPathSegment> path,
+        ObjectSerializer serializer)
     {
-        var v = (IObjectGraphVisitor<TContext>)visitor;
-        var c = (TContext)context;
-        v.VisitMappingStart(value, typeof(string), typeof(object), c);
+        Debug.Assert(visitor != null);
+        Debug.Assert(context != null);
+        Debug.Assert(value.Value != null);
+
+        if (context.GetType() != typeof(Nothing))
+        {
+            _objectFactory.ExecuteOnSerializing(value.Value);
+        }
+
+        visitor.VisitMappingStart(value, typeof(string), typeof(object), context, serializer);
 
         var source = value.NonNullValue();
-        foreach (var propertyDescriptor in _typeDescriptor.GetProperties(value.Type, value.Value))
+        foreach (var propertyDescriptor in _typeDescriptor.GetProperties(value.Type, source))
         {
             var propertyValue = propertyDescriptor.Read(source);
-
-            if (v.EnterMapping(propertyDescriptor, propertyValue, c))
+            if (visitor.EnterMapping(propertyDescriptor, propertyValue, context, serializer))
             {
-                Traverse(new BetterObjectDescriptor(propertyDescriptor.Name, typeof(string), typeof(string)), v, currentDepth, c);
-                Traverse(propertyValue, v, currentDepth, c);
+                Traverse(null, propertyDescriptor.Name, new BetterObjectDescriptor(propertyDescriptor.Name, typeof(string), typeof(string), ScalarStyle.Plain), visitor, context, path, serializer);
+                Traverse(propertyDescriptor, propertyDescriptor.Name, propertyValue, visitor, context, path, serializer);
             }
         }
 
-        v.VisitMappingEnd(value, c);
+        visitor.VisitMappingEnd(value, context, serializer);
+
+        if (context.GetType() != typeof(Nothing))
+        {
+            _objectFactory.ExecuteOnSerialized(value.Value);
+        }
     }
 
     private IObjectDescriptor GetObjectDescriptor(object? value, Type staticType)
     {
         return new BetterObjectDescriptor(value, _typeResolver.Resolve(staticType, value), staticType);
+    }
+
+    protected internal readonly struct ObjectPathSegment
+    {
+        public readonly object Name;
+        public readonly IObjectDescriptor Value;
+
+        public ObjectPathSegment(object name, IObjectDescriptor value)
+        {
+            this.Name = name;
+            this.Value = value;
+        }
     }
 }

--- a/src/Docfx.YamlSerialization/ObjectGraphVisitors/ExclusiveObjectGraphVisitor.cs
+++ b/src/Docfx.YamlSerialization/ObjectGraphVisitors/ExclusiveObjectGraphVisitor.cs
@@ -23,13 +23,13 @@ internal sealed class ExclusiveObjectGraphVisitor : ChainedObjectGraphVisitor
         return type.IsValueType ? Activator.CreateInstance(type) : null;
     }
 
-    public override bool EnterMapping(IPropertyDescriptor key, IObjectDescriptor value, IEmitter context)
+    public override bool EnterMapping(IPropertyDescriptor key, IObjectDescriptor value, IEmitter context, ObjectSerializer serializer)
     {
         var defaultValueAttribute = key.GetCustomAttribute<DefaultValueAttribute>();
         object? defaultValue = defaultValueAttribute != null
             ? defaultValueAttribute.Value
             : GetDefault(key.Type);
 
-        return !Equals(value.Value, defaultValue) && base.EnterMapping(key, value, context);
+        return !Equals(value.Value, defaultValue) && base.EnterMapping(key, value, context, serializer);
     }
 }

--- a/src/Docfx.YamlSerialization/TypeInspectors/EmitTypeInspector.cs
+++ b/src/Docfx.YamlSerialization/TypeInspectors/EmitTypeInspector.cs
@@ -456,6 +456,12 @@ public class EmitTypeInspector : ExtensibleTypeInspectorSkeleton
 
         public Type? TypeOverride { get; set; }
 
+        public bool AllowNulls { get; set; }
+
+        public bool Required { get; set; }
+
+        public Type? ConverterType { get; set; }
+
         public T GetCustomAttribute<T>() where T : Attribute => (T)_skeleton.GetCustomAttribute(typeof(T));
 
         public IObjectDescriptor Read(object target)
@@ -515,6 +521,12 @@ public class EmitTypeInspector : ExtensibleTypeInspectorSkeleton
         public Type Type => _skeleton.Type;
 
         public Type? TypeOverride { get; set; }
+
+        public bool AllowNulls { get; set; }
+
+        public bool Required { get; set; }
+
+        public Type? ConverterType { get; set; }
 
         public T? GetCustomAttribute<T>() where T : Attribute => null;
 

--- a/src/Docfx.YamlSerialization/TypeInspectors/ExtensibleNamingConventionTypeInspector.cs
+++ b/src/Docfx.YamlSerialization/TypeInspectors/ExtensibleNamingConventionTypeInspector.cs
@@ -25,4 +25,10 @@ public sealed class ExtensibleNamingConventionTypeInspector : ExtensibleTypeInsp
 
     public override IPropertyDescriptor? GetProperty(Type type, object? container, string name) =>
         innerTypeDescriptor.GetProperty(type, container, name);
+
+    public override string GetEnumName(Type enumType, string name) =>
+        innerTypeDescriptor.GetEnumName(enumType, name);
+
+    public override string GetEnumValue(object enumValue) =>
+        innerTypeDescriptor.GetEnumValue(enumValue);
 }

--- a/src/Docfx.YamlSerialization/TypeInspectors/ExtensibleReadableAndWritablePropertiesTypeInspector.cs
+++ b/src/Docfx.YamlSerialization/TypeInspectors/ExtensibleReadableAndWritablePropertiesTypeInspector.cs
@@ -21,4 +21,10 @@ public sealed class ExtensibleReadableAndWritablePropertiesTypeInspector : Exten
 
     public override IPropertyDescriptor? GetProperty(Type type, object? container, string name) =>
         _innerTypeDescriptor.GetProperty(type, container, name);
+
+    public override string GetEnumName(Type enumType, string name) =>
+       _innerTypeDescriptor.GetEnumName(enumType, name);
+
+    public override string GetEnumValue(object enumValue) =>
+        _innerTypeDescriptor.GetEnumValue(enumValue);
 }

--- a/src/Docfx.YamlSerialization/TypeInspectors/ExtensibleTypeInspectorSkeleton.cs
+++ b/src/Docfx.YamlSerialization/TypeInspectors/ExtensibleTypeInspectorSkeleton.cs
@@ -11,12 +11,11 @@ public abstract class ExtensibleTypeInspectorSkeleton : ITypeInspector, IExtensi
 {
     public abstract IEnumerable<IPropertyDescriptor> GetProperties(Type type, object? container);
 
-    public IPropertyDescriptor GetProperty(Type type, object? container, string name, bool ignoreUnmatched)
+    public IPropertyDescriptor GetProperty(Type type, object? container, string name, bool ignoreUnmatched, bool caseInsensitivePropertyMatching)
     {
-        var candidates =
-            from p in GetProperties(type, container)
-            where p.Name == name
-            select p;
+        var candidates = caseInsensitivePropertyMatching
+            ? GetProperties(type, container).Where(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+            : GetProperties(type, container).Where(p => p.Name == name);
 
         using var enumerator = candidates.GetEnumerator();
         if (!enumerator.MoveNext())
@@ -61,4 +60,8 @@ public abstract class ExtensibleTypeInspectorSkeleton : ITypeInspector, IExtensi
     }
 
     public virtual IPropertyDescriptor? GetProperty(Type type, object? container, string name) => null;
+
+    public abstract string GetEnumName(Type enumType, string name);
+
+    public abstract string GetEnumValue(object enumValue);
 }

--- a/src/Docfx.YamlSerialization/TypeInspectors/ExtensibleYamlAttributesTypeInspector.cs
+++ b/src/Docfx.YamlSerialization/TypeInspectors/ExtensibleYamlAttributesTypeInspector.cs
@@ -48,4 +48,10 @@ public sealed class ExtensibleYamlAttributesTypeInspector : ExtensibleTypeInspec
 
     public override IPropertyDescriptor? GetProperty(Type type, object? container, string name) =>
         innerTypeDescriptor.GetProperty(type, container, name);
+
+    public override string GetEnumName(Type enumType, string name) =>
+        innerTypeDescriptor.GetEnumName(enumType, name);
+
+    public override string GetEnumValue(object enumValue) =>
+        innerTypeDescriptor.GetEnumValue(enumValue);
 }

--- a/src/Docfx.YamlSerialization/YamlDeserializer.cs
+++ b/src/Docfx.YamlSerialization/YamlDeserializer.cs
@@ -70,11 +70,14 @@ public sealed class YamlDeserializer
     public YamlDeserializer(
         IObjectFactory? objectFactory = null,
         INamingConvention? namingConvention = null,
+        INamingConvention? enumNamingConvention = null,
         bool ignoreUnmatched = false,
-        bool ignoreNotFoundAnchor = true)
+        bool ignoreNotFoundAnchor = true,
+        bool caseInsensitivePropertyMatching = false)
     {
         objectFactory ??= new DefaultEmitObjectFactory();
         namingConvention ??= NullNamingConvention.Instance;
+        enumNamingConvention ??= NullNamingConvention.Instance;
 
         _typeDescriptor.TypeDescriptor =
             new ExtensibleYamlAttributesTypeInspector(
@@ -98,24 +101,24 @@ public sealed class YamlDeserializer
         [
             new TypeConverterNodeDeserializer(_converters),
             new NullNodeDeserializer(),
-            new ScalarNodeDeserializer(attemptUnknownTypeDeserialization: false, _reflectionTypeConverter, YamlFormatter.Default, NullNamingConvention.Instance),
-            new EmitArrayNodeDeserializer(),
+            new ScalarNodeDeserializer(attemptUnknownTypeDeserialization: false, _reflectionTypeConverter, _typeDescriptor, YamlFormatter.Default, enumNamingConvention),
+            new EmitArrayNodeDeserializer(enumNamingConvention,_typeDescriptor),
             new EmitGenericDictionaryNodeDeserializer(objectFactory),
             new DictionaryNodeDeserializer(objectFactory, duplicateKeyChecking: true),
-            new EmitGenericCollectionNodeDeserializer(objectFactory),
-            new CollectionNodeDeserializer(objectFactory, NullNamingConvention.Instance),
+            new EmitGenericCollectionNodeDeserializer(objectFactory, enumNamingConvention,_typeDescriptor),
+            new CollectionNodeDeserializer(objectFactory, enumNamingConvention, _typeDescriptor),
             new EnumerableNodeDeserializer(),
-            new ExtensibleObjectNodeDeserializer(objectFactory, _typeDescriptor, ignoreUnmatched)
+            new ExtensibleObjectNodeDeserializer(objectFactory, _typeDescriptor, enumNamingConvention, ignoreUnmatched, caseInsensitivePropertyMatching),
         ];
         _tagMappings = new Dictionary<TagName, Type>(PredefinedTagMappings);
         TypeResolvers =
         [
             new TagNodeTypeResolver(_tagMappings),
             new DefaultContainersNodeTypeResolver(),
-            new ScalarYamlNodeTypeResolver()
+            new ScalarYamlNodeTypeResolver(),
         ];
 
-        NodeValueDeserializer nodeValueDeserializer = new(NodeDeserializers, TypeResolvers, _reflectionTypeConverter, NullNamingConvention.Instance);
+        NodeValueDeserializer nodeValueDeserializer = new(NodeDeserializers, TypeResolvers, _reflectionTypeConverter, enumNamingConvention, _typeDescriptor);
         if (ignoreNotFoundAnchor)
         {
             _valueDeserializer = new LooseAliasValueDeserializer(nodeValueDeserializer);

--- a/src/Docfx.YamlSerialization/YamlDeserializer.cs
+++ b/src/Docfx.YamlSerialization/YamlDeserializer.cs
@@ -52,9 +52,18 @@ public sealed class YamlDeserializer
             return TypeDescriptor.GetProperties(type, container);
         }
 
-        public IPropertyDescriptor GetProperty(Type type, object? container, string name, bool ignoreUnmatched)
+        public IPropertyDescriptor GetProperty(Type type, object? container, string name, bool ignoreUnmatched, bool caseInsensitivePropertyMatching)
         {
-            return TypeDescriptor.GetProperty(type, container, name, ignoreUnmatched);
+            return TypeDescriptor.GetProperty(type, container, name, ignoreUnmatched, caseInsensitivePropertyMatching);
+        }
+
+        public string GetEnumName(Type enumType, string name)
+        {
+            return TypeDescriptor.GetEnumName(enumType, name);
+        }
+        public string GetEnumValue(object enumValue)
+        {
+            return TypeDescriptor.GetEnumValue(enumValue);
         }
     }
 

--- a/src/Docfx.YamlSerialization/YamlSerializer.cs
+++ b/src/Docfx.YamlSerialization/YamlSerializer.cs
@@ -11,6 +11,7 @@ using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.EventEmitters;
 using YamlDotNet.Serialization.NamingConventions;
+using YamlDotNet.Serialization.ObjectFactories;
 using YamlDotNet.Serialization.ObjectGraphVisitors;
 using YamlDotNet.Serialization.TypeInspectors;
 using YamlDotNet.Serialization.TypeResolvers;
@@ -23,11 +24,15 @@ public class YamlSerializer
     private readonly SerializationOptions _options;
     private readonly INamingConvention _namingConvention;
     private readonly ITypeResolver _typeResolver;
+    private readonly ITypeInspector _typeDescriptor;
+    private readonly IObjectFactory _objectFactory;
+    private readonly Settings _settings;
 
-    public YamlSerializer(SerializationOptions options = SerializationOptions.None, INamingConvention? namingConvention = null)
+    public YamlSerializer(SerializationOptions options = SerializationOptions.None, INamingConvention? namingConvention = null, Settings? settings = null)
     {
         _options = options;
         _namingConvention = namingConvention ?? NullNamingConvention.Instance;
+        _settings = settings ?? new Settings();
 
         Converters = new List<IYamlTypeConverter>();
         foreach (IYamlTypeConverter yamlTypeConverter in YamlTypeConverters.BuiltInConverters)
@@ -38,6 +43,9 @@ public class YamlSerializer
         _typeResolver = IsOptionSet(SerializationOptions.DefaultToStaticType)
             ? new StaticTypeResolver()
             : new DynamicTypeResolver();
+
+        _typeDescriptor = CreateTypeInspector();
+        _objectFactory = new DefaultObjectFactory();
     }
 
     private bool IsOptionSet(SerializationOptions option)
@@ -66,7 +74,7 @@ public class YamlSerializer
         emitter.Emit(new StreamStart());
         emitter.Emit(new DocumentStart());
 
-        traversalStrategy.Traverse(graph, emittingVisitor, emitter);
+        traversalStrategy.Traverse(graph, emittingVisitor, emitter, GetObjectSerializer(emitter));
 
         emitter.Emit(new DocumentEnd(true));
         emitter.Emit(new StreamEnd());
@@ -76,6 +84,8 @@ public class YamlSerializer
     {
         IObjectGraphVisitor<IEmitter> emittingVisitor = new EmittingObjectGraphVisitor(eventEmitter);
 
+        emittingVisitor = new CustomSerializationObjectGraphVisitor(emittingVisitor, Converters, GetObjectSerializer(emitter));
+
         void nestedObjectSerializer(object? v, Type? t = null) => SerializeValue(emitter, v, t);
 
         emittingVisitor = new CustomSerializationObjectGraphVisitor(emittingVisitor, Converters, nestedObjectSerializer);
@@ -83,7 +93,8 @@ public class YamlSerializer
         if (!IsOptionSet(SerializationOptions.DisableAliases))
         {
             var anchorAssigner = new AnchorAssigner(Converters);
-            traversalStrategy.Traverse(graph, anchorAssigner, default);
+
+            traversalStrategy.Traverse(graph, anchorAssigner, default, GetObjectSerializer(emitter));
 
             emittingVisitor = new AnchorAssigningObjectGraphVisitor(emittingVisitor, eventEmitter, anchorAssigner);
         }
@@ -110,7 +121,12 @@ public class YamlSerializer
             graph
         );
 
-        traversalStrategy.Traverse(graph, emittingVisitor, emitter);
+        traversalStrategy.Traverse(graph, emittingVisitor, emitter, GetObjectSerializer(emitter));
+    }
+
+    private ObjectSerializer GetObjectSerializer(IEmitter emitter)
+    {
+        return (object? v, Type? t = null) => SerializeValue(emitter, v, t);
     }
 
     private IEventEmitter CreateEventEmitter()
@@ -119,7 +135,7 @@ public class YamlSerializer
 
         if (IsOptionSet(SerializationOptions.JsonCompatible))
         {
-            return new JsonEventEmitter(writer, YamlFormatter.Default, NullNamingConvention.Instance);
+            return new JsonEventEmitter(writer, YamlFormatter.Default, NullNamingConvention.Instance, _typeDescriptor);
         }
         else
         {
@@ -130,29 +146,28 @@ public class YamlSerializer
                 quoteYaml1_1Strings: false,
                 defaultScalarStyle: ScalarStyle.Any,
                 formatter: YamlFormatter.Default,
-                enumNamingConvention: NullNamingConvention.Instance);
+                enumNamingConvention: NullNamingConvention.Instance,
+                typeInspector: _typeDescriptor);
         }
     }
 
     private IObjectGraphTraversalStrategy CreateTraversalStrategy()
     {
+        return IsOptionSet(SerializationOptions.Roundtrip)
+            ? new RoundtripObjectGraphTraversalStrategy(Converters, this, _typeDescriptor, _typeResolver, 50, _namingConvention, _settings, _objectFactory)
+            : new FullObjectGraphTraversalStrategy(this, _typeDescriptor, _typeResolver, 50, _namingConvention, _objectFactory);
+    }
+
+    private ITypeInspector CreateTypeInspector()
+    {
         ITypeInspector typeDescriptor = new EmitTypeInspector(_typeResolver);
         if (IsOptionSet(SerializationOptions.Roundtrip))
-        {
             typeDescriptor = new ReadableAndWritablePropertiesTypeInspector(typeDescriptor);
-        }
 
         typeDescriptor = new NamingConventionTypeInspector(typeDescriptor, _namingConvention);
         typeDescriptor = new YamlAttributesTypeInspector(typeDescriptor);
 
-        if (IsOptionSet(SerializationOptions.Roundtrip))
-        {
-            return new RoundtripObjectGraphTraversalStrategy(this, typeDescriptor, _typeResolver, 50);
-        }
-        else
-        {
-            return new FullObjectGraphTraversalStrategy(this, typeDescriptor, _typeResolver, 50, _namingConvention);
-        }
+        return typeDescriptor;
     }
 }
 


### PR DESCRIPTION
This PR update YamlDotNet version from `15.3.0` to `16.3.0`.

YamlDotNet `16.x` introduce several **breaking changes**. 
So it need to adjust API interfaces.  
And it need to fix code that using ILGenerator invoking YamlDotNet APIs.

#### What's changed in this PR

**1. Update YamlDotNet version from `15.3.0` to `16.3.0`(https://github.com/dotnet/docfx/commit/dd4dc888854cbf1c1a13d83d9cadc979a19c871c)**

**2. Update `ITypeInspector` derived classes(https://github.com/dotnet/docfx/commit/62acf92dee6d9945360a9b9033050272de668fef)**

**3. Update `IPropertyDescriptor` derived classes(https://github.com/dotnet/docfx/commit/da1ec004fc09970999f031f3943e8b718fe43a39)**

**4. Update `YamlDeserializer`(https://github.com/dotnet/docfx/commit/4a77a6ba7ad337c12842062753f28c56493e5aa7)**

**5. Update `YamlSerializer`(https://github.com/dotnet/docfx/commit/eb22ffda3b8960693e0e105990aa8064f7ec92ea)**

**6. Update `IObjectGraphTraversalStrategy` derived classes(https://github.com/dotnet/docfx/commit/eea6952e4f993d4611c51f58b695bec09a0c04c0)**

Update `FullObjectGraphTraversalStrategy.cs` file based on latest YamlDotNet code.

**7. Update `INodeDeserializer` derived classes(https://github.com/dotnet/docfx/commit/139bf3154de6f70b2a08939df74659adf7aeb3e7)**

**8. Update `IObjectGraphVisitor` derived classes(https://github.com/dotnet/docfx/commit/151bacbeaa100331145f7c6bde6a1db25506f9eb)**
