### PR TITLE
chore: add .net10 supports for nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,6 +15,11 @@ jobs:
     permissions:
       packages: write
     steps:
+    - uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          10.x
+
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
@@ -27,12 +32,10 @@ jobs:
     - uses: ./.github/actions/build
 
     - name: dotnet test
-      id: test-net90
-      run: dotnet test -c Release -f net9.0 --no-build
+      run: dotnet test -c Release -f net8.0 --no-build
 
-    - name: Report failed tests
-      if: ${{ failure() && steps.test-net90.outcome == 'failure' }}
-      uses: ./.github/actions/report-failed-tests
+    - name: dotnet test
+      run: dotnet test -c Release -f net10.0 --no-build
     
     - name: dotnet pack
       run: dotnet pack -c Release /p:Version=${{ steps.version.outputs.version }} /p:ApiCompatGenerateSuppressionFile=true -o drop/nuget

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows:
       - ci
+      - nightly
     types:
       - completed
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(DOCFX_PREVIEW_BUILD)' == 'true'">net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(DOCFX_PREVIEW_BUILD)' == 'true'">net8.0;net10.0</TargetFrameworks>
     <LangVersion>Preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,10 +18,7 @@
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />
     <PackageVersion Include="Stubble.Core" Version="1.10.8" />
-    <PackageVersion Include="System.Collections.Immutable" Version="9.0.2" />
     <PackageVersion Include="System.Composition" Version="9.0.2" />
-    <PackageVersion Include="System.Formats.Asn1" Version="9.0.2" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.2" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 

--- a/src/Docfx.Common/Docfx.Common.csproj
+++ b/src/Docfx.Common/Docfx.Common.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="Spectre.Console" />
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Docfx.Dotnet/Docfx.Dotnet.csproj
+++ b/src/Docfx.Dotnet/Docfx.Dotnet.csproj
@@ -25,7 +25,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Formats.Asn1" />
     <PackageReference Include="HtmlAgilityPack" />
     <PackageReference Include="ICSharpCode.Decompiler" />
     <PackageReference Include="OneOf" />

--- a/src/Docfx.MarkdigEngine/Docfx.MarkdigEngine.csproj
+++ b/src/Docfx.MarkdigEngine/Docfx.MarkdigEngine.csproj
@@ -2,7 +2,6 @@
   <ItemGroup>
     <PackageReference Include="Markdig" />
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Docfx.Plugins/Docfx.Plugins.csproj
+++ b/src/Docfx.Plugins/Docfx.Plugins.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -28,12 +28,6 @@
     <ProjectReference Include="$(MSBuildThisFileDirectory)Docfx.Tests.Common/Docfx.Tests.Common.csproj" />
   </ItemGroup>
 
-  <!-- Set additional PackagesReferences to suppress warning MSB3277 (Assembly version conflict) -->
-  <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" />
-    <PackageReference Include="System.Text.Json" />
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />


### PR DESCRIPTION
This PR add .NET 10 target for nightly build CI.


**What changed in this PR**

#### 1. `.github/workflows/nightly.yml`
- Add build/test settings for .NET 10 (and .NET 8 (LTS))
- Remove `Report failed tests` step. 

#### 2. `.github/workflows/reports.yml`
- Add `nightly` build CI as trigger

#### 3. `Directory.Build.props`
- Modify nightly build CI target framework to .NET8(LTS) / .NET 10

#### 4. Other changes
When build project with .NET SDK 10 Preview.
[NU1511 warnings](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1511) are reported for following packages. 

- System.Collections.Immutable
- System.Text.Json
- System.Formats.Asn1

Currently there is no need to use latest NuGet packages.
So I've removed these references from projects.
