### PR TITLE
Build template models in Jint's hidden-class representation, prepare scripts once, and bound script execution

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="ICSharpCode.Decompiler" Version="9.1.0.7988" />
-    <PackageVersion Include="Jint" Version="4.6.1" />
+    <PackageVersion Include="Jint" Version="4.15.3" />
     <PackageVersion Include="JsonSchema.Net" Version="7.4.0" />
     <PackageVersion Include="Markdig" Version="1.1.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.58.0" />

--- a/src/Docfx.Build/Docfx.Build.csproj
+++ b/src/Docfx.Build/Docfx.Build.csproj
@@ -2,6 +2,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Docfx.App" />
     <InternalsVisibleTo Include="Docfx.Build.Common.Tests" />
+    <InternalsVisibleTo Include="Docfx.Build.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Docfx.Build/TemplateProcessors/Preprocessors/JintProcessorHelper.cs
+++ b/src/Docfx.Build/TemplateProcessors/Preprocessors/JintProcessorHelper.cs
@@ -11,12 +11,14 @@ public static class JintProcessorHelper
     {
         if (raw is IDictionary<string, object> dict)
         {
-            var jsObject = new JsObject(engine);
-            foreach (var pair in dict)
-            {
-                jsObject.FastSetDataProperty(pair.Key, ConvertObjectToJsValue(engine, pair.Value));
-            }
-            return jsObject;
+            // Build the object directly in the engine's hidden class ("shape") representation rather than
+            // storing a property descriptor per property. Every document of a given document type is handed
+            // to the template with the same property layout, so the objects built here end up sharing one
+            // interned shape and the property reads in the template script stay monomorphic across documents.
+            //
+            // Layouts the representation cannot express - integer-index-like keys, very wide objects - fall
+            // back to the ordinary property-dictionary representation silently and correctly.
+            return JsObject.CreateFromEntries(engine, ConvertEntries(engine, dict));
         }
 
         if (raw is IList<object> list)
@@ -32,5 +34,18 @@ public static class JintProcessorHelper
         }
 
         return JsValue.FromObject(engine, raw);
+    }
+
+    /// <summary>
+    /// Streams the converted entries instead of materializing them into an array first: the entries are
+    /// enumerated exactly once while the object is being built, so a model with many properties does not
+    /// need a temporary buffer of its own size.
+    /// </summary>
+    private static IEnumerable<KeyValuePair<string, JsValue>> ConvertEntries(Jint.Engine engine, IDictionary<string, object> dict)
+    {
+        foreach (var pair in dict)
+        {
+            yield return new KeyValuePair<string, JsValue>(pair.Key, ConvertObjectToJsValue(engine, pair.Value));
+        }
     }
 }

--- a/src/Docfx.Build/TemplateProcessors/Preprocessors/PreprocessorLoader.cs
+++ b/src/Docfx.Build/TemplateProcessors/Preprocessors/PreprocessorLoader.cs
@@ -1,9 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
 
+using Acornima.Ast;
+
 using Docfx.Common;
+using Jint;
 
 namespace Docfx.Build.Engine;
 
@@ -58,7 +62,10 @@ public class PreprocessorLoader
             var extension = Path.GetExtension(res.Path);
             if (extension.Equals(TemplateJintPreprocessor.Extension, System.StringComparison.OrdinalIgnoreCase))
             {
-                return new PreprocessorWithResourcePool(() => new TemplateJintPreprocessor(_reader, res, _context, name), _maxParallelism);
+                // Every preprocessor the pool creates for this template runs the same script sources,
+                // so let them share one parsed copy of each.
+                var preparedScripts = new ConcurrentDictionary<string, Prepared<Script>>();
+                return new PreprocessorWithResourcePool(() => new TemplateJintPreprocessor(_reader, res, _context, name, preparedScripts), _maxParallelism);
             }
             else
             {

--- a/src/Docfx.Build/TemplateProcessors/Preprocessors/TemplateJintPreprocessor.cs
+++ b/src/Docfx.Build/TemplateProcessors/Preprocessors/TemplateJintPreprocessor.cs
@@ -167,35 +167,38 @@ public class TemplateJintPreprocessor : ITemplatePreprocessor
             markup = new Func<string, string, string>(utility.Markup),
         };
 
-        var engine = CreateDefaultEngine();
-
-        var requireAction = new Func<string, object>(
-            s =>
+        // Each engine registers `require` from this delegate itself. Copying the function object out of one
+        // engine and into another - which is what `CreateEngine(engine, RequireFuncVariableName)` used to do -
+        // hands a JsValue to an engine that did not create it; a JsValue holds a hard reference to the engine
+        // and realm that created it and passing one across is not a supported arrangement.
+        object Require(string s)
+        {
+            if (!s.StartsWith(RequireRelativePathPrefix, StringComparison.Ordinal))
             {
-                if (!s.StartsWith(RequireRelativePathPrefix, StringComparison.Ordinal))
-                {
-                    throw new ArgumentException($"Only relative path starting with `{RequireRelativePathPrefix}` is supported in require");
-                }
-                var relativePath = (RelativePath)s.Substring(RequireRelativePathPrefix.Length);
-                s = relativePath.BasedOn(rootPath);
+                throw new ArgumentException($"Only relative path starting with `{RequireRelativePathPrefix}` is supported in require");
+            }
+            var relativePath = (RelativePath)s.Substring(RequireRelativePathPrefix.Length);
+            s = relativePath.BasedOn(rootPath);
 
-                var script = resourceCollection?.GetResource(s);
-                if (string.IsNullOrWhiteSpace(script))
-                {
-                    return null;
-                }
+            var script = resourceCollection?.GetResource(s);
+            if (string.IsNullOrWhiteSpace(script))
+            {
+                return null;
+            }
 
-                if (!engineCache.TryGetValue(s, out Jint.Engine cachedEngine))
-                {
-                    cachedEngine = CreateEngine(engine, RequireFuncVariableName);
-                    engineCache[s] = cachedEngine;
-                    cachedEngine.Execute(Prepare(s, script));
-                }
+            if (!engineCache.TryGetValue(s, out Jint.Engine cachedEngine))
+            {
+                cachedEngine = CreateDefaultEngine();
+                cachedEngine.SetValue(RequireFuncVariableName, (Func<string, object>)Require);
+                engineCache[s] = cachedEngine;
+                cachedEngine.Execute(Prepare(s, script));
+            }
 
-                return cachedEngine.GetValue(ExportsVariableName);
-            });
+            return cachedEngine.GetValue(ExportsVariableName);
+        }
 
-        engine.SetValue(RequireFuncVariableName, requireAction);
+        var engine = CreateDefaultEngine();
+        engine.SetValue(RequireFuncVariableName, (Func<string, object>)Require);
         engineCache[rootPath] = engine;
         engine.Execute(Prepare(scriptResource.Path, scriptResource.Content));
 
@@ -214,20 +217,6 @@ public class TemplateJintPreprocessor : ITemplatePreprocessor
         return engine;
     }
 
-    private Jint.Engine CreateEngine(Jint.Engine engine, params string[] sharedVariables)
-    {
-        var newEngine = CreateDefaultEngine();
-        if (sharedVariables != null)
-        {
-            foreach (var sharedVariable in sharedVariables)
-            {
-                newEngine.SetValue(sharedVariable, engine.GetValue(sharedVariable));
-            }
-        }
-
-        return newEngine;
-    }
-
     /// <summary>
     /// Parses <paramref name="content"/> once per <paramref name="path"/> and reuses the result. The
     /// preprocessor pool builds one instance - and therefore one engine - per parallelism slot, and they
@@ -241,16 +230,24 @@ public class TemplateJintPreprocessor : ITemplatePreprocessor
 
     private Jint.Engine CreateDefaultEngine()
     {
-        // Template scripts come from the docset being built, so a faulty one must fail the document
-        // instead of pinning a render thread. Both limits apply per call into the engine.
+        var utilityObject = _utilityObject;
+
         var engine = new Jint.Engine(options => options
+            // Template scripts come from the docset being built, so a faulty one must fail the document
+            // instead of pinning a render thread. All three limits apply per call into the engine.
             .TimeoutInterval(ExecutionTimeout)
             .MaxStatements(MaxExecutionStatements)
-            .CancellationToken(_cancellationToken));
+            .CancellationToken(_cancellationToken)
+            // `console` and `templateUtility` are ambient conveniences that most template scripts never
+            // mention, so build the wrapper only for the engines whose script actually reads the name. That
+            // is worth doing here because engines are not scarce: the preprocessor pool creates one per
+            // parallelism slot, and `require` creates one more per module.
+            .AddLazyGlobal(ConsoleVariableName, static e => JsValue.FromObject(e, ConsoleObject))
+            .AddLazyGlobal(UtilityVariableName, e => JsValue.FromObject(e, utilityObject)));
 
