### PR TITLE
chore: Add badge for DeepWiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![ci](https://github.com/dotnet/docfx/actions/workflows/ci.yml/badge.svg)](https://github.com/dotnet/docfx/actions/workflows/ci.yml)
 [![nightly](https://github.com/dotnet/docfx/actions/workflows/nightly.yml/badge.svg)](https://github.com/dotnet/docfx/actions/workflows/nightly.yml)
 [![Help Wanted](https://img.shields.io/github/issues/dotnet/docfx/help-wanted?label=help-wanted)](https://github.com/dotnet/docfx/labels/help-wanted)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/dotnet/docfx)
 
 * [Getting Started](#getting-started)
 * [Contributing](#contributing)


### PR DESCRIPTION
This PR add badge for [DeepWiki](https://deepwiki.com/dotnet/docfx) on `README.md`.

Badge is created by [Official DeepWiki Badge Maker](https://deepwiki.com/badge-maker)
And by placing this badge on `README.md` file.
DeepWiki's content is expected to be updated automatically on a weekly basis.