### PR TITLE
Qualify UIDs by assembly to disambiguate shared namespaces

### DIFF
--- a/docs/docs/dotnet-api-docs.md
+++ b/docs/docs/dotnet-api-docs.md
@@ -112,6 +112,209 @@ When the file extension is `.cs` or `.vb`, docfx uses the latest supported .NET 
 }
 ```
 
+## Assemblies that share namespaces
+
+A UID, the identifier docfx uses to address an API, is derived from the fully qualified name of the API
+alone. When a single docfx project documents several assemblies that declare the same namespace, their
+APIs therefore end up with the same UID: pages overwrite each other, `DuplicateUids` warnings are
+reported, and every link to a shared namespace resolves to whichever assembly happened to win.
+
+This is common when shipping platform or version specific packages that intentionally expose the same
+API surface, for example `MyLib.Ef8` and `MyLib.Ef9`.
+
+### Put the assembly in the UID
+
+[`assemblyUids`](../reference/docfx-json-reference.md#assemblyuids) lists the assemblies whose APIs carry
+the assembly they are declared in as a component of their UID, separated from the rest by `::`. It sits at
+the top level of `docfx.json`, next to `metadata` rather than inside it, and covers every `src` entry of
+the project:
+
+```json
+{
+  "assemblyUids": [ "MyLib", "MyLib.Ef8", "MyLib.Ef9" ],
+  "metadata": [
+    { "src": [ "src/MyLib/MyLib.csproj" ],         "dest": "api/core" },
+    { "src": [ "src/MyLib.Ef8/MyLib.Ef8.csproj" ], "dest": "api/ef8" },
+    { "src": [ "src/MyLib.Ef9/MyLib.Ef9.csproj" ], "dest": "api/ef9" }
+  ]
+}
+```
+
+`MyLib.Widget` becomes `MyLib::MyLib.Widget`, `MyLib.Ef8::MyLib.Widget` and `MyLib.Ef9::MyLib.Widget`, so
+each keeps its own page, and `<see cref="..."/>` links and the table of contents follow. Everything
+displayed keeps naming the namespace as it is declared — `MyLib` stays `MyLib`, not
+`MyLib.Ef8.MyLib` — because the assembly is a component of the identity, not a namespace segment. How the
+assembly itself is shown is up to [`assemblyLabel`](#showing-which-assembly-a-namespace-comes-from).
+
+Give an assembly a shorter component by naming it explicitly, in which case the whole setting is an object
+instead of an array:
+
+```json
+{
+  "assemblyUids": {
+    "MyLib": null,
+    "MyLib.Ef8": "Ef8",
+    "MyLib.Ef9": "Ef9"
+  }
+}
+```
+
+`null` means the assembly's own name, so this yields `MyLib::MyLib.Widget` and `Ef8::MyLib.Widget`. A
+component may contain letters, digits, underscores and dashes, separated by dots.
+
+It is a project level setting because it has to be. An entry mints UIDs not only for the APIs it
+documents but also for the APIs it *references*: the `MyLib.Ef8` entry emits reference UIDs for the
+`MyLib` types that appear in its own signatures, and those must come out identical to the UIDs the
+`MyLib` entry produced. If each entry carried its own list, an entry could not see the others' and those
+references would come out unqualified, point at UIDs no page has, and **render as plain text with no link
+and no warning**.
+
+The practical consequence: **list every assembly whose APIs appear in another assembly's public
+signatures**, not just the ones you want split up. Leaving out a referenced assembly does not fail the
+build, it quietly drops links to it.
+
+### Showing which assembly a namespace comes from
+
+When two assemblies declare the same namespace, its pages need to say which one they belong to.
+[`assemblyLabel`](../reference/docfx-json-reference.md#assemblylabel), set per `metadata` entry, decides
+how:
+
+| value | what a namespace looks like |
+|---|---|
+| `auto` (default) | `suffix` with `"namespaceLayout": "flattened"`, `none` with `"nested"` |
+| `suffix` | `MyLib (MyLib.Ef8)` — the assembly is appended to the label and the page title |
+| `none` | `MyLib` — the namespace alone |
+| `page` | `MyLib`, with `Assembly: MyLib.Ef8.dll` named on the page, the way type pages do |
+
+With `"namespaceLayout": "nested"` the namespaces of each qualified assembly are grouped under a node
+naming that assembly, so the assembly is already visible and `auto` leaves the labels alone. That node has
+no page of its own. A flattened layout has nothing else to tell two assemblies apart, so `auto` appends
+the assembly to the label there.
+
+> [!NOTE]
+> With `"outputFormat": "apiPage"` or `"markdown"` this only affects the table of contents. Those formats
+> title a page from the symbol itself, so `suffix` does not reach the title and `page` has nowhere to name
+> the assembly.
+
+Authored links name the UID, so they name the assembly and the namespace as they really are:
+
+```md
+<xref:MyLib.Ef8::MyLib.Widget>
+@MyLib.Ef8::MyLib.Widget
+[the Ef8 widget](xref:MyLib.Ef8::MyLib.Widget)
+```
+
+### When several entries build the same assembly name
+
+Version specific packages are often *one* project built several times, sharing an `AssemblyName` and
+differing only by target framework. Qualifying by assembly name cannot tell those apart, so those entries
+use [`assemblyUidOverride`](../reference/docfx-json-reference.md#assemblyuidoverride), which names the
+entry instead:
+
+```json
+{
+  "assemblyUids": [ "MyLib" ],
+  "metadata": [
+    {
+      "src": [ "src/MyLib/MyLib.csproj" ],
+      "dest": "api/core"
+    },
+    {
+      "src": [ "src/MyLib.Ef/MyLib.Ef.Ef8.csproj" ],
+      "dest": "api/ef8",
+      "assemblyUidOverride": "Ef8"
+    },
+    {
+      "src": [ "src/MyLib.Ef/MyLib.Ef.Ef9.csproj" ],
+      "dest": "api/ef9",
+      "assemblyUidOverride": "Ef9"
+    }
+  ]
+}
+```
+
+Both `MyLib.Ef` projects build `MyLib.Ef.dll`. `assemblyUidOverride` separates them, and `MyLib` stays in
+`assemblyUids` because both of them reference it.
+
+#### What the override does and does not fix
+
+It fixes the collision *between the entries that declare it*: each gets its own pages, table of contents
+entries and file names, and everything inside those pages — references, `<see cref="..."/>` links, member
+anchors — is consistent with them.
+
+It does not fix two things, both following from the fact that it names an entry rather than an assembly:
+
+- **Links from other entries into those assemblies.** A fourth entry referencing `MyLib.Ef.dll` has no
+  way to know whether you meant `Ef8` or `Ef9`. Those references come out unqualified and lose their links,
+  with no warning. Fix this by
+  [nominating a default version](#nominate-a-default-version-for-links-from-elsewhere).
+- **Two same-named assemblies inside *one* entry.** Every assembly an entry documents gets the same
+  component, so if one entry's `src` glob matches the same assembly built for several target frameworks,
+  those copies still collide and are reported as `Ignore duplicated member`. The fix there is to narrow
+  the glob to one target framework.
+
+### Nominate a default version for links from elsewhere
+
+If anything else in the project references an assembly that several entries document, one of those
+versions has to be the target its links point at. Nominate it by giving the assembly that version's
+component in `assemblyUids` — **in addition to** the `assemblyUidOverride` on each entry, not instead of
+it:
+
+```json
+{
+  "assemblyUids": {
+    "MyLib": null,
+    "MyLib.Ef": "Ef9"
+  },
+  "metadata": [
+    { "src": [ "src/MyLib/MyLib.csproj" ],           "dest": "api/core" },
+    { "src": [ "src/MyLib.Ef/MyLib.Ef.Ef8.csproj" ], "dest": "api/ef8", "assemblyUidOverride": "Ef8" },
+    { "src": [ "src/MyLib.Ef/MyLib.Ef.Ef9.csproj" ], "dest": "api/ef9", "assemblyUidOverride": "Ef9" }
+  ]
+}
+```
+
+The two settings compose without any further option, because `assemblyUidOverride` only applies to the
+assemblies its own entry documents:
+
+| what is being generated | component used | why |
+|---|---|---|
+| the `api/ef8` pages | `Ef8` | that entry's `assemblyUidOverride` |
+| the `api/ef9` pages | `Ef9` | that entry's `assemblyUidOverride` |
+| a `MyLib.Ef` reference from any other entry | `Ef9` | `assemblyUids`, since no override applies |
+
+So both versions still get their own complete set of pages, and `MyLib::MyLib` pages that mention
+`MyLib.Ef` types link into `api/ef9`.
+
+**Which version to nominate**: normally the newest one you support, since that is where you want readers
+who arrive from an unrelated page to land. Nothing breaks if you pick another — the choice only decides
+where these particular links go.
+
+Two things to know about the nomination:
+
+- **All such links go to the one version you nominate.** A reference cannot resolve to "whichever version
+  the referencing assembly was built against": by the time the UID is minted, the only thing
+  distinguishing the versions is which entry documented them, and a reference carries no record of that.
+- **It does not affect hand-written `<xref>` links.** Those name a UID literally, so write the version you
+  mean — `<xref:Ef8::MyLib.Ef.Widget>` or `<xref:Ef9::MyLib.Ef.Widget>` — and the nomination is not
+  consulted.
+
+In short:
+
+| situation | option |
+|---|---|
+| the assembly has a name of its own | `assemblyUids` |
+| the assembly is referenced by other assemblies in the project | `assemblyUids` |
+| several entries build the same assembly name | `assemblyUidOverride` on each |
+| ... and other entries reference it | also give it a component in `assemblyUids`, naming the default target |
+| one entry matches the same assembly several times | narrow the `src` glob |
+
+> [!NOTE]
+> Enabling either option changes the UID, and therefore the output file name, of every API in the affected
+> assemblies: `::` becomes `--` in file names, as `:` is not legal there. Update anything that refers to
+> those UIDs by hand, such as `<xref>` links in markdown, overwrite files and external xref maps. Filter
+> rules in [`filter`](#filter-apis) configs are unaffected: they keep matching the unqualified API surface.
+
 ## Customization Options
 
 There are several options available for customizing .NET API pages that are tailored to your specific needs and preferences. To customize .NET API pages for DocFX, you can use the following options:

--- a/docs/docs/dotnet-api-docs.md
+++ b/docs/docs/dotnet-api-docs.md
@@ -143,8 +143,12 @@ the project:
 `MyLib.Widget` becomes `MyLib::MyLib.Widget`, `MyLib.Ef8::MyLib.Widget` and `MyLib.Ef9::MyLib.Widget`, so
 each keeps its own page, and `<see cref="..."/>` links and the table of contents follow. Everything
 displayed keeps naming the namespace as it is declared — `MyLib` stays `MyLib`, not
-`MyLib.Ef8.MyLib` — because the assembly is a component of the identity, not a namespace segment. How the
-assembly itself is shown is up to [`assemblyLabel`](#showing-which-assembly-a-namespace-comes-from).
+`MyLib.Ef8.MyLib` — because the assembly is a component of the identity, not a namespace segment.
+
+So this changes the UIDs, the file names and therefore the page URLs, and nothing that is displayed. Existing
+`<xref>` links in markdown, overwrite files and external xref maps name UIDs, so they need updating by hand;
+titles, labels and breadcrumbs read as they did. To name the assembly as well, see
+[`assemblyLabel`](#showing-which-assembly-a-namespace-comes-from).
 
 Give an assembly a shorter component by naming it explicitly, in which case the whole setting is an object
 instead of an array:
@@ -175,26 +179,88 @@ build, it quietly drops links to it.
 
 ### Showing which assembly a namespace comes from
 
-When two assemblies declare the same namespace, its pages need to say which one they belong to.
-[`assemblyLabel`](../reference/docfx-json-reference.md#assemblylabel), set per `metadata` entry, decides
-how:
+Qualifying an assembly changes what its pages are *called by*, not what they *read as*: by default nothing
+displayed mentions the assembly, so enabling `assemblyUids` leaves every label, title and breadcrumb exactly
+as it was. Where two assemblies declare the same namespace, that leaves two pages reading alike, and
+[`assemblyLabel`](../reference/docfx-json-reference.md#assemblylabel), set per `metadata` entry, says how to
+tell them apart:
 
 | value | what a namespace looks like |
 |---|---|
-| `auto` (default) | `suffix` with `"namespaceLayout": "flattened"`, `none` with `"nested"` |
-| `suffix` | `MyLib (MyLib.Ef8)` — the assembly is appended to the label and the page title |
-| `none` | `MyLib` — the namespace alone |
+| `none` (default) | `MyLib` — the namespace alone |
+| `shared` | `MyLib (MyLib.Ef8)`, but only for the namespaces more than one assembly of this entry declares |
+| `suffix` | `MyLib (MyLib.Ef8)` for every namespace of a qualified assembly |
 | `page` | `MyLib`, with `Assembly: MyLib.Ef8.dll` named on the page, the way type pages do |
 
-With `"namespaceLayout": "nested"` the namespaces of each qualified assembly are grouped under a node
-naming that assembly, so the assembly is already visible and `auto` leaves the labels alone. That node has
-no page of its own. A flattened layout has nothing else to tell two assemblies apart, so `auto` appends
-the assembly to the label there.
+The examples below are all the same project, an entry documenting `MyLib` and `MyLib.Ef8` where both declare
+`MyLib` and `MyLib.Data` and only `MyLib.Ef8` declares `MyLib.Ef8.Internal`. The table of contents is
+ordered by UID, which is why the `MyLib.Ef8` namespaces come first.
+
+```
+none (default)                     shared
+──────────────────────────────     ──────────────────────────────
+MyLib                              MyLib (MyLib.Ef8)
+MyLib.Data                         MyLib.Data (MyLib.Ef8)
+MyLib.Ef8.Internal                 MyLib.Ef8.Internal
+MyLib                              MyLib (MyLib)
+MyLib.Data                         MyLib.Data (MyLib)
+
+# Namespace MyLib                  # Namespace MyLib (MyLib.Ef8)
+
+suffix                             page
+──────────────────────────────     ──────────────────────────────
+MyLib (MyLib.Ef8)                  MyLib
+MyLib.Data (MyLib.Ef8)             MyLib.Data
+MyLib.Ef8.Internal (MyLib.Ef8)     MyLib.Ef8.Internal
+MyLib (MyLib)                      MyLib
+MyLib.Data (MyLib)                 MyLib.Data
+
+# Namespace MyLib (MyLib.Ef8)      # Namespace MyLib
+                                   Assembly: MyLib.Ef8.dll
+```
+
+`MyLib.Ef8.Internal` is the difference between `shared` and `suffix`: only one assembly declares it, so
+there is nothing to tell apart and `shared` leaves it alone.
+
+`shared` compares the namespaces of one `metadata` entry, because that is all an entry can see — entries are
+generated one after another, each writing its output before the next is compiled. So a project that gives
+every assembly its own entry, which is the usual shape when each also has its own `dest`, gets no labels
+from `shared` even where its namespaces do collide across entries; use `suffix` on those entries instead. A
+project that documents several assemblies in one entry is what `shared` is for.
+
+`"namespaceLayout": "nested"` is the other way to show it: the namespaces of each qualified assembly are
+grouped under a node naming that assembly, which has no page of its own. That works with `none`, so the
+labels stay clean:
+
+```
+MyLib                  <- the assembly
+  MyLib
+    Data
+      Row
+    Widget
+MyLib.Ef8              <- the assembly
+  MyLib
+    Data
+      Row
+    Ef8.Internal
+      Helper
+    Widget
+```
 
 > [!NOTE]
 > With `"outputFormat": "apiPage"` or `"markdown"` this only affects the table of contents. Those formats
-> title a page from the symbol itself, so `suffix` does not reach the title and `page` has nowhere to name
-> the assembly.
+> title a page from the symbol itself, so `shared` and `suffix` do not reach the title and `page` has
+> nowhere to name the assembly.
+
+A few cases where a namespace is not labelled even though it looks like it should be, all following from the
+fact that the label is decided per entry, from the pages that entry produces:
+
+- A namespace no assembly declares directly, which a nested layout adds only to hold the ones below it, has
+  no assembly of its own, so its row stays plain while its children are labelled.
+- Two assemblies given the *same* component, which is what `assemblyUidOverride` does when one entry
+  documents several, share one set of pages. `suffix` labels them once; `shared` sees nothing to tell apart.
+- Two assemblies that are *not* in `assemblyUids` still collapse onto one page, as before, and no label can
+  separate them. Qualify them to fix that.
 
 Authored links name the UID, so they name the assembly and the namespace as they really are:
 

--- a/docs/reference/docfx-json-reference.md
+++ b/docs/reference/docfx-json-reference.md
@@ -27,6 +27,54 @@ Overrides default log message severity level. Key is the log code, supported val
 }
 ```
 
