### PR TITLE
chore: Add cooldown setting for npm related package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,8 @@ updates:
   directory: "/templates"
   schedule:
     interval: daily
+  cooldown:
+    default-days: 14
   groups:
     typescript-eslint:
       patterns:


### PR DESCRIPTION
This PR add [cooldown setting for dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#setting-up-a-cooldown-period-for-dependency-updates) that using npm ecosystem.

npm related package are used for building docfx templates.
And it not needed to be updated on daily basis.

This PR introduce 14 days cooldown time to avoid 0-day attacks that relating npm ecosystem. 