### PR TITLE
feat(actions): add nuget trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,7 @@ jobs:
     needs: sign
     permissions:
       contents: write
+      id-token: write
     steps:
     - uses: actions/setup-dotnet@v5
       with:
@@ -90,9 +91,15 @@ jobs:
         name: bin
         path: drop/bin
 
+    - name: NuGet login
+      uses: NuGet/login@v1
+      id: nuget-login
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
     - name: Publish NuGet packages
       run: |
-        dotnet nuget push drop/nuget/*.nupkg --api-key "${{ secrets.NUGET_KEY }}" --skip-duplicate --source https://api.nuget.org/v3/index.json
+        dotnet nuget push drop/nuget/*.nupkg --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --skip-duplicate --source https://api.nuget.org/v3/index.json
 
     - name: Upload GitHub release
       run: |


### PR DESCRIPTION
### Solves #10821

#### Motivation

As described in [the official announcement](https://devblogs.microsoft.com/dotnet/enhanced-security-is-here-with-the-new-trust-publishing-on-nuget-org/) and issue #10821, the new **Trusted Publishing** feature greatly enhances package publishing security on NuGet.org.

We successfully tested this approach with our own NuGet library:

- [GitHub Actions run example](https://github.com/micheloliveira-com/ReactiveLock/actions/runs/18042183860/workflow)  
- [Corresponding commit](https://github.com/micheloliveira-com/ReactiveLock/commit/a9353d6ddc7cb45f386e816c6ab5ea2837bd1513)

#### Required changes in this repository

> **Recommendation followed from announcement:**  
> For security, always use a GitHub secret like `${{ secrets.NUGET_USER }}` for your NuGet.org username (profile name), **not your email address**.

- Add `secrets.NUGET_USER` to this repository, using the **NuGet.org username (profile name)** of the package owner (docfx in this case).  
- The old `secrets.NUGET_KEY` secret can be removed from this repository **and also from the NuGet.org account** if it was only used here.  

#### One-time configuration on NuGet.org

According to the documentation:

1. Sign in to NuGet.org.  
2. Open your user menu (top-right) → **Trusted Publishing** (next to “API Keys”).  
3. Create a policy:  
   - **Package owner:** you or your organization (e.g. `docfx`).  
   - **Repository owner/repository:** your GitHub org/user and repository name (e.g. `docfx`).  
   - **Workflow file:** the YAML file under `.github/workflows/` (e.g. `release.yml`).  
   - **Environment (optional):** specify if your workflow uses GitHub Actions environments.  

This setup eliminates the need for long-lived API keys and improves the overall security of the publishing process.
