### PR TITLE
Focus inputs when clicking icons in nav and TOC search inputs

### DIFF
--- a/templates/modern/src/nav.scss
+++ b/templates/modern/src/nav.scss
@@ -71,6 +71,7 @@
         position: absolute;
         left: .8rem;
         opacity: .5;
+        pointer-events: none;
       }
 
       >input {

--- a/templates/modern/src/toc.scss
+++ b/templates/modern/src/toc.scss
@@ -84,6 +84,7 @@ $expand-stub-width: .85rem;
       position: absolute;
       left: .6rem;
       opacity: .5;
+      pointer-events: none;
     }
 
     >input {


### PR DESCRIPTION
Disable pointer events for icons in the navigation and table of contents search inputs to improve user interaction.
This allows to the input to be focused when clicking the icon

<img width="276" height="74" alt="image" src="https://github.com/user-attachments/assets/eb52228e-79be-40e1-8260-97f67223ab9e" />
