### PR TITLE
Include global type metadata for all output formats

### DIFF
--- a/src/Docfx.Dotnet/DotnetApiCatalog.Toc.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.Toc.cs
@@ -62,7 +62,7 @@ partial class DotnetApiCatalog
             switch (symbol)
             {
                 case INamespaceSymbol { IsGlobalNamespace: true } ns:
-                    foreach (var child in ns.GetNamespaceMembers())
+                    foreach (var child in ns.GetMembers())
                         foreach (var item in CreateToc(child, compilation))
                             yield return item;
                     break;


### PR DESCRIPTION
When using output formats `apiPage` or `markdown`, types from the global namespace is not included.