### PR TITLE
chore: fix build failure issue when using c# 14 extension members

### DIFF
--- a/samples/csharp/docfx.json
+++ b/samples/csharp/docfx.json
@@ -3,20 +3,37 @@
     {
       "src": [
         "src/*.csproj"
+      ],      
+      "outputFormat": "mref",
+      "memberLayout": "separatePages",
+      "output": "obj/api"
+    },
+    {
+      "src": [
+        "src/*.csproj"
+      ],      
+      "outputFormat": "apiPage",
+      "memberLayout": "separatePages",
+      "output": "obj/apipage"
+    },
+    {
+      "src": [
+        "src/*.csproj"
       ],
-      "dest": "api"
-    }
+      "outputFormat": "markdown",
+      "memberLayout": "separatePages",
+      "output": "obj/md"
+    },
   ],
   "build": {
     "content": [
-      {
-        "files": [
-          "api/**/*.yml",
-          "toc.yml"
-        ]
-      }
+      { "files": [ "*.{md,yml}" ]},
+      { "files": [ "**/*.yml" ], "src": "obj/api", "dest": "api" },
+      { "files": [ "**/*.yml" ], "src": "obj/apipage", "dest": "apipage" },
+      { "files": [ "**/*.{md,yml}" ], "src": "obj/md", "dest": "md" },
     ],
-    "dest": "_site",
+    "output": "_site",
+    "template": ["default", "modern"],
     "exportViewModel": true
   }
 }

--- a/samples/csharp/index.md
+++ b/samples/csharp/index.md
@@ -1,0 +1,3 @@
+---
+_layout: landing
+---

--- a/samples/csharp/src/CSharp13.cs
+++ b/samples/csharp/src/CSharp13.cs
@@ -1,0 +1,12 @@
+﻿namespace CSharp13;
+
+// https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-13#allows-ref-struct
+public class AllowRefStruct<T>
+    where T : allows ref struct
+{
+    // Use T as a ref struct:
+    public void Method(scoped T p)
+    {
+        // The parameter p must follow ref safety rules
+    }
+}

--- a/samples/csharp/src/CSharp14.cs
+++ b/samples/csharp/src/CSharp14.cs
@@ -1,0 +1,78 @@
+﻿namespace CSharp14;
+
+// https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#the-field-keyword
+public class FieldBackedPropertySample
+{
+    public int FieldBackedProperty
+    {
+        get;
+        set => field = value;
+    }
+}
+
+public class SampleClass
+{
+    public required string Value { get; init; }
+}
+
+public static class SampleClassExtensions
+{
+    // Extension block
+    extension(SampleClass sample)
+    {
+        // Extension property:
+        public string ExtensionProperty => sample.Value;
+
+        // Extension method:
+        public void ExtensionMethod()
+        {
+        }
+    }
+
+    // Extension block for static type
+    extension(SampleClass)
+    {
+        // static extension method:
+        public static void StaticExtensionMethod()
+        {
+        }
+
+        // static extension property:
+        public static int StaticExtensionProperty => default;
+
+        // static user defined operator:
+        public static SampleClass operator +(SampleClass value1, SampleClass value2)
+            => new() { Value = value1.Value + value2.Value };
+    }
+}
+
+public class UserDefinedCompoundAssignmentOperatorsSample
+{
+    public int? Value { get; set; }
+
+    public override string? ToString() => Value?.ToString();
+
+    public void operator ++() { Value += 1; }
+
+    public void operator --() { Value -= 1; }
+
+    public void operator +=(UserDefinedCompoundAssignmentOperatorsSample c) { Value += c?.Value; }
+
+    public void operator -=(UserDefinedCompoundAssignmentOperatorsSample c) { Value -= c?.Value; }
+
+    public void operator *=(UserDefinedCompoundAssignmentOperatorsSample c) { Value *= c?.Value; }
+
+    public void operator /=(UserDefinedCompoundAssignmentOperatorsSample c) { Value /= c?.Value; }
+
+    public void operator %=(UserDefinedCompoundAssignmentOperatorsSample c) { Value %= c?.Value; }
+
+    public void operator &=(UserDefinedCompoundAssignmentOperatorsSample c) { Value &= c?.Value; }
+
+    public void operator |=(UserDefinedCompoundAssignmentOperatorsSample c) { Value |= c?.Value; }
+
+    public void operator ^=(UserDefinedCompoundAssignmentOperatorsSample c) { Value ^= c?.Value; }
+
+    public void operator <<=(int shift) { Value <<= shift; }
+
+    public void operator >>=(int shift) { Value >>= shift; }
+}

--- a/samples/csharp/toc.yml
+++ b/samples/csharp/toc.yml
@@ -1,0 +1,8 @@
+﻿- name: API Documentation
+  items:
+  - name: .NET API
+    href: obj/api/
+  - name: .NET API (apipage)
+    href: obj/apipage/
+  - name: .NET API (markdown)
+    href: obj/md/

--- a/src/Docfx.Dotnet/DotnetApiCatalog.Toc.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.Toc.cs
@@ -26,6 +26,7 @@ partial class DotnetApiCatalog
         Method,
         Event,
         Operator,
+        Extension,
     }
 
     class TocNode
