### PR TITLE
chore: Reduce suggestion analyzer message

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -158,6 +158,7 @@ dotnet_diagnostic.IDE0005.severity = warning    # IDE0005: Remove unnecessary im
 dotnet_diagnostic.IDE0035.severity = suggestion # IDE0035: Remove unreachable code
 dotnet_diagnostic.IDE0051.severity = suggestion # IDE0051: Remove unused private member
 dotnet_diagnostic.IDE0052.severity = suggestion # IDE0052: Remove unread private member
+dotnet_diagnostic.IDE0058.severity = silent     # IDE0058: Remove unnecessary expression value
 dotnet_diagnostic.IDE0080.severity = suggestion # IDE0080: Remove unnecessary suppression operator
 dotnet_diagnostic.IDE0100.severity = suggestion # IDE0100: Remove unnecessary equality operator
 dotnet_diagnostic.IDE0110.severity = suggestion # IDE0110: Remove unnecessary discard

--- a/.editorconfig
+++ b/.editorconfig
@@ -162,6 +162,7 @@ dotnet_diagnostic.IDE0058.severity = silent     # IDE0058: Remove unnecessary ex
 dotnet_diagnostic.IDE0080.severity = suggestion # IDE0080: Remove unnecessary suppression operator
 dotnet_diagnostic.IDE0100.severity = suggestion # IDE0100: Remove unnecessary equality operator
 dotnet_diagnostic.IDE0110.severity = suggestion # IDE0110: Remove unnecessary discard
+dotnet_diagnostic.IDE0130.severity = silent     # IDE0130: Namespace does not match folder structure
 dotnet_diagnostic.IDE0240.severity = suggestion # IDE0240: Nullable directive is redundant
 dotnet_diagnostic.IDE0241.severity = suggestion # IDE0241: Nullable directive is unnecessary
 

--- a/src/Docfx.App/PdfBuilder.cs
+++ b/src/Docfx.App/PdfBuilder.cs
@@ -221,7 +221,7 @@ static class PdfBuilder
 
             async Task<byte[]> PrintHeaderFooterCore()
             {
-                await pageLimiter.WaitAsync();
+                await pageLimiter.WaitAsync(cancellationToken);
                 var page = pagePool.TryTake(out var pooled) ? pooled : await context.NewPageAsync();
 
                 try

--- a/src/Docfx.Build.Common/DisposableDocumentProcessor.cs
+++ b/src/Docfx.Build.Common/DisposableDocumentProcessor.cs
@@ -22,6 +22,15 @@ public abstract class DisposableDocumentProcessor : IDocumentProcessor, IDisposa
 
     public void Dispose()
     {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposing)
+            return;
+
         if (BuildSteps != null)
         {
             foreach (var buildStep in BuildSteps)

--- a/src/Docfx.Build.RestApi/RestApiDocumentProcessor.cs
+++ b/src/Docfx.Build.RestApi/RestApiDocumentProcessor.cs
@@ -248,7 +248,8 @@ public class RestApiDocumentProcessor : ReferenceDocumentProcessorBase
 
     private static string ChangeFileExtension(string file)
     {
-        return file.Substring(0, file.Length - SupportedFileEndings.First(s => IsSupportedFileEnding(file, s)).Length) + ".json";
+        var suffix = SupportedFileEndings.First(s => IsSupportedFileEnding(file, s));
+        return $"{file.AsSpan(0, file.Length - suffix.Length)}.json";
     }
 
     private static Dictionary<string, object> MergeMetadata(IDictionary<string, object> item, IDictionary<string, object> overwriteItems)

--- a/src/Docfx.Build.SchemaDriven/Processors/MarkdownInterpreter.cs
+++ b/src/Docfx.Build.SchemaDriven/Processors/MarkdownInterpreter.cs
@@ -37,7 +37,7 @@ public class MarkdownInterpreter : IInterpreter
         context.Dependency.UnionWith(mr.Dependency);
 
         if (mr.Html.StartsWith("<p"))
-            mr.Html = mr.Html.Insert(mr.Html.IndexOf(">"), " jsonPath=\"" + path + "\"");
+            mr.Html = mr.Html.Insert(mr.Html.IndexOf('>'), " jsonPath=\"" + path + "\"");
         return mr.Html;
     }
 }

--- a/src/Docfx.Build.SchemaDriven/Processors/MergeTypeInterpreter.cs
+++ b/src/Docfx.Build.SchemaDriven/Processors/MergeTypeInterpreter.cs
@@ -17,9 +17,4 @@ public class MergeTypeInterpreter : IInterpreter
         // TODO implement
         return value;
     }
-
-    private static object MergeCore(object value, IProcessContext context)
-    {
-        return value;
-    }
 }

