### PR TITLE
chore: Fix nightly build CI

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,13 +22,7 @@
      -->
     <NoWarn>$(NoWarn);NU1507;NU5104;NU5111</NoWarn>
   </PropertyGroup>
-  
-  <!-- Following settings is temporary workaround to suppress warning NU1903: Package 'Microsoft.Build.Tasks.Core' 17.7.2 has a known low severity vulnerability -->
-  <PropertyGroup>
-    <!-- `all` is default NuGetAuditMode when build with .NET SDK 10 or later -->
-    <NuGetAuditMode>direct</NuGetAuditMode>
-  </PropertyGroup>
-  
+
   <PropertyGroup>
     <ContentTargetFolders>contentFiles</ContentTargetFolders>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,6 +28,13 @@
     <PackageVersion Include="Microsoft.Build" Version="17.14.8"    Condition="'$(TargetFramework)' != 'net8.0'"/>
   </ItemGroup>
 
+  <!-- Temporary settings to suppress NU1901 warning. -->
+  <!-- TODO: Remove these settings after `Microsoft.CodeAnalysis.Workspaces.MSBuild` dependency is updated. -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="[17.11.31]" Condition="'$(TargetFramework)' == 'net8.0'"/>
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.14.8"    Condition="'$(TargetFramework)' != 'net8.0'"/>
+  </ItemGroup>
+
   <ItemGroup>
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />

--- a/src/Docfx.Dotnet/Docfx.Dotnet.csproj
+++ b/src/Docfx.Dotnet/Docfx.Dotnet.csproj
@@ -39,6 +39,9 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
+    <!-- Temporary settings to suppress NU1901 warning. -->
+    <!-- TODO: Remove this setting after `Microsoft.CodeAnalysis.Workspaces.MSBuild` dependency is updated. -->
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
#10689 fix seems not works as expected.

This PR update transitive `Microsoft.Build.Tasks.Core` package instead.

When updating only `Microsoft.Build.Tasks.Core` package to latest version.
It cause following **runtime error** on `docfx metadata` command on .NET 8
> FileNotFoundException: Could not load file or assembly 'Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral,
PublicKeyToken=b03f5f7f11d50a3a'.

So I've updated package version that maching to `Microsoft.Build` package version.
 


