### PR TITLE
Fix command order in root help usage

### DIFF
--- a/src/docfx/Extensions/DocfxHelpProvider.cs
+++ b/src/docfx/Extensions/DocfxHelpProvider.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Spectre.Console;
+using Spectre.Console.Cli;
+using Spectre.Console.Cli.Help;
+using Spectre.Console.Rendering;
+
+#nullable enable
+
+namespace Docfx;
+
+internal sealed class DocfxHelpProvider : HelpProvider
+{
+    private readonly UsageStyle? _usageStyle;
+
+    public DocfxHelpProvider(ICommandAppSettings settings)
+        : base(settings)
+    {
+        _usageStyle = settings.HelpProviderStyles?.Usage;
+    }
+
+    public override IEnumerable<IRenderable> GetUsage(ICommandModel model, ICommandInfo? command)
+    {
+        if (command is not { IsDefaultCommand: true, Parent: null }
+            || !model.Commands.Any(command => !command.IsHidden && !command.IsDefaultCommand))
+        {
+            return base.GetUsage(model, command);
+        }
+
+        var usage = new Paragraph()
+            .Append("USAGE:", _usageStyle?.Header)
+            .Append("\n    ")
+            .Append(model.ApplicationName)
+            .Append(" [COMMAND]", _usageStyle?.Command);
+
+        foreach (var argument in command.Parameters.OfType<ICommandArgument>().Where(argument => argument.IsRequired).OrderBy(argument => argument.Position))
+        {
+            usage.Append($" <{argument.Value}>", _usageStyle?.RequiredArgument);
+        }
+
+        foreach (var argument in command.Parameters.OfType<ICommandArgument>().Where(argument => !argument.IsRequired).OrderBy(argument => argument.Position))
+        {
+            usage.Append($" [{argument.Value}]", _usageStyle?.OptionalArgument);
+        }
+
+        usage.Append(" [OPTIONS]\n", _usageStyle?.Options);
+        return [usage];
+    }
+}

--- a/src/docfx/Program.cs
+++ b/src/docfx/Program.cs
@@ -13,14 +13,23 @@ internal class Program
 {
     internal static int Main(string[] args)
     {
+        return Run(args);
+    }
+
+    internal static int Run(string[] args, IAnsiConsole? console = null)
+    {
         var app = new CommandApp();
 
         app.SetDefaultCommand<DefaultCommand>();
         app.Configure(config =>
         {
             config.SetApplicationName("docfx");
+            config.SetHelpProvider(new DocfxHelpProvider(config.Settings));
             config.UseStrictParsing();
             config.SetExceptionHandler(OnException);
+
+            if (console is not null)
+                config.ConfigureConsole(console);
 
             config.AddCommand<InitCommand>("init");
             config.AddCommand<BuildCommand>("build");

--- a/test/docfx.Tests/CommandLineTest.cs
+++ b/test/docfx.Tests/CommandLineTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Docfx.Common;
+using Spectre.Console;
 
 namespace Docfx.Tests;
 
@@ -28,6 +29,24 @@ public class CommandLineTest
         Assert.Equal(0, Program.Main(["download", "--help"]));
         Assert.Equal(0, Program.Main(["merge", "--help"]));
         Assert.Equal(0, Program.Main(["template", "--help"]));
+    }
+
+    [Fact]
+    public static void PrintsRootUsageInCommandFirstOrder()
+    {
+        using var writer = new StringWriter();
+        var console = AnsiConsole.Create(new()
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(writer),
+        });
+
+        Assert.Equal(0, Program.Run(["-?"], console));
+
+        var output = writer.ToString();
+        Assert.Contains("docfx [COMMAND] [config] [OPTIONS]", output);
+        Assert.DoesNotContain("docfx [config] [OPTIONS] [COMMAND]", output);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #11034

Uses Spectre.Console.Cli's custom `HelpProvider` extension point to render the optional command before the default command's arguments and options. All non-root usage output continues through Spectre's default provider.

Adds a focused test for `docfx -?` that asserts `docfx [COMMAND] [config] [OPTIONS]` and guards against the previous order.

Validation:
- `dotnet format test\docfx.Tests\docfx.Tests.csproj --no-restore --verify-no-changes --include src\docfx\Program.cs src\docfx\Extensions\DocfxHelpProvider.cs test\docfx.Tests\CommandLineTest.cs`
- `dotnet build test\docfx.Tests\docfx.Tests.csproj --configuration Release --framework net8.0 --no-restore --warnAsError`
- `dotnet test test\docfx.Tests\docfx.Tests.csproj --configuration Release --framework net8.0 --no-build --no-restore --filter "FullyQualifiedName~Docfx.Tests.CommandLineTest"`