### PR TITLE
deps: Update NuGet package dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,35 +4,35 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="HtmlAgilityPack" Version="1.12.1" />
+    <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="ICSharpCode.Decompiler" Version="9.1.0.7988" />
-    <PackageVersion Include="Jint" Version="4.2.2" />
-    <PackageVersion Include="JsonSchema.Net" Version="7.3.4" />
-    <PackageVersion Include="Markdig" Version="0.41.2" />
-    <PackageVersion Include="Microsoft.Playwright" Version="1.52.0" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Jint" Version="4.4.1" />
+    <PackageVersion Include="JsonSchema.Net" Version="7.4.0" />
+    <PackageVersion Include="Markdig" Version="0.42.0" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.55.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="OneOf.SourceGenerator" Version="3.0.271" />
-    <PackageVersion Include="PdfPig" Version="0.1.10" />
+    <PackageVersion Include="PdfPig" Version="0.1.11" />
     <PackageVersion Include="PlantUml.Net" Version="1.4.80" />
     <PackageVersion Include="Spectre.Console" Version="0.52.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.52.0" />
     <PackageVersion Include="Stubble.Core" Version="1.10.8" />
-    <PackageVersion Include="System.Composition" Version="9.0.6" />
+    <PackageVersion Include="System.Composition" Version="9.0.10" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 
+  <!-- TODO: Remove `Microsoft.Build` settings after `Microsoft.CodeAnalysis.Workspaces.MSBuild` dependency is updated to `5.0.0` -->
   <!-- .slnx solution format is supported Microsoft.Build 17.13.9 or later. -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Build" Version="[17.11.31]" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageVersion Include="Microsoft.Build" Version="17.14.8" Condition="'$(TargetFramework)' != 'net8.0'" />
+    <PackageVersion Include="Microsoft.Build" Version="[17.11.48]" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.Build" Version="17.14.28" Condition="'$(TargetFramework)' != 'net8.0'" />
   </ItemGroup>
 
   <!-- Temporary settings to suppress NU1901 warning. -->
-  <!-- TODO: Remove these settings after `Microsoft.CodeAnalysis.Workspaces.MSBuild` dependency is updated. -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="[17.11.31]" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.14.8" Condition="'$(TargetFramework)' != 'net8.0'" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="[17.11.48]" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.14.28" Condition="'$(TargetFramework)' != 'net8.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Docfx.App/PdfBuilder.cs
+++ b/src/Docfx.App/PdfBuilder.cs
@@ -26,6 +26,7 @@ using UglyToad.PdfPig.Outline.Destinations;
 using UglyToad.PdfPig.Writer;
 
 using static Docfx.Build.HtmlTemplate;
+using static UglyToad.PdfPig.Writer.PdfDocumentBuilder;
 
 #nullable enable
 
@@ -442,7 +443,10 @@ static class PdfBuilder
 
                     pageNumber++;
 
-                    var pageBuilder = builder.AddPage(document, i, x => CopyLink(node, x));
+                    var pageBuilder = builder.AddPage(document, i, new AddPageOptions
+                    {
+                        CopyLinkFunc = x => CopyLink(node, x),
+                    });
 
                     if (isCoverPage)
                         continue;

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -3,8 +3,8 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('$(MSBuildThisFile)', '$(MSBuildThisFileDirectory)../'))" />
 
   <ItemGroup>
-    <PackageVersion Include="AwesomeAssertions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.2.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
     <PackageVersion Include="Verify.Xunit" Version="31.0.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
This PR update following package dependencies.

#### 1. `Microsoft.Build`/`Microsoft.Build.Tasks.Core`
Current referenced packages are marked as vulnerable.
So update these packages to latest versions.

Note: These packages will be removed after Roslyn `5.0.0`  are released.

#### 2. `PdfPig`
Update package version and modify code that relating [breaking changes](https://github.com/UglyToad/PdfPig/releases/tag/v0.1.11).

#### 3. Other packages 
Update following packages to latest version.
- `HtmlAgilityPack`
- `Jint`
- `JsonSchema.Net`
- `Markdig`
- `Microsoft.Playwright`
- `Newtonsoft.Json`
- `System.Composition`