+## `assemblyUids`
+
+The assemblies whose APIs carry the assembly they are declared in as a component of their UID, separated
+from the namespace qualified name by `::`. Use it when a single docfx project documents several assemblies
+that share namespaces, which would otherwise produce colliding UIDs. Assemblies that are not listed are
+left unchanged.
+
+An array qualifies each assembly by its own name:
+
+```json
+{
+  "assemblyUids": [ "MyLib", "MyLib.Ef8" ],
+  "metadata": [
+    { "src": [ "src/MyLib/MyLib.csproj" ],         "dest": "api/core" },
+    { "src": [ "src/MyLib.Ef8/MyLib.Ef8.csproj" ], "dest": "api/ef8" }
+  ]
+}
+```
+
+`MyLib.Widget` from `MyLib.dll` gets the UID `MyLib::MyLib.Widget` and the same type name from
+`MyLib.Ef8.dll` gets `MyLib.Ef8::MyLib.Widget`, so each keeps its own page, TOC entry and cross
+references. In the output file name the `::` becomes `--`, as `:` is not a legal file name character:
+`MyLib--MyLib.Widget.html`.
+
+An object names the component to use instead, where `null` means the assembly's own name:
+
+```json
+{
+  "assemblyUids": {
+    "MyLib": null,
+    "MyLib.Ef8": "Ef8"
+  }
+}
+```
+
+A component may contain letters, digits, underscores and dashes, separated by dots, e.g. `MyLib.Tools`,
+`my-lib` or `net8.0`. Unlike a namespace, it may start with a digit, and it is never displayed as part of
+a namespace — see [`assemblyLabel`](#assemblylabel) for how the assembly is shown.
+
+**It is a project level setting, not a per `metadata` entry one, and it has to be.** An entry mints UIDs
+not only for the APIs it documents but also for the APIs it *references*, and those must come out
+identical to the UIDs produced by the entry that documents them, or the links break — so every entry has
+to agree on which assemblies are qualified. Declaring the same assembly twice with different components is
+reported as an `InvalidAssemblyUid` warning and the first one wins.
+
+Only affects the `docfx metadata` stage. See
+[Assemblies that share namespaces](../docs/dotnet-api-docs.md#assemblies-that-share-namespaces).
+
 ## `build`
 
 Configuration options that are applied for `docfx build` command:
@@ -479,6 +527,76 @@ Specifies whether explicit interface implementations are included in the generat
 ### `globalNamespaceId`
 
 Specify the name to use for the global namespace. The default value is an empty string.
+
+### `assemblyUidOverride`
+
+The assembly component to use in the UIDs of the assemblies documented by this entry, instead of their
+assembly name.
+
+Use it **only** when several entries document assemblies that share an *assembly name* and so cannot be
+told apart by name — most often per target version builds of one project, which share an `AssemblyName`
+and differ only by target framework:
+
+```json
+{
+  "assemblyUids": [ "MyLib" ],
+  "metadata": [
+    {
+      "src": [ "src/MyLib/MyLib.csproj" ],
+      "dest": "api/core"
+    },
+    {
+      "src": [ "src/MyLib.Ef/MyLib.Ef.Ef8.csproj" ],
+      "dest": "api/ef8",
+      "assemblyUidOverride": "Ef8"
+    },
+    {
+      "src": [ "src/MyLib.Ef/MyLib.Ef.Ef9.csproj" ],
+      "dest": "api/ef9",
+      "assemblyUidOverride": "Ef9"
+    }
+  ]
+}
+```
+
+Both `MyLib.Ef` projects build `MyLib.Ef.dll`, so qualifying by assembly name cannot give them different
+components.
+
+The override has two limits, both following from the fact that it names an *entry* rather than an
+assembly:
+
+- **Other entries cannot see it.** An entry referencing `MyLib.Ef.dll` has no way to know whether you
+  meant `Ef8` or `Ef9`, so its references come out unqualified and silently render without a link. To give
+  those references somewhere to go, also give the assembly a component in
+  [`assemblyUids`](#assemblyuids), naming the version they should point at. The two settings compose,
+  because the override only applies to the assemblies its own entry documents — see
+  [Nominate a default version for links from
+  elsewhere](../docs/dotnet-api-docs.md#nominate-a-default-version-for-links-from-elsewhere).
+- **It does not disambiguate within one entry.** All the assemblies an entry documents get the same
+  component, so if one entry compiles two assemblies with the same name — a glob matching several target
+  framework folders, for instance — they still collide.
+
+See [Assemblies that share namespaces](../docs/dotnet-api-docs.md#assemblies-that-share-namespaces)
+for a worked example.
+
+### `assemblyLabel`
+
+Specifies how the assembly of a namespace is shown, for assemblies listed in
+[`assemblyUids`](#assemblyuids). Assemblies that are not listed there are unaffected.
+
+| value | what a namespace looks like |
+|---|---|
+| `auto` (default) | `suffix` with `"namespaceLayout": "flattened"`, `none` with `"nested"` |
+| `suffix` | `MyLib (MyLib.Ef8)` — the assembly is appended to the label and the page title |
+| `none` | `MyLib` — the namespace alone |
+| `page` | `MyLib`, with `Assembly: MyLib.Ef8.dll` named on the page, the way type pages do |
+
+The assembly is never part of the namespace itself: a page always names the namespace as it is declared in
+the source, whatever this is set to. Only the UID carries the assembly.
+
+With `"namespaceLayout": "nested"` the namespaces of each qualified assembly are grouped under a node
+naming that assembly, so `auto` leaves the labels alone there. A flattened layout has nothing else to tell
+two assemblies apart, so `auto` appends the assembly.
 
 ## File Mappings
 

--- a/docs/reference/docfx-json-reference.md
+++ b/docs/reference/docfx-json-reference.md
@@ -586,17 +586,20 @@ Specifies how the assembly of a namespace is shown, for assemblies listed in
 
 | value | what a namespace looks like |
 |---|---|
-| `auto` (default) | `suffix` with `"namespaceLayout": "flattened"`, `none` with `"nested"` |
-| `suffix` | `MyLib (MyLib.Ef8)` — the assembly is appended to the label and the page title |
-| `none` | `MyLib` — the namespace alone |
+| `none` (default) | `MyLib` — the namespace alone |
+| `shared` | `MyLib (MyLib.Ef8)`, but only for the namespaces more than one assembly of this entry declares |
+| `suffix` | `MyLib (MyLib.Ef8)` for every namespace of a qualified assembly |
 | `page` | `MyLib`, with `Assembly: MyLib.Ef8.dll` named on the page, the way type pages do |
 
 The assembly is never part of the namespace itself: a page always names the namespace as it is declared in
 the source, whatever this is set to. Only the UID carries the assembly.
 
-With `"namespaceLayout": "nested"` the namespaces of each qualified assembly are grouped under a node
-naming that assembly, so `auto` leaves the labels alone there. A flattened layout has nothing else to tell
-two assemblies apart, so `auto` appends the assembly.
+`shared` compares the namespaces of its own `metadata` entry, so an entry documenting a single assembly never
+labels anything. `"namespaceLayout": "nested"` is the alternative: it groups the namespaces of each qualified
+assembly under a node naming that assembly, which needs no label at all.
+
+See [Showing which assembly a namespace comes from](../docs/dotnet-api-docs.md#showing-which-assembly-a-namespace-comes-from)
+for what each value renders.
 
 ## File Mappings
 

--- a/schemas/docfx.schema.json
+++ b/schemas/docfx.schema.json
@@ -656,9 +656,9 @@
           },
           "assemblyLabel": {
             "type": "string",
-            "enum": ["auto", "suffix", "none", "page"],
-            "default": "auto",
-            "description": "Specifies how the assembly of a namespace is shown, for assemblies listed in assemblyUids. `auto` appends the assembly to the namespace label in a flattened layout and shows the namespace on its own in a nested layout, where the per assembly root node already names it. `suffix` always appends it, `none` never does, and `page` names the assembly on the namespace page instead, the way type pages do."
+            "enum": ["none", "shared", "suffix", "page"],
+            "default": "none",
+            "description": "Specifies how the assembly of a namespace is shown, for assemblies listed in assemblyUids. `none` shows the namespace on its own, so qualifying an assembly changes what its pages are addressed by and not what they read as. `shared` appends the assembly to the namespace label, as in `MyLib (MyLib.Ef8)`, but only for the namespaces that more than one assembly documented by the same metadata entry declares. `suffix` appends it to every namespace of a qualified assembly. `page` names the assembly on the namespace page instead, the way type pages do."
           },
           "properties": {
             "type": "object",

--- a/schemas/docfx.schema.json
+++ b/schemas/docfx.schema.json
@@ -20,6 +20,25 @@
     },
     "rules": {
       "$ref": "#/$defs/ruleConfig"
+    },
+    "assemblyUids": {
+      "description": "The assemblies whose APIs carry the assembly they are declared in as a component of their UID, as in `MyLib.Tools::MyLib.Tools.Widget`, to disambiguate assemblies that share namespaces. Assemblies that are not listed are left unchanged. This is a project level setting because every metadata entry has to agree on which assemblies are qualified: an entry mints UIDs for the APIs it references as well as the ones it documents. Accepts an array of assembly names, each qualified by its own name, or an object naming the component to use instead.",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_\\-]+(\\.[A-Za-z0-9_\\-]+)*$"
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "type": ["string", "null"],
+            "pattern": "^[A-Za-z0-9_\\-]+(\\.[A-Za-z0-9_\\-]+)*$"
+          }
+        }
+      ]
     }
   },
   "$defs": {
@@ -629,6 +648,17 @@
           "globalNamespaceId": {
             "type": "string",
             "description": "Specify the name to use for the global namespace."
+          },
+          "assemblyUidOverride": {
+            "type": "string",
+            "description": "The assembly component to use in the UIDs of the assemblies documented by this entry, instead of their assembly name. Needed only when several entries document assemblies that share an assembly name, such as per target version builds of one project, which the project level assemblyUids cannot tell apart. Because it is scoped to its own entry, other entries cannot see it, so an assembly that other entries reference belongs in assemblyUids instead.",
+            "pattern": "^[A-Za-z0-9_\\-]+(\\.[A-Za-z0-9_\\-]+)*$"
+          },
+          "assemblyLabel": {
+            "type": "string",
+            "enum": ["auto", "suffix", "none", "page"],
+            "default": "auto",
+            "description": "Specifies how the assembly of a namespace is shown, for assemblies listed in assemblyUids. `auto` appends the assembly to the namespace label in a flattened layout and shows the namespace on its own in a nested layout, where the per assembly root node already names it. `suffix` always appends it, `none` never does, and `page` names the assembly on the namespace page instead, the way type pages do."
           },
           "properties": {
             "type": "object",

--- a/src/Docfx.App/Config/DocfxConfig.cs
+++ b/src/Docfx.App/Config/DocfxConfig.cs
@@ -16,4 +16,12 @@ class DocfxConfig
     public BuildJsonConfig? build { get; init; }
 
     public Dictionary<string, LogLevel>? rules { get; init; }
+
+    /// <summary>
+    /// The assemblies whose APIs carry their assembly in their UID, to disambiguate assemblies that share
+    /// namespaces. It lives here rather than inside a `metadata` entry because it applies to the whole
+    /// project: an entry mints UIDs for the APIs it references as well as the ones it documents, so all
+    /// entries have to agree on which assemblies are qualified.
+    /// </summary>
+    public AssemblyUidConfig? assemblyUids { get; init; }
 }

--- a/src/Docfx.Build.ManagedReference/BuildOutputs/ApiBuildOutput.cs
+++ b/src/Docfx.Build.ManagedReference/BuildOutputs/ApiBuildOutput.cs
@@ -89,6 +89,15 @@ public class ApiBuildOutput
     [JsonPropertyName("namespace")]
     public ApiReferenceBuildOutput NamespaceName { get; set; }
 
+    /// <summary>
+    /// The assembly to name on the page of this namespace, set only when <c>assemblyLabel</c> asks for it.
+    /// The namespace partials render it, so it has to be carried over from the view model.
+    /// </summary>
+    [YamlMember(Alias = "namespaceAssembly")]
+    [JsonProperty("namespaceAssembly")]
+    [JsonPropertyName("namespaceAssembly")]
+    public string NamespaceAssembly { get; set; }
+
     [YamlMember(Alias = "summary")]
     [JsonProperty("summary")]
     [JsonPropertyName("summary")]
@@ -250,6 +259,7 @@ public class ApiBuildOutput
             Documentation = model.Documentation,
             AssemblyNameList = model.AssemblyNameList,
             NamespaceName = ApiBuildOutputUtility.GetReferenceViewModel(model.NamespaceName, references, model.SupportedLanguages),
+            NamespaceAssembly = model.NamespaceAssembly,
             Summary = model.Summary,
             AdditionalNotes = model.AdditionalNotes,
             Remarks = model.Remarks,

--- a/src/Docfx.Dotnet/AssemblyUidConfig.cs
+++ b/src/Docfx.Dotnet/AssemblyUidConfig.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Docfx;
+
+/// <summary>
+/// The assemblies whose APIs carry an assembly component in their UID, mapped to that component.
+/// A null value means the assembly is qualified by its own name, which is the normal case.
+/// <para>
+/// Accepts both shapes: an array of assembly names, <c>[ "MyLib", "MyLib.Tools" ]</c>, and an object that
+/// names the component explicitly, <c>{ "MyLib.Tools": "Tools" }</c>.
+/// </para>
+/// </summary>
+[Newtonsoft.Json.JsonConverter(typeof(AssemblyUidConfigConverter.NewtonsoftJsonConverter))]
+[System.Text.Json.Serialization.JsonConverter(typeof(AssemblyUidConfigConverter.SystemTextJsonConverter))]
+internal class AssemblyUidConfig : Dictionary<string, string>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AssemblyUidConfig"/> class.
+    /// </summary>
+    public AssemblyUidConfig()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AssemblyUidConfig"/> class.
+    /// </summary>
+    /// <param name="assemblyUids">The assembly name to component pairs copied to the new instance.</param>
+    public AssemblyUidConfig(IEnumerable<KeyValuePair<string, string>> assemblyUids) : base(assemblyUids)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AssemblyUidConfig"/> class from assembly names alone,
+    /// each qualified by its own name.
+    /// </summary>
+    /// <param name="assemblyNames">The names of the assemblies to qualify.</param>
+    public AssemblyUidConfig(IEnumerable<string> assemblyNames)
+    {
+        foreach (var assemblyName in assemblyNames)
+        {
+            // A name repeated in the array means the same thing twice, and an empty one is reported as an
+            // invalid entry later. Neither is worth throwing out of a JSON converter over.
+            this[assemblyName ?? ""] = null;
+        }
+    }
+}

--- a/src/Docfx.Dotnet/AssemblyUidConfigConverter.NewtonsoftJson.cs
+++ b/src/Docfx.Dotnet/AssemblyUidConfigConverter.NewtonsoftJson.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Docfx;
+
+internal partial class AssemblyUidConfigConverter
+{
+    /// <summary>
+    /// JsonConverter for <see cref="AssemblyUidConfig"/>.
+    /// </summary>
+    internal class NewtonsoftJsonConverter : JsonConverter
+    {
+        /// <inheritdoc/>
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(AssemblyUidConfig);
+        }
+
+        /// <inheritdoc/>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonToken.StartArray:
+                    return new AssemblyUidConfig(JArray.Load(reader).Select(item => item.ToString()));
+
+                case JsonToken.StartObject:
+                    var result = new AssemblyUidConfig();
+                    foreach (var property in JObject.Load(reader).Properties())
+                    {
+                        result[property.Name] = property.Value.Type is JTokenType.Null ? null : property.Value.ToString();
+                    }
+                    return result;
+
+                default:
+                    throw new JsonSerializationException($"TokenType({reader.TokenType}) is not supported.");
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var assemblyUids = (AssemblyUidConfig)value;
+
+            // An array is the shape this was most likely authored in, so it is the shape it round trips
+            // to, unless a component was named explicitly.
+            if (assemblyUids.Values.All(component => component is null))
+            {
+                writer.WriteStartArray();
+                foreach (var assemblyName in assemblyUids.Keys)
+                {
+                    writer.WriteValue(assemblyName);
+                }
+                writer.WriteEndArray();
+                return;
+            }
+
+            writer.WriteStartObject();
+            foreach (var (assemblyName, component) in assemblyUids)
+            {
+                writer.WritePropertyName(assemblyName);
+                writer.WriteValue(component);
+            }
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/Docfx.Dotnet/AssemblyUidConfigConverter.SystemTextJson.cs
+++ b/src/Docfx.Dotnet/AssemblyUidConfigConverter.SystemTextJson.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Docfx;
+
+internal partial class AssemblyUidConfigConverter
+{
+    /// <summary>
+    /// JsonConverter for <see cref="AssemblyUidConfig"/>.
+    /// </summary>
+    internal class SystemTextJsonConverter : JsonConverter<AssemblyUidConfig>
+    {
+        public override AssemblyUidConfig Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.StartArray:
+                    return new AssemblyUidConfig(JsonSerializer.Deserialize<string[]>(ref reader, options));
+
+                case JsonTokenType.StartObject:
+                    return new AssemblyUidConfig(JsonSerializer.Deserialize<Dictionary<string, string>>(ref reader, options));
+
+                default:
+                    throw new JsonException($"TokenType({reader.TokenType}) is not supported.");
+            }
+        }
+
+        public override void Write(Utf8JsonWriter writer, AssemblyUidConfig value, JsonSerializerOptions options)
+        {
+            // An array is the shape this was most likely authored in, so it is the shape it round trips
+            // to, unless a component was named explicitly.
+            if (value.Values.All(component => component is null))
+            {
+                writer.WriteStartArray();
+                foreach (var assemblyName in value.Keys)
+                {
+                    writer.WriteStringValue(assemblyName);
+                }
+                writer.WriteEndArray();
+                return;
+            }
+
+            writer.WriteStartObject();
+            foreach (var (assemblyName, component) in value)
+            {
+                writer.WritePropertyName(assemblyName);
+                writer.WriteStringValue(component);
+            }
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/Docfx.Dotnet/AssemblyUidConfigConverter.cs
+++ b/src/Docfx.Dotnet/AssemblyUidConfigConverter.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Docfx;
+
+/// <summary>
+/// Converters for <see cref="AssemblyUidConfig"/>, which accepts an array of assembly names as well as a
+/// map from assembly name to component. An array entry is stored with a null component, meaning the
+/// assembly is qualified by its own name.
+/// </summary>
+internal partial class AssemblyUidConfigConverter
+{
+}

--- a/src/Docfx.Dotnet/DotnetApiCatalog.ApiPage.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.ApiPage.cs
@@ -746,6 +746,7 @@ partial class DotnetApiCatalog
                     AddReferenceDelegate = (a, b) => { },
                     Source = src,
                     ResolveCode = ResolveCode,
+                    ResolveAssemblyUid = commentId => VisitorHelper.GetAssemblyUidForCommentId(commentId, compilation),
                 };
 
                 var comment = symbol.GetDocumentationComment(compilation, expandIncludes: true, expandInheritdoc: true);

--- a/src/Docfx.Dotnet/DotnetApiCatalog.ManagedReference.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.ManagedReference.cs
@@ -42,6 +42,8 @@ partial class DotnetApiCatalog
             return;
         }
 
+        ApplyAssemblyLabel(allMembers, config);
+
         ResolveAndExportYamlMetadata(allMembers, allReferences);
 
         return;
@@ -131,6 +133,52 @@ partial class DotnetApiCatalog
                 }
                 return true;
             });
+        }
+    }
+
+    /// <summary>
+    /// Appends the assembly a namespace was declared in to the names it is displayed under, as
+    /// <c>assemblyLabel</c> asks. It runs after the merge rather than in the symbol visitor because
+    /// <see cref="AssemblyLabel.Shared"/> has to know which namespaces more than one of this item's
+    /// assemblies declares, and a visitor only ever sees one assembly at a time.
+    /// </summary>
+    internal static void ApplyAssemblyLabel(Dictionary<string, MetadataItem> allMembers, ExtractMetadataConfig config)
+    {
+        if (config.AssemblyLabel is not (AssemblyLabel.Shared or AssemblyLabel.Suffix))
+            return;
+
+        var namespaces = allMembers.Values.Where(x => x.Type is MemberType.Namespace).ToList();
+
+        // `allMembers` is keyed by uid, so two namespaces that trim to the same name are two distinct
+        // declarations of it. That also covers a qualified assembly colliding with an unqualified one,
+        // whose namespace carries no component and so is left alone below.
+        var shared = config.AssemblyLabel is AssemblyLabel.Shared
+            ? namespaces
+                .GroupBy(x => VisitorHelper.TrimAssemblyUid(x.Name), StringComparer.Ordinal)
+                .Where(x => x.Count() > 1)
+                .SelectMany(x => x)
+                .ToHashSet()
+            : null;
+
+        foreach (var @namespace in namespaces)
+        {
+            if (@namespace.AssemblyUid is not { } assemblyUid)
+                continue;
+
+            if (shared is not null && !shared.Contains(@namespace))
+                continue;
+
+            Append(@namespace.DisplayNames, assemblyUid);
+            Append(@namespace.DisplayNamesWithType, assemblyUid);
+            Append(@namespace.DisplayQualifiedNames, assemblyUid);
+        }
+
+        static void Append(SortedList<SyntaxLanguage, string> names, string assemblyUid)
+        {
+            foreach (var language in names.Keys.ToArray())
+            {
+                names[language] = $"{names[language]} ({assemblyUid})";
+            }
         }
     }
 

--- a/src/Docfx.Dotnet/DotnetApiCatalog.ManagedReference.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.ManagedReference.cs
@@ -72,7 +72,10 @@ partial class DotnetApiCatalog
             var members = model.Members;
             foreach (var memberModel in members)
             {
-                var fileName = memberModel.Name.Replace('`', '-');
+                // Page level UIDs contain neither `#` nor `*`, so this only differs from replacing the
+                // backticks by also mapping the `::` of the assembly component, which is not a legal
+                // file name character. It has to match what `SymbolUrlResolver` builds hrefs from.
+                var fileName = VisitorHelper.PathFriendlyId(memberModel.Name);
                 var outputFileName = GetUniqueFileNameWithSuffix(fileName + Constants.YamlExtension, outputFileNames);
                 string itemFilePath = Path.Combine(config.OutputFolder, outputFileName);
                 var memberViewModel = memberModel.ToPageViewModel(config);

--- a/src/Docfx.Dotnet/DotnetApiCatalog.Toc.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.Toc.cs
@@ -47,13 +47,48 @@ partial class DotnetApiCatalog
 
         var filter = new SymbolFilter(config, options);
         var tocNodes = new Dictionary<string, TocNode>();
+        var assemblyRoots = new Dictionary<string, TocNode>();
         var ext = config.OutputFormat is MetadataOutputFormat.Markdown ? ".md" : ".yml";
-        var toc = assemblies.SelectMany(a => CreateToc(a.symbol.GlobalNamespace, a.compilation)).ToList();
+        var toc = assemblies.SelectMany(a => CreateAssemblyToc(a.symbol, a.compilation)).ToList();
 
         SortToc(toc, null);
 
         YamlUtility.Serialize(Path.Combine(config.OutputFolder, "toc.yml"), toc, YamlMime.TableOfContent);
         return toc;
+
+        // With a nested layout, the namespaces of an assembly that carries an assembly component in its
+        // UIDs are grouped under a node naming that assembly, which is the only place the assembly is
+        // named. The node has no page of its own, like the category nodes.
+        IEnumerable<TocNode> CreateAssemblyToc(IAssemblySymbol assembly, Compilation compilation)
+        {
+            var nodes = CreateToc(assembly.GlobalNamespace, compilation).ToList();
+
+            if (config.NamespaceLayout is not NamespaceLayout.Nested
+             || VisitorHelper.GetAssemblyUid(assembly) is not { } assemblyUid
+             || nodes.Count is 0)
+            {
+                return nodes;
+            }
+
+            // Two assemblies can resolve to the same component, e.g. under an `assemblyUidOverride` that
+            // covers several of them, and then they share the one node rather than repeating its name.
+            if (assemblyRoots.TryGetValue(assemblyUid, out var existing))
+            {
+                existing.items!.AddRange(nodes);
+                existing.containsLeafNodes |= nodes.Any(x => x.containsLeafNodes);
+                return [];
+            }
+
+            assemblyRoots[assemblyUid] = new TocNode
+            {
+                name = assemblyUid,
+                items = nodes,
+                type = TocNodeType.Namespace,
+                containsLeafNodes = nodes.Any(x => x.containsLeafNodes),
+            };
+
+            return [assemblyRoots[assemblyUid]];
+        }
 
         IEnumerable<TocNode> CreateToc(ISymbol symbol, Compilation compilation)
         {
@@ -94,10 +129,21 @@ partial class DotnetApiCatalog
                 if (!tocNodes.TryGetValue(id, out var node))
                 {
                     idExists = false;
+                    var name = config.NamespaceLayout is NamespaceLayout.Nested ? symbol.Name : symbol.ToString() ?? "";
+
+                    // In a flattened layout nothing else distinguishes two assemblies that declare the
+                    // same namespace, so the assembly is appended to the label. A nested layout groups by
+                    // assembly instead, see `CreateAssemblyToc`.
+                    if (config.ResolvedAssemblyLabel is AssemblyLabel.Suffix
+                     && VisitorHelper.GetAssemblyUid(symbol) is { } assemblyUid)
+                    {
+                        name = $"{name} ({assemblyUid})";
+                    }
+
                     tocNodes.Add(id, node = new()
                     {
                         id = id,
-                        name = config.NamespaceLayout is NamespaceLayout.Nested ? symbol.Name : symbol.ToString() ?? "",
+                        name = name,
                         href = $"{id}{ext}",
                         type = TocNodeType.Namespace,
                     });

--- a/src/Docfx.Dotnet/DotnetApiCatalog.Toc.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.Toc.cs
@@ -31,7 +31,7 @@ partial class DotnetApiCatalog
 
     class TocNode
     {
-        public string name { get; init; } = "";
+        public string name { get; set; } = "";
         public string? href { get; init; }
         public List<TocNode>? items { get; set; }
 
@@ -39,6 +39,11 @@ partial class DotnetApiCatalog
         internal string? id;
         internal bool containsLeafNodes;
         internal List<(ISymbol symbol, Compilation compilation)> symbols = [];
+
+        // Set on the nodes of declared namespaces only, so that `assemblyLabel` can group them by the
+        // namespace they declare. The assembly grouping nodes are namespace typed too, but carry neither.
+        internal string? namespaceName;
+        internal string? assemblyUid;
     }
 
     private static List<TocNode> CreateToc(List<(IAssemblySymbol symbol, Compilation compilation)> assemblies, ExtractMetadataConfig config, DotnetApiOptions options)
@@ -51,10 +56,41 @@ partial class DotnetApiCatalog
         var ext = config.OutputFormat is MetadataOutputFormat.Markdown ? ".md" : ".yml";
         var toc = assemblies.SelectMany(a => CreateAssemblyToc(a.symbol, a.compilation)).ToList();
 
+        // Before the sort, which orders by name, since the label is part of the name that is ordered.
+        ApplyAssemblyLabel();
+
         SortToc(toc, null);
 
         YamlUtility.Serialize(Path.Combine(config.OutputFolder, "toc.yml"), toc, YamlMime.TableOfContent);
         return toc;
+
+        // Appends the assembly a namespace was declared in to its label, as `assemblyLabel` asks. A node
+        // that contains no leaf node is never emitted, so it neither gets a label nor counts as another
+        // declaration of its namespace.
+        void ApplyAssemblyLabel()
+        {
+            if (config.AssemblyLabel is not (AssemblyLabel.Shared or AssemblyLabel.Suffix))
+                return;
+
+            // Grouped before the qualified ones are picked out, not after: an unqualified assembly
+            // declaring the same namespace is another declaration of it, and dropping it first would
+            // leave the qualified one looking unique.
+            var namespaces = tocNodes.Values
+                .Where(x => x.namespaceName is not null && x.containsLeafNodes)
+                .GroupBy(x => x.namespaceName, StringComparer.Ordinal);
+
+            foreach (var group in namespaces)
+            {
+                if (config.AssemblyLabel is AssemblyLabel.Shared && group.Count() is 1)
+                    continue;
+
+                foreach (var node in group)
+                {
+                    if (node.assemblyUid is { } assemblyUid)
+                        node.name = $"{node.name} ({assemblyUid})";
+                }
+            }
+        }
 
         // With a nested layout, the namespaces of an assembly that carries an assembly component in its
         // UIDs are grouped under a node naming that assembly, which is the only place the assembly is
@@ -129,23 +165,17 @@ partial class DotnetApiCatalog
                 if (!tocNodes.TryGetValue(id, out var node))
                 {
                     idExists = false;
-                    var name = config.NamespaceLayout is NamespaceLayout.Nested ? symbol.Name : symbol.ToString() ?? "";
 
-                    // In a flattened layout nothing else distinguishes two assemblies that declare the
-                    // same namespace, so the assembly is appended to the label. A nested layout groups by
-                    // assembly instead, see `CreateAssemblyToc`.
-                    if (config.ResolvedAssemblyLabel is AssemblyLabel.Suffix
-                     && VisitorHelper.GetAssemblyUid(symbol) is { } assemblyUid)
-                    {
-                        name = $"{name} ({assemblyUid})";
-                    }
-
+                    // The declared namespace is recorded whole, whatever the layout shows, because
+                    // `ApplyAssemblyLabel` groups on it and a nested label is only the last segment.
                     tocNodes.Add(id, node = new()
                     {
                         id = id,
-                        name = name,
+                        name = config.NamespaceLayout is NamespaceLayout.Nested ? symbol.Name : symbol.ToString() ?? "",
                         href = $"{id}{ext}",
                         type = TocNodeType.Namespace,
+                        namespaceName = symbol.ToString(),
+                        assemblyUid = VisitorHelper.GetAssemblyUid(symbol),
                     });
                 }
 

--- a/src/Docfx.Dotnet/DotnetApiCatalog.cs
+++ b/src/Docfx.Dotnet/DotnetApiCatalog.cs
@@ -3,8 +3,10 @@
 
 using System.Diagnostics;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Docfx.Common;
 using Docfx.Plugins;
+using Microsoft.CodeAnalysis;
 using Newtonsoft.Json.Linq;
 using YamlDotNet.Serialization;
 
@@ -44,7 +46,11 @@ public static partial class DotnetApiCatalog
             if (config.TryGetValue("metadata", out var value))
             {
                 Logger.Rules = config["rules"]?.ToObject<Dictionary<string, LogLevel>>();
-                await Exec(value.ToObject<MetadataJsonConfig>(NewtonsoftJsonUtility.DefaultSerializer.Value), options, configDirectory);
+                await Exec(
+                    value.ToObject<MetadataJsonConfig>(NewtonsoftJsonUtility.DefaultSerializer.Value),
+                    options,
+                    configDirectory,
+                    assemblyUids: config["assemblyUids"]?.ToObject<AssemblyUidConfig>(NewtonsoftJsonUtility.DefaultSerializer.Value));
             }
         }
         finally
@@ -55,15 +61,30 @@ public static partial class DotnetApiCatalog
         }
     }
 
