### PR TITLE
chore: Fix nightly build error on CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -63,6 +63,7 @@ jobs:
         <configuration>
           <packageSources>
             <clear />
+            <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
             <add key="github" value="https://nuget.pkg.github.com/dotnet/index.json" />
           </packageSources>
           <packageSourceCredentials>


### PR DESCRIPTION
This PR fix nightly build CI error that occurred after merged PR #10860.
