### PR TITLE
chore: Fix nightly build CI error

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,13 +22,13 @@
      -->
     <NoWarn>$(NoWarn);NU1507;NU5104;NU5111</NoWarn>
   </PropertyGroup>
-
-  <!-- Following settings is workaround to suppress warning NU1903: Package 'Microsoft.Build.Tasks.Core' 17.7.2 has a known high severity vulnerability -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <!-- `all` is default NuGetAuditMode for .NET SDK 10 or later -->
+  
+  <!-- Following settings is temporary workaround to suppress warning NU1903: Package 'Microsoft.Build.Tasks.Core' 17.7.2 has a known low severity vulnerability -->
+  <PropertyGroup>
+    <!-- `all` is default NuGetAuditMode when build with .NET SDK 10 or later -->
     <NuGetAuditMode>direct</NuGetAuditMode>
   </PropertyGroup>
-
+  
   <PropertyGroup>
     <ContentTargetFolders>contentFiles</ContentTargetFolders>
 


### PR DESCRIPTION
This PR intended to fix nightly build CI error.

#10679 enable `NuGetAuditMode: direct` setting for .NET 10 target only.
But it seems it also required for other target frameworks when build with .NET 10 SDK.