-    internal static async Task Exec(MetadataJsonConfig config, DotnetApiOptions options, string configDirectory, string outputDirectory = null, CancellationToken cancellationToken = default)
+    internal static async Task Exec(
+        MetadataJsonConfig config,
+        DotnetApiOptions options,
+        string configDirectory,
+        string outputDirectory = null,
+        AssemblyUidConfig assemblyUids = null,
+        CancellationToken cancellationToken = default)
     {
         var stopwatch = Stopwatch.StartNew();
 
+        var originalGlobalNamespaceId = VisitorHelper.GlobalNamespaceId;
+        var originalAssemblyUids = VisitorHelper.AssemblyUids;
+        var originalAssemblyUidOverride = VisitorHelper.AssemblyUidOverride;
+        var originalAssemblyUidOverrideAssemblies = VisitorHelper.AssemblyUidOverrideAssemblies;
+
         try
         {
-            string originalGlobalNamespaceId = VisitorHelper.GlobalNamespaceId;
-
             EnvironmentContext.SetBaseDirectory(configDirectory);
+
+            // Whether an assembly is qualified is a property of the assembly, not of the metadata item that
+            // documents it, which is why this is a project level setting: every item has to agree for the
+            // references it makes into assemblies documented by another item to resolve.
+            VisitorHelper.AssemblyUids = ValidateAssemblyUids(assemblyUids);
+            ValidateAssemblyUidOverrides(config);
 
             foreach (var item in config)
             {
@@ -72,11 +93,13 @@ public static partial class DotnetApiCatalog
 
                 await Build(ConvertConfig(item, configDirectory, outputDirectory), options);
             }
-
-            VisitorHelper.GlobalNamespaceId = originalGlobalNamespaceId;
         }
         finally
         {
+            VisitorHelper.GlobalNamespaceId = originalGlobalNamespaceId;
+            VisitorHelper.AssemblyUids = originalAssemblyUids;
+            VisitorHelper.AssemblyUidOverride = originalAssemblyUidOverride;
+            VisitorHelper.AssemblyUidOverrideAssemblies = originalAssemblyUidOverrideAssemblies;
             EnvironmentContext.Clean();
         }
 
@@ -85,6 +108,14 @@ public static partial class DotnetApiCatalog
         async Task Build(ExtractMetadataConfig config, DotnetApiOptions options)
         {
             var assemblies = await Compile(config);
+
+            // `assemblyUidOverride` applies to the assemblies this metadata item documents, which are only
+            // known once they are compiled. It stays constant for the whole item, so the parallel
+            // API page generation can read it safely.
+            VisitorHelper.AssemblyUidOverride = config.AssemblyUidOverride;
+            VisitorHelper.AssemblyUidOverrideAssemblies = string.IsNullOrEmpty(config.AssemblyUidOverride)
+                ? null
+                : new HashSet<IAssemblySymbol>(assemblies.Select(a => a.symbol), SymbolEqualityComparer.Default);
 
             switch (config.OutputFormat)
             {
@@ -115,6 +146,90 @@ public static partial class DotnetApiCatalog
         }
     }
 
+    // A UID ends up as a file name, an xref key and an HTML anchor, so the assembly component is
+    // restricted to the characters that are safe in all three: letters, digits, underscores and dashes,
+    // with dots as separators. Dashes are allowed because assembly names, which are the components in the
+    // normal case, often contain them. Unlike a namespace, a segment may start with a digit, so both
+    // `7zip.Net` style assembly names and `net8.0` style components work.
+    [GeneratedRegex(@"^[A-Za-z0-9_\-]+(\.[A-Za-z0-9_\-]+)*$")]
+    private static partial Regex AssemblyUidRegex();
+
+    private const string AssemblyUidGrammar =
+        "An assembly component may contain letters, digits, underscores and dashes, separated by dots, e.g. 'MyLib', 'MyLib.V2' or 'net8.0'.";
+
+    private static bool IsValidAssemblyUid(string assemblyUid)
+    {
+        return !string.IsNullOrEmpty(assemblyUid) && AssemblyUidRegex().IsMatch(assemblyUid);
+    }
+
+    /// <summary>
+    /// Drops invalid entries from the project level <c>assemblyUids</c> and makes lookups by assembly name
+    /// case insensitive, as assembly names are.
+    /// </summary>
+    private static Dictionary<string, string> ValidateAssemblyUids(AssemblyUidConfig assemblyUids)
+    {
+        if (assemblyUids is null)
+        {
+            return null;
+        }
+
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (assemblyName, component) in assemblyUids)
+        {
+            if (string.IsNullOrWhiteSpace(assemblyName))
+            {
+                Logger.LogWarning("Ignoring 'assemblyUids' entry with an empty assembly name.", code: "InvalidAssemblyUid");
+                continue;
+            }
+
+            // A null component means the assembly is qualified by its own name, so the name itself has to
+            // be usable as a component. It is checked here rather than once per symbol, as the configured
+            // name and the real one differ at most in casing.
+            if (!IsValidAssemblyUid(component ?? assemblyName))
+            {
+                Logger.LogWarning(
+                    component is null
+                        ? $"Ignoring 'assemblyUids' entry '{assemblyName}', which cannot be used as an assembly component. {AssemblyUidGrammar}"
+                        : $"Ignoring invalid assembly component '{component}' for assembly '{assemblyName}'. {AssemblyUidGrammar}",
+                    code: "InvalidAssemblyUid");
+                continue;
+            }
+
+            if (result.TryGetValue(assemblyName, out var existingComponent))
+            {
+                if (existingComponent != component)
+                {
+                    Logger.LogWarning(
+                        $"Assembly '{assemblyName}' is mapped to both assembly component '{existingComponent}' and '{component}', '{existingComponent}' is used.",
+                        code: "InvalidAssemblyUid");
+                }
+                continue;
+            }
+
+            result.Add(assemblyName, component);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Drops each metadata item's <c>assemblyUidOverride</c> if it isn't a usable assembly component.
+    /// </summary>
+    private static void ValidateAssemblyUidOverrides(MetadataJsonConfig config)
+    {
+        foreach (var item in config)
+        {
+            if (item.AssemblyUidOverride is not null && !IsValidAssemblyUid(item.AssemblyUidOverride))
+            {
+                Logger.LogWarning(
+                    $"Ignoring invalid assembly component '{item.AssemblyUidOverride}'. {AssemblyUidGrammar}",
+                    code: "InvalidAssemblyUid");
+                item.AssemblyUidOverride = null;
+            }
+        }
+    }
+
     private static ExtractMetadataConfig ConvertConfig(MetadataJsonItemConfig configModel, string configDirectory, string outputDirectory)
     {
         var projects = configModel.Src;
@@ -136,6 +251,8 @@ public static partial class DotnetApiCatalog
             IncludePrivateMembers = configModel?.IncludePrivateMembers ?? false,
             IncludeExplicitInterfaceImplementations = configModel?.IncludeExplicitInterfaceImplementations ?? false,
             GlobalNamespaceId = configModel?.GlobalNamespaceId,
+            AssemblyUidOverride = configModel?.AssemblyUidOverride,
+            AssemblyLabel = configModel?.AssemblyLabel ?? default,
             MSBuildProperties = configModel?.Properties,
             OutputFormat = configModel?.OutputFormat ?? default,
             OutputFolder = outputFolder,

--- a/src/Docfx.Dotnet/Filters/RoslynFilterData.cs
+++ b/src/Docfx.Dotnet/Filters/RoslynFilterData.cs
@@ -11,7 +11,9 @@ internal class RoslynFilterData
     {
         return new SymbolFilterData
         {
-            Id = VisitorHelper.GetId(symbol),
+            // Filter rules are written against the actual API surface, so they see the id
+            // without the prefix configured by `assemblyUidPrefixes`/`uidPrefix`.
+            Id = VisitorHelper.GetRawId(symbol),
             Kind = GetExtendedSymbolKindFromSymbol(symbol),
             Attributes = symbol.GetAttributes().Select(GetAttributeFilterData)
         };
@@ -21,7 +23,7 @@ internal class RoslynFilterData
     {
         return new AttributeFilterData
         {
-            Id = VisitorHelper.GetId(attribute.AttributeClass),
+            Id = VisitorHelper.GetRawId(attribute.AttributeClass),
             ConstructorArguments = attribute.ConstructorArguments.Select(GetLiteralString).ToList(),
             ConstructorNamedArguments = attribute.NamedArguments.ToDictionary(pair => pair.Key, pair => GetLiteralString(pair.Value))
         };
@@ -91,7 +93,7 @@ internal class RoslynFilterData
 
             if (name != null)
             {
-                return $"{VisitorHelper.GetId(namedType)}.{name}";
+                return $"{VisitorHelper.GetRawId(namedType)}.{name}";
             }
 
             // todo : define filter data format (language neutral), just use number for combine case by now.
@@ -115,7 +117,7 @@ internal class RoslynFilterData
         var value = constant.Value;
         if (value is ISymbol)
         {
-            return VisitorHelper.GetId(constant.Value as ISymbol);
+            return VisitorHelper.GetRawId(constant.Value as ISymbol);
         }
 
         return value?.ToString() ?? "null";

--- a/src/Docfx.Dotnet/ManagedReference/ExtractMetadataConfig.cs
+++ b/src/Docfx.Dotnet/ManagedReference/ExtractMetadataConfig.cs
@@ -23,6 +23,19 @@ internal class ExtractMetadataConfig
 
     public string GlobalNamespaceId { get; init; }
 
+    public string AssemblyUidOverride { get; init; }
+
+    public AssemblyLabel AssemblyLabel { get; init; }
+
+    /// <summary>
+    /// <see cref="AssemblyLabel"/> with <see cref="Docfx.AssemblyLabel.Auto"/> resolved against the
+    /// namespace layout: a nested layout groups by assembly already, while a flattened one has nothing
+    /// else to tell two assemblies that declare the same namespace apart.
+    /// </summary>
+    public AssemblyLabel ResolvedAssemblyLabel => AssemblyLabel is Docfx.AssemblyLabel.Auto
+        ? NamespaceLayout is Docfx.NamespaceLayout.Nested ? Docfx.AssemblyLabel.None : Docfx.AssemblyLabel.Suffix
+        : AssemblyLabel;
+
     public string CodeSourceBasePath { get; init; }
 
     public bool DisableDefaultFilter { get; init; }

--- a/src/Docfx.Dotnet/ManagedReference/ExtractMetadataConfig.cs
+++ b/src/Docfx.Dotnet/ManagedReference/ExtractMetadataConfig.cs
@@ -27,15 +27,6 @@ internal class ExtractMetadataConfig
 
     public AssemblyLabel AssemblyLabel { get; init; }
 
-    /// <summary>
-    /// <see cref="AssemblyLabel"/> with <see cref="Docfx.AssemblyLabel.Auto"/> resolved against the
-    /// namespace layout: a nested layout groups by assembly already, while a flattened one has nothing
-    /// else to tell two assemblies that declare the same namespace apart.
-    /// </summary>
-    public AssemblyLabel ResolvedAssemblyLabel => AssemblyLabel is Docfx.AssemblyLabel.Auto
-        ? NamespaceLayout is Docfx.NamespaceLayout.Nested ? Docfx.AssemblyLabel.None : Docfx.AssemblyLabel.Suffix
-        : AssemblyLabel;
-
     public string CodeSourceBasePath { get; init; }
 
     public bool DisableDefaultFilter { get; init; }

--- a/src/Docfx.Dotnet/ManagedReference/MetadataItem.cs
+++ b/src/Docfx.Dotnet/ManagedReference/MetadataItem.cs
@@ -72,6 +72,24 @@ internal class MetadataItem : ICloneable
     [JsonPropertyName("namespace")]
     public string NamespaceName { get; set; }
 
+    /// <summary>
+    /// The assembly component of <see cref="Name"/>, set on the namespaces of assemblies configured to
+    /// carry one. The nested table of contents groups by it, which is why it is kept next to the UID
+    /// instead of being parsed back out of it.
+    /// </summary>
+    [YamlIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
+    public string AssemblyUid { get; set; }
+
+    /// <summary>
+    /// The assembly to name on the page of this namespace, set only when <c>assemblyLabel</c> asks for it.
+    /// </summary>
+    [YamlMember(Alias = "namespaceAssembly")]
+    [JsonProperty("namespaceAssembly")]
+    [JsonPropertyName("namespaceAssembly")]
+    public string NamespaceAssembly { get; set; }
+
     [YamlMember(Alias = Constants.PropertyName.Source)]
     [JsonProperty(Constants.PropertyName.Source)]
     [JsonPropertyName(Constants.PropertyName.Source)]

--- a/src/Docfx.Dotnet/ManagedReference/Models/ItemViewModel.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Models/ItemViewModel.cs
@@ -259,6 +259,16 @@ public class ItemViewModel : IOverwriteDocumentViewModel, IItemWithMetadata
     [UniqueIdentityReference]
     public string NamespaceName { get; set; }
 
+    /// <summary>
+    /// The assembly to name on the page of this namespace, set only when <c>assemblyLabel</c> asks for it.
+    /// It is what lets a namespace page say which assembly it belongs to, the way a type page does,
+    /// without having to say it in the title.
+    /// </summary>
+    [YamlMember(Alias = "namespaceAssembly")]
+    [JsonProperty("namespaceAssembly")]
+    [JsonPropertyName("namespaceAssembly")]
+    public string NamespaceAssembly { get; set; }
+
     [YamlMember(Alias = "summary")]
     [JsonProperty("summary")]
     [JsonPropertyName("summary")]

--- a/src/Docfx.Dotnet/ManagedReference/Resolvers/YamlMetadataResolver.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Resolvers/YamlMetadataResolver.cs
@@ -78,61 +78,39 @@ internal static class YamlMetadataResolver
             Items = []
         };
         Dictionary<string, MetadataItem> namespacedItems = [];
+        Dictionary<string, MetadataItem> assemblyRoots = [];
 
-        var dotsPerNamespace = namespaces.ToDictionary(x => x.Key, x => x.Value.Name.Where(y => y == '.').Count());
+        // Nesting follows the namespace, so only the dots of the namespace count. A UID that carries an
+        // assembly component contributes the dots of that component as well, and they are not levels.
+        var dotsPerNamespace = namespaces.ToDictionary(x => x.Key, x => VisitorHelper.TrimAssemblyUid(x.Value.Name).Count(y => y == '.'));
         foreach (var member in namespaces
             .OrderBy(x => dotsPerNamespace[x.Key])
             .Select(x => x.Value)
         )
         {
-            if (member.Name.Contains('.'))
+            foreach (var partialParentNamespace in GetParentNamespaces(member.Name))
             {
-                var parents = GetParentNamespaces(member.Name);
-                foreach (var partialParentNamespace in parents)
+                if (!namespacedItems.ContainsKey(partialParentNamespace))
                 {
-                    if (!namespacedItems.ContainsKey(partialParentNamespace))
+                    var missingNamespace = new MetadataItem()
                     {
-                        var missingNamespace = new MetadataItem()
-                        {
-                            Type = MemberType.Namespace,
-                            Name = partialParentNamespace,
-                            Items = [],
-                            DisplayNames = [],
-                            DisplayNamesWithType = [],
-                            DisplayQualifiedNames = []
-                        };
-                        missingNamespace.DisplayNames.Add(SyntaxLanguage.Default, partialParentNamespace);
-                        namespacedItems[partialParentNamespace] = missingNamespace;
-                        allReferences.TryAdd(partialParentNamespace, new());
+                        Type = MemberType.Namespace,
+                        Name = partialParentNamespace,
+                        AssemblyUid = member.AssemblyUid,
+                        Items = [],
+                        DisplayNames = [],
+                        DisplayNamesWithType = [],
+                        DisplayQualifiedNames = []
+                    };
+                    missingNamespace.DisplayNames.Add(SyntaxLanguage.Default, VisitorHelper.TrimAssemblyUid(partialParentNamespace));
+                    namespacedItems[partialParentNamespace] = missingNamespace;
+                    allReferences.TryAdd(partialParentNamespace, new());
 
-                        if (!partialParentNamespace.Contains('.'))
-                        {
-                            root.Items.Add(missingNamespace);
-                            missingNamespace.Parent = root;
-                        }
-                        else
-                        {
-                            var parentNamespace = namespacedItems[partialParentNamespace.Substring(0, partialParentNamespace.LastIndexOf('.'))];
-                            missingNamespace.Parent = parentNamespace;
-                            parentNamespace.Items.Add(missingNamespace);
-                        }
-                    }
-                }
-
-                var directParentNamespace = parents.Last();
-                if (namespacedItems.TryGetValue(directParentNamespace, out var parent))
-                {
-                    parent.Items.Add(member);
-                    member.Parent = parent;
-                }
-                else
-                {
-                    root.Items.Add(member);
-                    member.Parent = root;
+                    Attach(missingNamespace);
                 }
             }
-            else
-                root.Items.Add(member);
+
+            Attach(member);
 
             namespacedItems[member.Name] = member;
         }
@@ -151,18 +129,78 @@ internal static class YamlMetadataResolver
             }
         }
 
+        // Assembly roots have no UID to be ordered by, so they are ordered by the label they show. The
+        // namespaces among them are ordered by UID again in `ToTocViewModel`, so this only decides where
+        // the roots land, and it is skipped entirely when there are none.
+        if (assemblyRoots.Count > 0)
+        {
+            root.Items = root.Items
+                .OrderBy(x => x.DisplayNames?.GetLanguageProperty(SyntaxLanguage.Default) ?? x.Name, StringComparer.Ordinal)
+                .ToList();
+        }
+
         return root;
+
+        // Attaches an item to its direct parent namespace, or to the root of the assembly it belongs to
+        // when it is a top level namespace.
+        void Attach(MetadataItem item)
+        {
+            var directParentNamespace = GetParentNamespaces(item.Name).LastOrDefault();
+
+            var parent = directParentNamespace is not null && namespacedItems.TryGetValue(directParentNamespace, out var parentNamespace)
+                ? parentNamespace
+                : GetAssemblyRoot(item.AssemblyUid);
+
+            parent.Items.Add(item);
+            item.Parent = parent;
+        }
+
+        MetadataItem GetAssemblyRoot(string assemblyUid)
+        {
+            if (assemblyUid is null)
+            {
+                return root;
+            }
+
+            if (!assemblyRoots.TryGetValue(assemblyUid, out var assemblyRoot))
+            {
+                // This node exists to group the namespaces of one assembly and has no page of its own, so
+                // it must not carry a UID: `MemberType.Toc` is what keeps `BuildMembers` from making a page
+                // for it and `ToTocItemViewModel` from emitting a UID that resolves to nothing.
+                assemblyRoots[assemblyUid] = assemblyRoot = new MetadataItem()
+                {
+                    Type = MemberType.Toc,
+                    Items = [],
+                    DisplayNames = new() { [SyntaxLanguage.Default] = assemblyUid },
+                    DisplayNamesWithType = [],
+                    DisplayQualifiedNames = [],
+                    Parent = root,
+                };
+
+                root.Items.Add(assemblyRoot);
+            }
+
+            return assemblyRoot;
+        }
     }
 
+    /// <summary>
+    /// Enumerates the UIDs of the namespaces containing <paramref name="originalNamespace"/>, outermost
+    /// first. The assembly component is not a namespace level, so it is kept on every UID yielded instead
+    /// of being split on.
+    /// </summary>
     private static IEnumerable<string> GetParentNamespaces(string originalNamespace)
     {
-        var namespaces = originalNamespace.Split('.');
+        var namespaceName = VisitorHelper.TrimAssemblyUid(originalNamespace);
+        var assemblyUid = originalNamespace[..^namespaceName.Length];
+
+        var namespaces = namespaceName.Split('.');
         var fullNamespace = "";
         foreach (var @namespace in namespaces)
         {
             fullNamespace += $".{@namespace}";
-            if (fullNamespace.TrimStart('.') != originalNamespace)
-                yield return fullNamespace.TrimStart('.');
+            if (fullNamespace.TrimStart('.') != namespaceName)
+                yield return assemblyUid + fullNamespace.TrimStart('.');
         }
     }
 
@@ -177,7 +215,11 @@ internal static class YamlMetadataResolver
         {
             if (metadataItem.Type == MemberType.Namespace)
             {
-                if (metadataItem.Parent?.Items.Count == 1 && metadataItem.Parent.Parent != null)
+                // A namespace is never promoted out of an assembly root, even when it is the only one:
+                // that root is the only thing naming the assembly. The outer root is excluded by having no
+                // parent of its own, as before.
+                if (metadataItem.Parent?.Type is not MemberType.Toc
+                 && metadataItem.Parent?.Items.Count == 1 && metadataItem.Parent.Parent != null)
                 {
                     metadataItem.Parent.Parent.Items.Add(metadataItem);
                     metadataItem.Parent.Parent.Items.Remove(metadataItem.Parent);

--- a/src/Docfx.Dotnet/ManagedReference/Visitors/SymbolVisitorAdapter.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Visitors/SymbolVisitorAdapter.cs
@@ -130,6 +130,64 @@ internal partial class SymbolVisitorAdapter : SymbolVisitor<MetadataItem>
             return null;
         }
         item.Type = MemberType.Namespace;
+
+        // Roslyn has no name for the global namespace, so its display names come out empty and its table of
+        // contents node shows nothing at all (dotnet/docfx#9458). `globalNamespaceId` is the name docfx
+        // gives it, and already its uid, so that is what it is called.
+        if (symbol.IsGlobalNamespace && !string.IsNullOrEmpty(VisitorHelper.GlobalNamespaceId))
+        {
+            SetDisplayNames(item.DisplayNames, VisitorHelper.GlobalNamespaceId);
+            SetDisplayNames(item.DisplayNamesWithType, VisitorHelper.GlobalNamespaceId);
+            SetDisplayNames(item.DisplayQualifiedNames, VisitorHelper.GlobalNamespaceId);
+        }
+
+        // The UID of this namespace carries the assembly it was declared in, but its display names must
+        // not: they name the namespace as it appears in the source. Where two assemblies declare the same
+        // namespace, `assemblyLabel` decides how they are told apart on the page and in the table of
+        // contents; a nested layout needs nothing, as it groups by assembly already.
+        if (VisitorHelper.GetAssemblyUid(symbol) is { } assemblyUid)
+        {
+            item.AssemblyUid = assemblyUid;
+
+            switch (_config.ResolvedAssemblyLabel)
+            {
+                case AssemblyLabel.Suffix:
+                    AppendAssembly(item.DisplayNames);
+                    AppendAssembly(item.DisplayNamesWithType);
+                    AppendAssembly(item.DisplayQualifiedNames);
+                    break;
+
+                case AssemblyLabel.Page:
+                    // The page names the assembly, so it names the real one rather than the component,
+                    // which may have been given a shorter name in the configuration. There is always a
+                    // containing assembly here, as that is what the component was looked up from.
+                    item.NamespaceAssembly = symbol.ContainingAssembly.Name;
+                    break;
+            }
+
+            void AppendAssembly(SortedList<SyntaxLanguage, string> names)
+            {
+                foreach (var language in names.Keys.ToArray())
+                {
+                    names[language] = $"{names[language]} ({assemblyUid})";
+                }
+            }
+        }
+
+        static void SetDisplayNames(SortedList<SyntaxLanguage, string> names, string name)
+        {
+            if (names.Count is 0)
+            {
+                names.Add(SyntaxLanguage.Default, name);
+                return;
+            }
+
+            foreach (var language in names.Keys.ToArray())
+            {
+                names[language] = name;
+            }
+        }
+
         item.Items = VisitDescendants(
             symbol.GetMembers().OfType<ITypeSymbol>(),
             t => t.GetMembers().OfType<ITypeSymbol>(),
@@ -721,6 +779,7 @@ internal partial class SymbolVisitorAdapter : SymbolVisitor<MetadataItem>
             AddReferenceDelegate = AddReferenceDelegate,
             Source = item.Source,
             ResolveCode = ResolveCode,
+            ResolveAssemblyUid = commentId => VisitorHelper.GetAssemblyUidForCommentId(commentId, _compilation),
         };
 
         void AddReferenceDelegate(string id, string commentId)

--- a/src/Docfx.Dotnet/ManagedReference/Visitors/SymbolVisitorAdapter.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Visitors/SymbolVisitorAdapter.cs
@@ -142,35 +142,20 @@ internal partial class SymbolVisitorAdapter : SymbolVisitor<MetadataItem>
         }
 
         // The UID of this namespace carries the assembly it was declared in, but its display names must
-        // not: they name the namespace as it appears in the source. Where two assemblies declare the same
-        // namespace, `assemblyLabel` decides how they are told apart on the page and in the table of
-        // contents; a nested layout needs nothing, as it groups by assembly already.
+        // not: they name the namespace as it appears in the source. Where `assemblyLabel` asks for the
+        // assembly to be appended to the label, that happens in `ApplyAssemblyLabel`, once every assembly
+        // of this metadata item has been visited, since only then is it known which namespaces more than
+        // one of them declares.
         if (VisitorHelper.GetAssemblyUid(symbol) is { } assemblyUid)
         {
             item.AssemblyUid = assemblyUid;
 
-            switch (_config.ResolvedAssemblyLabel)
+            if (_config.AssemblyLabel is AssemblyLabel.Page)
             {
-                case AssemblyLabel.Suffix:
-                    AppendAssembly(item.DisplayNames);
-                    AppendAssembly(item.DisplayNamesWithType);
-                    AppendAssembly(item.DisplayQualifiedNames);
-                    break;
-
-                case AssemblyLabel.Page:
-                    // The page names the assembly, so it names the real one rather than the component,
-                    // which may have been given a shorter name in the configuration. There is always a
-                    // containing assembly here, as that is what the component was looked up from.
-                    item.NamespaceAssembly = symbol.ContainingAssembly.Name;
-                    break;
-            }
-
-            void AppendAssembly(SortedList<SyntaxLanguage, string> names)
-            {
-                foreach (var language in names.Keys.ToArray())
-                {
-                    names[language] = $"{names[language]} ({assemblyUid})";
-                }
+                // The page names the assembly, so it names the real one rather than the component, which
+                // may have been given a shorter name in the configuration. There is always a containing
+                // assembly here, as that is what the component was looked up from.
+                item.NamespaceAssembly = symbol.ContainingAssembly.Name;
             }
         }
 

--- a/src/Docfx.Dotnet/ManagedReference/Visitors/VisitorHelper.cs
+++ b/src/Docfx.Dotnet/ManagedReference/Visitors/VisitorHelper.cs
@@ -16,15 +16,80 @@ internal static partial class VisitorHelper
 {
     public static string GlobalNamespaceId { get; set; }
 
+    /// <summary>
+    /// Separates the assembly component of a UID from the namespace qualified name that follows it, as in
+    /// <c>MyLib.Tools::MyLib.Tools.Widget</c>. It is deliberately not a dot: the component names an
+    /// assembly, not a namespace, so it must not read as one.
+    /// </summary>
+    public const string AssemblyUidSeparator = "::";
+
+    /// <summary>
+    /// The assemblies whose APIs carry an assembly component in their UID, mapped to that component.
+    /// A null value means the assembly's own name is used, which is the normal case.
+    /// This is assigned once before metadata generation starts and is only read afterwards,
+    /// so it is safe to read from the parallel API page generation.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> AssemblyUids { get; set; }
+
+    /// <summary>
+    /// The assembly component used for every API declared in <see cref="AssemblyUidOverrideAssemblies"/>.
+    /// It takes precedence over <see cref="AssemblyUids"/>, which lets metadata items that document
+    /// assemblies sharing an assembly name give them distinct UIDs.
+    /// This is assigned once per metadata item, before its APIs are generated.
+    /// </summary>
+    public static string AssemblyUidOverride { get; set; }
+
+    /// <summary>
+    /// The assemblies <see cref="AssemblyUidOverride"/> applies to, i.e. the assemblies documented by the
+    /// metadata item that is currently being processed.
+    /// </summary>
+    public static HashSet<IAssemblySymbol> AssemblyUidOverrideAssemblies { get; set; }
+
+    private static bool IsAssemblyUidConfigured => AssemblyUids is { Count: > 0 } || !string.IsNullOrEmpty(AssemblyUidOverride);
+
     [GeneratedRegex(@"``\d+$")]
     private static partial Regex GenericMethodPostFix();
 
     public static string PathFriendlyId(string id)
     {
-        return id.Replace('`', '-').Replace('#', '-').Replace("*", "");
+        // `:` is not a legal file name character, so the assembly component separator becomes dashes.
+        // One dash per character, because `PathUtility.ToCleanUrlFileName` replaces each character it
+        // rejects with a single dash, and it is what names the member pages that `memberLayout:
+        // separatePages` splits out. The two have to agree or the hrefs miss those pages.
+        return id.Replace(':', '-').Replace('`', '-').Replace('#', '-').Replace("*", "");
+    }
+
+    /// <summary>
+    /// Removes the assembly component from a UID, leaving the namespace qualified name it addresses.
+    /// A UID without an assembly component is returned unchanged.
+    /// </summary>
+    public static string TrimAssemblyUid(string uid)
+    {
+        if (uid is null)
+        {
+            return null;
+        }
+
+        var separator = uid.IndexOf(AssemblyUidSeparator, StringComparison.Ordinal);
+        return separator < 0 ? uid : uid[(separator + AssemblyUidSeparator.Length)..];
     }
 
     public static string GetId(ISymbol symbol)
+    {
+        return GetId(symbol, applyAssemblyUid: true);
+    }
+
+    /// <summary>
+    /// Gets the id of a symbol without applying any configured assembly component.
+    /// API filters use this so that filter rules keep matching the actual API surface
+    /// regardless of the configured assembly components.
+    /// </summary>
+    public static string GetRawId(ISymbol symbol)
+    {
+        return GetId(symbol, applyAssemblyUid: false);
+    }
+
+    private static string GetId(ISymbol symbol, bool applyAssemblyUid)
     {
         if (symbol == null)
         {
@@ -33,7 +98,12 @@ internal static partial class VisitorHelper
 
         if (symbol is INamespaceSymbol { IsGlobalNamespace: true })
         {
-            return GlobalNamespaceId;
+            // The global namespace of a qualified assembly is qualified too, otherwise two assemblies
+            // whose APIs sit in the global namespace would share the one page named after
+            // `globalNamespaceId`, which is the collision this is all meant to avoid.
+            return applyAssemblyUid && !string.IsNullOrEmpty(GlobalNamespaceId) && GetAssemblyUid(symbol) is { } assemblyUid
+                ? assemblyUid + AssemblyUidSeparator + GlobalNamespaceId
+                : GlobalNamespaceId;
         }
 
         if (symbol is IAssemblySymbol assemblySymbol)
@@ -46,7 +116,7 @@ internal static partial class VisitorHelper
             return "dynamic";
         }
 
-        var id = GetDocumentationCommentId(symbol)?.Substring(2);
+        var id = GetDocumentationCommentId(symbol, applyAssemblyUid)?.Substring(2);
 
         if ((id is null) && (symbol is IFunctionPointerTypeSymbol functionPointerTypeSymbol))
         {
@@ -60,7 +130,7 @@ internal static partial class VisitorHelper
         return id;
     }
 
-    private static string GetDocumentationCommentId(ISymbol symbol)
+    private static string GetDocumentationCommentId(ISymbol symbol, bool applyAssemblyUid = true)
     {
         string str = symbol.GetDocumentationCommentId();
         if (string.IsNullOrEmpty(str))
@@ -77,7 +147,86 @@ internal static partial class VisitorHelper
                 str = str.Insert(2, GlobalNamespaceId + ".");
             }
         }
+
+        if (applyAssemblyUid && GetAssemblyUid(symbol) is { } assemblyUid)
+        {
+            str = str.Insert(2, assemblyUid + AssemblyUidSeparator);
+        }
+
         return str;
+    }
+
+    /// <summary>
+    /// Gets the assembly component of the UID of <paramref name="symbol"/>, i.e. the configured component
+    /// of the assembly that declares it, or <see langword="null"/> when it is not qualified.
+    /// </summary>
+    public static string GetAssemblyUid(ISymbol symbol)
+    {
+        if (symbol is null || !IsAssemblyUidConfigured)
+        {
+            return null;
+        }
+
+        // Type parameters are scoped to their declaring API, qualifying them would break the
+        // `` `0 `` / ` ``0 ` references used by the documentation comment id format.
+        if (symbol is ITypeParameterSymbol)
+        {
+            return null;
+        }
+
+        // ContainingAssembly is null for symbols that don't belong to a single assembly,
+        // e.g. merged namespaces or some symbols reached through cref resolution.
+        return symbol.ContainingAssembly is { } assembly ? GetAssemblyUid(assembly) : null;
+    }
+
+    /// <summary>
+    /// Gets the assembly component configured for <paramref name="assembly"/>, or <see langword="null"/>
+    /// when its APIs are not qualified by it.
+    /// </summary>
+    public static string GetAssemblyUid(IAssemblySymbol assembly)
+    {
+        if (assembly is null || !IsAssemblyUidConfigured)
+        {
+            return null;
+        }
+
+        // The component of the metadata item being processed wins, so that assemblies sharing an
+        // assembly name can still be told apart by the item that documents each of them.
+        if (!string.IsNullOrEmpty(AssemblyUidOverride) && AssemblyUidOverrideAssemblies is { } assemblies && assemblies.Contains(assembly))
+        {
+            return AssemblyUidOverride;
+        }
+
+        // A null value means the assembly is qualified by its own name, which is the normal case. The name
+        // comes from the assembly rather than from the configured key, so its casing is always the real one.
+        return AssemblyUids is { } assemblyUids && assemblyUids.TryGetValue(assembly.Name, out var component)
+            ? component ?? assembly.Name
+            : null;
+    }
+
+    /// <summary>
+    /// Gets the assembly component of the UID of the API a documentation comment id (i.e. a cref) points
+    /// to, or <see langword="null"/> when the target is not qualified or cannot be resolved.
+    /// </summary>
+    public static string GetAssemblyUidForCommentId(string commentId, Compilation compilation)
+    {
+        if (string.IsNullOrEmpty(commentId) || !IsAssemblyUidConfigured)
+        {
+            return null;
+        }
+
+        // `Overload:` is a docfx concept, Roslyn only knows about declaration id kinds.
+        const string overloadPrefix = "Overload:";
+        if (commentId.StartsWith(overloadPrefix, StringComparison.Ordinal))
+        {
+            var body = commentId[overloadPrefix.Length..];
+            return GetAssemblyUid(ResolveDeclarationId($"M:{body}"))
+                ?? GetAssemblyUid(ResolveDeclarationId($"P:{body}"));
+        }
+
+        return GetAssemblyUid(ResolveDeclarationId(commentId));
+
+        ISymbol ResolveDeclarationId(string id) => DocumentationCommentId.GetFirstSymbolForDeclarationId(id, compilation);
     }
 
     public static string GetCommentId(ISymbol symbol)

--- a/src/Docfx.Dotnet/MetadataJsonConfig.cs
+++ b/src/Docfx.Dotnet/MetadataJsonConfig.cs
@@ -66,21 +66,23 @@ internal enum NamespaceLayout
 internal enum AssemblyLabel
 {
     /// <summary>
-    /// Appends the assembly to the namespace label in a flattened layout, where nothing else
-    /// distinguishes two assemblies that declare the same namespace, and shows the namespace on its own
-    /// in a nested layout, where the per assembly root node already names it. This is the default.
-    /// </summary>
-    Auto,
-
-    /// <summary>
-    /// Appends the assembly to the namespace label, as in <c>MyLib.Tools (MyLib.Tools.dll)</c>.
-    /// </summary>
-    Suffix,
-
-    /// <summary>
-    /// Shows the namespace on its own, with no mention of the assembly it comes from.
+    /// Shows the namespace on its own, with no mention of the assembly it comes from. This is the default,
+    /// so qualifying an assembly changes what a page is called by, not what it reads as.
     /// </summary>
     None,
+
+    /// <summary>
+    /// Appends the assembly to the namespace label, as in <c>MyLib (MyLib.Tools)</c>, but only for the
+    /// namespaces that more than one assembly documented by the same <c>metadata</c> entry declares. The
+    /// namespaces only one assembly declares are shown on their own, as there is nothing to tell apart.
+    /// </summary>
+    Shared,
+
+    /// <summary>
+    /// Appends the assembly to the namespace label, as in <c>MyLib (MyLib.Tools)</c>, for every namespace
+    /// of a qualified assembly.
+    /// </summary>
+    Suffix,
 
     /// <summary>
     /// Shows the namespace on its own, and names the assembly on the namespace page instead, the way

--- a/src/Docfx.Dotnet/MetadataJsonConfig.cs
+++ b/src/Docfx.Dotnet/MetadataJsonConfig.cs
@@ -60,6 +60,36 @@ internal enum NamespaceLayout
 }
 
 /// <summary>
+/// Specifies how the assembly of a namespace is shown, for assemblies listed in
+/// <c>assemblyUids</c>. Has no effect on assemblies that are not listed there.
+/// </summary>
+internal enum AssemblyLabel
+{
+    /// <summary>
+    /// Appends the assembly to the namespace label in a flattened layout, where nothing else
+    /// distinguishes two assemblies that declare the same namespace, and shows the namespace on its own
+    /// in a nested layout, where the per assembly root node already names it. This is the default.
+    /// </summary>
+    Auto,
+
+    /// <summary>
+    /// Appends the assembly to the namespace label, as in <c>MyLib.Tools (MyLib.Tools.dll)</c>.
+    /// </summary>
+    Suffix,
+
+    /// <summary>
+    /// Shows the namespace on its own, with no mention of the assembly it comes from.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Shows the namespace on its own, and names the assembly on the namespace page instead, the way
+    /// type pages do.
+    /// </summary>
+    Page,
+}
+
+/// <summary>
 /// Specifies the sort order for enums.
 /// </summary>
 internal enum EnumSortOrder
@@ -177,6 +207,28 @@ internal class MetadataJsonItemConfig
     [JsonProperty("globalNamespaceId")]
     [JsonPropertyName("globalNamespaceId")]
     public string GlobalNamespaceId { get; set; }
+
+    /// <summary>
+    /// The assembly component to use in the UIDs of the assemblies documented by this entry, instead of
+    /// their assembly name. Needed only when several entries document assemblies that share an assembly
+    /// name, such as per target version builds of one project, which the project level <c>assemblyUids</c>
+    /// cannot tell apart.
+    /// <para>
+    /// Because it is scoped to its own entry, other entries cannot see it, so an assembly that other
+    /// entries reference belongs in <c>assemblyUids</c> instead.
+    /// </para>
+    /// </summary>
+    [JsonProperty("assemblyUidOverride")]
+    [JsonPropertyName("assemblyUidOverride")]
+    public string AssemblyUidOverride { get; set; }
+
+    /// <summary>
+    /// Specifies how the assembly of a namespace is shown, for assemblies that carry an assembly
+    /// component in their UIDs.
+    /// </summary>
+    [JsonProperty("assemblyLabel")]
+    [JsonPropertyName("assemblyLabel")]
+    public AssemblyLabel AssemblyLabel { get; set; }
 
     /// <summary>
     /// An optional set of MSBuild properties used when interpreting project files. These

--- a/src/Docfx.Dotnet/Parsers/XmlComment.cs
+++ b/src/Docfx.Dotnet/Parsers/XmlComment.cs
@@ -132,6 +132,17 @@ internal partial class XmlComment
         }
     }
 
