### PR TITLE
chore: fix lint.yml workflow errors on ci

### DIFF
--- a/test/Docfx.Dotnet.Tests/SymbolUrlResolverUnitTest.cs
+++ b/test/Docfx.Dotnet.Tests/SymbolUrlResolverUnitTest.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.RegularExpressions;
-using Microsoft.CodeAnalysis;
 using Xunit;
 
 namespace Docfx.Dotnet.Tests;


### PR DESCRIPTION
This PR intended to fix following `lint.yml` CI workflow errors.

```
Warning: D:\a\docfx\docfx\test\Docfx.Dotnet.Tests\SymbolUrlResolverUnitTest.cs(5,1): warning IDE0005: Using directive is unnecessary. [D:\a\docfx\docfx\test\Docfx.Dotnet.Tests\Docfx.Dotnet.Tests.csproj]
Warning: D:\a\docfx\docfx\test\Docfx.Dotnet.Tests\SymbolUrlResolverUnitTest.cs(5,1): warning IDE0005: Using directive is unnecessary. [D:\a\docfx\docfx\test\Docfx.Dotnet.Tests\Docfx.Dotnet.Tests.csproj]
```