+        // `exports` stays eager: it is read back off the engine after the script has run, whether or not the
+        // script itself ever mentioned the name.
         engine.SetValue(ExportsVariableName, new JsObject(engine));
-        engine.SetValue(ConsoleVariableName, ConsoleObject);
-        engine.SetValue(UtilityVariableName, _utilityObject);
 
         return engine;
     }

--- a/src/Docfx.Build/TemplateProcessors/Preprocessors/TemplateJintPreprocessor.cs
+++ b/src/Docfx.Build/TemplateProcessors/Preprocessors/TemplateJintPreprocessor.cs
@@ -66,7 +66,7 @@ public class TemplateJintPreprocessor : ITemplatePreprocessor
     /// <c>transform</c> for one document. Without it an accidental infinite loop in a template script
     /// hangs a build thread forever instead of failing the document.
     /// </summary>
-    private static readonly TimeSpan ExecutionTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan DefaultExecutionTimeout = TimeSpan.FromSeconds(30);
 
     /// <summary>
     /// Statement budget for a single preprocessor call. Deliberately far above what transforming even a
@@ -78,6 +78,16 @@ public class TemplateJintPreprocessor : ITemplatePreprocessor
     private object _utilityObject;
 
     private readonly CancellationToken _cancellationToken;
+
+    private readonly TimeSpan _executionTimeout;
+
+    /// <summary>
+    /// Every engine this preprocessor owns, keyed by resource path: the template's engine under the
+    /// template's own path, plus one per <c>require</c>d module. A preprocessor instance is rented from
+    /// <c>PreprocessorWithResourcePool</c> for the duration of one call, so this is only ever touched by
+    /// one thread at a time.
+    /// </summary>
+    private readonly Dictionary<string, Jint.Engine> _engineCache = [];
 
     /// <summary>
     /// Parsed sources, keyed by resource path, shared by every preprocessor instance created for the same
@@ -110,10 +120,12 @@ public class TemplateJintPreprocessor : ITemplatePreprocessor
         ResourceInfo scriptResource,
         DocumentBuildContext context,
         string name,
