### PR TITLE
fix: IOException is thrown when file access conflicts.

### DIFF
--- a/src/Docfx.Common/FileAbstractLayer/ManifestFileWriter.cs
+++ b/src/Docfx.Common/FileAbstractLayer/ManifestFileWriter.cs
@@ -43,9 +43,9 @@ public class ManifestFileWriter : FileWriterBase
             }
             if (_noRandomFile)
             {
-                Directory.CreateDirectory(
-                    Path.Combine(_manifestFolder, file.RemoveWorkingFolder().GetDirectoryPath()));
-                var result = File.Create(Path.Combine(_manifestFolder, file.RemoveWorkingFolder()));
+                var path = Path.Combine(_manifestFolder, file.RemoveWorkingFolder());
+                Directory.CreateDirectory(Path.GetDirectoryName(path));
+                var result = new FileStream(path, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite);
                 entry.LinkToPath = null;
                 return result;
             }
@@ -53,7 +53,7 @@ public class ManifestFileWriter : FileWriterBase
             {
                 var path = Path.Combine(OutputFolder, file.RemoveWorkingFolder());
                 Directory.CreateDirectory(Path.GetDirectoryName(path));
-                var result = File.Create(path);
+                var result = new FileStream(path, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite);
                 entry.LinkToPath = path;
                 return result;
             }


### PR DESCRIPTION
This PR intended to fix #8654. (Related PR #10637 #10785)

**What's changed in this PR**
1. Replace `File.Create` to `new FileStream` with  `FileShare.ReadWrite`
2. Cleanup `_noRandomFile` code.

**Background**
There is a comment that `IOException` issue is occurred when build docs with `docfx serve`.

It is possible for an IOException to be thrown when when the `docfx build` and `docfx serve` commands are executed in parallel.
Because [`File.Create` open file with `FileShare.None`](https://source.dot.net/#System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/IO/File.cs,70)

So it need to modify code to  use `FileShare.ReadWrite`.

If reported issue is not resolved by this changes.
It need to use retry logics that are proposed on other PRs
