### PR TITLE
chore: Add dedicated `environment` for release.yml workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: release
     steps:
     - uses: actions/checkout@v5
 


### PR DESCRIPTION
This PR intended to isolate `release.yml` workflow with other workflows.
It's required because `release.yml` using secrets. that should not be exposed to public.

**Required steps before running updated release workflow**
1. Create new `release` environment at https://github.com/dotnet/docfx/settings/environments
2. Create **new** secrets for NuGet package sign/publish.
3. Register new secrets to `release` environment
4. Invalidate **old** secrets. And remove secrets from other environments/repository.
5. delete `feature/watch` branch that using `pull_request_target`