-        ConcurrentDictionary<string, Prepared<Script>> preparedScripts)
+        ConcurrentDictionary<string, Prepared<Script>> preparedScripts,
+        TimeSpan? executionTimeout = null)
     {
         _preparedScripts = preparedScripts;
         _cancellationToken = context?.CancellationToken ?? CancellationToken.None;
+        _executionTimeout = executionTimeout ?? DefaultExecutionTimeout;
 
         if (!string.IsNullOrWhiteSpace(scriptResource.Content))
         {
@@ -138,6 +150,7 @@ public class TemplateJintPreprocessor : ITemplatePreprocessor
     {
         if (_getOptionsFunc != null)
         {
+            ResetConstraints();
             return _getOptionsFunc(model);
         }
 
@@ -148,16 +161,38 @@ public class TemplateJintPreprocessor : ITemplatePreprocessor
     {
         if (_transformFunc != null)
         {
+            ResetConstraints();
             return _transformFunc(model);
         }
 
         return model;
     }
 
+    /// <summary>
+    /// Rearms the timeout and clears the statement counter on every engine this preprocessor owns, so all
+    /// three limits bound one document rather than the lifetime of a pooled preprocessor.
+    /// <para>
+    /// Only the template's own engine is entered through a public Jint API - <see cref="Jint.Engine.Invoke"/>,
+    /// which resets that engine's constraints itself. A <c>require</c>d module's exported function belongs to
+    /// the module's engine, so calling it is an ordinary function call that charges the <em>module</em>
+    /// engine's constraint instances without ever going through an entry point that resets them. Since a
+    /// timeout deadline is armed only on reset and a statement counter is only cleared on reset, leaving
+    /// them alone would give a module engine a deadline fixed at preprocessor construction and a statement
+    /// budget spanning the whole build.
+    /// </para>
+    /// </summary>
+    private void ResetConstraints()
+    {
+        foreach (var engine in _engineCache.Values)
+        {
+            engine.Constraints.Reset();
+        }
+    }
+
     private Jint.Engine SetupEngine(ResourceFileReader resourceCollection, ResourceInfo scriptResource, DocumentBuildContext context)
     {
         var rootPath = (RelativePath)scriptResource.Path;
-        var engineCache = new Dictionary<string, Jint.Engine>();
+        var engineCache = _engineCache;
 
         var utility = new TemplateUtility(context);
         _utilityObject = new
@@ -234,8 +269,10 @@ public class TemplateJintPreprocessor : ITemplatePreprocessor
 
         var engine = new Jint.Engine(options => options
             // Template scripts come from the docset being built, so a faulty one must fail the document
-            // instead of pinning a render thread. All three limits apply per call into the engine.
-            .TimeoutInterval(ExecutionTimeout)
+            // instead of pinning a render thread. Every engine gets its own limits, including the ones
+            // `require` builds, so a runaway loop inside a module function is bounded too; ResetConstraints
+            // is what makes them bound one document rather than the preprocessor's whole lifetime.
+            .TimeoutInterval(_executionTimeout)
             .MaxStatements(MaxExecutionStatements)
             .CancellationToken(_cancellationToken)
             // `console` and `templateUtility` are ambient conveniences that most template scripts never

--- a/src/Docfx.Build/TemplateProcessors/Preprocessors/TemplateJintPreprocessor.cs
+++ b/src/Docfx.Build/TemplateProcessors/Preprocessors/TemplateJintPreprocessor.cs
@@ -1,6 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
+
+using Acornima.Ast;
+
 using Docfx.Common;
 using Jint;
 using Jint.Native;
@@ -57,7 +61,32 @@ public class TemplateJintPreprocessor : ITemplatePreprocessor
 
     private const string NullString = "null";
 
+    /// <summary>
+    /// Wall clock budget for a single preprocessor call, that is one <c>getOptions</c> or
+    /// <c>transform</c> for one document. Without it an accidental infinite loop in a template script
+    /// hangs a build thread forever instead of failing the document.
+    /// </summary>
+    private static readonly TimeSpan ExecutionTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Statement budget for a single preprocessor call. Deliberately far above what transforming even a
+    /// very large model costs, so it only ever catches a runaway script. A saturated value such as
+    /// <see cref="int.MaxValue"/> would register no limit at all, so this has to be a real number.
+    /// </summary>
+    private const int MaxExecutionStatements = 50_000_000;
+
     private object _utilityObject;
+
+    private readonly CancellationToken _cancellationToken;
+
+    /// <summary>
+    /// Parsed sources, keyed by resource path, shared by every preprocessor instance created for the same
+    /// template. A <see cref="Prepared{TProgram}"/> is immutable and safe to execute from several engines
+    /// and threads, so the template and everything it <c>require</c>s is parsed once instead of once per
+    /// engine in the preprocessor pool.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, Prepared<Script>> _preparedScripts;
+
     private static readonly object ConsoleObject = new
     {
         log = new Action<object>(s => Logger.Log(s ?? NullString)),
@@ -72,7 +101,20 @@ public class TemplateJintPreprocessor : ITemplatePreprocessor
     private Func<object, object> _getOptionsFunc;
 
     public TemplateJintPreprocessor(ResourceFileReader resourceCollection, ResourceInfo scriptResource, DocumentBuildContext context, string name = null)
+        : this(resourceCollection, scriptResource, context, name, new ConcurrentDictionary<string, Prepared<Script>>())
     {
+    }
+
+    internal TemplateJintPreprocessor(
+        ResourceFileReader resourceCollection,
+        ResourceInfo scriptResource,
+        DocumentBuildContext context,
+        string name,
+        ConcurrentDictionary<string, Prepared<Script>> preparedScripts)
+    {
+        _preparedScripts = preparedScripts;
+        _cancellationToken = context?.CancellationToken ?? CancellationToken.None;
+
         if (!string.IsNullOrWhiteSpace(scriptResource.Content))
         {
             SetupEngine(resourceCollection, scriptResource, context);
@@ -147,7 +189,7 @@ public class TemplateJintPreprocessor : ITemplatePreprocessor
                 {
                     cachedEngine = CreateEngine(engine, RequireFuncVariableName);
                     engineCache[s] = cachedEngine;
-                    cachedEngine.Execute(script, s);
+                    cachedEngine.Execute(Prepare(s, script));
                 }
 
                 return cachedEngine.GetValue(ExportsVariableName);
@@ -155,7 +197,7 @@ public class TemplateJintPreprocessor : ITemplatePreprocessor
 
         engine.SetValue(RequireFuncVariableName, requireAction);
         engineCache[rootPath] = engine;
-        engine.Execute(scriptResource.Content, scriptResource.Path);
+        engine.Execute(Prepare(scriptResource.Path, scriptResource.Content));
 
         var value = engine.GetValue(ExportsVariableName);
         if (value.IsObject())
@@ -186,9 +228,25 @@ public class TemplateJintPreprocessor : ITemplatePreprocessor
         return newEngine;
     }
 
+    /// <summary>
+    /// Parses <paramref name="content"/> once per <paramref name="path"/> and reuses the result. The
+    /// preprocessor pool builds one instance - and therefore one engine - per parallelism slot, and they
+    /// all run the same sources, so without this the template and every module it requires would be
+    /// re-parsed for each slot.
+    /// </summary>
+    private Prepared<Script> Prepare(string path, string content)
+    {
+        return _preparedScripts.GetOrAdd(path, static (source, code) => Jint.Engine.PrepareScript(code, source), content);
+    }
+
     private Jint.Engine CreateDefaultEngine()
     {
-        var engine = new Jint.Engine();
+        // Template scripts come from the docset being built, so a faulty one must fail the document
+        // instead of pinning a render thread. Both limits apply per call into the engine.
+        var engine = new Jint.Engine(options => options
+            .TimeoutInterval(ExecutionTimeout)
+            .MaxStatements(MaxExecutionStatements)
+            .CancellationToken(_cancellationToken));
 
         engine.SetValue(ExportsVariableName, new JsObject(engine));
         engine.SetValue(ConsoleVariableName, ConsoleObject);

--- a/src/Docfx.Build/TemplateProcessors/Template.cs
+++ b/src/Docfx.Build/TemplateProcessors/Template.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
+
 using Docfx.Common;
 using Newtonsoft.Json.Linq;
 
@@ -73,7 +75,62 @@ public class Template
             return null;
         }
 
-        return JObject.FromObject(obj).ToObject<TransformModelOptions>();
+        return ReadOptions(obj);
+    }
+
+    /// <summary>
+    /// Reads the two fields <see cref="TransformModelOptions"/> declares straight off the value the
+    /// preprocessor returned. A script preprocessor hands back a property bag, so serializing it to JSON
+    /// and deserializing it into the options type - once per document, per template - is pure overhead.
+    /// </summary>
+    private static TransformModelOptions ReadOptions(object obj)
+    {
+        if (obj is not IDictionary<string, object> properties)
+        {
+            // A preprocessor that is not script based can return anything; keep converting those.
+            return JObject.FromObject(obj).ToObject<TransformModelOptions>();
+        }
+
+        var result = new TransformModelOptions();
+
+        if (TryGetValue(properties, "isShared", out var isShared) && isShared != null)
+        {
+            result.IsShared = isShared as bool? ?? Convert.ToBoolean(isShared, CultureInfo.InvariantCulture);
+        }
+
+        if (TryGetValue(properties, "bookmarks", out var bookmarks) && bookmarks is IDictionary<string, object> bookmarkProperties)
+        {
+            var map = new Dictionary<string, string>(bookmarkProperties.Count);
+            foreach (var pair in bookmarkProperties)
+            {
+                map[pair.Key] = Convert.ToString(pair.Value, CultureInfo.InvariantCulture);
+            }
+
+            result.Bookmarks = map;
+        }
+
+        return result;
+    }
+
+    private static bool TryGetValue(IDictionary<string, object> properties, string name, out object value)
+    {
+        if (properties.TryGetValue(name, out value))
+        {
+            return true;
+        }
+
+        // The JSON conversion this replaced matched property names case-insensitively.
+        foreach (var pair in properties)
+        {
+            if (string.Equals(pair.Key, name, StringComparison.OrdinalIgnoreCase))
+            {
+                value = pair.Value;
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
     }
 
     /// <summary>

--- a/test/Docfx.Build.Tests/JintProcessorHelperTest.cs
+++ b/test/Docfx.Build.Tests/JintProcessorHelperTest.cs
@@ -31,6 +31,38 @@ public class JintProcessorHelperTest
         }
     }
 
+    /// <summary>
+    /// Jint's default for CLR arrays became a live view in 4.14: script writing to such an array writes
+    /// through to the CLR array itself. This bump crosses that change, and it is inert here only because
+    /// <see cref="JintProcessorHelper.ConvertObjectToJsValue"/> builds every array itself and never hands a
+    /// CLR array to Jint's converter. What keeps that true is that model arrays arrive as
+    /// <c>IList&lt;object&gt;</c> - <c>ConvertToObjectHelper</c> produces <c>object[]</c>, which qualifies -
+    /// so a model conversion that ever yielded a typed array such as <c>int[]</c> would silently start
+    /// handing script a live view onto docfx's own model. The counters make that observable.
+    /// </summary>
+    [Trait("Related", "JintProcessor")]
+    [Fact]
+    public void TestObjectConvertCrossesNoClrArrays()
+    {
+        var engine = new Jint.Engine();
+        var model = ConvertToObjectHelper.ConvertStrongTypeToObject(new TestData());
+
+        engine.SetValue("model", JintProcessorHelper.ConvertObjectToJsValue(engine, model));
+
+        // Read the arrays from script, so a conversion deferred to first access would still be counted.
+        Assert.Equal("ValueA,ValueB", engine.Evaluate("model.ValueList.join(',')").AsString());
+
+        var diagnostics = engine.Advanced.GetInteropConversionDiagnostics();
+        Assert.Equal(0, diagnostics.ArrayLiveViewConversions);
+        Assert.Equal(0, diagnostics.ArrayCopyConversions);
+
+        // Control, so the zeros above cannot pass vacuously: a CLR array that does reach Jint's converter is
+        // counted. Summing the two modes keeps this independent of which one is the current default.
+        engine.SetValue("clrArray", new[] { 1, 2, 3 });
+        var control = engine.Advanced.GetInteropConversionDiagnostics();
+        Assert.Equal(1, control.ArrayLiveViewConversions + control.ArrayCopyConversions);
+    }
+
     [Trait("Related", "JintProcessor")]
     [Fact]
     public void TestObjectConvertKeepsDeclarationOrder()
@@ -72,14 +104,16 @@ public class JintProcessorHelperTest
         Assert.Equal("uid0|uid1|uid2", engine.Evaluate("[model0, model1, model2].map(function (m) { return m.uid; }).join('|')").AsString());
         Assert.True(engine.Evaluate("[model0, model1, model2].every(function (m) { return m.type === 'Class'; })").AsBoolean());
 
-        // The point of building models this way is the shared hidden class, and the conversion falls back to
-        // the ordinary property dictionary silently when it cannot reach it - so assert the optimization
-        // actually happened. GetObjectRepresentation is a diagnostic Jint documents for exactly this, and is
-        // deliberately not part of its compatibility contract: if a future Jint changes what these models get,
-        // this assertion is how docfx finds out.
-        Assert.Equal(
-            ObjectRepresentation.HiddenClass,
-            engine.Advanced.GetObjectRepresentation(engine.Evaluate("model0").AsObject()));
+        // The point of building models this way is that documents of one document type share a hidden class,
+        // and the conversion falls back to a per-object property dictionary silently when it cannot reach one.
+        // HasSharedShape is the predicate Jint documents as stable for exactly this question - "is this
+        // object's own storage a layout shared with its siblings" - and which a host may therefore pin for the
+        // documented success case of the factory it called. If a future change stops these models being
+        // shaped, this is how docfx finds out.
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.True(engine.Advanced.HasSharedShape(engine.Evaluate($"model{i}").AsObject()));
+        }
     }
 
     /// <summary>
@@ -105,7 +139,9 @@ public class JintProcessorHelperTest
         Assert.Equal("one", engine.Evaluate("model['1']").AsString());
         Assert.Equal("n", engine.Evaluate("model.name").AsString());
 
-        // Unlike the HiddenClass assertion above, this one pins a *limitation* rather than a property:
+        // Unlike the HasSharedShape assertion above, this one pins a *limitation* rather than a property, and
+        // deliberately keeps using the finer-grained non-contract diagnostic, because naming the exact
+        // fallback representation is the whole point of the assertion:
         // integer-index-like keys are something today's Jint cannot express in a hidden class, so the
         // conversion falls back. If a future Jint learns to shape them - a pure improvement for docfx - this
         // line will go red on good news, not on a docfx defect. The assertions above it already cover

--- a/test/Docfx.Build.Tests/JintProcessorHelperTest.cs
+++ b/test/Docfx.Build.Tests/JintProcessorHelperTest.cs
@@ -32,6 +32,72 @@ public class JintProcessorHelperTest
     }
 
     [Trait("Related", "JintProcessor")]
+    [Fact]
+    public void TestObjectConvertKeepsDeclarationOrder()
+    {
+        var engine = new Jint.Engine();
+        var model = new Dictionary<string, object>
+        {
+            ["title"] = "Hello",
+            ["nested"] = new Dictionary<string, object> { ["a"] = 1, ["b"] = "two" },
+            ["items"] = new List<object> { "x", "y" },
+        };
+
+        engine.SetValue("model", JintProcessorHelper.ConvertObjectToJsValue(engine, model));
+
+        Assert.Equal("title,nested,items", engine.Evaluate("Object.keys(model).join(',')").AsString());
+        Assert.Equal("Hello", engine.Evaluate("model.title").AsString());
+        Assert.Equal("a,b", engine.Evaluate("Object.keys(model.nested).join(',')").AsString());
+        Assert.Equal("two", engine.Evaluate("model.nested.b").AsString());
+        Assert.Equal("x,y", engine.Evaluate("model.items.join(',')").AsString());
+    }
+
+    /// <summary>
+    /// Documents of one document type share a model layout, which is what the conversion is built around.
+    /// Objects sharing a layout must stay indistinguishable from separately built ones.
+    /// </summary>
+    [Trait("Related", "JintProcessor")]
+    [Fact]
+    public void TestObjectConvertIsStableAcrossModelsOfTheSameShape()
+    {
+        var engine = new Jint.Engine();
+
+        for (var i = 0; i < 3; i++)
+        {
+            var model = new Dictionary<string, object> { ["uid"] = $"uid{i}", ["type"] = "Class" };
+            engine.SetValue($"model{i}", JintProcessorHelper.ConvertObjectToJsValue(engine, model));
+        }
+
+        Assert.Equal("uid,type", engine.Evaluate("Object.keys(model0).join(',')").AsString());
+        Assert.Equal("uid0|uid1|uid2", engine.Evaluate("[model0, model1, model2].map(function (m) { return m.uid; }).join('|')").AsString());
+        Assert.True(engine.Evaluate("[model0, model1, model2].every(function (m) { return m.type === 'Class'; })").AsBoolean());
+    }
+
+    /// <summary>
+    /// Integer-index-like keys cannot be expressed in the layout the conversion targets, so they take a
+    /// fallback path. It has to stay silent and correct.
+    /// </summary>
+    [Trait("Related", "JintProcessor")]
+    [Fact]
+    public void TestObjectConvertWithIntegerLikeKeys()
+    {
+        var engine = new Jint.Engine();
+        var model = new Dictionary<string, object>
+        {
+            ["name"] = "n",
+            ["1"] = "one",
+            ["2"] = "two",
+        };
+
+        engine.SetValue("model", JintProcessorHelper.ConvertObjectToJsValue(engine, model));
+
+        // Integer-like own keys are enumerated first in ascending order, exactly as for an object literal.
+        Assert.Equal("1,2,name", engine.Evaluate("Object.keys(model).join(',')").AsString());
+        Assert.Equal("one", engine.Evaluate("model['1']").AsString());
+        Assert.Equal("n", engine.Evaluate("model.name").AsString());
+    }
+
+    [Trait("Related", "JintProcessor")]
     [Theory]
     [InlineData("string", "string")]
     [InlineData(1, 1.0)]

--- a/test/Docfx.Build.Tests/JintProcessorHelperTest.cs
+++ b/test/Docfx.Build.Tests/JintProcessorHelperTest.cs
@@ -105,6 +105,11 @@ public class JintProcessorHelperTest
         Assert.Equal("one", engine.Evaluate("model['1']").AsString());
         Assert.Equal("n", engine.Evaluate("model.name").AsString());
 
+        // Unlike the HiddenClass assertion above, this one pins a *limitation* rather than a property:
+        // integer-index-like keys are something today's Jint cannot express in a hidden class, so the
+        // conversion falls back. If a future Jint learns to shape them - a pure improvement for docfx - this
+        // line will go red on good news, not on a docfx defect. The assertions above it already cover
+        // correctness; delete this one at that point rather than working around it.
         Assert.Equal(
             ObjectRepresentation.Dictionary,
             engine.Advanced.GetObjectRepresentation(engine.Evaluate("model").AsObject()));

--- a/test/Docfx.Build.Tests/JintProcessorHelperTest.cs
+++ b/test/Docfx.Build.Tests/JintProcessorHelperTest.cs
@@ -71,6 +71,15 @@ public class JintProcessorHelperTest
         Assert.Equal("uid,type", engine.Evaluate("Object.keys(model0).join(',')").AsString());
         Assert.Equal("uid0|uid1|uid2", engine.Evaluate("[model0, model1, model2].map(function (m) { return m.uid; }).join('|')").AsString());
         Assert.True(engine.Evaluate("[model0, model1, model2].every(function (m) { return m.type === 'Class'; })").AsBoolean());
+
+        // The point of building models this way is the shared hidden class, and the conversion falls back to
+        // the ordinary property dictionary silently when it cannot reach it - so assert the optimization
+        // actually happened. GetObjectRepresentation is a diagnostic Jint documents for exactly this, and is
+        // deliberately not part of its compatibility contract: if a future Jint changes what these models get,
+        // this assertion is how docfx finds out.
+        Assert.Equal(
+            ObjectRepresentation.HiddenClass,
+            engine.Advanced.GetObjectRepresentation(engine.Evaluate("model0").AsObject()));
     }
 
     /// <summary>
@@ -95,6 +104,10 @@ public class JintProcessorHelperTest
         Assert.Equal("1,2,name", engine.Evaluate("Object.keys(model).join(',')").AsString());
         Assert.Equal("one", engine.Evaluate("model['1']").AsString());
         Assert.Equal("n", engine.Evaluate("model.name").AsString());
+
+        Assert.Equal(
+            ObjectRepresentation.Dictionary,
+            engine.Advanced.GetObjectRepresentation(engine.Evaluate("model").AsObject()));
     }
 
     [Trait("Related", "JintProcessor")]

--- a/test/Docfx.Build.Tests/TemplatePreprocessorLoaderUnitTest.cs
+++ b/test/Docfx.Build.Tests/TemplatePreprocessorLoaderUnitTest.cs
@@ -34,6 +34,34 @@ public class TemplatePreprocessorLoaderUnitTest : TestBase
         Assert.Equal(input.a, ((dynamic)output).a);
     }
 