+    /// <summary>
+    /// Prepends the assembly component of the API <paramref name="commentId"/> points to, so that crefs
+    /// keep resolving when the target assembly is configured to carry one.
+    /// </summary>
+    private string ApplyAssemblyUid(string id, string commentId)
+    {
+        return _context?.ResolveAssemblyUid?.Invoke(commentId) is { } assemblyUid
+            ? $"{assemblyUid}{VisitorHelper.AssemblyUidSeparator}{id}"
+            : id;
+    }
+
     public string GetParameter(string name)
     {
         return Parameters.GetValueOrDefault(name);
@@ -335,6 +346,8 @@ internal partial class XmlComment
                     id += '*';
                 }
 
+                id = ApplyAssemblyUid(id, cref);
+
                 // When see and seealso are top level nodes in triple slash comments, do not convert it into xref node
                 if (item.Parent?.Parent != null)
                 {
@@ -439,7 +452,7 @@ internal partial class XmlComment
                     yield return new ExceptionInfo
                     {
                         Description = description,
-                        Type = id,
+                        Type = ApplyAssemblyUid(id, commentId),
                         CommentId = commentId,
                     };
                 }
@@ -447,7 +460,7 @@ internal partial class XmlComment
         }
     }
 
-    private static IEnumerable<LinkInfo> GetMultipleLinkInfo(XDocument doc, string selector)
+    private IEnumerable<LinkInfo> GetMultipleLinkInfo(XDocument doc, string selector)
     {
         var nodes = doc.XPathSelectElements(selector).ToArray();
 
@@ -490,7 +503,7 @@ internal partial class XmlComment
                     yield return new LinkInfo
                     {
                         AltText = altText,
-                        LinkId = id,
+                        LinkId = ApplyAssemblyUid(id, commentId),
                         CommentId = commentId,
                         LinkType = LinkType.CRef
                     };

--- a/src/Docfx.Dotnet/Parsers/XmlCommentParserContext.cs
+++ b/src/Docfx.Dotnet/Parsers/XmlCommentParserContext.cs
@@ -13,5 +13,11 @@ internal class XmlCommentParserContext
 
     public Func<string, string> ResolveCode { get; init; }
 
+    /// <summary>
+    /// Resolves the assembly component of the UID of the API a cref points to, or <see langword="null"/>
+    /// when that API isn't qualified by an assembly.
+    /// </summary>
+    public Func<string, string> ResolveAssemblyUid { get; init; }
+
     public SourceDetail Source { get; init; }
 }

--- a/src/Docfx.Dotnet/SymbolUrlResolver.cs
+++ b/src/Docfx.Dotnet/SymbolUrlResolver.cs
@@ -43,7 +43,14 @@ internal static partial class SymbolUrlResolver
         if (commentId is null)
             return null;
 
-        var parts = commentId.Split(':');
+        // The file names and anchors this method builds come from VisitorHelper, so the assembly component
+        // has to be applied here as well, otherwise the generated links miss the pages they target.
+        if (VisitorHelper.GetAssemblyUid(symbol) is { } assemblyUid)
+            commentId = commentId.Insert(2, assemblyUid + VisitorHelper.AssemblyUidSeparator);
+
+        // Only the first colon separates the declaration kind from the id, as the id itself contains the
+        // `::` of the assembly component.
+        var parts = commentId.Split(':', 2);
         var type = parts[0];
         var uid = parts[1];
         var ext = urlKind switch

--- a/src/Docfx.Dotnet/YamlViewModelExtensions.cs
+++ b/src/Docfx.Dotnet/YamlViewModelExtensions.cs
@@ -144,14 +144,20 @@ internal static class YamlViewModelExtensions
         {
             Uid = item.Name,
             Name = item.DisplayNames.GetLanguageProperty(SyntaxLanguage.Default),
-            Type = item.Type.ToString(),
+
+            // An assembly grouping node is not an API of its own: it has no UID, no page, and no member
+            // kind to report. Everything else is one of the API kinds.
+            Type = item.Type is MemberType.Toc ? null : item.Type.ToString(),
         };
 
         if (item.Type is MemberType.Namespace)
         {
             if (result.Name.StartsWith(parentNamespace))
                 result.Name = result.Name.Substring(parentNamespace.Length);
-            parentNamespace = $"{item.Name}.";
+
+            // Trimming compares against what is displayed, so the assembly component of the UID has no
+            // place in it. For an unqualified namespace this is the UID itself.
+            parentNamespace = $"{VisitorHelper.TrimAssemblyUid(item.Name)}.";
         }
 
         if (item.Items != null)
@@ -264,6 +270,7 @@ internal static class YamlViewModelExtensions
             Documentation = model.Documentation,
             AssemblyNameList = model.AssemblyNameList,
             NamespaceName = model.NamespaceName,
+            NamespaceAssembly = model.NamespaceAssembly,
             Summary = model.Summary,
             Remarks = model.Remarks,
             Examples = model.Examples,

--- a/src/Docfx.MarkdigEngine.Extensions/Xref/XrefInlineShortParser.cs
+++ b/src/Docfx.MarkdigEngine.Extensions/Xref/XrefInlineShortParser.cs
@@ -57,7 +57,20 @@ class XrefInlineShortParser : InlineParser
             }
 
             var nextChar = slice.PeekCharExtra(1);
-            if (ContinuableCharacters.Contains(c) && (nextChar.IsWhiteSpaceOrZero() || StopCharacters.Contains(nextChar) || ContinuableCharacters.Contains(nextChar)))
+
+            // `::` separates the assembly component of a .NET UID from the namespace qualified name, as in
+            // `@MyLib.Tools::MyLib.Tools.Widget`. Both colons are continuable characters, so without this
+            // the UID would end at the first one. It only continues while something follows the pair.
+            if (c == ':' && nextChar == ':' && ContinuesUid(slice.PeekCharExtra(2)))
+            {
+                href.Append(c);
+                href.Append(nextChar);
+                slice.NextChar();
+                c = slice.NextChar();
+                continue;
+            }
+
+            if (ContinuableCharacters.Contains(c) && !ContinuesUid(nextChar))
             {
                 break;
             }
