### PR TITLE
chore: Migrate assertion library to AwesomeAssertions

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="xunit" />

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('$(MSBuildThisFile)', '$(MSBuildThisFileDirectory)../'))" />
 
   <ItemGroup>
-    <PackageVersion Include="FluentAssertions" Version="[7.1.0]" />
+    <PackageVersion Include="AwesomeAssertions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
     <PackageVersion Include="Verify.Xunit" Version="28.12.1" />

--- a/test/docfx.Tests/SerializationTests/JsonSerializationTest.cs
+++ b/test/docfx.Tests/SerializationTests/JsonSerializationTest.cs
@@ -33,7 +33,7 @@ public partial class JsonSerializationTest
         result.Should().BeEquivalentTo(model, customAssertionOptions);
     }
 
-    private static EquivalencyAssertionOptions<T> customAssertionOptions<T>(EquivalencyAssertionOptions<T> opt)
+    private static EquivalencyOptions<T> customAssertionOptions<T>(EquivalencyOptions<T> opt)
     {
         // By default. JsonElement is compared by reference because JsonElement don't override Equals.
         return opt.ComparingByMembers<JsonElement>()

--- a/test/docfx.Tests/SerializationTests/Shared/CustomEqualityEquivalencyStep.cs
+++ b/test/docfx.Tests/SerializationTests/Shared/CustomEqualityEquivalencyStep.cs
@@ -13,7 +13,7 @@ internal class CustomEqualityEquivalencyStep : IEquivalencyStep
     public EquivalencyResult Handle(
         Comparands comparands,
         IEquivalencyValidationContext context,
-        IEquivalencyValidator nestedValidator)
+        IValidateChildNodeEquivalency nestedValidator)
     {
         if (comparands.Subject is null || comparands.Expectation is null)
             return EquivalencyResult.ContinueWithNext;

--- a/test/docfx.Tests/SerializationTests/YamlSerializationTest.cs
+++ b/test/docfx.Tests/SerializationTests/YamlSerializationTest.cs
@@ -55,7 +55,7 @@ public partial class YamlSerializationTest
         newtownsoftJsonModel.Should().BeEquivalentTo(systemTextJsonModel, customAssertionOptions);
     }
 
-    private static EquivalencyAssertionOptions<T> customAssertionOptions<T>(EquivalencyAssertionOptions<T> opt)
+    private static EquivalencyOptions<T> customAssertionOptions<T>(EquivalencyOptions<T> opt)
     {
         // By default. JsonElement is compared by reference because JsonElement don't override Equals.
         return opt.ComparingByMembers<JsonElement>()


### PR DESCRIPTION
This PR changes assertion library from `FluentAssertion` to `AwesomeAssertions` (Community forked version)
And update version from `7.x` to `8.x`.

**Package Statistics**
- https://www.nuget.org/packages/FluentAssertions/7.2.0
- https://www.nuget.org/packages/AwesomeAssertions

I've also tried to migrate to [Shoudly](https://www.nuget.org/packages/shouldly)
But some equivalency assertion is hard to migrated. (Missing some features that are available on FluentAssertions)
