### PR TITLE
chore: Add AnalyzerLoadFailed event handler logics to report warning

### DIFF
--- a/src/Docfx.Common/Loggers/WarningCodes.cs
+++ b/src/Docfx.Common/Loggers/WarningCodes.cs
@@ -25,6 +25,12 @@ public static class WarningCodes
         public const string InvalidTocInclude = "InvalidTocInclude";
     }
 
+    public static class Metadata
+    {
+        public const string FailedToResolveAnalyzer = "FailedToResolveAnalyzer";
+        public const string FailedToLoadAnalyzer = "FailedToLoadAnalyzer";
+    }
+
     public static class Markdown
     {
         public const string InvalidInclude = "InvalidInclude";

--- a/src/Docfx.Dotnet/DotnetApiCatalog.Compile.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.Compile.cs
@@ -147,7 +147,22 @@ partial class DotnetApiCatalog
                 {
                     Logger.LogWarning($"There is .NET Analyzer that can't be resolved. "
                                     + $"If this analyzer is .NET Source Generator project. "
-                                    + $"Try build with `dotnet build -c Release` command before running docfx. Path: {unresolvedAnalyzer.FullPath}");
+                                    + $"Try build with `dotnet build -c Release` command before running docfx. Path: {unresolvedAnalyzer.FullPath}",
+                                    code: WarningCodes.Metadata.FailedToResolveAnalyzer);
+                }
+
+                foreach (var analyzer in project.AnalyzerReferences.OfType<AnalyzerFileReference>())
+                {
+                    analyzer.AnalyzerLoadFailed += (sender, e) =>
+                    {
+                        var analyzerName = analyzer.Display;
+                        var errorCode = e.ErrorCode;
+                        var referencedCompilerVersion = e.ReferencedCompilerVersion;
+
+                        Logger.LogWarning($"Failed to load .NET Analyzer. AnalyzerName: {analyzerName}, ErrorCode: {errorCode}, ReferencedCompilerVersion: {referencedCompilerVersion}",
+                                          code: WarningCodes.Metadata.FailedToLoadAnalyzer);
+                    };
+
                 }
             }
 


### PR DESCRIPTION
This PR fix issue that relating to #10542.

Currently docfx don't report analyzer found but failed to load.
This PR add `AnalyzerLoadFailed` event handler. and add logics to report as warning.

**Example warning message**

> warning: FailedToLoadAnalyzer: Failed to load .NET Analyzer. AnalyzerName: Microsoft.CodeAnalysis.Razor.Compiler, ErrorCode: ReferencesNewerCompiler, ReferencedCompilerVersion: 4.14.0.0