@@ -82,6 +95,11 @@ class XrefInlineShortParser : InlineParser
         processor.Inline = xrefInline;
 
         return true;
+
+        static bool ContinuesUid(char c)
+        {
+            return !c.IsWhiteSpaceOrZero() && !StopCharacters.Contains(c) && !ContinuableCharacters.Contains(c);
+        }
     }
 
     private static bool MatchXrefShortcutWithQuote(InlineProcessor processor, ref StringSlice slice)

--- a/src/docfx/Models/DefaultCommand.cs
+++ b/src/docfx/Models/DefaultCommand.cs
@@ -42,7 +42,7 @@ class DefaultCommand : Command<DefaultCommand.Options>
 
             if (config.metadata is not null)
             {
-                DotnetApiCatalog.Exec(config.metadata, new(), configDirectory).GetAwaiter().GetResult();
+                DotnetApiCatalog.Exec(config.metadata, new(), configDirectory, assemblyUids: config.assemblyUids).GetAwaiter().GetResult();
             }
 
             if (config.build is not null)

--- a/src/docfx/Models/MetadataCommand.cs
+++ b/src/docfx/Models/MetadataCommand.cs
@@ -15,7 +15,7 @@ internal class MetadataCommand : AsyncCommand<MetadataCommandOptions>
         {
             var (config, baseDirectory) = Docset.GetConfig(options.Config);
             MergeOptionsToConfig(options, config);
-            await DotnetApiCatalog.Exec(config.metadata, new(), baseDirectory, options.OutputFolder, cancellationToken);
+            await DotnetApiCatalog.Exec(config.metadata, new(), baseDirectory, options.OutputFolder, config.assemblyUids, cancellationToken);
         });
     }
 

--- a/templates/default/partials/namespace.tmpl.partial
+++ b/templates/default/partials/namespace.tmpl.partial
@@ -1,6 +1,9 @@
 {{!Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license.}}
 
 <h1 id="{{id}}" data-uid="{{uid}}" class="text-break">{{>partials/title}}</h1>