@@ -135,6 +136,12 @@ partial class DotnetApiCatalog
             {
                 var idExists = true;
                 var id = VisitorHelper.PathFriendlyId(VisitorHelper.GetId(symbol));
+
+                // TODO: Handle C# 14 Extension Members. It'll be shown on `static class` and target type of extension.
+                // Currently Extension symbol is skipped.
+                if (type.TypeKind == TypeKind.Extension)
+                    yield break;
+
                 if (!tocNodes.TryGetValue(id, out var node))
                 {
                     idExists = false;

--- a/src/Docfx.Dotnet/ManagedReference/Models/MemberType.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Models/MemberType.cs
@@ -22,5 +22,6 @@ public enum MemberType
     Operator,
     Container,
     AttachedEvent,
-    AttachedProperty
+    AttachedProperty,
+    Extension,
 }

--- a/src/Docfx.Dotnet/ManagedReference/Resolvers/ResolveExtensionMember.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Resolvers/ResolveExtensionMember.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Docfx.DataContracts.ManagedReference;
+
+#nullable enable
+
+namespace Docfx.Dotnet;
+
+internal class ResolveExtensionMember : IResolverPipeline
+{
+    public void Run(MetadataModel yaml, ResolverContext context)
+    {
+        // Remove extension from root members.
+        yaml.Members.RemoveAll(x => x.Type == MemberType.Extension);
+
+        // Remove extension from TocYamlViewModel items.
+        ProcessItem(yaml.TocYamlViewModel);
+    }
+
+    private static void ProcessItem(MetadataItem metadataItem)
+    {
+        if (metadataItem.IsInvalid || metadataItem.Items == null)
+            return;
+
+        metadataItem.Items.RemoveAll(x => x.Type == MemberType.Extension);
+
+        foreach (var item in metadataItem.Items)
+            ProcessItem(item);
+    }
+}

--- a/src/Docfx.Dotnet/ManagedReference/Resolvers/YamlMetadataResolver.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Resolvers/YamlMetadataResolver.cs
@@ -16,6 +16,7 @@ internal static class YamlMetadataResolver
         new NormalizeSyntax(),
         new BuildMembers(),
         new SetDerivedClass(),
+        new ResolveExtensionMember(),
         new BuildToc()
     ];
 

--- a/src/Docfx.Dotnet/ManagedReference/Visitors/SymbolVisitorAdapter.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Visitors/SymbolVisitorAdapter.cs
@@ -197,7 +197,15 @@ internal partial class SymbolVisitorAdapter : SymbolVisitor<MetadataItem>
             }
         }
 
-        AddReference(symbol);
+        if (symbol.IsExtension)
+        {
+            // Currently extension symbol is skipped and reference is not added.
+            // TODO: Handle C# 14 Extension Member definition.
+        }
+        else
+        {
+            AddReference(symbol);
+        }
 
         item.Attributes = GetAttributeInfo(symbol.GetAttributes());
 

--- a/src/Docfx.Dotnet/ManagedReference/Visitors/VisitorHelper.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Visitors/VisitorHelper.cs
@@ -192,6 +192,8 @@ internal static partial class VisitorHelper
                 return MemberType.Struct;
             case TypeKind.Delegate:
                 return MemberType.Delegate;
+            case TypeKind.Extension:
+                return MemberType.Extension;
             default:
                 return MemberType.Default;
         }

--- a/src/Docfx.Dotnet/YamlViewModelExtensions.cs
+++ b/src/Docfx.Dotnet/YamlViewModelExtensions.cs
@@ -12,7 +12,13 @@ internal static class YamlViewModelExtensions
 {
     public static bool IsPageLevel(this MemberType type)
     {
-        return type == MemberType.Namespace || type == MemberType.Class || type == MemberType.Enum || type == MemberType.Delegate || type == MemberType.Interface || type == MemberType.Struct;
+        return type is MemberType.Namespace
+                    or MemberType.Class
+                    or MemberType.Enum
+                    or MemberType.Delegate
+                    or MemberType.Interface
+                    or MemberType.Struct
+                    or MemberType.Extension;
     }
 
     /// <summary>
@@ -22,7 +28,11 @@ internal static class YamlViewModelExtensions
     /// <returns></returns>
     public static bool AllowMultipleItems(this MemberType type)
     {
-        return type == MemberType.Class || type == MemberType.Enum || type == MemberType.Delegate || type == MemberType.Interface || type == MemberType.Struct;
+        return type is MemberType.Class
+                    or MemberType.Enum
+                    or MemberType.Delegate
+                    or MemberType.Interface
+                    or MemberType.Struct;
     }
 
     public static MetadataItem ShrinkToSimpleToc(this MetadataItem item)


### PR DESCRIPTION
This PR add **limited** support for C# 14 Extension members syntax.

Currently it throw exception when some C# features are used.
By this PR it can use C# 14 syntax without error.

**What's changed in this PR**
- Add code to handle `TypeKind.Extension` enum value.
- Add code to **skip** `Extension Members` symbol as temporary workaround for issue described below.
- Add C# 13/14 syntax test code under `samples/csharp/src` directory.

**Background**
When using C# extension members 
`INamedTypeSymbol` is generated per extension blocks.
And following property is exposed.
- `ExtensionGroupingName` // e.g. `<G>$8B58B811E742D8E9EA7E14F878F87B0F`
- `ExtensionMarkerName`     // e.g. `<M>$2C37A6F24442AF359D03A7723186221C`
- `ExtensionParameter`:       // `IParameterSymbol` that specified at extension block.

These names are used for DocumentationCommentId also.
And it contains `<`, `>` chars so need to be escape when output YAML files. 

**Limitation**
- Extension Members are not shown on target type's extension method/property.
- `extension blocks` are not shown on `static class` extensions.