### PR TITLE
fix: Navigation layout issue on mobile display size

### DIFF
--- a/templates/modern/src/docfx.scss
+++ b/templates/modern/src/docfx.scss
@@ -5,6 +5,7 @@
 
 @use "mixins";
 @use "bootstrap/scss/bootstrap" with (
+  $enable-important-utilities: false,
   $container-max-widths: (
     xxl: 1768px
   )


### PR DESCRIPTION
This PR intended to fix #10835.

When using default `$enable-important-utilities: true` setting that break layout on mobile display size.
So it need revert `$enable-important-utilities: false` setting.