+{{#namespaceAssembly}}
+<h6><strong>{{__global.assembly}}</strong>: {{namespaceAssembly}}.dll</h6>
+{{/namespaceAssembly}}
 <div class="markdown level0 summary">{{{summary}}}</div>
 <div class="markdown level0 conceptual">{{{conceptual}}}</div>
 <div class="markdown level0 remarks">{{{remarks}}}</div>

--- a/templates/modern/partials/namespace.tmpl.partial
+++ b/templates/modern/partials/namespace.tmpl.partial
@@ -1,6 +1,11 @@
 {{!Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license.}}
 
 <h1 id="{{id}}" data-uid="{{uid}}" class="text-break">{{>partials/title}}</h1>
+{{#namespaceAssembly}}
+<div class="facts text-secondary">
+  <dl><dt>{{__global.assembly}}</dt><dd>{{namespaceAssembly}}.dll</dd></dl>
+</div>
+{{/namespaceAssembly}}
 <div class="markdown level0 summary">{{{summary}}}</div>
 <div class="markdown level0 conceptual">{{{conceptual}}}</div>
 <div class="markdown level0 remarks">{{{remarks}}}</div>

--- a/test/Docfx.Dotnet.Tests/AssemblyUidUnitTest.cs
+++ b/test/Docfx.Dotnet.Tests/AssemblyUidUnitTest.cs
@@ -1,0 +1,600 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Web;
+using Docfx.DataContracts.ManagedReference;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Docfx.Dotnet.Tests;
+
+/// <summary>
+/// Tests for the <c>assemblyUids</c> and <c>assemblyUidOverride</c> metadata options, which make the
+/// assembly a component of the UID of every API it declares, as in <c>Pkg::Shared.Widget</c>, so that
+/// assemblies sharing a namespace don't collide.
+/// </summary>
+[Collection("docfx STA")]
+public class AssemblyUidUnitTest : IDisposable
+{
+    private static readonly Dictionary<string, string> EmptyMSBuildProperties = [];
+
+    private const string SharedLibraryCode =
+        """
+        namespace Shared;
+
+        /// <summary>A widget.</summary>
+        public class Widget
+        {
+            /// <summary>Does something.</summary>
+            public void Do() { }
+
+            /// <summary>Does something else.</summary>
+            public void Do(int value) { }
+        }
+        """;
+
+    public void Dispose()
+    {
+        VisitorHelper.AssemblyUids = null;
+        VisitorHelper.AssemblyUidOverride = null;
+        VisitorHelper.AssemblyUidOverrideAssemblies = null;
+        VisitorHelper.GlobalNamespaceId = null;
+    }
+
+    /// <summary>
+    /// Qualifies each assembly by its own name, which is the array form of <c>assemblyUids</c>.
+    /// </summary>
+    private static void UseAssemblyUids(params string[] assemblyNames)
+    {
+        VisitorHelper.AssemblyUids = assemblyNames.ToDictionary(name => name, _ => (string)null, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Names the component of each assembly explicitly, which is the object form of <c>assemblyUids</c>.
+    /// </summary>
+    private static void UseAssemblyUids(params (string assembly, string component)[] components)
+    {
+        VisitorHelper.AssemblyUids = components.ToDictionary(x => x.assembly, x => x.component, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The href of a cref is URL encoded on the way into the comment (<c>XmlComment.ResolveCrefLink</c>) and
+    /// decoded again on the way out (<c>XRefDetails.From</c>), so the `::` of an assembly component appears
+    /// percent encoded in between.
+    /// </summary>
+    private static string XrefTo(string uid) => $"<xref href=\"{HttpUtility.UrlEncode(uid)}\"";
+
+    private static MetadataItem Verify(string code, string assemblyName = "test.dll", ExtractMetadataConfig config = null, params MetadataReference[] references)
+    {
+        var compilation = CompilationHelper.CreateCompilationFromCSharpCode(code, EmptyMSBuildProperties, assemblyName, references);
+        Assert.Empty(compilation.GetDeclarationDiagnostics());
+        return compilation.Assembly.GenerateMetadataItem(compilation, config);
+    }
+
+    /// <summary>
+    /// Compiles <paramref name="code"/> into an in-memory assembly that can be referenced by another compilation.
+    /// </summary>
+    private static MetadataReference CreateReference(string code, string assemblyName)
+    {
+        var compilation = CompilationHelper.CreateCompilationFromCSharpCode(code, EmptyMSBuildProperties, assemblyName);
+        Assert.Empty(compilation.GetDeclarationDiagnostics());
+        return compilation.ToMetadataReference();
+    }
+
+    [Fact]
+    public void UidsAreUnchangedWhenNoAssemblyIsQualified()
+    {
+        var output = Verify(SharedLibraryCode);
+
+        var @namespace = output.Items[0];
+        Assert.Equal("Shared", @namespace.Name);
+        Assert.Equal("N:Shared", @namespace.CommentId);
+        Assert.Equal("Shared", @namespace.DisplayNames[SyntaxLanguage.CSharp]);
+        Assert.Equal("Shared.Widget", @namespace.Items[0].Name);
+    }
+
+    [Fact]
+    public void NamespaceTypeAndMemberUidsCarryTheAssembly()
+    {
+        UseAssemblyUids(("test.dll", "Pkg"));
+
+        var output = Verify(SharedLibraryCode);
+
+        var @namespace = output.Items[0];
+        Assert.Equal("Pkg::Shared", @namespace.Name);
+        Assert.Equal("N:Pkg::Shared", @namespace.CommentId);
+
+        var type = @namespace.Items[0];
+        Assert.Equal("Pkg::Shared.Widget", type.Name);
+        Assert.Equal("T:Pkg::Shared.Widget", type.CommentId);
+        Assert.Equal("Pkg::Shared", type.NamespaceName);
+
+        var method = type.Items.First(i => i.Name.Contains("Do(System.Int32)"));
+        Assert.Equal("Pkg::Shared.Widget.Do(System.Int32)", method.Name);
+        Assert.Equal("M:Pkg::Shared.Widget.Do(System.Int32)", method.CommentId);
+        Assert.Equal("Pkg::Shared.Widget.Do*", method.Overload);
+    }
+
+    /// <summary>
+    /// The component defaults to the name of the assembly, so the UID names something that exists.
+    /// </summary>
+    [Fact]
+    public void TheAssemblyNameIsTheDefaultComponent()
+    {
+        UseAssemblyUids("MyLib.Tools");
+
+        var output = Verify(SharedLibraryCode, "MyLib.Tools");
+
+        Assert.Equal("MyLib.Tools::Shared", output.Items[0].Name);
+        Assert.Equal("MyLib.Tools::Shared.Widget", output.Items[0].Items[0].Name);
+    }
+
+    /// <summary>
+    /// The assembly is a component of the UID, not a namespace segment, so it has no place in the names
+    /// that are displayed. With a flattened layout it is appended to the namespace label, as nothing else
+    /// there tells two assemblies declaring the same namespace apart.
+    /// </summary>
+    [Fact]
+    public void NamespaceDisplayNamesKeepTheRealNamespace()
+    {
+        UseAssemblyUids(("test.dll", "Pkg"));
+
+        var @namespace = Verify(SharedLibraryCode).Items[0];
+
+        Assert.Equal("Shared (Pkg)", @namespace.DisplayNames[SyntaxLanguage.CSharp]);
+        Assert.Equal("Shared (Pkg)", @namespace.DisplayNamesWithType[SyntaxLanguage.CSharp]);
+        Assert.Equal("Shared (Pkg)", @namespace.DisplayQualifiedNames[SyntaxLanguage.CSharp]);
+
+        // Type display names are unaffected, and keep naming the namespace as it is declared.
+        var type = @namespace.Items[0];
+        Assert.Equal("Widget", type.DisplayNames[SyntaxLanguage.CSharp]);
+        Assert.Equal("Shared.Widget", type.DisplayQualifiedNames[SyntaxLanguage.CSharp]);
+    }
+
+    /// <summary>
+    /// The enums are internal, so the cases name them as strings.
+    /// </summary>
+    [Theory]
+    [InlineData("None", "Flattened", "Shared", null)]
+    [InlineData("Suffix", "Flattened", "Shared (Pkg)", null)]
+    // `page` names the real assembly, `test.dll` here, rather than the component it was given.
+    [InlineData("Page", "Flattened", "Shared", "test.dll")]
+    [InlineData("Auto", "Flattened", "Shared (Pkg)", null)]
+    [InlineData("Auto", "Nested", "Shared", null)]
+    public void AssemblyLabelDecidesHowTheAssemblyIsShown(string assemblyLabel, string namespaceLayout, string expectedName, string expectedNamespaceAssembly)
+    {
+        UseAssemblyUids(("test.dll", "Pkg"));
+
+        var config = new ExtractMetadataConfig
+        {
+            AssemblyLabel = Enum.Parse<AssemblyLabel>(assemblyLabel),
+            NamespaceLayout = Enum.Parse<NamespaceLayout>(namespaceLayout),
+        };
+
+        var @namespace = Verify(SharedLibraryCode, config: config).Items[0];
+
+        Assert.Equal(expectedName, @namespace.DisplayNames[SyntaxLanguage.CSharp]);
+        Assert.Equal(expectedNamespaceAssembly, @namespace.NamespaceAssembly);
+
+        // Whatever is displayed, the UID is the same.
+        Assert.Equal("Pkg::Shared", @namespace.Name);
+    }
+
+    [Fact]
+    public void TwoAssembliesSharingANamespaceGetDistinctUids()
+    {
+        UseAssemblyUids("a.dll", "b.dll");
+
+        var a = Verify(SharedLibraryCode, "a.dll");
+        var b = Verify(SharedLibraryCode, "b.dll");
+
+        Assert.Equal("a.dll::Shared", a.Items[0].Name);
+        Assert.Equal("b.dll::Shared", b.Items[0].Name);
+        Assert.Equal("a.dll::Shared.Widget", a.Items[0].Items[0].Name);
+        Assert.Equal("b.dll::Shared.Widget", b.Items[0].Items[0].Name);
+    }
+
+    [Fact]
+    public void CrossAssemblyReferencesUseTheTargetAssemblyComponent()
+    {
+        UseAssemblyUids(("a.dll", "A"), ("b.dll", "B"));
+
+        var reference = CreateReference(SharedLibraryCode, "a.dll");
+        var output = Verify(
+            """
+            namespace Shared;
+
+            /// <summary>A gadget.</summary>
+            public class Gadget : Widget { }
+            """,
+            "b.dll",
+            references: reference);
+
+        var type = output.Items[0].Items[0];
+        Assert.Equal("B::Shared.Gadget", type.Name);
+
+        // The base type lives in a.dll, so it must carry A's component, not B's.
+        Assert.Equal(["System.Object", "A::Shared.Widget"], type.Inheritance);
+    }
+
+    [Fact]
+    public void UnqualifiedAssembliesAreLeftUnchanged()
+    {
+        UseAssemblyUids(("b.dll", "B"));
+
+        var reference = CreateReference(SharedLibraryCode, "a.dll");
+        var output = Verify(
+            """
+            namespace Other;
+
+            /// <summary>A gadget.</summary>
+            public class Gadget : Shared.Widget { }
+            """,
+            "b.dll",
+            references: reference);
+
+        var type = output.Items[0].Items[0];
+        Assert.Equal("B::Other.Gadget", type.Name);
+
+        // Neither the unlisted assembly nor the framework is qualified.
+        Assert.Equal(["System.Object", "Shared.Widget"], type.Inheritance);
+    }
+
+    [Fact]
+    public void CrefsToQualifiedAssembliesAreResolved()
+    {
+        UseAssemblyUids(("a.dll", "A"), ("b.dll", "B"));
+
+        var reference = CreateReference(SharedLibraryCode, "a.dll");
+        var output = Verify(
+            """
+            namespace Other;
+
+            /// <summary>Wraps a <see cref="Shared.Widget"/>.</summary>
+            /// <seealso cref="Shared.Widget"/>
+            /// <seealso cref="System.String"/>
+            public class Gadget
+            {
+                /// <summary>Wraps.</summary>
+                /// <exception cref="System.InvalidOperationException">Always.</exception>
+                /// <exception cref="Shared.Widget">Never.</exception>
+                public void Wrap() { }
+            }
+            """,
+            "b.dll",
+            references: reference);
+
+        var type = output.Items[0].Items[0];
+
+        Assert.Contains(XrefTo("A::Shared.Widget"), type.Summary);
+        Assert.Equal(["A::Shared.Widget", "System.String"], type.SeeAlsos.Select(x => x.LinkId));
+
+        var method = type.Items[0];
+        Assert.Equal(["System.InvalidOperationException", "A::Shared.Widget"], method.Exceptions.Select(x => x.Type));
+    }
+
+    /// <summary>
+    /// `Overload:` crefs only appear in hand authored XML documentation, so this exercises the
+    /// comment parser directly instead of going through a C# compilation.
+    /// </summary>
+    [Fact]
+    public void OverloadCrefsCarryTheAssembly()
+    {
+        UseAssemblyUids(("a.dll", "A"));
+
+        var compilation = CompilationHelper.CreateCompilationFromCSharpCode(SharedLibraryCode, EmptyMSBuildProperties, "a.dll");
+        var context = new XmlCommentParserContext
+        {
+            ResolveAssemblyUid = commentId => VisitorHelper.GetAssemblyUidForCommentId(commentId, compilation),
+        };
+
+        var comment = XmlComment.Parse(
+            """
+            <member name="T:Other.Gadget">
+              <summary>See <see cref="Overload:Shared.Widget.Do"/>.</summary>
+            </member>
+            """, context);
+
+        Assert.Contains(XrefTo("A::Shared.Widget.Do*"), comment.Summary);
+    }
+
+    [Fact]
+    public void GenericsAndTypeParametersCarryTheAssemblyOnlyOnce()
+    {
+        UseAssemblyUids(("test.dll", "Pkg"));
+
+        var output = Verify(
+            """
+            using System.Collections.Generic;
+
+            namespace Shared;
+
+            /// <summary>A box.</summary>
+            public class Box<T>
+            {
+                /// <summary>Gets many.</summary>
+                public List<T> GetMany<TOther>(T value, TOther other) => null;
+            }
+            """);
+
+        var type = output.Items[0].Items[0];
+        Assert.Equal("Pkg::Shared.Box`1", type.Name);
+
+        var method = type.Items[0];
+        Assert.Equal("Pkg::Shared.Box`1.GetMany``1(`0,``0)", method.Name);
+        Assert.Equal("Pkg::Shared.Box`1.GetMany*", method.Overload);
+
+        // The component is applied exactly once, everywhere.
+        Assert.DoesNotContain(output.References.Keys, key => key.Contains("Pkg::Pkg"));
+    }
+
+    /// <summary>
+    /// Several metadata items can document assemblies that share an assembly name, e.g. per target
+    /// version variants of one project. The per item component is the only way to tell those apart.
+    /// </summary>
+    [Fact]
+    public void PerItemOverrideDistinguishesAssembliesSharingAnAssemblyName()
+    {
+        var v1 = CompilationHelper.CreateCompilationFromCSharpCode(SharedLibraryCode, EmptyMSBuildProperties, "MyLib.dll");
+        var v2 = CompilationHelper.CreateCompilationFromCSharpCode(SharedLibraryCode, EmptyMSBuildProperties, "MyLib.dll");
+
+        var a = GenerateWithOverride(v1, "V1");
+        var b = GenerateWithOverride(v2, "V2");
+
+        Assert.Equal("V1::Shared", a.Items[0].Name);
+        Assert.Equal("V2::Shared", b.Items[0].Name);
+        Assert.Equal("V1::Shared.Widget", a.Items[0].Items[0].Name);
+        Assert.Equal("V2::Shared.Widget", b.Items[0].Items[0].Name);
+    }
+
+    [Fact]
+    public void PerItemOverrideWinsOverTheProjectLevelSetting()
+    {
+        UseAssemblyUids(("test.dll", "FromMap"));
+
+        var compilation = CompilationHelper.CreateCompilationFromCSharpCode(SharedLibraryCode, EmptyMSBuildProperties, "test.dll");
+        var output = GenerateWithOverride(compilation, "FromItem");
+
+        Assert.Equal("FromItem::Shared.Widget", output.Items[0].Items[0].Name);
+    }
+
+    [Fact]
+    public void PerItemOverrideDoesNotApplyToOtherAssemblies()
+    {
+        // `a.dll` is documented by another metadata item, so it is addressed through the project level map.
+        UseAssemblyUids(("a.dll", "A"));
+
+        var reference = CreateReference(SharedLibraryCode, "a.dll");
+        var compilation = CompilationHelper.CreateCompilationFromCSharpCode(
+            """
+            namespace Other;
+
+            /// <summary>A gadget.</summary>
+            public class Gadget : Shared.Widget { }
+            """,
+            EmptyMSBuildProperties, "b.dll", reference);
+
+        var output = GenerateWithOverride(compilation, "B");
+        var type = output.Items[0].Items[0];
+
+        Assert.Equal("B::Other.Gadget", type.Name);
+        Assert.Equal(["System.Object", "A::Shared.Widget"], type.Inheritance);
+    }
+
+    /// <summary>
+    /// An assembly documented under a per item override can still be listed in <c>assemblyUids</c>, which
+    /// makes that entry the target other items link to. This is the only way to give other items something
+    /// to point at when several of them document assemblies sharing an assembly name.
+    /// </summary>
+    [Fact]
+    public void TheProjectLevelSettingIsTheDefaultTargetForOtherItems()
+    {
+        // `Shared.dll` is documented twice, once per version, and the map names V2 as the default target.
+        UseAssemblyUids(("Shared", "V2"), ("consumer.dll", "Consumer"));
+
+        var v1 = CompilationHelper.CreateCompilationFromCSharpCode(SharedLibraryCode, EmptyMSBuildProperties, "Shared");
+        var v2 = CompilationHelper.CreateCompilationFromCSharpCode(SharedLibraryCode, EmptyMSBuildProperties, "Shared");
+
+        // Each item's own override still wins for the assembly it documents.
+        Assert.Equal("V1::Shared.Widget", GenerateWithOverride(v1, "V1").Items[0].Items[0].Name);
+        Assert.Equal("V2::Shared.Widget", GenerateWithOverride(v2, "V2").Items[0].Items[0].Name);
+
+        // An item that only references it falls back to the map, so its links land on the V2 pages.
+        var consumer = CompilationHelper.CreateCompilationFromCSharpCode(
+            """
+            namespace Consumes;
+
+            /// <summary>A gadget.</summary>
+            public class Gadget : Shared.Widget { }
+            """,
+            EmptyMSBuildProperties, "consumer.dll", v2.ToMetadataReference());
+
+        var type = consumer.Assembly.GenerateMetadataItem(consumer).Items[0].Items[0];
+
+        Assert.Equal("Consumer::Consumes.Gadget", type.Name);
+        Assert.Equal(["System.Object", "V2::Shared.Widget"], type.Inheritance);
+    }
+
+    [Fact]
+    public void CrefsCarryThePerItemOverrideToo()
+    {
+        var compilation = CompilationHelper.CreateCompilationFromCSharpCode(
+            """
+            namespace Shared;
+
+            /// <summary>A widget.</summary>
+            public class Widget { }
+
+            /// <summary>Wraps a <see cref="Widget"/>.</summary>
+            /// <seealso cref="Widget"/>
+            public class Gadget { }
+            """,
+            EmptyMSBuildProperties, "test.dll");
+
+        var type = GenerateWithOverride(compilation, "Pkg").Items[0].Items.Single(x => x.Name.EndsWith("Gadget"));
+
+        Assert.Equal("Pkg::Shared.Gadget", type.Name);
+        Assert.Contains(XrefTo("Pkg::Shared.Widget"), type.Summary);
+        Assert.Equal(["Pkg::Shared.Widget"], type.SeeAlsos.Select(x => x.LinkId));
+    }
+
+    private static MetadataItem GenerateWithOverride(Compilation compilation, string assemblyUid)
+    {
+        VisitorHelper.AssemblyUidOverride = assemblyUid;
+        VisitorHelper.AssemblyUidOverrideAssemblies = new(SymbolEqualityComparer.Default) { compilation.Assembly };
+        try
+        {
+            return compilation.Assembly.GenerateMetadataItem(compilation);
+        }
+        finally
+        {
+            VisitorHelper.AssemblyUidOverride = null;
+            VisitorHelper.AssemblyUidOverrideAssemblies = null;
+        }
+    }
+
+    /// <summary>
+    /// A component may start with a digit and contain dashes, unlike a namespace, because assembly names
+    /// do and target framework style components are useful.
+    /// </summary>
+    [Theory]
+    [InlineData("net8.0")]
+    [InlineData("7zip.Net")]
+    [InlineData("my-lib")]
+    public void ComponentsAreNotRestrictedToNamespaceGrammar(string component)
+    {
+        UseAssemblyUids(("test.dll", component));
+
+        var output = Verify(SharedLibraryCode);
+
+        Assert.Equal($"{component}::Shared", output.Items[0].Name);
+        Assert.Equal($"{component}::Shared.Widget", output.Items[0].Items[0].Name);
+        Assert.Equal($"T:{component}::Shared.Widget", output.Items[0].Items[0].CommentId);
+    }
+
+    /// <summary>
+    /// The global namespace is qualified as well, otherwise two assemblies whose APIs sit in it would
+    /// share the one page named after <c>globalNamespaceId</c>.
+    /// </summary>
+    [Fact]
+    public void GlobalNamespaceIdComposesWithTheAssemblyComponent()
+    {
+        UseAssemblyUids(("test.dll", "Pkg"));
+        VisitorHelper.GlobalNamespaceId = "Global";
+
+        var output = Verify(
+            """
+            /// <summary>A widget.</summary>
+            public class Widget { }
+            """);
+
+        var @namespace = output.Items[0];
+        Assert.Equal("Pkg::Global", @namespace.Name);
+        Assert.Equal("Pkg::Global.Widget", @namespace.Items[0].Name);
+        Assert.Equal("Pkg::Global", @namespace.Items[0].NamespaceName);
+    }
+
+    /// <summary>
+    /// https://github.com/dotnet/docfx/issues/9458: the table of contents node of the global namespace
+    /// shows no name at all. Checked here without any assembly component, so it is the plain behaviour.
+    /// </summary>
+    [Fact]
+    public void GlobalNamespaceHasADisplayName()
+    {
+        VisitorHelper.GlobalNamespaceId = "Global";
+
+        var @namespace = Verify(
+            """
+            /// <summary>A widget.</summary>
+            public class Widget { }
+            """).Items[0];
+
+        Assert.Equal("Global", @namespace.Name);
+        Assert.Equal("Global", @namespace.DisplayNames[SyntaxLanguage.CSharp]);
+    }
+
+    [Fact]
+    public void FilterRulesMatchUnqualifiedUids()
+    {
+        UseAssemblyUids(("test.dll", "Pkg"));
+
+        var output = Verify(
+            """
+            namespace Shared;
+
+            /// <summary>A widget.</summary>
+            public class Widget { }
+
+            /// <summary>A hidden widget.</summary>
+            public class HiddenWidget { }
+            """,
+            config: new() { FilterConfigFile = "TestData/filterconfig.assemblyuid.yml" });
+
+        // The filter file matches `Shared.HiddenWidget`, i.e. the API surface, not `Pkg::Shared.HiddenWidget`.
+        Assert.Equal(["Pkg::Shared.Widget"], output.Items[0].Items.Select(x => x.Name));
+    }
+
+    /// <summary>
+    /// A repeated or empty entry in the array form is a configuration typo, reported later as an invalid
+    /// entry, so it must not throw out of the JSON converter that builds this.
+    /// </summary>
+    [Fact]
+    public void RepeatedAndEmptyArrayEntriesAreTolerated()
+    {
+        var assemblyUids = new AssemblyUidConfig(["MyLib", "MyLib", null, "MyLib.Tools"]);
+
+        Assert.Equal(["MyLib", "", "MyLib.Tools"], assemblyUids.Keys);
+        Assert.All(assemblyUids.Values, Assert.Null);
+    }
+
+    /// <summary>
+    /// A UID becomes a file name, and `:` is not a legal file name character. One dash per character is
+    /// what <c>PathUtility.ToCleanUrlFileName</c> produces for the member pages of
+    /// <c>memberLayout: separatePages</c>, so the two agree.
+    /// </summary>
+    [Theory]
+    [InlineData("Pkg::Shared.Widget", "Pkg--Shared.Widget")]
+    [InlineData("Pkg::Shared.Box`1", "Pkg--Shared.Box-1")]
+    [InlineData("Shared.Widget", "Shared.Widget")]
+    public void QualifiedUidsMapToLegalFileNames(string uid, string expected)
+    {
+        Assert.Equal(expected, VisitorHelper.PathFriendlyId(uid));
+    }
+
+    [Theory]
+    [InlineData("Pkg::Shared.Widget", "Shared.Widget")]
+    [InlineData("Shared.Widget", "Shared.Widget")]
+    [InlineData("MyLib.Tools::Shared", "Shared")]
+    public void TheAssemblyComponentCanBeTrimmedBackOff(string uid, string expected)
+    {
+        Assert.Equal(expected, VisitorHelper.TrimAssemblyUid(uid));
+    }
+
+    /// <summary>
+    /// The href of a reference is built from the comment id rather than from the metadata item, so it has
+    /// to arrive at the same file name and anchor the pages are written under.
+    /// </summary>
+    [Fact]
+    public void ReferenceUrlsPointAtTheQualifiedPages()
+    {
+        UseAssemblyUids(("test.dll", "Pkg"));
+
+        var compilation = CompilationHelper.CreateCompilationFromCSharpCode(SharedLibraryCode, EmptyMSBuildProperties, "test.dll");
+        var allAssemblies = new HashSet<IAssemblySymbol>(SymbolEqualityComparer.Default) { compilation.Assembly };
+
+        var type = compilation.Assembly.GetTypeByMetadataName("Shared.Widget");
+        Assert.NotNull(type);
+        var method = type.GetMembers("Do").First();
+
+        Assert.Equal("Pkg--Shared.Widget.html", SymbolUrlResolver.GetDocfxUrl(type, MemberLayout.SamePage, SymbolUrlKind.Html, allAssemblies));
+        Assert.Equal("Pkg--Shared.html", SymbolUrlResolver.GetDocfxUrl(type.ContainingNamespace, MemberLayout.SamePage, SymbolUrlKind.Html, allAssemblies));
+
+        // On a type page the member is an anchor, and on its own page it is a file of its own.
+        Assert.Equal(
+            "Pkg--Shared.Widget.html#Pkg__Shared_Widget_Do",
+            SymbolUrlResolver.GetDocfxUrl(method, MemberLayout.SamePage, SymbolUrlKind.Html, allAssemblies));
+        Assert.Equal(
+            "Pkg--Shared.Widget.Do.html#Pkg__Shared_Widget_Do",
+            SymbolUrlResolver.GetDocfxUrl(method, MemberLayout.SeparatePages, SymbolUrlKind.Html, allAssemblies));
+    }
+}

--- a/test/Docfx.Dotnet.Tests/AssemblyUidUnitTest.cs
+++ b/test/Docfx.Dotnet.Tests/AssemblyUidUnitTest.cs
@@ -131,8 +131,9 @@ public class AssemblyUidUnitTest : IDisposable
 
     /// <summary>
     /// The assembly is a component of the UID, not a namespace segment, so it has no place in the names
-    /// that are displayed. With a flattened layout it is appended to the namespace label, as nothing else
-    /// there tells two assemblies declaring the same namespace apart.
+    /// that are displayed. The visitor never appends it — <c>assemblyLabel</c> is applied once the whole
+    /// metadata item has been visited, see <see cref="AssemblyLabelAppendsTheAssemblyWhereItIsAsked"/> —
+    /// but it does record the component, which both that pass and the nested layout grouping need.
     /// </summary>
     [Fact]
     public void NamespaceDisplayNamesKeepTheRealNamespace()
@@ -141,9 +142,10 @@ public class AssemblyUidUnitTest : IDisposable
 
         var @namespace = Verify(SharedLibraryCode).Items[0];
 
-        Assert.Equal("Shared (Pkg)", @namespace.DisplayNames[SyntaxLanguage.CSharp]);
-        Assert.Equal("Shared (Pkg)", @namespace.DisplayNamesWithType[SyntaxLanguage.CSharp]);
-        Assert.Equal("Shared (Pkg)", @namespace.DisplayQualifiedNames[SyntaxLanguage.CSharp]);
+        Assert.Equal("Shared", @namespace.DisplayNames[SyntaxLanguage.CSharp]);
+        Assert.Equal("Shared", @namespace.DisplayNamesWithType[SyntaxLanguage.CSharp]);
+        Assert.Equal("Shared", @namespace.DisplayQualifiedNames[SyntaxLanguage.CSharp]);
+        Assert.Equal("Pkg", @namespace.AssemblyUid);
 
         // Type display names are unaffected, and keep naming the namespace as it is declared.
         var type = @namespace.Items[0];
@@ -152,32 +154,97 @@ public class AssemblyUidUnitTest : IDisposable
     }
 
     /// <summary>
-    /// The enums are internal, so the cases name them as strings.
+    /// `page` is the one value the visitor acts on, as it names the real assembly rather than the component
+    /// it was given. The enums are internal, so the cases name them as strings.
     /// </summary>
     [Theory]
-    [InlineData("None", "Flattened", "Shared", null)]
-    [InlineData("Suffix", "Flattened", "Shared (Pkg)", null)]
-    // `page` names the real assembly, `test.dll` here, rather than the component it was given.
-    [InlineData("Page", "Flattened", "Shared", "test.dll")]
-    [InlineData("Auto", "Flattened", "Shared (Pkg)", null)]
-    [InlineData("Auto", "Nested", "Shared", null)]
-    public void AssemblyLabelDecidesHowTheAssemblyIsShown(string assemblyLabel, string namespaceLayout, string expectedName, string expectedNamespaceAssembly)
+    [InlineData("None", null)]
+    [InlineData("Shared", null)]
+    [InlineData("Suffix", null)]
+    [InlineData("Page", "test.dll")]
+    public void AssemblyLabelPageNamesTheAssemblyOnThePage(string assemblyLabel, string expectedNamespaceAssembly)
     {
         UseAssemblyUids(("test.dll", "Pkg"));
 
-        var config = new ExtractMetadataConfig
-        {
-            AssemblyLabel = Enum.Parse<AssemblyLabel>(assemblyLabel),
-            NamespaceLayout = Enum.Parse<NamespaceLayout>(namespaceLayout),
-        };
+        var config = new ExtractMetadataConfig { AssemblyLabel = Enum.Parse<AssemblyLabel>(assemblyLabel) };
 
         var @namespace = Verify(SharedLibraryCode, config: config).Items[0];
 
-        Assert.Equal(expectedName, @namespace.DisplayNames[SyntaxLanguage.CSharp]);
         Assert.Equal(expectedNamespaceAssembly, @namespace.NamespaceAssembly);
 
         // Whatever is displayed, the UID is the same.
         Assert.Equal("Pkg::Shared", @namespace.Name);
+    }
+
+    /// <summary>
+    /// `shared` appends the assembly only to the namespaces more than one assembly of the same metadata
+    /// item declares, `suffix` to all of them, and the layout has no say in either. The cases pair a
+    /// namespace both assemblies declare with one only the first does.
+    /// </summary>
+    [Theory]
+    [InlineData("None", "Flattened", "Shared", "Shared", "Only")]
+    [InlineData("None", "Nested", "Shared", "Shared", "Only")]
+    [InlineData("Page", "Flattened", "Shared", "Shared", "Only")]
+    [InlineData("Shared", "Flattened", "Shared (A)", "Shared (B)", "Only")]
+    [InlineData("Shared", "Nested", "Shared (A)", "Shared (B)", "Only")]
+    [InlineData("Suffix", "Flattened", "Shared (A)", "Shared (B)", "Only (A)")]
+    [InlineData("Suffix", "Nested", "Shared (A)", "Shared (B)", "Only (A)")]
+    public void AssemblyLabelAppendsTheAssemblyWhereItIsAsked(
+        string assemblyLabel, string namespaceLayout, string expectedSharedInA, string expectedSharedInB, string expectedOnly)
+    {
+        var members = new[]
+        {
+            CreateNamespace("A::Shared", "Shared", "A"),
+            CreateNamespace("B::Shared", "Shared", "B"),
+            CreateNamespace("A::Only", "Only", "A"),
+        }.ToDictionary(x => x.Name);
+
+        DotnetApiCatalog.ApplyAssemblyLabel(members, new ExtractMetadataConfig
+        {
+            AssemblyLabel = Enum.Parse<AssemblyLabel>(assemblyLabel),
+            NamespaceLayout = Enum.Parse<NamespaceLayout>(namespaceLayout),
+        });
+
+        Assert.Equal(expectedSharedInA, members["A::Shared"].DisplayNames[SyntaxLanguage.Default]);
+        Assert.Equal(expectedSharedInB, members["B::Shared"].DisplayNames[SyntaxLanguage.Default]);
+        Assert.Equal(expectedOnly, members["A::Only"].DisplayNames[SyntaxLanguage.Default]);
+
+        // All three names are labelled together, so it is enough to spot check the other two.
+        Assert.Equal(expectedSharedInA, members["A::Shared"].DisplayNamesWithType[SyntaxLanguage.Default]);
+        Assert.Equal(expectedSharedInA, members["A::Shared"].DisplayQualifiedNames[SyntaxLanguage.Default]);
+    }
+
+    /// <summary>
+    /// A namespace declared by an assembly that is not qualified carries no component, so it is never
+    /// labelled — but it still counts as another declaration of its namespace, which is what makes the
+    /// qualified one worth labelling under `shared`.
+    /// </summary>
+    [Fact]
+    public void AnUnqualifiedAssemblyCountsAsADeclarationButIsNotLabelled()
+    {
+        var members = new[]
+        {
+            CreateNamespace("A::Shared", "Shared", "A"),
+            CreateNamespace("Shared", "Shared", assemblyUid: null),
+        }.ToDictionary(x => x.Name);
+
+        DotnetApiCatalog.ApplyAssemblyLabel(members, new ExtractMetadataConfig { AssemblyLabel = AssemblyLabel.Shared });
+
+        Assert.Equal("Shared (A)", members["A::Shared"].DisplayNames[SyntaxLanguage.Default]);
+        Assert.Equal("Shared", members["Shared"].DisplayNames[SyntaxLanguage.Default]);
+    }
+
+    private static MetadataItem CreateNamespace(string uid, string displayName, string assemblyUid)
+    {
+        return new MetadataItem
+        {
+            Type = MemberType.Namespace,
+            Name = uid,
+            AssemblyUid = assemblyUid,
+            DisplayNames = new() { [SyntaxLanguage.Default] = displayName },
+            DisplayNamesWithType = new() { [SyntaxLanguage.Default] = displayName },
+            DisplayQualifiedNames = new() { [SyntaxLanguage.Default] = displayName },
+        };
     }
 
     [Fact]

--- a/test/Docfx.Dotnet.Tests/TestData/filterconfig.assemblyuid.yml
+++ b/test/Docfx.Dotnet.Tests/TestData/filterconfig.assemblyuid.yml
@@ -1,0 +1,4 @@
+apiRules:
+- exclude:
+    uidRegex: ^Shared\.HiddenWidget$
+    type: Type

--- a/test/Docfx.MarkdigEngine.Extensions.Tests/XrefTest.cs
+++ b/test/Docfx.MarkdigEngine.Extensions.Tests/XrefTest.cs
@@ -50,4 +50,43 @@ public class XrefTest
 ";
         TestUtility.VerifyMarkup(content, expected);
     }
+
+    /// <summary>
+    /// A .NET UID can carry the assembly it belongs to, separated by `::`. Both colons are characters the
+    /// shortcut form otherwise stops at, so the UID would end at the assembly without them being handled.
+    /// </summary>
+    [Fact]
+    public void XrefTestAssemblyQualifiedUid()
+    {
+        //arrange
+        var content = @"@MyLib.Tools::MyLib.Tools.Widget
+<xref:MyLib.Tools::MyLib.Tools.Widget>
+[link_text](xref:MyLib.Tools::MyLib.Tools.Widget)
+@""MyLib.Tools::MyLib.Tools.Widget""
+@MyLib.Tools::MyLib.Tools.Widget, and a sentence ending in the UID: @MyLib.Tools::MyLib.Tools.Widget.
+";
+        // assert
+        var expected = @"<p><xref href=""MyLib.Tools::MyLib.Tools.Widget"" data-throw-if-not-resolved=""False"" data-raw-source=""@MyLib.Tools::MyLib.Tools.Widget""></xref>
+<xref href=""MyLib.Tools::MyLib.Tools.Widget"" data-throw-if-not-resolved=""True"" data-raw-source=""&lt;xref:MyLib.Tools::MyLib.Tools.Widget&gt;""></xref>
+<a href=""xref:MyLib.Tools::MyLib.Tools.Widget"">link_text</a>
+<xref href=""MyLib.Tools::MyLib.Tools.Widget"" data-throw-if-not-resolved=""False"" data-raw-source=""@&quot;MyLib.Tools::MyLib.Tools.Widget&quot;""></xref>
+<xref href=""MyLib.Tools::MyLib.Tools.Widget"" data-throw-if-not-resolved=""False"" data-raw-source=""@MyLib.Tools::MyLib.Tools.Widget""></xref>, and a sentence ending in the UID: <xref href=""MyLib.Tools::MyLib.Tools.Widget"" data-throw-if-not-resolved=""False"" data-raw-source=""@MyLib.Tools::MyLib.Tools.Widget""></xref>.</p>
+";
+        TestUtility.VerifyMarkup(content, expected);
+    }
+
+    /// <summary>
+    /// A trailing `::` is punctuation, not part of the UID.
+    /// </summary>
+    [Fact]
+    public void XrefTestTrailingColonsEndTheUid()
+    {
+        //arrange
+        var content = @"@MyLib.Tools:: and @MyLib.Tools::
+";
+        // assert
+        var expected = @"<p><xref href=""MyLib.Tools"" data-throw-if-not-resolved=""False"" data-raw-source=""@MyLib.Tools""></xref>:: and <xref href=""MyLib.Tools"" data-throw-if-not-resolved=""False"" data-raw-source=""@MyLib.Tools""></xref>::</p>
+";
+        TestUtility.VerifyMarkup(content, expected);
+    }
 }

--- a/test/docfx.Tests/AssemblyUidBuildTest.cs
+++ b/test/docfx.Tests/AssemblyUidBuildTest.cs
@@ -96,4 +96,66 @@ public class AssemblyUidBuildTest : TestBase
         Assert.Contains("href=\"a--Shared.html\">Shared</a>", type);
         Assert.Contains("data-uid=\"a::Shared.Widget\"", type);
     }
+
+    /// <summary>
+    /// Every `assemblyLabel` value asserted on the rendered HTML, which is the only place its effect is
+    /// actually visible: a value can be written into the `.yml` faithfully and still render nothing, as
+    /// `page` did. Assembly `a` declares `Shared` and `Other`, `b` declares `Shared` alone, so `Other` is
+    /// the namespace only one assembly declares.
+    /// </summary>
+    [Theory]
+    [Trait("Related", "docfx")]
+    // Unset: what a namespace read as before any of this existed.
+    [InlineData(null, "Namespace Shared", "Namespace Other", false)]
+    [InlineData("none", "Namespace Shared", "Namespace Other", false)]
+    [InlineData("shared", "Namespace Shared (a)", "Namespace Other", false)]
+    [InlineData("suffix", "Namespace Shared (a)", "Namespace Other (a)", false)]
+    [InlineData("page", "Namespace Shared", "Namespace Other", true)]
+    public async Task AssemblyLabelRendersOnTheNamespacePage(
+        string assemblyLabel, string expectedSharedTitle, string expectedOtherTitle, bool expectsAssemblyOnPage)
+    {
+        foreach (var (name, source) in new[] { ("a", "assemblyuid.a.cs.sample.1"), ("b", "assemblyuid.single.b.cs.sample.1") })
+        {
+            var folder = Path.Combine(_projectFolder, name);
+            Directory.CreateDirectory(folder);
+            File.Copy("Assets/assemblyuid.csproj.sample.1", Path.Combine(folder, $"{name}.csproj"));
+            File.Copy($"Assets/{source}", Path.Combine(folder, "Widget.cs"));
+        }
+
+        var label = assemblyLabel is null ? "" : $"\"assemblyLabel\": \"{assemblyLabel}\",";
+        var configPath = Path.Combine(_projectFolder, "docfx.json");
+        await File.WriteAllTextAsync(configPath,
+            $$"""
+            {
+              "assemblyUids": [ "a", "b" ],
+              "metadata": [
+                {
+                  "src": [ { "files": [ "*/*.csproj" ] } ],
+                  {{label}}
+                  "dest": "api"
+                }
+              ],
+              "build": {
+                "content": [ { "files": [ "api/**.yml" ] } ],
+                "template": [ "default" ],
+                "dest": "_site"
+              }
+            }
+            """);
+
+        await DotnetApiCatalog.GenerateManagedReferenceYamlFiles(configPath);
+        await Docset.Build(configPath);
+
+        var site = Path.Combine(_projectFolder, "_site", "api");
+        var shared = await File.ReadAllTextAsync(Path.Combine(site, "a--Shared.html"));
+        var other = await File.ReadAllTextAsync(Path.Combine(site, "a--Other.html"));
+
+        Assert.Contains($"<title>{expectedSharedTitle} ", shared);
+        Assert.Contains($">{expectedSharedTitle}</h1>", shared);
+        Assert.Contains($">{expectedOtherTitle}</h1>", other);
+
+        // `page` names the real assembly on the page rather than in the title, the way a type page does.
+        Assert.Equal(expectsAssemblyOnPage, shared.Contains("<strong>Assembly</strong>: a.dll"));
+        Assert.Equal(expectsAssemblyOnPage, other.Contains("<strong>Assembly</strong>: a.dll"));
+    }
 }

--- a/test/docfx.Tests/AssemblyUidBuildTest.cs
+++ b/test/docfx.Tests/AssemblyUidBuildTest.cs
@@ -1,0 +1,99 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Docfx.Dotnet;
+using Docfx.Tests.Common;
+
+namespace Docfx.Tests;
+
+/// <summary>
+/// Builds a site out of two assemblies that share a namespace and are qualified by `assemblyUids`, which
+/// covers what the metadata tests cannot: the `docfx.json` binding of the option, the file names the build
+/// stage writes, and whether links to a UID carrying an assembly component resolve.
+/// </summary>
+[Collection("docfx STA")]
+public class AssemblyUidBuildTest : TestBase
+{
+    private readonly string _projectFolder;
+
+    public AssemblyUidBuildTest()
+    {
+        _projectFolder = GetRandomFolder();
+    }
+
+    [Fact]
+    [Trait("Related", "docfx")]
+    public async Task BuildsSiteWithAssemblyQualifiedUids()
+    {
+        foreach (var name in new[] { "a", "b" })
+        {
+            var folder = Path.Combine(_projectFolder, name);
+            Directory.CreateDirectory(folder);
+            File.Copy("Assets/assemblyuid.csproj.sample.1", Path.Combine(folder, $"{name}.csproj"));
+            File.Copy($"Assets/assemblyuid.{name}.cs.sample.1", Path.Combine(folder, "Widget.cs"));
+        }
+
+        // Both assemblies declare `Shared.Widget`, and the markdown links to each of them by UID, in the
+        // shortcut form and in the xref form.
+        await File.WriteAllTextAsync(Path.Combine(_projectFolder, "index.md"),
+            """
+            # Widgets
+
+            @a::Shared.Widget and <xref:b::Shared.Widget> and [the method](xref:a::Shared.Widget.Do).
+            """);
+
+        var configPath = Path.Combine(_projectFolder, "docfx.json");
+        await File.WriteAllTextAsync(configPath,
+            """
+            {
+              "assemblyUids": [ "a", "b" ],
+              "metadata": [
+                {
+                  "src": [ { "files": [ "*/*.csproj" ] } ],
+                  "dest": "api",
+                  "memberLayout": "separatePages"
+                }
+              ],
+              "build": {
+                "content": [ { "files": [ "index.md", "api/**.yml" ] } ],
+                "template": [ "default" ],
+                "dest": "_site"
+              }
+            }
+            """);
+
+        // Both entry points manage the log listeners themselves, so an unresolved link cannot be observed
+        // through a `TestListenerScope` here. The rendered HTML says it just as well: an xref that does not
+        // resolve is written out as plain text with no href at all.
+        await DotnetApiCatalog.GenerateManagedReferenceYamlFiles(configPath);
+        await Docset.Build(configPath);
+
+        var site = Path.Combine(_projectFolder, "_site");
+
+        // `::` is not legal in a file name, so it becomes `--`, both for the type pages and for the member
+        // pages that `separatePages` splits out in the build stage.
+        Assert.True(File.Exists(Path.Combine(site, "api", "a--Shared.Widget.html")));
+        Assert.True(File.Exists(Path.Combine(site, "api", "b--Shared.Widget.html")));
+        Assert.True(File.Exists(Path.Combine(site, "api", "a--Shared.Widget.Do.html")));
+
+        // A constructor is the case where the two stages sanitize a second character, `#ctor` -> `-ctor`,
+        // so it is the one that shows the file name and the href still agree.
+        Assert.True(File.Exists(Path.Combine(site, "api", "a--Shared.Widget.-ctor.html")));
+        var namespacePage = await File.ReadAllTextAsync(Path.Combine(site, "api", "a--Shared.html"));
+        Assert.DoesNotContain("a::Shared.Widget.#ctor", namespacePage);
+
+        // Every authored link resolves, each to its own assembly.
+        var index = await File.ReadAllTextAsync(Path.Combine(site, "index.html"));
+        Assert.Contains("href=\"api/a--Shared.Widget.html\"", index);
+        Assert.Contains("href=\"api/b--Shared.Widget.html\"", index);
+        // The member link lands on its own page and on the anchor of the member within it.
+        Assert.Contains("href=\"api/a--Shared.Widget.Do.html#a__Shared_Widget_Do\"", index);
+
+        // The references inside a page follow too: the type page links to the namespace page of its own
+        // assembly, and the link reads as the namespace is declared. The UID itself still appears in
+        // `data-uid`, which is where it belongs.
+        var type = await File.ReadAllTextAsync(Path.Combine(site, "api", "a--Shared.Widget.html"));
+        Assert.Contains("href=\"a--Shared.html\">Shared</a>", type);
+        Assert.Contains("data-uid=\"a::Shared.Widget\"", type);
+    }
+}

--- a/test/docfx.Tests/Assets/assemblyuid.a.cs.sample.1
+++ b/test/docfx.Tests/Assets/assemblyuid.a.cs.sample.1
@@ -1,0 +1,28 @@
+namespace Shared
+{
+    /// <summary>
+    /// The widget of assembly A.
+    /// </summary>
+    public class Widget
+    {
+        /// <summary>
+        /// Creates a widget.
+        /// </summary>
+        public Widget() { }
+
+        /// <summary>
+        /// Does something.
+        /// </summary>
+        public void Do() { }
+    }
+}
+
+namespace Other
+{
+    /// <summary>
+    /// The gadget of assembly A.
+    /// </summary>
+    public class Gadget
+    {
+    }
+}

--- a/test/docfx.Tests/Assets/assemblyuid.b.cs.sample.1
+++ b/test/docfx.Tests/Assets/assemblyuid.b.cs.sample.1
@@ -1,0 +1,23 @@
+namespace Shared
+{
+    /// <summary>
+    /// The widget of assembly B.
+    /// </summary>
+    public class Widget
+    {
+        /// <summary>
+        /// Does something else.
+        /// </summary>
+        public void Do() { }
+    }
+}
+
+namespace Other
+{
+    /// <summary>
+    /// The gadget of assembly B.
+    /// </summary>
+    public class Gadget
+    {
+    }
+}

--- a/test/docfx.Tests/Assets/assemblyuid.csproj.sample.1
+++ b/test/docfx.Tests/Assets/assemblyuid.csproj.sample.1
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+  </PropertyGroup>
+</Project>

--- a/test/docfx.Tests/Assets/assemblyuid.single.a.cs.sample.1
+++ b/test/docfx.Tests/Assets/assemblyuid.single.a.cs.sample.1
@@ -1,0 +1,13 @@
+namespace Shared
+{
+    /// <summary>
+    /// The widget of assembly A.
+    /// </summary>
+    public class Widget
+    {
+        /// <summary>
+        /// Does something.
+        /// </summary>
+        public void Do() { }
+    }
+}

--- a/test/docfx.Tests/Assets/assemblyuid.single.b.cs.sample.1
+++ b/test/docfx.Tests/Assets/assemblyuid.single.b.cs.sample.1
@@ -1,0 +1,13 @@
+namespace Shared
+{
+    /// <summary>
+    /// The widget of assembly B.
+    /// </summary>
+    public class Widget
+    {
+        /// <summary>
+        /// Does something.
+        /// </summary>
+        public void Do() { }
+    }
+}

--- a/test/docfx.Tests/MetadataCommandTest.cs
+++ b/test/docfx.Tests/MetadataCommandTest.cs
@@ -388,16 +388,107 @@ public class MetadataCommandTest : TestBase
             Assert.Contains($"{assembly}::Shared.Widget.Do", memberViewModel.Items.Select(x => x.Uid));
         }
 
-        // The namespaces are distinguishable in the TOC, and read as the namespace they are, with the
-        // assembly appended because a flattened layout has nothing else to tell them apart.
+        // The namespaces are distinguishable in the TOC by their UID, and read as the namespace they are:
+        // `assemblyLabel` is unset, so nothing names the assembly and the labels are what they were before
+        // any of this existed.
         var tocViewModel = YamlUtility.Deserialize<TocItemViewModel>(Path.Combine(_outputFolder, "toc.yml")).Items;
         Assert.Equal(["a::Other", "a::Shared", "b::Other", "b::Shared"], tocViewModel.Select(x => x.Uid));
-        Assert.Equal(["Other (a)", "Shared (a)", "Other (b)", "Shared (b)"], tocViewModel.Select(x => x.Name));
+        Assert.Equal(["Other", "Shared", "Other", "Shared"], tocViewModel.Select(x => x.Name));
 
         // ... and both are addressable through the manifest.
         var manifest = JsonUtility.Deserialize<Dictionary<string, string>>(Path.Combine(_outputFolder, ".manifest"));
         Assert.Equal("a--Shared.Widget.yml", manifest["a::Shared.Widget"]);
         Assert.Equal("b--Shared.Widget.yml", manifest["b::Shared.Widget"]);
+    }
+
+    /// <summary>
+    /// `suffix` names the assembly of every namespace of a qualified assembly, in the table of contents and
+    /// on the page, whatever the layout.
+    /// </summary>
+    [Fact]
+    [Trait("Related", "docfx")]
+    public async Task TestMetadataCommandWithAssemblyLabelSuffix()
+    {
+        var projects = CreateProjectsSharingANamespace();
+
+        await DotnetApiCatalog.Exec(
+            new(new MetadataJsonItemConfig
+            {
+                Dest = _outputFolder,
+                Src = new(new FileMappingItem([.. projects])) { Expanded = true },
+                AssemblyLabel = AssemblyLabel.Suffix,
+            }),
+            new(), Directory.GetCurrentDirectory(),
+            assemblyUids: new(["a", "b"]));
+
+        var tocViewModel = YamlUtility.Deserialize<TocItemViewModel>(Path.Combine(_outputFolder, "toc.yml")).Items;
+        Assert.Equal(["Other (a)", "Shared (a)", "Other (b)", "Shared (b)"], tocViewModel.Select(x => x.Name));
+
+        var @namespace = YamlUtility.Deserialize<PageViewModel>(Path.Combine(_outputFolder, "a--Shared.yml")).Items[0];
+        Assert.Equal("Shared (a)", @namespace.Name);
+        Assert.Equal("Shared (a)", @namespace.NameWithType);
+        Assert.Equal("Shared (a)", @namespace.FullName);
+    }
+
+    /// <summary>
+    /// `shared` names the assembly only where more than one assembly of this metadata item declares the
+    /// namespace. Assembly `a` declares `Shared` and `Other`, `b` declares `Shared` alone, so only `Shared`
+    /// is labelled.
+    /// </summary>
+    [Fact]
+    [Trait("Related", "docfx")]
+    public async Task TestMetadataCommandWithAssemblyLabelShared()
+    {
+        var projects = CreateProjects(("a", "assemblyuid.a.cs.sample.1"), ("b", "assemblyuid.single.b.cs.sample.1"));
+
+        await DotnetApiCatalog.Exec(
+            new(new MetadataJsonItemConfig
+            {
+                Dest = _outputFolder,
+                Src = new(new FileMappingItem([.. projects])) { Expanded = true },
+                AssemblyLabel = AssemblyLabel.Shared,
+            }),
+            new(), Directory.GetCurrentDirectory(),
+            assemblyUids: new(["a", "b"]));
+
+        // Ordered by UID: `a::Other`, `a::Shared`, `b::Shared`.
+        var tocViewModel = YamlUtility.Deserialize<TocItemViewModel>(Path.Combine(_outputFolder, "toc.yml")).Items;
+        Assert.Equal(["a::Other", "a::Shared", "b::Shared"], tocViewModel.Select(x => x.Uid));
+        Assert.Equal(["Other", "Shared (a)", "Shared (b)"], tocViewModel.Select(x => x.Name));
+
+        // The page agrees with the table of contents, both for the labelled namespace and the plain one.
+        Assert.Equal("Shared (a)", YamlUtility.Deserialize<PageViewModel>(Path.Combine(_outputFolder, "a--Shared.yml")).Items[0].Name);
+        Assert.Equal("Other", YamlUtility.Deserialize<PageViewModel>(Path.Combine(_outputFolder, "a--Other.yml")).Items[0].Name);
+    }
+
+    /// <summary>
+    /// The `apiPage` and `markdown` formats build their table of contents on their own path, which follows
+    /// the same rule. Those formats title a page from the symbol, so only the labels can be asserted.
+    /// </summary>
+    [Theory]
+    [Trait("Related", "docfx")]
+    // Unset: nothing names the assembly.
+    [InlineData("None", "Other", "Shared", "Shared")]
+    [InlineData("Shared", "Other", "Shared (a)", "Shared (b)")]
+    [InlineData("Suffix", "Other (a)", "Shared (a)", "Shared (b)")]
+    public async Task TestMetadataCommandAssemblyLabelInMarkdownToc(
+        string assemblyLabel, string expectedOther, string expectedSharedInA, string expectedSharedInB)
+    {
+        var projects = CreateProjects(("a", "assemblyuid.a.cs.sample.1"), ("b", "assemblyuid.single.b.cs.sample.1"));
+
+        await DotnetApiCatalog.Exec(
+            new(new MetadataJsonItemConfig
+            {
+                Dest = _outputFolder,
+                Src = new(new FileMappingItem([.. projects])) { Expanded = true },
+                OutputFormat = MetadataOutputFormat.Markdown,
+                AssemblyLabel = Enum.Parse<AssemblyLabel>(assemblyLabel),
+            }),
+            new(), Directory.GetCurrentDirectory(),
+            assemblyUids: new(["a", "b"]));
+
+        var tocViewModel = YamlUtility.Deserialize<List<TocItemViewModel>>(Path.Combine(_outputFolder, "toc.yml"));
+        Assert.Equal([expectedOther, expectedSharedInA, expectedSharedInB], tocViewModel.Select(x => x.Name));
     }
 
     [Fact]
@@ -448,12 +539,12 @@ public class MetadataCommandTest : TestBase
             new(), Directory.GetCurrentDirectory(),
             assemblyUids: new(["a", "b"]));
 
