### PR TITLE
chore: Fix seed assembly project build failure

### DIFF
--- a/samples/seed/dotnet/assembly/BuildFromAssembly.csproj
+++ b/samples/seed/dotnet/assembly/BuildFromAssembly.csproj
@@ -9,11 +9,4 @@
     <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
After PR #10562 is merged.
Snapshot diffs are found that relating seed project's `BuildFromAssembly` metadata.

It's caused by failed metadata generation  with `error NU1008:` and error reported as normal logs.

**What's included in this PR**
- Remove unused `Microsoft.SourceLink.GitHub` reference from `BuildFromAssembly.csproj`
- Add exitcode validation to snapshot tests.
