### PR TITLE
chore: Fix dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  ignore:
+    - dependency-name: "Verify.*"
   groups:
     roslyn:
       patterns:
@@ -20,14 +22,6 @@ updates:
       - "xunit.*"
       - "xunit.v3"
       - "xunit.v3.*"
-
-  - package-ecosystem: "nuget"
-    target-branch: main
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    allow:
-      - dependency-name: "Verify.*"
 
 - package-ecosystem: npm
   target-branch: main


### PR DESCRIPTION
It seems #10910 changes are not works as expected and causing validation errors.
And it's not possibly to define multiple nuget sources with same `target-branch`/ `directory` pairs.

This PR include following changes
1. Remove section for `Verify.*` packages
2. Add ignore settings for `Verify.*` packages (It's expected to be updated manually)


