### PR TITLE
chore: Explicitly specify ordinal sort order for xrefmap

### DIFF
--- a/src/Docfx.Build/XRefMaps/XRefSpecUidComparer.cs
+++ b/src/Docfx.Build/XRefMaps/XRefSpecUidComparer.cs
@@ -11,6 +11,6 @@ public sealed class XRefSpecUidComparer : Comparer<XRefSpec>
 
     public override int Compare(XRefSpec x, XRefSpec y)
     {
-        return StringComparer.InvariantCulture.Compare(x.Uid, y.Uid);
+        return StringComparer.Ordinal.Compare(x.Uid, y.Uid);
     }
 }


### PR DESCRIPTION
This PR change XRefSpecUidComparer's StringComparer from `InvariantCulture` to `Ordinal`.

docfx v2.70.0 or later version using `InvariantGlobalization` mode.
So xrefmap is expected to be sorted by `Ordinal` orders even when using `StringComparer.InvariantCulture`.

**Background**
~~On Alpine .NET 9/10 SDK container image.~~
~~InvariantGlobalization mode is unexpectedly disabled. And generating xrefmap that sorted different orders.~~
~~(It's container image side issue. It should not be overridden by environment variable)~~

See: #10900 for details.