### PR TITLE
fix: bicep.js import error of samples site

### DIFF
--- a/samples/seed/template/public/main.js
+++ b/samples/seed/template/public/main.js
@@ -1,4 +1,4 @@
-import { bicep } from './bicep.js'
+import bicep from './bicep.js'
 
 export default {
   iconLinks: [


### PR DESCRIPTION
This PR intended to fix `samples` site script import error.
See: https://github.com/dotnet/docfx/pull/10715#issuecomment-3034620180

It's expected CI snapshot tests timeout issue is resolved by this PR