-        // The namespace page is titled `Namespace {name}`, and that name is the namespace, qualified by
-        // the assembly it comes from rather than by a namespace segment that does not exist.
+        // The namespace page is titled `Namespace {name}`, and that name is the namespace as it is declared,
+        // not a namespace segment that does not exist. Only the UID and the file name carry the assembly.
         var @namespace = YamlUtility.Deserialize<PageViewModel>(Path.Combine(_outputFolder, "a--Shared.yml")).Items[0];
-        Assert.Equal("Shared (a)", @namespace.Name);
-        Assert.Equal("Shared (a)", @namespace.NameWithType);
-        Assert.Equal("Shared (a)", @namespace.FullName);
+        Assert.Equal("Shared", @namespace.Name);
+        Assert.Equal("Shared", @namespace.NameWithType);
+        Assert.Equal("Shared", @namespace.FullName);
 
         // The type pages of that namespace agree with it.
         var type = YamlUtility.Deserialize<PageViewModel>(Path.Combine(_outputFolder, "a--Shared.Widget.yml"));
@@ -573,16 +664,25 @@ public class MetadataCommandTest : TestBase
 
     private List<string> CreateProjects(string sourceAssetFormat)
     {
+        return CreateProjects([.. new[] { "a", "b" }.Select(name => (name, string.Format(sourceAssetFormat, name)))]);
+    }
+
+    /// <summary>
+    /// Creates one project per given name out of the named asset, so that the assemblies can contribute
+    /// different namespaces rather than mirroring each other.
+    /// </summary>
+    private List<string> CreateProjects(params (string name, string sourceAsset)[] projects)
+    {
         var result = new List<string>();
 
-        foreach (var name in new[] { "a", "b" })
+        foreach (var (name, sourceAsset) in projects)
         {
             var folder = Path.Combine(_projectFolder, name);
             Directory.CreateDirectory(folder);
 
             var projectFile = Path.Combine(folder, $"{name}.csproj");
             File.Copy("Assets/assemblyuid.csproj.sample.1", projectFile);
-            File.Copy($"Assets/{string.Format(sourceAssetFormat, name)}", Path.Combine(folder, "Widget.cs"));
+            File.Copy($"Assets/{sourceAsset}", Path.Combine(folder, "Widget.cs"));
 
             result.Add(projectFile);
         }

--- a/test/docfx.Tests/MetadataCommandTest.cs
+++ b/test/docfx.Tests/MetadataCommandTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Docfx.Common;
@@ -330,6 +330,264 @@ public class MetadataCommandTest : TestBase
 
         Assert.Equal("Samples.Foo.Bar", tocViewModel[1].Items[1].Uid);
         Assert.Equal("Bar", tocViewModel[1].Items[1].Name);
+    }
+
+    [Fact]
+    [Trait("Related", "docfx")]
+    public async Task TestMetadataCommandWithoutAssemblyUidsDropsDuplicatedApis()
+    {
+        var projects = CreateProjectsSharingANamespace();
+
+        using var listener = new TestListenerScope();
+
+        await DotnetApiCatalog.Exec(
+            new(new MetadataJsonItemConfig { Dest = _outputFolder, Src = new(new FileMappingItem([.. projects])) { Expanded = true } }),
+            new(), Directory.GetCurrentDirectory());
+
+        // Both assemblies declare `Shared.Widget`, so one of them is dropped.
+        Assert.Contains(listener.GetItemsByLogLevel(LogLevel.Warning), x => x.Message.Contains("Ignore duplicated member"));
+        Assert.True(File.Exists(Path.Combine(_outputFolder, "Shared.Widget.yml")));
+        Assert.False(File.Exists(Path.Combine(_outputFolder, "a--Shared.Widget.yml")));
+        Assert.False(File.Exists(Path.Combine(_outputFolder, "b--Shared.Widget.yml")));
+    }
+
+    [Fact]
+    [Trait("Related", "docfx")]
+    public async Task TestMetadataCommandWithAssemblyUids()
+    {
+        var projects = CreateProjectsSharingANamespace();
+
+        using var listener = new TestListenerScope();
+
+        await DotnetApiCatalog.Exec(
+            new(new MetadataJsonItemConfig
+            {
+                Dest = _outputFolder,
+                Src = new(new FileMappingItem([.. projects])) { Expanded = true },
+            }),
+            new(), Directory.GetCurrentDirectory(),
+            // The array form: each assembly is qualified by its own name.
+            assemblyUids: new(["a", "b"]));
+
+        Assert.DoesNotContain(listener.GetItemsByLogLevel(LogLevel.Warning), x => x.Message.Contains("Ignore duplicated member"));
+
+        // Each assembly gets its own page instead of overwriting the other one, and `::` becomes dashes in
+        // the file name, as `:` is not legal there.
+        foreach (var (assembly, description) in new[] { ("a", "The widget of assembly A."), ("b", "The widget of assembly B.") })
+        {
+            var file = Path.Combine(_outputFolder, $"{assembly}--Shared.Widget.yml");
+            Assert.True(File.Exists(file), $"{file} is missing.");
+
+            var memberViewModel = YamlUtility.Deserialize<PageViewModel>(file);
+            Assert.Equal($"{assembly}::Shared.Widget", memberViewModel.Items[0].Uid);
+            Assert.Equal($"T:{assembly}::Shared.Widget", memberViewModel.Items[0].CommentId);
+            Assert.Equal($"{assembly}::Shared", memberViewModel.Items[0].NamespaceName);
+            Assert.Equal(description, memberViewModel.Items[0].Summary);
+
+            // The members of the type are on the same page and carry the component too.
+            Assert.Contains($"{assembly}::Shared.Widget.Do", memberViewModel.Items.Select(x => x.Uid));
+        }
+
+        // The namespaces are distinguishable in the TOC, and read as the namespace they are, with the
+        // assembly appended because a flattened layout has nothing else to tell them apart.
+        var tocViewModel = YamlUtility.Deserialize<TocItemViewModel>(Path.Combine(_outputFolder, "toc.yml")).Items;
+        Assert.Equal(["a::Other", "a::Shared", "b::Other", "b::Shared"], tocViewModel.Select(x => x.Uid));
+        Assert.Equal(["Other (a)", "Shared (a)", "Other (b)", "Shared (b)"], tocViewModel.Select(x => x.Name));
+
+        // ... and both are addressable through the manifest.
+        var manifest = JsonUtility.Deserialize<Dictionary<string, string>>(Path.Combine(_outputFolder, ".manifest"));
+        Assert.Equal("a--Shared.Widget.yml", manifest["a::Shared.Widget"]);
+        Assert.Equal("b--Shared.Widget.yml", manifest["b::Shared.Widget"]);
+    }
+
+    [Fact]
+    [Trait("Related", "docfx")]
+    public async Task TestMetadataCommandWithAssemblyUidsAndNestedToc()
+    {
+        var projects = CreateProjectsSharingANamespace();
+
+        await DotnetApiCatalog.Exec(
+            new(new MetadataJsonItemConfig
+            {
+                Dest = _outputFolder,
+                Src = new(new FileMappingItem([.. projects])) { Expanded = true },
+                NamespaceLayout = NamespaceLayout.Nested,
+            }),
+            new(), Directory.GetCurrentDirectory(),
+            assemblyUids: new() { ["a"] = "A", ["b"] = "B" });
+
+        // A node per assembly groups the namespaces of that assembly. It names the assembly and has no
+        // page of its own, so it carries no uid, and the namespaces under it keep their own names.
+        var tocViewModel = YamlUtility.Deserialize<TocItemViewModel>(Path.Combine(_outputFolder, "toc.yml")).Items;
+        Assert.Equal(["A", "B"], tocViewModel.Select(x => x.Name));
+        Assert.Equal([null, null], tocViewModel.Select(x => x.Uid));
+        Assert.Equal(["A::Other", "A::Shared"], tocViewModel[0].Items.Select(x => x.Uid));
+        Assert.Equal(["Other", "Shared"], tocViewModel[0].Items.Select(x => x.Name));
+        Assert.Equal(["B::Other", "B::Shared"], tocViewModel[1].Items.Select(x => x.Uid));
+        Assert.Equal("A::Shared.Widget", tocViewModel[0].Items[1].Items[0].Uid);
+        Assert.Equal("B::Shared.Widget", tocViewModel[1].Items[1].Items[0].Uid);
+    }
+
+    /// <summary>
+    /// The assembly is a component of the UID and not a namespace segment, so the page reads as the
+    /// namespace it documents: the title, the namespace its types report, and the namespace they link to
+    /// all agree, and an authored xref names a real namespace behind the real assembly.
+    /// </summary>
+    [Fact]
+    [Trait("Related", "docfx")]
+    public async Task TestMetadataCommandAssemblyUidDoesNotSurfaceAsANamespace()
+    {
+        var projects = CreateProjectsSharingANamespace();
+
+        await DotnetApiCatalog.Exec(
+            new(new MetadataJsonItemConfig
+            {
+                Dest = _outputFolder,
+                Src = new(new FileMappingItem([.. projects])) { Expanded = true },
+            }),
+            new(), Directory.GetCurrentDirectory(),
+            assemblyUids: new(["a", "b"]));
+
+        // The namespace page is titled `Namespace {name}`, and that name is the namespace, qualified by
+        // the assembly it comes from rather than by a namespace segment that does not exist.
+        var @namespace = YamlUtility.Deserialize<PageViewModel>(Path.Combine(_outputFolder, "a--Shared.yml")).Items[0];
+        Assert.Equal("Shared (a)", @namespace.Name);
+        Assert.Equal("Shared (a)", @namespace.NameWithType);
+        Assert.Equal("Shared (a)", @namespace.FullName);
+
+        // The type pages of that namespace agree with it.
+        var type = YamlUtility.Deserialize<PageViewModel>(Path.Combine(_outputFolder, "a--Shared.Widget.yml"));
+        Assert.Equal("Shared.Widget", type.Items[0].FullName);
+        Assert.Equal("a::Shared", type.Items[0].NamespaceName);
+        Assert.Equal("Shared", type.References.Single(x => x.Uid == "a::Shared").Name);
+
+        // An authored xref names the real assembly and the real namespace.
+        var manifest = JsonUtility.Deserialize<Dictionary<string, string>>(Path.Combine(_outputFolder, ".manifest"));
+        Assert.Contains("a::Shared.Widget", manifest.Keys);
+        Assert.DoesNotContain("a.Shared.Widget", manifest.Keys);
+    }
+
+    /// <summary>
+    /// An assembly root is kept even when the assembly contributes a single namespace, where the single
+    /// child collapse in <c>YamlMetadataResolver.GenerateNestedToc</c> would otherwise promote that
+    /// namespace and drop the only node naming the assembly.
+    /// </summary>
+    [Fact]
+    [Trait("Related", "docfx")]
+    public async Task TestMetadataCommandNestedTocKeepsTheAssemblyRootOfASingleNamespace()
+    {
+        var projects = CreateProjectsSharingTheirOnlyNamespace();
+
+        await DotnetApiCatalog.Exec(
+            new(new MetadataJsonItemConfig
+            {
+                Dest = _outputFolder,
+                Src = new(new FileMappingItem([.. projects])) { Expanded = true },
+                NamespaceLayout = NamespaceLayout.Nested,
+            }),
+            new(), Directory.GetCurrentDirectory(),
+            assemblyUids: new() { ["a"] = "A", ["b"] = "B" });
+
+        var tocViewModel = YamlUtility.Deserialize<TocItemViewModel>(Path.Combine(_outputFolder, "toc.yml")).Items;
+
+        Assert.Equal(["A", "B"], tocViewModel.Select(x => x.Name));
+        Assert.Equal(["Shared"], tocViewModel[0].Items.Select(x => x.Name));
+        Assert.Equal(["A::Shared"], tocViewModel[0].Items.Select(x => x.Uid));
+        Assert.Equal("A::Shared.Widget", tocViewModel[0].Items[0].Items[0].Uid);
+    }
+
+    /// <summary>
+    /// assemblyUidOverride is scoped to its own metadata item, so two items can use it even
+    /// though the project level assemblyUids could not tell their assemblies apart by name.
+    /// </summary>
+    [Fact]
+    [Trait("Related", "docfx")]
+    public async Task TestMetadataCommandWithAssemblyUidOverride()
+    {
+        var projects = CreateProjectsSharingANamespace();
+        var otherOutputFolder = GetRandomFolder();
+
+        await DotnetApiCatalog.Exec(
+            new(
+                new MetadataJsonItemConfig
+                {
+                    Dest = _outputFolder,
+                    Src = new(new FileMappingItem(projects[0])) { Expanded = true },
+                    AssemblyUidOverride = "First",
+                },
+                new MetadataJsonItemConfig
+                {
+                    Dest = otherOutputFolder,
+                    Src = new(new FileMappingItem(projects[1])) { Expanded = true },
+                    AssemblyUidOverride = "Second",
+                }),
+            new(), Directory.GetCurrentDirectory());
+
+        foreach (var (folder, prefix) in new[] { (_outputFolder, "First"), (otherOutputFolder, "Second") })
+        {
+            var file = Path.Combine(folder, $"{prefix}--Shared.Widget.yml");
+            Assert.True(File.Exists(file), $"{file} is missing.");
+            Assert.Equal($"{prefix}::Shared.Widget", YamlUtility.Deserialize<PageViewModel>(file).Items[0].Uid);
+        }
+    }
+
+    [Fact]
+    [Trait("Related", "docfx")]
+    public async Task TestMetadataCommandWithInvalidAssemblyUids()
+    {
+        var projects = CreateProjectsSharingANamespace();
+
+        using var listener = new TestListenerScope();
+
+        await DotnetApiCatalog.Exec(
+            new(new MetadataJsonItemConfig
+            {
+                Dest = _outputFolder,
+                Src = new(new FileMappingItem(projects[0])) { Expanded = true },
+                AssemblyUidOverride = "not a component",
+            }),
+            new(), Directory.GetCurrentDirectory(),
+            assemblyUids: new() { ["a"] = "also/invalid", [""] = "A" });
+
+        // Every invalid value is reported and dropped, and generation continues unqualified.
+        Assert.Equal(3, listener.GetItemsByLogLevel(LogLevel.Warning).Count(x => x.Code == "InvalidAssemblyUid"));
+        Assert.True(File.Exists(Path.Combine(_outputFolder, "Shared.Widget.yml")));
+    }
+
+    /// <summary>
+    /// Creates two projects, `a` and `b`, that both declare `Shared.Widget`.
+    /// </summary>
+    private List<string> CreateProjectsSharingANamespace()
+    {
+        return CreateProjects("assemblyuid.{0}.cs.sample.1");
+    }
+
+    /// <summary>
+    /// Creates two projects, `a` and `b`, that both declare `Shared.Widget` and nothing else, so each
+    /// assembly contributes exactly one namespace.
+    /// </summary>
+    private List<string> CreateProjectsSharingTheirOnlyNamespace()
+    {
+        return CreateProjects("assemblyuid.single.{0}.cs.sample.1");
+    }
+
+    private List<string> CreateProjects(string sourceAssetFormat)
+    {
+        var result = new List<string>();
+
+        foreach (var name in new[] { "a", "b" })
+        {
+            var folder = Path.Combine(_projectFolder, name);
+            Directory.CreateDirectory(folder);
+
+            var projectFile = Path.Combine(folder, $"{name}.csproj");
+            File.Copy("Assets/assemblyuid.csproj.sample.1", projectFile);
+            File.Copy($"Assets/{string.Format(sourceAssetFormat, name)}", Path.Combine(folder, "Widget.cs"));
+
+            result.Add(projectFile);
+        }
+
+        return result;
     }
 
     private void CheckResult()

