### PR TITLE
fix: httpclient error on macos ci and lint.yml errors

### DIFF
--- a/src/Docfx.Build/XRefMaps/XRefMapDownloader.cs
+++ b/src/Docfx.Build/XRefMaps/XRefMapDownloader.cs
@@ -3,6 +3,8 @@
 
 using System.IO.Compression;
 using System.Net;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
 using Docfx.Common;
 
 using EnvironmentVariables = Docfx.DataContracts.Common.Constants.EnvironmentVariables;
@@ -158,6 +160,20 @@ public sealed class XRefMapDownloader
         {
             AutomaticDecompression = DecompressionMethods.All,
             CheckCertificateRevocationList = !EnvironmentVariables.NoCheckCertificateRevocationList,
+            ServerCertificateCustomValidationCallback = (req, cert, chain, errors) =>
+            {
+                if (errors == SslPolicyErrors.None)
+                    return true;
+
+                // Ignore OCSP validation error on macos. (On GitHub Actions environment. OSCP HTTP access seems be blocked)
+                if (OperatingSystem.IsMacOS())
+                {
+                    if (chain?.ChainStatus != null && chain.ChainStatus.All(s => s.Status == X509ChainStatusFlags.RevocationStatusUnknown))
+                        return true;
+                }
+
+                return false;
+            }
         })
         {
             Timeout = TimeSpan.FromMinutes(30), // Default: 100 seconds

--- a/test/Docfx.Dotnet.Tests/SymbolUrlResolverUnitTest.cs
+++ b/test/Docfx.Dotnet.Tests/SymbolUrlResolverUnitTest.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.RegularExpressions;
-using Microsoft.CodeAnalysis;
 using Xunit;
 
 namespace Docfx.Dotnet.Tests;


### PR DESCRIPTION
From `Mar 4`, `XRefArchiveBuilderTest.TestDownload` test is continuously failed on `macos-latest`.

And following exception is internally thrown.

```
Failed Docfx.Build.Engine.Tests.XRefArchiveBuilderTest.TestDownload [381 ms]
  Error Message:
   System.Net.Http.HttpRequestException : The SSL connection could not be established, see inner exception.
---- System.Security.Authentication.AuthenticationException : The remote certificate is invalid because of errors in the certificate chain: RevocationStatusUnknown
  Stack Trace:
     at System.Net.Http.ConnectHelper.EstablishSslConnectionAsync(SslClientAuthenticationOptions sslOptions, HttpRequestMessage request, Boolean async, Stream stream, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.ConnectAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.CreateHttp11ConnectionAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.InjectNewHttp11ConnectionAsync(QueueItem queueItem)
   at System.Threading.Tasks.TaskCompletionSourceWithCancellation`1.WaitWithCancellationAsync(CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.SendWithVersionDetectionAndRetryAsync(HttpRequestMessage request, Boolean async, Boolean doRequestAuth, CancellationToken cancellationToken)
   at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.DecompressionHandler.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.SocketsHttpHandler.<SendAsync>g__CreateHandlerAndSendAsync|115_0(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.GetStreamAsyncCore(HttpRequestMessage request, CancellationToken cancellationToken)
   at Docfx.Build.Engine.XRefMapDownloader.DownloadFromWebAsync(Uri uri, CancellationToken token) in /_/src/Docfx.Build/XRefMaps/XRefMapDownloader.cs:line 166
   at Docfx.Build.Engine.XRefMapDownloader.DownloadBySchemeAsync(Uri uri, CancellationToken token) in /_/src/Docfx.Build/XRefMaps/XRefMapDownloader.cs:line 93
   at Docfx.Build.Engine.XRefMapDownloader.<>c__DisplayClass3_0.<<DownloadAsync>b__0>d.MoveNext() in /_/src/Docfx.Build/XRefMaps/XRefMapDownloader.cs:line 53
--- End of stack trace from previous location ---
   at Docfx.Build.Engine.XRefMapDownloader.DownloadAsync(Uri uri, CancellationToken token) in /_/src/Docfx.Build/XRefMaps/XRefMapDownloader.cs:line 47
   at Docfx.Build.Engine.XRefArchiveBuilder.DownloadCoreAsync(Uri uri, XRefArchive xa, CancellationToken cancellationToken) in /_/src/Docfx.Build/XRefMaps/XRefArchiveBuilder.cs:line 41
   at Docfx.Build.Engine.XRefArchiveBuilder.DownloadAsync(Uri uri, String outputFile, CancellationToken cancellationToken) in /_/src/Docfx.Build/XRefMaps/XRefArchiveBuilder.cs:line 27
   at Docfx.Build.Engine.Tests.XRefArchiveBuilderTest.TestDownload() in /_/test/Docfx.Build.Tests/XRefArchiveBuilderTest.cs:line 23
--- End of stack trace from previous location ---
----- Inner Stack Trace -----
   at System.Net.Security.SslStream.SendAuthResetSignal(ReadOnlySpan`1 alert, ExceptionDispatchInfo exception)
   at System.Net.Security.SslStream.CompleteHandshake(SslAuthenticationOptions sslAuthenticationOptions)
   at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](Boolean receiveFirst, Byte[] reAuthenticationData, CancellationToken cancellationToken)
   at System.Net.Http.ConnectHelper.EstablishSslConnectionAsync(SslClientAuthenticationOptions sslOptions, HttpRequestMessage request, Boolean async, Stream stream, CancellationToken cancellationToken)
```

As far as I've confirmed.
Server certificate of `https://dotnet.github.io` has no issues.
But it seems failed to access OCSP endpoint with **HTTP** protocol and cause `RevocationStatusUnknown` error.

This PR add logics to skip `RevocationStatusUnknown` errors on macos
(On Windows/Linux environment, OSCP endpoint seems not be used)