+    [Fact]
+    public void TestGetOptionsIsReadFromScriptResult()
+    {
+        using var listener = new TestListenerScope();
+        var preprocessor = Load(
+            "a.ext.TMPL.js",
+            "exports.getOptions = function(model) { return { isShared: true, bookmarks: { uid1: 'bookmark1' } }; }");
+
+        Assert.NotNull(preprocessor);
+        Assert.True(preprocessor.ContainsGetOptions);
+
+        var options = new Template(null, preprocessor).GetOptions(new { a = 1 });
+
+        Assert.NotNull(options);
+        Assert.True(options.IsShared);
+        Assert.Equal("bookmark1", options.Bookmarks["uid1"]);
+    }
+
+    [Fact]
+    public void TestRunawayScriptIsStopped()
+    {
+        using var listener = new TestListenerScope();
+        var preprocessor = Load("a.ext.TMPL.js", "exports.transform = function(model) { var i = 0; while (true) { i = i + 1; } }");
+
+        Assert.NotNull(preprocessor);
+        Assert.Throws<InvalidPreprocessorException>(() => preprocessor.TransformModel(new { a = 1 }));
+    }
+
     private ITemplatePreprocessor Load(string path, string content)
     {
         var loader = new PreprocessorLoader(new LocalFileResourceReader(_inputFolder), null, 64);

--- a/test/Docfx.Build.Tests/TemplatePreprocessorLoaderUnitTest.cs
+++ b/test/Docfx.Build.Tests/TemplatePreprocessorLoaderUnitTest.cs
@@ -1,7 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
+
+using Acornima.Ast;
+
 using Docfx.Tests.Common;
+
+using Jint;
+using Jint.Runtime;
 
 using Xunit;
 
@@ -100,9 +107,83 @@ public class TemplatePreprocessorLoaderUnitTest : TestBase
         Assert.Throws<InvalidPreprocessorException>(() => preprocessor.TransformModel(new { a = 1 }));
     }
 
