### PR TITLE
chore: Add `cache-control` response header for `docfx serve`

### DIFF
--- a/src/Docfx.App/RunServe.cs
+++ b/src/Docfx.App/RunServe.cs
@@ -89,6 +89,17 @@ internal static class RunServe
 
         // Fix the issue that .JSON file is 404 when running docfx serve
         fileServerOptions.StaticFileOptions.ServeUnknownFileTypes = true;
+
+        // Set `Cache-Control` response header. (To avoid browser's default heuristic cache)
+        fileServerOptions.StaticFileOptions.OnPrepareResponse = ctx =>
+        {
+            var headers = ctx.Context.Response.GetTypedHeaders();
+            headers.CacheControl = new Microsoft.Net.Http.Headers.CacheControlHeaderValue
+            {
+                MaxAge = TimeSpan.FromSeconds(60),
+            };
+        };
+
         return app.UseFileServer(fileServerOptions);
     }
 


### PR DESCRIPTION
This PR intended to fix browser cache related problems when using `docfx serve` command.

**Background**
Currently `docfx serve` command using default `UseStaticFiles` setting.
So `Cache-Control` header is not written. And [browser's default heuristic caching policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching#heuristic_caching) is used.

When using `docfx serve` command, sometimes cached contents are shown.
And it need to force refresh cache with `Ctrl+F5` or `Disable Cache` on Developer Tools.

**What's changed in this PR**
`cache-control: max-age=60` is added on response header.
When max-age is expired. Browser request content to server with ETag.

If there is no changes. `304 Not Modified`  response is returned.
Therefore, the load on the `Kestrel` side is not expected to be significant when using `cache-control: max-age=60`  setting.