### PR TITLE
fix: XML comment parse logics for block element that is adjacent to markdown content

### DIFF
--- a/src/Docfx.Dotnet/Parsers/XmlComment.Extensions.cs
+++ b/src/Docfx.Dotnet/Parsers/XmlComment.Extensions.cs
@@ -102,9 +102,15 @@ static file class XElementExtensions
 
         switch (prevNode.NodeType)
         {
-            // If prev node is HTML element. No need to insert empty line.
             case XmlNodeType.Element:
-                return false;
+
+                // No need to insert empty line, if prev node is HTML element and it's not <pre> tag. T
+                if (node.Name != "pre")
+                    return false;
+
+                // <pre> tag needs empty line before. Without this setting, markdown parser treat code as markdown block.
+                var prevElementNode = (XElement)prevNode;
+                return prevElementNode.Name.LocalName != "pre";
 
             // Ensure empty lines exists before text node.
             case XmlNodeType.Text:
@@ -125,6 +131,12 @@ static file class XElementExtensions
     {
         if (!elem.TryGetNonWhitespacePrevNode(out var prevNode))
             return;
+
+        if (prevNode.NodeType == XmlNodeType.Element)
+        {
+            elem.AddBeforeSelf(new XText("\n"));
+            return;
+        }
 
         Debug.Assert(prevNode.NodeType == XmlNodeType.Text);
 

--- a/test/Docfx.Dotnet.Tests/XmlCommentTests/XmlCommentRemarksTest.cs
+++ b/test/Docfx.Dotnet.Tests/XmlCommentTests/XmlCommentRemarksTest.cs
@@ -30,8 +30,10 @@ public class XmlCommentRemarksTest
             // Expected Markdown
             """
             <ul><li>
+
                         <pre><code class="lang-c#">public class XmlElement
                 : XmlLinkedNode</code></pre>
+
                     </li></ul>
             """
          );
@@ -62,6 +64,47 @@ public class XmlCommentRemarksTest
             <pre><code class="lang-csharp">CSharpCode2</code></pre>
             """
          );
+    }
+
+    // UnitTest for https://github.com/dotnet/docfx/issues/10965
+    [Fact]
+    public void Remarks_WithExample()
+    {
+        ValidateRemarks(
+            // Input XML
+            """
+            <member>
+              <remarks>
+              Message
+              <example>
+              <code><![CDATA[
+              public class User
+              {
+                  aaa
+              
+                  bbb
+                  ccc
+              }]]></code>
+              </example>
+              </remarks>
+            </member>
+            """,
+            // Expected Markdown
+            """
+            Message
+
+            <example>
+
+            <pre><code class="lang-csharp">public class User
+            {
+                aaa
+
+                bbb
+                ccc
+            }</code></pre>
+
+            </example>
+            """);
     }
 
     private static void ValidateRemarks(string input, string expected)

--- a/test/Docfx.Dotnet.Tests/XmlCommentTests/XmlCommentSummaryTest.Code.cs
+++ b/test/Docfx.Dotnet.Tests/XmlCommentTests/XmlCommentSummaryTest.Code.cs
@@ -29,6 +29,28 @@ public partial class XmlCommentSummaryTest
     }
 
     [Fact]
+    public void Code_Block_WithoutNewLine()
+    {
+        ValidateSummary(
+           // Input XML
+           """
+           <summary>
+           Paragraph1<code><![CDATA[
+           DELETE /articles/1 HTTP/1.1
+           ]]></code>Paragraph2
+           </summary>
+           """,
+           // Expected Markdown
+           """
+           Paragraph1
+
+           <pre><code class="lang-csharp">DELETE /articles/1 HTTP/1.1</code></pre>
+
+           Paragraph2
+           """);
+    }
+
+    [Fact]
     public void Code_Inline()
     {
         ValidateSummary(

--- a/test/Docfx.Dotnet.Tests/XmlCommentTests/XmlCommentSummaryTest.Code.cs
+++ b/test/Docfx.Dotnet.Tests/XmlCommentTests/XmlCommentSummaryTest.Code.cs
@@ -175,4 +175,111 @@ public partial class XmlCommentSummaryTest
             Paragraph2
             """);
     }