+    /// <summary>
+    /// A function exported by a <c>require</c>d module belongs to that module's engine, so calling it from
+    /// the template's engine is not a public entry into the module's engine and does not reset the module
+    /// engine's execution constraints. The timeout deadline is armed only on reset, so unless the
+    /// preprocessor resets every engine it owns per call, a pooled preprocessor that has been alive longer
+    /// than the timeout starts every module call against a deadline that has already passed - and fails
+    /// every remaining document of the build.
+    /// </summary>
+    [Fact]
+    public void TestModuleCallIsNotBoundedByAStaleDeadline()
+    {
+        using var listener = new TestListenerScope();
+
+        // Generous enough that a cold CI runner cannot make a single call exceed it - the point of the test
+        // is the deadline going stale between calls, not how long one call takes - while still keeping the
+        // aging sleep below short.
+        var timeout = TimeSpan.FromSeconds(1);
+
+        CreateFile(
+            "mod.js",
+            "exports.value = function() { var s = 0; for (var i = 0; i < 2000; i++) { s = s + i; } return 'module:' + s; };",
+            _inputFolder);
+
+        var preprocessor = LoadWithTimeout(
+            "a.ext.TMPL.js",
+            "var mod = require('./mod.js'); exports.transform = function(model) { return { value: mod.value() }; }",
+            timeout);
+
+        // The first document is inside the window whether or not constraints are reset per call.
+        Assert.Equal("module:1999000", ((dynamic)preprocessor.TransformModel(new { a = 1 })).value);
+
+        // Age the preprocessor past its own timeout, which is what a pooled slot does during a real build.
+        Thread.Sleep(timeout + TimeSpan.FromMilliseconds(500));
+
+        Assert.Equal("module:1999000", ((dynamic)preprocessor.TransformModel(new { a = 1 })).value);
+    }
+
+    /// <summary>
+    /// The other half of the same contract: rearming a module engine's constraints per call must not turn
+    /// into removing them. A runaway loop inside a <c>require</c>d module has to be bounded too, and only
+    /// the module engine's own constraints can bound it - the template engine's are checked only while
+    /// template-engine statements are executing.
+    /// </summary>
+    [Fact]
+    public void TestRunawayScriptInsideModuleIsStopped()
+    {
+        using var listener = new TestListenerScope();
+        CreateFile("mod.js", "exports.value = function() { var i = 0; while (true) { i = i + 1; } };", _inputFolder);
+
+        var preprocessor = LoadWithTimeout(
+            "a.ext.TMPL.js",
+            "var mod = require('./mod.js'); exports.transform = function(model) { return { value: mod.value() }; }",
+            TimeSpan.FromSeconds(1));
+
+        // Which limit fires first is a race decided by machine speed - a fast machine burns the statement
+        // budget inside the timeout window, a slow one runs out of time first - so assert that the runaway
+        // was stopped, not which of the two limits stopped it.
+        var exception = Assert.ThrowsAny<Exception>(() => preprocessor.TransformModel(new { a = 1 }));
+        Assert.True(
+            exception is TimeoutException or StatementsCountOverflowException,
+            $"Expected an execution constraint to stop the module's runaway loop, but got: {exception}");
+    }
+
     private ITemplatePreprocessor Load(string path, string content)
     {
         var loader = new PreprocessorLoader(new LocalFileResourceReader(_inputFolder), null, 64);
         return loader.Load(new ResourceInfo(path, content));
+    }
+
+    private ITemplatePreprocessor LoadWithTimeout(string path, string content, TimeSpan executionTimeout)
+    {
+        return new TemplateJintPreprocessor(
+            new LocalFileResourceReader(_inputFolder),
+            new ResourceInfo(path, content),
+            context: null,
+            name: null,
+            preparedScripts: new ConcurrentDictionary<string, Prepared<Script>>(),
+            executionTimeout: executionTimeout);
     }
 }

--- a/test/Docfx.Build.Tests/TemplatePreprocessorLoaderUnitTest.cs
+++ b/test/Docfx.Build.Tests/TemplatePreprocessorLoaderUnitTest.cs
@@ -52,6 +52,44 @@ public class TemplatePreprocessorLoaderUnitTest : TestBase
         Assert.Equal("bookmark1", options.Bookmarks["uid1"]);
     }
 
