### PR TITLE
chore: Remove Microsoft.SourceLink.GitHub dependency

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,8 +41,4 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.12.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.12.0" />
   </ItemGroup>
-
-  <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR remove `Microsoft.SourceLink.GitHub` global package reference from projects.

Because [SourceLink feature is included by default from .NET SDK 8 or later](https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/source-link)
So it's no need to explicitly add package reference.