### PR TITLE
feat(pdf): Add pdfTocSource option to generate TOC from document head…

### DIFF
--- a/docs/docs/pdf.md
+++ b/docs/docs/pdf.md
@@ -75,6 +75,33 @@ Sets the PDF output file name. The default value is `toc.pdf`.
 
 Indicates whether to include a "Table of Contents" pages at the beginning.
 
+### `pdfTocSource`
+
+Controls the source for the PDF Table of Contents. Possible values:
+
+- `toc` (default): Generates TOC from the `toc.yml` structure.
+- `headings`: Generates TOC from headings (h1, h2, h3, etc.) extracted from document content.
+
+When set to `headings`, the TOC reflects the actual heading structure within each document rather than the navigation defined in `toc.yml`. This is useful for single-document or small documentation sets where you want the PDF TOC to show the internal sections of each document.
+
+```yaml
+pdf: true
+pdfTocPage: true
+pdfTocSource: headings
+items:
+- name: My Document
+  href: my-document.md
+```
+
+### `pdfTocHeadingDepth`
+
+Maximum heading level to include in the PDF TOC when `pdfTocSource` is `headings`. Default is `3`, which includes h1, h2, and h3 headings. Set to a higher value (up to 6) to include deeper heading levels.
+
+```yaml
+pdfTocSource: headings
+pdfTocHeadingDepth: 4  # Include h1-h4 headings
+```
+
 ### `pdfCoverPage`
 
 A path to an HTML page relative to the root of the output directory. The HTML page will be inserted at the beginning of the PDF file as cover page.

--- a/schemas/toc.schema.json
+++ b/schemas/toc.schema.json
@@ -106,6 +106,19 @@
           "type": "boolean",
           "default": false,
           "description": "If set to true, Child items are displayed as dropdown on top navigation bar."
+        },
+        "pdfTocSource": {
+          "type": "string",
+          "enum": ["toc", "headings"],
+          "default": "toc",
+          "description": "Source for PDF Table of Contents. 'toc' uses toc.yml structure (default), 'headings' extracts headings from document content."
+        },
+        "pdfTocHeadingDepth": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 6,
+          "default": 3,
+          "description": "Maximum heading level to include in PDF TOC when pdfTocSource is 'headings'. For example, 3 includes h1, h2, and h3."
         }
       }
     },


### PR DESCRIPTION
…ings

Add new configuration options to control PDF Table of Contents source:
- pdfTocSource: 'toc' (default) or 'headings' to extract from document content
- pdfTocHeadingDepth: maximum heading level to include (1-6, default 3)

When pdfTocSource is set to 'headings', the PDF TOC is generated by extracting h1-h6 headings from the rendered HTML pages instead of using the toc.yml structure. This is particularly useful for print-style publications using docfx for markdown-to-PDF generation, where the TOC should reflect the document's internal heading structure rather than website navigation.

Fixes #10994