--- a/src/Docfx.Build.SchemaDriven/SchemaDrivenDocumentProcessor.cs
+++ b/src/Docfx.Build.SchemaDriven/SchemaDrivenDocumentProcessor.cs
@@ -185,8 +185,7 @@ public class SchemaDrivenDocumentProcessor : DisposableDocumentProcessor
 
         if (((IDictionary<string, object>)model.Properties).TryGetValue("XrefSpec", out var value))
         {
-            var xrefSpec = value as XRefSpec;
-            if (xrefSpec != null)
+            if (value is XRefSpec xrefSpec)
             {
                 result.XRefSpecs = [xrefSpec];
             }

--- a/src/Docfx.Build/Conceptual/ConceptualDocumentProcessor.cs
+++ b/src/Docfx.Build/Conceptual/ConceptualDocumentProcessor.cs
@@ -107,8 +107,7 @@ class ConceptualDocumentProcessor : DisposableDocumentProcessor
 
         if (((IDictionary<string, object>)model.Properties).TryGetValue("XrefSpec", out var value))
         {
-            var xrefSpec = value as XRefSpec;
-            if (xrefSpec != null)
+            if (value is XRefSpec xrefSpec)
             {
                 result.XRefSpecs = [xrefSpec];
             }

--- a/src/Docfx.Build/DocumentBuilder.cs
+++ b/src/Docfx.Build/DocumentBuilder.cs
@@ -12,7 +12,7 @@ using Docfx.Plugins;
 
 namespace Docfx.Build.Engine;
 
-public class DocumentBuilder : IDisposable
+public sealed class DocumentBuilder : IDisposable
 {
     [ImportMany]
     internal IEnumerable<IDocumentProcessor> Processors { get; set; }

--- a/src/Docfx.Build/DocumentBuilder.cs
+++ b/src/Docfx.Build/DocumentBuilder.cs
@@ -146,7 +146,7 @@ public sealed class DocumentBuilder : IDisposable
             .WriteToManifest(generatedManifest, parameters[0].OutputBaseDir)
             .Create();
 
-        _postProcessorsManager.Process(generatedManifest, outputDirectory);
+        _postProcessorsManager.Process(generatedManifest, outputDirectory, cancellationToken);
 
         generatedManifest.Dereference(parameters[0].OutputBaseDir, parameters[0].MaxParallelism);
 

--- a/src/Docfx.Build/PostProcessors/ExtractSearchIndex.cs
+++ b/src/Docfx.Build/PostProcessors/ExtractSearchIndex.cs
@@ -18,7 +18,9 @@ partial class ExtractSearchIndex : IPostProcessor
     [GeneratedRegex(@"\s+")]
     private static partial Regex s_regexWhiteSpace();
 
-    private static readonly Regex s_regexCase = new(@"[a-z0-9]+|[A-Z0-9]+[a-z0-9]*|[0-9]+", RegexOptions.Compiled);
+
+    [GeneratedRegex(@"[a-z0-9]+|[A-Z0-9]+[a-z0-9]*|[0-9]+")]
+    private static partial Regex s_regexCase();
 
     private static readonly HashSet<string> s_htmlInlineTags = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -185,7 +187,7 @@ partial class ExtractSearchIndex : IPostProcessor
             return [string.Empty];
         }
         str = WebUtility.HtmlDecode(str);
-        return s_regexCase.Matches(str).Select(m => m.Value).ToArray();
+        return s_regexCase().Matches(str).Select(m => m.Value).ToArray();
     }
 
     private static List<string> GetStemAggregations(string str)

--- a/src/Docfx.Build/TableOfContents/TocDocumentProcessor.cs
+++ b/src/Docfx.Build/TableOfContents/TocDocumentProcessor.cs
@@ -72,7 +72,7 @@ class TocDocumentProcessor : DisposableDocumentProcessor
         model.Content = toc;
     }
 
-    private void UpdateTocItemHref(TocItemViewModel toc, FileModel model, IDocumentBuildContext context, string includedFrom = null)
+    private static void UpdateTocItemHref(TocItemViewModel toc, FileModel model, IDocumentBuildContext context, string includedFrom = null)
     {
         if (toc.IsHrefUpdated) return;
 
@@ -170,7 +170,7 @@ class TocDocumentProcessor : DisposableDocumentProcessor
         return fli.Href + segments;
     }
 
-    private void RegisterTocToContext(TocItemViewModel toc, FileModel model, IDocumentBuildContext context)
+    private static void RegisterTocToContext(TocItemViewModel toc, FileModel model, IDocumentBuildContext context)
     {
         var key = model.Key;
 
@@ -180,7 +180,7 @@ class TocDocumentProcessor : DisposableDocumentProcessor
         context.RegisterTocInfo(new() { TocFileKey = key, Order = toc.Order ?? 0 });
     }
 
