### PR TITLE
chore: Modify `Verify.Xunit` package update scheduling policy to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,8 +20,14 @@ updates:
       - "xunit.*"
       - "xunit.v3"
       - "xunit.v3.*"
-      - "Verify.Xunit"
-      - "Verify.XunitV3"
+
+  - package-ecosystem: "nuget"
+    target-branch: main
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-name: "Verify.*"
 
 - package-ecosystem: npm
   target-branch: main


### PR DESCRIPTION
This PR modify `Verify.*` package update schedule from `daily` to `monthly`.

This package is frequently updated. and it's notified as `xunit` group updates  
(Because this package require latest xunit dependencies)

So this PR separate `Verify.*` package update policy. and remove these packages from xunit grouping. 