### PR TITLE
chore: remove unnecessary using to fix the Lint check

### DIFF
--- a/test/Docfx.Dotnet.Tests/SymbolUrlResolverUnitTest.cs
+++ b/test/Docfx.Dotnet.Tests/SymbolUrlResolverUnitTest.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.RegularExpressions;
-using Microsoft.CodeAnalysis;
 using Xunit;
 
 namespace Docfx.Dotnet.Tests;


### PR DESCRIPTION
The **Lint** check (`dotnet format --no-restore --verify-no-changes`) is currently failing on `main` and therefore on every open pull request. This removes the one directive it flags.

```
test/Docfx.Dotnet.Tests/SymbolUrlResolverUnitTest.cs(5,1): warning IDE0005: Using directive is unnecessary.
```

### Why the directive is genuinely unnecessary

No name written in that file resolves through `Microsoft.CodeAnalysis`. The symbol types only ever appear bound to `var` — `CompilationHelper.CreateCompilationFromAssembly` is deconstructed into `var (compilation, assembly)`, and everything afterwards (`assembly.GetTypeByMetadataName`, `type.GetMembers`) is an instance member call, which needs no using. The file compiles unchanged without it.

### Evidence that this is pre-existing rather than PR-specific

- A clean worktree of `main` at `2a436495ed` reproduces the failure exactly: `dotnet format --no-restore --verify-no-changes` exits 2 with that single warning and nothing else.
- The same failure is on #11081, #11080, #11077 and #11073 — the file belongs to `Docfx.Dotnet.Tests`, which none of them touch.
- An older PR, #11074, passed Lint, so the diagnostic started appearing at some point independent of any change in the repository.

### Verification

- `dotnet format --no-restore --verify-no-changes` — the exact CI command — now exits **0** across the whole solution.
- `Docfx.Dotnet.Tests`, Release, `net10.0`: 172/172 passing, 0 build warnings.

### A durable fix worth considering separately

The repository pins no `global.json`, so the analyzer set is whatever SDK the runner image happens to ship. IDE0005's analysis got stricter in a newer Roslyn and the check went red without anything in the repository changing — which is a failure mode that will recur on the next image bump. Pinning an SDK version in `global.json` (with `rollForward` set to taste) would make the lint result reproducible rather than dependent on runner timing. I have left that out of this PR, since removing the directive is what unblocks CI today and the pin is a separate decision for you to make.
