### PR TITLE
fix: handle NRE

### DIFF
--- a/src/Docfx.Dotnet/ManagedReference/Visitors/SymbolVisitorAdapter.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Visitors/SymbolVisitorAdapter.cs
@@ -731,6 +731,12 @@ internal partial class SymbolVisitorAdapter : SymbolVisitor<MetadataItem>
                     ? Path.GetDirectoryName(Path.GetFullPath(Path.Combine(EnvironmentContext.BaseDirectory, sourcePath)))
                     : null);
 
+            if (basePath == null)
+            {
+                Logger.LogWarning($"Source file '{source}' not found.", code: "CodeNotFound");
+                return null;
+            }
+
             var path = Path.GetFullPath(Path.Combine(basePath, source));
             if (!File.Exists(path))
             {


### PR DESCRIPTION
`basePath` can be null, and if it is, it causes the `Path.Combine` method to throw an exception.

https://learn.microsoft.com/en-us/dotnet/api/system.io.path.combine?view=net-9.0

> Exceptions
> [ArgumentNullException](https://learn.microsoft.com/en-us/dotnet/api/system.argumentnullexception?view=net-9.0)
path1 or path2 is null.