+
+    [Fact]
+    public void Code_StartsWithSameLine()
+    {
+        ValidateSummary(
+            // Input XML
+            """
+            <summary>
+              <example>
+              Paragraph: <code><![CDATA[
+                Code]]></code>
+              </example>
+            </summary>
+            """,
+            // Expected Markdown
+            """
+            <example>
+            Paragraph: 
+
+            <pre><code class="lang-csharp">Code</code></pre>
+
+            </example>
+            """);
+    }
+
+    [Fact]
+    public void Code_SingleLineWithParagraph()
+    {
+        ValidateSummary(
+            // Input XML
+            """
+            <summary>
+              <example>
+              Paragraph1<code>Code</code>
+              Paragraph2
+              </example>
+            </summary>
+            """,
+            // Expected Markdown
+            """
+            <example>
+            Paragraph1
+
+            <pre><code class="lang-csharp">Code</code></pre>
+
+            Paragraph2
+            </example>
+            """);
+    }
+
+    [Fact]
+    public void Code_SingleLineWithMultipleParagraphs()
+    {
+        ValidateSummary(
+            // Input XML
+            """
+            <summary>
+              <example>
+              aaa<p>bbb</p>ccc<code>Code</code>ddd<p>eee</p>fff
+              </example>
+            </summary>
+            """,
+            // Expected Markdown
+            """
+            <example>
+            aaa
+
+            <p>bbb</p>
+
+            ccc
+
+            <pre><code class="lang-csharp">Code</code></pre>
+
+            ddd
+            
+            <p>eee</p>
+            
+            fff
+            </example>
+            """);
+    }
+
+    [Fact]
+    public void Code_Indented()
+    {
+        ValidateSummary(
+            // Input XML
+            """
+            <summary>
+              <example>
+              Paragraph
+              <code>
+              Code
+              </code>
+              </example>
+            </summary>
+            """,
+            // Expected Markdown
+            """
+            <example>
+            Paragraph
+
+            <pre><code class="lang-csharp">Code</code></pre>
+
+            </example>
+            """);
+    }
 }

--- a/test/Docfx.Dotnet.Tests/XmlCommentTests/XmlCommentSummaryTest.Code.cs
+++ b/test/Docfx.Dotnet.Tests/XmlCommentTests/XmlCommentSummaryTest.Code.cs
@@ -116,4 +116,63 @@ public partial class XmlCommentSummaryTest
             }</code></pre>
             """);
     }
+
+    [Fact]
+    public void Code_ParentHtmlTagExist()
+    {
+        ValidateSummary(
+            // Input XML
+            """
+            <summary>
+            <para>Paragraph1</para>
+            <div>
+              <code><![CDATA[
+              public class Sample
+              {
+                  line1
+              
+                  line2
+              }]]></code>
+            </div>
+            <para>Paragraph2</para>
+            </summary>
+            """,
+            // Expected Markdown
+            """
+            <p>Paragraph1</p>
+            <div>
+
+              <pre><code class="lang-csharp">public class Sample
+            {
+                line1
+           
+                line2
+            }</code></pre>
+
+            </div>
+            <p>Paragraph2</p>
+            """);
+    }
+
+    [Fact]
+    public void Code_MultipleBlockWithoutNewLine()
+    {
+        ValidateSummary(
+            // Input XML
+            """
+            <summary>
+            Paragraph1
+            <code>var x = 1;</code><code>var x = 2;</code>
+            Paragraph2
+            </summary>
+            """,
+            // Expected Markdown
+            """
+            Paragraph1
+
+            <pre><code class="lang-csharp">var x = 1;</code></pre><pre><code class="lang-csharp">var x = 2;</code></pre>
+
+            Paragraph2
+            """);
+    }
 }

--- a/test/Docfx.Dotnet.Tests/XmlCommentTests/XmlCommentSummaryTest.Code.cs
+++ b/test/Docfx.Dotnet.Tests/XmlCommentTests/XmlCommentSummaryTest.Code.cs
@@ -69,4 +69,51 @@ public partial class XmlCommentSummaryTest
             Paragraph2
             """);
     }
+
+
+    [Fact]
+    public void Code_HtmlTagExistBefore()
+    {
+        ValidateSummary(
+            // Input XML
+            """
+            <summary>
+            paragraph1
+            <para>paragraph2</para>
+            <code><![CDATA[
+            public class Sample
+            {
+                line1
+            
+                line2
+            }]]></code>
+            <code><![CDATA[
+            public class Sample2
+            {
+                line1
+            
+                line2
+            }]]></code>
+            </summary>
+            """,
+            // Expected Markdown
+            """
+            paragraph1
+
+            <p>paragraph2</p>
+
+            <pre><code class="lang-csharp">public class Sample
+            {
+                line1
+           
+                line2
+            }</code></pre>
+            <pre><code class="lang-csharp">public class Sample2
+            {
+                line1
+            
+                line2
+            }</code></pre>
+            """);
+    }
 }

