### PR TITLE
deps: Update playwright version to 1.60.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="Jint" Version="4.6.1" />
     <PackageVersion Include="JsonSchema.Net" Version="7.4.0" />
     <PackageVersion Include="Markdig" Version="1.1.0" />
-    <PackageVersion Include="Microsoft.Playwright" Version="1.58.0" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.60.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="OneOf.SourceGenerator" Version="3.0.271" />

--- a/src/Docfx.Build/XRefMaps/XRefMapDownloader.cs
+++ b/src/Docfx.Build/XRefMaps/XRefMapDownloader.cs
@@ -3,6 +3,8 @@
 
 using System.IO.Compression;
 using System.Net;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
 using Docfx.Common;
 
 using EnvironmentVariables = Docfx.DataContracts.Common.Constants.EnvironmentVariables;
@@ -158,6 +160,20 @@ public sealed class XRefMapDownloader
         {
             AutomaticDecompression = DecompressionMethods.All,
             CheckCertificateRevocationList = !EnvironmentVariables.NoCheckCertificateRevocationList,
+            ServerCertificateCustomValidationCallback = (req, cert, chain, errors) =>
+            {
+                if (errors == SslPolicyErrors.None)
+                    return true;
+
+                // Ignore OCSP validation error on macos. (On GitHub Actions environment. OSCP HTTP access seems be blocked)
+                if (OperatingSystem.IsMacOS())
+                {
+                    if (chain?.ChainStatus != null && chain.ChainStatus.All(s => s.Status == X509ChainStatusFlags.RevocationStatusUnknown))
+                        return true;
+                }
+
+                return false;
+            }
         })
         {
             Timeout = TimeSpan.FromMinutes(30), // Default: 100 seconds

--- a/src/Docfx.Build/XRefMaps/XRefMapDownloader.cs
+++ b/src/Docfx.Build/XRefMaps/XRefMapDownloader.cs
@@ -3,8 +3,6 @@
 
 using System.IO.Compression;
 using System.Net;
-using System.Net.Security;
-using System.Security.Cryptography.X509Certificates;
 using Docfx.Common;
 
 using EnvironmentVariables = Docfx.DataContracts.Common.Constants.EnvironmentVariables;
@@ -160,20 +158,6 @@ public sealed class XRefMapDownloader
         {
             AutomaticDecompression = DecompressionMethods.All,
             CheckCertificateRevocationList = !EnvironmentVariables.NoCheckCertificateRevocationList,
-            ServerCertificateCustomValidationCallback = (req, cert, chain, errors) =>
-            {
-                if (errors == SslPolicyErrors.None)
-                    return true;
-
-                // Ignore OCSP validation error on macos. (On GitHub Actions environment. OSCP HTTP access seems be blocked)
-                if (OperatingSystem.IsMacOS())
-                {
-                    if (chain?.ChainStatus != null && chain.ChainStatus.All(s => s.Status == X509ChainStatusFlags.RevocationStatusUnknown))
-                        return true;
-                }
-
-                return false;
-            }
         })
         {
             Timeout = TimeSpan.FromMinutes(30), // Default: 100 seconds


### PR DESCRIPTION
This PR update Playwright version to 1.60.0 to avoid hang when running `docfx pdf` command with latest Node.js v24.16.0 or v26.x
See `https://github.com/nodejs/node/issues/63487`

~~This PR also contains other PR commit to pass CI.~~ (It seems be resolved by #11092 )