+    /// <summary>
+    /// The shipped templates chain <c>require</c> - a primary script requires a common script which requires
+    /// another - and every module gets its own engine, so this covers the whole chain resolving and the
+    /// exported functions still being callable.
+    /// </summary>
+    [Fact]
+    public void TestRequireResolvesChainedModules()
+    {
+        using var listener = new TestListenerScope();
+        CreateFile("inner.js", "exports.value = function() { return 'inner'; };", _inputFolder);
+        CreateFile("outer.js", "var inner = require('./inner.js'); exports.value = function() { return inner.value() + '+outer'; };", _inputFolder);
+
+        var preprocessor = Load(
+            "a.ext.TMPL.js",
+            "var outer = require('./outer.js'); exports.transform = function(model) { return { value: outer.value() }; }");
+
+        Assert.NotNull(preprocessor);
+        Assert.True(preprocessor.ContainsModelTransformation);
+
+        var output = preprocessor.TransformModel(new { a = 1 });
+        Assert.Equal("inner+outer", ((dynamic)output).value);
+    }
+
+    /// <summary>
+    /// <c>console</c> is registered lazily, so it is only built for engines whose script mentions it. Reading
+    /// the name has to be indistinguishable from an eagerly registered global.
+    /// </summary>
+    [Fact]
+    public void TestConsoleIsAvailableToScripts()
+    {
+        using var listener = new TestListenerScope();
+        var preprocessor = Load("a.ext.TMPL.js", "exports.transform = function(model) { console.warn('from template'); return model; }");
+
+        preprocessor.TransformModel(new { a = 1 });
+
+        Assert.Contains(listener.Items, i => i.Message == "from template");
+    }
+
     [Fact]
     public void TestRunawayScriptIsStopped()
     {


### PR DESCRIPTION
docfx's Jint usage lives in three files under `src/Docfx.Build/TemplateProcessors/Preprocessors/`, plus one drive-by in `Template.cs`. This PR bumps Jint **4.6.1 → 4.15.3** and reworks that usage against the embedding surface 4.15 added.

> **Jint 4.15.3 is released and on nuget.org.** A 4.15 pin is required, not optional: `JsObject.CreateFromEntries` and `Options.AddLazyGlobal` do not exist before 4.15.0, `Engine.Advanced.GetInteropConversionDiagnostics` not before 4.15.1, and `Engine.Advanced.HasSharedShape` not before 4.15.3.

The version jump itself is large — 4.6.1 is from ~2026-03 — and carries a lot of interop and interpreter work plus spec-conformance fixes that docfx gets for free. Some of it is directly relevant to how docfx uses Jint: resolved CLR members are now cached process-wide on the shared `TypeResolver` rather than per engine, CLR property/field access is compiled instead of reflected per hit, and host delegates no longer re-reflect their parameter metadata on every call. That last one is what `require` and the `console` / `templateUtility` members were paying.

---

### 1. Build model objects in Jint's hidden-class representation

`JintProcessorHelper.ConvertObjectToJsValue` built every model object with a `jsObject.FastSetDataProperty(...)` loop. Despite the name that is not the fast way to project host data into a new object: it stores a raw `PropertyDescriptor`, which is a dictionary-mode operation, so each model gets a property dictionary and a descriptor per property, and the object permanently forfeits Jint's shape (hidden class) inline cache.

`JsObject.CreateFromEntries` drives the incremental hidden-class path instead. This matters specifically for docfx because **every document of a given document type is handed to the template with the same model layout**, so repeated calls presenting the same key sequence intern and share one shape — which is what keeps the property reads in `transform`/`getOptions` monomorphic across a whole docset rather than megamorphic.

The `IEnumerable<KeyValuePair<...>>` overload is used deliberately: the source is an `IDictionary` that cannot be viewed as a span, and materialising a temporary array of the model's size just to call the span overload would cost the very allocation the shaped representation saves. The entries are streamed through a local iterator and walked exactly once.

Key sets the representation cannot express — integer-index-like keys, objects past the shape property cap, excessive layout fan-out — fall back to the ordinary dictionary representation mid-build, silently and correctly. That fallback is exercised by the existing `TestJObjectConvertWithJToken` test (its `ValueDict` is keyed `"1"` / `"key"`) and by a new test that pins the resulting own-key order.

Because the fallback is silent, the tests assert it directly. The claim this rests on is not merely that a model is *shaped* but that documents of one type **share** a layout, and `Engine.Advanced.HasSharedShape` (4.15.3) is documented as the stable predicate for exactly that question — one a host may pin for the documented success case of the factory it called. The positive assertion uses it. The integer-index-like fallback keeps the finer-grained `GetObjectRepresentation`, which is deliberately *not* a compatibility contract, because naming the exact fallback representation is that assertion's whole point; it is annotated as expected to go red on a future Jint that learns to shape such keys — good news arriving as a red test, not a docfx defect.

**One behavioural risk the version jump carries, now pinned.** Jint's default for CLR arrays became a *live view* in 4.14 — script writing to such an array writes through to the CLR array itself — and this bump crosses that change. It is inert for docfx only because `ConvertObjectToJsValue` builds every array itself, via the `JsArray` ownership-transfer constructor, and never hands a CLR array to Jint's converter. What keeps that true is narrow: model arrays arrive as `IList<object>` (`ConvertToObjectHelper` produces `object[]`, which qualifies), so a model conversion that ever yielded a typed array such as `int[]` would fall through and start handing script a live view onto docfx's own model object. 4.15.1's `Engine.Advanced.GetInteropConversionDiagnostics` makes that observable, and a new test asserts a representative model crosses **zero** CLR arrays under either mode — with a control line proving the counters are live rather than vacuously zero.

### 2. Prepare template scripts once instead of once per pool slot

Template sources and `require`d module sources were executed from text via `engine.Execute(source, path)`. `PreprocessorWithResourcePool` creates one preprocessor — and therefore one engine — per parallelism slot, so that was P parses of the template plus P parses of every module it requires.

They are now parsed once through `Engine.PrepareScript` and shared across the pool: a `Prepared<Script>` is immutable and documented as reusable and thread-safe, and Jint re-derives any per-node cached state when a prepared script runs against a different realm. Preparation also attaches static analysis data and constant folding, so the shared copy executes slightly faster too.

The cache is per template (created in `PreprocessorLoader.Load` and handed to each pooled instance), keyed by resource path — no process-wide static state, nothing that outlives a build. The existing public `TemplateJintPreprocessor` constructor is unchanged; an `internal` overload takes the shared cache.

### 3. Give the preprocessor engines execution constraints

`CreateDefaultEngine` called `new Jint.Engine()` with no options at all — no timeout, no statement limit, no cancellation. A `while (true) {}` in a `.tmpl.js` from the docset being built would pin a render thread for the lifetime of the process.

Every engine the preprocessor owns now registers a 30 s timeout, a 50,000,000 statement budget, and the build's `CancellationToken` (reachable via `DocumentBuildContext`, and correctly absent when there is no context). `TemplateJintPreprocessor` resets them all at the top of `GetOptions`/`TransformModel`, so they bound **one document** rather than the lifetime of a pooled preprocessor.

That reset is not optional, and getting it wrong is not a subtle inefficiency — it is a build-breaking bug, so it is worth stating why. Jint resets an engine's constraints when the engine is entered through a public API such as `Engine.Invoke`, and that covers the template's own engine. It does not cover the engines `require` builds: a module's exported function belongs to the module's engine, so `common.transform(model)` is an ordinary function call that charges the *module* engine's constraint instances without passing through any entry point that resets them. A timeout deadline is armed only on reset and a statement counter is only cleared on reset, so without an explicit reset a module engine would carry a deadline fixed at preprocessor construction — meaning every document handled by a pool slot older than 30 s would fail with a spurious `TimeoutException` — and a statement budget spanning the whole build. Two tests pin both directions: a module call still succeeds after the preprocessor has been aged past its own timeout, and a runaway loop *inside* a module is still stopped (which is why the constraints stay registered on module engines rather than being dropped from them).

The sample docsets keep every pool slot's active phase well under 30 s, so this failure mode is structurally invisible to the snapshot suite; the tests above are what cover it.

The values are deliberately real numbers: Jint treats saturated values (`MaxStatements(int.MaxValue)`, `TimeoutInterval(TimeSpan.MaxValue)`) as "remove the constraint", so spelling "effectively unlimited" that way would silently produce an engine with *no* limit. The statement budget is orders of magnitude above what transforming even a very large model costs; a runaway loop hits it in about a second.

On cost: the timeout and cancellation constraints are amortized (checked at a bounded cadence, not per statement). The statement counter is exact, but because it is the *only* exact constraint registered here Jint charges it inline rather than disarming the interpreter's tight-loop lanes, so ordinary template execution is not slowed by having it. If you would rather not carry a statement budget at all, dropping that one line leaves the timeout doing the same job less deterministically.

A new test asserts that a runaway `transform` fails the document instead of hanging.

### 4. Register `require` per engine instead of copying a function object between engines

`require` gives every module its own `Engine`, and built it with `CreateEngine(engine, RequireFuncVariableName)` — which read the `require` function *out of one engine* and installed that same `JsValue` into another. A `JsValue` that is an `ObjectInstance` holds a hard reference to the engine and realm that created it; passing one to a different engine is not a supported arrangement in Jint, and is neither validated nor made safe. It happened to work because a `DelegateWrapper` mostly just forwards to its CLR delegate.

Each engine now registers `require` from the CLR delegate itself. Same delegate, same module cache, same resolution — only without a value crossing an engine boundary. `CreateEngine` is gone.

This does not finish the job: the module's `exports` object is still created in the module's engine and returned into the engine that called `require`, and the shipped templates then call functions off it — `ManagedReference.html.primary.js` does `overwrite.transform(model)` on a function that belongs to a different engine. Removing that needs the CommonJS wrapper-function change described under *Follow-up*, which is an observable semantic change and belongs in its own PR. This change removes the half that can be removed without one.

Two notes on what remains. First, the *value* side of that crossing does hold together under 4.15: the member inline caches key on tokens carried by the object (shape identity, properties version) rather than on the reading engine, mutations route through the object's own engine, and the shared `TypeResolver` cache is keyed by interop profile, which both engines share. What does **not** cross safely is execution-scoped state, and this PR introduces exactly that — which is why §3's reset has to walk every engine rather than relying on the entry point. Second, one small behaviour change falls out of registering `require` from the delegate: a module engine's `require` is now `NonEnumerable`, where copying the `JsValue` previously made it enumerable. It is observable only to a module script enumerating its own globals, no shipped template does, and the root and module engines now agree — but it is a behaviour change, so it is recorded rather than left implicit.

### 5. Register `console` and `templateUtility` lazily

`Options.AddLazyGlobal` defers building a global until a script reads the name. Most template scripts never mention `console` or `templateUtility`, and engines are not scarce in this design: the preprocessor pool builds one per parallelism slot and `require` builds one more per module — a bundle with 5 shared modules at `MaxParallelism` 16 is 96 engines.

The flags match: `AddLazyGlobal`'s default is the configurable/enumerable/writable combination `SetValue(string, object)` produces, which is what these two used. `exports` stays eager, because it is read back off the engine after the script runs whether or not the script ever mentioned the name.

### 6. Drop the Newtonsoft round trip in `Template.GetOptions`

`GetOptions` did `JObject.FromObject(obj).ToObject<TransformModelOptions>()` — once per document, per template — to read two fields off a value the script engine already handed back as a property bag. It now reads `isShared` and `bookmarks` directly, matching names case-insensitively as the converter did. Anything that is not a property bag (a preprocessor that is not script based) still goes through the converter, so nothing that worked before stops working.

---

### Jint 4.15 feature audit

Everything 4.15.0, 4.15.1 and 4.15.3 added that could plausibly apply here, and what was done with it. 4.15.2 is absent because it adds no API — it was a fix release (async/generator suspension state, bound-of-bound functions, inherited-accessor receivers, a built-in shape probe fast-miss). The version notes name the release each item landed in, not the pin.

| Feature | Verdict | Why |
|---|---|---|
| `JsObject.CreateFromEntries` | **Adopted** | §1 — the model marshal is the one place docfx builds a fresh object per document. |
| `Engine.Advanced.HasSharedShape` *(4.15.3)* | **Adopted** (tests only) | §1 — the contract-stable predicate for "do these models share a layout", which is the property the PR's design rests on. Replaces the non-contract enum for the positive assertion. |
| `Engine.Advanced.GetObjectRepresentation` | **Adopted** (tests only) | §1 — retained only for the *negative* case, where naming the exact fallback representation is the point. Not used in production code; explicitly not a compatibility contract. |
| `AppContext` switch `Jint.EnableHostContractVerification` *(4.15.3)* | Declined | Every verifier it enables is gated on a host extension point — `TryGetOwnPropertyValue` (`OwnValueHook`), the built-in-shape probe, an `Ordinary` semantics claim, `ArrayLikeObject.HasIndex` — and docfx implements none of them; its models are plain engine-owned objects with no host contract to contradict. Enabling it would verify nothing while reading to a future maintainer as though it did. Worth adding the day docfx gains its first host object. |
| `Engine.Advanced.AddLazyGlobal` (post-construction) *(4.15.3)* | Declined | docfx's only post-construction global is `require`, which is the one nearly every shipped template does use, so deferring it would rarely pay; the two that genuinely often go untouched, `console` and `templateUtility`, are already deferred through the options-time API. |
| `Options.AddImmutableCrossing` *(4.15.3)* | Declined | It memoizes reads through `ObjectWrapper`, and docfx's hot traffic — the models — deliberately does not cross as wrappers at all. The only wrapped objects are `console` and `templateUtility`, read a handful of times per document at most and now lazy besides, and declaring compiler-generated anonymous types by runtime `GetType()` would be a fragile registration for that. |
| `PropertyDescriptor` `CreateLazy` *(4.15.3)* | Declined | docfx constructs no `PropertyDescriptor`s; it hands Jint values, not descriptors. |
| `Engine.Advanced.WithRestoredGlobals` *(4.15.3)* | Declined | An ergonomic scope around capture/restore, which docfx declined on its merits below — there is no per-document global state to clear, so a nicer wrapper around it changes nothing. |
| `Options.AddLazyGlobal` | **Adopted** | §5. |
| `Engine.Advanced.GetInteropConversionDiagnostics` *(4.15.1)* | **Adopted** (tests only) | §1 — pins that the model marshal crosses no CLR array, so the live-view default this bump inherits from 4.14 cannot reach docfx's own model objects. Diagnostic only, never branched on. |
| "values do not cross engines" (newly documented rule) | **Partly adopted** | §4 — the `require` function no longer crosses; the module `exports` object still does, pending the follow-up. |
| Interop and interpreter work: shared `TypeResolver` member cache, compiled property/field access, delegate metadata caching, built-in fast-call lane, constraints no longer disarming the tight-loop lane | **Adopted implicitly** | Arrives with the bump, no code change. It is also what makes `console` / `templateUtility` / `require` cheap enough that reworking them by hand is not worth it — see `JsObjectShape` below. |
| `JsObjectLayout` + `JsObject.Create` | Skipped | Stronger than `CreateFromEntries` *when the key set is known before the loop*. docfx's is not: the model arrives as an `IDictionary` whose keys are data-driven, so a layout could only be found by a lookup keyed on the very key sequence you would have to walk to build it, and the values would have to be materialised into an array first. `CreateFromEntries` interns the same shape across documents by transition, without either cost. |
| `JsObjectLayout.CreateBuilder().AddLazy(...)` — lazy slots *(4.15.1)* | Skipped | Re-checked, because a deferral opportunity does exist in principle: `ConvertObjectToJsValue` recurses eagerly over the whole model graph, so a template reading only part of a large model pays for the rest. But lazy slots are declarable only on a layout, and Jint states the boundary directly — "`CreateFromEntries` is deliberately not extended: lazy members are declared on a layout, and a runtime key set has nowhere to declare them." docfx's key sets are runtime-derived, so the factory it can use is precisely the one that cannot carry lazy slots. Worth noting the value would be limited anyway: the CLR-side values are already materialised before Jint sees them, so a factory could only defer the *conversion*, and the shipped templates iterate `model.children` — the large part — on every document. |
| `JsObjectShape` | Skipped | Would replace the reflected anonymous objects behind `console` / `templateUtility`. Three reasons not to: a shape's `Method` delegates take `JsValue` arguments, so converting would change host-boundary argument coercion on a surface third-party templates depend on; `templateUtility` closes over per-build state and so cannot be the process-shared `static readonly` shape the API targets; and the per-call reflection that motivated the idea is already gone with the bump. |
| `Engine.Advanced.CaptureGlobalSnapshot` / `RestoreGlobalSnapshot` | Skipped | Jint positions it as a configuration-reuse primitive for hosts that need a clean global per evaluation. docfx needs the opposite: nothing is re-registered per document — the model crosses as a *function argument* — and the global surface is set up once per engine and then deliberately persists for the whole build. There is no per-document global state to clear, so restoring between documents would buy nothing and only add a way to lose state the templates rely on. |
| `Prepared<T>.ReferencedGlobals` | Skipped | Aimed at hosts whose ambient API is large and whose CLR-side construction is the expensive part. docfx's is three names — two of which §5 now defers anyway, and the third is a single delegate wrapper. It would also not be a sufficient input on its own, since `require` has to be installed on every module engine transitively. |
| `JsonParser.Parse(ReadOnlySpan<char>)` / `(ReadOnlySpan<byte>)`, `JsonSerializer.Serialize(…, IBufferWriter<byte>)` | Skipped | No JSON crosses the boundary. Models cross as object graphs, and the `transform` result feeds the Mustache renderer, not a serializer. 4.15.1's added docs reinforce the skip rather than change it: an `IBufferWriter` caller who wants a string re-pays the transcode the overload exists to avoid, and the string overloads return `JsValue.Undefined` for a value with no JSON representation — so `Serialize(v).ToString()` would silently yield the literal text `"undefined"`. Neither trap is reachable from here. |
| `Engine.Advanced.GetPropertyAccessSemantics` *(4.15.1)* | Not applicable | Lets a test observe the semantics the engine derived for a *host* type. docfx defines none. |
| `PropertyFlag.NonWritable` / `OnlyConfigurable` *(4.15.1)* | Not applicable | Additive names for two combinations; nothing renamed. docfx spells no flags — `AddLazyGlobal` is taken at its default, which remains `ConfigurableEnumerableWritable`, the combination `SetValue(string, object)` produces. |
| `ObjectInstance.GetOwnProperties` routing docs *(4.15.1)* | Nothing to reconcile | The new remarks warn that a host overriding only `GetOwnProperties` ships keys no script-visible enumeration can see. docfx overrides nothing, so the gotcha cannot bite; the method is on its path only as a *caller* (CLR conversion, i.e. the `ToObject()` on every transform result), which is unchanged. |
| `ArrayLikeObject` | Skipped | For *live* indexed collections. docfx's model arrays are snapshots, and copying a snapshot into a `JsArray` once — which `ConvertObjectToJsValue` already does, using the ownership-transfer constructor — is what that API's own guidance recommends instead. |
| `AddObjectConverter(converter, params Type[])` | Not applicable | docfx registers no object converters. |
| `Options.Interop.EnumConversion` / `EnumConversionMode` | Not applicable | No CLR enums cross the boundary. |
| `NullPropagatingReferenceResolver` + `ReferenceResolverInterests` | Skipped | Would turn a `TypeError` on a nullish base into `undefined` for every template in the ecosystem. That is a language-semantics change for third-party template authors, not an optimization. |
| Host-object hooks: `PropertyAccessSemantics`, `TryGetOwnPropertyValue`, `ProbeOwnProperty`, `JsObjectShape.SetHostState` | Not applicable | docfx defines no `ObjectInstance` subclass, and no custom Jint type at all. |

---

### Not done here — follow-up

`require` still creates a **whole extra `Engine` per module**, and the module's `exports` object — created in the module's engine — is still returned into the calling engine's script, which then calls functions off it. §4 removed the other half of that (the `require` function object no longer crosses), but the object graph still does.

The conventional CommonJS shim — wrapping the module source in `(function (exports, require, module) { ... })` and executing it in the *same* engine, with the exports object cached before the body runs so the existing "unfinished copy" cycle behaviour is preserved — would remove both the extra engines and the remaining cross-engine values. It is left out of this PR because it is an observable semantic change (module code would see the host engine's globals, and reassigning `exports` rather than mutating it would behave differently), which deserves its own PR and its own discussion.

### Measured effect

BenchmarkDotNet, default job, `[MemoryDiagnoser]`, .NET 10.0.10, x64. 64 ManagedReference-shaped models per operation through `TemplateJintPreprocessor.TransformModel` — a deep marshal in, the JS call, and a deep unmarshal back out, once per document. **BEFORE** is this PR's merge base (`2a436495ed`, Jint 4.6.1); **AFTER** is the PR tip (Jint 4.15.1). Both sides ran back to back on an otherwise idle machine from identical harness sources.

| Lane | BEFORE | AFTER | Time | Allocated |
|---|---|---|---|---|
| transform, self-contained template | 2.078 ms · 3.09 MB | 1.990 ms · 2.75 MB | **−4.2 %** | **−11.0 %** |
| transform, through a `require`d module | 2.118 ms · 3.10 MB | 1.989 ms · 2.76 MB | **−6.2 %** | **−11.0 %** |

The pin has since moved to 4.15.3; the table above was measured at 4.15.1 and has not been re-run, since neither later release changes a default execution path (4.15.2 was fixes, 4.15.3 additive API) and re-measuring would only add noise.

StdDev was ≈0.6 % of the mean on every row, so the time deltas are several times the run-to-run spread; the allocation figures are deterministic. Gen1 collections roughly halved (15.6 → 7.8 per 1 000 ops on the first lane, 19.5 → 7.8 on the second), which is the property-descriptor-per-property churn going away.

Four honesty notes:

- **This delta conflates two things.** BEFORE is the merge base, so it carries Jint **4.6.1**; the measurement is "what merging this PR does", not "what `CreateFromEntries` does". Four minor versions of engine and interop work are in the same number, and none of it is separated out here.
- **The `require` lane exists for fairness, not decoration.** §3's constraint reset is per-call work proportional to the number of engines a preprocessor owns, and a template with no modules owns exactly one — the cheapest possible case for the AFTER side. Every shipped template uses `require`, so that lane is the representative one. It is also where the older arrangement was relatively worse: BEFORE, adding a module cost ~2 % (2.078 → 2.118 ms) because the module engine re-parsed its own source and a function object was copied across the engine boundary; AFTER, the two lanes are indistinguishable.
- **§2's win is not in these numbers.** Sharing one `Prepared<Script>` across a pool is a *construction*-time effect that only materialises across concurrent pool rents, which is not what this benchmark exercises. Treat §2 as unmeasured here rather than as measured-and-small.
- **The harness is local and deliberately not part of this repository** — docfx has no benchmark project, and adding one for a single review is not a change worth carrying. It uses only docfx's public API so the identical source compiles against both sides.

### Verification

- Full solution, Release: builds clean, 0 warnings, against Jint 4.15.3 restored from nuget.org. Package provenance checked: the nuspec in `jint.4.15.3.nupkg` records `commit="a304aa5dac…"`, which is what the `v4.15.3` tag on `sebastienros/jint` points at.
- `Docfx.Build.Tests`, Release, `net10.0`: green (119 passed). Ten new tests cover this area — own-key order and nesting; zero CLR arrays crossing the model marshal, with a live-counter control; models sharing a layout, plus the hidden-class representation; the integer-index-like key fallback, plus the dictionary representation; `getOptions` reading; a chained `require` (a template requiring a module that itself requires another, which is the shipped-template pattern); `console` reaching the logger through the lazy global; the runaway-script guard; a module call surviving a preprocessor aged past its own timeout; and a runaway loop *inside* a module still being stopped. The last two were written red first — before the per-call reset, the aged-preprocessor test fails with `TimeoutException` thrown from `TimeConstraint.Check()` inside the module function's loop.
- `Docfx.Build.Tests` is granted `InternalsVisibleTo` (following `Docfx.Build.Common.Tests`, already in that list) so the two constraint tests can construct a preprocessor with a short timeout instead of sleeping for 30 s. The timeout is an optional parameter on the existing `internal` constructor; the public constructor and the default are unchanged.
- `docfx.Snapshot.Tests` is the important gate for a change to model marshalling and to `require`, since it renders the shipped templates — `require` chains and all — over the sample docsets. Because those tests `AutoVerify` locally, the suite was run repeatedly on the same machine, with and without the changes, and the resulting verified trees compared by content hash: **784 of 785 rendered snapshots are byte-identical across every pair**. The one exception, `BuildFromProject.SourceGenerator.html.view.verified.json`, carries git-remote and absolute-path detection that varies between runs; re-running at *unchanged* source reproduced both of its observed contents, so the variation is environmental rather than behavioural. (Comparing against the committed baseline instead is not meaningful — a local run legitimately differs from the CI-produced files in `_key` / `_tocKey` paths, which is why the comparison is run-to-run.) The suite's blind spot is anything depending on wall clock or cumulative scale, which is exactly the constraint-reset failure mode above; the two unit tests cover that instead. It was re-run for the 4.15.1 and 4.15.2 pin moves — both trees byte-identical to their predecessor. 4.15.2 earned its run because two of its fixes changed existing property read and probe lanes and docfx's models are shape-mode receivers read on every document. 4.15.3 was not re-run, and deliberately so: all seven of its commits are additive API or documentation, every new behaviour is opt-in, and none of them alters an execution path docfx is already on.
- **The two red checks on this PR are pre-existing and unrelated — neither is caused by these changes.**
  - **Lint** (`dotnet format --no-restore --verify-no-changes`) fails on `test/Docfx.Dotnet.Tests/SymbolUrlResolverUnitTest.cs(5,1): IDE0005`. A clean worktree of `main` at this PR's merge base reproduces it exactly, and PRs #11081, #11080, #11077 and #11073 all fail Lint the same way. `Docfx.Dotnet.Tests` references only `Docfx.Dotnet`, neither of which this PR touches; `dotnet format --verify-no-changes` on the two projects it *does* touch exits 0. The repo pins no `global.json`, so this looks like SDK/analyzer drift on the runner image. Left out of this PR deliberately rather than smuggled in; it is sent separately as #11085, which turns the whole-solution `dotnet format --verify-no-changes` green again. This PR's Lint check should pass once that merges.
  - **test (macos-latest)** fails only on `XRefArchiveBuilderTest.TestDownload`, which downloads `http://dotnet.github.io/docfx/xrefmap.yml` — a network flake. Every new test in this PR passed on that runner (`Docfx.Build.Tests` reported 117 passed / 1 failed / 3 skipped of 121, the one failure being `TestDownload`), and `docfx.Snapshot.Tests` was green there.
- The other build/template test projects are green too: `Docfx.Build.ManagedReference.Tests`, `Docfx.Build.RestApi.Tests`, `Docfx.Build.RestApi.WithPlugins.Tests`, `Docfx.Build.SchemaDriven.Tests`, `Docfx.Build.UniversalReference.Tests`, `Docfx.Build.OverwriteDocuments.Tests`, `Docfx.Build.Common.Tests`, and `docfx.Tests` (115/115).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uV6H9cTntzsoKiaJRBn4f
