### PR TITLE
Make xref archive download test hermetic

### DIFF
--- a/test/Docfx.Build.Tests/XRefArchiveBuilderTest.cs
+++ b/test/Docfx.Build.Tests/XRefArchiveBuilderTest.cs
@@ -11,25 +11,34 @@ public class XRefArchiveBuilderTest
     [Fact]
     public async Task TestDownload()
     {
-        const string ZipFile = "test.zip";
-        var builder = new XRefArchiveBuilder();
+        var tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDirectory);
 
-        // Download following xrefmap.yml content.
-        // ```
-        // ### YamlMime:XRefMap
-        // sorted: true
-        // references: []
-        // ```
-        Assert.True(await builder.DownloadAsync(new Uri("http://dotnet.github.io/docfx/xrefmap.yml"), ZipFile));
-
-        using (var xar = XRefArchive.Open(ZipFile, XRefArchiveMode.Read))
+        try
         {
+            var xrefMapFile = Path.Combine(tempDirectory, "xrefmap.yml");
+            var archiveFile = Path.Combine(tempDirectory, "test.zip");
+            await File.WriteAllTextAsync(
+                xrefMapFile,
+                """
+                ### YamlMime:XRefMap
+                sorted: true
+                references: []
+                """);
+
+            var builder = new XRefArchiveBuilder();
+            Assert.True(await builder.DownloadAsync(new Uri(xrefMapFile), archiveFile));
+
+            using var xar = XRefArchive.Open(archiveFile, XRefArchiveMode.Read);
             var map = xar.GetMajor();
             Assert.Null(map.HrefUpdated);
             Assert.True(map.Sorted);
             Assert.NotNull(map.References);
             Assert.Null(map.Redirections);
         }
-        File.Delete(ZipFile);
+        finally
+        {
+            Directory.Delete(tempDirectory, true);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- replace the live `dotnet.github.io` xrefmap request with a minimal local fixture
- isolate the fixture and generated archive in a unique temporary directory and always clean it up
- remove the HTTP-to-HTTPS redirect dependency that causes the required macOS CI test to fail

## Validation

`dotnet test test\Docfx.Build.Tests\Docfx.Build.Tests.csproj --no-build --no-restore --framework net8.0 --filter "FullyQualifiedName=Docfx.Build.Engine.Tests.XRefArchiveBuilderTest.TestDownload" --verbosity minimal` (1 passed)