--- a/test/Docfx.Dotnet.Tests/XmlCommentTests/XmlCommentSummaryTest.List.cs
+++ b/test/Docfx.Dotnet.Tests/XmlCommentTests/XmlCommentSummaryTest.List.cs
@@ -114,8 +114,10 @@ public partial class XmlCommentSummaryTest
             Paragraph1
 
             <ul><li>
+
                         <pre><code class="lang-c#">public class XmlElement
                 : XmlLinkedNode</code></pre>
+
                     </li></ul>
 
             Paragraph2
@@ -168,10 +170,12 @@ public partial class XmlCommentSummaryTest
             <a href="https://example.org">example</a>
             <p>This is <code class="paramref">ref</code> a sample of exception node</p>
             <ul><li>
+
                 <pre><code class="lang-c#">public class XmlElement
               : XmlLinkedNode</code></pre>
+
                 <ol><li>
-                    word inside list-&gt;listItem-&gt;list-&gt;listItem-&gt;para.&gt;
+                    word inside list->listItem->list->listItem->para.>
                     the second line.
                     </li><li>item2 in numbered list</li></ol>
                 </li><li>item2 in bullet list</li><li>

--- a/test/Docfx.Dotnet.Tests/XmlCommentTests/XmlCommentSummaryTest.Others.cs
+++ b/test/Docfx.Dotnet.Tests/XmlCommentTests/XmlCommentSummaryTest.Others.cs
@@ -8,7 +8,7 @@ namespace Docfx.Dotnet.Tests;
 public partial class XmlCommentSummaryTest
 {
     [Fact]
-    public void Example()
+    public void ExampleWithParagraph()
     {
         ValidateSummary(
             // Input XML
@@ -26,7 +26,9 @@ public partial class XmlCommentSummaryTest
             Paragraph1
 
             <example>
+
               <pre><code class="lang-csharp">code content</code></pre>
+
             </example>
 
             Paragraph2

--- a/test/Docfx.Dotnet.Tests/XmlCommentUnitTest.Issue10553.cs
+++ b/test/Docfx.Dotnet.Tests/XmlCommentUnitTest.Issue10553.cs
@@ -29,8 +29,11 @@ public partial class XmlCommentUnitTest
         var expected = """
                 Converts action result without parameters into action result with null parameter.
 
-                <example><pre><code class="lang-csharp">return NotFound() -&gt; return NotFound(null)
+                <example>
+
+                <pre><code class="lang-csharp">return NotFound() -&gt; return NotFound(null)
                 return NotFound() -&gt; return NotFound(null)</code></pre>
+
                 </example>
 
                 This ensures our formatter is invoked, where we'll build a JSON:API compliant response. For details, see:

--- a/test/Docfx.Dotnet.Tests/XmlCommentUnitTest.cs
+++ b/test/Docfx.Dotnet.Tests/XmlCommentUnitTest.cs
@@ -408,10 +408,12 @@ public partial class XmlCommentUnitTest
             <a href="https://example.org">example</a>
             <p>This is <code class="paramref">ref</code> a sample of exception node</p>
             <ul><li>
+
                         <pre><code class="lang-c#">public class XmlElement
                 : XmlLinkedNode</code></pre>
+
                         <ol><li>
-                                    word inside list-&gt;listItem-&gt;list-&gt;listItem-&gt;para.&gt;
+                                    word inside list->listItem->list->listItem->para.>
                                     the second line.
                                 </li><li>item2 in numbered list</li></ol>
                     </li><li>item2 in bullet list</li><li>

--- a/test/Docfx.Dotnet.Tests/XmlCommentUnitTest.cs
+++ b/test/Docfx.Dotnet.Tests/XmlCommentUnitTest.cs
@@ -581,6 +581,7 @@ public partial class XmlCommentUnitTest
             <p>
             Paragraph.
             </p>
+
             <pre><code class="lang-csharp">public sealed class Issue10385
             {
                 public int AAA {get;set;}


### PR DESCRIPTION
This PR intended to fix #10965

I've added additional code to handle case that `<code>` element is adjacent to markdown content.

In this case,
It need to insert extra newline, and it need to copy indent chars for `TrimEachLine`.