### PR TITLE
deps: update AwesomeAssertions version to 9.0.0

### DIFF
--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('$(MSBuildThisFile)', '$(MSBuildThisFileDirectory)../'))" />
 
   <ItemGroup>
-    <PackageVersion Include="AwesomeAssertions" Version="8.2.0" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
     <PackageVersion Include="Verify.Xunit" Version="30.1.0" />

--- a/test/Docfx.Build.Common.Tests/FileLinkInfoTest.cs
+++ b/test/Docfx.Build.Common.Tests/FileLinkInfoTest.cs
@@ -1,8 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using AwesomeAssertions;
 using Docfx.Common;
-using FluentAssertions;
 using Xunit;
 
 namespace Docfx.MarkdigEngine.Tests;

--- a/test/Docfx.Build.SchemaDriven.Tests/JsonPointerTest.cs
+++ b/test/Docfx.Build.SchemaDriven.Tests/JsonPointerTest.cs
@@ -1,13 +1,14 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using AwesomeAssertions;
 using Docfx.Common;
 using Docfx.Exceptions;
 using Docfx.Tests.Common;
-using FluentAssertions;
 using Xunit;
 
 namespace Docfx.Build.SchemaDriven.Tests;
+
 public class JsonPointerTest : TestBase
 {
     [Fact]

--- a/test/Docfx.Build.Tests/TemplateManagerUnitTest.DotnetToolMode.cs
+++ b/test/Docfx.Build.Tests/TemplateManagerUnitTest.DotnetToolMode.cs
@@ -1,9 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using AwesomeAssertions;
 using Docfx.Common;
 using Docfx.Tests.Common;
-using FluentAssertions;
 using Xunit;
 using Switches = Docfx.DataContracts.Common.Constants.Switches;
 

--- a/test/Docfx.Build.Tests/XRefMapDownloaderTest.cs
+++ b/test/Docfx.Build.Tests/XRefMapDownloaderTest.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace Docfx.Build.Engine.Tests;

--- a/test/Docfx.Build.Tests/XRefMapSerializationTest.cs
+++ b/test/Docfx.Build.Tests/XRefMapSerializationTest.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text;
+using AwesomeAssertions;
 using Docfx.Common;
-using FluentAssertions;
 using Xunit;
 
 namespace Docfx.Build.Engine.Tests;

--- a/test/Docfx.Common.Tests/ConvertToObjectHelperTest.cs
+++ b/test/Docfx.Common.Tests/ConvertToObjectHelperTest.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json.Serialization;
-using FluentAssertions;
+using AwesomeAssertions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;

--- a/test/Docfx.Common.Tests/PathUtilityTest.cs
+++ b/test/Docfx.Common.Tests/PathUtilityTest.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace Docfx.Common.Tests;

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/PlantUmlTest.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/PlantUmlTest.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace Docfx.MarkdigEngine.Tests;

--- a/test/docfx.Tests/JsonConverterTest.cs
+++ b/test/docfx.Tests/JsonConverterTest.cs
@@ -3,8 +3,8 @@
 
 using System.Collections;
 using System.Reflection;
+using AwesomeAssertions;
 using Docfx.Common;
-using FluentAssertions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/test/docfx.Tests/JsonSchemaTest.cs
+++ b/test/docfx.Tests/JsonSchemaTest.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
+using AwesomeAssertions;
 using Docfx.Common;
 using Docfx.DataContracts.Common;
 using Docfx.Tests.Common;
-using FluentAssertions;
 using YamlDotNet.Serialization;
 
 namespace Docfx.Tests;

--- a/test/docfx.Tests/SerializationTests/JsonSerializationEncoderTest.cs
+++ b/test/docfx.Tests/SerializationTests/JsonSerializationEncoderTest.cs
@@ -1,8 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using AwesomeAssertions;
 using Docfx.Common;
-using FluentAssertions;
 
 namespace docfx.Tests;
 
@@ -30,7 +30,7 @@ public partial class JsonSerializationEncoderTest
         // Compare serialized result text with `StringComparer.OrdinalIgnoreCase`
         //  - SystemTextJson escape chars with capital case(`\u001B`)
         //  - NewtonsoftJson escape chars with lower case  (`\u001b`)
-        ((object)systemTextJsonResult).Should().Be(newtonsoftJsonResult, StringComparer.OrdinalIgnoreCase); // Currently StringAssertions don't expose overload that accepts StringComparer. (See: https://github.com/fluentassertions/fluentassertions/issues/2720)
+        systemTextJsonResult.Should().BeEquivalentTo(newtonsoftJsonResult, options => options.IgnoringCase());
     }
 
     [Theory]

--- a/test/docfx.Tests/SerializationTests/JsonSerializationTest.MarkdownServiceProperties.cs
+++ b/test/docfx.Tests/SerializationTests/JsonSerializationTest.MarkdownServiceProperties.cs
@@ -1,8 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using AwesomeAssertions;
 using Docfx.Plugins;
-using FluentAssertions;
 using Markdig.Extensions.MediaLinks;
 
 namespace docfx.Tests;

--- a/test/docfx.Tests/SerializationTests/JsonSerializationTest.cs
+++ b/test/docfx.Tests/SerializationTests/JsonSerializationTest.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
+using AwesomeAssertions;
+using AwesomeAssertions.Equivalency;
 using Docfx.Common;
-using FluentAssertions;
-using FluentAssertions.Equivalency;
 
 namespace docfx.Tests;
 

--- a/test/docfx.Tests/SerializationTests/Shared/CustomEqualityEquivalencyStep.cs
+++ b/test/docfx.Tests/SerializationTests/Shared/CustomEqualityEquivalencyStep.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using FluentAssertions.Equivalency;
+using AwesomeAssertions.Equivalency;
 using Newtonsoft.Json.Linq;
 
 #nullable enable

--- a/test/docfx.Tests/SerializationTests/YamlSerializationTest.ApiPage.cs
+++ b/test/docfx.Tests/SerializationTests/YamlSerializationTest.ApiPage.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
+using AwesomeAssertions;
 using Docfx.Build.ApiPage;
 using Docfx.Common;
 using Docfx.Tests;
-using FluentAssertions;
 using YamlDotNet.Serialization;
 
 namespace docfx.Tests;

--- a/test/docfx.Tests/SerializationTests/YamlSerializationTest.cs
+++ b/test/docfx.Tests/SerializationTests/YamlSerializationTest.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
+using AwesomeAssertions;
+using AwesomeAssertions.Equivalency;
 using Docfx.Common;
 using Docfx.YamlSerialization;
-using FluentAssertions;
-using FluentAssertions.Equivalency;
 namespace docfx.Tests;
 
 public partial class YamlSerializationTest


### PR DESCRIPTION
This PR update `AwesomeAssertions` version to 9.0.0. and rewrite namespaces.

Additionally, I've updated `JsonSerializationEncoderTest.cs` tests to use new API that compare string with IgnoreCase.