--- a/test/docfx.Tests/SerializationTests/TestData/DocfxConfig/docfx_01.json
+++ b/test/docfx.Tests/SerializationTests/TestData/DocfxConfig/docfx_01.json
@@ -54,5 +54,9 @@
       "modern",
       "template"
     ]
+  },
+  "assemblyUids": {
+    "MyLib": null,
+    "MyLib.Extensions": "MyLib.V2"
   }
 }

--- a/test/docfx.Tests/SerializationTests/TestData/DocfxConfig/docfx_02.json
+++ b/test/docfx.Tests/SerializationTests/TestData/DocfxConfig/docfx_02.json
@@ -95,5 +95,6 @@
   },
   "rules": {
     "InvalidCref": "info"
-  }
+  },
+  "assemblyUids": [ "MyLib", "MyLib.Tools" ]
 }

--- a/test/docfx.Tests/SerializationTests/TestData/MetadataJsonConfig/metadataJsonConfig_02.json
+++ b/test/docfx.Tests/SerializationTests/TestData/MetadataJsonConfig/metadataJsonConfig_02.json
@@ -38,6 +38,8 @@
     "namespaceLayout": "nested",
     "enumSortOrder": "declaringOrder",
     "outputFormat": "markdown",
+    "assemblyUidOverride": "MyLib.V3",
+    "assemblyLabel": "page",
     "output": "obj/md"
   },
   {


### PR DESCRIPTION
Fixes #8966. Also fixes #9371 and #9458, and covers the request in #2041 (closes #2041) / discussions #8204 and #8018.

## Problem

A docfx UID is Roslyn's documentation comment id minus its `X:` prefix (`VisitorHelper.GetId`), so it carries no assembly component. When one docfx project documents several assemblies that declare the same namespace, their APIs collapse onto one identity:

- `MergeMembers` keys a flat `Dictionary<string, MetadataItem>` by UID. Namespaces and classes are silently merged; everything else is dropped with an `Ignore duplicated member` warning.
- The `.yml` file name is the UID, so pages overwrite each other and `.manifest` warns.
- At build time `DocumentBuildContext.XRefSpecMap` reports `DuplicateUids` and then picks the winner **alphabetically by href**. That is why every link to a shared namespace lands in whichever project happened to win, which is the symptom users report.

This is routine for platform or version specific packages that intentionally expose the same API surface — per-EF-Core-version packages, Xamarin/WinForms/WPF variants, `Abstractions` plus implementation pairs.

`globalNamespaceId` does not help: it only applies to symbols in the global namespace, as noted on #8966.

## Why not resolve hrefs at the metadata stage

The suggestion on #8966 was to "resolve the right project for the API pages by moving the resolve logic from build stage to metadata stage". That fixes hrefs only. It does not stop `MergeMembers` from dropping or merging same-UID pages, so the affected APIs still never get a page at all. Disambiguating the UID is the only fix that addresses every symptom.

## Solution

Two opt-in settings that decide identity, plus one that decides display.

### `assemblyUids` — a project level `docfx.json` property

Names the assemblies whose APIs carry the assembly they are declared in as a component of their UID. An array qualifies each assembly by its own name:

```json
{
  "assemblyUids": [ "MyLib", "MyLib.Ef8" ],
  "metadata": [
    { "src": [ "src/MyLib/MyLib.csproj" ],         "dest": "api/core" },
    { "src": [ "src/MyLib.Ef8/MyLib.Ef8.csproj" ], "dest": "api/ef8" }
  ]
}
```

`MyLib.Widget` becomes `MyLib::MyLib.Widget` and `MyLib.Ef8::MyLib.Widget`, so each keeps its own page, TOC entry and cross references. An object form names the component to use instead (`{ "MyLib.Ef8": "Ef8" }`), where `null` means the assembly's own name. Assemblies that are not listed are untouched, so BCL/NuGet references, Microsoft Learn links and existing xref maps are unaffected.

`::` rather than a dot is the point: the component names an assembly, not a namespace, so it must not read as one. In the output file name the `::` becomes `--`, as `:` is not a legal file name character: `MyLib--MyLib.Widget.html`.

It sits next to `metadata` rather than inside an entry, and that placement is load bearing: an entry mints UIDs not only for the APIs it documents but also for the APIs it *references*, and those must come out identical to the UIDs produced by the entry that documents them. A per entry list cannot do that, because an entry cannot see another entry's settings.

That is measured, not assumed. On a real 17 entry project (linq2db, details below), replacing this with a per entry list on every entry leaves **6690 cross-entry references across 163 pages** pointing at UIDs no page has. They render as plain text with **no link, no warning and no error** — the total warning count is identical either way.

### `assemblyUidOverride` — per entry, for entries that build the same assembly name

Version specific packages are often *one* project built several times, sharing an `AssemblyName` and differing only by target framework, which qualifying by assembly name cannot separate:

```json
{
  "assemblyUids": { "MyLib": null, "MyLib.Ef": "Ef9" },
  "metadata": [
    { "src": [ "src/MyLib/MyLib.csproj" ],           "dest": "api/core" },
    { "src": [ "src/MyLib.Ef/MyLib.Ef.Ef8.csproj" ], "dest": "api/ef8", "assemblyUidOverride": "Ef8" },
    { "src": [ "src/MyLib.Ef/MyLib.Ef.Ef9.csproj" ], "dest": "api/ef9", "assemblyUidOverride": "Ef9" }
  ]
}
```

It takes precedence over `assemblyUids` for the assemblies its own entry documents, so `api/ef8` and `api/ef9` each get a complete set of pages, while giving `MyLib.Ef` the component `Ef9` in `assemblyUids` nominates the version that links from other entries resolve to. The two settings compose without a third option.

Its limits are documented, since they are not obvious: other entries cannot see it, and it does not disambiguate two same-named assemblies inside *one* entry (every assembly an entry documents gets the same component, so a glob matching several target framework folders still collides — narrowing the glob is the fix there).

A component may contain letters, digits, underscores and dashes, separated by dots, e.g. `MyLib.Tools`, `my-lib` or `net8.0`, and unlike a namespace it may start with a digit, so assembly names like `7zip.Net` work. The restriction exists because the UID becomes a file name, an xref key and an HTML anchor. Invalid components, empty assembly names, repeated entries and conflicting mappings are reported as `InvalidAssemblyUid` and skipped.

### `assemblyLabel` — per entry, how the assembly is shown

Nothing displayed names the assembly unless this asks for it, so enabling `assemblyUids` on an existing site leaves every label, title and breadcrumb as it was:

| value | what a namespace looks like |
|---|---|
| `none` (default) | `MyLib` — the namespace alone |
| `shared` | `MyLib (MyLib.Ef8)`, but only for the namespaces more than one assembly of this entry declares |
| `suffix` | `MyLib (MyLib.Ef8)` for every namespace of a qualified assembly |
| `page` | `MyLib`, with `Assembly: MyLib.Ef8.dll` named on the page, the way type pages do |

Over one entry documenting `MyLib` and `MyLib.Ef8`, where both declare `MyLib` and `MyLib.Data` and only `MyLib.Ef8` declares `MyLib.Ef8.Internal` — this is real generated output, ordered by UID:

```
none (default)                     shared
────────────────                   ──────────────────────────────
MyLib                              MyLib (MyLib.Ef8)
MyLib.Data                         MyLib.Data (MyLib.Ef8)
MyLib.Ef8.Internal                 MyLib.Ef8.Internal     <- one assembly, no label
MyLib                              MyLib (MyLib)
MyLib.Data                         MyLib.Data (MyLib)

# Namespace MyLib                  # Namespace MyLib (MyLib.Ef8)

suffix                             page
──────────────────────────────     ──────────────────────────────
MyLib (MyLib.Ef8)                  MyLib
MyLib.Data (MyLib.Ef8)             MyLib.Data
MyLib.Ef8.Internal (MyLib.Ef8)     MyLib.Ef8.Internal
MyLib (MyLib)                      MyLib
MyLib.Data (MyLib)                 MyLib.Data

# Namespace MyLib (MyLib.Ef8)      # Namespace MyLib
                                   Assembly: MyLib.Ef8.dll
```

`shared` compares the namespaces of one `metadata` entry, and cannot do otherwise: entries are generated one after another, each writing its output before the next is compiled. A project that gives every assembly its own entry therefore gets no labels from `shared` even where namespaces collide across entries, and wants `suffix` on those entries; a project documenting several assemblies in one entry, which is Lucene.NET's shape, is what `shared` is for. Documented, with the other cases where a namespace is deliberately not labelled.

`namespaceLayout: nested` is the other way to show it, and answers #8018: the namespaces of each qualified assembly are grouped under a node naming that assembly, which has no page of its own. Authored links name the UID, so they name the real assembly and the real namespace: `<xref:MyLib.Ef8::MyLib.Widget>`, `@MyLib.Ef8::MyLib.Widget`.

### Alternative considered

A single per entry setting would be enough if `Exec` compiled *every* entry first, collected assembly → component, and only then generated; cross-entry references would resolve from that table, the project level setting would not be needed, and `shared` could compare the whole project. Not done here: it holds every Roslyn compilation in memory simultaneously (17 projects across multiple target frameworks in the case above), and restructuring the compile pipeline is a much larger change than this bug warrants. Happy to pursue it separately.

## Implementation

The component is inserted in the private `VisitorHelper.GetDocumentationCommentId`, next to the existing `globalNamespaceId` insertion. That single hook covers uids, comment ids, overload ids, the references table, spec ids, TOC node ids and output file names. It is skipped for type parameters and for symbols with no containing assembly (cref-resolved symbols hit the latter).

`assemblyUidOverride` is applied in `Build` right after `Compile`, since an entry's assemblies are only known once compiled. It is constant for the whole entry, so the parallel API page generation reads it safely.

Four consumers do not go through that hook and needed to follow the component explicitly:

1. **`SymbolUrlResolver.GetDocfxUrl`** built hrefs from the raw Roslyn comment id, and split it on *every* `:`, so a qualified UID collapsed to its assembly and every generated URL pointed at one page. It now splits once and applies the component like the rest.
2. **crefs.** `XmlComment` turns `T:Foo.Bar` into a uid by pure text strip with no symbol context, so `<see cref="..."/>` produced dangling xrefs. A `ResolveAssemblyUid` callback on `XmlCommentParserContext` resolves the target through the compilation using `DocumentationCommentId.GetFirstSymbolForDeclarationId` — the same call `AddReference` already makes — and is supplied by both the mref and apiPage comment parsers. It is a no-op when neither setting is used.
3. **File names.** `VisitorHelper.PathFriendlyId` maps `:` to `-`, one dash per character, because that is exactly what `PathUtility.ToCleanUrlFileName` does to the member pages `memberLayout: separatePages` splits out in the *build* stage. The two have to agree or those hrefs miss their pages, and the yml page names now go through the same helper so `:` never reaches the filesystem.
4. **API filters** use a new `VisitorHelper.GetRawId`, so `filterConfig` `uidRegex` rules keep matching the actual API surface and existing filter files keep working when the settings are enabled.

`assemblyLabel` is applied in `ApplyAssemblyLabel`, after `MergeMembers`, rather than in the symbol visitor: `shared` has to know which namespaces more than one of the entry's assemblies declares, and a visitor only ever sees one assembly. `suffix` shares that implementation. `MergeMembers` keys on the uid alone and `MergeReferences` touches only the references table, so nothing reads a display name in between, and the TOC label, the page `name`/`nameWithType`/`fullName` and the xrefmap all pick it up as before. `DotnetApiCatalog.Toc.cs` applies the same rule for `apiPage` and `markdown`, grouping the namespace nodes *before* picking out the qualified ones — an unqualified assembly declaring the same namespace is another declaration of it — and before `SortToc`, which orders by the name the label is part of.

With `namespaceLayout: nested`, `YamlMetadataResolver` groups each qualified assembly's namespaces under a node naming that assembly. That node carries no UID, so it needs no page and cannot report `UidNotFound`, and the single child collapse no longer promotes a namespace out of it — otherwise an assembly with one namespace lost the only node naming it. `XrefInlineShortParser` accepts `::`, since both colons are characters the `@uid` shortcut otherwise stops at.

The global namespace is qualified as well, so two assemblies whose APIs sit in it no longer share the one page named by `globalNamespaceId`. That surfaced that the global namespace had no display name at all, leaving an empty TOC node: **fixes #9458**.

### `assemblyLabel: page` could not render

Worth calling out as its own defect, because it is what shaped the tests. `SymbolVisitorAdapter` set `ItemViewModel.NamespaceAssembly`, it was written to the `.yml`, and the `{{#namespaceAssembly}}` blocks were in the default and modern namespace partials — but `ManagedReferenceDocumentProcessor.UpdateModelContent` replaces the model with `ApiBuildOutput.FromModel`, which had no such property and never copied it. Being a declared `[YamlMember]`, it could not arrive through the `Metadata` catch-all either. So the option was documented, tested at the metadata level, and rendered nothing.

That is why every `assemblyLabel` value is now asserted on rendered HTML, one theory row each: metadata level assertions passed the whole time while the page showed nothing.

## Behaviour when unset

Inert: `GetAssemblyUid` returns immediately when neither setting is configured, so there is no behaviour change and no measurable cost. The TOC grouping, the label handling and the file name mapping cannot fire without a component, and `assemblyLabel` shows nothing until it is set.

No `.verified.*` file is touched by this PR. `SeedMarkdown`, which uses `namespaceLayout: nested` and the markdown output format — the two code paths this touches most — comes out byte identical against the committed baselines.

## Tests

- `test/Docfx.Dotnet.Tests/AssemblyUidUnitTest.cs`, new: namespace/type/member/overload uids and comment ids; the assembly name as the default component; two assemblies sharing a namespace getting distinct uids; cross-assembly references carrying the *target's* component; unlisted assemblies and framework types untouched; crefs, seealsos, exceptions and `Overload:` crefs; generics and type parameters qualified exactly once; components with digits and dashes; composition with `globalNamespaceId`; filter rules still matching unqualified uids; `::` → `--` file names and the hrefs and anchors `SymbolUrlResolver` derives from them; the override separating assemblies that share an assembly name, winning over the project level setting, and not leaking to other assemblies; and no component at all when nothing is configured. Plus `ApplyAssemblyLabel` driven directly over a shared and a unique namespace for every value and both layouts, and the unqualified assembly that counts as a declaration without being labelled.
- `test/docfx.Tests/MetadataCommandTest.cs`, end to end over real projects that share a namespace: the `Ignore duplicated member` warning and lost page **without** the settings, which locks in the regression; distinct pages, `.manifest` entries and TOC entries **with** them; that the assembly does not surface as a namespace anywhere; plain labels by default; `suffix` labelling all of them, in the TOC and on the page; `shared` labelling only the shared one, over two assemblies of which one declares an extra namespace; the nested per assembly grouping, including the single namespace case; two entries separated by the override; invalid values reported and dropped; and the `apiPage`/`markdown` TOC path, which had no coverage of this at all.
- `test/docfx.Tests/AssemblyUidBuildTest.cs`, new: builds a site from `docfx.json` (so the JSON binding is covered too) with `memberLayout: separatePages`, and asserts the type and member page file names, that `@a::Ns.Type`, `<xref:...>` and `[text](xref:...)` all resolve to the right assembly with the right anchor, and that the namespace link on a type page reads as the namespace while the UID stays in `data-uid`. Plus one theory row per `assemblyLabel` value asserting the **rendered HTML** — the heading, the title and the assembly line — including `none`, which pins that enabling `assemblyUids` changes nothing displayed.
- `test/Docfx.MarkdigEngine.Extensions.Tests/XrefTest.cs`: the `::` shortcut in all four xref forms, and a trailing `::` still ending the uid.
- Serialization round-trip fixtures cover both the array and object forms for Newtonsoft ↔ System.Text.Json parity, and all three settings are in `schemas/docfx.schema.json` (which is `additionalProperties: false`).

## Docs

- `docs/reference/docfx-json-reference.md`: `assemblyUids` under global properties, `assemblyUidOverride` and `assemblyLabel` under `metadata`.
- `docs/docs/dotnet-api-docs.md`: the "Assemblies that share namespaces" section — how to qualify an assembly and why the setting is project level, what each `assemblyLabel` value renders (the block above, taken from a real run), why `shared` is per entry, what the override does and does not fix, and how to nominate the version that links from elsewhere resolve to. Includes the caveat that enabling either identity setting changes UIDs and file names, so `<xref>` links in markdown, overwrite files and external xref maps need updating by hand — and that nothing displayed changes.

## Validated against a real project

Tested end to end on the linq2db documentation site, which is the motivating case: 17 metadata entries, 2389 generated API files, several assemblies sharing the `LinqToDB` namespace, and four Entity Framework Core packages built from one shared props file so that all four produce the assembly name `linq2db.EntityFrameworkCore`. That last detail is what motivated `assemblyUidOverride`.

Because the component defaults to the assembly name, that project's twelve entry prefix map collapses to a plain list.

linq2db carried a private patch for this since #8966 was filed, which prefixes the whole comment id with the assembly name. Comparing that patch against this PR, both from source on the same Roslyn version, all 2389 generated API file names line up while the site build improves substantially:

| | private patch | this PR |
|---|---|---|
| total warnings | 1302 | 68 |
| `InvalidBookmark` (dead in-page anchors) | 1197 | 1 |
| `Ignore duplicated member` | 28 | 0 |
| `InvalidAssemblyReference` | 5 | 0 |
| `DuplicateUids` / `UidNotFound` | 0 | 0 |
| errors | 0 | 0 |

Of those 68, 61 are MSBuild noise from the projects themselves (duplicate source files, one analyzer load failure) and 6 are docfx warnings that predate this work: 5 `InvalidFileLink` from Microsoft Learn relative links inside linq2db's own XML comments, and 1 `InvalidBookmark` from a hand written `#remarks` anchor. The difference against the private patch is exactly the consumers listed under Implementation: that patch emits a malformed `commentId` (`linq2db.T:LinqToDB...`, with the prefix landing before the kind marker), unqualified namespace and type hrefs pointing at pages that do not exist, and ~1200 member anchors that do not match the bookmarks on their own pages.

Reading the result: the `LinqToDB` namespace declared by both `linq2db` and `linq2db.Tools` now has a page each, `linq2db--LinqToDB.html` and `linq2db.Tools--LinqToDB.html`, and both are titled `Namespace LinqToDB` and read as `LinqToDB` in the table of contents, because that is the namespace they document. The site is [linq2db/docs#66](https://github.com/linq2db/docs/pull/66).

## Not included

- The pre-existing `globalNamespaceId` inconsistency in `GetDocfxUrl` — it builds hrefs from the raw comment id, so `globalNamespaceId` is already missing from them. Left alone to keep the "no change when unset" guarantee exact; happy to fix it here or separately.
- `assemblyLabel`'s page effects under `"outputFormat": "apiPage"` or `"markdown"`. Those formats title a page from the symbol itself, so only the TOC label follows the setting there. Documented rather than changed.
- Unioning `AssemblyNameList` when `MergeMembers` merges a namespace or class page. This is a real gap — `samples/seed`'s own `CatLibrary.Core` namespace page reports only `CatLibrary` although half its types come from `CatLibrary.Core` — but it changes default output, would need a snapshot update, and both shipped templates render only `assemblies.0`, so nothing would become visible without a template change too. Better as its own PR.
- A CLI option, consistent with the other map and collection valued metadata settings.
