### PR TITLE
chore: Update node.js version to 24 (Latest LTS version)

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -3,9 +3,9 @@ description: build the project
 runs:
   using: "composite"
   steps:
-  - uses: actions/setup-node@v4
+  - uses: actions/setup-node@v6
     with:
-      node-version: 22
+      node-version: 24
 
   - uses: actions/setup-dotnet@v4
     with:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ We welcome code contributions through pull requests, issues tagged as **[`help-w
 
 - Install [Visual Studio 2022 (Community or higher)](https://www.visualstudio.com/) and make sure you have the latest updates.
 - Install [.NET SDK](https://dotnet.microsoft.com/download/dotnet) 8.x and 9.x.
-- Install NodeJS (22.x.x).
+- Install NodeJS (24.x.x).
 
 ### Build and Test
 


### PR DESCRIPTION
This PR update node.js version from 22 to 24. and update `actions/setup-node` version.
It's similar update as #10331