### PR TITLE
chore: Fix nightly build ci error

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,6 +23,12 @@
     <NoWarn>$(NoWarn);NU1507;NU5104;NU5111</NoWarn>
   </PropertyGroup>
 
+  <!-- Following settings is workaround to suppress warning NU1903: Package 'Microsoft.Build.Tasks.Core' 17.7.2 has a known high severity vulnerability -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <!-- `all` is default NuGetAuditMode for .NET SDK 10 or later -->
+    <NuGetAuditMode>direct</NuGetAuditMode>
+  </PropertyGroup>
+
   <PropertyGroup>
     <ContentTargetFolders>contentFiles</ContentTargetFolders>
 

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -4,7 +4,7 @@
 
   <ItemGroup>
     <PackageVersion Include="AwesomeAssertions" Version="8.2.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
     <PackageVersion Include="Verify.Xunit" Version="30.1.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />


### PR DESCRIPTION
This PR intended to fix nightly build CI failure.

**Background**
Following warnings are raised, when running build with .NET 10 SDK preview.4 or later.
> NU1903: Package 'Microsoft.Build.Tasks.Core' 17.7.2 has a known high severity vulnerability

It seems be caused by [`NuGetAuditMode` default value is changed from `direct` to `all`](https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages#configuring-nuget-audit) on latest SDK.
And vulnerable package `Microsoft.Build.Tasks.Core` is transitively referenced by `Microsoft.CodeAnalysis.Workspaces.MSBuild`.

This PR add setting to overwrite `NuGetAuditMode` to `direct` for .NET 10 as a temporary workaround.
This settings will be removed when `Microsoft.CodeAnalysis.Workspaces.MSBuild` package is updated.

**Additional changes**
Update `Microsoft.NET.Test.Sdk` version to `17.14.0`



