### PR TITLE
build(deps): bump PdfPig from 0.1.9 to 0.1.10

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="OneOf.SourceGenerator" Version="3.0.271" />
-    <PackageVersion Include="PdfPig" Version="0.1.9" />
+    <PackageVersion Include="PdfPig" Version="0.1.10" />
     <PackageVersion Include="PlantUml.Net" Version="1.4.80" />
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />

--- a/test/docfx.Snapshot.Tests/SamplesTest.cs
+++ b/test/docfx.Snapshot.Tests/SamplesTest.cs
@@ -84,7 +84,7 @@ public class SamplesTest : IDisposable
                     p.Number,
                     p.NumberOfImages,
                     Text = ExtractText(p),
-                    Links = p.ExperimentalAccess.GetAnnotations().Select(ToLink).ToArray(),
+                    Links = p.GetAnnotations().Select(ToLink).ToArray(),
                 }).ToArray(),
                 Bookmarks = document.TryGetBookmarks(out var bookmarks) ? ToBookmarks(bookmarks.Roots) : null,
             };


### PR DESCRIPTION
This PR intended to supersede PR #10581.

- Update PdfPig Version
- Remove obsolete `ExperimentalAccess` property access.