-    private void RegisterTocMapToContext(TocItemViewModel item, FileModel model, IDocumentBuildContext context)
+    private static void RegisterTocMapToContext(TocItemViewModel item, FileModel model, IDocumentBuildContext context)
     {
         var key = model.Key;
         // If tocHref is set, href is originally RelativeFolder type, and href is set to the homepage of TocHref,

--- a/src/Docfx.Build/TemplateProcessors/TemplateManager.cs
+++ b/src/Docfx.Build/TemplateProcessors/TemplateManager.cs
@@ -89,7 +89,7 @@ public class TemplateManager
     {
         ArgumentException.ThrowIfNullOrEmpty(outputDirectory);
 
-        if (!resourceNames.Any())
+        if (resourceNames.Count == 0)
             return false;
 
         bool isEmpty = true;

--- a/src/Docfx.Build/XRefMaps/XRefArchive.cs
+++ b/src/Docfx.Build/XRefMaps/XRefArchive.cs
@@ -13,7 +13,6 @@ public sealed class XRefArchive : IXRefContainer, IDisposable
     #region Consts / Fields
     public const string MajorFileName = "xrefmap.yml";
 
-    private readonly object _syncRoot = new();
     private readonly XRefArchiveMode _mode;
     private readonly ZipArchive _archive;
     private readonly List<string> _entries;

--- a/src/Docfx.Build/XRefMaps/XRefArchiveReader.cs
+++ b/src/Docfx.Build/XRefMaps/XRefArchiveReader.cs
@@ -5,7 +5,7 @@ using Docfx.Common;
 
 namespace Docfx.Build.Engine;
 
-public class XRefArchiveReader : XRefRedirectionReader, IDisposable
+public sealed class XRefArchiveReader : XRefRedirectionReader, IDisposable
 {
     #region Fields
     private readonly LruList<Tuple<string, XRefMap>> _lru;

--- a/src/Docfx.Build/XRefMaps/XRefCollection.cs
+++ b/src/Docfx.Build/XRefMaps/XRefCollection.cs
@@ -44,7 +44,7 @@ internal sealed class XRefCollection
             AddToDownloadList(_uris, cancellationToken);
             var dict = new Dictionary<string, IXRefContainer>();
 
-            while (_processing.Any())
+            while (_processing.Count != 0)
             {
                 Task<IXRefContainer> task = await Task.WhenAny(_processing.Keys)
                                                       .WaitAsync(cancellationToken);

--- a/src/Docfx.Build/XRefMaps/XRefMapDownloader.cs
+++ b/src/Docfx.Build/XRefMaps/XRefMapDownloader.cs
@@ -80,7 +80,7 @@ public sealed class XRefMapDownloader
     /// <remarks>
     /// Support scheme: http, https, file.
     /// </remarks>
-    private async ValueTask<IXRefContainer> DownloadBySchemeAsync(Uri uri, CancellationToken token = default)
+    private static async ValueTask<IXRefContainer> DownloadBySchemeAsync(Uri uri, CancellationToken token = default)
     {
         IXRefContainer result;
         if (uri.IsFile)

--- a/src/Docfx.Common/Git/GitUtility.cs
+++ b/src/Docfx.Common/Git/GitUtility.cs
@@ -168,7 +168,7 @@ public static partial class GitUtility
             foreach (var text in File.ReadAllLines(configPath))
             {
                 var line = text.Trim();
-                if (line.StartsWith("["))
+                if (line.StartsWith('['))
                 {
                     var remote = RemoteRegex().Replace(line, "$1");
                     key = remote != line ? remote : "";

--- a/src/Docfx.Common/Loggers/CompositeLogListener.cs
+++ b/src/Docfx.Common/Loggers/CompositeLogListener.cs
@@ -3,7 +3,7 @@
 
 namespace Docfx.Common;
 
-public class CompositeLogListener : ILoggerListener
+public sealed class CompositeLogListener : ILoggerListener
 {
     private readonly object _sync = new();
     private readonly List<ILoggerListener> _listeners = [];

--- a/src/Docfx.Common/Path/RelativePath.cs
+++ b/src/Docfx.Common/Path/RelativePath.cs
@@ -447,10 +447,8 @@ public sealed class RelativePath : IEquatable<RelativePath>
 
     private IEnumerable<string> GetSubdirectories(int skip)
     {
-        if (_parts.Length <= skip)
-        {
-            throw new ArgumentOutOfRangeException(nameof(skip));
-        }
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(skip, _parts.Length);
+
         return _parts.Take(_parts.Length - skip - 1);
     }
 

--- a/src/Docfx.Common/YamlDeserializerWithFallback.cs
+++ b/src/Docfx.Common/YamlDeserializerWithFallback.cs
@@ -19,9 +19,8 @@ public class YamlDeserializerWithFallback
     }
 
     public static YamlDeserializerWithFallback Create<T>() =>
-        new(
-            (Func<TextReader> tr) => YamlUtility.Deserialize<T>(tr()),
-            (string path) => YamlUtility.Deserialize<T>(path));
+        new(tr => YamlUtility.Deserialize<T>(tr()),
+            path => YamlUtility.Deserialize<T>(path));
 
     public YamlDeserializerWithFallback WithFallback<T>() =>
         new(

--- a/src/Docfx.DataContracts.Common/ExternalReferences/ExternalReferencePackageWriter.cs
+++ b/src/Docfx.DataContracts.Common/ExternalReferences/ExternalReferencePackageWriter.cs
@@ -7,7 +7,7 @@ using Docfx.Common;
 
 namespace Docfx.DataContracts.Common;
 
-public class ExternalReferencePackageWriter : IDisposable
+public sealed class ExternalReferencePackageWriter : IDisposable
 {
     private readonly ZipArchive _zip;
 

--- a/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/CodeSnippet.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/CodeSnippet.cs
@@ -111,7 +111,7 @@ public class CodeSnippet : LeafBlock
 
     public string GetHighlightLinesString()
     {
-        if (HighlightRanges != null && HighlightRanges.Any())
+        if (HighlightRanges != null && HighlightRanges.Count != 0)
         {
             return string.Join(',', HighlightRanges.Select(highlight =>
             {

--- a/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
@@ -418,20 +418,6 @@ public class HtmlCodeSnippetRenderer : HtmlObjectRenderer<CodeSnippet>
         return sb.ToString();
     }
 
-    private static bool IsLineInRange(int lineNumber, List<CodeRange> allCodeRanges)
-    {
-        if (allCodeRanges.Count == 0) return true;
-
-        for (int rangeNumber = 0; rangeNumber < allCodeRanges.Count; rangeNumber++)
-        {
-            var range = allCodeRanges[rangeNumber];
-            if (lineNumber >= range.Start && lineNumber <= range.End)
-                return true;
-        }
-
-        return false;
-    }
-
     private string GetWarning()
     {
         var warningTitle = _context.GetToken(WarningTitleId) ?? DefaultWarningTitle;

--- a/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/CodeSnippet/HtmlCodeSnippetRenderer.cs
@@ -155,14 +155,14 @@ public class HtmlCodeSnippetRenderer : HtmlObjectRenderer<CodeSnippet>
         {
             foreach (var (language, aliases) in s_languageAlias.Select(i => (i.Key, i.Value)))
             {
-                Debug.Assert(!language.StartsWith("."));
+                Debug.Assert(!language.StartsWith('.'));
 
                 s_languageByFileExtension.Add(language, language);
                 s_languageByFileExtension.Add($".{language}", language);
 
                 foreach (var alias in aliases)
                 {
-                    Debug.Assert(!alias.StartsWith("."));
+                    Debug.Assert(!alias.StartsWith('.'));
 
                     s_languageByFileExtension.Add(alias, language);
                     s_languageByFileExtension.Add($".{alias}", language);

--- a/src/Docfx.MarkdigEngine.Extensions/ExtensionsHelper.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/ExtensionsHelper.cs
@@ -253,7 +253,7 @@ public static partial class ExtensionsHelper
 
         if (includedFilePath.Length >= 1 && includedFilePath.First() == '<' && slice.CurrentChar == '>')
         {
-            includedFilePath = includedFilePath.Substring(1, includedFilePath.Length - 1).Trim();
+            includedFilePath = includedFilePath.Substring(1).Trim();
         }
 
         if (slice.CurrentChar == ')')

--- a/src/Docfx.MarkdigEngine.Extensions/MarkdigExtensionSettingConverter.NewtonsoftJson.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/MarkdigExtensionSettingConverter.NewtonsoftJson.cs
@@ -41,7 +41,7 @@ internal partial class MarkdigExtensionSettingConverter
                         var name = prop.Name;
 
                         var options = prop.Value;
-                        if (options.Count() == 0)
+                        if (!options.Any())
                         {
                             return new MarkdigExtensionSetting(name);
                         }

--- a/src/Docfx.MarkdigEngine.Extensions/MarkdigExtensionSettingConverter.SystemTextJson.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/MarkdigExtensionSettingConverter.SystemTextJson.cs
@@ -53,7 +53,7 @@ internal partial class MarkdigExtensionSettingConverter
             if (value == null)
                 return;
 
-            var model = (MarkdigExtensionSetting)value;
+            var model = value;
 
             if (model.Options == null || !model.Options.HasValue)
             {

--- a/src/Docfx.MarkdigEngine.Extensions/MarkdownExtensions.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/MarkdownExtensions.cs
@@ -59,7 +59,7 @@ public static class MarkdownExtensions
         this MarkdownPipelineBuilder pipeline,
         MarkdigExtensionSetting[] optionalExtensions)
     {
-        if (!optionalExtensions.Any())
+        if (optionalExtensions.Length == 0)
         {
             return pipeline;
         }

--- a/src/Docfx.MarkdigEngine.Extensions/MonikerRange/MonikerRangeParser.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/MonikerRange/MonikerRangeParser.cs
@@ -10,7 +10,7 @@ namespace Docfx.MarkdigEngine.Extensions;
 
 public class MonikerRangeParser : BlockParser
 {
-    private const string StartString = "moniker";
+    // private const string StartString = "moniker";
     private const string EndString = "moniker-end";
     private const char Colon = ':';
 

--- a/src/Docfx.MarkdigEngine.Extensions/QuoteSectionNote/QuoteSectionNoteRender.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/QuoteSectionNote/QuoteSectionNoteRender.cs
@@ -104,7 +104,7 @@ public partial class QuoteSectionNoteRender : HtmlObjectRenderer<QuoteSectionNot
     {
         if (link.StartsWith("http:"))
         {
-            link = "https:" + link.Substring("http:".Length);
+            link = $"https:{link.AsSpan("http:".Length)}";
         }
         if (Uri.TryCreate(link, UriKind.Absolute, out Uri videoLink))
         {

--- a/src/Docfx.Plugins/DefaultFileAbstractLayer.cs
+++ b/src/Docfx.Plugins/DefaultFileAbstractLayer.cs
@@ -5,7 +5,7 @@ using System.Collections.Immutable;
 
 namespace Docfx.Plugins;
 
-public class DefaultFileAbstractLayer : IFileAbstractLayer
+public sealed class DefaultFileAbstractLayer : IFileAbstractLayer
 {
     public IEnumerable<string> GetAllInputFiles()
     {

--- a/src/Docfx.Plugins/DocumentExceptionExtensions.cs
+++ b/src/Docfx.Plugins/DocumentExceptionExtensions.cs
@@ -72,11 +72,7 @@ public static class DocumentExceptionExtensions
     {
         ArgumentNullException.ThrowIfNull(elements);
         ArgumentNullException.ThrowIfNull(action);
-
-        if (parallelism <= 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(parallelism));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(parallelism);
 
         try
         {

--- a/src/Docfx.YamlSerialization/YamlDeserializer.cs
+++ b/src/Docfx.YamlSerialization/YamlDeserializer.cs
@@ -146,7 +146,7 @@ public sealed class YamlDeserializer
 
     public object? Deserialize(TextReader input, IValueDeserializer? deserializer = null)
     {
-        return Deserialize(input, typeof(object), deserializer);
+        return Deserialize<object>(input, deserializer);
     }
 
     public object? Deserialize(TextReader input, Type type, IValueDeserializer? deserializer = null)
@@ -161,7 +161,7 @@ public sealed class YamlDeserializer
 
     public object? Deserialize(IParser reader, IValueDeserializer? deserializer = null)
     {
-        return Deserialize(reader, typeof(object), deserializer);
+        return Deserialize<object>(reader, deserializer);
     }
 
     /// <summary>

--- a/src/docfx/Models/MetadataCommand.cs
+++ b/src/docfx/Models/MetadataCommand.cs
@@ -69,7 +69,7 @@ internal class MetadataCommand : Command<MetadataCommandOptions>
                 if (index > -1)
                 {
                     // Latter one overwrites former one
-                    properties[pair.Substring(0, index)] = pair.Substring(index + 1, pair.Length - index - 1);
+                    properties[pair.Substring(0, index)] = pair.Substring(index + 1);
                 }
             }
         }

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -5,4 +5,6 @@ root = false
 csharp_style_unused_value_expression_statement_preference = discard_variable:silent # IDE0058: Remove unnecessary expression value
 csharp_style_unused_value_assignment_preference           = discard_variable:silent # IDE0059: Remove unnecessary value assignment
 
+dotnet_diagnostic.CA1816.severity = none # CA1816: Call GC.SuppressFinalize correctly
+
 dotnet_diagnostic.SYSLIB1045.severity = silent  # SYSLIB1045: Convert to 'GeneratedRegexAttribute'.

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -6,5 +6,6 @@ csharp_style_unused_value_expression_statement_preference = discard_variable:sil
 csharp_style_unused_value_assignment_preference           = discard_variable:silent # IDE0059: Remove unnecessary value assignment
 
 dotnet_diagnostic.CA1816.severity = none # CA1816: Call GC.SuppressFinalize correctly
+dotnet_diagnostic.CA1861.severity = none # CA1861: Avoid constant arrays as arguments
 
 dotnet_diagnostic.SYSLIB1045.severity = silent  # SYSLIB1045: Convert to 'GeneratedRegexAttribute'.

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -7,5 +7,6 @@ csharp_style_unused_value_assignment_preference           = discard_variable:sil
 
 dotnet_diagnostic.CA1816.severity = none # CA1816: Call GC.SuppressFinalize correctly
 dotnet_diagnostic.CA1861.severity = none # CA1861: Avoid constant arrays as arguments
+dotnet_diagnostic.CA1869.severity = none # CA1869: Cache and reuse 'JsonSerializerOptions' instances
 
 dotnet_diagnostic.SYSLIB1045.severity = silent  # SYSLIB1045: Convert to 'GeneratedRegexAttribute'.

--- a/test/Docfx.Build.SchemaDriven.Tests/MarkdownFragmentsValidationTest.cs
+++ b/test/Docfx.Build.SchemaDriven.Tests/MarkdownFragmentsValidationTest.cs
@@ -21,7 +21,7 @@ public class MarkdownFragmentsValidationTest : TestBase
     private TemplateManager _templateManager;
     private FileCollection _files;
 
-    private TestLoggerListener _listener = new();
+    private readonly TestLoggerListener _listener = new();
     private string _rawModelFilePath;
 
     private const string RawModelFileExtension = ".raw.json";

--- a/test/Docfx.Build.SchemaDriven.Tests/MergeMarkdownFragmentsTest.cs
+++ b/test/Docfx.Build.SchemaDriven.Tests/MergeMarkdownFragmentsTest.cs
@@ -44,7 +44,7 @@ public class MergeMarkdownFragmentsTest : TestBase
     }
 
     [Fact]
-    void TestMergeMarkdownFragments()
+    public void TestMergeMarkdownFragments()
     {
         // Arrange
         CreateFile("Suppressions.yml.md", File.ReadAllText("TestData/inputs/Suppressions.yml.md"), _inputFolder);

--- a/test/Docfx.Build.Tests/ConceptualDocumentProcessorTest.cs
+++ b/test/Docfx.Build.Tests/ConceptualDocumentProcessorTest.cs
@@ -384,7 +384,7 @@ Some content";
 
         // Test `manifest.json` content
         var manifest = GetOutputManifest();
-        Assert.True(manifest.Files.Count == 1);
+        Assert.Single(manifest.Files);
         Assert.True(manifest.Files[0].Type == Constants.DocumentType.Redirection);
     }
 

--- a/test/Docfx.Build.Tests/DocumentBuilderTest.cs
+++ b/test/Docfx.Build.Tests/DocumentBuilderTest.cs
@@ -273,7 +273,7 @@ public class DocumentBuilderTest : TestBase
                 Assert.True(File.Exists(Path.Combine(_outputFolder, resourceFile + RawModelFileExtension)));
                 var meta = JsonUtility.Deserialize<Dictionary<string, object>>(Path.Combine(_outputFolder, resourceFile + RawModelFileExtension));
                 Assert.Single(meta);
-                Assert.True(!meta.ContainsKey("meta"));
+                Assert.False(meta.ContainsKey("meta"));
             }
 
             {

--- a/test/Docfx.Build.Tests/FileMetadataHelperTest.cs
+++ b/test/Docfx.Build.Tests/FileMetadataHelperTest.cs
@@ -15,26 +15,26 @@ public class FileMetadataHelperTest
         var baseDir = "inputFolder";
         var left = new FileMetadata(baseDir, new Dictionary<string, ImmutableArray<FileMetadataItem>>
         {
-            ["meta"] = ImmutableArray.Create(
+            ["meta"] = [
                 new FileMetadataItem(new GlobMatcher("*.md"), "meta", 1L),
                 new FileMetadataItem(new GlobMatcher("*.m"), "meta", true),
                 new FileMetadataItem(new GlobMatcher("abc"), "meta", "string"),
                 new FileMetadataItem(new GlobMatcher("/[]\\*.cs"), "meta", new Dictionary<string, object> { ["key"] = "2" }),
                 new FileMetadataItem(new GlobMatcher("*/*.cs"), "meta", new object[] { "1", "2" }),
                 new FileMetadataItem(new GlobMatcher("**"), "meta", new Dictionary<string, object> { ["key"] = new object[] { "1", "2" } })
-            )
+            ]
         });
 
         var right = new FileMetadata(baseDir, new Dictionary<string, ImmutableArray<FileMetadataItem>>
         {
-            ["meta"] = ImmutableArray.Create(
+            ["meta"] = [
                 new FileMetadataItem(new GlobMatcher("*.md"), "meta", 1L),
                 new FileMetadataItem(new GlobMatcher("*.m"), "meta", true),
                 new FileMetadataItem(new GlobMatcher("abc"), "meta", "string"),
                 new FileMetadataItem(new GlobMatcher("/[]\\*.cs"), "meta", new Dictionary<string, object> { ["key"] = "2" }),
                 new FileMetadataItem(new GlobMatcher("*/*.cs"), "meta", new object[] { "1", "2" }),
                 new FileMetadataItem(new GlobMatcher("**"), "meta", new Dictionary<string, object> { ["key"] = new object[] { "1", "2" } })
-            )
+            ]
         });
 
         var actual = FileMetadataHelper.GetChangedGlobs(left, right).ToList();
@@ -48,26 +48,26 @@ public class FileMetadataHelperTest
         var patterns = new string[] { "*md", "*.m", "abc", "/[]\\*.cs", "*/*.cs", "**" };
         var left = new FileMetadata("inputFolder1", new Dictionary<string, ImmutableArray<FileMetadataItem>>
         {
-            ["meta"] = ImmutableArray.Create(
+            ["meta"] = [
                 new FileMetadataItem(new GlobMatcher(patterns[0]), "meta", 1L),
                 new FileMetadataItem(new GlobMatcher(patterns[1]), "meta", true),
                 new FileMetadataItem(new GlobMatcher(patterns[2]), "meta", "string"),
                 new FileMetadataItem(new GlobMatcher(patterns[3]), "meta", new Dictionary<string, object> { ["key"] = "2" }),
                 new FileMetadataItem(new GlobMatcher(patterns[4]), "meta", new object[] { "1", "2" }),
                 new FileMetadataItem(new GlobMatcher(patterns[5]), "meta", new Dictionary<string, object> { ["key"] = new object[] { "1", "2" } })
-            )
+            ]
         });
 
         var right = new FileMetadata("inputFolder2", new Dictionary<string, ImmutableArray<FileMetadataItem>>
         {
-            ["meta"] = ImmutableArray.Create(
+            ["meta"] = [
                 new FileMetadataItem(new GlobMatcher(patterns[0]), "meta", 1L),
                 new FileMetadataItem(new GlobMatcher(patterns[1]), "meta", true),
                 new FileMetadataItem(new GlobMatcher(patterns[2]), "meta", "string"),
                 new FileMetadataItem(new GlobMatcher(patterns[3]), "meta", new Dictionary<string, object> { ["key"] = "2" }),
                 new FileMetadataItem(new GlobMatcher(patterns[4]), "meta", new object[] { "1", "2" }),
                 new FileMetadataItem(new GlobMatcher(patterns[5]), "meta", new Dictionary<string, object> { ["key"] = new object[] { "1", "2" } })
-            )
+            ]
         });
 
         var actualResults = FileMetadataHelper.GetChangedGlobs(left, right).ToList();
@@ -83,26 +83,26 @@ public class FileMetadataHelperTest
         var patternsB = new string[] { "*mdB", "*.mB", "abcB", "/[]\\*.csB", "*/*.csB", "**B" };
         var left = new FileMetadata(baseDir, new Dictionary<string, ImmutableArray<FileMetadataItem>>
         {
-            ["meta"] = ImmutableArray.Create(
+            ["meta"] = [
                 new FileMetadataItem(new GlobMatcher(patternsA[0]), "meta", 1L),
                 new FileMetadataItem(new GlobMatcher(patternsA[1]), "meta", true),
                 new FileMetadataItem(new GlobMatcher(patternsA[2]), "meta", "string"),
                 new FileMetadataItem(new GlobMatcher(patternsA[3]), "meta", new Dictionary<string, object> { ["key"] = "2" }),
                 new FileMetadataItem(new GlobMatcher(patternsA[4]), "meta", new object[] { "1", "2" }),
                 new FileMetadataItem(new GlobMatcher(patternsA[5]), "meta", new Dictionary<string, object> { ["key"] = new object[] { "1", "2" } })
-            )
+            ]
         });
 
         var right = new FileMetadata(baseDir, new Dictionary<string, ImmutableArray<FileMetadataItem>>
         {
-            ["meta"] = ImmutableArray.Create(
+            ["meta"] = [
                 new FileMetadataItem(new GlobMatcher(patternsB[0]), "meta", 1L),
                 new FileMetadataItem(new GlobMatcher(patternsB[1]), "meta", true),
                 new FileMetadataItem(new GlobMatcher(patternsB[2]), "meta", "string"),
                 new FileMetadataItem(new GlobMatcher(patternsB[3]), "meta", new Dictionary<string, object> { ["key"] = "2" }),
                 new FileMetadataItem(new GlobMatcher(patternsB[4]), "meta", new object[] { "1", "2" }),
                 new FileMetadataItem(new GlobMatcher(patternsB[5]), "meta", new Dictionary<string, object> { ["key"] = new object[] { "1", "2" } })
-            )
+            ]
         });
 
         var actualResults = FileMetadataHelper.GetChangedGlobs(left, right).ToList();
@@ -230,13 +230,13 @@ public class FileMetadataHelperTest
 
         var right = new FileMetadata(baseDir, new Dictionary<string, ImmutableArray<FileMetadataItem>>
         {
-            ["meta"] = ImmutableArray.Create(
+            ["meta"] = [
                 new FileMetadataItem(new GlobMatcher(patterns[0]), "meta", 1L),
                 new FileMetadataItem(new GlobMatcher(patterns[1]), "meta", true),
                 new FileMetadataItem(new GlobMatcher(patterns[2]), "meta", "string"),
                 new FileMetadataItem(new GlobMatcher(patterns[3]), "meta", new Dictionary<string, object> { ["key"] = "2" }),
                 new FileMetadataItem(new GlobMatcher(patterns[4]), "meta", new object[] { "1", "2" })
-            )
+            ]
         });
 
         var actualResults = FileMetadataHelper.GetChangedGlobs(left, right).ToList();

--- a/test/Docfx.Build.Tests/PostProcessors/SitemapGeneratorTests.cs
+++ b/test/Docfx.Build.Tests/PostProcessors/SitemapGeneratorTests.cs
@@ -5,7 +5,6 @@ using System.Xml.Linq;
 using Docfx.Plugins;
 using Docfx.Tests.Common;
 using Xunit;
-using Xunit.Abstractions;
 using DocumentType = Docfx.DataContracts.Common.Constants.DocumentType;
 
 namespace Docfx.Build.Engine.Tests;
@@ -13,13 +12,6 @@ namespace Docfx.Build.Engine.Tests;
 [Collection("docfx STA")]
 public class SitemapGeneratorTests : TestBase
 {
-    private readonly ITestOutputHelper _output;
-
-    public SitemapGeneratorTests(ITestOutputHelper output)
-    {
-        _output = output;
-    }
-
     public override void Dispose()
     {
         base.Dispose();

--- a/test/Docfx.Build.Tests/PostProcessors/SitemapGeneratorTests.cs
+++ b/test/Docfx.Build.Tests/PostProcessors/SitemapGeneratorTests.cs
@@ -59,7 +59,7 @@ public class SitemapGeneratorTests : TestBase
         var sitemap = XDocument.Load(sitemapPath);
         var ns = sitemap.Root.Name.Namespace;
         var urls = sitemap.Root.Elements(ns + "url").ToArray();
-        Assert.True(urls.Length == 4);
+        Assert.Equal(4, urls.Length);
 
         // URLs are ordered based on HTML output's RelativePath.
         Assert.EndsWith("/Conceptual.html", urls[0].Element(ns + "loc").Value);

--- a/test/Docfx.Glob.Tests/GlobFileTest.cs
+++ b/test/Docfx.Glob.Tests/GlobFileTest.cs
@@ -87,7 +87,7 @@ public class GlobFileTest : TestBase
         foreach (var i in items)
         {
             var item = cwd + "/" + i;
-            if (item.EndsWith("/"))
+            if (item.EndsWith('/'))
             {
                 Directory.CreateDirectory(item);
             }

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/CodeTest.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/CodeTest.cs
@@ -7,7 +7,7 @@ namespace Docfx.MarkdigEngine.Tests;
 
 public class CodeTest
 {
-    public static string contentCSharp = @"using System;
+    private static readonly string contentCSharp = @"using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
@@ -216,7 +216,7 @@ namespace TableSnippets
         }
     }
 }";
-    public static string contentCSharp2 = @"using System;
+    private static readonly string contentCSharp2 = @"using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -376,7 +376,7 @@ namespace ChangeFeedSample
         }
     }
 }";
-    public static string contentCSharpRegion = @"using Microsoft.AspNetCore.Builder;
+    private static readonly string contentCSharpRegion = @"using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -446,7 +446,7 @@ namespace TagHelpersBuiltIn
         }
     }
 }";
-    public static string contentASPNet = @"@{
+    private static readonly string contentASPNet = @"@{
     ViewData[""Title""] = ""Anchor Tag Helper"";
 }
 
@@ -650,7 +650,7 @@ namespace TagHelpersBuiltIn
         </tr>
     </tfoot>
 </table>";
-    public static string contentVB = @"'<Snippet1>
+    private static readonly string contentVB = @"'<Snippet1>
 Class ADSetupInformation
 
     Shared Sub Main()
@@ -709,7 +709,7 @@ Class AppDomain2
 End Class
 '</snippet3>
 ";
-    public static string contentCPP = @"//<Snippet1>
+    private static readonly string contentCPP = @"//<Snippet1>
 using namespace System;
 
 int main()
@@ -771,7 +771,7 @@ int main()
     AppDomain4::Main();
 }
 // </snippet2>";
-    public static string contentCPP2 = @"//<Snippet1>
+    private static readonly string contentCPP2 = @"//<Snippet1>
 using namespace System;
 
 using namespace System::Collections::Generic;
@@ -947,7 +947,7 @@ Remove(""doc"")
 Key ""doc"" is not found.
  */
 //</ Snippet1  >";
-    public static string contentCrazy = @"//<Snippet1>
+    private static readonly string contentCrazy = @"//<Snippet1>
 using namespace System;
 
 int main()
@@ -1009,7 +1009,7 @@ int main()
     AppDomain4::Main();
 }
 // </snippet2>";
-    public static string contentSQL = @"-- <everything>
+    private static readonly string contentSQL = @"-- <everything>
 --<students>
 SELECT * FROM Students
 WHERE Grade = 12
@@ -1022,7 +1022,7 @@ WHERE Grade = 12
 AND Class = 'Math'
 --</teachers>
 --</everything>";
-    public static string contentPython = @"#<everything>
+    private static readonly string contentPython = @"#<everything>
 #<first>
 from flask import Flask
 app = Flask(__name__)
@@ -1035,21 +1035,21 @@ def hello():
 #</second>
 #</everything>
 ";
-    public static string contentBatch = @"REM <snippet>
+    private static readonly string contentBatch = @"REM <snippet>
 :Label1
 	:Label2
 :: Comment line 3
 REM </snippet>
 	:: Comment line 4
 IF EXIST C:\AUTOEXEC.BAT REM AUTOEXEC.BAT exists";
-    public static string contentErlang = @"-module(hello_world).
+    private static readonly string contentErlang = @"-module(hello_world).
 -compile(export_all).
 
 % <snippet>
 hello() ->
     io:format(""hello world~n"").
 % </snippet>";
-    public static string contentLisp = @";<everything>
+    private static readonly string contentLisp = @";<everything>
 USER(64): (member 'b '(perhaps today is a good day to die)) ; test fails
 NIL
 ;<inner>
@@ -1057,7 +1057,7 @@ USER(65): (member 'a '(perhaps today is a good day to die)) ; returns non-NIL
 '(a good day to die)
 ; </inner>
 ;</everything>";
-    public static string contentRuby = @"source 'https://rubygems.org'
+    private static readonly string contentRuby = @"source 'https://rubygems.org'
 git_source(:github) { |repo| ""https://github.com/#{repo}.git"" }
 
 ruby '2.6.5'
@@ -1119,7 +1119,7 @@ gem 'httparty', '~> 0.17.1'
 gem 'activerecord-session_store', '~> 1.1'
 # </GemFileSnippet>
 ";
-    public static string contentCSS = @"body {
+    private static readonly string contentCSS = @"body {
   padding-top: 70px;
 }
 

--- a/test/Docfx.Tests.Common/TestBase.cs
+++ b/test/Docfx.Tests.Common/TestBase.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Docfx.Tests.Common;
 
-public class TestBase : IClassFixture<TestBase>, IDisposable
+public class TestBase : IDisposable
 {
     private readonly List<string> _folderCollection = [];
     private readonly object _locker = new();

--- a/test/Docfx.Tests.Common/TestListenerScope.cs
+++ b/test/Docfx.Tests.Common/TestListenerScope.cs
@@ -7,7 +7,7 @@ namespace Docfx.Tests.Common;
 
 public class TestListenerScope : ILoggerListener, IDisposable
 {
-    private static AsyncLocal<List<ILogItem>> s_items = new();
+    private readonly static AsyncLocal<List<ILogItem>> s_items = new();
     private readonly LogLevel _logLevel;
 
     public List<ILogItem> Items => s_items.Value;

--- a/test/Docfx.Tests.Common/TestListenerScope.cs
+++ b/test/Docfx.Tests.Common/TestListenerScope.cs
@@ -7,7 +7,7 @@ namespace Docfx.Tests.Common;
 
 public class TestListenerScope : ILoggerListener, IDisposable
 {
-    private readonly static AsyncLocal<List<ILogItem>> s_items = new();
+    private static readonly AsyncLocal<List<ILogItem>> s_items = new();
     private readonly LogLevel _logLevel;
 
     public List<ILogItem> Items => s_items.Value;

--- a/test/docfx.Snapshot.Tests/SamplesTest.cs
+++ b/test/docfx.Snapshot.Tests/SamplesTest.cs
@@ -211,7 +211,7 @@ public class SamplesTest : IDisposable
         }
     }
 
-    private string ExtractText(Page page)
+    private static string ExtractText(Page page)
     {
         // Gets PDF text content
         var text = ContentOrderTextExtractor.GetText(page, new ContentOrderTextExtractor.Options { ReplaceWhitespaceWithSpace = true });

--- a/test/docfx.Tests/DocsetBuildTest.cs
+++ b/test/docfx.Tests/DocsetBuildTest.cs
@@ -229,7 +229,7 @@ public class DocsetBuildTest : TestBase
         // Test redirect page.is excluded from sitemap.
         var sitemapXml = outputs["sitemap.xml"]();
         var urls = XDocument.Parse(sitemapXml).Root.Elements();
-        Assert.True(!urls.Any());
+        Assert.False(urls.Any());
     }
 
     [Fact]

--- a/test/docfx.Tests/JsonSchemaTest.cs
+++ b/test/docfx.Tests/JsonSchemaTest.cs
@@ -6,7 +6,6 @@ using Docfx.Common;
 using Docfx.DataContracts.Common;
 using Docfx.Tests.Common;
 using FluentAssertions;
-using Xunit.Abstractions;
 using YamlDotNet.Serialization;
 
 namespace Docfx.Tests;
@@ -14,13 +13,6 @@ namespace Docfx.Tests;
 [Collection("docfx STA")]
 public class JsonSchemaTest : TestBase
 {
-    private readonly ITestOutputHelper output;
-
-    public JsonSchemaTest(ITestOutputHelper output)
-    {
-        this.output = output;
-    }
-
     [Theory]
     [InlineData("docs/docfx.json")]
     [InlineData("samples/csharp/docfx.json")]

--- a/test/docfx.Tests/SerializationTests/JsonSerializationTest.cs
+++ b/test/docfx.Tests/SerializationTests/JsonSerializationTest.cs
@@ -13,7 +13,7 @@ public partial class JsonSerializationTest
     /// <summary>
     /// Helper method to validate serialize/deserialize results.
     /// </summary>
-    protected void ValidateJsonRoundTrip<T>(T model)
+    private static void ValidateJsonRoundTrip<T>(T model)
     {
         // 1. Validate serialized result.
         var newtonsoftJson = NewtonsoftJsonUtility.Serialize(model);

--- a/test/docfx.Tests/SerializationTests/YamlSerializationTest.cs
+++ b/test/docfx.Tests/SerializationTests/YamlSerializationTest.cs
@@ -15,7 +15,7 @@ public partial class YamlSerializationTest
     /// <summary>
     /// Helper method to validate serialize/deserialize results.
     /// </summary>
-    protected void ValidateYamlRoundTrip<T>(T model)
+    private static void ValidateYamlRoundTrip<T>(T model)
     {
         // Act
         using var writer = new StringWriter();
@@ -31,7 +31,7 @@ public partial class YamlSerializationTest
     /// <summary>
     /// Helper method to validate serialize/deserialize results.
     /// </summary>
-    protected void ValidateYamlJsonRoundTrip<T>(T model)
+    protected static void ValidateYamlJsonRoundTrip<T>(T model)
     {
         // 1. Serialize to JSON with YamlDotNet
         using var writer = new StringWriter();


### PR DESCRIPTION
This PR intended to reduce analyzer suggestion messages (It's tracked by #9207)

**Suggestion messages that suppressed on solution level**
Following suggestion messages raise a lot of message.
But it's not useful. So these messages are suppressed on solution level.  
- IDE0058: Remove unnecessary expression value
- IDE0130: Namespace does not match folder structure

**Suggestion messages that suppressed on test project level**
Following **performance related ** suggestion messages are suppressed on test projects.
- CA1816: Call GC.SuppressFinalize correctly
- CA1861: Avoid constant arrays as arguments
- CA1869: Cache and reuse 'JsonSerializerOptions' instances
